### PR TITLE
feat(export): data export — CSV/JSON for price history and favorites

### DIFF
--- a/lib/core/export/data_exporter.dart
+++ b/lib/core/export/data_exporter.dart
@@ -1,0 +1,308 @@
+import 'dart:convert';
+
+import '../data/storage_repository.dart';
+
+/// Categories of user data that can be exported individually.
+///
+/// Each category maps to a CSV table with a stable column layout.
+/// The JSON export always contains all categories.
+enum ExportCategory {
+  favorites,
+  priceHistory,
+  alerts,
+  fillUps,
+  ratings,
+  ignoredStations,
+  profiles,
+  itineraries,
+}
+
+/// Service that exports user data (GDPR data portability) to JSON and CSV.
+///
+/// The exporter is a pure function of a [StorageRepository] snapshot — it
+/// performs no I/O and contains no tracking metadata. API keys are never
+/// included in the output.
+///
+/// JSON output is a single document containing all categories. CSV output
+/// is per-category because CSV has no native support for heterogeneous
+/// tables. Callers can use [exportAllAsCsv] to get a map of
+/// `{categoryName: csvString}` for batch export.
+class DataExporter {
+  final StorageRepository _storage;
+  final String _appVersion;
+  final DateTime Function() _now;
+
+  DataExporter(
+    this._storage, {
+    String appVersion = '4.3.0',
+    DateTime Function()? now,
+  })  : _appVersion = appVersion,
+        _now = now ?? DateTime.now;
+
+  // --------------------------------------------------------------------------
+  // JSON
+  // --------------------------------------------------------------------------
+
+  /// Returns all user data as a pretty-printed JSON document.
+  ///
+  /// Excludes API keys (security) and cache entries (ephemeral).
+  String exportToJson() {
+    final data = <String, dynamic>{
+      'exportedAt': _now().toUtc().toIso8601String(),
+      'appVersion': _appVersion,
+      'favorites': _storage.getFavoriteIds(),
+      'favoriteStationData': _storage.getAllFavoriteStationData(),
+      'ignoredStations': _storage.getIgnoredIds(),
+      'ratings': _storage.getRatings(),
+      'profiles': _storage.getAllProfiles(),
+      'alerts': _storage.getAlerts(),
+      'fillUps': _readFillUps(),
+      'itineraries': _storage.getItineraries(),
+      'priceHistory': _readPriceHistory(),
+    };
+    return const JsonEncoder.withIndent('  ').convert(data);
+  }
+
+  // --------------------------------------------------------------------------
+  // CSV
+  // --------------------------------------------------------------------------
+
+  /// Returns a single CSV string for a given category.
+  ///
+  /// All CSVs use RFC 4180 escaping: fields containing commas, quotes, CR,
+  /// or LF are wrapped in double quotes and embedded quotes are doubled.
+  String exportToCsv(ExportCategory category) {
+    switch (category) {
+      case ExportCategory.favorites:
+        return _favoritesCsv();
+      case ExportCategory.priceHistory:
+        return _priceHistoryCsv();
+      case ExportCategory.alerts:
+        return _alertsCsv();
+      case ExportCategory.fillUps:
+        return _fillUpsCsv();
+      case ExportCategory.ratings:
+        return _ratingsCsv();
+      case ExportCategory.ignoredStations:
+        return _ignoredCsv();
+      case ExportCategory.profiles:
+        return _profilesCsv();
+      case ExportCategory.itineraries:
+        return _itinerariesCsv();
+    }
+  }
+
+  /// Returns a map of `{categoryName: csvString}` for every category.
+  Map<String, String> exportAllAsCsv() {
+    return {
+      for (final c in ExportCategory.values) c.name: exportToCsv(c),
+    };
+  }
+
+  // --------------------------------------------------------------------------
+  // Category encoders
+  // --------------------------------------------------------------------------
+
+  String _favoritesCsv() {
+    final ids = _storage.getFavoriteIds();
+    final data = _storage.getAllFavoriteStationData();
+    const header = ['station_id', 'name', 'brand', 'street', 'place', 'postcode', 'lat', 'lng'];
+    final rows = <List<Object?>>[header];
+    for (final id in ids) {
+      final d = data[id];
+      final m = d is Map ? d.cast<String, dynamic>() : const <String, dynamic>{};
+      rows.add([
+        id,
+        m['name'],
+        m['brand'],
+        m['street'],
+        m['place'],
+        m['postCode'] ?? m['postcode'],
+        m['lat'],
+        m['lng'] ?? m['lon'],
+      ]);
+    }
+    return _encodeCsv(rows);
+  }
+
+  String _priceHistoryCsv() {
+    const header = ['station_id', 'timestamp', 'fuel_type', 'price'];
+    final rows = <List<Object?>>[header];
+    for (final key in _storage.getPriceHistoryKeys()) {
+      for (final record in _storage.getPriceRecords(key)) {
+        final ts = record['timestamp'] ?? record['recordedAt'];
+        final fuel = record['fuelType'] ?? record['fuel'];
+        final price = record['price'];
+        if (fuel is Map) {
+          for (final entry in fuel.entries) {
+            rows.add([key, ts, entry.key, entry.value]);
+          }
+        } else if (price is Map) {
+          for (final entry in price.entries) {
+            rows.add([key, ts, entry.key, entry.value]);
+          }
+        } else {
+          rows.add([key, ts, fuel, price]);
+        }
+      }
+    }
+    return _encodeCsv(rows);
+  }
+
+  String _alertsCsv() {
+    const header = [
+      'id',
+      'station_id',
+      'fuel_type',
+      'threshold_price',
+      'direction',
+      'enabled',
+      'created_at',
+    ];
+    final rows = <List<Object?>>[header];
+    for (final a in _storage.getAlerts()) {
+      rows.add([
+        a['id'],
+        a['stationId'] ?? a['station_id'],
+        a['fuelType'] ?? a['fuel_type'],
+        a['thresholdPrice'] ?? a['threshold'] ?? a['price'],
+        a['direction'],
+        a['enabled'],
+        a['createdAt'] ?? a['created_at'],
+      ]);
+    }
+    return _encodeCsv(rows);
+  }
+
+  String _fillUpsCsv() {
+    const header = [
+      'id',
+      'station_id',
+      'station_name',
+      'timestamp',
+      'fuel_type',
+      'liters',
+      'price_per_liter',
+      'total_cost',
+      'odometer_km',
+      'notes',
+    ];
+    final rows = <List<Object?>>[header];
+    for (final f in _readFillUps()) {
+      rows.add([
+        f['id'],
+        f['stationId'] ?? f['station_id'],
+        f['stationName'] ?? f['station_name'],
+        f['timestamp'] ?? f['date'],
+        f['fuelType'] ?? f['fuel_type'],
+        f['liters'] ?? f['volume'],
+        f['pricePerLiter'] ?? f['price_per_liter'] ?? f['price'],
+        f['totalCost'] ?? f['total'] ?? f['total_cost'],
+        f['odometer'] ?? f['odometer_km'],
+        f['notes'],
+      ]);
+    }
+    return _encodeCsv(rows);
+  }
+
+  String _ratingsCsv() {
+    const header = ['station_id', 'rating'];
+    final rows = <List<Object?>>[header];
+    _storage.getRatings().forEach((k, v) => rows.add([k, v]));
+    return _encodeCsv(rows);
+  }
+
+  String _ignoredCsv() {
+    const header = ['station_id'];
+    final rows = <List<Object?>>[header];
+    for (final id in _storage.getIgnoredIds()) {
+      rows.add([id]);
+    }
+    return _encodeCsv(rows);
+  }
+
+  String _profilesCsv() {
+    const header = ['id', 'name', 'fuel_type', 'radius_km', 'sort_by'];
+    final rows = <List<Object?>>[header];
+    for (final p in _storage.getAllProfiles()) {
+      rows.add([
+        p['id'],
+        p['name'],
+        p['fuelType'] ?? p['fuel_type'],
+        p['radius'] ?? p['radiusKm'] ?? p['radius_km'],
+        p['sortBy'] ?? p['sort_by'],
+      ]);
+    }
+    return _encodeCsv(rows);
+  }
+
+  String _itinerariesCsv() {
+    const header = ['id', 'name', 'origin', 'destination', 'created_at'];
+    final rows = <List<Object?>>[header];
+    for (final it in _storage.getItineraries()) {
+      rows.add([
+        it['id'],
+        it['name'],
+        it['origin'],
+        it['destination'],
+        it['createdAt'] ?? it['created_at'],
+      ]);
+    }
+    return _encodeCsv(rows);
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  /// Reads fill-ups from the settings box if present. Fill-ups are not yet
+  /// a first-class storage category (#148) — this reader tolerates either an
+  /// eventual dedicated interface or the current settings-based storage.
+  List<Map<String, dynamic>> _readFillUps() {
+    final raw = _storage.getSetting('fillUps');
+    if (raw is List) {
+      return raw
+          .whereType<Map>()
+          .map((e) => e.cast<String, dynamic>())
+          .toList(growable: false);
+    }
+    return const [];
+  }
+
+  Map<String, List<Map<String, dynamic>>> _readPriceHistory() {
+    final result = <String, List<Map<String, dynamic>>>{};
+    for (final key in _storage.getPriceHistoryKeys()) {
+      result[key] = _storage.getPriceRecords(key);
+    }
+    return result;
+  }
+
+  /// RFC 4180 CSV encoder — no dependency on the `csv` package.
+  ///
+  /// - Uses `,` separator and `\r\n` line ending (Excel-friendly).
+  /// - Wraps fields in `"` when they contain `,`, `"`, `\r`, or `\n`.
+  /// - Doubles embedded `"` characters inside quoted fields.
+  /// - `null` renders as an empty cell.
+  String _encodeCsv(List<List<Object?>> rows) {
+    final buf = StringBuffer();
+    for (final row in rows) {
+      for (var i = 0; i < row.length; i++) {
+        if (i > 0) buf.write(',');
+        buf.write(_encodeCell(row[i]));
+      }
+      buf.write('\r\n');
+    }
+    return buf.toString();
+  }
+
+  String _encodeCell(Object? value) {
+    if (value == null) return '';
+    final s = value.toString();
+    final needsQuoting = s.contains(',') ||
+        s.contains('"') ||
+        s.contains('\n') ||
+        s.contains('\r');
+    if (!needsQuoting) return s;
+    return '"${s.replaceAll('"', '""')}"';
+  }
+}

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
+import '../../../../core/export/data_exporter.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -54,6 +55,8 @@ class _PrivacyDashboardScreenState
           // Action buttons
           _ExportButton(onPressed: () => _exportData(context)),
           const SizedBox(height: 12),
+          _ExportCsvButton(onPressed: () => _exportDataCsv(context)),
+          const SizedBox(height: 12),
           _DeleteAllButton(onPressed: () => _deleteAllData(context)),
 
           SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
@@ -70,6 +73,25 @@ class _PrivacyDashboardScreenState
     SnackBarHelper.showSuccess(
       context,
       l?.privacyExportSuccess ?? 'Data exported to clipboard',
+    );
+  }
+
+  Future<void> _exportDataCsv(BuildContext ctx) async {
+    final storage = ref.read(storageRepositoryProvider);
+    final exporter = DataExporter(storage);
+    final parts = exporter.exportAllAsCsv();
+    final buf = StringBuffer();
+    parts.forEach((name, csv) {
+      buf
+        ..writeln('# $name')
+        ..writeln(csv);
+    });
+    await Clipboard.setData(ClipboardData(text: buf.toString()));
+    if (!mounted) return;
+    final l = AppLocalizations.of(context);
+    SnackBarHelper.showSuccess(
+      context,
+      l?.privacyExportCsvSuccess ?? 'CSV data exported to clipboard',
     );
   }
 
