### PR TITLE
fix(sync): retry public.users upsert with backoff, sign out on failure

### DIFF
--- a/lib/core/sync/supabase_client.dart
+++ b/lib/core/sync/supabase_client.dart
@@ -7,6 +7,12 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 class TankSyncClient {
   static bool _initialized = false;
 
+  /// Max retry attempts for the public.users upsert after auth signup/signin.
+  static const maxUpsertRetries = 3;
+
+  /// Base delay for exponential backoff between upsert retries.
+  static const upsertRetryBaseDelay = Duration(milliseconds: 500);
+
   /// Initialize the Supabase client. Safe to call multiple times — subsequent
   /// calls are no-ops.
   static Future<void> init({
@@ -52,17 +58,7 @@ class TankSyncClient {
     final response = await c.auth.signInAnonymously();
     final userId = response.user?.id;
     if (userId != null) {
-      // Ensure user exists in public.users table.
-      // Supabase auth creates auth.users but NOT public.users.
-      // The FK constraint on favorites/alerts requires public.users to exist.
-      try {
-        await c.from('users').upsert(
-          {'id': userId},
-          onConflict: 'id',
-        );
-      } catch (e) {
-        debugPrint('TankSync: users upsert failed: $e');
-      }
+      await _ensurePublicUser(c, userId);
     }
     return userId;
   }
@@ -77,11 +73,7 @@ class TankSyncClient {
     );
     final userId = response.user?.id;
     if (userId != null) {
-      try {
-        await c.from('users').upsert({'id': userId}, onConflict: 'id');
-      } catch (e) {
-        debugPrint('TankSync: users upsert failed: $e');
-      }
+      await _ensurePublicUser(c, userId);
     }
     return userId;
   }
@@ -96,13 +88,50 @@ class TankSyncClient {
     );
     final userId = response.user?.id;
     if (userId != null) {
-      try {
-        await c.from('users').upsert({'id': userId}, onConflict: 'id');
-      } catch (e) {
-        debugPrint('TankSync: users upsert failed: $e');
-      }
+      await _ensurePublicUser(c, userId);
     }
     return userId;
+  }
+
+  /// Ensure the user exists in `public.users` (required by FK constraints
+  /// on favorites/alerts). Retries with exponential backoff; if all retries
+  /// fail, signs out to restore consistent state and rethrows.
+  static Future<void> _ensurePublicUser(
+    SupabaseClient c,
+    String userId,
+  ) async {
+    Object? lastError;
+    for (var attempt = 0; attempt < maxUpsertRetries; attempt++) {
+      try {
+        await c.from('users').upsert({'id': userId}, onConflict: 'id');
+        return; // success
+      } catch (e) {
+        lastError = e;
+        debugPrint(
+          'TankSync: users upsert attempt ${attempt + 1}/$maxUpsertRetries failed: $e',
+        );
+        if (attempt < maxUpsertRetries - 1) {
+          await Future<void>.delayed(
+            upsertRetryBaseDelay * (1 << attempt),
+          );
+        }
+      }
+    }
+
+    // All retries exhausted — sign out to prevent inconsistent state
+    // where auth.users exists but public.users doesn't.
+    debugPrint('TankSync: users upsert failed after $maxUpsertRetries attempts, signing out');
+    try {
+      await c.auth.signOut();
+    } catch (e) {
+      debugPrint('TankSync: sign-out after upsert failure also failed: $e');
+    }
+    _initialized = false;
+    throw StateError(
+      'Failed to create public.users row after $maxUpsertRetries attempts. '
+      'Signed out to prevent inconsistent state. '
+      'Original error: $lastError',
+    );
   }
 
   /// Get the current user's email (null for anonymous users).

--- a/test/core/sync/supabase_client_test.dart
+++ b/test/core/sync/supabase_client_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/sync/supabase_client.dart';
 
@@ -59,6 +61,93 @@ void main() {
         // Should not throw — just returns early.
         await TankSyncClient.signOut();
       }
+    });
+  });
+
+  group('TankSyncClient upsert retry constants', () {
+    test('maxUpsertRetries is at least 2', () {
+      expect(TankSyncClient.maxUpsertRetries, greaterThanOrEqualTo(2));
+    });
+
+    test('maxUpsertRetries is at most 5', () {
+      expect(TankSyncClient.maxUpsertRetries, lessThanOrEqualTo(5));
+    });
+
+    test('upsertRetryBaseDelay is reasonable', () {
+      expect(
+        TankSyncClient.upsertRetryBaseDelay.inMilliseconds,
+        greaterThanOrEqualTo(100),
+      );
+      expect(
+        TankSyncClient.upsertRetryBaseDelay.inMilliseconds,
+        lessThanOrEqualTo(2000),
+      );
+    });
+  });
+
+  group('TankSyncClient upsert retry regression', () {
+    test('no silent catch blocks remain in supabase_client.dart', () {
+      final source = File(
+        'lib/core/sync/supabase_client.dart',
+      ).readAsStringSync();
+
+      // Count occurrences of the old pattern: catch (e) { debugPrint(...); }
+      // without a rethrow or throw. The _ensurePublicUser method has a
+      // deliberate catch-retry-rethrow pattern, but individual auth methods
+      // should NOT have their own try/catch blocks around the upsert.
+      final authMethods = ['signInAnonymously', 'signUpWithEmail', 'signInWithEmail'];
+      for (final method in authMethods) {
+        final methodStart = source.indexOf('static Future<String?> $method');
+        if (methodStart == -1) continue;
+        // Find the next static method or end of class
+        final nextStatic = source.indexOf('static ', methodStart + 1);
+        final methodBody = nextStatic > 0
+            ? source.substring(methodStart, nextStatic)
+            : source.substring(methodStart);
+
+        expect(
+          methodBody.contains('try {'),
+          isFalse,
+          reason: '$method should not have inline try/catch — '
+              'upsert retries are handled by _ensurePublicUser',
+        );
+      }
+    });
+
+    test('_ensurePublicUser method exists with retry logic', () {
+      final source = File(
+        'lib/core/sync/supabase_client.dart',
+      ).readAsStringSync();
+
+      expect(source, contains('_ensurePublicUser'));
+      expect(source, contains('maxUpsertRetries'));
+      expect(source, contains('upsertRetryBaseDelay'));
+    });
+
+    test('all auth methods delegate to _ensurePublicUser', () {
+      final source = File(
+        'lib/core/sync/supabase_client.dart',
+      ).readAsStringSync();
+
+      // Each auth method should call _ensurePublicUser
+      final callCount = '_ensurePublicUser('.allMatches(source).length;
+      // 3 calls (one per auth method) + 1 definition = at least 4 occurrences of the name
+      expect(callCount, greaterThanOrEqualTo(3),
+        reason: 'All 3 auth methods should call _ensurePublicUser',
+      );
+    });
+
+    test('_ensurePublicUser signs out on failure', () {
+      final source = File(
+        'lib/core/sync/supabase_client.dart',
+      ).readAsStringSync();
+
+      // Find _ensurePublicUser method body
+      final methodStart = source.indexOf('_ensurePublicUser');
+      final methodBody = source.substring(methodStart);
+
+      expect(methodBody, contains('signOut'));
+      expect(methodBody, contains('StateError'));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Replace 3 silent `catch (e) { debugPrint(...) }` blocks in auth methods with shared `_ensurePublicUser` helper
- Retry upsert with exponential backoff (3 attempts, 500ms base delay)
- If all retries fail, sign out to prevent inconsistent auth/public.users state
- Throw `StateError` so callers can surface actionable error message

Closes #54

## Test plan
- [x] `flutter analyze` — zero warnings
- [x] 15 supabase_client tests pass (8 existing + 7 new)
- [x] Full suite: 1724 pass (1 pre-existing Argentina network timeout)
- [x] Source-level regression: no silent catches, all auth methods delegate to helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)