### PR TITLE
feat: migrate alerts/favorites screens to shared EmptyState

### DIFF
--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/models/price_alert.dart';
 import '../../providers/alert_provider.dart';
@@ -12,7 +13,6 @@ class AlertsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final alerts = ref.watch(alertProvider);
-    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
     return Scaffold(
@@ -24,31 +24,11 @@ class AlertsScreen extends ConsumerWidget {
         ),
       ),
       body: alerts.isEmpty
-          ? Center(
-              child: Padding(
-                padding: const EdgeInsets.all(32),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.notifications_off_outlined,
-                        size: 64, color: Colors.grey.shade400),
-                    const SizedBox(height: 16),
-                    Text(
-                      l10n?.noPriceAlerts ?? 'No price alerts',
-                      style: theme.textTheme.titleMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      l10n?.noPriceAlertsHint ?? 'Create an alert from a station\'s detail page.',
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: Colors.grey.shade600,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
-                ),
-              ),
+          ? EmptyState(
+              icon: Icons.notifications_off_outlined,
+              title: l10n?.noPriceAlerts ?? 'No price alerts',
+              subtitle: l10n?.noPriceAlertsHint ??
+                  'Create an alert from a station\'s detail page.',
             )
           : ListView.builder(
               itemCount: alerts.length,

--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -6,6 +6,7 @@ import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
+import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../../core/theme/fuel_colors.dart';
@@ -92,42 +93,16 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
     AsyncValue<ServiceResult<List<Station>>> stationsState,
   ) {
     if (favoriteIds.isEmpty) {
-      return Center(
-        child: Semantics(
-          label: 'No favorites yet. Tap the star on a station to save it as a favorite.',
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(Icons.star_outline, size: 80, color: Colors.grey,
-                semanticLabel: 'Empty favorites',
-              ),
-              const SizedBox(height: 24),
-              Text(
-                l10n?.noFavorites ?? 'No favorites yet',
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: Colors.grey[600],
-                ),
-              ),
-              const SizedBox(height: 8),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 32),
-                child: Text(
-                  l10n?.noFavoritesHint ??
-                  'Tap the star on a station to save it here',
-                  textAlign: TextAlign.center,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Colors.grey[500],
-                  ),
-                ),
-              ),
-              const SizedBox(height: 24),
-              FilledButton.icon(
-                onPressed: () => context.go('/'),
-                icon: const Icon(Icons.search),
-                label: Text(l10n?.search ?? 'Search Stations'),
-              ),
-            ],
-          ),
+      return Semantics(
+        label: 'No favorites yet. Tap the star on a station to save it as a favorite.',
+        child: EmptyState(
+          icon: Icons.star_outline,
+          iconSize: 80,
+          title: l10n?.noFavorites ?? 'No favorites yet',
+          subtitle: l10n?.noFavoritesHint ??
+              'Tap the star on a station to save it here',
+          actionLabel: l10n?.search ?? 'Search Stations',
+          onAction: () => context.go('/'),
         ),
       );
     }
@@ -248,31 +223,11 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
     return Consumer(builder: (context, ref, _) {
       final alerts = ref.watch(alertProvider);
       if (alerts.isEmpty) {
-        return Center(
-          child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.notifications_off_outlined,
-                    size: 64, color: Colors.grey.shade400),
-                const SizedBox(height: 16),
-                Text(
-                  l10n?.noPriceAlerts ?? 'No price alerts',
-                  style: Theme.of(context).textTheme.titleMedium,
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  l10n?.noPriceAlertsHint ?? 'Create an alert from a station\'s detail page.',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Colors.grey.shade600,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
-          ),
+        return EmptyState(
+          icon: Icons.notifications_off_outlined,
+          title: l10n?.noPriceAlerts ?? 'No price alerts',
+          subtitle: l10n?.noPriceAlertsHint ??
+              'Create an alert from a station\'s detail page.',
         );
       }
       return ListView.builder(


### PR DESCRIPTION
## Summary
`core/widgets/empty_state.dart` already existed but two screens were still using hand-rolled empty states. This PR migrates them.

- `alerts_screen.dart`: 'no alerts' placeholder → EmptyState
- `favorites_screen.dart`: 'no favorites' (with CTA) + 'no price alerts' placeholders → EmptyState
- Removes ~60 lines of duplicated layout code
- Semantics wrapper preserved for the favorites case (a11y)

## Test plan
- [x] flutter analyze clean
- [x] Favorites screen tests still pass (empty state + hint + CTA)
- [x] Alerts screen tests still pass

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)