### PR TITLE
fix: add retry with exponential backoff for background price fetch

### DIFF
--- a/lib/core/background/background_retry.dart
+++ b/lib/core/background/background_retry.dart
@@ -1,0 +1,71 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+/// Retry configuration for background network requests.
+class BackgroundRetryConfig {
+  final int maxAttempts;
+  final Duration baseDelay;
+
+  const BackgroundRetryConfig({
+    this.maxAttempts = 3,
+    this.baseDelay = const Duration(seconds: 2),
+  });
+}
+
+/// Fetches JSON from a URL with retry and exponential backoff.
+/// Returns the parsed response data on success, null if all retries fail.
+Future<Map<String, dynamic>?> fetchWithRetry({
+  required Dio dio,
+  required String url,
+  required Map<String, dynamic> queryParameters,
+  BackgroundRetryConfig config = const BackgroundRetryConfig(),
+}) async {
+  for (var attempt = 0; attempt < config.maxAttempts; attempt++) {
+    try {
+      final response = await dio.get(
+        url,
+        queryParameters: queryParameters,
+      );
+      if (response.data is Map<String, dynamic>) {
+        return response.data as Map<String, dynamic>;
+      }
+      return null;
+    } on DioException catch (e) {
+      final isLastAttempt = attempt == config.maxAttempts - 1;
+      if (isLastAttempt || !isRetryable(e)) {
+        debugPrint(
+          'BackgroundRetry: failed after ${attempt + 1} '
+          'attempt(s): ${e.type} - ${e.message}',
+        );
+        return null;
+      }
+      // Exponential backoff: 2s, 4s, 8s...
+      final delay = config.baseDelay * (1 << attempt);
+      debugPrint(
+        'BackgroundRetry: retry ${attempt + 1}/${config.maxAttempts} '
+        'after ${delay.inSeconds}s (${e.type})',
+      );
+      await Future<void>.delayed(delay);
+    }
+  }
+  return null;
+}
+
+/// Whether a DioException is worth retrying (transient network issues).
+bool isRetryable(DioException e) {
+  switch (e.type) {
+    case DioExceptionType.connectionTimeout:
+    case DioExceptionType.sendTimeout:
+    case DioExceptionType.receiveTimeout:
+    case DioExceptionType.connectionError:
+      return true;
+    case DioExceptionType.badResponse:
+      // Retry on server errors (5xx), not on client errors (4xx)
+      final statusCode = e.response?.statusCode;
+      return statusCode != null && statusCode >= 500;
+    case DioExceptionType.cancel:
+    case DioExceptionType.badCertificate:
+    case DioExceptionType.unknown:
+      return false;
+  }
+}

--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -9,6 +9,7 @@ import '../../features/search/domain/entities/fuel_type.dart';
 import '../../features/widget/data/home_widget_service.dart';
 import '../notifications/notification_service.dart';
 import '../storage/hive_storage.dart';
+import 'background_retry.dart';
 
 /// Manages periodic background tasks via Android WorkManager.
 ///