@@ -420,6 +442,25 @@ class _ExportButton extends StatelessWidget {
         onPressed: onPressed,
         icon: const Icon(Icons.download),
         label: Text(l?.privacyExportButton ?? 'Export all data as JSON'),
+      ),
+    );
+  }
+}
+
+class _ExportCsvButton extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const _ExportCsvButton({required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: onPressed,
+        icon: const Icon(Icons.table_chart),
+        label: Text(l?.privacyExportCsvButton ?? 'Export all data as CSV'),
       ),
     );
   }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -592,6 +592,8 @@
   "privacyViewServerData": "Serverdaten anzeigen",
   "privacyExportButton": "Alle Daten als JSON exportieren",
   "privacyExportSuccess": "Daten in die Zwischenablage exportiert",
+  "privacyExportCsvButton": "Alle Daten als CSV exportieren",
+  "privacyExportCsvSuccess": "CSV-Daten in die Zwischenablage exportiert",
   "privacyDeleteButton": "Alle Daten löschen",
   "privacyDeleteTitle": "Alle Daten löschen?",
   "privacyDeleteBody": "Dies löscht unwiderruflich:\n\n- Alle Favoriten und Stationsdaten\n- Alle Suchprofile\n- Alle Preisalarme\n- Allen Preisverlauf\n- Alle zwischengespeicherten Daten\n- Ihren API-Schlüssel\n- Alle App-Einstellungen\n\nDie App wird auf den Ausgangszustand zurückgesetzt. Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -592,6 +592,8 @@
   "privacyViewServerData": "View server data",
   "privacyExportButton": "Export all data as JSON",
   "privacyExportSuccess": "Data exported to clipboard",
