### PR TITLE
fix: Replace hardcoded English strings with ARB localization

### DIFF
--- a/lib/features/itinerary/presentation/screens/itineraries_screen.dart
+++ b/lib/features/itinerary/presentation/screens/itineraries_screen.dart
@@ -57,7 +57,7 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
                     onDismissed: () {
                       ref.read(itineraryProvider.notifier).delete(it.id);
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('${it.name} deleted')),
+                        SnackBar(content: Text(AppLocalizations.of(context)?.itineraryDeleted(it.name) ?? '${it.name} deleted')),
                       );
                     },
                     child: ListTile(
@@ -107,7 +107,7 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
     context.go('/');
 
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Loading route: ${it.name}')),
+      SnackBar(content: Text(AppLocalizations.of(context)?.loadingRoute(it.name) ?? 'Loading route: ${it.name}')),
     );
   }
 

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -64,7 +64,7 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Refresh failed: $e')),
+          SnackBar(content: Text(AppLocalizations.of(context)?.refreshFailed ?? 'Refresh failed. Please try again.')),
         );
       }
     } finally {

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -56,7 +56,7 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
           return SliverFillRemaining(
             child: Center(
               child: Text(
-                'No stations found along this route.',
+                l10n?.noStationsAlongThisRoute ?? 'No stations found along this route.',
                 style: TextStyle(fontSize: 16, color: Colors.grey[600]),
                 textAlign: TextAlign.center,
               ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -307,5 +307,19 @@
   "noSavedRoutes": "Keine gespeicherten Routen",
   "noSavedRoutesHint": "Suche entlang einer Route und speichere sie fuer schnellen Zugriff.",
   "saveRoute": "Route speichern",
-  "routeName": "Routenname"
+  "routeName": "Routenname",
+
+  "itineraryDeleted": "{name} gelöscht",
+  "@itineraryDeleted": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "loadingRoute": "Route wird geladen: {name}",
+  "@loadingRoute": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "refreshFailed": "Aktualisierung fehlgeschlagen. Bitte erneut versuchen."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -307,5 +307,19 @@
   "noSavedRoutes": "No saved routes",
   "noSavedRoutesHint": "Search along a route and save it for quick access later.",
   "saveRoute": "Save route",
-  "routeName": "Route name"
+  "routeName": "Route name",
+
+  "itineraryDeleted": "{name} deleted",
+  "@itineraryDeleted": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "loadingRoute": "Loading route: {name}",
+  "@loadingRoute": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "refreshFailed": "Refresh failed. Please try again."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1825,6 +1825,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Route name'**
   String get routeName;
+
+  /// No description provided for @itineraryDeleted.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} deleted'**
+  String itineraryDeleted(String name);
+
+  /// No description provided for @loadingRoute.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading route: {name}'**
+  String loadingRoute(String name);
+
+  /// No description provided for @refreshFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh failed. Please try again.'**
+  String get refreshFailed;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -912,4 +912,17 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -912,4 +912,17 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -910,4 +910,17 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -913,4 +913,18 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get routeName => 'Routenname';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name gelöscht';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Route wird geladen: $name';
+  }
+
+  @override
+  String get refreshFailed =>
+      'Aktualisierung fehlgeschlagen. Bitte erneut versuchen.';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -914,4 +914,17 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -906,4 +906,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -913,4 +913,17 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get routeName => 'Nombre de la ruta';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -908,4 +908,17 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -910,4 +910,17 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -917,4 +917,17 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get routeName => 'Nom de l\'itinéraire';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -909,4 +909,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -914,4 +914,17 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -913,4 +913,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get routeName => 'Nome del percorso';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -911,4 +911,17 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -913,4 +913,17 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -909,4 +909,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -914,4 +914,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -912,4 +912,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -913,4 +913,17 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -913,4 +913,17 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -913,4 +913,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -907,4 +907,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -911,4 +911,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get routeName => 'Route name';
+
+  @override
+  String itineraryDeleted(String name) {
+    return '$name deleted';
+  }
+
+  @override
+  String loadingRoute(String name) {
+    return 'Loading route: $name';
+  }
+
+  @override
+  String get refreshFailed => 'Refresh failed. Please try again.';
 }

--- a/test/features/search/presentation/widgets/route_results_view_test.dart
+++ b/test/features/search/presentation/widgets/route_results_view_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/route_search/domain/entities/route_info.dart';
+import 'package:tankstellen/features/route_search/providers/route_search_provider.dart';
+import 'package:tankstellen/features/search/presentation/widgets/route_results_view.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('RouteResultsView', () {
+    testWidgets('shows localized empty message when no stations found',
+        (tester) async {
+      final test = standardTestOverrides();
+
+      final emptyResult = RouteSearchResult(
+        route: RouteInfo(
+          geometry: [const LatLng(48.0, 2.0), const LatLng(49.0, 3.0)],
+          distanceKm: 100,
+          durationMinutes: 60,
+          samplePoints: [const LatLng(48.5, 2.5)],
+        ),
+        stations: [],
+      );
+
+      await pumpApp(
+        tester,
+        const CustomScrollView(slivers: [RouteResultsView()]),
+        overrides: [
+          ...test.overrides,
+          routeSearchStateProvider
+              .overrideWith(() => _FixedRouteSearch(emptyResult)),
+        ],
+      );
+
+      expect(
+        find.text('No stations found along this route.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows localized start search message when no search performed',
+        (tester) async {
+      final test = standardTestOverrides();
+
+      await pumpApp(
+        tester,
+        const CustomScrollView(slivers: [RouteResultsView()]),
+        overrides: [
+          ...test.overrides,
+          routeSearchStateProvider
+              .overrideWith(() => _FixedRouteSearch(null)),
+        ],
+      );
+
+      expect(
+        find.text('Search to find fuel stations.'),
+        findsOneWidget,
+      );
+    });
+  });
+}
+
+class _FixedRouteSearch extends RouteSearchState {
+  final RouteSearchResult? _result;
+  _FixedRouteSearch(this._result);
+
+  @override
+  AsyncValue<RouteSearchResult?> build() => AsyncValue.data(_result);
+}


### PR DESCRIPTION
## Summary
- Added 3 new ARB keys (itineraryDeleted, loadingRoute, refreshFailed) to en + de
- Replaced hardcoded strings in route_results_view, itineraries_screen, ev_station_detail_screen
- No more raw exception messages shown to users

Closes #7

## Test plan
- [x] `flutter analyze` passes
- [x] `flutter test` passes (2 new l10n tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)