### PR TITLE
refactor: Narrow repository storage types to segregated interfaces

### DIFF
--- a/lib/features/alerts/data/repositories/alert_repository.dart
+++ b/lib/features/alerts/data/repositories/alert_repository.dart
@@ -1,11 +1,11 @@
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/data/storage_repository.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../search/domain/entities/station.dart';
 import '../models/price_alert.dart';
 
-/// Repository for managing price alerts, backed by Hive storage.
+/// Repository for managing price alerts, backed by [AlertStorage].
 class AlertRepository {
-  final HiveStorage _storage;
+  final AlertStorage _storage;
 
   AlertRepository(this._storage);
 

--- a/lib/features/price_history/data/repositories/price_history_repository.dart
+++ b/lib/features/price_history/data/repositories/price_history_repository.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import '../../../search/domain/entities/fuel_type.dart';
-import '../../../../core/storage/hive_storage.dart';
+import '../../../../core/data/storage_repository.dart';
 import '../models/price_record.dart';
 
 /// Trend direction for a fuel price over a time window.
@@ -23,10 +23,10 @@ class PriceStats {
   });
 }
 
-/// Persists price snapshots per station via [HiveStorage] and provides
+/// Persists price snapshots per station via [PriceHistoryStorage] and provides
 /// query/aggregation methods for price history analysis.
 class PriceHistoryRepository {
-  final HiveStorage _storage;
+  final PriceHistoryStorage _storage;
 
   PriceHistoryRepository(this._storage);
 


### PR DESCRIPTION
## Summary
- AlertRepository now depends on AlertStorage (not HiveStorage)
- PriceHistoryRepository now depends on PriceHistoryStorage (not HiveStorage)
- Follows Interface Segregation Principle

Closes #16

## Test plan
- [x] `flutter analyze` passes (zero errors)
- [x] No behavior changes — HiveStorage implements all interfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)