### PR TITLE
feat: Parallel batch queries for route search (3-5 concurrent)

### DIFF
--- a/lib/features/route_search/data/helpers/batch_query_helper.dart
+++ b/lib/features/route_search/data/helpers/batch_query_helper.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../../search/domain/entities/fuel_type.dart';
+import '../../../search/domain/entities/search_result_item.dart';
+import '../../domain/route_search_strategy.dart';
+
+/// Executes station queries in concurrent batches for faster route search.
+///
+/// Instead of querying each sample point sequentially (N * 500ms),
+/// processes [batchSize] points concurrently, then waits before the
+/// next batch. A 33-point route with batch size 4 takes ~4s instead of ~17s.
+class BatchQueryHelper {
+  final int batchSize;
+
+  const BatchQueryHelper({this.batchSize = 4});
+
+  /// Query stations at all [samplePoints] using concurrent batches.
+  ///
+  /// Returns deduplicated results. Failed individual queries are skipped
+  /// without aborting the batch.
+  Future<List<SearchResultItem>> queryAll({
+    required List<LatLng> samplePoints,
+    required StationQueryFunction queryStations,
+    required FuelType fuelType,
+    required double searchRadiusKm,
+  }) async {
+    final seen = <String>{};
+    final results = <SearchResultItem>[];
+    int successCount = 0;
+    int failCount = 0;
+
+    for (var batchStart = 0; batchStart < samplePoints.length; batchStart += batchSize) {
+      final batchEnd = (batchStart + batchSize).clamp(0, samplePoints.length);
+      final batch = samplePoints.sublist(batchStart, batchEnd);
+
+      // Execute batch concurrently
+      final futures = batch.map((point) async {
+        try {
+          return await queryStations(
+            lat: point.latitude,
+            lng: point.longitude,
+            radiusKm: searchRadiusKm,
+            fuelType: fuelType,
+          );
+        } catch (e) {
+          debugPrint('BatchQuery: point ${point.latitude},${point.longitude} failed: $e');
+          return <SearchResultItem>[];
+        }
+      });
+
+      final batchResults = await Future.wait(futures);
+
+      for (final stations in batchResults) {
+        if (stations.isNotEmpty) successCount++;
+        else failCount++;
+        for (final item in stations) {
+          if (seen.add(item.id)) {
+            results.add(item);
+          }
+        }
+      }
+
+      // Brief pause between batches to respect rate limits
+      if (batchEnd < samplePoints.length) {
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      }
+    }
+
+    debugPrint('BatchQuery: $successCount succeeded, $failCount empty/failed, ${results.length} unique stations');
+    return results;
+  }
+}

--- a/lib/features/route_search/data/strategies/balanced_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/balanced_search_strategy.dart
@@ -7,6 +7,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
+import '../helpers/batch_query_helper.dart';
 
 /// Balanced strategy: finds stations with a good balance between
 /// price and distance from route (minimal detour).
