### PR TITLE
refactor: extract ReportService from report screen presentation layer

### DIFF
--- a/lib/core/services/report_service.dart
+++ b/lib/core/services/report_service.dart
@@ -1,0 +1,75 @@
+import 'package:dio/dio.dart';
+
+import '../constants/api_constants.dart';
+import '../error/exceptions.dart';
+import 'dio_factory.dart';
+
+/// Result of submitting a price/status complaint to the Tankerkoenig API.
+class ReportResult {
+  final bool success;
+  final String? message;
+
+  const ReportResult({required this.success, this.message});
+}
+
+/// Service for submitting price/status complaints to the Tankerkoenig API.
+///
+/// Replaces the raw Dio call that was previously in report_screen.dart,
+/// routing through DioFactory for consistent configuration and providing
+/// typed exceptions for error handling.
+class ReportService {
+  final Dio _dio;
+
+  ReportService()
+      : _dio = DioFactory.create(baseUrl: ApiConstants.baseUrl);
+
+  /// Visible for testing — accepts a custom Dio instance.
+  ReportService.withDio(this._dio);
+
+  /// Submit a complaint to the Tankerkoenig API.
+  ///
+  /// [stationId] — the Tankerkoenig station UUID.
+  /// [reportType] — the API value for the report type (e.g. 'wrongDiesel').
+  /// [apiKey] — the user's Tankerkoenig API key.
+  /// [correction] — optional corrected price (required for price reports).
+  Future<ReportResult> submitComplaint({
+    required String stationId,
+    required String reportType,
+    required String? apiKey,
+    double? correction,
+  }) async {
+    if (apiKey == null || apiKey.isEmpty) {
+      throw const ApiException(message: 'API key required');
+    }
+
+    try {
+      final response = await _dio.post(
+        ApiConstants.complaintEndpoint,
+        data: {
+          'id': stationId,
+          'type': reportType,
+          if (correction != null) 'correction': correction,
+          'apikey': apiKey,
+        },
+      );
+
+      final data = response.data;
+      if (data is Map<String, dynamic> && data['ok'] == true) {
+        return ReportResult(
+          success: true,
+          message: data['message']?.toString(),
+        );
+      }
+
+      return ReportResult(
+        success: true,
+        message: data is Map ? data['message']?.toString() : null,
+      );
+    } on DioException catch (e) {
+      throw ApiException(
+        message: e.message ?? 'Network error submitting report',
+        statusCode: e.response?.statusCode,
+      );
+    }
+  }
+}

