### PR TITLE
fix(security): replace all force-unwraps in supabase_client.dart

### DIFF
--- a/lib/core/sync/supabase_client.dart
+++ b/lib/core/sync/supabase_client.dart
@@ -47,20 +47,21 @@ class TankSyncClient {
   /// Returns the user ID on success, or `null` if the client is not ready.
   /// Also ensures the user exists in `public.users` (required by FK constraints).
   static Future<String?> signInAnonymously() async {
-    if (client == null) return null;
-    final response = await client!.auth.signInAnonymously();
+    final c = client;
+    if (c == null) return null;
+    final response = await c.auth.signInAnonymously();
     final userId = response.user?.id;
     if (userId != null) {
       // Ensure user exists in public.users table.
       // Supabase auth creates auth.users but NOT public.users.
       // The FK constraint on favorites/alerts requires public.users to exist.
       try {
-        await client!.from('users').upsert(
+        await c.from('users').upsert(
           {'id': userId},
           onConflict: 'id',
         );
-      } catch (e) { debugPrint('Silent catch: $e');
-        // Ignore — user may already exist
+      } catch (e) {
+        debugPrint('TankSync: users upsert failed: $e');
       }
     }
     return userId;
@@ -68,32 +69,38 @@ class TankSyncClient {
 
   /// Sign up with email and password. Creates both auth.users and public.users rows.
   static Future<String?> signUpWithEmail(String email, String password) async {
-    if (client == null) return null;
-    final response = await client!.auth.signUp(
+    final c = client;
+    if (c == null) return null;
+    final response = await c.auth.signUp(
       email: email,
       password: password,
     );
     final userId = response.user?.id;
     if (userId != null) {
       try {
-        await client!.from('users').upsert({'id': userId}, onConflict: 'id');
-      } catch (e) { debugPrint('Silent catch: $e');}
+        await c.from('users').upsert({'id': userId}, onConflict: 'id');
+      } catch (e) {
+        debugPrint('TankSync: users upsert failed: $e');
+      }
     }
     return userId;
   }
 
   /// Sign in with existing email account.
   static Future<String?> signInWithEmail(String email, String password) async {
-    if (client == null) return null;
-    final response = await client!.auth.signInWithPassword(
+    final c = client;
+    if (c == null) return null;
+    final response = await c.auth.signInWithPassword(
       email: email,
       password: password,
     );
     final userId = response.user?.id;
     if (userId != null) {
       try {
-        await client!.from('users').upsert({'id': userId}, onConflict: 'id');
-      } catch (e) { debugPrint('Silent catch: $e');}
+        await c.from('users').upsert({'id': userId}, onConflict: 'id');
+      } catch (e) {
+        debugPrint('TankSync: users upsert failed: $e');
+      }
     }
     return userId;
   }
@@ -102,14 +109,16 @@ class TankSyncClient {
   static String? get currentEmail => client?.auth.currentUser?.email;
 
   /// Whether the current user has an email account (not anonymous).
-  static bool get hasEmailAccount =>
-      client?.auth.currentUser?.email != null &&
-      client!.auth.currentUser!.email!.isNotEmpty;
+  static bool get hasEmailAccount {
+    final email = client?.auth.currentUser?.email;
+    return email != null && email.isNotEmpty;
+  }
 
   /// Sign out and reset the initialisation flag so [init] can be called again.
   static Future<void> signOut() async {
-    if (client == null) return;
-    await client!.auth.signOut();
+    final c = client;
+    if (c == null) return;
+    await c.auth.signOut();
     _initialized = false;
   }
 }

--- a/test/core/sync/supabase_client_test.dart
+++ b/test/core/sync/supabase_client_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/supabase_client.dart';
+
+void main() {
+  group('TankSyncClient (uninitialized)', () {
+    test('client is null before init', () {
+      // TankSyncClient uses a static _initialized flag. In test isolation
+      // we can only verify the un-initialized path (Supabase.initialize
+      // requires real network). The purpose of this test is to confirm that
+      // null-safe accessors do NOT throw when client is null.
+      // Note: if a previous test in the suite called init(), this may
+      // already be true — we guard with the isConnected check.
+      if (!TankSyncClient.isConnected) {
+        expect(TankSyncClient.client, isNull);
+      }
+    });
+
+    test('isConnected is false before init', () {
+      if (TankSyncClient.client == null) {
+        expect(TankSyncClient.isConnected, isFalse);
+      }
+    });
+
+    test('currentEmail is null before init', () {
+      if (TankSyncClient.client == null) {
+        expect(TankSyncClient.currentEmail, isNull);
+      }
+    });
+
+    test('hasEmailAccount is false before init', () {
+      if (TankSyncClient.client == null) {
+        expect(TankSyncClient.hasEmailAccount, isFalse);
+      }
+    });
+
+    test('signInAnonymously returns null before init', () async {
+      if (TankSyncClient.client == null) {
+        final result = await TankSyncClient.signInAnonymously();
+        expect(result, isNull);
+      }
+    });
+
+    test('signUpWithEmail returns null before init', () async {
+      if (TankSyncClient.client == null) {
+        final result = await TankSyncClient.signUpWithEmail('a@b.c', 'pw');
+        expect(result, isNull);
+      }
+    });
+
+    test('signInWithEmail returns null before init', () async {
+      if (TankSyncClient.client == null) {
+        final result = await TankSyncClient.signInWithEmail('a@b.c', 'pw');
+        expect(result, isNull);
+      }
+    });
+
+    test('signOut does not throw before init', () async {
+      if (TankSyncClient.client == null) {
+        // Should not throw — just returns early.
+        await TankSyncClient.signOut();
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Eliminates 8 `client!` force-unwraps by capturing into local `final c = client`
- Fixes triple-unwrap in `hasEmailAccount` with null-safe chain
- Replaces generic 'Silent catch' messages with descriptive context

## Test plan
- [x] 8 new unit tests: all methods return safely when client is null
- [x] flutter analyze clean

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)