@@ -28,32 +29,15 @@ class BalancedSearchStrategy implements RouteSearchStrategy {
     required StationQueryFunction queryStations,
     double? maxDetourKm,
   }) async {
-    final seen = <String>{};
-    final results = <SearchResultItem>[];
-
     debugPrint('BalancedSearch: querying ${route.samplePoints.length} points with radius=${searchRadiusKm}km');
 
-    for (var i = 0; i < route.samplePoints.length; i++) {
-      final point = route.samplePoints[i];
-      try {
-        final stations = await queryStations(
-          lat: point.latitude,
-          lng: point.longitude,
-          radiusKm: searchRadiusKm,
-          fuelType: fuelType,
-        );
-        for (final item in stations) {
-          if (seen.add(item.id)) {
-            results.add(item);
-          }
-        }
-      } catch (e) {
-        debugPrint('BalancedSearch: point $i FAILED: $e');
-      }
-      if (i < route.samplePoints.length - 1) {
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-      }
-    }
+    const batchHelper = BatchQueryHelper(batchSize: 4);
+    final results = await batchHelper.queryAll(
+      samplePoints: route.samplePoints,
+      queryStations: queryStations,
+      fuelType: fuelType,
+      searchRadiusKm: searchRadiusKm,
+    );
 
     // Filter by detour distance
     final detourLimit = maxDetourKm ?? searchRadiusKm;

--- a/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
@@ -7,6 +7,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
+import '../helpers/batch_query_helper.dart';
 
 /// Strategy that prioritizes finding the cheapest stations along the route.
 ///
@@ -27,36 +28,23 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
     required StationQueryFunction queryStations,
     double? maxDetourKm,
   }) async {
-    final seen = <String>{};
-    final results = <SearchResultItem>[];
-
     // Use wider radius but sample every other point for speed
     final effectiveRadius = searchRadiusKm * 1.5;
     final step = route.samplePoints.length > 10 ? 2 : 1;
+    final sampledPoints = [
+      for (var i = 0; i < route.samplePoints.length; i += step)
+        route.samplePoints[i],
+    ];
 
-    debugPrint('CheapestSearch: querying ${(route.samplePoints.length / step).ceil()} points with radius=${effectiveRadius.toStringAsFixed(1)}km');
+    debugPrint('CheapestSearch: querying ${sampledPoints.length} points with radius=${effectiveRadius.toStringAsFixed(1)}km');
 
-    for (var i = 0; i < route.samplePoints.length; i += step) {
-      final point = route.samplePoints[i];
-      try {
-        final stations = await queryStations(
-          lat: point.latitude,
-          lng: point.longitude,
-          radiusKm: effectiveRadius,
-          fuelType: fuelType,
-        );
-        for (final item in stations) {
-          if (seen.add(item.id)) {
-            results.add(item);
-          }
-        }
-      } catch (e) {
-        debugPrint('CheapestSearch: point $i FAILED: $e');
-      }
-      if (i + step < route.samplePoints.length) {
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-      }
-    }
+    const batchHelper = BatchQueryHelper(batchSize: 4);
+    final results = await batchHelper.queryAll(
+      samplePoints: sampledPoints,
+      queryStations: queryStations,
+      fuelType: fuelType,
+      searchRadiusKm: effectiveRadius,
+    );
 
     // Filter by detour distance (more generous for cheapest strategy)
     final detourLimit = (maxDetourKm ?? searchRadiusKm) * 1.5;

--- a/lib/features/route_search/data/strategies/uniform_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/uniform_search_strategy.dart
@@ -7,6 +7,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
+import '../helpers/batch_query_helper.dart';
 
 /// Default strategy: samples every ~15km along the route,
 /// queries stations at each sample point, deduplicates, and filters
@@ -26,38 +27,15 @@ class UniformSearchStrategy implements RouteSearchStrategy {
     required StationQueryFunction queryStations,
     double? maxDetourKm,
   }) async {
-    final seen = <String>{};
-    final results = <SearchResultItem>[];
-    int successCount = 0;
-    int failCount = 0;
-
     debugPrint('UniformSearch: querying ${route.samplePoints.length} sample points with radius=${searchRadiusKm}km');
 
-    for (var i = 0; i < route.samplePoints.length; i++) {
-      final point = route.samplePoints[i];
-      try {
-        final stations = await queryStations(
-          lat: point.latitude,
-          lng: point.longitude,
-          radiusKm: searchRadiusKm,
-          fuelType: fuelType,
-        );
-        for (final item in stations) {
-          if (seen.add(item.id)) {
-            results.add(item);
-          }
-        }
-        successCount++;
-      } catch (e) {
-        failCount++;
-        debugPrint('UniformSearch: point $i FAILED: $e');
-      }
-      // Rate limit: wait 500ms between API calls
-      if (i < route.samplePoints.length - 1) {
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-      }
-    }
-    debugPrint('UniformSearch: $successCount succeeded, $failCount failed, ${results.length} unique stations');
+    const batchHelper = BatchQueryHelper(batchSize: 4);
+    final results = await batchHelper.queryAll(
+      samplePoints: route.samplePoints,
+      queryStations: queryStations,
+      fuelType: fuelType,
+      searchRadiusKm: searchRadiusKm,
+    );
 
     // Filter by detour distance
     final detourLimit = maxDetourKm ?? searchRadiusKm;

--- a/test/features/route_search/data/helpers/batch_query_helper_test.dart
+++ b/test/features/route_search/data/helpers/batch_query_helper_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/route_search/data/helpers/batch_query_helper.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+
+void main() {
+  group('BatchQueryHelper', () {
+    test('processes all sample points in batches', () async {
+      final queriedPoints = <String>[];
+      const helper = BatchQueryHelper(batchSize: 3);
+
+      final points = List.generate(10, (i) => LatLng(48.0 + i * 0.1, 2.0));
+
+      final results = await helper.queryAll(
+        samplePoints: points,
+        fuelType: FuelType.e10,
+        searchRadiusKm: 10.0,
+        queryStations: ({
+          required double lat,
+          required double lng,
+          required double radiusKm,
+          required FuelType fuelType,
+        }) async {
+          queriedPoints.add('${lat.toStringAsFixed(1)}');
+          return [
+            FuelStationResult(Station(
+              id: 'st-${lat.toStringAsFixed(1)}',
+              name: 'Station',
+              brand: 'Test',
+              street: '',
+              postCode: '',
+              place: '',
+              lat: lat,
+              lng: lng,
+              dist: 1.0,
+              isOpen: true,
+              e10: 1.50,
+            )),
+          ];
+        },
+      );
+
+      // All 10 points queried
+      expect(queriedPoints, hasLength(10));
+      // All 10 stations returned (unique IDs)
+      expect(results, hasLength(10));
+    });
+
+    test('deduplicates stations from overlapping queries', () async {
+      const helper = BatchQueryHelper(batchSize: 2);
+
+      final points = [const LatLng(48.0, 2.0), const LatLng(48.1, 2.0)];
+
+      final results = await helper.queryAll(
+        samplePoints: points,
+        fuelType: FuelType.e10,
+        searchRadiusKm: 10.0,
+        queryStations: ({
+          required double lat,
+          required double lng,
+          required double radiusKm,
+          required FuelType fuelType,
+        }) async {
+          // Both points return the same station
+          return [
+            FuelStationResult(Station(
+              id: 'shared-station',
+              name: 'Shared',
+              brand: 'Test',
+              street: '',
+              postCode: '',
+              place: '',
+              lat: 48.05,
+              lng: 2.0,
+              dist: 1.0,
+              isOpen: true,
+              e10: 1.50,
+            )),
+          ];
+        },
+      );
+
+      // Deduplicated to 1
+      expect(results, hasLength(1));
+    });
+
+    test('handles individual query failures gracefully', () async {
+      const helper = BatchQueryHelper(batchSize: 2);
+      int callCount = 0;
+
+      final points = List.generate(4, (i) => LatLng(48.0 + i * 0.1, 2.0));
+
+      final results = await helper.queryAll(
+        samplePoints: points,
+        fuelType: FuelType.e10,
+        searchRadiusKm: 10.0,
+        queryStations: ({
+          required double lat,
+          required double lng,
+          required double radiusKm,
+          required FuelType fuelType,
+        }) async {
+          callCount++;
+          // Fail every other query
+          if (callCount % 2 == 0) throw Exception('API error');
+          return [
+            FuelStationResult(Station(
+              id: 'st-$callCount',
+              name: 'Station',
+              brand: 'Test',
+              street: '',
+              postCode: '',
+              place: '',
+              lat: lat,
+              lng: lng,
+              dist: 1.0,
+              isOpen: true,
+              e10: 1.50,
+            )),
+          ];
+        },
+      );
+
+      // 2 out of 4 succeed
+      expect(results, hasLength(2));
+      // All 4 were attempted
+      expect(callCount, 4);
+    });
+
+    test('batch size 1 processes sequentially', () async {
+      const helper = BatchQueryHelper(batchSize: 1);
+      final timestamps = <int>[];
+
+      final points = [const LatLng(48.0, 2.0), const LatLng(49.0, 2.0)];
+
+      await helper.queryAll(
+        samplePoints: points,
+        fuelType: FuelType.e10,
+        searchRadiusKm: 10.0,
+        queryStations: ({
+          required double lat,
+          required double lng,
+          required double radiusKm,
+          required FuelType fuelType,
+        }) async {
+          timestamps.add(DateTime.now().millisecondsSinceEpoch);
+          return [];
+        },
+      );
+
+      expect(timestamps, hasLength(2));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Created BatchQueryHelper that processes sample points in concurrent batches of 4
- Updated all 3 strategies (uniform, cheapest, balanced) to use batch queries
- 33-point route: ~17s → ~4s

Closes #13

## Test plan
- [x] `flutter analyze` passes
- [x] 4 new tests for BatchQueryHelper (batching, dedup, error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)