### PR TITLE
refactor: Remove all direct HiveStorage imports from presentation layer

### DIFF
--- a/lib/core/location/location_consent.dart
+++ b/lib/core/location/location_consent.dart
@@ -1,24 +1,17 @@
 import 'package:flutter/material.dart';
 import '../data/storage_repository.dart';
-import '../storage/hive_storage.dart';
 
 class LocationConsentDialog {
   static const String _consentKey = 'location_consent_given';
 
-  /// Check consent using the abstract StorageRepository.
-  static bool hasConsent(StorageRepository storage) {
+  /// Check consent using the narrow SettingsStorage interface.
+  static bool hasConsent(SettingsStorage storage) {
     return storage.getSetting(_consentKey) == true;
   }
 
-  /// Record consent using the abstract StorageRepository.
-  static Future<void> recordConsent(StorageRepository storage) async {
+  /// Record consent using the narrow SettingsStorage interface.
+  static Future<void> recordConsent(SettingsStorage storage) async {
     await storage.putSetting(_consentKey, true);
-  }
-
-  /// Legacy overload for backward compatibility with HiveStorage.
-  @Deprecated('Use StorageRepository overload instead')
-  static bool hasConsentLegacy(HiveStorage storage) {
-    return storage.getSetting(_consentKey) == true;
   }
 
   static Future<bool> show(BuildContext context) async {

--- a/lib/core/services/service_providers.g.dart
+++ b/lib/core/services/service_providers.g.dart
@@ -140,4 +140,4 @@ final class GeocodingChainProvider
   }
 }
 
-String _$geocodingChainHash() => r'eeec337ab41021c84fa78038c52f1f357276d182';
+String _$geocodingChainHash() => r'9d3e3d6160af0a2bbeafca30eb14d69641cbae4e';

--- a/lib/core/storage/storage_providers.dart
+++ b/lib/core/storage/storage_providers.dart
@@ -1,0 +1,41 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../data/storage_repository.dart';
+import 'hive_storage.dart';
+
+part 'storage_providers.g.dart';
+
+/// Narrow provider for API key operations (presentation-safe).
+@Riverpod(keepAlive: true)
+ApiKeyStorage apiKeyStorage(Ref ref) => ref.watch(hiveStorageProvider);
+
+/// Narrow provider for app settings (presentation-safe).
+@Riverpod(keepAlive: true)
+SettingsStorage settingsStorage(Ref ref) => ref.watch(hiveStorageProvider);
+
+/// Narrow provider for cache + storage management (presentation-safe).
+@Riverpod(keepAlive: true)
+StorageManagement storageManagement(Ref ref) => StorageManagement(ref.watch(hiveStorageProvider));
+
+/// Combines cache, price history, and stats operations for the storage settings screen.
+class StorageManagement {
+  final HiveStorage _storage;
+  StorageManagement(this._storage);
+
+  ({int settings, int profiles, int favorites, int cache, int priceHistory, int alerts, int total})
+      get storageStats => _storage.storageStats;
+
+  int get profileCount => _storage.profileCount;
+  int get favoriteCount => _storage.favoriteCount;
+  int get cacheEntryCount => _storage.cacheEntryCount;
+  int get priceHistoryEntryCount => _storage.priceHistoryEntryCount;
+  int get alertCount => _storage.alertCount;
+  List<String> getIgnoredIds() => _storage.getIgnoredIds();
+  Map<String, int> getRatings() => _storage.getRatings();
+
+  Future<void> clearCache() => _storage.clearCache();
+  Future<void> clearPriceHistory() => _storage.clearPriceHistory();
+  Future<void> deleteApiKey() => _storage.deleteApiKey();
+
+  Future<void> savePriceRecords(String stationId, List<Map<String, dynamic>> records) =>
+      _storage.savePriceRecords(stationId, records);
+}

--- a/lib/core/storage/storage_providers.g.dart
+++ b/lib/core/storage/storage_providers.g.dart
@@ -1,0 +1,154 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'storage_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Narrow provider for API key operations (presentation-safe).
+
+@ProviderFor(apiKeyStorage)
+final apiKeyStorageProvider = ApiKeyStorageProvider._();
+
+/// Narrow provider for API key operations (presentation-safe).
+
+final class ApiKeyStorageProvider
+    extends $FunctionalProvider<ApiKeyStorage, ApiKeyStorage, ApiKeyStorage>
+    with $Provider<ApiKeyStorage> {
+  /// Narrow provider for API key operations (presentation-safe).
+  ApiKeyStorageProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'apiKeyStorageProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$apiKeyStorageHash();
+
+  @$internal
+  @override
+  $ProviderElement<ApiKeyStorage> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  ApiKeyStorage create(Ref ref) {
+    return apiKeyStorage(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ApiKeyStorage value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ApiKeyStorage>(value),
+    );
+  }
+}
+
+String _$apiKeyStorageHash() => r'3b9e06c7d8886cf008dd6950e21982c1ba634aa5';
+
+/// Narrow provider for app settings (presentation-safe).
+
+@ProviderFor(settingsStorage)
+final settingsStorageProvider = SettingsStorageProvider._();
+
+/// Narrow provider for app settings (presentation-safe).
+
+final class SettingsStorageProvider
+    extends
+        $FunctionalProvider<SettingsStorage, SettingsStorage, SettingsStorage>
+    with $Provider<SettingsStorage> {
+  /// Narrow provider for app settings (presentation-safe).
+  SettingsStorageProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'settingsStorageProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$settingsStorageHash();
+
+  @$internal
+  @override
+  $ProviderElement<SettingsStorage> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  SettingsStorage create(Ref ref) {
+    return settingsStorage(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SettingsStorage value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SettingsStorage>(value),
+    );
+  }
+}
+
+String _$settingsStorageHash() => r'79d5e3b00ed88836938003399827b5e66594159c';
+
+/// Narrow provider for cache + storage management (presentation-safe).
+
+@ProviderFor(storageManagement)
+final storageManagementProvider = StorageManagementProvider._();
+
+/// Narrow provider for cache + storage management (presentation-safe).
+
+final class StorageManagementProvider
+    extends
+        $FunctionalProvider<
+          StorageManagement,
+          StorageManagement,
+          StorageManagement
+        >
+    with $Provider<StorageManagement> {
+  /// Narrow provider for cache + storage management (presentation-safe).
+  StorageManagementProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'storageManagementProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$storageManagementHash();
+
+  @$internal
+  @override
+  $ProviderElement<StorageManagement> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  StorageManagement create(Ref ref) {
+    return storageManagement(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(StorageManagement value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<StorageManagement>(value),
+    );
+  }
+}
+
+String _$storageManagementHash() => r'965e4f04f5b60889c5329bbde96030f0d8349f39';

--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'8aa20643ab32a6b6f4c3f6c3f4a90a42e356e61b';
+String _$syncStateHash() => r'2f68093f7753cbd0b13f7363ecaed8f7cc70390b';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/features/alerts/providers/alert_provider.g.dart
+++ b/lib/features/alerts/providers/alert_provider.g.dart
@@ -83,7 +83,7 @@ final class AlertNotifierProvider
   }
 }
 
-String _$alertNotifierHash() => r'adae03f8a59473c9167c2702a5f9afc6eafd8059';
+String _$alertNotifierHash() => r'8735ffc899b32f314dd61963a1d195bce93bd469';
 
 abstract class _$AlertNotifier extends $Notifier<List<PriceAlert>> {
   List<PriceAlert> build();

--- a/lib/features/favorites/providers/favorites_provider.g.dart
+++ b/lib/features/favorites/providers/favorites_provider.g.dart
@@ -68,7 +68,7 @@ final class FavoritesProvider
   }
 }
 
