### PR TITLE
fix: Move side effects out of build() in search screen

### DIFF
--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -47,8 +47,24 @@ class SearchScreen extends ConsumerStatefulWidget {
 class _SearchScreenState extends ConsumerState<SearchScreen> {
   bool _filtersExpanded = true;
   bool _searchBarExpanded = true;
-  bool _autoSearchTriggered = false;
   RouteSearchStrategyType _selectedStrategy = RouteSearchStrategyType.uniform;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final profile = ref.read(activeProfileProvider);
+      if (profile?.landingScreen == LandingScreen.cheapest) {
+        final zip = profile?.homeZipCode;
+        if (zip != null && zip.isNotEmpty) {
+          _performZipSearch(zip);
+        } else {
+          _performGpsSearch();
+        }
+      }
+    });
+  }
 
   // ---------------------------------------------------------------------------
   // Search actions
@@ -148,25 +164,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     final isLandscape =
         MediaQuery.of(context).orientation == Orientation.landscape;
 
-    // Auto-search for "cheapest nearby" landing screen
-    if (!_autoSearchTriggered) {
-      _autoSearchTriggered = true;
-      final profile = ref.read(activeProfileProvider);
-      if (profile?.landingScreen == LandingScreen.cheapest) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-          final zip = profile?.homeZipCode;
-          if (zip != null && zip.isNotEmpty) {
-            _performZipSearch(zip);
-          } else {
-            _performGpsSearch();
-          }
-        });
-      }
-    }
-
     if (isLandscape && !_searchBarExpanded && _filtersExpanded) {
-      _filtersExpanded = false;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) setState(() => _filtersExpanded = false);
+      });
     }
 
     return Scaffold(

--- a/test/features/search/presentation/screens/search_screen_test.dart
+++ b/test/features/search/presentation/screens/search_screen_test.dart
@@ -118,5 +118,27 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets('rebuild does not re-trigger auto-search side effects',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const SearchScreen(),
+        overrides: [
+          ...test.overrides,
+          userPositionNullOverride(),
+        ],
+      );
+
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(Scaffold), findsAtLeast(1));
+      expect(find.text('Search to find fuel stations.'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Moved auto-search logic from build() to initState() with addPostFrameCallback
- Landscape filter collapse now uses addPostFrameCallback instead of direct mutation
- station_detail_screen had no actual build() side effects (callbacks only)

Closes #17

## Test plan
- [x] `flutter analyze` passes
- [x] `flutter test` passes (1 new rebuild-safety test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)