### PR TITLE
refactor: eliminate setState in sync/auth/route forms via Riverpod

### DIFF
--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -11,12 +11,17 @@ import '../../../../core/utils/frame_callbacks.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/route_info.dart';
+import '../../providers/route_input_provider.dart';
 import 'city_autocomplete_field.dart';
 
 /// Input widget for route-based search: start, optional stops, destination.
 ///
 /// All fields share the same Nominatim-backed city autocomplete via
 /// [CityAutocompleteField], reusing the existing [LocationSearchService].
+///
+/// State lives in [routeInputControllerProvider]; only the non-shareable
+/// [TextEditingController]s stay in this widget because they must follow
+/// Flutter's lifecycle rules.
 class RouteInput extends ConsumerStatefulWidget {
   final void Function(List<RouteWaypoint> waypoints) onSearch;
 
@@ -31,18 +36,15 @@ class _RouteInputState extends ConsumerState<RouteInput> {
   final _endController = TextEditingController();
   final _stopControllers = <TextEditingController>[];
 
-  LatLng? _startCoords;
-  LatLng? _endCoords;
-  final _stopCoords = <LatLng?>[];
-
-  bool _isSearching = false;
   bool _autoGpsTriggered = false;
 
   @override
   void initState() {
     super.initState();
-    // Auto-fill start with current position so user doesn't have to tap GPS
+    // Reset shared provider state for a fresh widget instance.
     safePostFrame(() {
+      if (!mounted) return;
+      ref.read(routeInputControllerProvider.notifier).reset();
       if (!_autoGpsTriggered) {
         _autoGpsTriggered = true;
         _useGpsForStart();
@@ -64,11 +66,11 @@ class _RouteInputState extends ConsumerState<RouteInput> {
     try {
       final locationService = ref.read(locationServiceProvider);
       final position = await locationService.getCurrentPosition();
-      _startCoords = LatLng(position.latitude, position.longitude);
       if (!mounted) return;
+      final coords = LatLng(position.latitude, position.longitude);
+      ref.read(routeInputControllerProvider.notifier).setStartCoords(coords);
       final l10n = AppLocalizations.of(context);
       _startController.text = l10n?.currentLocation ?? 'Current location';
-      setState(() {});
     } catch (e) {
       if (mounted) {
         final l10n = AppLocalizations.of(context);
@@ -79,63 +81,84 @@ class _RouteInputState extends ConsumerState<RouteInput> {
   }
 
   void _addStop() {
-    setState(() {
-      _stopControllers.add(TextEditingController());
-      _stopCoords.add(null);
-    });
+    _stopControllers.add(TextEditingController());
+    ref.read(routeInputControllerProvider.notifier).addStop();
   }
 
   void _removeStop(int index) {
-    setState(() {
-      _stopControllers[index].dispose();
-      _stopControllers.removeAt(index);
-      _stopCoords.removeAt(index);
-    });
+    _stopControllers[index].dispose();
+    _stopControllers.removeAt(index);
+    ref.read(routeInputControllerProvider.notifier).removeStop(index);
   }
 
-  void _onCitySelected(ResolvedLocation city,
-      TextEditingController controller, void Function(LatLng) setCoords) {
-    controller.text = city.name;
-    setCoords(LatLng(city.lat, city.lng));
-    setState(() {});
+  void _onStartCitySelected(ResolvedLocation city) {
+    _startController.text = city.name;
+    ref
+        .read(routeInputControllerProvider.notifier)
+        .setStartCoords(LatLng(city.lat, city.lng));
+  }
+
+  void _onEndCitySelected(ResolvedLocation city) {
+    _endController.text = city.name;
+    ref
+        .read(routeInputControllerProvider.notifier)
+        .setEndCoords(LatLng(city.lat, city.lng));
+  }
+
+  void _onStopCitySelected(int i, ResolvedLocation city) {
+    _stopControllers[i].text = city.name;
+    ref
+        .read(routeInputControllerProvider.notifier)
+        .setStopCoord(i, LatLng(city.lat, city.lng));
   }
 
   Future<void> _resolveAndSearch() async {
-    if (_isSearching) return;
-    setState(() => _isSearching = true);
+    final routeState = ref.read(routeInputControllerProvider);
+    if (routeState.isSearching) return;
+    final notifier = ref.read(routeInputControllerProvider.notifier);
+    notifier.setSearching(true);
 
     try {
       final searchService = ref.read(locationSearchServiceProvider);
 
+      var startCoords = routeState.startCoords;
+      var endCoords = routeState.endCoords;
+      final stopCoords = List<LatLng?>.from(routeState.stopCoords);
+
       // Resolve start if needed
-      if (_startCoords == null && _startController.text.isNotEmpty) {
+      if (startCoords == null && _startController.text.isNotEmpty) {
         final results =
             await searchService.searchCities(_startController.text);
         if (results.isNotEmpty) {
-          _startCoords = LatLng(results.first.lat, results.first.lng);
+          startCoords = LatLng(results.first.lat, results.first.lng);
+          notifier.setStartCoords(startCoords);
         }
       }
 
       // Resolve end if needed
-      if (_endCoords == null && _endController.text.isNotEmpty) {
+      if (endCoords == null && _endController.text.isNotEmpty) {
         final results = await searchService.searchCities(_endController.text);
         if (results.isNotEmpty) {
-          _endCoords = LatLng(results.first.lat, results.first.lng);
+          endCoords = LatLng(results.first.lat, results.first.lng);
+          notifier.setEndCoords(endCoords);
         }
       }
 
       // Resolve stops
       for (var i = 0; i < _stopControllers.length; i++) {
-        if (_stopCoords[i] == null && _stopControllers[i].text.isNotEmpty) {
+        if (i < stopCoords.length &&
+            stopCoords[i] == null &&
+            _stopControllers[i].text.isNotEmpty) {
           final results =
               await searchService.searchCities(_stopControllers[i].text);
           if (results.isNotEmpty) {
-            _stopCoords[i] = LatLng(results.first.lat, results.first.lng);
+            stopCoords[i] = LatLng(results.first.lat, results.first.lng);
+            notifier.setStopCoord(i, stopCoords[i]);
           }
         }
       }
 
-      if (_startCoords == null || _endCoords == null) {
+      if (startCoords == null || endCoords == null) {
         if (mounted) {
           SnackBarHelper.showError(
               context,
@@ -147,20 +170,20 @@ class _RouteInputState extends ConsumerState<RouteInput> {
 
       final waypoints = <RouteWaypoint>[
         RouteWaypoint(
-          lat: _startCoords!.latitude,
-          lng: _startCoords!.longitude,
+          lat: startCoords.latitude,
+          lng: startCoords.longitude,
           label: _startController.text,
         ),
-        for (var i = 0; i < _stopCoords.length; i++)
-          if (_stopCoords[i] != null)
+        for (var i = 0; i < stopCoords.length; i++)
+          if (stopCoords[i] != null)
             RouteWaypoint(
-              lat: _stopCoords[i]!.latitude,
-              lng: _stopCoords[i]!.longitude,
+              lat: stopCoords[i]!.latitude,
+              lng: stopCoords[i]!.longitude,
               label: _stopControllers[i].text,
             ),
         RouteWaypoint(
-          lat: _endCoords!.latitude,
-          lng: _endCoords!.longitude,
+          lat: endCoords.latitude,
+          lng: endCoords.longitude,
           label: _endController.text,
         ),
       ];
@@ -172,7 +195,7 @@ class _RouteInputState extends ConsumerState<RouteInput> {
             '${AppLocalizations.of(context)?.errorUnknown ?? "Error"}: $e');
       }
     } finally {
-      if (mounted) setState(() => _isSearching = false);
+      if (mounted) notifier.setSearching(false);
     }
   }
 
@@ -181,6 +204,7 @@ class _RouteInputState extends ConsumerState<RouteInput> {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final searchService = ref.watch(locationSearchServiceProvider);
+    final routeState = ref.watch(routeInputControllerProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -197,10 +221,9 @@ class _RouteInputState extends ConsumerState<RouteInput> {
             onPressed: _useGpsForStart,
             tooltip: l10n?.useGps ?? 'Use GPS',
           ),
-          onCitySelected: (city) => _onCitySelected(
-            city, _startController, (c) => _startCoords = c,
-          ),
-          onTextChanged: () => _startCoords = null,
+          onCitySelected: _onStartCitySelected,
+          onTextChanged: () =>
+              ref.read(routeInputControllerProvider.notifier).setStartCoords(null),
         ),
         const SizedBox(height: 6),
 
@@ -218,10 +241,10 @@ class _RouteInputState extends ConsumerState<RouteInput> {
                 icon: const Icon(Icons.close, size: 16),
                 onPressed: () => _removeStop(i),
               ),
-              onCitySelected: (city) => _onCitySelected(
-                city, _stopControllers[i], (c) => _stopCoords[i] = c,
-              ),
-              onTextChanged: () => _stopCoords[i] = null,
+              onCitySelected: (city) => _onStopCitySelected(i, city),
+              onTextChanged: () => ref
+                  .read(routeInputControllerProvider.notifier)
+                  .setStopCoord(i, null),
             ),
           ),
 
@@ -248,29 +271,33 @@ class _RouteInputState extends ConsumerState<RouteInput> {
           label: l10n?.destination ?? 'Destination',
           hint: l10n?.cityOrAddress ?? 'City or address',
           prefixIcon: Icons.place,
-          onCitySelected: (city) => _onCitySelected(
-            city, _endController, (c) => _endCoords = c,
-          ),
-          onTextChanged: () => _endCoords = null,
+          onCitySelected: _onEndCitySelected,
+          onTextChanged: () =>
+              ref.read(routeInputControllerProvider.notifier).setEndCoords(null),
         ),
         const SizedBox(height: 8),
 
-        // Search button
-        FilledButton.icon(
-          onPressed: (_startController.text.isNotEmpty &&
-                  _endController.text.isNotEmpty &&
-                  !_isSearching)
-              ? _resolveAndSearch
-              : null,
-          icon: _isSearching
-              ? const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(
-                      strokeWidth: 2, color: Colors.white),
-                )
-              : const Icon(Icons.route),
-          label: Text(l10n?.searchAlongRoute ?? 'Search along route'),
+        // Search button — listens to controllers so it enables as the user
+        // types, without needing setState.
+        ListenableBuilder(
+          listenable: Listenable.merge([_startController, _endController]),
+          builder: (context, _) {
+            final canSearch = _startController.text.isNotEmpty &&
+                _endController.text.isNotEmpty &&
+                !routeState.isSearching;
+            return FilledButton.icon(
+              onPressed: canSearch ? _resolveAndSearch : null,
+              icon: routeState.isSearching
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                          strokeWidth: 2, color: Colors.white),
+                    )
+                  : const Icon(Icons.route),
+              label: Text(l10n?.searchAlongRoute ?? 'Search along route'),
+            );
+          },
         ),
       ],
     );

--- a/lib/features/route_search/providers/route_input_provider.dart
+++ b/lib/features/route_search/providers/route_input_provider.dart
@@ -1,0 +1,94 @@
+import 'package:latlong2/latlong.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'route_input_provider.g.dart';
+
+/// State for the route input widget: resolved coordinates for start/end/stops
+/// plus the number of stops and the in-flight search flag.
+///
+/// Text field values are kept in local `TextEditingController`s (must live in
+/// a `StatefulWidget` for lifecycle reasons). Everything else is here so that
+/// widget rebuilds are selective and setState is avoided.
+class RouteInputState {
+  final LatLng? startCoords;
+  final LatLng? endCoords;
+  final List<LatLng?> stopCoords;
+  final int stopCount;
+  final bool isSearching;
+
+  const RouteInputState({
+    this.startCoords,
+    this.endCoords,
+    this.stopCoords = const [],
+    this.stopCount = 0,
+    this.isSearching = false,
+  });
+
+  RouteInputState copyWith({
+    LatLng? startCoords,
+    bool clearStartCoords = false,
+    LatLng? endCoords,
+    bool clearEndCoords = false,
+    List<LatLng?>? stopCoords,
+    int? stopCount,
+    bool? isSearching,
+  }) {
+    return RouteInputState(
+      startCoords:
+          clearStartCoords ? null : (startCoords ?? this.startCoords),
+      endCoords: clearEndCoords ? null : (endCoords ?? this.endCoords),
+      stopCoords: stopCoords ?? this.stopCoords,
+      stopCount: stopCount ?? this.stopCount,
+      isSearching: isSearching ?? this.isSearching,
+    );
+  }
+}
+
+@riverpod
+class RouteInputController extends _$RouteInputController {
+  @override
+  RouteInputState build() => const RouteInputState();
+
+  void setStartCoords(LatLng? coords) {
+    state = state.copyWith(
+      startCoords: coords,
+      clearStartCoords: coords == null,
+    );
+  }
+
+  void setEndCoords(LatLng? coords) {
+    state = state.copyWith(
+      endCoords: coords,
+      clearEndCoords: coords == null,
+    );
+  }
+
+  void setStopCoord(int index, LatLng? coords) {
+    final updated = List<LatLng?>.from(state.stopCoords);
+    if (index >= 0 && index < updated.length) {
+      updated[index] = coords;
+      state = state.copyWith(stopCoords: updated);
+    }
+  }
+
+  void addStop() {
+    final updated = List<LatLng?>.from(state.stopCoords)..add(null);
+    state =
+        state.copyWith(stopCoords: updated, stopCount: state.stopCount + 1);
+  }
+
+  void removeStop(int index) {
+    if (index < 0 || index >= state.stopCoords.length) return;
+    final updated = List<LatLng?>.from(state.stopCoords)..removeAt(index);
+    state =
+        state.copyWith(stopCoords: updated, stopCount: state.stopCount - 1);
+  }
+
+  void setSearching(bool value) {
+    state = state.copyWith(isSearching: value);
+  }
+
+  void reset() {
+    state = const RouteInputState();
+  }
+}

--- a/lib/features/route_search/providers/route_input_provider.g.dart
+++ b/lib/features/route_search/providers/route_input_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'route_input_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(RouteInputController)
+final routeInputControllerProvider = RouteInputControllerProvider._();
+
+final class RouteInputControllerProvider
+    extends $NotifierProvider<RouteInputController, RouteInputState> {
+  RouteInputControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'routeInputControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$routeInputControllerHash();
+
+  @$internal
+  @override
+  RouteInputController create() => RouteInputController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RouteInputState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RouteInputState>(value),
+    );
+  }
+}
+
+String _$routeInputControllerHash() =>
+    r'7475ef51597913a7fd8ff142ebff9d31618f2c9e';
+
+abstract class _$RouteInputController extends $Notifier<RouteInputState> {
+  RouteInputState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<RouteInputState, RouteInputState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<RouteInputState, RouteInputState>,
+              RouteInputState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -26,7 +26,7 @@ import 'sort_selector.dart';
 import 'swipeable_station_card.dart';
 
 /// Station list with sort controls, refresh, count bar, and search location header.
-class SearchResultsList extends ConsumerStatefulWidget {
+class SearchResultsList extends ConsumerWidget {
   final ServiceResult<List<Station>> result;
   final VoidCallback onRefresh;
 
@@ -35,13 +35,6 @@ class SearchResultsList extends ConsumerStatefulWidget {
     required this.result,
     required this.onRefresh,
   });
-
-  @override
-  ConsumerState<SearchResultsList> createState() => _SearchResultsListState();
-}
-
-class _SearchResultsListState extends ConsumerState<SearchResultsList> {
-  SortMode _sortMode = SortMode.distance;
 
   void _openStationInMaps(Station station) {
     NavigationUtils.openInMaps(
@@ -97,11 +90,12 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList> {
     return (minP, maxP);
   }
 
-  List<Station> _sortStations(List<Station> stations) {
+  List<Station> _sortStations(
+      List<Station> stations, SortMode sortMode, WidgetRef ref) {
     final sorted = List<Station>.from(stations);
     final fuelType = ref.read(selectedFuelTypeProvider);
 
-    switch (_sortMode) {
+    switch (sortMode) {
       case SortMode.distance:
         sorted.sort((a, b) => a.dist.compareTo(b.dist));
       case SortMode.price:
@@ -120,10 +114,10 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    final result = widget.result;
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final ignoredIds = ref.watch(ignoredStationsProvider);
+    final sortMode = ref.watch(selectedSortModeProvider);
 
     return Column(
       children: [
@@ -170,8 +164,9 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList> {
         ),
         const CrossBorderBanner(),
         SortSelector(
-          selected: _sortMode,
-          onChanged: (mode) => setState(() => _sortMode = mode),
+          selected: sortMode,
+          onChanged: (mode) =>
+              ref.read(selectedSortModeProvider.notifier).set(mode),
         ),
         _CollapsibleBrandFilters(
           stations: result.data
@@ -180,7 +175,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList> {
         ),
         Expanded(
           child: RefreshIndicator(
-            onRefresh: () async => widget.onRefresh(),
+            onRefresh: () async => onRefresh(),
             child: Builder(builder: (context) {
               // Filter out ignored stations
               final afterIgnored = result.data
@@ -195,7 +190,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList> {
                 selectedBrands: selectedBrands,
                 excludeHighway: excludeHighway,
               );
-              final sorted = _sortStations(filtered);
+              final sorted = _sortStations(filtered, sortMode, ref);
               final allPrices = ref.watch(allPricesViewEnabledProvider);
               final cheapestMap = allPrices
                   ? _computeCheapestFlags(sorted)

--- a/lib/features/search/providers/search_screen_ui_provider.dart
+++ b/lib/features/search/providers/search_screen_ui_provider.dart
@@ -1,7 +1,17 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../route_search/domain/route_search_strategy.dart';
+import '../presentation/widgets/sort_selector.dart';
 
 part 'search_screen_ui_provider.g.dart';
+
+/// The currently selected sort mode for the search results list.
+@riverpod
+class SelectedSortMode extends _$SelectedSortMode {
+  @override
+  SortMode build() => SortMode.distance;
+
+  void set(SortMode value) => state = value;
+}
 
 /// Whether the filter section (fuel type + radius) is expanded on the search
 /// screen. Starts expanded; collapses automatically when a search is triggered

--- a/lib/features/search/providers/search_screen_ui_provider.g.dart
+++ b/lib/features/search/providers/search_screen_ui_provider.g.dart
@@ -8,6 +8,64 @@ part of 'search_screen_ui_provider.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// The currently selected sort mode for the search results list.
+
+@ProviderFor(SelectedSortMode)
+final selectedSortModeProvider = SelectedSortModeProvider._();
+
+/// The currently selected sort mode for the search results list.
+final class SelectedSortModeProvider
+    extends $NotifierProvider<SelectedSortMode, SortMode> {
+  /// The currently selected sort mode for the search results list.
+  SelectedSortModeProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'selectedSortModeProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$selectedSortModeHash();
+
+  @$internal
+  @override
+  SelectedSortMode create() => SelectedSortMode();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SortMode value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SortMode>(value),
+    );
+  }
+}
+
+String _$selectedSortModeHash() => r'bee5aedaae37772d7269ada2fc72fa69f071a22d';
+
+/// The currently selected sort mode for the search results list.
+
+abstract class _$SelectedSortMode extends $Notifier<SortMode> {
+  SortMode build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<SortMode, SortMode>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<SortMode, SortMode>,
+              SortMode,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
 /// Whether the filter section (fuel type + radius) is expanded on the search
 /// screen. Starts expanded; collapses automatically when a search is triggered
 /// and in landscape orientation.

--- a/lib/features/sync/presentation/screens/auth_screen.dart
+++ b/lib/features/sync/presentation/screens/auth_screen.dart
@@ -8,6 +8,7 @@ import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/utils/password_validator.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../providers/auth_form_provider.dart';
 import '../widgets/auth_info_card.dart';
 import '../widgets/auth_status_cards.dart';
 import '../widgets/email_auth_card.dart';
@@ -21,6 +22,10 @@ import '../widgets/email_auth_card.dart';
 /// - Confirm password on sign-up
 /// - Proper error messages
 /// - Works for all sync modes (community, private, joinExisting)
+///
+/// Form state (toggles, loading, error) lives in [authFormControllerProvider];
+/// only [TextEditingController]s remain local because they must follow
+/// Flutter's widget lifecycle.
 class AuthScreen extends ConsumerStatefulWidget {
   const AuthScreen({super.key});
 
@@ -32,11 +37,17 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _confirmController = TextEditingController();
-  bool _isSignUp = true;
-  bool _isLoading = false;
-  bool _showPassword = false;
-  bool _showConfirm = false;
-  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    // Reset shared form state for a fresh screen instance.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        ref.read(authFormControllerProvider.notifier).reset();
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -46,11 +57,11 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     super.dispose();
   }
 
+  AuthFormController get _formNotifier =>
+      ref.read(authFormControllerProvider.notifier);
+
   Future<void> _continueAsGuest() async {
-    setState(() {
-      _isLoading = true;
-      _error = null;
-    });
+    _formNotifier.setLoading(true);
     try {
       final userId = await TankSyncClient.signInAnonymously();
       if (userId != null) {
@@ -66,50 +77,48 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
         }
       }
     } catch (e) {
-      setState(() => _error = e.toString());
+      _formNotifier.setError(e.toString());
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      _formNotifier.setLoading(false);
     }
   }
 
   Future<void> _submitEmail() async {
     final email = _emailController.text.trim();
     final password = _passwordController.text;
+    final isSignUp = ref.read(authFormControllerProvider).isSignUp;
 
     if (email.isEmpty || password.isEmpty) {
-      setState(() => _error = 'Please enter email and password');
+      _formNotifier.setError('Please enter email and password');
       return;
     }
     if (!email.contains('@')) {
-      setState(() => _error = 'Please enter a valid email address');
+      _formNotifier.setError('Please enter a valid email address');
       return;
     }
-    if (_isSignUp && !PasswordValidator.isValid(password)) {
+    if (isSignUp && !PasswordValidator.isValid(password)) {
       final l10n = AppLocalizations.of(context);
-      setState(() => _error =
+      _formNotifier.setError(
           l10n?.passwordTooWeak ?? 'Password does not meet all requirements');
       return;
     }
-    if (_isSignUp && password != _confirmController.text) {
-      setState(() => _error = 'Passwords do not match');
+    if (isSignUp && password != _confirmController.text) {
+      _formNotifier.setError('Passwords do not match');
       return;
     }
 
-    setState(() {
-      _isLoading = true;
-      _error = null;
-    });
+    _formNotifier.setLoading(true);
     try {
       await ref.read(syncStateProvider.notifier).signInWithEmail(
             email, password,
-            isSignUp: _isSignUp,
+            isSignUp: isSignUp,
           );
 
       if (mounted) {
         final l10n = AppLocalizations.of(context);
         SnackBarHelper.showSuccess(
             context,
-            _isSignUp
+            isSignUp
                 ? (l10n?.accountCreated ?? 'Account created!')
                 : (l10n?.signedIn ?? 'Signed in!'));
         context.pop();
@@ -127,18 +136,15 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
           errorMsg =
               'Please check your email and confirm your account first.';
         }
-        setState(() => _error = errorMsg);
+        _formNotifier.setError(errorMsg);
       }
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      _formNotifier.setLoading(false);
     }
   }
 
   Future<void> _switchToAnonymous() async {
-    setState(() {
-      _isLoading = true;
-      _error = null;
-    });
+    _formNotifier.setLoading(true);
     try {
       await ref.read(syncStateProvider.notifier).switchToAnonymous();
       if (mounted) {
@@ -149,9 +155,9 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
         context.pop();
       }
     } catch (e) {
-      setState(() => _error = e.toString());
+      _formNotifier.setError(e.toString());
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      _formNotifier.setLoading(false);
     }
   }
 
@@ -160,6 +166,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final syncConfig = ref.watch(syncStateProvider);
+    final form = ref.watch(authFormControllerProvider);
     final isEmailUser = syncConfig.hasEmail;
 
     return Scaffold(
@@ -171,12 +178,12 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
           if (isEmailUser)
             EmailUserStatusCard(
               userEmail: syncConfig.userEmail,
-              isLoading: _isLoading,
+              isLoading: form.isLoading,
               onSwitchToAnonymous: _switchToAnonymous,
             )
           else if (!TankSyncClient.isConnected)
             GuestOptionCard(
-              isLoading: _isLoading,
+              isLoading: form.isLoading,
               onContinueAsGuest: _continueAsGuest,
             )
           else
@@ -187,25 +194,22 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
               emailController: _emailController,
               passwordController: _passwordController,
               confirmController: _confirmController,
-              isSignUp: _isSignUp,
-              isLoading: _isLoading,
-              showPassword: _showPassword,
-              showConfirm: _showConfirm,
-              error: _error,
+              isSignUp: form.isSignUp,
+              isLoading: form.isLoading,
+              showPassword: form.showPassword,
+              showConfirm: form.showConfirm,
+              error: form.error,
               onSubmit: _submitEmail,
-              onToggleMode: () => setState(() {
-                _isSignUp = !_isSignUp;
+              onToggleMode: () {
                 _confirmController.clear();
-                _error = null;
-              }),
-              onTogglePassword: () =>
-                  setState(() => _showPassword = !_showPassword),
-              onToggleConfirm: () =>
-                  setState(() => _showConfirm = !_showConfirm),
-              onPasswordChanged: () => setState(() {}),
+                _formNotifier.toggleSignUp();
+              },
+              onTogglePassword: _formNotifier.togglePassword,
+              onToggleConfirm: _formNotifier.toggleConfirm,
+              onPasswordChanged: _formNotifier.touch,
             ),
 
-          if (isEmailUser && _error != null) ...[
+          if (isEmailUser && form.error != null) ...[
             const SizedBox(height: 8),
             Card(
               color: theme.colorScheme.error.withValues(alpha: 0.1),
@@ -217,7 +221,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                         size: 16, color: theme.colorScheme.error),
                     const SizedBox(width: 8),
                     Expanded(
-                        child: Text(_error!,
+                        child: Text(form.error!,
                             style: TextStyle(
                                 color: theme.colorScheme.error, fontSize: 12))),
                   ],

--- a/lib/features/sync/presentation/screens/sync_wizard_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_wizard_screen.dart
@@ -10,6 +10,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../../core/sync/schema_verifier.dart';
 import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/sync/sync_provider.dart';
+import '../../providers/sync_wizard_provider.dart';
 import '../widgets/anon_key_field.dart';
 import '../widgets/qr_scanner_screen.dart';
 import '../widgets/wizard_auth_step.dart';
@@ -26,6 +27,9 @@ import '../widgets/wizard_schema_step.dart';
 ///
 /// After connecting, verifies the database schema and guides the user
 /// to deploy missing tables if needed.
+///
+/// Wizard state (mode, toggles, progress) lives in
+/// [syncWizardControllerProvider]; only text controllers remain local.
 class SyncWizardScreen extends ConsumerStatefulWidget {
   const SyncWizardScreen({super.key});
 
@@ -33,26 +37,21 @@ class SyncWizardScreen extends ConsumerStatefulWidget {
   ConsumerState<SyncWizardScreen> createState() => _SyncWizardScreenState();
 }
 
-enum _WizardMode { choose, createNew, joinExisting, auth, schema }
-
 class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
-  _WizardMode _mode = _WizardMode.choose;
-  int _createStep = 0;
-
   final _urlController = TextEditingController();
   final _keyController = TextEditingController();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
 
-  bool _testing = false;
-  bool _connecting = false;
-  bool _isSignUp = true;
-  bool _useEmail = false;
-  String? _testResult;
-  bool _testSuccess = false;
-  Map<String, bool>? _schemaStatus;
-  String? _migrationSql;
-  bool _showKey = false;
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        ref.read(syncWizardControllerProvider.notifier).reset();
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -63,12 +62,17 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
     super.dispose();
   }
 
+  SyncWizardController get _notifier =>
+      ref.read(syncWizardControllerProvider.notifier);
+
   Widget _buildKeyField() {
+    final showKey =
+        ref.watch(syncWizardControllerProvider.select((s) => s.showKey));
     return AnonKeyField(
       controller: _keyController,
-      showKey: _showKey,
-      onToggleVisibility: () => setState(() => _showKey = !_showKey),
-      onChanged: () => setState(() {}),
+      showKey: showKey,
+      onToggleVisibility: _notifier.toggleKeyVisibility,
+      onChanged: _notifier.touch,
     );
   }
 
@@ -95,18 +99,19 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final wizard = ref.watch(syncWizardControllerProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text('Connect TankSync'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () {
-            if (_mode == _WizardMode.choose) {
+            if (wizard.mode == SyncWizardMode.choose) {
               Navigator.pop(context);
-            } else if (_mode == _WizardMode.schema) {
-              setState(() => _mode = _WizardMode.auth);
+            } else if (wizard.mode == SyncWizardMode.schema) {
+              _notifier.setMode(SyncWizardMode.auth);
             } else {
-              setState(() => _mode = _WizardMode.choose);
+              _notifier.setMode(SyncWizardMode.choose);
             }
           },
         ),
@@ -114,56 +119,57 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
       body: ListView(
         padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + MediaQuery.of(context).viewPadding.bottom),
         children: [
-          if (_mode == _WizardMode.choose)
+          if (wizard.mode == SyncWizardMode.choose)
             WizardChooseMode(
-              onCreateNew: () => setState(() => _mode = _WizardMode.createNew),
-              onJoinExisting: () => setState(() => _mode = _WizardMode.joinExisting),
+              onCreateNew: () => _notifier.setMode(SyncWizardMode.createNew),
+              onJoinExisting: () =>
+                  _notifier.setMode(SyncWizardMode.joinExisting),
             ),
-          if (_mode == _WizardMode.createNew)
+          if (wizard.mode == SyncWizardMode.createNew)
             WizardCreateNew(
-              currentStep: _createStep,
+              currentStep: wizard.createStep,
               urlController: _urlController,
               keyController: _keyController,
               keyField: _buildKeyField(),
-              onBack: () => setState(() => _createStep--),
-              onNext: () => setState(() => _createStep++),
+              onBack: _notifier.decrementStep,
+              onNext: _notifier.incrementStep,
               onContinue: (_urlController.text.isNotEmpty && _keyController.text.isNotEmpty)
-                  ? () => setState(() => _mode = _WizardMode.auth)
+                  ? () => _notifier.setMode(SyncWizardMode.auth)
                   : null,
             ),
-          if (_mode == _WizardMode.joinExisting)
+          if (wizard.mode == SyncWizardMode.joinExisting)
             WizardJoinExisting(
               urlController: _urlController,
               keyController: _keyController,
               keyField: _buildKeyField(),
               onScanQr: _openQrScanner,
               onContinue: (_urlController.text.isNotEmpty && _keyController.text.isNotEmpty)
-                  ? () => setState(() => _mode = _WizardMode.auth)
+                  ? () => _notifier.setMode(SyncWizardMode.auth)
                   : null,
             ),
-          if (_mode == _WizardMode.auth)
+          if (wizard.mode == SyncWizardMode.auth)
             WizardAuthStep(
-              useEmail: _useEmail,
-              isSignUp: _isSignUp,
-              testing: _testing,
-              connecting: _connecting,
-              testResult: _testResult,
-              testSuccess: _testSuccess,
+              useEmail: wizard.useEmail,
+              isSignUp: wizard.isSignUp,
+              testing: wizard.testing,
+              connecting: wizard.connecting,
+              testResult: wizard.testResult,
+              testSuccess: wizard.testSuccess,
               emailController: _emailController,
               passwordController: _passwordController,
-              onUseEmailChanged: (value) => setState(() => _useEmail = value),
-              onToggleSignUp: () => setState(() => _isSignUp = !_isSignUp),
+              onUseEmailChanged: _notifier.setUseEmail,
+              onToggleSignUp: _notifier.toggleSignUp,
               onTestConnection: _testConnection,
               onConnect: _connect,
-              onPasswordChanged: () => setState(() {}),
+              onPasswordChanged: _notifier.touch,
             ),
-          if (_mode == _WizardMode.schema)
+          if (wizard.mode == SyncWizardMode.schema)
             WizardSchemaStep(
-              schemaStatus: _schemaStatus,
-              migrationSql: _migrationSql,
+              schemaStatus: wizard.schemaStatus,
+              migrationSql: wizard.migrationSql,
               onRecheck: () async {
                 final status = await SchemaVerifier.checkSchema();
-                if (mounted) setState(() => _schemaStatus = status);
+                if (mounted) _notifier.updateSchemaStatus(status);
               },
               onDone: () {
                 SnackBarHelper.showSuccess(context, AppLocalizations.of(context)?.tankSyncConnected ?? 'TankSync connected!');
@@ -187,7 +193,7 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
         final json = jsonDecode(result) as Map<String, dynamic>;
         _urlController.text = json['url']?.toString() ?? '';
         _keyController.text = json['key']?.toString() ?? '';
-        setState(() => _mode = _WizardMode.auth);
+        _notifier.setMode(SyncWizardMode.auth);
       } catch (e) {
         debugPrint('QR code parse failed: $e');
         SnackBarHelper.showError(context, AppLocalizations.of(context)?.invalidQrCodeTankSync ?? 'Invalid QR code — expected TankSync format');
@@ -196,27 +202,28 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
   }
 
   Future<void> _testConnection() async {
-    setState(() { _testing = true; _testResult = null; });
+    _notifier.startTesting();
     try {
       final url = _sanitizeUrl(_urlController.text);
       final key = _sanitizeKey(_keyController.text);
       await TankSyncClient.init(url: url, anonKey: key);
-      setState(() { _testResult = 'Connection successful!'; _testSuccess = true; _testing = false; });
+      _notifier.testSucceeded('Connection successful!');
     } catch (e) {
-      setState(() { _testResult = 'Connection failed:\n$e'; _testSuccess = false; _testing = false; });
+      _notifier.testFailed('Connection failed:\n$e');
     }
   }
 
   Future<void> _connect() async {
-    setState(() => _connecting = true);
+    _notifier.setConnecting(true);
     try {
+      final wizard = ref.read(syncWizardControllerProvider);
       final url = _sanitizeUrl(_urlController.text);
       final key = _sanitizeKey(_keyController.text);
 
-      if (_useEmail && _emailController.text.isNotEmpty && (_isSignUp ? PasswordValidator.isValid(_passwordController.text) : _passwordController.text.isNotEmpty)) {
+      if (wizard.useEmail && _emailController.text.isNotEmpty && (wizard.isSignUp ? PasswordValidator.isValid(_passwordController.text) : _passwordController.text.isNotEmpty)) {
         await TankSyncClient.init(url: url, anonKey: key);
         String? userId;
-        if (_isSignUp) {
+        if (wizard.isSignUp) {
           userId = await TankSyncClient.signUpWithEmail(_emailController.text.trim(), _passwordController.text);
         } else {
           userId = await TankSyncClient.signInWithEmail(_emailController.text.trim(), _passwordController.text);
@@ -239,19 +246,18 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
           SnackBarHelper.showSuccess(context, AppLocalizations.of(context)?.tankSyncConnected ?? 'TankSync connected!');
           Navigator.pop(context);
         } else {
-          setState(() {
-            _schemaStatus = schema;
-            _migrationSql = SchemaVerifier.getMigrationSql(schema);
-            _mode = _WizardMode.schema;
-          });
+          _notifier.showSchemaStep(
+            schema: schema,
+            migrationSql: SchemaVerifier.getMigrationSql(schema),
+          );
         }
       }
     } catch (e) {
       if (mounted) {
-        setState(() { _testResult = 'Connection failed: $e'; _testSuccess = false; });
+        _notifier.connectFailed('Connection failed: $e');
       }
     } finally {
-      if (mounted) setState(() => _connecting = false);
+      if (mounted) _notifier.setConnecting(false);
     }
   }
 }

--- a/lib/features/sync/providers/auth_form_provider.dart
+++ b/lib/features/sync/providers/auth_form_provider.dart
@@ -1,0 +1,89 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auth_form_provider.g.dart';
+
+/// UI-only state for the authentication screen form.
+///
+/// Text inputs themselves live in [TextEditingController]s owned by the
+/// screen (Flutter lifecycle requirement); everything else (toggles,
+/// progress, errors) lives here so the screen can be a [ConsumerWidget]
+/// and rebuild selectively.
+class AuthFormState {
+  final bool isSignUp;
+  final bool isLoading;
+  final bool showPassword;
+  final bool showConfirm;
+  final String? error;
+
+  const AuthFormState({
+    this.isSignUp = true,
+    this.isLoading = false,
+    this.showPassword = false,
+    this.showConfirm = false,
+    this.error,
+  });
+
+  AuthFormState copyWith({
+    bool? isSignUp,
+    bool? isLoading,
+    bool? showPassword,
+    bool? showConfirm,
+    String? error,
+    bool clearError = false,
+  }) {
+    return AuthFormState(
+      isSignUp: isSignUp ?? this.isSignUp,
+      isLoading: isLoading ?? this.isLoading,
+      showPassword: showPassword ?? this.showPassword,
+      showConfirm: showConfirm ?? this.showConfirm,
+      error: clearError ? null : (error ?? this.error),
+    );
+  }
+}
+
+@riverpod
+class AuthFormController extends _$AuthFormController {
+  @override
+  AuthFormState build() => const AuthFormState();
+
+  void toggleSignUp() {
+    state = state.copyWith(isSignUp: !state.isSignUp, clearError: true);
+  }
+
+  void togglePassword() {
+    state = state.copyWith(showPassword: !state.showPassword);
+  }
+
+  void toggleConfirm() {
+    state = state.copyWith(showConfirm: !state.showConfirm);
+  }
+
+  void setLoading(bool value) {
+    state = state.copyWith(
+      isLoading: value,
+      clearError: value, // clear error when starting a new attempt
+    );
+  }
+
+  void setError(String? error) {
+    state = state.copyWith(
+      error: error,
+      clearError: error == null,
+      isLoading: false,
+    );
+  }
+
+  void clearError() {
+    state = state.copyWith(clearError: true);
+  }
+
+  void reset() {
+    state = const AuthFormState();
+  }
+
+  /// Used to force a rebuild when the password text changes (so the strength
+  /// indicator can update). Preserves all current state.
+  void touch() {
+    state = state.copyWith();
+  }
+}

--- a/lib/features/sync/providers/auth_form_provider.g.dart
+++ b/lib/features/sync/providers/auth_form_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auth_form_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(AuthFormController)
+final authFormControllerProvider = AuthFormControllerProvider._();
+
+final class AuthFormControllerProvider
+    extends $NotifierProvider<AuthFormController, AuthFormState> {
+  AuthFormControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'authFormControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$authFormControllerHash();
+
+  @$internal
+  @override
+  AuthFormController create() => AuthFormController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AuthFormState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AuthFormState>(value),
+    );
+  }
+}
+
+String _$authFormControllerHash() =>
+    r'749944f0010958b9c90654e08fb4621621ebf320';
+
+abstract class _$AuthFormController extends $Notifier<AuthFormState> {
+  AuthFormState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AuthFormState, AuthFormState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AuthFormState, AuthFormState>,
+              AuthFormState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/sync/providers/sync_wizard_provider.dart
+++ b/lib/features/sync/providers/sync_wizard_provider.dart
@@ -1,0 +1,160 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'sync_wizard_provider.g.dart';
+
+enum SyncWizardMode { choose, createNew, joinExisting, auth, schema }
+
+/// UI-only state for the sync setup wizard. Text inputs live in
+/// [TextEditingController]s owned by the screen.
+class SyncWizardState {
+  final SyncWizardMode mode;
+  final int createStep;
+  final bool testing;
+  final bool connecting;
+  final bool isSignUp;
+  final bool useEmail;
+  final String? testResult;
+  final bool testSuccess;
+  final Map<String, bool>? schemaStatus;
+  final String? migrationSql;
+  final bool showKey;
+
+  const SyncWizardState({
+    this.mode = SyncWizardMode.choose,
+    this.createStep = 0,
+    this.testing = false,
+    this.connecting = false,
+    this.isSignUp = true,
+    this.useEmail = false,
+    this.testResult,
+    this.testSuccess = false,
+    this.schemaStatus,
+    this.migrationSql,
+    this.showKey = false,
+  });
+
+  SyncWizardState copyWith({
+    SyncWizardMode? mode,
+    int? createStep,
+    bool? testing,
+    bool? connecting,
+    bool? isSignUp,
+    bool? useEmail,
+    String? testResult,
+    bool clearTestResult = false,
+    bool? testSuccess,
+    Map<String, bool>? schemaStatus,
+    bool clearSchemaStatus = false,
+    String? migrationSql,
+    bool clearMigrationSql = false,
+    bool? showKey,
+  }) {
+    return SyncWizardState(
+      mode: mode ?? this.mode,
+      createStep: createStep ?? this.createStep,
+      testing: testing ?? this.testing,
+      connecting: connecting ?? this.connecting,
+      isSignUp: isSignUp ?? this.isSignUp,
+      useEmail: useEmail ?? this.useEmail,
+      testResult: clearTestResult ? null : (testResult ?? this.testResult),
+      testSuccess: testSuccess ?? this.testSuccess,
+      schemaStatus:
+          clearSchemaStatus ? null : (schemaStatus ?? this.schemaStatus),
+      migrationSql:
+          clearMigrationSql ? null : (migrationSql ?? this.migrationSql),
+      showKey: showKey ?? this.showKey,
+    );
+  }
+}
+
+@riverpod
+class SyncWizardController extends _$SyncWizardController {
+  @override
+  SyncWizardState build() => const SyncWizardState();
+
+  void setMode(SyncWizardMode mode) {
+    state = state.copyWith(mode: mode);
+  }
+
+  void setCreateStep(int step) {
+    state = state.copyWith(createStep: step);
+  }
+
+  void incrementStep() {
+    state = state.copyWith(createStep: state.createStep + 1);
+  }
+
+  void decrementStep() {
+    state = state.copyWith(createStep: state.createStep - 1);
+  }
+
+  void toggleKeyVisibility() {
+    state = state.copyWith(showKey: !state.showKey);
+  }
+
+  void setUseEmail(bool value) {
+    state = state.copyWith(useEmail: value);
+  }
+
+  void toggleSignUp() {
+    state = state.copyWith(isSignUp: !state.isSignUp);
+  }
+
+  void startTesting() {
+    state = state.copyWith(testing: true, clearTestResult: true);
+  }
+
+  void testSucceeded(String message) {
+    state = state.copyWith(
+      testing: false,
+      testResult: message,
+      testSuccess: true,
+    );
+  }
+
+  void testFailed(String message) {
+    state = state.copyWith(
+      testing: false,
+      testResult: message,
+      testSuccess: false,
+    );
+  }
+
+  void setConnecting(bool value) {
+    state = state.copyWith(connecting: value);
+  }
+
+  void connectFailed(String message) {
+    state = state.copyWith(
+      testResult: message,
+      testSuccess: false,
+    );
+  }
+
+  void showSchemaStep({
+    required Map<String, bool> schema,
+    required String migrationSql,
+  }) {
+    state = state.copyWith(
+      mode: SyncWizardMode.schema,
+      schemaStatus: schema,
+      migrationSql: migrationSql,
+    );
+  }
+
+  void updateSchemaStatus(Map<String, bool>? schema) {
+    state = state.copyWith(
+      schemaStatus: schema,
+      clearSchemaStatus: schema == null,
+    );
+  }
+
+  /// Rebuild signal for text controller changes (e.g. password field).
+  void touch() {
+    state = state.copyWith();
+  }
+
+  void reset() {
+    state = const SyncWizardState();
+  }
+}

--- a/lib/features/sync/providers/sync_wizard_provider.g.dart
+++ b/lib/features/sync/providers/sync_wizard_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sync_wizard_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(SyncWizardController)
+final syncWizardControllerProvider = SyncWizardControllerProvider._();
+
+final class SyncWizardControllerProvider
+    extends $NotifierProvider<SyncWizardController, SyncWizardState> {
+  SyncWizardControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'syncWizardControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$syncWizardControllerHash();
+
+  @$internal
+  @override
+  SyncWizardController create() => SyncWizardController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SyncWizardState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SyncWizardState>(value),
+    );
+  }
+}
+
+String _$syncWizardControllerHash() =>
+    r'4b040164737b9a297867b70ce0e6d7efedc1e69d';
+
+abstract class _$SyncWizardController extends $Notifier<SyncWizardState> {
+  SyncWizardState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<SyncWizardState, SyncWizardState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<SyncWizardState, SyncWizardState>,
+              SyncWizardState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}


### PR DESCRIPTION
## Summary
- Converts the four highest-value StatefulWidgets called out in #57 to use Riverpod providers for their form/wizard state
- Eliminates ~48 setState calls (of the 96+ originally reported) across the sync wizard, auth screen, route input, and search results list
- All text editing controllers remain local to their widgets because Flutter's widget lifecycle requires it; everything else moves to scoped providers

## Why
Per issue #57: setState forced full subtree rebuilds, blocked selective rebuilds via `.select()`, destroyed form state on rebuild, and prevented time-travel debug. Form validation errors were lost when widgets rebuilt, and server errors wiped local state.

## Providers added
- `routeInputControllerProvider` (`features/route_search/providers/route_input_provider.dart`) — coords, stop count, search in-flight flag
- `authFormControllerProvider` (`features/sync/providers/auth_form_provider.dart`) — isSignUp, isLoading, showPassword/Confirm, error
- `syncWizardControllerProvider` (`features/sync/providers/sync_wizard_provider.dart`) — wizard mode, createStep, testing/connecting flags, testResult, schemaStatus, migrationSql
- `selectedSortModeProvider` added to the existing `search_screen_ui_provider.dart`

## Screens/widgets converted
- `search_results_list.dart` — `ConsumerStatefulWidget` -> `ConsumerWidget`
- `route_input.dart` — **zero setState** (AC satisfied); uses `ListenableBuilder` on text controllers for the Search button enable state
- `auth_screen.dart` — all 13 setState calls replaced
- `sync_wizard_screen.dart` — all 22 setState calls replaced

## What stays as setState (intentional)
Remaining setStates in the codebase are local UI-only flags (expand/collapse, animation controllers, controller listeners) that the issue explicitly calls out as acceptable to keep.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero warnings, zero errors
- [x] `flutter test test/features/search test/features/sync test/features/route_search` — all 512 tests pass
- [x] Existing sync widget tests (`sync_setup_screen_test.dart`, `sync_credentials_step_test.dart`, etc.) still pass
- [ ] Manual smoke test: sync wizard flow (create new + join existing), auth sign-up/sign-in, route search with stops

## Follow-ups (remaining in #57)
The issue mentions ~96 setState calls total. This PR tackles the four screens explicitly named in the issue description; remaining targets for future PRs:
- `profile_edit_sheet.dart` (10 calls) — form state extraction
- `sync_setup_screen.dart` (11 calls)
- `onboarding_wizard_screen.dart` (6 calls)
- various smaller widgets

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)