-String _$favoritesHash() => r'eaf6917fbc2ae8f7238519c3e93ffb77655c7ee6';
+String _$favoritesHash() => r'b19310178145c484fa60ed84f5eabfdea959cf5a';
 
 /// Manages the user's list of favorite station IDs.
 ///
@@ -183,40 +183,40 @@ final class IsFavoriteFamily extends $Family
   String toString() => r'isFavoriteProvider';
 }
 
-/// Loads cached station data for favorites and refreshes prices.
+/// Loads station data for favorites and refreshes prices.
 ///
-/// ## Data flow:
-/// 1. Read cached Station objects from CacheManager (30-min TTL)
-/// 2. Check connectivity — if offline, return cached data with `isStale: true`
-/// 3. If online, batch-refresh prices via StationService.getPrices()
-/// 4. Merge fresh prices into cached stations, update cache
-/// 5. On API failure, fall back to cached data with stale flag
+/// ## Data flow (local-first):
+/// 1. Load persisted Station objects from Hive (permanent, never expires)
+/// 2. Check connectivity — if offline, return persisted data with `isStale: true`
+/// 3. If online, refresh prices via StationService.getPrices()
+/// 4. Merge fresh prices into stations, persist updated data back
+/// 5. On API failure, serve persisted data with stale flag
 
 @ProviderFor(FavoriteStations)
 final favoriteStationsProvider = FavoriteStationsProvider._();
 
