### PR TITLE
perf: use package:collection sortedBy in Argentina service

### DIFF
--- a/lib/core/services/impl/argentina_station_service.dart
+++ b/lib/core/services/impl/argentina_station_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
 import '../../../features/search/data/models/search_params.dart';
 import '../../../features/search/domain/entities/station.dart';
@@ -54,8 +55,7 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
       // before merging, so we keep the raw-record filtering inline.
       var filtered = nearbyRaw.where((e) => e.dist <= params.radiusKm).toList();
       if (filtered.isEmpty && nearbyRaw.isNotEmpty) {
-        nearbyRaw.sort((a, b) => a.dist.compareTo(b.dist));
-        filtered = nearbyRaw.take(200).toList();
+        filtered = nearbyRaw.sortedBy<num>((e) => e.dist).take(200).toList();
       }
 
       for (final entry in filtered) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -202,7 +202,7 @@ packages:
     source: hosted
     version: "4.11.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   json_annotation: ^4.11.0
 
   # Utilities
+  collection: ^1.19.0
   uuid: ^4.5.1
   connectivity_plus: ^7.1.0
   shared_preferences: ^2.5.5


### PR DESCRIPTION
## Summary
Replaces in-place sort + take with `sortedBy<num>((e) => e.dist).take(200)` — same Big-O, but non-mutating and more expressive. Declares `package:collection` as a direct dependency (already transitive via Flutter SDK).

## Test plan
- [x] flutter analyze clean
- [x] Argentina service tests pass (41 tests)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)