### PR TITLE
fix(i18n): replace hardcoded German strings with l10n lookups

### DIFF
--- a/lib/core/location/location_service.dart
+++ b/lib/core/location/location_service.dart
@@ -31,8 +31,8 @@ class LocationService {
     if (permission == LocationPermission.deniedForever) {
       throw const LocationException(
         message:
-            'Standortberechtigung wurde dauerhaft verweigert. '
-            'Bitte aktivieren Sie sie in den Einstellungen.',
+            'Location permission permanently denied. '
+            'Please enable it in Settings.',
       );
     }
 

--- a/lib/core/services/impl/tankerkoenig_station_service.dart
+++ b/lib/core/services/impl/tankerkoenig_station_service.dart
@@ -149,7 +149,7 @@ class TankerkoenigStationService with StationServiceHelpers implements StationSe
   void _checkOk(dynamic data) {
     if (data is Map<String, dynamic> && data['ok'] != true) {
       throw ApiException(
-        message: data['message']?.toString() ?? 'Unbekannter API-Fehler',
+        message: data['message']?.toString() ?? 'Unknown API error',
       );
     }
   }

--- a/lib/features/profile/presentation/widgets/profile_list_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_list_section.dart
@@ -46,7 +46,7 @@ class ProfileListSection extends ConsumerWidget {
                             .read(activeProfileProvider.notifier)
                             .switchProfile(profile.id);
                       },
-                      child: const Text('Aktivieren'),
+                      child: Text(AppLocalizations.of(context)?.activate ?? 'Activate'),
                     ),
                   IconButton(
                     icon: const Icon(Icons.edit),
@@ -132,7 +132,7 @@ class ProfileListSection extends ConsumerWidget {
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: const Text('Abbrechen'),
+            child: Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, controller.text),

--- a/test/features/profile/presentation/widgets/profile_card_test.dart
+++ b/test/features/profile/presentation/widgets/profile_card_test.dart
@@ -73,11 +73,11 @@ void main() {
       // Active profile uses person (filled) icon, not person_outline.
       expect(find.byIcon(Icons.person), findsOneWidget);
       expect(find.byIcon(Icons.person_outline), findsNothing);
-      // No Aktivieren button for the active profile.
-      expect(find.text('Aktivieren'), findsNothing);
+      // No Activate button for the active profile.
+      expect(find.text('Activate'), findsNothing);
     });
 
-    testWidgets('shows Aktivieren button for inactive profile',
+    testWidgets('shows Activate button for inactive profile',
         (tester) async {
       // profile-1 is active, profile-2 is inactive
       when(() => mockRepo.getActiveProfile()).thenReturn(_testProfile);
@@ -95,8 +95,8 @@ void main() {
         ],
       );
 
-      // The inactive profile should show an Aktivieren button.
-      expect(find.text('Aktivieren'), findsOneWidget);
+      // The inactive profile should show an Activate button.
+      expect(find.text('Activate'), findsOneWidget);
       // The inactive profile uses person_outline icon.
       expect(find.byIcon(Icons.person_outline), findsOneWidget);
     });


### PR DESCRIPTION
## Summary
Replaces 4 hardcoded German strings with l10n lookups or English fallbacks:
- `profile_list_section.dart`: 'Aktivieren' → `l10n.activate`, 'Abbrechen' → `l10n.cancel`
- `location_service.dart`: German permission error → English
- `tankerkoenig_station_service.dart`: 'Unbekannter API-Fehler' → 'Unknown API error'

## Test plan
- [x] flutter analyze clean
- [x] Updated profile_card_test to match English fallback
- [x] All 56 profile tests pass

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)