--- a/lib/features/report/presentation/screens/report_screen.dart
+++ b/lib/features/report/presentation/screens/report_screen.dart
@@ -1,9 +1,8 @@
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import '../../../../core/constants/api_constants.dart';
-import '../../../../core/constants/app_constants.dart';
+import '../../../../core/error/exceptions.dart';
+import '../../../../core/services/report_service.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/sync/sync_provider.dart';
@@ -75,33 +74,21 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
     try {
       final apiKeys = ref.read(apiKeyStorageProvider);
       final apiKey = apiKeys.getApiKey();
+      final price = _selectedType!.needsPrice
+          ? double.tryParse(_priceController.text.replaceAll(',', '.'))
+          : null;
 
-      final dio = Dio(BaseOptions(
-        baseUrl: ApiConstants.baseUrl,
-        headers: {'User-Agent': AppConstants.userAgent},
-      ));
-
-      await dio.post(
-        ApiConstants.complaintEndpoint,
-        data: {
-          'id': widget.stationId,
-          'type': _selectedType!.apiValue,
-          if (_selectedType!.needsPrice)
-            'correction': double.tryParse(
-              _priceController.text.replaceAll(',', '.'),
-            ),
-          'apikey': apiKey,
-        },
+      await ReportService().submitComplaint(
+        stationId: widget.stationId,
+        reportType: _selectedType!.apiValue,
+        apiKey: apiKey,
+        correction: price,
       );
 
       // Also submit to Supabase community reports if connected
       if (_selectedType!.needsPrice && TankSyncClient.isConnected) {
         final syncConfig = ref.read(syncStateProvider);
-        final price = double.tryParse(
-          _priceController.text.replaceAll(',', '.'),
-        );
         if (price != null && syncConfig.userId != null) {
-          // Map report type to fuel type string
           final fuelType = switch (_selectedType!) {
             ReportType.wrongE5 => 'e5',
             ReportType.wrongE10 => 'e10',
@@ -128,7 +115,7 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
         );
         context.pop();
       }
-    } on DioException catch (e) {
+    } on ApiException catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/test/core/services/report_service_test.dart
+++ b/test/core/services/report_service_test.dart
@@ -1,0 +1,233 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/report_service.dart';
+
+void main() {
+  group('ReportService', () {
+    group('submitComplaint', () {
+      test('succeeds with valid API response', () async {
+        final dio = Dio();
+        dio.httpClientAdapter = _MockAdapter([
+          _MockResponse(200, {'ok': true, 'message': 'Report accepted'}),
+        ]);
+
+        final service = ReportService.withDio(dio);
+        final result = await service.submitComplaint(
+          stationId: 'abc-123',
+          reportType: 'wrongDiesel',
+          apiKey: 'test-key',
+          correction: 1.459,
+        );
+
+        expect(result.success, isTrue);
+        expect(result.message, 'Report accepted');
+      });
+
+      test('succeeds without correction for status reports', () async {
+        final dio = Dio();
+        dio.httpClientAdapter = _MockAdapter([
+          _MockResponse(200, {'ok': true}),
+        ]);
+
+        final service = ReportService.withDio(dio);
+        final result = await service.submitComplaint(
+          stationId: 'abc-123',
+          reportType: 'wrongStatusOpen',
+          apiKey: 'test-key',
+        );
+
+        expect(result.success, isTrue);
+      });
+
+      test('throws ApiException when API key is null', () async {
+        final service = ReportService.withDio(Dio());
+
+        expect(
+          () => service.submitComplaint(
+            stationId: 'abc-123',
+            reportType: 'wrongDiesel',
+            apiKey: null,
+          ),
+          throwsA(isA<ApiException>().having(
+            (e) => e.message,
+            'message',
+            contains('API key'),
+          )),
+        );
+      });
+
+      test('throws ApiException when API key is empty', () async {
+        final service = ReportService.withDio(Dio());
+
+        expect(
+          () => service.submitComplaint(
+            stationId: 'abc-123',
+            reportType: 'wrongDiesel',
+            apiKey: '',
+          ),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('throws ApiException on network error', () async {
+        final dio = Dio();
+        dio.httpClientAdapter = _MockAdapter([
+          _MockResponse(500, 'Internal Server Error'),
+        ]);
+
+        final service = ReportService.withDio(dio);
+
+        expect(
+          () => service.submitComplaint(
+            stationId: 'abc-123',
+            reportType: 'wrongDiesel',
+            apiKey: 'test-key',
+            correction: 1.459,
+          ),
+          throwsA(isA<ApiException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            500,
+          )),
+        );
+      });
+
+      test('throws ApiException on connection timeout', () async {
+        final dio = Dio(BaseOptions(
+          connectTimeout: const Duration(milliseconds: 1),
+        ));
+        // Use an unreachable address to trigger timeout
+        dio.options.baseUrl = 'http://192.0.2.1'; // RFC 5737 TEST-NET
+
+        final service = ReportService.withDio(dio);
+
+        expect(
+          () => service.submitComplaint(
+            stationId: 'abc-123',
+            reportType: 'wrongDiesel',
+            apiKey: 'test-key',
+          ),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('handles non-map response body gracefully', () async {
+        final dio = Dio();
+        dio.httpClientAdapter = _MockAdapter([
+          _MockResponse(200, 'OK'),
+        ]);
+
+        final service = ReportService.withDio(dio);
+        final result = await service.submitComplaint(
+          stationId: 'abc-123',
+          reportType: 'wrongE5',
+          apiKey: 'test-key',
+          correction: 1.5,
+        );
+
+        expect(result.success, isTrue);
+        expect(result.message, isNull);
+      });
+    });
+
+    group('ReportResult', () {
+      test('stores success and message', () {
+        const result = ReportResult(success: true, message: 'Done');
+        expect(result.success, isTrue);
+        expect(result.message, 'Done');
+      });
+
+      test('message is optional', () {
+        const result = ReportResult(success: true);
+        expect(result.message, isNull);
+      });
+    });
+
+    group('source-level regression', () {
+      test('report_screen does not instantiate Dio directly', () {
+        final source = File(
+          'lib/features/report/presentation/screens/report_screen.dart',
+        ).readAsStringSync();
+
+        expect(
+          source.contains('Dio('),
+          isFalse,
+          reason: 'ReportScreen should use ReportService, not create Dio directly',
+        );
+        expect(
+          source.contains("import 'package:dio/dio.dart'"),
+          isFalse,
+          reason: 'ReportScreen should not import Dio',
+        );
+      });
+
+      test('report_screen uses ReportService', () {
+        final source = File(
+          'lib/features/report/presentation/screens/report_screen.dart',
+        ).readAsStringSync();
+
+        expect(source, contains('ReportService'));
+        expect(source, contains('submitComplaint'));
+      });
+    });
+  });
+}
+
+class _MockResponse {
+  final int statusCode;
+  final Object body;
+
+  const _MockResponse(this.statusCode, this.body);
+}
+
+class _MockAdapter implements HttpClientAdapter {
+  final List<_MockResponse> _responses;
+  int _index = 0;
+
+  _MockAdapter(this._responses);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (_index >= _responses.length) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.unknown,
+        error: 'No more mock responses',
+      );
+    }
+
+    final mock = _responses[_index++];
+
+    if (mock.statusCode >= 400) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.badResponse,
+        response: Response(
+          requestOptions: options,
+          statusCode: mock.statusCode,
+          data: mock.body,
+        ),
+      );
+    }
+
+    final encoded = jsonEncode(mock.body);
+    return ResponseBody.fromString(
+      encoded,
+      mock.statusCode,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## Summary
- Create `ReportService` in `lib/core/services/` with DioFactory, typed `ApiException` errors
- Remove direct Dio instantiation from `report_screen.dart`
- Add 11 tests: success paths, error paths (null key, empty key, 500, timeout, non-map response), source-level regression

Closes #53

## Test plan
- [x] `flutter analyze` — zero warnings
- [x] 11 new ReportService tests pass
- [x] Full suite: 1716 pass (2 pre-existing Argentina network timeouts)
- [x] Source-level regression tests verify no Dio in presentation layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)