### PR TITLE
chore: expand analysis_options.yaml with 20+ stable lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,9 +17,51 @@ analyzer:
     # Gradually adopt const constructors — info only, not blocking
     prefer_const_constructors: info
     prefer_const_declarations: info
+    prefer_const_literals_to_create_immutables: info
+    # Phase in at info so existing code isn't a wall of red; tighten once clean.
+    avoid_print: info
+    avoid_slow_async_io: info
+    avoid_type_to_string: info
+    cancel_subscriptions: info
+    close_sinks: info
+    no_logic_in_create_state: info
+    prefer_void_to_null: info
+    test_types_in_equals: info
+    throw_in_finally: info
+    unnecessary_statements: info
+    unrelated_type_equality_checks: info
+    use_build_context_synchronously: info
+    valid_regexps: info
 
 linter:
   rules:
+    # Originals — kept promoted so new code stays clean.
     - avoid_catching_errors
     - prefer_const_constructors
     - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+
+    # Correctness — strongly recommended by dart.dev / lint.pub.
+    - avoid_slow_async_io
+    - avoid_type_to_string
+    - cancel_subscriptions
+    - close_sinks
+    - no_adjacent_strings_in_list
+    - no_logic_in_create_state
+    - prefer_void_to_null
+    - test_types_in_equals
+    - throw_in_finally
+    - unnecessary_statements
+    - unrelated_type_equality_checks
+    - use_build_context_synchronously
+    - valid_regexps
+
+    # Style / maintainability.
+    - avoid_print
+    - avoid_unnecessary_containers
+    - prefer_final_locals
+    - prefer_single_quotes
+    - sized_box_for_whitespace
+    - sort_child_properties_last
+    - unawaited_futures
+    - use_key_in_widget_constructors


### PR DESCRIPTION
## Summary
Adds a curated set of correctness and style lints at `info` severity. Gradual adoption — no fatal-level promotions yet, so master CI (`flutter analyze --no-fatal-infos`) stays green.

## What's new
**Correctness:** avoid_slow_async_io, cancel_subscriptions, close_sinks, no_logic_in_create_state, test_types_in_equals, throw_in_finally, unnecessary_statements, unrelated_type_equality_checks, use_build_context_synchronously, valid_regexps, avoid_type_to_string, prefer_void_to_null, no_adjacent_strings_in_list.

**Style:** avoid_print, avoid_unnecessary_containers, prefer_final_locals, prefer_single_quotes, sized_box_for_whitespace, sort_child_properties_last, unawaited_futures, use_key_in_widget_constructors, prefer_const_literals_to_create_immutables.

## Test plan
- [x] `flutter analyze --no-fatal-infos` exits 0
- [x] Issue count: 241 → 270 (29 new info items, no warnings/errors)

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)