+  "privacyExportCsvButton": "Export all data as CSV",
+  "privacyExportCsvSuccess": "CSV data exported to clipboard",
   "privacyDeleteButton": "Delete all data",
   "privacyDeleteTitle": "Delete all data?",
   "privacyDeleteBody": "This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2528,6 +2528,18 @@ abstract class AppLocalizations {
   /// **'Data exported to clipboard'**
   String get privacyExportSuccess;
 
+  /// No description provided for @privacyExportCsvButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Export all data as CSV'**
+  String get privacyExportCsvButton;
+
+  /// No description provided for @privacyExportCsvSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'CSV data exported to clipboard'**
+  String get privacyExportCsvSuccess;
+
   /// No description provided for @privacyDeleteButton.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1306,6 +1306,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1306,6 +1306,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1304,6 +1304,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1316,6 +1316,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get privacyExportSuccess => 'Daten in die Zwischenablage exportiert';
 
   @override
+  String get privacyExportCsvButton => 'Alle Daten als CSV exportieren';
+
+  @override
+  String get privacyExportCsvSuccess =>
+      'CSV-Daten in die Zwischenablage exportiert';
+
+  @override
   String get privacyDeleteButton => 'Alle Daten löschen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1308,6 +1308,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1299,6 +1299,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1307,6 +1307,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1301,6 +1301,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1304,6 +1304,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1311,6 +1311,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1303,6 +1303,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1308,6 +1308,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1307,6 +1307,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1305,6 +1305,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1307,6 +1307,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1303,6 +1303,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1308,6 +1308,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1306,6 +1306,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1307,6 +1307,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1306,6 +1306,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1307,6 +1307,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1301,6 +1301,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1305,6 +1305,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
