### PR TITLE
fix(search): Prix-Carburants postal-code path now respects radius

### DIFF
--- a/lib/core/services/impl/prix_carburants_station_service.dart
+++ b/lib/core/services/impl/prix_carburants_station_service.dart
@@ -54,11 +54,17 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     }
 
     // Parse all results into Station objects
-    final stations = <Station>[];
+    final parsed = <Station>[];
     for (final r in allResults) {
       final station = _parseStation(r, params.lat, params.lng);
-      if (station != null) stations.add(station);
+      if (station != null) parsed.add(station);
     }
+
+    // Filter by radius. The postal-code query (`cp='...'`) returns every
+    // station sharing that code regardless of distance, so without this
+    // post-filter the `radiusKm` parameter would be silently ignored on
+    // the CP path — bug #298.
+    final stations = filterByRadius(parsed, params.radiusKm);
 
     // Sort
     sortStations(stations, params);
@@ -104,12 +110,14 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     double lat, double lng, double radiusKm, {CancelToken? cancelToken}
   ) async {
     // Use within_distance with km unit — the distance() function with meters
-    // is unreliable on this API and often returns 0 results.
-    final radiusInt = radiusKm.round();
+    // is unreliable on this API and often returns 0 results. Preserve one
+    // decimal of precision so sub-km radius selections aren't silently
+    // rounded to the nearest integer.
+    final radiusStr = radiusKm.toStringAsFixed(1);
     try {
       final response = await _dio.get(_baseUrl, queryParameters: {
         'where':
-            "within_distance(geom,geom'POINT($lng $lat)',${radiusInt}km)",
+            "within_distance(geom,geom'POINT($lng $lat)',${radiusStr}km)",
         'limit': 50,
       }, cancelToken: cancelToken);
       return _extractResults(response.data);

--- a/test/core/services/impl/prix_carburants_station_service_test.dart
+++ b/test/core/services/impl/prix_carburants_station_service_test.dart
@@ -698,6 +698,135 @@ void main() {
       expect(result.data, hasLength(2));
     });
   });
