### PR TITLE
chore: add safePostFrame helper + migrate 4 call sites

### DIFF
--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import '../core/utils/frame_callbacks.dart';
 import '../l10n/app_localizations.dart';
 
 /// The main app shell with bottom navigation bar and page transitions.
@@ -119,8 +120,8 @@ class _ShellScreenState extends State<ShellScreen> with TickerProviderStateMixin
     // Keep in sync with go_router's actual index (e.g. deep link or redirect)
     final routerIndex = widget.navigationShell.currentIndex;
     if (routerIndex != _currentIndex && !_isTransitioning) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && routerIndex != _currentIndex) {
+      safePostFrame(() {
+        if (routerIndex != _currentIndex) {
           setState(() => _currentIndex = routerIndex);
         }
       });

--- a/lib/core/utils/frame_callbacks.dart
+++ b/lib/core/utils/frame_callbacks.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/widgets.dart';
+
+/// Post-frame callback helper that guards against `setState`-after-dispose.
+///
+/// `WidgetsBinding.instance.addPostFrameCallback` fires one frame later, which
+/// is long enough for the widget to be unmounted. Callers that reach for
+/// `setState` or `ref.read`/`ref.watch` from inside the callback must therefore
+/// re-check `mounted` first. This extension centralises that guard so callers
+/// no longer have to remember.
+extension SafePostFrameCallbackOnState on State {
+  /// Runs [callback] after the next frame, but only if this [State] is still
+  /// mounted at that point.
+  void safePostFrame(VoidCallback callback) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      callback();
+    });
+  }
+}

--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -7,6 +7,7 @@ import 'package:latlong2/latlong.dart';
 import '../../../../core/location/location_service.dart';
 import '../../../../core/services/location_search_provider.dart';
 import '../../../../core/services/location_search_service.dart';
+import '../../../../core/utils/frame_callbacks.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/route_info.dart';
 
@@ -39,7 +40,7 @@ class _RouteInputState extends ConsumerState<RouteInput> {
   void initState() {
     super.initState();
     // Auto-fill start with current position so user doesn't have to tap GPS
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    safePostFrame(() {
       if (!_autoGpsTriggered) {
         _autoGpsTriggered = true;
         _useGpsForStart();

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -8,6 +8,7 @@ import '../../../../core/location/user_position_provider.dart';
 import '../../../../core/services/location_search_service.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/utils/frame_callbacks.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -52,8 +53,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
+    safePostFrame(() {
       final profile = ref.read(activeProfileProvider);
       if (profile?.landingScreen == LandingScreen.cheapest) {
         final zip = profile?.homeZipCode;
@@ -165,8 +165,8 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         MediaQuery.of(context).orientation == Orientation.landscape;
 
     if (isLandscape && !_searchBarExpanded && _filtersExpanded) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) setState(() => _filtersExpanded = false);
+      safePostFrame(() {
+        setState(() => _filtersExpanded = false);
       });
     }
 

--- a/lib/features/search/presentation/widgets/location_input.dart
+++ b/lib/features/search/presentation/widgets/location_input.dart
@@ -5,6 +5,7 @@ import '../../../../core/country/country_config.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/services/location_search_provider.dart';
 import '../../../../core/services/location_search_service.dart';
+import '../../../../core/utils/frame_callbacks.dart';
 import '../../../profile/providers/profile_provider.dart';
 
 /// Unified location input: auto-detects GPS (empty), ZIP (digits), or city (text).
@@ -38,7 +39,7 @@ class _LocationInputState extends ConsumerState<LocationInput> {
   void initState() {
     super.initState();
     // Pre-fill with profile's home zip code if configured
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    safePostFrame(() {
       final profile = ref.read(activeProfileProvider);
       if (profile?.homeZipCode != null && profile!.homeZipCode!.isNotEmpty) {
         _controller.text = profile.homeZipCode!;

--- a/test/core/utils/frame_callbacks_test.dart
+++ b/test/core/utils/frame_callbacks_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/frame_callbacks.dart';
+
+void main() {
+  group('safePostFrame', () {
+    testWidgets('runs the callback after a frame', (tester) async {
+      var invocations = 0;
+      await tester.pumpWidget(MaterialApp(
+        home: _Harness(onInit: (state) => state.safePostFrame(() => invocations++)),
+      ));
+      // pumpWidget pumps a frame, which drains post-frame callbacks.
+      expect(invocations, 1);
+    });
+
+    testWidgets('skips callback after widget is unmounted', (tester) async {
+      var invocations = 0;
+      _HarnessState? captured;
+      await tester.pumpWidget(MaterialApp(
+        home: _Harness(onInit: (state) => captured = state),
+      ));
+      expect(captured, isNotNull);
+
+      // Schedule a callback from a live state, then replace the tree so that
+      // the state is disposed before the next frame drains callbacks.
+      captured!.safePostFrame(() => invocations++);
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      // Force another frame to ensure any scheduled callback has had its shot.
+      SchedulerBinding.instance.scheduleFrame();
+      await tester.pump();
+
+      expect(invocations, 0);
+    });
+  });
+}
+
+typedef _OnInit = void Function(_HarnessState state);
+
+class _Harness extends StatefulWidget {
+  const _Harness({required this.onInit});
+  final _OnInit onInit;
+
+  @override
+  State<_Harness> createState() => _HarnessState();
+}
+
+class _HarnessState extends State<_Harness> {
+  @override
+  void initState() {
+    super.initState();
+    widget.onInit(this);
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}


### PR DESCRIPTION
## Summary
- New `core/utils/frame_callbacks.dart` with `SafePostFrameCallbackOnState.safePostFrame()` extension that wraps `WidgetsBinding.instance.addPostFrameCallback` in a mounted check
- Migrates 4 State call sites (shell_screen, route_input, location_input, search_screen x2) — removes repetitive manual `if (!mounted) return` boilerplate
- `nearby_map_view.dart` left as-is (ConsumerWidget with no State; has its own try/catch around mapController.move)

## Test plan
- [x] 2 new widget tests (mounted happy path + unmount-skips-callback)
- [x] `flutter analyze` clean (no new warnings)
- [x] `flutter test test/core/utils/` passes

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)