@@ -52,6 +53,12 @@ class BackgroundService {
 
   /// Receive timeout for Tankerkoenig prices batch requests in the BG isolate.
   static const bgReceiveTimeout = Duration(seconds: 15);
+
+  /// Max retry attempts for transient network failures in the background task.
+  static const maxRetryAttempts = 3;
+
+  /// Base delay for exponential backoff between retries.
+  static const retryBaseDelay = Duration(seconds: 2);
 
   static Future<void> init() async {
     await Workmanager().initialize(callbackDispatcher);
@@ -109,38 +116,39 @@ Future<void> _refreshPricesAndCheckAlerts() async {
     final now = DateTime.now();
     final prices = <String, Map<String, dynamic>>{};
     if (apiKey != null && apiKey.isNotEmpty) {
-      try {
-        final dio = Dio(BaseOptions(
-          connectTimeout: BackgroundService.bgConnectTimeout,
-          receiveTimeout: BackgroundService.bgReceiveTimeout,
-        ));
+      final dio = Dio(BaseOptions(
+        connectTimeout: BackgroundService.bgConnectTimeout,
+        receiveTimeout: BackgroundService.bgReceiveTimeout,
+      ));
 
-        // Tankerkoenig prices endpoint (batch)
-        const batchSize = BackgroundService.tankerkoenigBatchSize;
-        for (var i = 0; i < allStationIds.length; i += batchSize) {
-          final batch = allStationIds.sublist(
-            i,
-            i + batchSize > allStationIds.length ? allStationIds.length : i + batchSize,
-          );
-          final ids = batch.join(',');
-          final response = await dio.get(
-            'https://creativecommons.tankerkoenig.de/json/prices.php',
-            queryParameters: {'ids': ids, 'apikey': apiKey},
-          );
-          final data = response.data as Map<String, dynamic>;
-          if (data['ok'] == true && data['prices'] != null) {
-            final rawPrices = data['prices'] as Map<String, dynamic>;
-            for (final entry in rawPrices.entries) {
-              if (entry.value is Map) {
-                prices[entry.key] = Map<String, dynamic>.from(entry.value as Map);
-              }
+      // Tankerkoenig prices endpoint (batch) with retry
+      const batchSize = BackgroundService.tankerkoenigBatchSize;
+      for (var i = 0; i < allStationIds.length; i += batchSize) {
+        final batch = allStationIds.sublist(
+          i,
+          i + batchSize > allStationIds.length ? allStationIds.length : i + batchSize,
+        );
+        final ids = batch.join(',');
+
+        final data = await fetchWithRetry(
+          dio: dio,
+          url: 'https://creativecommons.tankerkoenig.de/json/prices.php',
+          queryParameters: {'ids': ids, 'apikey': apiKey},
+          config: const BackgroundRetryConfig(
+            maxAttempts: BackgroundService.maxRetryAttempts,
+            baseDelay: BackgroundService.retryBaseDelay,
+          ),
+        );
+        if (data != null && data['ok'] == true && data['prices'] != null) {
+          final rawPrices = data['prices'] as Map<String, dynamic>;
+          for (final entry in rawPrices.entries) {
+            if (entry.value is Map) {
+              prices[entry.key] = Map<String, dynamic>.from(entry.value as Map);
             }
           }
         }
-        debugPrint('BackgroundService: fetched prices for ${prices.length} stations');
-      } catch (e) {
-        debugPrint('BackgroundService: price fetch failed: $e');
       }
+      debugPrint('BackgroundService: fetched prices for ${prices.length} stations');
     }
 
     // 3. Record price history for each station
@@ -197,7 +205,7 @@ Future<void> _refreshPricesAndCheckAlerts() async {
       }
     }
 
-    // 5. Evaluate alerts
+    // 5. Evaluate alerts (prices may be empty if all retries failed)
     final activeAlerts = alerts.where((a) => a.isActive).toList();
 
     if (activeAlerts.isNotEmpty && prices.isNotEmpty) {

--- a/test/core/background/background_retry_test.dart
+++ b/test/core/background/background_retry_test.dart
@@ -1,0 +1,379 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/background_retry.dart';
+
+void main() {
+  group('isRetryable', () {
+    test('connectionTimeout is retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.connectionTimeout,
+          requestOptions: RequestOptions(),
+        )),
+        isTrue,
+      );
+    });
+
+    test('sendTimeout is retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.sendTimeout,
+          requestOptions: RequestOptions(),
+        )),
+        isTrue,
+      );
+    });
+
+    test('receiveTimeout is retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.receiveTimeout,
+          requestOptions: RequestOptions(),
+        )),
+        isTrue,
+      );
+    });
+
+    test('connectionError is retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.connectionError,
+          requestOptions: RequestOptions(),
+        )),
+        isTrue,
+      );
+    });
+
+    test('500 server error is retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.badResponse,
+          requestOptions: RequestOptions(),
+          response: Response(
+            requestOptions: RequestOptions(),
+            statusCode: 500,
+          ),
+        )),
+        isTrue,
+      );
+    });
+
+    test('503 service unavailable is retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.badResponse,
+          requestOptions: RequestOptions(),
+          response: Response(
+            requestOptions: RequestOptions(),
+            statusCode: 503,
+          ),
+        )),
+        isTrue,
+      );
+    });
+
+    test('400 bad request is not retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.badResponse,
+          requestOptions: RequestOptions(),
+          response: Response(
+            requestOptions: RequestOptions(),
+            statusCode: 400,
+          ),
+        )),
+        isFalse,
+      );
+    });
+
+    test('404 not found is not retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.badResponse,
+          requestOptions: RequestOptions(),
+          response: Response(
+            requestOptions: RequestOptions(),
+            statusCode: 404,
+          ),
+        )),
+        isFalse,
+      );
+    });
+
+    test('cancel is not retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.cancel,
+          requestOptions: RequestOptions(),
+        )),
+        isFalse,
+      );
+    });
+
+    test('badCertificate is not retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.badCertificate,
+          requestOptions: RequestOptions(),
+        )),
+        isFalse,
+      );
+    });
+
+    test('unknown is not retryable', () {
+      expect(
+        isRetryable(DioException(
+          type: DioExceptionType.unknown,
+          requestOptions: RequestOptions(),
+        )),
+        isFalse,
+      );
+    });
+  });
+
+  group('BackgroundRetryConfig', () {
+    test('default config has 3 attempts and 2s base delay', () {
+      const config = BackgroundRetryConfig();
+      expect(config.maxAttempts, 3);
+      expect(config.baseDelay, const Duration(seconds: 2));
+    });
+
+    test('custom config overrides defaults', () {
+      const config = BackgroundRetryConfig(
+        maxAttempts: 5,
+        baseDelay: Duration(seconds: 1),
+      );
+      expect(config.maxAttempts, 5);
+      expect(config.baseDelay, const Duration(seconds: 1));
+    });
+  });
+
+  group('fetchWithRetry', () {
+    late Dio dio;
+    late _MockAdapter adapter;
+
+    setUp(() {
+      adapter = _MockAdapter();
+      dio = Dio()..httpClientAdapter = adapter;
+    });
+
+    test('returns data on first success', () async {
+      adapter.responses = [
+        _MockResponse(data: {'ok': true, 'prices': {}}, statusCode: 200),
+      ];
+
+      final result = await fetchWithRetry(
+        dio: dio,
+        url: 'https://example.com/api',
+        queryParameters: {'key': 'value'},
+        config: const BackgroundRetryConfig(
+          maxAttempts: 3,
+          baseDelay: Duration(milliseconds: 1),
+        ),
+      );
+
+      expect(result, isNotNull);
+      expect(result!['ok'], isTrue);
+      expect(adapter.requestCount, 1);
+    });
+
+    test('retries on timeout and succeeds on second attempt', () async {
+      adapter.responses = [
+        _MockResponse(
+          error: DioExceptionType.connectionTimeout,
+        ),
+        _MockResponse(data: {'ok': true, 'result': 42}, statusCode: 200),
+      ];
+
+      final result = await fetchWithRetry(
+        dio: dio,
+        url: 'https://example.com/api',
+        queryParameters: {},
+        config: const BackgroundRetryConfig(
+          maxAttempts: 3,
+          baseDelay: Duration(milliseconds: 1),
+        ),
+      );
+
+      expect(result, isNotNull);
+      expect(result!['result'], 42);
+      expect(adapter.requestCount, 2);
+    });
+
+    test('returns null after exhausting all retries', () async {
+      adapter.responses = [
+        _MockResponse(error: DioExceptionType.connectionTimeout),
+        _MockResponse(error: DioExceptionType.connectionTimeout),
+        _MockResponse(error: DioExceptionType.connectionTimeout),
+      ];
+
+      final result = await fetchWithRetry(
+        dio: dio,
+        url: 'https://example.com/api',
+        queryParameters: {},
+        config: const BackgroundRetryConfig(
+          maxAttempts: 3,
+          baseDelay: Duration(milliseconds: 1),
+        ),
+      );
+
+      expect(result, isNull);
+      expect(adapter.requestCount, 3);
+    });
+
+    test('does not retry on non-retryable error (cancel)', () async {
+      adapter.responses = [
+        _MockResponse(error: DioExceptionType.cancel),
+      ];
+
+      final result = await fetchWithRetry(
+        dio: dio,
+        url: 'https://example.com/api',
+        queryParameters: {},
+        config: const BackgroundRetryConfig(
+          maxAttempts: 3,
+          baseDelay: Duration(milliseconds: 1),
+        ),
+      );
+
+      expect(result, isNull);
+      expect(adapter.requestCount, 1);
+    });
+
+    test('retries on 500 server error', () async {
+      adapter.responses = [
+        _MockResponse(statusCode: 500),
+        _MockResponse(data: {'recovered': true}, statusCode: 200),
+      ];
+
+      final result = await fetchWithRetry(
+        dio: dio,
+        url: 'https://example.com/api',
+        queryParameters: {},
+        config: const BackgroundRetryConfig(
+          maxAttempts: 3,
+          baseDelay: Duration(milliseconds: 1),
+        ),
+      );
+
+      expect(result, isNotNull);
+      expect(result!['recovered'], isTrue);
+      expect(adapter.requestCount, 2);
+    });
+
+    test('does not retry on 404 client error', () async {
+      adapter.responses = [
+        _MockResponse(statusCode: 404),
+      ];
+
+      final result = await fetchWithRetry(
+        dio: dio,
+        url: 'https://example.com/api',
+        queryParameters: {},
+        config: const BackgroundRetryConfig(
+          maxAttempts: 3,
+          baseDelay: Duration(milliseconds: 1),
+        ),
+      );
+
+      expect(result, isNull);
+      expect(adapter.requestCount, 1);
+    });
+
+    test('returns null when response data is not a Map', () async {
+      adapter.responses = [
+        _MockResponse(data: 'not a map', statusCode: 200),
+      ];
+
+      final result = await fetchWithRetry(
+        dio: dio,
+        url: 'https://example.com/api',
+        queryParameters: {},
+        config: const BackgroundRetryConfig(
+          maxAttempts: 1,
+          baseDelay: Duration(milliseconds: 1),
+        ),
+      );
+
+      expect(result, isNull);
+    });
+  });
+}
+
+/// Mock response definition for testing.
+class _MockResponse {
+  final dynamic data;
+  final int statusCode;
+  final DioExceptionType? error;
+
+  _MockResponse({this.data, this.statusCode = 200, this.error});
+}
+
+/// Simple mock HTTP adapter that returns predefined responses in order.
+class _MockAdapter implements HttpClientAdapter {
+  List<_MockResponse> responses = [];
+  int requestCount = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final index = requestCount++;
+    if (index >= responses.length) {
+      throw DioException(
+        type: DioExceptionType.connectionError,
+        requestOptions: options,
+        message: 'No more mock responses',
+      );
+    }
+
+    final mock = responses[index];
+
+    if (mock.error != null) {
+      if (mock.error == DioExceptionType.badResponse) {
+        throw DioException(
+          type: DioExceptionType.badResponse,
+          requestOptions: options,
+          response: Response(
+            requestOptions: options,
+            statusCode: mock.statusCode,
+          ),
+        );
+      }
+      throw DioException(
+        type: mock.error!,
+        requestOptions: options,
+      );
+    }
+
+    if (mock.statusCode >= 400) {
+      throw DioException(
+        type: DioExceptionType.badResponse,
+        requestOptions: options,
+        response: Response(
+          requestOptions: options,
+          statusCode: mock.statusCode,
+          data: mock.data,
+        ),
+      );
+    }
+
+    final jsonString = mock.data is String
+        ? mock.data as String
+        : jsonEncode(mock.data);
+    return ResponseBody.fromString(
+      jsonString,
+      mock.statusCode,
+      headers: {
+        'content-type': ['application/json; charset=utf-8'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## Summary
- Extract reusable `fetchWithRetry` utility with configurable retry count and exponential backoff
- Background price fetch now retries up to 3 times (2s, 4s, 8s delays) on transient failures
- Only retries on timeouts, connection errors, and 5xx server errors — not client errors or cancellations

## Test plan
- [x] 20 new tests for retry logic (isRetryable + fetchWithRetry with mock adapter)
- [x] Tests cover: success on first try, retry then success, exhausted retries, non-retryable errors, 500 vs 404, non-map responses
- [x] All 1701 tests pass
- [x] `flutter analyze` clean

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)