### PR TITLE
refactor: eliminate setState in profile/sync-setup/onboarding forms

### DIFF
--- a/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
@@ -1,11 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../../../../core/country/country_config.dart';
 import '../../../../core/language/language_provider.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../data/models/user_profile.dart';
+import '../../providers/profile_edit_provider.dart';
 
-class ProfileEditSheet extends StatefulWidget {
+/// Profile edit bottom sheet. Form state (fuel, radius, rating mode, etc.)
+/// lives in [profileEditControllerProvider] so changes trigger selective
+/// rebuilds and survive ephemeral widget rebuilds. Text values for name and
+/// zip code remain in local [TextEditingController]s because controllers must
+/// follow the Flutter widget lifecycle.
+class ProfileEditSheet extends ConsumerStatefulWidget {
   final UserProfile profile;
   final Future<void> Function(UserProfile) onSave;
   final VoidCallback? onDelete;
@@ -18,22 +26,12 @@ class ProfileEditSheet extends StatefulWidget {
   });
 
   @override
-  State<ProfileEditSheet> createState() => _ProfileEditSheetState();
+  ConsumerState<ProfileEditSheet> createState() => _ProfileEditSheetState();
 }
 
-class _ProfileEditSheetState extends State<ProfileEditSheet> {
+class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
   late final TextEditingController _nameController;
   late final TextEditingController _zipController;
-  late FuelType _fuelType;
-  late double _radius;
-  late LandingScreen _landingScreen;
-  late String? _countryCode;
-  late String? _languageCode;
-  late double _routeSegmentKm;
-  late bool _avoidHighways;
-  late bool _showFuel;
-  late bool _showElectric;
-  late String _ratingMode;
 
   @override
   void initState() {
@@ -42,16 +40,6 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
     _zipController = TextEditingController(
       text: widget.profile.homeZipCode ?? '',
     );
-    _fuelType = widget.profile.preferredFuelType;
-    _radius = widget.profile.defaultSearchRadius;
-    _landingScreen = widget.profile.landingScreen;
-    _countryCode = widget.profile.countryCode;
-    _languageCode = widget.profile.languageCode;
-    _routeSegmentKm = widget.profile.routeSegmentKm;
-    _avoidHighways = widget.profile.avoidHighways;
-    _showFuel = widget.profile.showFuel;
-    _showElectric = widget.profile.showElectric;
-    _ratingMode = widget.profile.ratingMode;
   }
 
   @override
@@ -100,6 +88,10 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
 
   @override
   Widget build(BuildContext context) {
+    final editState = ref.watch(profileEditControllerProvider(widget.profile));
+    final editCtrl =
+        ref.read(profileEditControllerProvider(widget.profile).notifier);
+
     return DraggableScrollableSheet(
       initialChildSize: 0.7,
       minChildSize: 0.5,
@@ -126,7 +118,7 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
               ),
               const SizedBox(height: 16),
               DropdownButtonFormField<FuelType>(
-                initialValue: _fuelType,
+                initialValue: editState.fuelType,
                 decoration: InputDecoration(
                   labelText:
                       AppLocalizations.of(context)?.preferredFuel ?? 'Preferred fuel',
@@ -139,7 +131,9 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
                           child: Text(t.displayName),
                         ))
                     .toList(),
-                onChanged: (v) => setState(() => _fuelType = v ?? _fuelType),
+                onChanged: (v) {
+                  if (v != null) editCtrl.setFuelType(v);
+                },
               ),
               const SizedBox(height: 16),
               Row(
@@ -148,15 +142,15 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
                       '${AppLocalizations.of(context)?.defaultRadius ?? "Radius"}:'),
                   Expanded(
                     child: Slider(
-                      value: _radius,
+                      value: editState.radius,
                       min: 1,
                       max: 25,
                       divisions: 24,
-                      label: '${_radius.round()} km',
-                      onChanged: (v) => setState(() => _radius = v),
+                      label: '${editState.radius.round()} km',
+                      onChanged: editCtrl.setRadius,
                     ),
                   ),
-                  Text('${_radius.round()} km'),
+                  Text('${editState.radius.round()} km'),
                 ],
               ),
               const SizedBox(height: 16),
@@ -165,44 +159,43 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
                   Text('${AppLocalizations.of(context)?.routeSegment ?? "Route segment"}:'),
                   Expanded(
                     child: Slider(
-                      value: _routeSegmentKm,
+                      value: editState.routeSegmentKm,
                       min: 50,
                       max: 1000,
                       divisions: 19,
-                      label: '${_routeSegmentKm.round()} km',
-                      onChanged: (v) =>
-                          setState(() => _routeSegmentKm = v),
+                      label: '${editState.routeSegmentKm.round()} km',
+                      onChanged: editCtrl.setRouteSegmentKm,
                     ),
                   ),
-                  Text('${_routeSegmentKm.round()} km'),
+                  Text('${editState.routeSegmentKm.round()} km'),
                 ],
               ),
               Padding(
                 padding: const EdgeInsets.only(left: 4),
                 child: Text(
-                  AppLocalizations.of(context)?.showCheapestEveryNKm(_routeSegmentKm.round()) ?? 'Show cheapest station every ${_routeSegmentKm.round()} km along route',
+                  AppLocalizations.of(context)?.showCheapestEveryNKm(editState.routeSegmentKm.round()) ?? 'Show cheapest station every ${editState.routeSegmentKm.round()} km along route',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
                 ),
               ),
               SwitchListTile(
-                value: _avoidHighways,
-                onChanged: (v) => setState(() => _avoidHighways = v),
+                value: editState.avoidHighways,
+                onChanged: editCtrl.setAvoidHighways,
                 title: Text(AppLocalizations.of(context)?.avoidHighways ?? 'Avoid highways'),
                 subtitle: Text(AppLocalizations.of(context)?.avoidHighwaysDesc ?? 'Route calculation avoids toll roads and highways'),
                 dense: true,
               ),
               SwitchListTile(
-                value: _showFuel,
-                onChanged: (v) => setState(() => _showFuel = v),
+                value: editState.showFuel,
+                onChanged: editCtrl.setShowFuel,
                 title: Text(AppLocalizations.of(context)?.showFuelStations ?? 'Show fuel stations'),
                 subtitle: Text(AppLocalizations.of(context)?.showFuelStationsDesc ?? 'Include gas, diesel, LPG, CNG stations'),
                 dense: true,
               ),
               SwitchListTile(
-                value: _showElectric,
-                onChanged: (v) => setState(() => _showElectric = v),
+                value: editState.showElectric,
+                onChanged: editCtrl.setShowElectric,
                 title: Text(AppLocalizations.of(context)?.showEvStations ?? 'Show EV charging stations'),
                 subtitle: Text(AppLocalizations.of(context)?.showEvStationsDesc ?? 'Include electric charging stations in search results'),
                 dense: true,
@@ -217,15 +210,15 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
                   ButtonSegment(value: 'private', label: Text('Private'), icon: Icon(Icons.lock, size: 16)),
                   ButtonSegment(value: 'shared', label: Text('Shared'), icon: Icon(Icons.people, size: 16)),
                 ],
