### PR TITLE
perf: add ValueKey to dynamic list items

### DIFF
--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -55,7 +55,7 @@ class AlertsScreen extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(vertical: 8),
               itemBuilder: (context, index) {
                 final alert = alerts[index];
-                return _AlertListTile(alert: alert);
+                return _AlertListTile(key: ValueKey(alert.id), alert: alert);
               },
             ),
     );
@@ -65,7 +65,7 @@ class AlertsScreen extends ConsumerWidget {
 class _AlertListTile extends ConsumerWidget {
   final PriceAlert alert;
 
-  const _AlertListTile({required this.alert});
+  const _AlertListTile({super.key, required this.alert});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -168,6 +168,7 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
           final isSelected = _selectedStationIds.contains(station.id);
           final price = station.priceFor(widget.selectedFuel);
           return GestureDetector(
+            key: ValueKey('route-station-${station.id}'),
             onTap: () => setState(() {
               if (isSelected) {
                 _selectedStationIds.remove(station.id);

--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -398,6 +398,7 @@ class _CityAutocompleteFieldState extends State<_CityAutocompleteField> {
                 itemBuilder: (context, index) {
                   final city = _suggestions[index];
                   return ListTile(
+                    key: ValueKey('city-${city.lat}-${city.lng}-${city.name}'),
                     dense: true,
                     visualDensity: VisualDensity.compact,
                     leading: const Icon(Icons.place, size: 16),

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -317,6 +317,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
               (context, index) {
                 final station = result.data[index];
                 return EVStationCard(
+                  key: ValueKey('ev-${station.id}'),
                   result: EVStationResult(station),
                   onTap: () => context.push('/ev-station', extra: station),
                 );

--- a/lib/features/search/presentation/widgets/location_input.dart
+++ b/lib/features/search/presentation/widgets/location_input.dart
@@ -202,6 +202,7 @@ class _LocationInputState extends ConsumerState<LocationInput> {
                 final city = _suggestions[i];
                 final isSelected = _selectedCity == city;
                 return ListTile(
+                  key: ValueKey('city-${city.lat}-${city.lng}-${city.name}'),
                   dense: true,
                   selected: isSelected,
                   leading: const Icon(Icons.place, size: 18),

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -88,6 +88,7 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
                 return _buildDismissibleCard(context, l10n, item, fuelType, result);
               } else if (item is EVStationResult) {
                 return EVStationCard(
+                  key: ValueKey('route-ev-${item.station.id}'),
                   result: item,
                   onTap: () => context.push('/ev-station', extra: item.station),
                 );

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -125,6 +125,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList> {
                   final station = sorted[index];
                   final isFav = ref.watch(isFavoriteProvider(station.id));
                   return _SwipeableStationCard(
+                    key: ValueKey('station-${station.id}'),
                     station: station,
                     isFavorite: isFav,
                     onNavigate: () => _openStationInMaps(station),
@@ -170,6 +171,7 @@ class _SwipeableStationCard extends ConsumerWidget {
   final VoidCallback onFavoriteTap;
 
   const _SwipeableStationCard({
+    super.key,
     required this.station,
     required this.isFavorite,
     required this.onNavigate,


### PR DESCRIPTION
## Summary
Adds stable `ValueKey`s to every `ListView.builder`/`SliverChildBuilderDelegate` child that was previously keyless: search results, EV lists, alert list, route-map station chips, and both city-autocomplete popovers.

Stations keyed by `station.id`; cities keyed by `lat/lng/name` tuple (they have no stable id).

## Test plan
- [x] `flutter analyze` clean
- [x] All existing search/favorites/alerts tests still pass (no key-less lookups in test code)

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)