### PR TITLE
fix: Use dynamic app version for Sentry release tracking

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'app/app.dart';
 import 'core/background/background_service.dart';
@@ -92,13 +93,17 @@ Future<void> main() async {
   }
 
   if (sentryDsn != null && sentryDsn.isNotEmpty) {
+    // Read version from pubspec.yaml metadata at runtime
+    final packageInfo = await PackageInfo.fromPlatform();
+    final release = 'tankstellen@${packageInfo.version}+${packageInfo.buildNumber}';
+
     // Sentry enabled — use SentryFlutter to capture errors
     await SentryFlutter.init(
       (options) {
         options.dsn = sentryDsn;
         options.tracesSampleRate = 0.2; // 20% of transactions
         options.environment = 'production';
-        options.release = 'fuel-prices@1.0.0';
+        options.release = release;
       },
       appRunner: () => _runApp(container),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -611,10 +611,10 @@ packages:
     dependency: transitive
     description:
       name: geolocator_linux
-      sha256: d64112a205931926f4363bb6bd48f14cb38e7326833041d170615586cd143797
+      sha256: c4e966f0a7a87e70049eac7a2617f9e16fd4c585a26e4330bdfc3a71e6a721f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.3"
   geolocator_platform_interface:
     dependency: transitive
     description:
@@ -973,13 +973,13 @@ packages:
     source: hosted
     version: "2.2.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "8.3.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   shared_preferences: ^2.5.5
   url_launcher: ^6.3.1
   flutter_secure_storage: ^10.0.0
+  package_info_plus: ^8.3.0
   sentry_flutter: ^9.16.0
   workmanager: ^0.9.0
   shimmer: ^3.0.0


### PR DESCRIPTION
## Summary
- Added `package_info_plus` to read version from pubspec at runtime
- Sentry release now reports `tankstellen@version+build` instead of hardcoded `fuel-prices@1.0.0`

Closes #2

## Test plan
- [x] `flutter analyze` passes
- [x] `flutter test` passes
- [ ] Manual: verify Sentry dashboard shows correct version after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)