### PR TITLE
fix(security): use encrypted Hive boxes in background isolate

### DIFF
--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:workmanager/workmanager.dart';
 
 import '../../features/alerts/data/repositories/alert_repository.dart';
@@ -85,13 +84,8 @@ void callbackDispatcher() {
 /// evaluate alerts, and fire notifications.
 Future<void> _refreshPricesAndCheckAlerts() async {
   try {
-    // Initialize Hive in isolate
-    await Hive.initFlutter();
-    await Hive.openBox('settings');
-    await Hive.openBox('favorites');
-    await Hive.openBox('alerts');
-    await Hive.openBox('cache');
-    await Hive.openBox('price_history');
+    // Initialize Hive in isolate with proper encryption
+    await HiveStorage.initInIsolate();
 
     final storage = HiveStorage();
 

--- a/lib/core/storage/hive_storage.dart
+++ b/lib/core/storage/hive_storage.dart
@@ -86,6 +86,20 @@ class HiveStorage implements StorageRepository {
     await Hive.openBox(_alertsBox);
   }
 
+  /// Initialize Hive in a background isolate with proper encryption.
+  /// Background isolates (WorkManager) run in separate Dart isolates and
+  /// must re-initialize Hive. This ensures encrypted boxes use the same
+  /// cipher as the main isolate.
+  static Future<void> initInIsolate() async {
+    await Hive.initFlutter();
+    final cipher = await _loadCipher();
+    await Hive.openBox(_settingsBox, encryptionCipher: cipher);
+    await Hive.openBox(_favoritesBox);
+    await Hive.openBox(_alertsBox);
+    await Hive.openBox(_cacheBox);
+    await Hive.openBox(_priceHistoryBox);
+  }
+
   @visibleForTesting
   static Future<void> initForTest() async {
     await Hive.openBox(_settingsBox);

--- a/test/core/background/background_service_test.dart
+++ b/test/core/background/background_service_test.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/background/background_service.dart';
 import 'package:tankstellen/core/notifications/notification_service.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
 
 void main() {
   group('BackgroundService', () {
@@ -10,6 +13,54 @@ void main() {
       // Flutter engine, this will throw a MissingPluginException.
       // We verify the method exists and is callable.
       expect(BackgroundService.init, isA<Function>());
+    });
+
+    test('retry constants are reasonable', () {
+      expect(BackgroundService.maxRetryAttempts, greaterThanOrEqualTo(2));
+      expect(BackgroundService.maxRetryAttempts, lessThanOrEqualTo(5));
+      expect(
+        BackgroundService.retryBaseDelay.inSeconds,
+        greaterThanOrEqualTo(1),
+      );
+    });
+  });
+
+  group('HiveStorage.initInIsolate', () {
+    test('initInIsolate method exists and is callable', () {
+      // initInIsolate requires platform channels (FlutterSecureStorage),
+      // so we can only verify the method signature exists.
+      expect(HiveStorage.initInIsolate, isA<Function>());
+    });
+
+    test('background service does not open Hive boxes directly', () {
+      // Verify the background service delegates Hive initialization
+      // to HiveStorage.initInIsolate (with encryption) rather than
+      // opening boxes directly without a cipher.
+      final source = File(
+        'lib/core/background/background_service.dart',
+      ).readAsStringSync();
+
+      // Should NOT contain direct Hive.openBox calls
+      expect(
+        source.contains('Hive.openBox'),
+        isFalse,
+        reason: 'Background service must use HiveStorage.initInIsolate() '
+            'instead of opening Hive boxes directly without encryption',
+      );
+
+      // Should NOT import hive_flutter directly
+      expect(
+        source.contains("import 'package:hive_flutter/hive_flutter.dart'"),
+        isFalse,
+        reason: 'Background service should not import Hive directly',
+      );
+
+      // Should use initInIsolate
+      expect(
+        source.contains('initInIsolate'),
+        isTrue,
+        reason: 'Background service must call HiveStorage.initInIsolate()',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `HiveStorage.initInIsolate()` that loads the AES cipher from FlutterSecureStorage and opens encrypted boxes properly
- Background service now delegates Hive init to this method instead of opening boxes directly without encryption
- Removes direct `hive_flutter` import from background service

## Test plan
- [x] New test: `initInIsolate method exists and is callable`
- [x] New test: `background service does not open Hive boxes directly` (source code assertion)
- [x] New test: `retry constants are reasonable`
- [x] All 1702 tests pass (2 pre-existing Argentina network timeouts)
- [x] `flutter analyze` clean

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)