-                selected: {_ratingMode},
-                onSelectionChanged: (s) => setState(() => _ratingMode = s.first),
+                selected: {editState.ratingMode},
+                onSelectionChanged: (s) => editCtrl.setRatingMode(s.first),
               ),
               Padding(
                 padding: const EdgeInsets.only(left: 4, top: 4),
                 child: Text(
-                  _ratingMode == 'local'
+                  editState.ratingMode == 'local'
                       ? 'Ratings saved on this device only'
-                      : _ratingMode == 'private'
+                      : editState.ratingMode == 'private'
                           ? 'Synced with your database (not visible to others)'
                           : 'Visible to all users of your database',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
@@ -235,7 +228,7 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
               ),
               const SizedBox(height: 16),
               DropdownButtonFormField<LandingScreen>(
-                initialValue: _landingScreen,
+                initialValue: editState.landingScreen,
                 decoration: InputDecoration(
                   labelText:
                       AppLocalizations.of(context)?.landingScreen ?? 'Start screen',
@@ -251,8 +244,9 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
                           )),
                         ))
                     .toList(),
-                onChanged: (v) =>
-                    setState(() => _landingScreen = v ?? _landingScreen),
+                onChanged: (v) {
+                  if (v != null) editCtrl.setLandingScreen(v);
+                },
               ),
               const SizedBox(height: 16),
               Text(
@@ -266,8 +260,8 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
                 children: Countries.all.map((c) {
                   return ChoiceChip(
                     label: Text('${c.flag} ${c.name}'),
-                    selected: c.code == _countryCode,
-                    onSelected: (_) => setState(() => _countryCode = c.code),
+                    selected: c.code == editState.countryCode,
+                    onSelected: (_) => editCtrl.setCountryCode(c.code),
                     visualDensity: VisualDensity.compact,
                   );
                 }).toList(),
@@ -284,9 +278,8 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
                 children: AppLanguages.all.map((l) {
                   return ChoiceChip(
                     label: Text(l.nativeName),
-                    selected: l.code == _languageCode,
-                    onSelected: (_) =>
-                        setState(() => _languageCode = l.code),
+                    selected: l.code == editState.languageCode,
+                    onSelected: (_) => editCtrl.setLanguageCode(l.code),
                     visualDensity: VisualDensity.compact,
                   );
                 }).toList(),
@@ -295,8 +288,8 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
               TextField(
                 controller: _zipController,
                 keyboardType: TextInputType.number,
-                maxLength: _countryCode != null
-                    ? (Countries.byCode(_countryCode!)?.postalCodeLength ?? 5)
+                maxLength: editState.countryCode != null
+                    ? (Countries.byCode(editState.countryCode!)?.postalCodeLength ?? 5)
                     : 5,
                 decoration: InputDecoration(
                   labelText:
@@ -313,19 +306,19 @@ class _ProfileEditSheetState extends State<ProfileEditSheet> {
                       onPressed: () async {
                         final updated = widget.profile.copyWith(
                           name: _nameController.text.trim(),
-                          preferredFuelType: _fuelType,
-                          defaultSearchRadius: _radius,
-                          landingScreen: _landingScreen,
+                          preferredFuelType: editState.fuelType,
+                          defaultSearchRadius: editState.radius,
+                          landingScreen: editState.landingScreen,
                           homeZipCode: _zipController.text.trim().isEmpty
                               ? null
                               : _zipController.text.trim(),
-                          countryCode: _countryCode,
-                          languageCode: _languageCode,
-                          routeSegmentKm: _routeSegmentKm,
-                          avoidHighways: _avoidHighways,
-                          showFuel: _showFuel,
-                          showElectric: _showElectric,
-                          ratingMode: _ratingMode,
+                          countryCode: editState.countryCode,
+                          languageCode: editState.languageCode,
+                          routeSegmentKm: editState.routeSegmentKm,
+                          avoidHighways: editState.avoidHighways,
+                          showFuel: editState.showFuel,
+                          showElectric: editState.showElectric,
+                          ratingMode: editState.ratingMode,
                         );
                         await widget.onSave(updated);
                         if (context.mounted) Navigator.pop(context);

--- a/lib/features/profile/providers/profile_edit_provider.dart
+++ b/lib/features/profile/providers/profile_edit_provider.dart
@@ -1,0 +1,101 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../search/domain/entities/fuel_type.dart';
+import '../data/models/user_profile.dart';
+
+part 'profile_edit_provider.g.dart';
+
+/// UI state for the profile edit sheet. Text input values live in
+/// [TextEditingController]s owned by the sheet itself (Flutter lifecycle);
+/// everything the form needs to rebuild on lives here.
+class ProfileEditState {
+  final FuelType fuelType;
+  final double radius;
+  final LandingScreen landingScreen;
+  final String? countryCode;
+  final String? languageCode;
+  final double routeSegmentKm;
+  final bool avoidHighways;
+  final bool showFuel;
+  final bool showElectric;
+  final String ratingMode;
+
+  const ProfileEditState({
+    required this.fuelType,
+    required this.radius,
+    required this.landingScreen,
+    required this.countryCode,
+    required this.languageCode,
+    required this.routeSegmentKm,
+    required this.avoidHighways,
+    required this.showFuel,
+    required this.showElectric,
+    required this.ratingMode,
+  });
+
+  factory ProfileEditState.fromProfile(UserProfile p) => ProfileEditState(
+        fuelType: p.preferredFuelType,
+        radius: p.defaultSearchRadius,
+        landingScreen: p.landingScreen,
+        countryCode: p.countryCode,
+        languageCode: p.languageCode,
+        routeSegmentKm: p.routeSegmentKm,
+        avoidHighways: p.avoidHighways,
+        showFuel: p.showFuel,
+        showElectric: p.showElectric,
+        ratingMode: p.ratingMode,
+      );
+
+  ProfileEditState copyWith({
+    FuelType? fuelType,
+    double? radius,
+    LandingScreen? landingScreen,
+    String? countryCode,
+    bool clearCountry = false,
+    String? languageCode,
+    bool clearLanguage = false,
+    double? routeSegmentKm,
+    bool? avoidHighways,
+    bool? showFuel,
+    bool? showElectric,
+    String? ratingMode,
+  }) {
+    return ProfileEditState(
+      fuelType: fuelType ?? this.fuelType,
+      radius: radius ?? this.radius,
+      landingScreen: landingScreen ?? this.landingScreen,
+      countryCode: clearCountry ? null : (countryCode ?? this.countryCode),
+      languageCode: clearLanguage ? null : (languageCode ?? this.languageCode),
+      routeSegmentKm: routeSegmentKm ?? this.routeSegmentKm,
+      avoidHighways: avoidHighways ?? this.avoidHighways,
+      showFuel: showFuel ?? this.showFuel,
+      showElectric: showElectric ?? this.showElectric,
+      ratingMode: ratingMode ?? this.ratingMode,
+    );
+  }
+}
+
+/// Family provider keyed on the profile id, so a sheet edit never leaks
+/// across profiles and each sheet gets its own scoped state that is
+/// automatically disposed when the sheet closes.
+@riverpod
+class ProfileEditController extends _$ProfileEditController {
+  @override
+  ProfileEditState build(UserProfile initial) =>
+      ProfileEditState.fromProfile(initial);
+
+  void setFuelType(FuelType v) => state = state.copyWith(fuelType: v);
+  void setRadius(double v) => state = state.copyWith(radius: v);
+  void setRouteSegmentKm(double v) =>
+      state = state.copyWith(routeSegmentKm: v);
+  void setAvoidHighways(bool v) => state = state.copyWith(avoidHighways: v);
+  void setShowFuel(bool v) => state = state.copyWith(showFuel: v);
+  void setShowElectric(bool v) => state = state.copyWith(showElectric: v);
+  void setRatingMode(String v) => state = state.copyWith(ratingMode: v);
+  void setLandingScreen(LandingScreen v) =>
+      state = state.copyWith(landingScreen: v);
+  void setCountryCode(String? v) =>
+      state = state.copyWith(countryCode: v, clearCountry: v == null);
+  void setLanguageCode(String? v) =>
+      state = state.copyWith(languageCode: v, clearLanguage: v == null);
+}

--- a/lib/features/profile/providers/profile_edit_provider.g.dart
+++ b/lib/features/profile/providers/profile_edit_provider.g.dart
@@ -1,0 +1,129 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'profile_edit_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Family provider keyed on the profile id, so a sheet edit never leaks
+/// across profiles and each sheet gets its own scoped state that is
+/// automatically disposed when the sheet closes.
+
+@ProviderFor(ProfileEditController)
+final profileEditControllerProvider = ProfileEditControllerFamily._();
+
+/// Family provider keyed on the profile id, so a sheet edit never leaks
+/// across profiles and each sheet gets its own scoped state that is
+/// automatically disposed when the sheet closes.
+final class ProfileEditControllerProvider
+    extends $NotifierProvider<ProfileEditController, ProfileEditState> {
+  /// Family provider keyed on the profile id, so a sheet edit never leaks
+  /// across profiles and each sheet gets its own scoped state that is
+  /// automatically disposed when the sheet closes.
+  ProfileEditControllerProvider._({
+    required ProfileEditControllerFamily super.from,
+    required UserProfile super.argument,
+  }) : super(
+         retry: null,
+         name: r'profileEditControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$profileEditControllerHash();
+
+  @override
+  String toString() {
+    return r'profileEditControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  ProfileEditController create() => ProfileEditController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ProfileEditState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ProfileEditState>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ProfileEditControllerProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$profileEditControllerHash() =>
+    r'999ee05169cce6a6d1a4994351baf1f61c599171';
+
+/// Family provider keyed on the profile id, so a sheet edit never leaks
+/// across profiles and each sheet gets its own scoped state that is
+/// automatically disposed when the sheet closes.
+
+final class ProfileEditControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          ProfileEditController,
+          ProfileEditState,
+          ProfileEditState,
+          ProfileEditState,
+          UserProfile
+        > {
+  ProfileEditControllerFamily._()
+    : super(
+        retry: null,
+        name: r'profileEditControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Family provider keyed on the profile id, so a sheet edit never leaks
+  /// across profiles and each sheet gets its own scoped state that is
+  /// automatically disposed when the sheet closes.
+
+  ProfileEditControllerProvider call(UserProfile initial) =>
+      ProfileEditControllerProvider._(argument: initial, from: this);
+
+  @override
+  String toString() => r'profileEditControllerProvider';
+}
+
+/// Family provider keyed on the profile id, so a sheet edit never leaks
+/// across profiles and each sheet gets its own scoped state that is
+/// automatically disposed when the sheet closes.
+
+abstract class _$ProfileEditController extends $Notifier<ProfileEditState> {
+  late final _$args = ref.$arg as UserProfile;
+  UserProfile get initial => _$args;
+
+  ProfileEditState build(UserProfile initial);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<ProfileEditState, ProfileEditState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<ProfileEditState, ProfileEditState>,
+              ProfileEditState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, () => build(_$args));
+  }
+}

--- a/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
+++ b/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
@@ -9,6 +9,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../profile/data/repositories/profile_repository.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../providers/api_key_validator_provider.dart';
+import '../../providers/onboarding_wizard_provider.dart';
 import '../widgets/api_key_step.dart';
 import '../widgets/completion_step.dart';
 import '../widgets/country_language_step.dart';
@@ -24,6 +25,11 @@ import '../widgets/welcome_step.dart';
 /// 4. Done — confirmation and finish
 ///
 /// The API Key step is conditionally shown based on the selected country.
+///
+/// Wizard progress and loading flag live in
+/// [onboardingWizardControllerProvider]; the API-key [TextEditingController]
+/// and the [PageController] remain local because they must follow the
+/// Flutter widget lifecycle.
 class OnboardingWizardScreen extends ConsumerStatefulWidget {
   const OnboardingWizardScreen({super.key});
 
@@ -36,8 +42,6 @@ class _OnboardingWizardScreenState
     extends ConsumerState<OnboardingWizardScreen> {
   final _pageController = PageController();
   final _apiKeyController = TextEditingController();
-  int _currentStep = 0;
-  bool _isLoading = false;
 
   /// Returns the total number of steps based on whether the selected country
   /// requires an API key.
@@ -46,7 +50,7 @@ class _OnboardingWizardScreenState
     return country.requiresApiKey ? 4 : 3;
   }
 
-  bool get _isLastStep => _currentStep == _stepCount - 1;
+  bool _isLastStep(int currentStep) => currentStep == _stepCount - 1;
 
   @override
   void dispose() {
@@ -56,7 +60,7 @@ class _OnboardingWizardScreenState
   }
 
   void _goToStep(int step) {
-    setState(() => _currentStep = step);
+    ref.read(onboardingWizardControllerProvider.notifier).setStep(step);
     _pageController.animateToPage(
       step,
       duration: const Duration(milliseconds: 300),
@@ -64,24 +68,24 @@ class _OnboardingWizardScreenState
     );
   }
 
-  void _next() {
-    if (_isLastStep) {
+  void _next(int currentStep) {
+    if (_isLastStep(currentStep)) {
       _finishOnboarding();
     } else {
-      _goToStep(_currentStep + 1);
+      _goToStep(currentStep + 1);
     }
   }
 
-  void _back() {
-    if (_currentStep > 0) {
-      _goToStep(_currentStep - 1);
+  void _back(int currentStep) {
+    if (currentStep > 0) {
+      _goToStep(currentStep - 1);
     }
   }
 
   /// Skips the current step (for optional steps like API key).
-  void _skip() {
-    if (!_isLastStep) {
-      _goToStep(_currentStep + 1);
+  void _skip(int currentStep) {
+    if (!_isLastStep(currentStep)) {
+      _goToStep(currentStep + 1);
     }
   }
 
@@ -101,7 +105,8 @@ class _OnboardingWizardScreenState
   }
 
   Future<bool> _validateAndSaveKey(String apiKey) async {
-    setState(() => _isLoading = true);
+    final ctrl = ref.read(onboardingWizardControllerProvider.notifier);
+    ctrl.setLoading(true);
     try {
       final validator = ref.read(apiKeyValidatorProvider);
       final result = await validator.validate(apiKey);
@@ -116,12 +121,13 @@ class _OnboardingWizardScreenState
       await apiKeys.setApiKey(apiKey);
       return true;
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      if (mounted) ctrl.setLoading(false);
     }
   }
 
   Future<void> _completeSetup() async {
-    setState(() => _isLoading = true);
+    final ctrl = ref.read(onboardingWizardControllerProvider.notifier);
+    ctrl.setLoading(true);
     try {
       final settings = ref.read(settingsStorageProvider);
       await settings.skipSetup();
@@ -141,15 +147,15 @@ class _OnboardingWizardScreenState
 
       if (mounted) context.go('/');
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      if (mounted) ctrl.setLoading(false);
     }
   }
 
   /// Returns whether the current step is an optional one that can be skipped.
-  bool get _isCurrentStepSkippable {
+  bool _isCurrentStepSkippable(int currentStep) {
     final country = ref.read(activeCountryProvider);
     // The API key step is skippable (index 2 when country requires key)
-    return country.requiresApiKey && _currentStep == 2;
+    return country.requiresApiKey && currentStep == 2;
   }
 
   List<Widget> _buildSteps() {
@@ -167,8 +173,11 @@ class _OnboardingWizardScreenState
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    // Watch country to rebuild when it changes (affects step count)
+    // Watch country to rebuild when it changes (affects step count).
     ref.watch(activeCountryProvider);
+    final wizardState = ref.watch(onboardingWizardControllerProvider);
+    final currentStep = wizardState.currentStep;
+    final isLoading = wizardState.isLoading;
     final steps = _buildSteps();
 
     return Scaffold(
@@ -178,13 +187,13 @@ class _OnboardingWizardScreenState
             const SizedBox(height: 16),
             // Progress indicator
             OnboardingProgressIndicator(
-              currentStep: _currentStep,
+              currentStep: currentStep,
               stepCount: _stepCount,
             ),
             const SizedBox(height: 8),
             // Step counter text
             Text(
-              '${_currentStep + 1} / $_stepCount',
+              '${currentStep + 1} / $_stepCount',
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -196,7 +205,9 @@ class _OnboardingWizardScreenState
                 controller: _pageController,
                 physics: const NeverScrollableScrollPhysics(),
                 onPageChanged: (index) {
-                  setState(() => _currentStep = index);
+                  ref
+                      .read(onboardingWizardControllerProvider.notifier)
+                      .setStep(index);
                 },
                 children: steps,
               ),
@@ -212,9 +223,9 @@ class _OnboardingWizardScreenState
               child: Row(
                 children: [
                   // Back button
-                  if (_currentStep > 0)
+                  if (currentStep > 0)
                     TextButton.icon(
-                      onPressed: _isLoading ? null : _back,
+                      onPressed: isLoading ? null : () => _back(currentStep),
                       icon: const Icon(Icons.arrow_back),
                       label: Text(l10n?.onboardingBack ?? 'Back'),
                     )
@@ -222,18 +233,19 @@ class _OnboardingWizardScreenState
                     const SizedBox(width: 80),
                   const Spacer(),
                   // Skip button (optional steps)
-                  if (_isCurrentStepSkippable)
+                  if (_isCurrentStepSkippable(currentStep))
                     Padding(
                       padding: const EdgeInsets.only(right: 8),
                       child: TextButton(
-                        onPressed: _isLoading ? null : _skip,
+                        onPressed:
+                            isLoading ? null : () => _skip(currentStep),
                         child: Text(l10n?.onboardingSkip ?? 'Skip'),
                       ),
                     ),
                   // Next / Finish button
                   FilledButton.icon(
-                    onPressed: _isLoading ? null : _next,
-                    icon: _isLoading
+                    onPressed: isLoading ? null : () => _next(currentStep),
+                    icon: isLoading
                         ? const SizedBox(
                             height: 18,
                             width: 18,
@@ -241,12 +253,12 @@ class _OnboardingWizardScreenState
                                 CircularProgressIndicator(strokeWidth: 2),
                           )
                         : Icon(
-                            _isLastStep
+                            _isLastStep(currentStep)
                                 ? Icons.check
                                 : Icons.arrow_forward,
                           ),
                     label: Text(
-                      _isLastStep
+                      _isLastStep(currentStep)
                           ? (l10n?.onboardingFinish ?? 'Get started')
                           : (l10n?.onboardingNext ?? 'Next'),
                     ),

--- a/lib/features/setup/providers/onboarding_wizard_provider.dart
+++ b/lib/features/setup/providers/onboarding_wizard_provider.dart
@@ -1,0 +1,32 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'onboarding_wizard_provider.g.dart';
+
+/// UI state for the multi-step onboarding wizard. API key text value lives
+/// in a local [TextEditingController]; everything else lives here.
+class OnboardingWizardState {
+  final int currentStep;
+  final bool isLoading;
+
+  const OnboardingWizardState({
+    this.currentStep = 0,
+    this.isLoading = false,
+  });
+
+  OnboardingWizardState copyWith({int? currentStep, bool? isLoading}) {
+    return OnboardingWizardState(
+      currentStep: currentStep ?? this.currentStep,
+      isLoading: isLoading ?? this.isLoading,
+    );
+  }
+}
+
+@riverpod
+class OnboardingWizardController extends _$OnboardingWizardController {
+  @override
+  OnboardingWizardState build() => const OnboardingWizardState();
+
+  void setStep(int step) => state = state.copyWith(currentStep: step);
+
+  void setLoading(bool loading) => state = state.copyWith(isLoading: loading);
+}

--- a/lib/features/setup/providers/onboarding_wizard_provider.g.dart
+++ b/lib/features/setup/providers/onboarding_wizard_provider.g.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'onboarding_wizard_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(OnboardingWizardController)
+final onboardingWizardControllerProvider =
+    OnboardingWizardControllerProvider._();
+
+final class OnboardingWizardControllerProvider
+    extends
+        $NotifierProvider<OnboardingWizardController, OnboardingWizardState> {
+  OnboardingWizardControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'onboardingWizardControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$onboardingWizardControllerHash();
+
+  @$internal
+  @override
+  OnboardingWizardController create() => OnboardingWizardController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(OnboardingWizardState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<OnboardingWizardState>(value),
+    );
+  }
+}
+
+String _$onboardingWizardControllerHash() =>
+    r'9bad97ee4caa63b16dac391c66b7f20a69b642ce';
+
+abstract class _$OnboardingWizardController
+    extends $Notifier<OnboardingWizardState> {
+  OnboardingWizardState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<OnboardingWizardState, OnboardingWizardState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<OnboardingWizardState, OnboardingWizardState>,
+              OnboardingWizardState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/sync/presentation/screens/sync_setup_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_setup_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/sync/sync_config.dart';
 import '../../../../core/sync/sync_provider.dart';
+import '../../providers/sync_setup_provider.dart';
 import '../widgets/auth_form_widget.dart';
 import '../widgets/qr_scanner_screen.dart';
 import '../widgets/sync_credentials_step.dart';
@@ -19,6 +20,8 @@ import '../widgets/sync_mode_card.dart';
 /// - Reusable widgets: [SyncModeCard], [AuthFormWidget] are app-agnostic.
 /// - Database credentials abstracted via [SyncState.connectCommunity()] and
 ///   [SyncState.connect(url, key)].
+/// - Wizard step + UI flags live in [syncSetupControllerProvider]; only the
+///   two [TextEditingController]s remain local (Flutter lifecycle).
 class SyncSetupScreen extends ConsumerStatefulWidget {
   const SyncSetupScreen({super.key});
 
@@ -26,16 +29,9 @@ class SyncSetupScreen extends ConsumerStatefulWidget {
   ConsumerState<SyncSetupScreen> createState() => _SyncSetupScreenState();
 }
 
-enum _Step { mode, credentials, auth, done }
-
 class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
-  _Step _step = _Step.mode;
-  SyncMode _selectedMode = SyncMode.none;
   final _urlController = TextEditingController();
   final _keyController = TextEditingController();
-  bool _isLoading = false;
-  String? _error;
-  bool _showKey = false;
 
   @override
   void dispose() {
@@ -44,35 +40,31 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
     super.dispose();
   }
 
-  String get _title => switch (_step) {
-    _Step.mode => 'Connect TankSync',
-    _Step.credentials => _selectedMode == SyncMode.private ? 'Your database' : 'Join a group',
-    _Step.auth => 'Your account',
-    _Step.done => 'Connected!',
-  };
+  String _titleFor(SyncSetupStep step, SyncMode mode) => switch (step) {
+        SyncSetupStep.mode => 'Connect TankSync',
+        SyncSetupStep.credentials =>
+          mode == SyncMode.private ? 'Your database' : 'Join a group',
+        SyncSetupStep.auth => 'Your account',
+        SyncSetupStep.done => 'Connected!',
+      };
 
   void _onBack() {
-    switch (_step) {
-      case _Step.mode:
+    final setup = ref.read(syncSetupControllerProvider);
+    final ctrl = ref.read(syncSetupControllerProvider.notifier);
+    switch (setup.step) {
+      case SyncSetupStep.mode:
         Navigator.pop(context);
-      case _Step.credentials:
-        setState(() => _step = _Step.mode);
-      case _Step.auth:
-        setState(() => _step = _selectedMode == SyncMode.community ? _Step.mode : _Step.credentials);
-      case _Step.done:
+      case SyncSetupStep.credentials:
+        ctrl.goToStep(SyncSetupStep.mode);
+      case SyncSetupStep.auth:
+        ctrl.goToStep(
+          setup.selectedMode == SyncMode.community
+              ? SyncSetupStep.mode
+              : SyncSetupStep.credentials,
+        );
+      case SyncSetupStep.done:
         Navigator.pop(context);
     }
-  }
-
-  void _selectMode(SyncMode mode) {
-    _selectedMode = mode;
-    setState(() {
-      if (mode == SyncMode.community) {
-        _step = _Step.auth;
-      } else {
-        _step = _Step.credentials;
-      }
-    });
   }
 
   Future<void> _onAuthSubmit({
@@ -81,31 +73,34 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
     String? password,
     required bool isSignUp,
   }) async {
-    setState(() { _isLoading = true; _error = null; });
+    final ctrl = ref.read(syncSetupControllerProvider.notifier);
+    final setup = ref.read(syncSetupControllerProvider);
+
+    ctrl.startLoading();
 
     try {
       final syncNotifier = ref.read(syncStateProvider.notifier);
 
-      if (_selectedMode == SyncMode.community) {
+      if (setup.selectedMode == SyncMode.community) {
         await syncNotifier.connectCommunity();
       } else {
         final url = _urlController.text.trim();
         final key = _keyController.text.trim();
-        await syncNotifier.connect(url, key, mode: _selectedMode);
+        await syncNotifier.connect(url, key, mode: setup.selectedMode);
       }
 
       if (isEmail && email != null && password != null) {
         await syncNotifier.signInWithEmail(email, password, isSignUp: isSignUp);
       }
 
-      if (mounted) setState(() => _step = _Step.done);
+      if (!mounted) return;
+      ctrl.goToStep(SyncSetupStep.done);
+      ctrl.stopLoading();
 
       await Future<void>.delayed(const Duration(milliseconds: 1500));
       if (mounted) Navigator.pop(context);
     } catch (e) {
-      if (mounted) setState(() => _error = e.toString());
-    } finally {
-      if (mounted) setState(() => _isLoading = false);
+      if (mounted) ctrl.setError(e.toString());
     }
   }
 
@@ -119,7 +114,6 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
         final json = jsonDecode(result) as Map<String, dynamic>;
         _urlController.text = json['url']?.toString() ?? '';
         _keyController.text = json['key']?.toString() ?? '';
-        setState(() {});
       } catch (e) {
         debugPrint('QR code parse failed: $e');
         if (mounted) {
@@ -131,11 +125,12 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final setup = ref.watch(syncSetupControllerProvider);
     return Scaffold(
       appBar: AppBar(
         title: Semantics(
           header: true,
-          child: Text(_title),
+          child: Text(_titleFor(setup.step, setup.selectedMode)),
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
@@ -145,46 +140,56 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
       ),
       body: AnimatedSwitcher(
         duration: const Duration(milliseconds: 250),
-        child: _buildStep(),
+        child: _buildStep(setup),
       ),
     );
   }
 
-  Widget _buildStep() {
+  Widget _buildStep(SyncSetupState setup) {
     final bottomPad = MediaQuery.of(context).viewPadding.bottom;
+    final ctrl = ref.read(syncSetupControllerProvider.notifier);
     return ListView(
-      key: ValueKey(_step),
+      key: ValueKey(setup.step),
       padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPad),
-      children: switch (_step) {
-        _Step.mode => _buildModeStep(),
-        _Step.credentials => [
-          SyncCredentialsStep(
-            selectedMode: _selectedMode,
-            urlController: _urlController,
-            keyController: _keyController,
-            showKey: _showKey,
-            onToggleKeyVisibility: () => setState(() => _showKey = !_showKey),
-            onScanQr: _scanQr,
-            onContinue: (_urlController.text.trim().isNotEmpty && _keyController.text.trim().isNotEmpty)
-                ? () => setState(() => _step = _Step.auth)
-                : null,
-            onChanged: () => setState(() {}),
-          ),
-        ],
-        _Step.auth => [
-          AuthFormWidget(
-            onSubmit: _onAuthSubmit,
-            isLoading: _isLoading,
-            error: _error,
-          ),
-        ],
-        _Step.done => _buildDoneStep(),
+      children: switch (setup.step) {
+        SyncSetupStep.mode => _buildModeStep(),
+        SyncSetupStep.credentials => [
+            ListenableBuilder(
+              listenable: Listenable.merge([_urlController, _keyController]),
+              builder: (context, _) {
+                final canContinue = _urlController.text.trim().isNotEmpty &&
+                    _keyController.text.trim().isNotEmpty;
+                return SyncCredentialsStep(
+                  selectedMode: setup.selectedMode,
+                  urlController: _urlController,
+                  keyController: _keyController,
+                  showKey: setup.showKey,
+                  onToggleKeyVisibility: ctrl.toggleKeyVisibility,
+                  onScanQr: _scanQr,
+                  onContinue: canContinue
+                      ? () => ctrl.goToStep(SyncSetupStep.auth)
+                      : null,
+                  // Rebuild handled by ListenableBuilder above; no-op.
+                  onChanged: () {},
+                );
+              },
+            ),
+          ],
+        SyncSetupStep.auth => [
+            AuthFormWidget(
+              onSubmit: _onAuthSubmit,
+              isLoading: setup.isLoading,
+              error: setup.error,
+            ),
+          ],
+        SyncSetupStep.done => _buildDoneStep(),
       },
     );
   }
 
   List<Widget> _buildModeStep() {
     final theme = Theme.of(context);
+    final ctrl = ref.read(syncSetupControllerProvider.notifier);
     return [
       Semantics(
         header: true,
@@ -206,7 +211,7 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
           subtitle: 'Share favorites & ratings with all users',
           privacyLabel: 'Shared',
           privacyColor: Colors.green,
-          onTap: () => _selectMode(SyncMode.community),
+          onTap: () => ctrl.selectMode(SyncMode.community),
         ),
       ),
       const SizedBox(height: 10),
@@ -220,7 +225,7 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
           subtitle: 'Your own Supabase — full data control',
           privacyLabel: 'Private',
           privacyColor: Colors.blue,
-          onTap: () => _selectMode(SyncMode.private),
+          onTap: () => ctrl.selectMode(SyncMode.private),
         ),
       ),
       const SizedBox(height: 10),
@@ -234,7 +239,7 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
           subtitle: 'Family or friends shared database',
           privacyLabel: 'Group',
           privacyColor: Colors.orange,
-          onTap: () => _selectMode(SyncMode.joinExisting),
+          onTap: () => ctrl.selectMode(SyncMode.joinExisting),
         ),
       ),
 

--- a/lib/features/sync/providers/sync_setup_provider.dart
+++ b/lib/features/sync/providers/sync_setup_provider.dart
@@ -1,0 +1,75 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/sync/sync_config.dart';
+
+part 'sync_setup_provider.g.dart';
+
+enum SyncSetupStep { mode, credentials, auth, done }
+
+/// UI-only state for the clean 3-step sync setup screen. Text input values
+/// live in [TextEditingController]s owned by the screen itself; wizard step,
+/// selected mode, loading/error state and the show-key toggle live here.
+class SyncSetupState {
+  final SyncSetupStep step;
+  final SyncMode selectedMode;
+  final bool isLoading;
+  final String? error;
+  final bool showKey;
+
+  const SyncSetupState({
+    this.step = SyncSetupStep.mode,
+    this.selectedMode = SyncMode.none,
+    this.isLoading = false,
+    this.error,
+    this.showKey = false,
+  });
+
+  SyncSetupState copyWith({
+    SyncSetupStep? step,
+    SyncMode? selectedMode,
+    bool? isLoading,
+    String? error,
+    bool clearError = false,
+    bool? showKey,
+  }) {
+    return SyncSetupState(
+      step: step ?? this.step,
+      selectedMode: selectedMode ?? this.selectedMode,
+      isLoading: isLoading ?? this.isLoading,
+      error: clearError ? null : (error ?? this.error),
+      showKey: showKey ?? this.showKey,
+    );
+  }
+}
+
+@riverpod
+class SyncSetupController extends _$SyncSetupController {
+  @override
+  SyncSetupState build() => const SyncSetupState();
+
+  void goToStep(SyncSetupStep step) => state = state.copyWith(step: step);
+
+  void selectMode(SyncMode mode) {
+    state = state.copyWith(
+      selectedMode: mode,
+      step: mode == SyncMode.community
+          ? SyncSetupStep.auth
+          : SyncSetupStep.credentials,
+    );
+  }
+
+  void toggleKeyVisibility() =>
+      state = state.copyWith(showKey: !state.showKey);
+
+  void startLoading() =>
+      state = state.copyWith(isLoading: true, clearError: true);
+
+  void stopLoading() => state = state.copyWith(isLoading: false);
+
+  void setError(String message) =>
+      state = state.copyWith(error: message, isLoading: false);
+
+  /// Rebuild signal for text-controller-driven UI (e.g. enabling the
+  /// continue button once URL/key are non-empty).
+  void touch() => state = state.copyWith();
+}

--- a/lib/features/sync/providers/sync_setup_provider.g.dart
+++ b/lib/features/sync/providers/sync_setup_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sync_setup_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(SyncSetupController)
+final syncSetupControllerProvider = SyncSetupControllerProvider._();
+
+final class SyncSetupControllerProvider
+    extends $NotifierProvider<SyncSetupController, SyncSetupState> {
+  SyncSetupControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'syncSetupControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$syncSetupControllerHash();
+
+  @$internal
+  @override
+  SyncSetupController create() => SyncSetupController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SyncSetupState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SyncSetupState>(value),
+    );
+  }
+}
+
+String _$syncSetupControllerHash() =>
+    r'abedbdcdb726fa9b7577c621f83ca81de0c43243';
+
+abstract class _$SyncSetupController extends $Notifier<SyncSetupState> {
+  SyncSetupState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<SyncSetupState, SyncSetupState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<SyncSetupState, SyncSetupState>,
+              SyncSetupState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/profile/providers/profile_edit_provider_test.dart
+++ b/test/features/profile/providers/profile_edit_provider_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/profile_edit_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+void main() {
+  const profile = UserProfile(
+    id: 'p1',
+    name: 'Test',
+    preferredFuelType: FuelType.e10,
+    defaultSearchRadius: 12,
+    landingScreen: LandingScreen.favorites,
+    countryCode: 'DE',
+    languageCode: 'de',
+    routeSegmentKm: 100,
+    avoidHighways: false,
+    showFuel: true,
+    showElectric: false,
+    ratingMode: 'local',
+  );
+
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer();
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('initial state matches profile', () {
+    final c = makeContainer();
+    final s = c.read(profileEditControllerProvider(profile));
+
+    expect(s.fuelType, FuelType.e10);
+    expect(s.radius, 12);
+    expect(s.landingScreen, LandingScreen.favorites);
+    expect(s.countryCode, 'DE');
+    expect(s.languageCode, 'de');
+    expect(s.routeSegmentKm, 100);
+    expect(s.avoidHighways, isFalse);
+    expect(s.showFuel, isTrue);
+    expect(s.showElectric, isFalse);
+    expect(s.ratingMode, 'local');
+  });
+
+  test('mutators update state', () {
+    final c = makeContainer();
+    final ctrl =
+        c.read(profileEditControllerProvider(profile).notifier);
+
+    ctrl.setFuelType(FuelType.diesel);
+    ctrl.setRadius(20);
+    ctrl.setRouteSegmentKm(250);
+    ctrl.setAvoidHighways(true);
+    ctrl.setShowFuel(false);
+    ctrl.setShowElectric(true);
+    ctrl.setRatingMode('shared');
+    ctrl.setLandingScreen(LandingScreen.cheapest);
+    ctrl.setCountryCode('FR');
+    ctrl.setLanguageCode('fr');
+
+    final s = c.read(profileEditControllerProvider(profile));
+    expect(s.fuelType, FuelType.diesel);
+    expect(s.radius, 20);
+    expect(s.routeSegmentKm, 250);
+    expect(s.avoidHighways, isTrue);
+    expect(s.showFuel, isFalse);
+    expect(s.showElectric, isTrue);
+    expect(s.ratingMode, 'shared');
+    expect(s.landingScreen, LandingScreen.cheapest);
+    expect(s.countryCode, 'FR');
+    expect(s.languageCode, 'fr');
+  });
+
+  test('each profile id scope is independent', () {
+    final c = makeContainer();
+    const other = UserProfile(id: 'p2', name: 'Other');
+
+    c
+        .read(profileEditControllerProvider(profile).notifier)
+        .setRadius(22);
+
+    final otherState = c.read(profileEditControllerProvider(other));
+    // Other scope is untouched and defaults to its own profile.
+    expect(otherState.radius, other.defaultSearchRadius);
+  });
+}

--- a/test/features/setup/providers/onboarding_wizard_provider_test.dart
+++ b/test/features/setup/providers/onboarding_wizard_provider_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/setup/providers/onboarding_wizard_provider.dart';
+
+void main() {
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer();
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('defaults to step 0, not loading', () {
+    final c = makeContainer();
+    final s = c.read(onboardingWizardControllerProvider);
+    expect(s.currentStep, 0);
+    expect(s.isLoading, isFalse);
+  });
+
+  test('setStep updates current step', () {
+    final c = makeContainer();
+    c.read(onboardingWizardControllerProvider.notifier).setStep(2);
+    expect(c.read(onboardingWizardControllerProvider).currentStep, 2);
+  });
+
+  test('setLoading toggles loading without touching step', () {
+    final c = makeContainer();
+    final ctrl = c.read(onboardingWizardControllerProvider.notifier);
+    ctrl.setStep(1);
+    ctrl.setLoading(true);
+    final s = c.read(onboardingWizardControllerProvider);
+    expect(s.currentStep, 1);
+    expect(s.isLoading, isTrue);
+  });
+}

--- a/test/features/sync/providers/sync_setup_provider_test.dart
+++ b/test/features/sync/providers/sync_setup_provider_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/sync_config.dart';
+import 'package:tankstellen/features/sync/providers/sync_setup_provider.dart';
+
+void main() {
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer();
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('starts at mode step, no mode selected', () {
+    final c = makeContainer();
+    final s = c.read(syncSetupControllerProvider);
+    expect(s.step, SyncSetupStep.mode);
+    expect(s.selectedMode, SyncMode.none);
+    expect(s.isLoading, isFalse);
+    expect(s.error, isNull);
+    expect(s.showKey, isFalse);
+  });
+
+  test('selectMode(community) jumps straight to auth', () {
+    final c = makeContainer();
+    c.read(syncSetupControllerProvider.notifier).selectMode(SyncMode.community);
+    final s = c.read(syncSetupControllerProvider);
+    expect(s.step, SyncSetupStep.auth);
+    expect(s.selectedMode, SyncMode.community);
+  });
+
+  test('selectMode(private) goes to credentials', () {
+    final c = makeContainer();
+    c.read(syncSetupControllerProvider.notifier).selectMode(SyncMode.private);
+    expect(c.read(syncSetupControllerProvider).step, SyncSetupStep.credentials);
+  });
+
+  test('toggleKeyVisibility flips showKey', () {
+    final c = makeContainer();
+    final ctrl = c.read(syncSetupControllerProvider.notifier);
+    ctrl.toggleKeyVisibility();
+    expect(c.read(syncSetupControllerProvider).showKey, isTrue);
+    ctrl.toggleKeyVisibility();
+    expect(c.read(syncSetupControllerProvider).showKey, isFalse);
+  });
+
+  test('startLoading clears error and sets loading', () {
+    final c = makeContainer();
+    final ctrl = c.read(syncSetupControllerProvider.notifier);
+    ctrl.setError('boom');
+    expect(c.read(syncSetupControllerProvider).error, 'boom');
+    ctrl.startLoading();
+    final s = c.read(syncSetupControllerProvider);
+    expect(s.isLoading, isTrue);
+    expect(s.error, isNull);
+  });
+
+  test('setError stops loading and stores message', () {
+    final c = makeContainer();
+    final ctrl = c.read(syncSetupControllerProvider.notifier);
+    ctrl.startLoading();
+    ctrl.setError('nope');
+    final s = c.read(syncSetupControllerProvider);
+    expect(s.error, 'nope');
+    expect(s.isLoading, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

Batch 2 of the setState cleanup started in #302. Moves form/wizard state for the next three highest-value widgets from StatefulWidget fields into scoped Riverpod providers so rebuilds become selective, state survives widget rebuilds, and the logic is unit-testable in isolation.

- **profile_edit_sheet** (10 setState removed): fuel/radius/landing/country/language/route-segment/avoid-highways/show-fuel/show-electric/rating-mode now live in \`profileEditControllerProvider\` (family keyed on profile id). Name + zip \`TextEditingController\`s remain local.
- **sync_setup_screen** (11 setState removed): wizard step, selected mode, loading, error, show-key now live in \`syncSetupControllerProvider\`. Credentials step uses a \`ListenableBuilder\` on URL+key controllers to recompute the Continue button's enabled state without setState.
- **onboarding_wizard_screen** (6 setState removed): current step and loading flag now live in \`onboardingWizardControllerProvider\`. \`PageController\` and API-key \`TextEditingController\` remain local.

Refs #57 — remaining setStates are smaller widgets (data_transparency, link_device, location_input, etc.) plus UI-only flags the issue explicitly calls out as acceptable to keep; issue stays open for a follow-up batch.

## Test plan

- [x] \`flutter analyze --no-fatal-infos\` — zero warnings, zero errors
- [x] New unit tests for all three providers (12 tests, all passing): defaults, mutators, mode-based navigation, loading/error transitions, family scoping
- [x] Existing \`profile_edit_sheet_test\` (10 tests) and \`onboarding_wizard_screen_test\` (11 tests) continue to pass unchanged
- [x] Full suite: 2928 pass / 1 pre-existing flaky network test (Argentina CSV connectivity timeout, unrelated)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>