-/// Loads cached station data for favorites and refreshes prices.
+/// Loads station data for favorites and refreshes prices.
 ///
-/// ## Data flow:
-/// 1. Read cached Station objects from CacheManager (30-min TTL)
-/// 2. Check connectivity — if offline, return cached data with `isStale: true`
-/// 3. If online, batch-refresh prices via StationService.getPrices()
-/// 4. Merge fresh prices into cached stations, update cache
-/// 5. On API failure, fall back to cached data with stale flag
+/// ## Data flow (local-first):
+/// 1. Load persisted Station objects from Hive (permanent, never expires)
+/// 2. Check connectivity — if offline, return persisted data with `isStale: true`
+/// 3. If online, refresh prices via StationService.getPrices()
+/// 4. Merge fresh prices into stations, persist updated data back
+/// 5. On API failure, serve persisted data with stale flag
 final class FavoriteStationsProvider
     extends
         $NotifierProvider<
           FavoriteStations,
           AsyncValue<ServiceResult<List<Station>>>
         > {
-  /// Loads cached station data for favorites and refreshes prices.
+  /// Loads station data for favorites and refreshes prices.
   ///
-  /// ## Data flow:
-  /// 1. Read cached Station objects from CacheManager (30-min TTL)
-  /// 2. Check connectivity — if offline, return cached data with `isStale: true`
-  /// 3. If online, batch-refresh prices via StationService.getPrices()
-  /// 4. Merge fresh prices into cached stations, update cache
-  /// 5. On API failure, fall back to cached data with stale flag
+  /// ## Data flow (local-first):
+  /// 1. Load persisted Station objects from Hive (permanent, never expires)
+  /// 2. Check connectivity — if offline, return persisted data with `isStale: true`
+  /// 3. If online, refresh prices via StationService.getPrices()
+  /// 4. Merge fresh prices into stations, persist updated data back
+  /// 5. On API failure, serve persisted data with stale flag
   FavoriteStationsProvider._()
     : super(
         from: null,
@@ -245,16 +245,16 @@ final class FavoriteStationsProvider
   }
 }
 
-String _$favoriteStationsHash() => r'5aa2012b25b1d51c87c23d2635e1c44ff815b012';
+String _$favoriteStationsHash() => r'3b569d570e9167392d5d53da321f2c2aaaca219e';
 
-/// Loads cached station data for favorites and refreshes prices.
+/// Loads station data for favorites and refreshes prices.
 ///
