### PR TITLE
refactor: extract Argentina fuel classifier to testable helper

### DIFF
--- a/lib/core/services/impl/argentina_fuel_classifier.dart
+++ b/lib/core/services/impl/argentina_fuel_classifier.dart
@@ -1,0 +1,68 @@
+/// Argentine "Secretaría de Energía" open-data CSV uses product strings like:
+///   - "Nafta (premium) de más de 95 Ron"
+///   - "Nafta (súper) entre 92 y 95 Ron"
+///   - "Gas Oil Grado 2"
+///   - "Gas Oil Grado 3"
+///   - "GNC"
+///
+/// These are classified into the five fuel columns the app renders. Kept as
+/// a pure function so its edge cases (accents, whitespace, case, "95 Ron"
+/// appearing in both premium and super strings, grade 2/3 ordering) can be
+/// tested without HTTP / Dio / the whole service chain.
+enum ArgentinaFuelCategory {
+  naftaPremium,
+  naftaRegular,
+  dieselPremium,
+  dieselRegular,
+  gnc,
+}
+
+ArgentinaFuelCategory? classifyArgentinaProduct(String producto) {
+  // Normalise: lowercase, collapse whitespace.
+  final p = producto.toLowerCase().replaceAll(RegExp(r'\s+'), ' ').trim();
+
+  // GNC is unambiguous.
+  if (p.contains('gnc')) return ArgentinaFuelCategory.gnc;
+
+  final isNafta = p.contains('nafta');
+  final isGasOil = p.contains('gas oil') || p.contains('gasoil');
+
+  // "super" appears inside BOTH "súper 92" AND the literal word "supermium" —
+  // but only the first is nafta. Because we gate on `isNafta` the collision
+  // can't happen.
+  //
+  // IMPORTANT: premium must win over super/92 because "Nafta (premium) de más
+  // de 95 Ron" technically contains the substring "95" (as does "Nafta (súper)
+  // entre 92 y 95 Ron"). Check premium markers FIRST.
+  if (isNafta) {
+    // Super/regular markers are checked BEFORE the premium "95 ron" fallback
+    // because "Nafta (súper) entre 92 y 95 Ron" contains both "super" AND
+    // "95 ron" — the word "súper" / "92" is the true signal.
+    final hasSuperMarker = p.contains('super') ||
+        p.contains('súper') ||
+        p.contains(' 92 ') ||
+        p.endsWith(' 92') ||
+        p.contains('grado 2');
+    if (hasSuperMarker && !p.contains('premium') && !p.contains('grado 3')) {
+      return ArgentinaFuelCategory.naftaRegular;
+    }
+    // Premium markers or the octane hint "95 ron" → premium. (In Argentina
+    // 95+ Ron is marketed as high-octane/premium.)
+    if (p.contains('premium') ||
+        p.contains('grado 3') ||
+        p.contains('95 ron')) {
+      return ArgentinaFuelCategory.naftaPremium;
+    }
+    // Bare "nafta" with no marker → regular.
+    return ArgentinaFuelCategory.naftaRegular;
+  }
+
+  if (isGasOil) {
+    if (p.contains('premium') || p.contains('grado 3')) {
+      return ArgentinaFuelCategory.dieselPremium;
+    }
+    return ArgentinaFuelCategory.dieselRegular;
+  }
+
+  return null;
+}

--- a/lib/core/services/impl/argentina_station_service.dart
+++ b/lib/core/services/impl/argentina_station_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
+import 'argentina_fuel_classifier.dart';
 import '../../../features/search/data/models/search_params.dart';
 import '../../../features/search/domain/entities/station.dart';
 import '../../utils/geo_utils.dart';
@@ -68,21 +69,21 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
           dist: dist,
         ));
 
-        // Map fuel types
-        // CSV product names: "Nafta (premium) de más de 95 Ron",
-        //   "Nafta (súper) entre 92 y 95 Ron",
-        //   "Gas Oil Grado 2", "Gas Oil Grado 3", "GNC"
-        final producto = raw.producto.toLowerCase();
-        if (producto.contains('nafta') && (producto.contains('premium') || producto.contains('95 ron') || producto.contains('grado 3'))) {
-          merged.naftaPremium ??= raw.precio;
-        } else if (producto.contains('nafta') && (producto.contains('súper') || producto.contains('super') || producto.contains('92') || producto.contains('grado 2'))) {
-          merged.naftaRegular ??= raw.precio;
-        } else if (producto.contains('gas oil') && (producto.contains('grado 3') || producto.contains('premium'))) {
-          merged.dieselPremium ??= raw.precio;
-        } else if (producto.contains('gas oil') && (producto.contains('grado 2') || !producto.contains('grado 3'))) {
-          merged.dieselRegular ??= raw.precio;
-        } else if (producto.contains('gnc')) {
-          merged.gnc ??= raw.precio;
+        // Map fuel types — classification lives in classifyArgentinaProduct
+        // so it can be unit-tested against the API's quirky product strings.
+        switch (classifyArgentinaProduct(raw.producto)) {
+          case ArgentinaFuelCategory.naftaPremium:
+            merged.naftaPremium ??= raw.precio;
+          case ArgentinaFuelCategory.naftaRegular:
+            merged.naftaRegular ??= raw.precio;
+          case ArgentinaFuelCategory.dieselPremium:
+            merged.dieselPremium ??= raw.precio;
+          case ArgentinaFuelCategory.dieselRegular:
+            merged.dieselRegular ??= raw.precio;
+          case ArgentinaFuelCategory.gnc:
+            merged.gnc ??= raw.precio;
+          case null:
+            break;
         }
       }
 

