### PR TITLE
fix(security): restrict Android Auto host validator to allowlisted hosts

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/TankstellenCarAppService.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/TankstellenCarAppService.kt
@@ -28,12 +28,15 @@ import androidx.car.app.validation.HostValidator
 class TankstellenCarAppService : CarAppService() {
 
     override fun createHostValidator(): HostValidator {
-        // Allow all hosts in debug, restrict in release
-        return if (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) {
-            HostValidator.ALLOW_ALL_HOSTS_VALIDATOR
-        } else {
-            HostValidator.ALLOW_ALL_HOSTS_VALIDATOR // TODO: restrict for production
+        // Allow all hosts in debug builds for testing
+        if (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) {
+            return HostValidator.ALLOW_ALL_HOSTS_VALIDATOR
         }
+
+        // In release, only allow known Android Auto host packages
+        return HostValidator.Builder(applicationContext)
+            .addAllowedHosts(androidx.car.app.R.array.hosts_allowlist_sample)
+            .build()
     }
 
     override fun onCreateSession(sessionInfo: SessionInfo): Session {

--- a/test/security/no_hardcoded_secrets_test.dart
+++ b/test/security/no_hardcoded_secrets_test.dart
@@ -164,6 +164,46 @@ void main() {
       }
     });
 
+    test('CarAppService does not use ALLOW_ALL_HOSTS_VALIDATOR in release', () {
+      final carAppFile = File(
+        'android/app/src/main/kotlin/de/tankstellen/tankstellen/TankstellenCarAppService.kt',
+      );
+      expect(carAppFile.existsSync(), isTrue,
+          reason: 'CarAppService.kt must exist');
+
+      final content = carAppFile.readAsStringSync();
+      final lines = content.split('\n');
+
+      // Find lines that use ALLOW_ALL_HOSTS_VALIDATOR outside the debug block
+      // The only acceptable use is inside the debug-only if-branch
+      var inDebugBlock = false;
+      final violations = <String>[];
+
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        // Track when we enter the debug-only branch
+        if (line.contains('FLAG_DEBUGGABLE')) {
+          inDebugBlock = true;
+          continue;
+        }
+        if (inDebugBlock && line.contains('ALLOW_ALL_HOSTS_VALIDATOR')) {
+          inDebugBlock = false; // consume the debug-only usage
+          continue;
+        }
+        if (line.contains('ALLOW_ALL_HOSTS_VALIDATOR')) {
+          violations.add('Line ${i + 1}: $line');
+        }
+      }
+
+      if (violations.isNotEmpty) {
+        fail(
+          'ALLOW_ALL_HOSTS_VALIDATOR used outside debug block:\n'
+          '${violations.join('\n')}\n'
+          'Release builds must use HostValidator.Builder with allowlisted hosts.',
+        );
+      }
+    });
+
     test('no private keys or PEM blocks', () {
       final pemPattern = RegExp(
         r'-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----',


### PR DESCRIPTION
## Summary
- Replace `ALLOW_ALL_HOSTS_VALIDATOR` in release builds with `HostValidator.Builder` using the car app library's built-in `hosts_allowlist_sample`
- Debug builds retain permissive validator for testing
- Add security regression test verifying the validator isn't used outside the debug code path

## Test plan
- [x] New test: `CarAppService does not use ALLOW_ALL_HOSTS_VALIDATOR in release`
- [x] All 1674 existing tests pass
- [x] `flutter analyze` clean (no errors/warnings)
- [x] Kotlin compilation succeeds

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)