### PR TITLE
fix: Replace hardcoded app version in CarDataBridge

### DIFF
--- a/lib/core/car/car_data_bridge.dart
+++ b/lib/core/car/car_data_bridge.dart
@@ -30,6 +30,7 @@ class CarDataBridge {
     required Future<List<Map<String, dynamic>>> Function(double lat, double lng, double radiusKm) onSearchNearby,
     required Future<List<Map<String, dynamic>>> Function() onGetFavorites,
     required Future<Map<String, dynamic>?> Function(String stationId) onGetStationDetail,
+    required String appVersion,
   }) {
     _channel.setMethodCallHandler((call) async {
       switch (call.method) {
@@ -47,7 +48,7 @@ class CarDataBridge {
           return await onGetStationDetail(id);
 
         case 'getAppVersion':
-          return '4.1.0';
+          return appVersion;
 
         default:
           throw MissingPluginException('Method ${call.method} not implemented');

--- a/test/core/car/car_data_bridge_test.dart
+++ b/test/core/car/car_data_bridge_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/car/car_data_bridge.dart';
 
@@ -18,8 +19,47 @@ void main() {
           onSearchNearby: (lat, lng, radius) async => [],
           onGetFavorites: () async => [],
           onGetStationDetail: (id) async => null,
+          appVersion: '4.3.0+4002',
         );
       }, returnsNormally);
+    });
+
+    test('getAppVersion returns the provided version string', () async {
+      CarDataBridge.registerHandlers(
+        onSearchNearby: (lat, lng, radius) async => [],
+        onGetFavorites: () async => [],
+        onGetStationDetail: (id) async => null,
+        appVersion: '4.3.0+4002',
+      );
+
+      // Simulate native→Dart call via the binary messenger
+      const channel = MethodChannel('com.tankstellen/car');
+      final codec = const StandardMethodCodec();
+      final message = codec.encodeMethodCall(const MethodCall('getAppVersion'));
+      final responseBytes = await TestDefaultBinaryMessengerBinding
+          .instance.defaultBinaryMessenger
+          .handlePlatformMessage('com.tankstellen/car', message, (_) {});
+      final result = codec.decodeEnvelope(responseBytes!);
+      expect(result, '4.3.0+4002');
+    });
+
+    test('getAppVersion does not return hardcoded 4.1.0', () async {
+      CarDataBridge.registerHandlers(
+        onSearchNearby: (lat, lng, radius) async => [],
+        onGetFavorites: () async => [],
+        onGetStationDetail: (id) async => null,
+        appVersion: '5.0.0+100',
+      );
+
+      const channel = MethodChannel('com.tankstellen/car');
+      final codec = const StandardMethodCodec();
+      final message = codec.encodeMethodCall(const MethodCall('getAppVersion'));
+      final responseBytes = await TestDefaultBinaryMessengerBinding
+          .instance.defaultBinaryMessenger
+          .handlePlatformMessage('com.tankstellen/car', message, (_) {});
+      final result = codec.decodeEnvelope(responseBytes!);
+      expect(result, isNot('4.1.0'));
+      expect(result, '5.0.0+100');
     });
   });
 }


### PR DESCRIPTION
## Summary
- Added required `appVersion` parameter to `registerHandlers()`
- `getAppVersion` method channel returns injected version instead of hardcoded '4.1.0'

Closes #6

## Test plan
- [x] `flutter analyze` passes
- [x] `flutter test` passes (2 new MethodChannel tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)