--- a/test/core/services/impl/argentina_fuel_classifier_test.dart
+++ b/test/core/services/impl/argentina_fuel_classifier_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/impl/argentina_fuel_classifier.dart';
+
+void main() {
+  group('classifyArgentinaProduct', () {
+    test('classifies real CSV strings from Secretaría de Energía', () {
+      expect(classifyArgentinaProduct('Nafta (premium) de más de 95 Ron'),
+          ArgentinaFuelCategory.naftaPremium);
+      expect(classifyArgentinaProduct('Nafta (súper) entre 92 y 95 Ron'),
+          ArgentinaFuelCategory.naftaRegular);
+      expect(classifyArgentinaProduct('Gas Oil Grado 2'),
+          ArgentinaFuelCategory.dieselRegular);
+      expect(classifyArgentinaProduct('Gas Oil Grado 3'),
+          ArgentinaFuelCategory.dieselPremium);
+      expect(classifyArgentinaProduct('GNC'), ArgentinaFuelCategory.gnc);
+    });
+
+    test('super marker wins over 95 ron octane hint (regression)', () {
+      // "Nafta (súper) entre 92 y 95 Ron" contains both "súper" AND "95 ron" —
+      // the super marker is the authoritative signal.
+      expect(classifyArgentinaProduct('Nafta (súper) entre 92 y 95 Ron'),
+          ArgentinaFuelCategory.naftaRegular);
+      expect(classifyArgentinaProduct('Nafta super 92 y 95'),
+          ArgentinaFuelCategory.naftaRegular);
+    });
+
+    test('95 ron without super marker → premium', () {
+      expect(classifyArgentinaProduct('Nafta de 95 Ron'),
+          ArgentinaFuelCategory.naftaPremium);
+      expect(classifyArgentinaProduct('Nafta 95 Ron'),
+          ArgentinaFuelCategory.naftaPremium);
+    });
+
+    test('grado 3 → premium, grado 2 → regular', () {
+      expect(classifyArgentinaProduct('Nafta grado 3'),
+          ArgentinaFuelCategory.naftaPremium);
+      expect(classifyArgentinaProduct('Nafta grado 2'),
+          ArgentinaFuelCategory.naftaRegular);
+      expect(classifyArgentinaProduct('Gas Oil Grado 3 premium'),
+          ArgentinaFuelCategory.dieselPremium);
+    });
+
+    test('is case-insensitive and whitespace-tolerant', () {
+      expect(classifyArgentinaProduct('NAFTA PREMIUM'),
+          ArgentinaFuelCategory.naftaPremium);
+      expect(classifyArgentinaProduct('  gnc  '), ArgentinaFuelCategory.gnc);
+      expect(classifyArgentinaProduct('Gas  Oil\tGrado 2'),
+          ArgentinaFuelCategory.dieselRegular);
+    });
+
+    test('handles gasoil as one word', () {
+      expect(classifyArgentinaProduct('Gasoil'),
+          ArgentinaFuelCategory.dieselRegular);
+      expect(classifyArgentinaProduct('Gasoil premium'),
+          ArgentinaFuelCategory.dieselPremium);
+    });
+
+    test('bare "nafta" with no marker → regular', () {
+      expect(classifyArgentinaProduct('Nafta'),
+          ArgentinaFuelCategory.naftaRegular);
+    });
+
+    test('unknown products → null', () {
+      expect(classifyArgentinaProduct('Kerosene'), isNull);
+      expect(classifyArgentinaProduct('Hidrógeno'), isNull);
+      expect(classifyArgentinaProduct(''), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Pulls the quirky product-string classification out of `searchStations()` into `classifyArgentinaProduct()` so it can be unit-tested. Fixes a latent bug where "Nafta (súper) entre 92 y 95 Ron" was being classified as **premium** because "95 ron" fired before "súper" was checked.

## What changed
- New `lib/core/services/impl/argentina_fuel_classifier.dart` with pure `classifyArgentinaProduct()` + `ArgentinaFuelCategory` enum
- Service call site collapses to a switch over the enum
- 8 new unit tests: real CSV strings, super-vs-95-ron regression, grado 2/3 distinction, gasoil-as-one-word, case/whitespace normalisation, unknown products

## Test plan
- [x] `flutter analyze` clean
- [x] 8/8 new classifier tests pass
- [x] All 49 pre-existing Argentina service tests still pass

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)