### PR TITLE
fix(test): update DrivingMarkerBuilder test dimensions to match #291

### DIFF
--- a/test/features/driving/presentation/screens/driving_mode_screen_test.dart
+++ b/test/features/driving/presentation/screens/driving_mode_screen_test.dart
@@ -254,8 +254,8 @@ void main() {
         onTap: () {},
       );
 
-      expect(marker.width, 120);
-      expect(marker.height, 56);
+      expect(marker.width, 150);
+      expect(marker.height, 62);
       expect(marker.point.latitude, testStation.lat);
       expect(marker.point.longitude, testStation.lng);
     });
@@ -306,8 +306,8 @@ void main() {
         onTap: () {},
       );
 
-      expect(marker.width, 120);
-      expect(marker.height, 56);
+      expect(marker.width, 150);
+      expect(marker.height, 62);
     });
   });
 


### PR DESCRIPTION
## Summary
PR #291 changed driving marker dimensions (width 120→150, height 56→62) but didn't update the corresponding tests in `driving_mode_screen_test.dart`. This caused CI failures on every parallel branch.

## Test plan
- [x] Local: 17 tests pass in driving_mode_screen_test.dart
- [ ] CI green