### PR TITLE
fix: Add 8s timeout to TankSync initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -60,31 +61,35 @@ Future<void> main() async {
     final key = storage.getSetting('supabase_anon_key') as String?;
     if (url != null && key != null) {
       try {
-        await TankSyncClient.init(url: url, anonKey: key);
-        // Re-authenticate if session expired
-        if (TankSyncClient.client?.auth.currentUser == null) {
-          debugPrint('TankSync: session expired, re-authenticating...');
-          await TankSyncClient.signInAnonymously();
-        }
-        // ALWAYS sync stored userId with the active session
-        final sessionId = TankSyncClient.client?.auth.currentUser?.id;
-        final storedId = storage.getSetting('sync_user_id') as String?;
-        if (sessionId != null && sessionId != storedId) {
-          debugPrint('TankSync: userId changed $storedId → $sessionId');
-          await storage.putSetting('sync_user_id', sessionId);
-        }
-        // Ensure public.users row exists (FK constraint requirement)
-        if (sessionId != null) {
-          try {
-            await TankSyncClient.client!.from('users').upsert(
-              {'id': sessionId},
-              onConflict: 'id',
-            );
-          } catch (e) {
-            debugPrint('TankSync: users upsert failed: $e');
+        await Future(() async {
+          await TankSyncClient.init(url: url, anonKey: key);
+          // Re-authenticate if session expired
+          if (TankSyncClient.client?.auth.currentUser == null) {
+            debugPrint('TankSync: session expired, re-authenticating...');
+            await TankSyncClient.signInAnonymously();
           }
-        }
-        debugPrint('TankSync: ready, userId=$sessionId');
+          // ALWAYS sync stored userId with the active session
+          final sessionId = TankSyncClient.client?.auth.currentUser?.id;
+          final storedId = storage.getSetting('sync_user_id') as String?;
+          if (sessionId != null && sessionId != storedId) {
+            debugPrint('TankSync: userId changed $storedId → $sessionId');
+            await storage.putSetting('sync_user_id', sessionId);
+          }
+          // Ensure public.users row exists (FK constraint requirement)
+          if (sessionId != null) {
+            try {
+              await TankSyncClient.client!.from('users').upsert(
+                {'id': sessionId},
+                onConflict: 'id',
+              );
+            } catch (e) {
+              debugPrint('TankSync: users upsert failed: $e');
+            }
+          }
+          debugPrint('TankSync: ready, userId=$sessionId');
+        }).timeout(const Duration(seconds: 8));
+      } on TimeoutException {
+        debugPrint('TankSync: init timed out after 8s, proceeding without sync');
       } catch (e) {
         debugPrint('TankSync init failed: $e');
       }


### PR DESCRIPTION
## Summary
- Wraps TankSync init block in `Future.timeout(Duration(seconds: 8))`
- App launches within 10s even if Supabase is completely unreachable
- Catches TimeoutException and proceeds without sync

Closes #3

## Test plan
- [x] `flutter analyze` passes
- [x] `flutter test` passes
- [ ] Manual: disable network, verify app launches within 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)