### PR TITLE
feat: Deploy server-side price alert Edge Functions + pg_cron

### DIFF
--- a/supabase/deploy.sh
+++ b/supabase/deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Deploy Supabase Edge Functions and apply migrations.
+# Usage: bash supabase/deploy.sh
+#
+# Prerequisites:
+# - supabase CLI installed and linked to the project
+# - SUPABASE_ACCESS_TOKEN set in environment
+
+set -e
+
+echo "Deploying Edge Functions..."
+supabase functions deploy check-alerts --no-verify-jwt
+supabase functions deploy record-prices --no-verify-jwt
+supabase functions deploy validate-report --no-verify-jwt
+
+echo "Applying database migrations..."
+supabase db push
+
+echo "Done. Edge Functions deployed and pg_cron schedules applied."
+echo ""
+echo "Verify with:"
+echo "  supabase functions list"
+echo "  SELECT * FROM cron.job;  -- in SQL editor"

--- a/supabase/migrations/20260403000001_pg_cron_alert_schedules.sql
+++ b/supabase/migrations/20260403000001_pg_cron_alert_schedules.sql
@@ -1,0 +1,43 @@
+-- Enable pg_cron extension (requires superuser, available on Supabase Pro+)
+-- On free tier, use an external cron (GitHub Actions, cron-job.org) instead.
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Schedule: check price alerts every 15 minutes
+-- Calls the check-alerts Edge Function via pg_net (HTTP from Postgres)
+SELECT cron.schedule(
+  'check-alerts-every-15min',
+  '*/15 * * * *',
+  $$
+  SELECT net.http_post(
+    url := current_setting('app.settings.supabase_url') || '/functions/v1/check-alerts',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || current_setting('app.settings.service_role_key'),
+      'Content-Type', 'application/json'
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+-- Schedule: record price snapshots every hour (for trend analysis)
+SELECT cron.schedule(
+  'record-prices-hourly',
+  '0 * * * *',
+  $$
+  SELECT net.http_post(
+    url := current_setting('app.settings.supabase_url') || '/functions/v1/record-prices',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || current_setting('app.settings.service_role_key'),
+      'Content-Type', 'application/json'
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+-- View scheduled jobs
+-- SELECT * FROM cron.job;
+
+-- To unschedule:
+-- SELECT cron.unschedule('check-alerts-every-15min');
+-- SELECT cron.unschedule('record-prices-hourly');


### PR DESCRIPTION
## Summary
- pg_cron migration: check-alerts every 15min, record-prices hourly
- Added deploy.sh for one-command Edge Function deployment
- Edge Functions already existed, now scheduled via pg_cron + pg_net

Closes #11

## Test plan
- [ ] Run `supabase db push` to apply pg_cron migration
- [ ] Verify cron jobs with `SELECT * FROM cron.job`

🤖 Generated with [Claude Code](https://claude.com/claude-code)