-/// ## Data flow:
-/// 1. Read cached Station objects from CacheManager (30-min TTL)
-/// 2. Check connectivity — if offline, return cached data with `isStale: true`
-/// 3. If online, batch-refresh prices via StationService.getPrices()
-/// 4. Merge fresh prices into cached stations, update cache
-/// 5. On API failure, fall back to cached data with stale flag
+/// ## Data flow (local-first):
+/// 1. Load persisted Station objects from Hive (permanent, never expires)
+/// 2. Check connectivity — if offline, return persisted data with `isStale: true`
+/// 3. If online, refresh prices via StationService.getPrices()
+/// 4. Merge fresh prices into stations, persist updated data back
+/// 5. On API failure, serve persisted data with stale flag
 
 abstract class _$FavoriteStations
     extends $Notifier<AsyncValue<ServiceResult<List<Station>>>> {

--- a/lib/features/profile/presentation/widgets/api_key_section.dart
+++ b/lib/features/profile/presentation/widgets/api_key_section.dart
@@ -3,7 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/country/country_provider.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/data/storage_repository.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../l10n/app_localizations.dart';
 
 class ApiKeySection extends ConsumerWidget {
@@ -11,7 +12,7 @@ class ApiKeySection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final storage = ref.watch(hiveStorageProvider);
+    final storage = ref.watch(apiKeyStorageProvider);
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final country = ref.watch(activeCountryProvider);
@@ -150,7 +151,7 @@ class ApiKeySection extends ConsumerWidget {
   }
 
   Future<void> _editApiKey(
-      BuildContext context, WidgetRef ref, HiveStorage storage) async {
+      BuildContext context, WidgetRef ref, ApiKeyStorage storage) async {
     final controller = TextEditingController(
       text: storage.getApiKey() ?? '',
     );
@@ -182,13 +183,13 @@ class ApiKeySection extends ConsumerWidget {
     if (result != null && result.isNotEmpty) {
       await storage.setApiKey(result);
       // Force rebuild to show updated status
-      ref.invalidate(hiveStorageProvider);
+      ref.invalidate(apiKeyStorageProvider);
     }
     controller.dispose();
   }
 
   Future<void> _editEvApiKey(
-      BuildContext context, WidgetRef ref, HiveStorage storage) async {
+      BuildContext context, WidgetRef ref, ApiKeyStorage storage) async {
     final controller = TextEditingController(
       text: storage.getEvApiKey() ?? '',
     );
@@ -220,7 +221,7 @@ class ApiKeySection extends ConsumerWidget {
     if (result != null && result.isNotEmpty) {
       await storage.setEvApiKey(result);
       // Force rebuild to show updated status
-      ref.invalidate(hiveStorageProvider);
+      ref.invalidate(apiKeyStorageProvider);
     }
     controller.dispose();
   }

--- a/lib/features/profile/presentation/widgets/config_verification_widget.dart
+++ b/lib/features/profile/presentation/widgets/config_verification_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../providers/profile_provider.dart';
 
@@ -15,15 +15,17 @@ class ConfigVerificationWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final storage = ref.read(hiveStorageProvider);
+    final apiKeys = ref.read(apiKeyStorageProvider);
+    final settings = ref.read(settingsStorageProvider);
+    final mgmt = ref.read(storageManagementProvider);
     final syncConfig = ref.watch(syncStateProvider);
     final profile = ref.watch(activeProfileProvider);
-    final hasApiKey = storage.hasApiKey();
+    final hasApiKey = apiKeys.hasApiKey();
     final isEmail = syncConfig.hasEmail;
-    final favCount = storage.getFavoriteIds().length;
-    final alertCount = storage.alertCount;
-    final ignoredCount = storage.getIgnoredIds().length;
-    final ratingsCount = storage.getRatings().length;
+    final favCount = mgmt.favoriteCount;
+    final alertCount = mgmt.alertCount;
+    final ignoredCount = mgmt.getIgnoredIds().length;
+    final ratingsCount = mgmt.getRatings().length;
     final ratingMode = profile?.ratingMode ?? 'local';
 
     return Card(
@@ -54,7 +56,7 @@ class ConfigVerificationWidget extends ConsumerWidget {
                 value: hasApiKey ? 'Configured' : 'Not set (demo mode)',
                 status: hasApiKey ? _Status.ok : _Status.warning),
             _ConfigRow(icon: Icons.ev_station, label: 'EV charging API key',
-                value: storage.hasCustomEvApiKey() ? 'Custom key' : 'Default (shared)',
+                value: apiKeys.hasCustomEvApiKey() ? 'Custom key' : 'Default (shared)',
                 status: _Status.ok),
 
             const Divider(height: 24),
@@ -92,7 +94,7 @@ class ConfigVerificationWidget extends ConsumerWidget {
                         ? 'Private (synced)'
                         : 'Shared (public)'),
             _ConfigRow(icon: Icons.location_on, label: 'GPS position',
-                value: storage.getSetting('user_position_lat') != null ? 'Stored' : 'Not stored',
+                value: settings.getSetting('user_position_lat') != null ? 'Stored' : 'Not stored',
                 privacy: 'Local only (never synced)'),
             _ConfigRow(icon: Icons.key, label: 'API keys',
                 value: hasApiKey ? 'Stored' : 'Not set',

--- a/lib/features/profile/presentation/widgets/location_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/location_section_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/location/user_position_provider.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/repositories/profile_repository.dart';
@@ -134,9 +134,9 @@ class _LocationSectionWidgetState
   }
 
   Widget _buildAutoSwitchToggle(ThemeData theme, AppLocalizations? l) {
-    final storage = ref.read(hiveStorageProvider);
+    final settings = ref.read(settingsStorageProvider);
     final autoSwitch =
-        storage.getSetting(StorageKeys.autoSwitchProfile) as bool? ?? false;
+        settings.getSetting(StorageKeys.autoSwitchProfile) as bool? ?? false;
 
     return SwitchListTile(
       contentPadding: EdgeInsets.zero,
@@ -154,7 +154,7 @@ class _LocationSectionWidgetState
       value: autoSwitch,
       onChanged: (value) {
         ref
-            .read(hiveStorageProvider)
+            .read(settingsStorageProvider)
             .putSetting(StorageKeys.autoSwitchProfile, value);
         setState(() {});
       },

--- a/lib/features/profile/presentation/widgets/storage_section.dart
+++ b/lib/features/profile/presentation/widgets/storage_section.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../../../../core/cache/cache_manager.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../l10n/app_localizations.dart';
 import 'storage_bar.dart';
 
@@ -17,8 +17,8 @@ class StorageSection extends ConsumerStatefulWidget {
 class _StorageSectionState extends ConsumerState<StorageSection> {
   @override
   Widget build(BuildContext context) {
-    final storage = ref.read(hiveStorageProvider);
-    final stats = storage.storageStats;
+    final storageMgmt = ref.read(storageManagementProvider);
+    final stats = storageMgmt.storageStats;
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
 
@@ -43,22 +43,22 @@ class _StorageSectionState extends ConsumerState<StorageSection> {
                   theme.colorScheme.primary,
                 ),
                 StorageSegment(
-                  '${l?.profile ?? "Profile"} (${storage.profileCount})',
+                  '${l?.profile ?? "Profile"} (${storageMgmt.profileCount})',
                   stats.profiles,
                   theme.colorScheme.secondary,
                 ),
                 StorageSegment(
-                  '${l?.favorites ?? "Favorites"} (${storage.favoriteCount})',
+                  '${l?.favorites ?? "Favorites"} (${storageMgmt.favoriteCount})',
                   stats.favorites,
                   theme.colorScheme.tertiary,
                 ),
                 StorageSegment(
-                  'Cache (${storage.cacheEntryCount} ${l?.entries ?? "entries"})',
+                  'Cache (${storageMgmt.cacheEntryCount} ${l?.entries ?? "entries"})',
                   stats.cache,
                   theme.colorScheme.error.withValues(alpha: 0.7),
                 ),
                 StorageSegment(
-                  'Price History (${storage.priceHistoryEntryCount})',
+                  'Price History (${storageMgmt.priceHistoryEntryCount})',
                   stats.priceHistory,
                   Colors.orange.withValues(alpha: 0.7),
                 ),
@@ -76,47 +76,47 @@ class _StorageSectionState extends ConsumerState<StorageSection> {
             StorageDetailRow(
               label: 'Profile',
               detail:
-                  '${storage.profileCount} ${l?.profilesStored ?? 'profiles'}',
+                  '${storageMgmt.profileCount} ${l?.profilesStored ?? 'profiles'}',
               bytes: stats.profiles,
               color: theme.colorScheme.secondary,
             ),
             StorageDetailRow(
               label: l?.favorites ?? 'Favorites',
               detail:
-                  '${storage.favoriteCount} ${l?.stationsMarked ?? 'stations'}',
+                  '${storageMgmt.favoriteCount} ${l?.stationsMarked ?? 'stations'}',
               bytes: stats.favorites,
               color: theme.colorScheme.tertiary,
             ),
             StorageDetailRow(
               label: 'Cache',
               detail:
-                  '${storage.cacheEntryCount} ${l?.cachedResponses ?? 'cached'}',
+                  '${storageMgmt.cacheEntryCount} ${l?.cachedResponses ?? 'cached'}',
               bytes: stats.cache,
               color: theme.colorScheme.error.withValues(alpha: 0.7),
             ),
             StorageDetailRow(
               label: 'Price History',
               detail:
-                  '${storage.priceHistoryEntryCount} stations tracked',
+                  '${storageMgmt.priceHistoryEntryCount} stations tracked',
               bytes: stats.priceHistory,
               color: Colors.orange.withValues(alpha: 0.7),
             ),
             StorageDetailRow(
               label: l?.priceAlerts ?? 'Alerts',
-              detail: '${storage.alertCount} configured',
+              detail: '${storageMgmt.alertCount} configured',
               bytes: stats.alerts,
               color: Colors.amber.withValues(alpha: 0.7),
             ),
             StorageDetailRow(
               label: 'Ignored',
-              detail: '${storage.getIgnoredIds().length} stations hidden',
-              bytes: storage.getIgnoredIds().length * 64,
+              detail: '${storageMgmt.getIgnoredIds().length} stations hidden',
+              bytes: storageMgmt.getIgnoredIds().length * 64,
               color: Colors.grey,
             ),
             StorageDetailRow(
               label: 'Ratings',
-              detail: '${storage.getRatings().length} stations rated',
-              bytes: storage.getRatings().length * 64,
+              detail: '${storageMgmt.getRatings().length} stations rated',
+              bytes: storageMgmt.getRatings().length * 64,
               color: Colors.amber,
             ),
             const Divider(height: 32),
@@ -157,13 +157,13 @@ class _StorageSectionState extends ConsumerState<StorageSection> {
               children: [
                 Expanded(
                   child: OutlinedButton.icon(
-                    onPressed: storage.cacheEntryCount > 0
+                    onPressed: storageMgmt.cacheEntryCount > 0
                         ? () => _clearCache(context)
                         : null,
                     icon: const Icon(Icons.delete_sweep),
                     label: Text(
-                      storage.cacheEntryCount > 0
-                          ? '${l?.clearCacheButton ?? "Clear cache"} (${storage.cacheEntryCount} ${l?.entries ?? "entries"})'
+                      storageMgmt.cacheEntryCount > 0
+                          ? '${l?.clearCacheButton ?? "Clear cache"} (${storageMgmt.cacheEntryCount} ${l?.entries ?? "entries"})'
                           : l?.cacheEmpty ?? 'Cache is empty',
                     ),
                   ),
@@ -262,10 +262,10 @@ class _StorageSectionState extends ConsumerState<StorageSection> {
     );
 
     if (confirmed == true) {
-      final storage = ref.read(hiveStorageProvider);
-      await storage.clearCache();
-      await storage.clearPriceHistory();
-      await storage.deleteApiKey();
+      final storageMgmt = ref.read(storageManagementProvider);
+      await storageMgmt.clearCache();
+      await storageMgmt.clearPriceHistory();
+      await storageMgmt.deleteApiKey();
       for (final boxName in ['settings', 'favorites', 'profiles']) {
         final box = Hive.box(boxName);
         await box.clear();

--- a/lib/features/report/presentation/screens/report_screen.dart
+++ b/lib/features/report/presentation/screens/report_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/constants/api_constants.dart';
 import '../../../../core/constants/app_constants.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -73,8 +73,8 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
 
     setState(() => _isSubmitting = true);
     try {
-      final storage = ref.read(hiveStorageProvider);
-      final apiKey = storage.getApiKey();
+      final apiKeys = ref.read(apiKeyStorageProvider);
+      final apiKey = apiKeys.getApiKey();
 
       final dio = Dio(BaseOptions(
         baseUrl: ApiConstants.baseUrl,

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../core/constants/app_constants.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -37,8 +37,8 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
   Future<void> _refreshStation() async {
     setState(() => _isRefreshing = true);
     try {
-      final storage = ref.read(hiveStorageProvider);
-      final apiKey = storage.getEvApiKey() ?? AppConstants.openChargeMapApiKey;
+      final apiKeys = ref.read(apiKeyStorageProvider);
+      final apiKey = apiKeys.getEvApiKey() ?? AppConstants.openChargeMapApiKey;
       final service = EVChargingService(apiKey: apiKey);
       final result = await service.searchStations(
         lat: _station.lat,

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -7,7 +7,7 @@ import '../../../../core/location/location_consent.dart';
 import '../../../../core/location/user_position_provider.dart';
 import '../../../../core/services/location_search_service.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -69,8 +69,8 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   Future<void> _performGpsSearch() async {
     final fuelType = ref.read(selectedFuelTypeProvider);
     final radius = ref.read(searchRadiusProvider);
-    final storage = ref.read(hiveStorageProvider);
-    if (!LocationConsentDialog.hasConsent(storage)) {
+    final settings = ref.read(settingsStorageProvider);
+    if (!LocationConsentDialog.hasConsent(settings)) {
       if (!mounted) return;
       final consented = await LocationConsentDialog.show(context);
       if (!consented) {
@@ -84,7 +84,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         }
         return;
       }
-      await LocationConsentDialog.recordConsent(storage);
+      await LocationConsentDialog.recordConsent(settings);
     }
     setState(() { _filtersExpanded = false; _searchBarExpanded = false; });
 
@@ -254,13 +254,13 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         SliverToBoxAdapter(
           child: UserPositionBar(
             onUpdatePosition: () async {
-              final storage = ref.read(hiveStorageProvider);
+              final settings = ref.read(settingsStorageProvider);
               final messenger = ScaffoldMessenger.of(context);
-              if (!LocationConsentDialog.hasConsent(storage)) {
+              if (!LocationConsentDialog.hasConsent(settings)) {
                 if (!mounted) return;
                 final consented = await LocationConsentDialog.show(context);
                 if (!consented) return;
-                await LocationConsentDialog.recordConsent(storage);
+                await LocationConsentDialog.recordConsent(settings);
               }
               try {
                 await ref.read(userPositionProvider.notifier).updateFromGps();

--- a/lib/features/search/presentation/widgets/demo_mode_banner.dart
+++ b/lib/features/search/presentation/widgets/demo_mode_banner.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/country/country_config.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Shows a demo-mode banner for API-key countries, or a country info bar for free APIs.
@@ -13,7 +13,7 @@ class DemoModeBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final storage = ref.read(hiveStorageProvider);
+    final storage = ref.read(apiKeyStorageProvider);
     final l10n = AppLocalizations.of(context);
 
     if (country.requiresApiKey && !storage.hasApiKey()) {

--- a/lib/features/search/providers/ignored_stations_provider.g.dart
+++ b/lib/features/search/providers/ignored_stations_provider.g.dart
@@ -65,7 +65,7 @@ final class IgnoredStationsProvider
   }
 }
 
-String _$ignoredStationsHash() => r'4a3c73b0fa6cfe556eaa4c872cdfea58a1239fcd';
+String _$ignoredStationsHash() => r'0d9ec013b21aeb662234e5e341692cb6a427bcef';
 
 /// Manages the user's list of ignored (hidden) station IDs.
 ///

--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -5,7 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../../../core/country/country_config.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/language/language_provider.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/data/repositories/profile_repository.dart';
 import '../../../profile/providers/profile_provider.dart';
@@ -62,8 +62,8 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
         }
         return;
       }
-      final storage = ref.read(hiveStorageProvider);
-      await storage.setApiKey(apiKey);
+      final apiKeys = ref.read(apiKeyStorageProvider);
+      await apiKeys.setApiKey(apiKey);
       await _finishSetup();
     } finally {
       if (mounted) setState(() => _isLoading = false);
@@ -71,8 +71,8 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
   }
 
   Future<void> _finishSetup() async {
-    final storage = ref.read(hiveStorageProvider);
-    await storage.skipSetup();
+    final settings = ref.read(settingsStorageProvider);
+    await settings.skipSetup();
 
     final country = ref.read(activeCountryProvider);
     final language = ref.read(activeLanguageProvider);

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/sync/sync_service.dart';
 import '../../../../core/theme/fuel_colors.dart';
@@ -428,7 +428,7 @@ class _PriceHistorySectionState extends ConsumerState<_PriceHistorySection> {
     try {
       final rows = await SyncService.fetchPriceHistory(widget.stationId);
       if (rows.isNotEmpty && mounted) {
-        final storage = ref.read(hiveStorageProvider);
+        final storageMgmt = ref.read(storageManagementProvider);
         final records = rows.map((r) => {
           'stationId': r['station_id'],
           'recordedAt': r['recorded_at'],
@@ -440,7 +440,7 @@ class _PriceHistorySectionState extends ConsumerState<_PriceHistorySection> {
           'lpg': r['lpg'],
           'cng': r['cng'],
         }).toList();
-        await storage.savePriceRecords(widget.stationId, records);
+        await storageMgmt.savePriceRecords(widget.stationId, records);
         ref.invalidate(priceHistoryProvider(widget.stationId));
       }
     } catch (e) {

--- a/lib/features/sync/presentation/screens/auth_screen.dart
+++ b/lib/features/sync/presentation/screens/auth_screen.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/sync/sync_provider.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Authentication screen for switching between anonymous and email accounts.
@@ -46,8 +46,8 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     try {
       final userId = await TankSyncClient.signInAnonymously();
       if (userId != null) {
-        final storage = ref.read(hiveStorageProvider);
-        await storage.putSetting('sync_user_id', userId);
+        final settings = ref.read(settingsStorageProvider);
+        await settings.putSetting('sync_user_id', userId);
         ref.invalidate(syncStateProvider);
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/sync/presentation/screens/sync_wizard_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_wizard_screen.dart
@@ -7,7 +7,7 @@ import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/schema_verifier.dart';
 import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/sync/sync_provider.dart';
@@ -653,11 +653,11 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
         } else {
           userId = await TankSyncClient.signInWithEmail(_emailController.text.trim(), _passwordController.text);
         }
-        final storage = ref.read(hiveStorageProvider);
-        await storage.putSetting('sync_enabled', true);
-        await storage.putSetting('supabase_url', url);
-        await storage.putSetting('supabase_anon_key', key);
-        if (userId != null) await storage.putSetting('sync_user_id', userId);
+        final settings = ref.read(settingsStorageProvider);
+        await settings.putSetting('sync_enabled', true);
+        await settings.putSetting('supabase_url', url);
+        await settings.putSetting('supabase_anon_key', key);
+        if (userId != null) await settings.putSetting('sync_user_id', userId);
         ref.invalidate(syncStateProvider);
       } else {
         await ref.read(syncStateProvider.notifier).connect(url, key);


### PR DESCRIPTION
## Summary
- Created narrow providers: apiKeyStorageProvider, settingsStorageProvider, storageManagementProvider
- Migrated 12 presentation files to use narrow interfaces instead of HiveStorage directly
- Zero hive_storage.dart imports remain in presentation layer

Closes #20

## Test plan
- [x] `flutter analyze` passes
- [x] `flutter test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)