### PR TITLE
refactor: use shared CsvParser in Argentina and MISE services

### DIFF
--- a/lib/core/services/impl/argentina_station_service.dart
+++ b/lib/core/services/impl/argentina_station_service.dart
@@ -11,6 +11,7 @@ import '../mixins/cached_dataset_mixin.dart';
 import '../mixins/station_service_helpers.dart';
 import '../service_result.dart';
 import '../station_service.dart';
+import '../utils/csv_parser.dart';
 
 /// Argentine fuel prices from Secretaría de Energía open data.
 /// Free, no API key. CSV with station-level prices + coordinates.
@@ -163,7 +164,7 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
 
     for (var i = 1; i < lines.length; i++) {
       // CSV with comma separator, fields may be quoted
-      final parts = _parseCsvLine(lines[i]);
+      final parts = CsvParser.parseLine(lines[i]);
       if (parts.length < 19) continue;
 
       final lat = double.tryParse(parts[16]) ?? 0;
@@ -185,27 +186,6 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
       ));
     }
     return stations;
-  }
-
-  /// Simple CSV line parser that handles quoted fields.
-  List<String> _parseCsvLine(String line) {
-    final result = <String>[];
-    var current = StringBuffer();
-    var inQuotes = false;
-
-    for (var i = 0; i < line.length; i++) {
-      final c = line[i];
-      if (c == '"') {
-        inQuotes = !inQuotes;
-      } else if (c == ',' && !inQuotes) {
-        result.add(current.toString().trim());
-        current = StringBuffer();
-      } else {
-        current.write(c);
-      }
-    }
-    result.add(current.toString().trim());
-    return result;
   }
 
   @override

--- a/lib/core/services/impl/mise_station_service.dart
+++ b/lib/core/services/impl/mise_station_service.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:dio/dio.dart';
 import '../../../features/search/data/models/search_params.dart';
 import '../../../features/search/domain/entities/station.dart';
@@ -9,6 +7,7 @@ import '../mixins/cached_dataset_mixin.dart';
 import '../mixins/station_service_helpers.dart';
 import '../service_result.dart';
 import '../station_service.dart';
+import '../utils/csv_parser.dart';
 
 /// Italian fuel prices from MIMIT (ex-MISE) open data CSV files.
 /// Free, no API key, no registration. Updated daily at 08:00.
@@ -102,25 +101,23 @@ class MiseStationService with StationServiceHelpers, CachedDatasetMixin implemen
 
   Map<String, _StationData> _parseStationsCsv(String csv) {
     final stations = <String, _StationData>{};
-    final lines = const LineSplitter().convert(csv);
+    final rows = CsvParser.parseAll(csv, skipLines: 2, separator: '|');
 
-    // Skip first line (date header) and second line (column headers)
-    for (var i = 2; i < lines.length; i++) {
-      final parts = lines[i].split('|');
+    for (final parts in rows) {
       if (parts.length < 10) continue;
 
-      final id = parts[0].trim();
-      final lat = double.tryParse(parts[8].trim()) ?? 0;
-      final lng = double.tryParse(parts[9].trim()) ?? 0;
+      final id = parts[0];
+      final lat = double.tryParse(parts[8]) ?? 0;
+      final lng = double.tryParse(parts[9]) ?? 0;
       if (lat == 0 || lng == 0) continue;
 
       stations[id] = _StationData(
-        brand: parts[2].trim(),
-        type: parts[3].trim(),
-        name: parts[4].trim(),
-        address: parts[5].trim(),
-        city: parts[6].trim(),
-        province: parts[7].trim(),
+        brand: parts[2],
+        type: parts[3],
+        name: parts[4],
+        address: parts[5],
+        city: parts[6],
+        province: parts[7],
         lat: lat,
         lng: lng,
       );
@@ -130,18 +127,16 @@ class MiseStationService with StationServiceHelpers, CachedDatasetMixin implemen
 
   Map<String, _PriceData> _parsePricesCsv(String csv) {
     final prices = <String, _PriceData>{};
-    final lines = const LineSplitter().convert(csv);
+    final rows = CsvParser.parseAll(csv, skipLines: 2, separator: '|');
 
-    // Skip first line (date header) and second line (column headers)
-    for (var i = 2; i < lines.length; i++) {
-      final parts = lines[i].split('|');
+    for (final parts in rows) {
       if (parts.length < 5) continue;
 
-      final id = parts[0].trim();
-      final fuel = parts[1].trim().toLowerCase();
-      final price = double.tryParse(parts[2].trim());
-      final isSelf = parts[3].trim() == '1';
-      final dateStr = parts[4].trim();
+      final id = parts[0];
+      final fuel = parts[1].toLowerCase();
+      final price = double.tryParse(parts[2]);
+      final isSelf = parts[3] == '1';
+      final dateStr = parts[4];
 
       if (price == null) continue;
 

--- a/test/core/utils/csv_parser_test.dart
+++ b/test/core/utils/csv_parser_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/utils/csv_parser.dart';
 
@@ -137,6 +139,54 @@ void main() {
 
     test('handles leading/trailing whitespace', () {
       expect(CsvParser.parseCommaDouble(' 1,50 '), closeTo(1.50, 0.01));
+    });
+  });
+
+  group('CsvParser adoption regression', () {
+    test('Argentina service uses CsvParser instead of inline parser', () {
+      final source = File(
+        'lib/core/services/impl/argentina_station_service.dart',
+      ).readAsStringSync();
+
+      expect(
+        source.contains('CsvParser.parseLine'),
+        isTrue,
+        reason: 'Argentina service should use CsvParser.parseLine',
+      );
+      expect(
+        source.contains('_parseCsvLine'),
+        isFalse,
+        reason: 'Argentina service should not have a private _parseCsvLine method',
+      );
+    });
+
+    test('MISE service uses CsvParser instead of inline parser', () {
+      final source = File(
+        'lib/core/services/impl/mise_station_service.dart',
+      ).readAsStringSync();
+
+      expect(
+        source.contains('CsvParser.parseAll'),
+        isTrue,
+        reason: 'MISE service should use CsvParser.parseAll',
+      );
+      expect(
+        source.contains('LineSplitter'),
+        isFalse,
+        reason: 'MISE service should not use LineSplitter directly',
+      );
+    });
+
+    test('both services import csv_parser.dart', () {
+      final argSource = File(
+        'lib/core/services/impl/argentina_station_service.dart',
+      ).readAsStringSync();
+      final miseSource = File(
+        'lib/core/services/impl/mise_station_service.dart',
+      ).readAsStringSync();
+
+      expect(argSource, contains('csv_parser.dart'));
+      expect(miseSource, contains('csv_parser.dart'));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Replace duplicated CSV parsing in Argentina service (`_parseCsvLine`) with `CsvParser.parseLine`
- Replace duplicated CSV parsing in MISE service (`LineSplitter` + `split('|')`) with `CsvParser.parseAll(separator: '|')`
- Add source-level regression tests to prevent re-introduction of inline parsers

Closes #132

## Test plan
- [x] `flutter analyze` — zero warnings
- [x] All 113 CSV/Argentina/MISE tests pass
- [x] Full suite: 1704 pass (3 pre-existing Argentina network timeouts)
- [x] Source-level regression tests verify CsvParser adoption

🤖 Generated with [Claude Code](https://claude.com/claude-code)