+
+  group('PrixCarburantsStationService radius filtering (#298)', () {
+    // Origin: Castelnau de Guers, France (43.45, 3.42).
+    // Stations placed at roughly 0.3, 1.5, 5, 12, 20 km from origin.
+    // Using latitude offsets only: 1° lat ≈ 111 km.
+    Map<String, dynamic> scatteredStations(String cp) {
+      const originLat = 43.45;
+      const originLng = 3.42;
+      double latFor(double km) => originLat + (km / 111.0);
+      return {
+        'results': [
+          {
+            'id': '${cp}01',
+            'adresse': 'Station A',
+            'cp': cp,
+            'geom': {'lat': latFor(0.3), 'lon': originLng},
+            'sp95_prix': 1.80,
+          },
+          {
+            'id': '${cp}02',
+            'adresse': 'Station B',
+            'cp': cp,
+            'geom': {'lat': latFor(1.5), 'lon': originLng},
+            'sp95_prix': 1.82,
+          },
+          {
+            'id': '${cp}03',
+            'adresse': 'Station C',
+            'cp': cp,
+            'geom': {'lat': latFor(5.0), 'lon': originLng},
+            'sp95_prix': 1.84,
+          },
+          {
+            'id': '${cp}04',
+            'adresse': 'Station D',
+            'cp': cp,
+            'geom': {'lat': latFor(12.0), 'lon': originLng},
+            'sp95_prix': 1.86,
+          },
+          {
+            'id': '${cp}05',
+            'adresse': 'Station E',
+            'cp': cp,
+            'geom': {'lat': latFor(20.0), 'lon': originLng},
+            'sp95_prix': 1.88,
+          },
+        ],
+      };
+    }
+
+    test('postal-code path filters stations by radius (regression #298)', () async {
+      final adapter = _TrackingMockAdapter()
+        ..addResponse(scatteredStations('34120'));
+
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      // 2 km radius: should keep only Station A (0.3 km) and Station B (1.5 km).
+      final result = await svc.searchStations(const SearchParams(
+        lat: 43.45, lng: 3.42, radiusKm: 2.0, postalCode: '34120',
+      ));
+
+      expect(adapter.lastRequestUri, contains('cp%3D%2734120%27'),
+          reason: 'should have taken the postal-code path');
+      expect(result.data.map((s) => s.id).toList(), ['3412001', '3412002'],
+          reason: 'only stations within 2 km should remain');
+      for (final s in result.data) {
+        expect(s.dist, lessThanOrEqualTo(2.0));
+      }
+    });
+
+    test('postal-code path with different radii returns different result counts (#298)', () async {
+      final adapter = _TrackingMockAdapter()
+        ..addResponse(scatteredStations('34120'))
+        ..addResponse(scatteredStations('34120'));
+
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      final narrow = await svc.searchStations(const SearchParams(
+        lat: 43.45, lng: 3.42, radiusKm: 1.0, postalCode: '34120',
+      ));
+      final wide = await svc.searchStations(const SearchParams(
+        lat: 43.45, lng: 3.42, radiusKm: 25.0, postalCode: '34120',
+      ));
+
+      // Core contract: the radius parameter must actually narrow results.
+      expect(narrow.data.length, lessThan(wide.data.length),
+          reason: 'radius=1km must return fewer stations than radius=25km');
+      expect(narrow.data.length, 1, reason: 'only the 0.3 km station fits in 1 km');
+      expect(wide.data.length, 5, reason: 'all 5 stations fit in 25 km');
+    });
+
+    test('geo path preserves decimal radius (no integer rounding) (#298)', () async {
+      final adapter = _TrackingMockAdapter()
+        ..addResponse({'results': []});
+
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      await svc.searchStations(const SearchParams(
+        lat: 43.45, lng: 3.42, radiusKm: 1.4,
+      ));
+
+      // Previous behaviour: radiusKm.round() → "1km", losing sub-km precision.
+      // Fixed: the URL must contain the exact decimal value.
+      expect(adapter.lastRequestUri, contains('1.4km'),
+          reason: 'decimal radius must be preserved in the geo query');
+      expect(adapter.lastRequestUri, isNot(contains('1km')),
+          reason: 'must not round to integer km');
+    });
+
+    test('geo path without postal code also respects radius (#298)', () async {
+      final adapter = _TrackingMockAdapter()
+        ..addResponse(scatteredStations('34120'));
+
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      // GPS search with no CP → geo-only path. Even so, the helper
+      // should filter anything the API returned beyond the radius.
+      final result = await svc.searchStations(const SearchParams(
+        lat: 43.45, lng: 3.42, radiusKm: 2.0,
+      ));
+
+      expect(adapter.lastRequestUri, contains('within_distance'));
+      expect(result.data.map((s) => s.id).toList(), ['3412001', '3412002']);
+    });
+  });
 }
 
 /// Mock Dio adapter that tracks requests and returns canned responses.


### PR DESCRIPTION
## Summary
Critical regression: changing the search radius (1 km vs 25 km) returned the **same results** for French users. Root cause was in `PrixCarburantsStationService`:

1. **Postal-code path ignored `radiusKm`.** The `where: cp='XXXXX'` query returns every station sharing that postal code regardless of distance, and the result was never post-filtered. Since GPS searches in France reverse-geocode a postal code before calling the service, every radius value produced the same result set.
2. **Geo path rounded `radiusKm` to an integer.** Sub-km slider values (e.g. 1.4 km) silently snapped to the nearest km.

## Fix
- Post-filter parsed stations through `filterByRadius(params.radiusKm)` on both the CP and geo paths.
- Preserve decimal precision in `_queryByGeo` (`toStringAsFixed(1)` instead of `round()`).

## Tests added
4 regression tests in `prix_carburants_station_service_test.dart`:
- Postal-code path filters stations by radius (only stations within 2 km remain from a 5-station scatter at 0.3/1.5/5/12/20 km)
- 1 km vs 25 km returns strictly different result counts (1 vs 5)
- Geo path preserves decimal radius in the URL (`1.4km`, not `1km`)
- Geo-only path (no postal code) also respects radius

## Test plan
- [x] `flutter test test/core/services/impl/prix_carburants_station_service_test.dart` — all 51 tests pass including the 4 new ones
- [x] `flutter analyze --no-fatal-infos` — no new warnings/errors
- [x] Existing Prix-Carburants search-strategy tests still pass
- [ ] Manual verification on-device: slider 1 km vs 25 km now returns different result sets

## Related
- Test-gap issue that lets similar bugs slip through again: #299

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)