+  String get privacyExportCsvButton => 'Export all data as CSV';
+
+  @override
+  String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override

--- a/test/core/export/data_exporter_test.dart
+++ b/test/core/export/data_exporter_test.dart
@@ -1,0 +1,259 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/export/data_exporter.dart';
+
+void main() {
+  group('DataExporter JSON', () {
+    test('exports an empty but well-formed document when storage is empty', () {
+      final exporter = DataExporter(
+        _FakeStorage(),
+        appVersion: '9.9.9',
+        now: () => DateTime.utc(2026, 4, 8, 12, 0, 0),
+      );
+      final json = exporter.exportToJson();
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+
+      expect(decoded['exportedAt'], '2026-04-08T12:00:00.000Z');
+      expect(decoded['appVersion'], '9.9.9');
+      expect(decoded['favorites'], isEmpty);
+      expect(decoded['favoriteStationData'], isEmpty);
+      expect(decoded['ignoredStations'], isEmpty);
+      expect(decoded['ratings'], isEmpty);
+      expect(decoded['profiles'], isEmpty);
+      expect(decoded['alerts'], isEmpty);
+      expect(decoded['fillUps'], isEmpty);
+      expect(decoded['itineraries'], isEmpty);
+      expect(decoded['priceHistory'], isEmpty);
+    });
+
+    test('never includes API keys in the output', () {
+      final storage = _FakeStorage()
+        ..apiKey = 'SECRET_KEY_123'
+        ..evApiKey = 'EV_SECRET_456';
+      final exporter = DataExporter(storage);
+      final json = exporter.exportToJson();
+
+      expect(json.contains('SECRET_KEY_123'), isFalse);
+      expect(json.contains('EV_SECRET_456'), isFalse);
+      expect(json.contains('apiKey'), isFalse);
+    });
+
+    test('serialises favorites, ratings, alerts, fill-ups, and price history', () {
+      final storage = _FakeStorage()
+        ..favoriteIds = ['s1', 's2']
+        ..favoriteData = {
+          's1': {'name': 'Alpha', 'brand': 'Aral', 'lat': 48.1, 'lng': 11.5},
+        }
+        ..ratings = {'s1': 4}
+        ..alerts = [
+          {'id': 'a1', 'stationId': 's1', 'fuelType': 'e5', 'thresholdPrice': 1.699},
+        ]
+        ..priceHistoryKeys = ['s1']
+        ..priceRecords = {
+          's1': [
+            {'timestamp': '2026-04-01T08:00:00Z', 'fuelType': 'e5', 'price': 1.72},
+          ],
+        }
+        ..settings = {
+          'fillUps': [
+            {
+              'id': 'f1',
+              'stationId': 's1',
+              'timestamp': '2026-04-02T10:00:00Z',
+              'fuelType': 'e5',
+              'liters': 42.5,
+              'pricePerLiter': 1.70,
+              'totalCost': 72.25,
+            },
+          ],
+        };
+
+      final json = jsonDecode(DataExporter(storage).exportToJson())
+          as Map<String, dynamic>;
+      expect(json['favorites'], ['s1', 's2']);
+      expect((json['favoriteStationData'] as Map)['s1']['name'], 'Alpha');
+      expect((json['ratings'] as Map)['s1'], 4);
+      expect((json['alerts'] as List).length, 1);
+      expect((json['fillUps'] as List).length, 1);
+      expect((json['fillUps'] as List).first['liters'], 42.5);
+      expect((json['priceHistory'] as Map)['s1'], isA<List>());
+    });
+  });
+
+  group('DataExporter CSV', () {
+    test('RFC 4180 escaping: quotes, commas, newlines, carriage returns', () {
+      final storage = _FakeStorage()
+        ..favoriteIds = ['s1']
+        ..favoriteData = {
+          's1': {
+            'name': 'Shell, "Downtown"',
+            'brand': 'line1\nline2',
+            'street': 'a\rb',
+            'place': 'plain',
+            'lat': 1.0,
+            'lng': 2.0,
+          },
+        };
+      final csv = DataExporter(storage).exportToCsv(ExportCategory.favorites);
+      final lines = csv.split('\r\n');
+
+      // Header + data + trailing empty from final CRLF
+      expect(lines.first,
+          'station_id,name,brand,street,place,postcode,lat,lng');
+      // Quoted because of comma and quote
+      expect(lines[1].contains('"Shell, ""Downtown"""'), isTrue);
+      // Quoted because of newline
+      expect(lines[1].contains('"line1\nline2"'), isTrue);
+      // Quoted because of CR
+      expect(lines[1].contains('"a\rb"'), isTrue);
+      // Plain field remains unquoted
+      expect(lines[1].contains(',plain,'), isTrue);
+    });
+
+    test('empty category returns header-only CSV', () {
+      final csv = DataExporter(_FakeStorage())
+          .exportToCsv(ExportCategory.favorites);
+      // One header row + trailing CRLF -> split yields 2 entries
+      expect(csv.endsWith('\r\n'), isTrue);
+      final lines = csv.split('\r\n');
+      expect(lines.length, 2);
+      expect(lines.first,
+          'station_id,name,brand,street,place,postcode,lat,lng');
+      expect(lines.last, '');
+    });
+
+    test('null cells render as empty strings', () {
+      final storage = _FakeStorage()
+        ..favoriteIds = ['s1']
+        ..favoriteData = {'s1': <String, dynamic>{}};
+      final csv = DataExporter(storage).exportToCsv(ExportCategory.favorites);
+      final dataLine = csv.split('\r\n')[1];
+      // 8 columns => 7 commas, all empty except the id
+      expect(dataLine, 's1,,,,,,,');
+    });
+
+    test('price history flattens fuelType maps into rows', () {
+      final storage = _FakeStorage()
+        ..priceHistoryKeys = ['s1']
+        ..priceRecords = {
+          's1': [
+            {
+              'timestamp': '2026-04-01T08:00:00Z',
+              'fuelType': {'e5': 1.72, 'e10': 1.70, 'diesel': 1.60},
+            },
+          ],
+        };
+      final csv =
+          DataExporter(storage).exportToCsv(ExportCategory.priceHistory);
+      final lines = csv.split('\r\n').where((l) => l.isNotEmpty).toList();
+      expect(lines.first, 'station_id,timestamp,fuel_type,price');
+      expect(lines.length, 4); // header + 3 fuel rows
+      expect(lines.any((l) => l.contains('e5,1.72')), isTrue);
+      expect(lines.any((l) => l.contains('diesel,1.6')), isTrue);
+    });
+
+    test('large dataset does not drop rows', () {
+      final records = List.generate(
+        5000,
+        (i) => {
+          'timestamp': '2026-04-01T08:00:00Z',
+          'fuelType': 'e5',
+          'price': 1.5 + (i % 100) / 1000,
+        },
+      );
+      final storage = _FakeStorage()
+        ..priceHistoryKeys = ['s1']
+        ..priceRecords = {'s1': records};
+      final csv =
+          DataExporter(storage).exportToCsv(ExportCategory.priceHistory);
+      final dataLines =
+          csv.split('\r\n').where((l) => l.isNotEmpty).toList();
+      expect(dataLines.length, 5001); // header + 5000 rows
+    });
+
+    test('exportAllAsCsv returns one entry per category', () {
+      final parts = DataExporter(_FakeStorage()).exportAllAsCsv();
+      expect(parts.keys.toSet(),
+          ExportCategory.values.map((c) => c.name).toSet());
+      for (final csv in parts.values) {
+        expect(csv.endsWith('\r\n'), isTrue);
+      }
+    });
+
+    test('ratings CSV contains station_id,rating rows', () {
+      final storage = _FakeStorage()..ratings = {'s1': 5, 's2': 3};
+      final csv = DataExporter(storage).exportToCsv(ExportCategory.ratings);
+      final lines = csv.split('\r\n').where((l) => l.isNotEmpty).toList();
+      expect(lines.first, 'station_id,rating');
+      expect(lines.contains('s1,5'), isTrue);
+      expect(lines.contains('s2,3'), isTrue);
+    });
+
+    test('alerts CSV maps expected columns', () {
+      final storage = _FakeStorage()
+        ..alerts = [
+          {
+            'id': 'a1',
+            'stationId': 's1',
+            'fuelType': 'e5',
+            'thresholdPrice': 1.699,
+            'direction': 'below',
+            'enabled': true,
+            'createdAt': '2026-04-01T00:00:00Z',
+          },
+        ];
+      final csv = DataExporter(storage).exportToCsv(ExportCategory.alerts);
+      final lines = csv.split('\r\n').where((l) => l.isNotEmpty).toList();
+      expect(lines.first,
+          'id,station_id,fuel_type,threshold_price,direction,enabled,created_at');
+      expect(
+        lines[1],
+        'a1,s1,e5,1.699,below,true,2026-04-01T00:00:00Z',
+      );
+    });
+  });
+}
+
+/// Hand-rolled fake that only implements the methods the exporter touches.
+class _FakeStorage extends Fake implements StorageRepository {
+  List<String> favoriteIds = [];
+  Map<String, dynamic> favoriteData = {};
+  List<String> ignoredIds = [];
+  Map<String, int> ratings = {};
+  List<Map<String, dynamic>> profiles = [];
+  List<Map<String, dynamic>> alerts = [];
+  List<Map<String, dynamic>> itineraries = [];
+  List<String> priceHistoryKeys = [];
+  Map<String, List<Map<String, dynamic>>> priceRecords = {};
+  Map<String, dynamic> settings = {};
+  String? apiKey;
+  String? evApiKey;
+
+  @override
+  List<String> getFavoriteIds() => favoriteIds;
+  @override
+  Map<String, dynamic> getAllFavoriteStationData() => favoriteData;
+  @override
+  List<String> getIgnoredIds() => ignoredIds;
+  @override
+  Map<String, int> getRatings() => ratings;
+  @override
+  List<Map<String, dynamic>> getAllProfiles() => profiles;
+  @override
+  List<Map<String, dynamic>> getAlerts() => alerts;
+  @override
+  List<Map<String, dynamic>> getItineraries() => itineraries;
+  @override
+  List<String> getPriceHistoryKeys() => priceHistoryKeys;
+  @override
+  List<Map<String, dynamic>> getPriceRecords(String stationId) =>
+      priceRecords[stationId] ?? const [];
+  @override
+  dynamic getSetting(String key) => settings[key];
+  @override
+  String? getApiKey() => apiKey;
+  @override
+  String? getEvApiKey() => evApiKey;
+}


### PR DESCRIPTION
## Summary
- Adds `DataExporter` service (`lib/core/export/data_exporter.dart`) with `exportToJson()` and per-category `exportToCsv()` methods covering favorites, price history, alerts, fill-ups, ratings, ignored stations, profiles, and itineraries.
- Wires a new "Export all data as CSV" button into the privacy dashboard alongside the existing JSON export. Output goes to clipboard, mirroring the current JSON flow.
- CSV encoder is RFC 4180 compliant (handles commas, embedded quotes, CR, LF) and has no third-party dependency — keeps the dependency footprint minimal.

## Why
Audit finding: the app had no GDPR data portability in CSV form. Users could only export JSON. Spreadsheet-friendly CSV is the standard deliverable for data-subject access requests.

## Privacy
- API keys are never exported (JSON or CSV).
- No tracking metadata is added to the output.
- Only the user's own on-device data is read.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero warnings/errors
- [x] `flutter test test/core/export/data_exporter_test.dart` — 11 new tests pass (empty data, large data with 5000 rows, quote/comma/newline/CR escaping, null cells, fuel-type map flattening, all categories)
- [x] Full `flutter test` — only unrelated Argentina network-test flake (passes in isolation)

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)