### PR TITLE
refactor: add SafeJsonAccessors for type-safe JSON access

### DIFF
--- a/lib/core/utils/json_extensions.dart
+++ b/lib/core/utils/json_extensions.dart
@@ -1,0 +1,73 @@
+/// Safe typed accessors for `Map<String, dynamic>` JSON payloads.
+///
+/// Replaces fragile `data['key'] as Type?` casts that throw at runtime if the
+/// API returns an unexpected type. Every getter returns `null` (or a default)
+/// instead of crashing.
+///
+/// Usage:
+/// ```dart
+/// final json = response.data as Map<String, dynamic>;
+/// final name = json.getString('name');           // String?
+/// final lat  = json.getDouble('lat');             // double?
+/// final ids  = json.getList<String>('ids');       // List<String>
+/// final addr = json.getMap('address');             // Map<String, dynamic>?
+/// ```
+extension SafeJsonAccessors on Map<String, dynamic> {
+  /// Returns the value at [key] as a [String], or `null` if missing or wrong type.
+  String? getString(String key) {
+    final v = this[key];
+    if (v is String) return v;
+    // Accept num/bool and convert to string (some APIs return numeric IDs).
+    if (v != null) return v.toString();
+    return null;
+  }
+
+  /// Returns the value at [key] as a [double], or `null` if missing or not numeric.
+  double? getDouble(String key) {
+    final v = this[key];
+    if (v is double) return v;
+    if (v is int) return v.toDouble();
+    if (v is num) return v.toDouble();
+    if (v is String) return double.tryParse(v);
+    return null;
+  }
+
+  /// Returns the value at [key] as an [int], or `null` if missing or not numeric.
+  int? getInt(String key) {
+    final v = this[key];
+    if (v is int) return v;
+    if (v is double) return v.toInt();
+    if (v is num) return v.toInt();
+    if (v is String) return int.tryParse(v);
+    return null;
+  }
+
+  /// Returns the value at [key] as a [bool], or `null` if missing.
+  /// Accepts `true`/`false`, `1`/`0`, `'true'`/`'false'`.
+  bool? getBool(String key) {
+    final v = this[key];
+    if (v is bool) return v;
+    if (v is int) return v != 0;
+    if (v is String) {
+      if (v.toLowerCase() == 'true') return true;
+      if (v.toLowerCase() == 'false') return false;
+    }
+    return null;
+  }
+
+  /// Returns the value at [key] as a `List<T>`, or an empty list if missing
+  /// or wrong type. Elements that don't match `T` are filtered out.
+  List<T> getList<T>(String key) {
+    final v = this[key];
+    if (v is List) return v.whereType<T>().toList();
+    return <T>[];
+  }
+
+  /// Returns the value at [key] as a `Map<String, dynamic>`, or `null`.
+  Map<String, dynamic>? getMap(String key) {
+    final v = this[key];
+    if (v is Map<String, dynamic>) return v;
+    if (v is Map) return Map<String, dynamic>.from(v);
+    return null;
+  }
+}

--- a/test/core/utils/json_extensions_test.dart
+++ b/test/core/utils/json_extensions_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/json_extensions.dart';
+
+void main() {
+  group('SafeJsonAccessors', () {
+    group('getString', () {
+      test('returns string value', () {
+        expect({'k': 'hello'}.getString('k'), 'hello');
+      });
+
+      test('converts num to string', () {
+        expect({'k': 42}.getString('k'), '42');
+        expect({'k': 3.14}.getString('k'), '3.14');
+      });
+
+      test('returns null for missing key', () {
+        expect(<String, dynamic>{}.getString('k'), isNull);
+      });
+
+      test('returns null for null value', () {
+        expect({'k': null}.getString('k'), isNull);
+      });
+    });
+
+    group('getDouble', () {
+      test('returns double value', () {
+        expect({'k': 3.14}.getDouble('k'), 3.14);
+      });
+
+      test('converts int to double', () {
+        expect({'k': 42}.getDouble('k'), 42.0);
+      });
+
+      test('parses string to double', () {
+        expect({'k': '3.14'}.getDouble('k'), 3.14);
+      });
+
+      test('returns null for non-numeric string', () {
+        expect({'k': 'abc'}.getDouble('k'), isNull);
+      });
+
+      test('returns null for missing key', () {
+        expect(<String, dynamic>{}.getDouble('k'), isNull);
+      });
+    });
+
+    group('getInt', () {
+      test('returns int value', () {
+        expect({'k': 42}.getInt('k'), 42);
+      });
+
+      test('truncates double to int', () {
+        expect({'k': 3.9}.getInt('k'), 3);
+      });
+
+      test('parses string to int', () {
+        expect({'k': '42'}.getInt('k'), 42);
+      });
+
+      test('returns null for non-numeric', () {
+        expect({'k': 'abc'}.getInt('k'), isNull);
+      });
+    });
+
+    group('getBool', () {
+      test('returns bool value', () {
+        expect({'k': true}.getBool('k'), isTrue);
+        expect({'k': false}.getBool('k'), isFalse);
+      });
+
+      test('converts int to bool', () {
+        expect({'k': 1}.getBool('k'), isTrue);
+        expect({'k': 0}.getBool('k'), isFalse);
+      });
+
+      test('parses string to bool', () {
+        expect({'k': 'true'}.getBool('k'), isTrue);
+        expect({'k': 'false'}.getBool('k'), isFalse);
+        expect({'k': 'TRUE'}.getBool('k'), isTrue);
+      });
+
+      test('returns null for non-bool string', () {
+        expect({'k': 'yes'}.getBool('k'), isNull);
+      });
+    });
+
+    group('getList', () {
+      test('returns typed list', () {
+        expect({'k': ['a', 'b']}.getList<String>('k'), ['a', 'b']);
+      });
+
+      test('filters mismatched types', () {
+        expect({'k': ['a', 1, 'b']}.getList<String>('k'), ['a', 'b']);
+      });
+
+      test('returns empty list for missing key', () {
+        expect(<String, dynamic>{}.getList<String>('k'), isEmpty);
+      });
+
+      test('returns empty list for non-list value', () {
+        expect({'k': 'not a list'}.getList<String>('k'), isEmpty);
+      });
+    });
+
+    group('getMap', () {
+      test('returns map value', () {
+        final inner = {'nested': 'value'};
+        expect({'k': inner}.getMap('k'), inner);
+      });
+
+      test('converts raw Map to typed Map', () {
+        final raw = <dynamic, dynamic>{'nested': 'value'};
+        expect({'k': raw}.getMap('k'), {'nested': 'value'});
+      });
+
+      test('returns null for missing key', () {
+        expect(<String, dynamic>{}.getMap('k'), isNull);
+      });
+
+      test('returns null for non-map value', () {
+        expect({'k': 'string'}.getMap('k'), isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
New `lib/core/utils/json_extensions.dart` with extension on `Map<String, dynamic>`:
- `getString`, `getDouble`, `getInt`, `getBool`, `getList<T>`, `getMap`
- All handle type coercion and return null/empty instead of throwing
- Foundation for #50 (unsafe casts in sync) and #91 (unsafe casts in background_service)

## Test plan
- [x] 25 unit tests
- [x] flutter analyze clean

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)