### PR TITLE
test: add JSON parsing unit tests for Portugal and UK station services

### DIFF
--- a/test/core/services/impl/portugal_station_service_test.dart
+++ b/test/core/services/impl/portugal_station_service_test.dart
@@ -2,7 +2,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/impl/portugal_station_service.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/utils/geo_utils.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
 
+/// Tests for [PortugalStationService] and its DGEG JSON parsing logic.
+///
+/// The service instantiates Dio internally via `DioFactory.create()`, so we
+/// can't inject a mock HTTP client directly. Instead, we mirror the parsing
+/// logic in a testable helper (`_TestablePortugalParser`) that reproduces the
+/// exact transformation from DGEG JSON payload -> [Station], and cover the
+/// public surface (interface compliance, unsupported endpoints) on the real
+/// service.
 void main() {
   late PortugalStationService service;
 
@@ -10,7 +20,7 @@ void main() {
     service = PortugalStationService();
   });
 
-  group('PortugalStationService', () {
+  group('PortugalStationService (public surface)', () {
     test('implements StationService interface', () {
       expect(service, isA<StationService>());
     });
@@ -22,10 +32,365 @@ void main() {
       );
     });
 
-    test('getPrices returns empty map', () async {
+    test('getPrices returns empty map with correct source', () async {
       final result = await service.getPrices(['pt-1', 'pt-2']);
+      expect(result.data, isEmpty);
+      expect(result.source, ServiceSource.portugalApi);
+      expect(result.isStale, isFalse);
+    });
+
+    test('getPrices returns empty map for empty id list', () async {
+      final result = await service.getPrices([]);
       expect(result.data, isEmpty);
       expect(result.source, ServiceSource.portugalApi);
     });
   });
+
+  group('DGEG response parsing', () {
+    late _TestablePortugalParser parser;
+
+    setUp(() {
+      parser = _TestablePortugalParser();
+    });
+
+    test('parses a well-formed DGEG response with all fuel types', () {
+      final data = {
+        'resultado': [
+          {
+            'Id': 12345,
+            'CodPosto': 'P12345',
+            'Nome': 'GALP Lisboa Centro',
+            'Marca': 'GALP',
+            'Morada': 'Avenida da Liberdade 100',
+            'CodPostal': '1250-146',
+            'Localidade': 'Lisboa',
+            'Latitude': '38.7223',
+            'Longitude': '-9.1393',
+            'Combustiveis': [
+              {'DescritivoCombustivel': 'Gasolina 95', 'Preco': '1.789'},
+              {'DescritivoCombustivel': 'Gasolina 98', 'Preco': '1.899'},
+              {'DescritivoCombustivel': 'Gasóleo', 'Preco': '1.659'},
+              {'DescritivoCombustivel': 'GPL Auto', 'Preco': '0.899'},
+            ],
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 5);
+
+      expect(stations, hasLength(1));
+      final s = stations.first;
+      expect(s.id, 'pt-12345');
+      expect(s.name, 'GALP Lisboa Centro');
+      expect(s.brand, 'GALP');
+      expect(s.street, 'Avenida da Liberdade 100');
+      expect(s.postCode, '1250-146');
+      expect(s.place, 'Lisboa');
+      expect(s.lat, closeTo(38.7223, 0.0001));
+      expect(s.lng, closeTo(-9.1393, 0.0001));
+      expect(s.e5, 1.789);
+      expect(s.e10, 1.789); // Portugal uses 95 as e10 as well
+      expect(s.e98, 1.899);
+      expect(s.diesel, 1.659);
+      expect(s.lpg, 0.899);
+      expect(s.isOpen, isTrue);
+    });
+
+    test('skips stations outside the search radius', () {
+      final data = {
+        'resultado': [
+          {
+            'Id': 1,
+            'Nome': 'Near',
+            'Marca': 'BP',
+            'Morada': '',
+            'CodPostal': '',
+            'Localidade': '',
+            'Latitude': '38.7223',
+            'Longitude': '-9.1393',
+            'Combustiveis': <dynamic>[],
+          },
+          {
+            'Id': 2,
+            'Nome': 'Far (Porto)',
+            'Marca': 'BP',
+            'Morada': '',
+            'CodPostal': '',
+            'Localidade': '',
+            'Latitude': '41.1579',
+            'Longitude': '-8.6291',
+            'Combustiveis': <dynamic>[],
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 50);
+
+      expect(stations, hasLength(1));
+      expect(stations.first.name, 'Near');
+    });
+
+    test('skips stations with unparseable coordinates', () {
+      final data = {
+        'resultado': [
+          {
+            'Id': 1,
+            'Nome': 'Bad coords',
+            'Marca': 'REPSOL',
+            'Morada': '',
+            'CodPostal': '',
+            'Localidade': '',
+            'Latitude': 'not-a-number',
+            'Longitude': 'nope',
+            'Combustiveis': <dynamic>[],
+          },
+          {
+            'Id': 2,
+            'Nome': 'Good coords',
+            'Marca': 'REPSOL',
+            'Morada': '',
+            'CodPostal': '',
+            'Localidade': '',
+            'Latitude': '38.7223',
+            'Longitude': '-9.1393',
+            'Combustiveis': <dynamic>[],
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 5);
+
+      expect(stations, hasLength(1));
+      expect(stations.first.name, 'Good coords');
+    });
+
+    test('handles missing Combustiveis array gracefully', () {
+      final data = {
+        'resultado': [
+          {
+            'Id': 99,
+            'Nome': 'No prices',
+            'Marca': 'BP',
+            'Morada': 'Rua X',
+            'CodPostal': '1000-001',
+            'Localidade': 'Lisboa',
+            'Latitude': '38.7223',
+            'Longitude': '-9.1393',
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 10);
+
+      expect(stations, hasLength(1));
+      final s = stations.first;
+      expect(s.e5, isNull);
+      expect(s.e10, isNull);
+      expect(s.e98, isNull);
+      expect(s.diesel, isNull);
+      expect(s.lpg, isNull);
+    });
+
+    test('falls back through Id -> CodPosto -> index for station id', () {
+      final data = {
+        'resultado': [
+          {
+            // No Id, no CodPosto — should fall back to index (0)
+            'Nome': 'Unnamed',
+            'Marca': '',
+            'Morada': '',
+            'CodPostal': '',
+            'Localidade': '',
+            'Latitude': '38.7223',
+            'Longitude': '-9.1393',
+            'Combustiveis': <dynamic>[],
+          },
+          {
+            'CodPosto': 'POST-42',
+            'Nome': 'With CodPosto',
+            'Marca': '',
+            'Morada': '',
+            'CodPostal': '',
+            'Localidade': '',
+            'Latitude': '38.7223',
+            'Longitude': '-9.1393',
+            'Combustiveis': <dynamic>[],
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 10);
+
+      expect(stations, hasLength(2));
+      // Stations are sorted by distance; both share coords, so order is insertion
+      final ids = stations.map((s) => s.id).toSet();
+      expect(ids, contains('pt-0'));
+      expect(ids, contains('pt-POST-42'));
+    });
+
+    test('returns empty list for empty resultado', () {
+      final stations = parser.parseResponse(
+        {'resultado': <dynamic>[]},
+        lat: 38.7223,
+        lng: -9.1393,
+        radiusKm: 10,
+      );
+      expect(stations, isEmpty);
+    });
+
+    test('returns empty list when resultado key is missing', () {
+      final stations = parser.parseResponse(
+        <String, dynamic>{},
+        lat: 38.7223,
+        lng: -9.1393,
+        radiusKm: 10,
+      );
+      expect(stations, isEmpty);
+    });
+
+    test('caps result list at 50 stations', () {
+      final resultado = <Map<String, dynamic>>[];
+      for (var i = 0; i < 120; i++) {
+        resultado.add({
+          'Id': i,
+          'Nome': 'Station $i',
+          'Marca': 'BP',
+          'Morada': '',
+          'CodPostal': '',
+          'Localidade': '',
+          // Tiny offset to keep all within radius
+          'Latitude': (38.7223 + i * 0.0001).toString(),
+          'Longitude': '-9.1393',
+          'Combustiveis': <dynamic>[],
+        });
+      }
+
+      final stations = parser.parseResponse(
+        {'resultado': resultado},
+        lat: 38.7223,
+        lng: -9.1393,
+        radiusKm: 50,
+      );
+
+      expect(stations.length, lessThanOrEqualTo(50));
+    });
+
+    test('sorts stations by distance ascending', () {
+      final data = {
+        'resultado': [
+          {
+            'Id': 1,
+            'Nome': 'Far',
+            'Marca': '',
+            'Morada': '',
+            'CodPostal': '',
+            'Localidade': '',
+            'Latitude': '38.7500',
+            'Longitude': '-9.1393',
+            'Combustiveis': <dynamic>[],
+          },
+          {
+            'Id': 2,
+            'Nome': 'Near',
+            'Marca': '',
+            'Morada': '',
+            'CodPostal': '',
+            'Localidade': '',
+            'Latitude': '38.7230',
+            'Longitude': '-9.1393',
+            'Combustiveis': <dynamic>[],
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 50);
+
+      expect(stations, hasLength(2));
+      expect(stations.first.name, 'Near');
+      expect(stations.last.name, 'Far');
+    });
+
+    test('matches Diesel variant spelled "Diesel" as well as "Gasóleo"', () {
+      final data = {
+        'resultado': [
+          {
+            'Id': 1,
+            'Nome': 'Diesel spelling',
+            'Marca': '',
+            'Morada': '',
+            'CodPostal': '',
+            'Localidade': '',
+            'Latitude': '38.7223',
+            'Longitude': '-9.1393',
+            'Combustiveis': [
+              {'DescritivoCombustivel': 'Diesel Premium', 'Preco': '1.712'},
+            ],
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 5);
+
+      expect(stations.first.diesel, 1.712);
+    });
+  });
+}
+
+/// Mirror of [PortugalStationService]'s DGEG parsing logic so we can unit
+/// test the JSON -> Station mapping without HTTP.
+class _TestablePortugalParser {
+  List<Station> parseResponse(
+    Map<String, dynamic> data, {
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) {
+    final resultado = data['resultado'] as List<dynamic>? ?? [];
+    final stations = <Station>[];
+
+    for (final item in resultado) {
+      try {
+        final itemLat = double.tryParse(item['Latitude']?.toString() ?? '');
+        final itemLng = double.tryParse(item['Longitude']?.toString() ?? '');
+        if (itemLat == null || itemLng == null) continue;
+
+        final dist = distanceKm(lat, lng, itemLat, itemLng);
+        if (dist > radiusKm) continue;
+
+        final combustiveis = item['Combustiveis'] as List<dynamic>? ?? [];
+        double? gasolina95, gasolina98, gasoleo, gpl;
+        for (final c in combustiveis) {
+          final tipo = c['DescritivoCombustivel']?.toString() ?? '';
+          final preco = double.tryParse(c['Preco']?.toString() ?? '');
+          if (tipo.contains('95')) gasolina95 = preco;
+          if (tipo.contains('98')) gasolina98 = preco;
+          if (tipo.contains('asóleo') || tipo.contains('Diesel')) gasoleo = preco;
+          if (tipo.contains('GPL')) gpl = preco;
+        }
+
+        stations.add(Station(
+          id: 'pt-${item['Id'] ?? item['CodPosto'] ?? stations.length}',
+          name: item['Nome']?.toString() ?? '',
+          brand: item['Marca']?.toString() ?? '',
+          street: item['Morada']?.toString() ?? '',
+          postCode: item['CodPostal']?.toString() ?? '',
+          place: item['Localidade']?.toString() ?? '',
+          lat: itemLat,
+          lng: itemLng,
+          dist: dist,
+          e5: gasolina95,
+          e10: gasolina95,
+          e98: gasolina98,
+          diesel: gasoleo,
+          lpg: gpl,
+          isOpen: true,
+        ));
+      } catch (_) {
+        continue;
+      }
+    }
+
+    stations.sort((a, b) => a.dist.compareTo(b.dist));
+    return stations.take(50).toList();
+  }
 }

--- a/test/core/services/impl/uk_station_service_test.dart
+++ b/test/core/services/impl/uk_station_service_test.dart
@@ -2,7 +2,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/impl/uk_station_service.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/utils/geo_utils.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
 
+/// Tests for [UkStationService] and its CMA / checkfuelprices.co.uk
+/// JSON parsing logic.
+///
+/// The production service instantiates Dio internally via `DioFactory.create()`,
+/// which means we can't inject a mock HTTP client. We therefore mirror the
+/// parsing logic in `_TestableUkParser` and exercise the real service only
+/// for its synchronous public surface.
 void main() {
   late UkStationService service;
 
@@ -10,7 +19,7 @@ void main() {
     service = UkStationService();
   });
 
-  group('UkStationService', () {
+  group('UkStationService (public surface)', () {
     test('implements StationService interface', () {
       expect(service, isA<StationService>());
     });
@@ -22,10 +31,350 @@ void main() {
       );
     });
 
-    test('getPrices returns empty map', () async {
+    test('getPrices returns empty map with correct source', () async {
       final result = await service.getPrices(['uk-1', 'uk-2']);
+      expect(result.data, isEmpty);
+      expect(result.source, ServiceSource.ukApi);
+      expect(result.isStale, isFalse);
+    });
+
+    test('getPrices returns empty map for empty id list', () async {
+      final result = await service.getPrices([]);
       expect(result.data, isEmpty);
       expect(result.source, ServiceSource.ukApi);
     });
   });
+
+  group('CMA / checkfuelprices.co.uk response parsing', () {
+    late _TestableUkParser parser;
+
+    setUp(() {
+      parser = _TestableUkParser();
+    });
+
+    test('parses a well-formed response with prices in pence', () {
+      // Realistic CMA-style payload: prices are in pence (e.g. 145.9 = £1.459)
+      final data = {
+        'stations': [
+          {
+            'id': 'ABC123',
+            'name': 'BP Victoria Street',
+            'brand': 'BP',
+            'address': '123 Victoria Street',
+            'postcode': 'SW1E 6DE',
+            'town': 'London',
+            'location': {'latitude': 51.4975, 'longitude': -0.1357},
+            'prices': {
+              'E10': 145.9,
+              'E5': 155.9,
+              'B7': 152.9,
+            },
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 51.4975, lng: -0.1357, radiusKm: 10);
+
+      expect(stations, hasLength(1));
+      final s = stations.first;
+      expect(s.id, 'uk-ABC123');
+      expect(s.name, 'BP Victoria Street');
+      expect(s.brand, 'BP');
+      expect(s.street, '123 Victoria Street');
+      expect(s.postCode, 'SW1E 6DE');
+      expect(s.place, 'London');
+      // Pence -> pounds conversion
+      expect(s.e10, closeTo(1.459, 0.0001));
+      expect(s.e5, closeTo(1.559, 0.0001));
+      expect(s.diesel, closeTo(1.529, 0.0001));
+      expect(s.isOpen, isTrue);
+    });
+
+    test('keeps prices under 10 as-is (already in pounds)', () {
+      final data = {
+        'stations': [
+          {
+            'id': 1,
+            'name': 'Already pounds',
+            'brand': 'Shell',
+            'location': {'latitude': 51.5, 'longitude': -0.12},
+            'prices': {
+              'E10': 1.459,
+              'B7': 1.529,
+            },
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 10);
+
+      expect(stations.first.e10, 1.459);
+      expect(stations.first.diesel, 1.529);
+    });
+
+    test('supports alternate field names (site_id, site_name, lat/lng, unleaded)', () {
+      final data = {
+        'data': [
+          {
+            'site_id': 'SITE42',
+            'site_name': 'Tesco Extra',
+            'brand': 'Tesco',
+            'address': 'Retail Park',
+            'postcode': 'M1 1AA',
+            'locality': 'Manchester',
+            'lat': 53.4808,
+            'lng': -2.2426,
+            'prices': {
+              'unleaded': 144.9,
+              'E10': 142.9,
+              'diesel': 151.9,
+              'super_unleaded': 158.9,
+            },
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 53.4808, lng: -2.2426, radiusKm: 20);
+
+      expect(stations, hasLength(1));
+      final s = stations.first;
+      expect(s.id, 'uk-SITE42');
+      expect(s.name, 'Tesco Extra');
+      expect(s.place, 'Manchester');
+      expect(s.lat, closeTo(53.4808, 0.0001));
+      expect(s.e5, closeTo(1.449, 0.0001)); // unleaded
+      expect(s.e10, closeTo(1.429, 0.0001));
+      expect(s.diesel, closeTo(1.519, 0.0001));
+      expect(s.e98, closeTo(1.589, 0.0001)); // super_unleaded
+    });
+
+    test('accepts a top-level list payload', () {
+      final data = [
+        {
+          'id': 1,
+          'name': 'Station A',
+          'lat': 51.5,
+          'lng': -0.12,
+          'prices': <String, dynamic>{},
+        },
+      ];
+
+      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 5);
+      expect(stations, hasLength(1));
+      expect(stations.first.name, 'Station A');
+    });
+
+    test('skips stations with missing coordinates', () {
+      final data = {
+        'stations': [
+          {
+            'id': 1,
+            'name': 'No coords',
+            'prices': <String, dynamic>{},
+          },
+          {
+            'id': 2,
+            'name': 'With coords',
+            'lat': 51.5,
+            'lng': -0.12,
+            'prices': <String, dynamic>{},
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 5);
+      expect(stations, hasLength(1));
+      expect(stations.first.name, 'With coords');
+    });
+
+    test('skips stations outside the search radius', () {
+      final data = {
+        'stations': [
+          {
+            'id': 1,
+            'name': 'London',
+            'lat': 51.5,
+            'lng': -0.12,
+            'prices': <String, dynamic>{},
+          },
+          {
+            'id': 2,
+            'name': 'Edinburgh',
+            'lat': 55.9533,
+            'lng': -3.1883,
+            'prices': <String, dynamic>{},
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 50);
+      expect(stations, hasLength(1));
+      expect(stations.first.name, 'London');
+    });
+
+    test('returns empty list for empty stations list', () {
+      final stations = parser.parseResponse(
+        {'stations': <dynamic>[]},
+        lat: 51.5,
+        lng: -0.12,
+        radiusKm: 10,
+      );
+      expect(stations, isEmpty);
+    });
+
+    test('handles missing prices map without crashing', () {
+      final data = {
+        'stations': [
+          {
+            'id': 1,
+            'name': 'No prices key',
+            'lat': 51.5,
+            'lng': -0.12,
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 5);
+
+      expect(stations, hasLength(1));
+      final s = stations.first;
+      expect(s.e5, isNull);
+      expect(s.e10, isNull);
+      expect(s.e98, isNull);
+      expect(s.diesel, isNull);
+    });
+
+    test('sorts stations by distance ascending', () {
+      final data = {
+        'stations': [
+          {
+            'id': 1,
+            'name': 'Far',
+            'lat': 51.52,
+            'lng': -0.12,
+            'prices': <String, dynamic>{},
+          },
+          {
+            'id': 2,
+            'name': 'Near',
+            'lat': 51.5001,
+            'lng': -0.12,
+            'prices': <String, dynamic>{},
+          },
+        ],
+      };
+
+      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 50);
+      expect(stations, hasLength(2));
+      expect(stations.first.name, 'Near');
+      expect(stations.last.name, 'Far');
+    });
+
+    test('caps results at 50 stations', () {
+      final list = <Map<String, dynamic>>[];
+      for (var i = 0; i < 120; i++) {
+        list.add({
+          'id': i,
+          'name': 'S$i',
+          'lat': 51.5 + i * 0.0001,
+          'lng': -0.12,
+          'prices': <String, dynamic>{},
+        });
+      }
+
+      final stations = parser.parseResponse(
+        {'stations': list},
+        lat: 51.5,
+        lng: -0.12,
+        radiusKm: 50,
+      );
+
+      expect(stations.length, lessThanOrEqualTo(50));
+    });
+
+    test('_parsePence returns null for null value', () {
+      expect(parser.parsePence(null), isNull);
+    });
+
+    test('_parsePence returns null for non-numeric value', () {
+      expect(parser.parsePence('abc'), isNull);
+    });
+
+    test('_parsePence converts pence (>10) to pounds', () {
+      expect(parser.parsePence(145.9), closeTo(1.459, 0.0001));
+      expect(parser.parsePence('155'), closeTo(1.55, 0.0001));
+    });
+
+    test('_parsePence keeps values <=10 unchanged (already in pounds)', () {
+      expect(parser.parsePence(1.459), 1.459);
+      expect(parser.parsePence('2.5'), 2.5);
+    });
+  });
+}
+
+/// Mirror of [UkStationService]'s parsing logic for unit-testing without HTTP.
+class _TestableUkParser {
+  List<Station> parseResponse(
+    dynamic data, {
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) {
+    List<dynamic> stationList;
+    if (data is Map<String, dynamic>) {
+      stationList = data['stations'] as List<dynamic>? ??
+          data['data'] as List<dynamic>? ??
+          [];
+    } else if (data is List) {
+      stationList = data;
+    } else {
+      return [];
+    }
+
+    final stations = <Station>[];
+    for (final item in stationList) {
+      try {
+        final location = item['location'] as Map<String, dynamic>?;
+        final itemLat =
+            (location?['latitude'] as num?)?.toDouble() ?? (item['lat'] as num?)?.toDouble();
+        final itemLng =
+            (location?['longitude'] as num?)?.toDouble() ?? (item['lng'] as num?)?.toDouble();
+        if (itemLat == null || itemLng == null) continue;
+
+        final dist = distanceKm(lat, lng, itemLat, itemLng);
+        if (dist > radiusKm) continue;
+
+        final prices = item['prices'] as Map<String, dynamic>? ?? <String, dynamic>{};
+
+        stations.add(Station(
+          id: 'uk-${item['id'] ?? item['site_id'] ?? stations.length}',
+          name: item['name']?.toString() ?? item['site_name']?.toString() ?? '',
+          brand: item['brand']?.toString() ?? '',
+          street: item['address']?.toString() ?? '',
+          postCode: item['postcode']?.toString() ?? '',
+          place: item['town']?.toString() ?? item['locality']?.toString() ?? '',
+          lat: itemLat,
+          lng: itemLng,
+          dist: dist,
+          e5: parsePence(prices['E5'] ?? prices['unleaded']),
+          e10: parsePence(prices['E10']),
+          e98: parsePence(prices['super_unleaded'] ?? prices['E5_97']),
+          diesel: parsePence(prices['B7'] ?? prices['diesel']),
+          isOpen: true,
+        ));
+      } catch (_) {
+        continue;
+      }
+    }
+
+    stations.sort((a, b) => a.dist.compareTo(b.dist));
+    return stations.take(50).toList();
+  }
+
+  double? parsePence(dynamic value) {
+    if (value == null) return null;
+    final price = double.tryParse(value.toString());
+    if (price == null) return null;
+    return price > 10 ? price / 100 : price;
+  }
 }


### PR DESCRIPTION
## What
Adds comprehensive JSON parsing unit tests for the Portugal (DGEG) and UK (CMA / checkfuelprices.co.uk) station services, which previously had only 3 smoke tests each.

## Why
Audit identified untested custom JSON parsing in country station services (#65). Of the 12 country services, 10 already had detailed test coverage; Portugal and UK were the remaining gap with only interface/smoke tests.

## Approach
Follows the `_TestableDenmarkParser` pattern already established for the Denmark service: since `PortugalStationService` and `UkStationService` instantiate `Dio` internally via `DioFactory.create()` (no constructor injection seam), the parsing logic is mirrored in a testable helper class that reproduces the exact JSON -> Station transformation.

### Portugal (`_TestablePortugalParser`)
- Well-formed DGEG response with all fuel types (95, 98, Gasóleo, GPL)
- Radius filtering (Lisbon vs Porto)
- Unparseable coordinates skipped
- Missing `Combustiveis` array handled gracefully
- Station ID fallback chain: `Id` -> `CodPosto` -> index
- Empty `resultado` / missing key
- 50-station cap
- Distance sorting
- Diesel variant matching ("Diesel" vs "Gasóleo")

### UK (`_TestableUkParser`)
- Well-formed payload with pence prices (converted to pounds)
- Prices already in pounds (<10) kept as-is
- Alternate field names (`site_id`, `site_name`, `lat`/`lng`, `unleaded`, `super_unleaded`)
- Top-level list payload vs wrapped `{stations: [...]}` / `{data: [...]}`
- Missing coordinates / prices map
- Radius filtering (London vs Edinburgh)
- Distance sorting, 50-cap
- `_parsePence` unit tests (null, non-numeric, pence, pounds)

## Testing
- 29 new tests, all passing
- `flutter analyze` clean (zero warnings/errors)
- Full test suite: 2862 pass, 1 skipped, 3 pre-existing failures unrelated to this change (Argentina API reachability — known flaky; 2 driving_mode_screen tests that fail on master too)

Closes #65