### PR TITLE
feat: add Navigate button to station detail screens

### DIFF
--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../core/constants/app_constants.dart';
+import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/widgets/star_rating.dart';
@@ -73,10 +73,8 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
   }
 
   void _navigateToStation() {
-    final url = 'https://www.google.com/maps/dir/?api=1'
-        '&destination=${_station.lat},${_station.lng}'
-        '&travelmode=driving';
-    launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    NavigationUtils.openInMaps(_station.lat, _station.lng,
+        label: _station.name);
   }
 
   @override

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -10,6 +10,7 @@ import '../../../alerts/providers/alert_provider.dart';
 import '../../../favorites/providers/favorites_provider.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
+import '../../../../core/utils/navigation_utils.dart';
 import '../../providers/station_detail_provider.dart';
 import '../widgets/price_history_section.dart';
 import '../widgets/price_tile.dart';
@@ -35,6 +36,17 @@ class StationDetailScreen extends ConsumerWidget {
           onPressed: () => context.pop(),
         ),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.directions),
+            onPressed: () {
+              final station = detailAsync.value?.data.station;
+              if (station != null) {
+                NavigationUtils.openInMaps(station.lat, station.lng,
+                    label: station.brand.isNotEmpty ? station.brand : station.street);
+              }
+            },
+            tooltip: l10n?.navigate ?? 'Navigate',
+          ),
           IconButton(
             icon: const Icon(Icons.notifications_outlined),
             onPressed: () => _showCreateAlertDialog(context, ref),


### PR DESCRIPTION
## Summary
- Adds directions icon to StationDetailScreen app bar (fuel stations)
- Updates EVStationDetailScreen to use shared NavigationUtils.openInMaps() instead of hardcoded Google Maps URL
- Both screens now use geo: URI which lets the OS present an app picker (Google Maps, Waze, OsmAnd, etc.)

## Test plan
- [x] flutter analyze clean
- [x] All search + station_detail tests pass

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)