### PR TITLE
feat: CO2 calculation engine for fuel fill-ups

### DIFF
--- a/lib/core/services/co2_calculator.dart
+++ b/lib/core/services/co2_calculator.dart
@@ -1,0 +1,107 @@
+import '../../features/consumption/domain/entities/fill_up.dart';
+import '../../features/search/domain/entities/fuel_type.dart';
+
+/// Pure utility for estimating CO2 emissions from fuel consumption.
+///
+/// Emission factors are well-to-wheel (WTW) values expressed in
+/// kilograms of CO2-equivalent per liter of fuel burned, based on the
+/// EU Joint Research Centre (JEC) WTW report v5 (2020).
+///
+/// These are intentionally conservative averages — real-world emissions
+/// vary with blend composition, refining pathway, and driving style.
+/// The goal of this engine is *awareness*, not audit-grade accounting.
+///
+/// All functions are pure and side-effect free: no I/O, no globals,
+/// no random values. They are safe to call from providers, background
+/// isolates, and widgets alike.
+class Co2Calculator {
+  Co2Calculator._();
+
+  // ── Emission factors (kg CO2 per liter, WTW) ────────────────────────────
+
+  /// E5 / SP95 petrol (5% ethanol). Source: EU JEC WTW v5.
+  static const double kgCo2PerLiterE5 = 2.31;
+
+  /// E10 petrol (10% ethanol). Slightly lower than E5 due to bio content.
+  static const double kgCo2PerLiterE10 = 2.27;
+
+  /// Super 98 (SP98) petrol — treated like E5 for CO2 purposes.
+  static const double kgCo2PerLiterE98 = 2.31;
+
+  /// Standard diesel (B7, 7% biodiesel blend). Source: EU JEC WTW v5.
+  static const double kgCo2PerLiterDiesel = 2.65;
+
+  /// Diesel Premium — equivalent to standard diesel for CO2 purposes.
+  static const double kgCo2PerLiterDieselPremium = 2.65;
+
+  /// E85 / Bioethanol (85% ethanol). Much lower WTW emissions due to
+  /// biogenic carbon uptake.
+  static const double kgCo2PerLiterE85 = 1.40;
+
+  /// LPG (Liquefied Petroleum Gas, butane/propane mix).
+  static const double kgCo2PerLiterLpg = 1.61;
+
+  /// CNG (Compressed Natural Gas) — sold per kg in most EU markets.
+  /// Returned per-liter-equivalent for API symmetry; callers working
+  /// with kg should multiply directly by [kgCo2PerKgCng].
+  static const double kgCo2PerKgCng = 2.54;
+
+  // ── Core lookup ──────────────────────────────────────────────────────────
+
+  /// Returns the CO2 emission factor (kg CO2 per liter) for the given
+  /// [fuelType]. Returns `null` for fuel types without a meaningful
+  /// per-liter factor (electric, hydrogen, CNG sold per kg, meta).
+  static double? emissionFactorFor(FuelType fuelType) {
+    return switch (fuelType) {
+      FuelTypeE5() => kgCo2PerLiterE5,
+      FuelTypeE10() => kgCo2PerLiterE10,
+      FuelTypeE98() => kgCo2PerLiterE98,
+      FuelTypeDiesel() => kgCo2PerLiterDiesel,
+      FuelTypeDieselPremium() => kgCo2PerLiterDieselPremium,
+      FuelTypeE85() => kgCo2PerLiterE85,
+      FuelTypeLpg() => kgCo2PerLiterLpg,
+      FuelTypeCng() => kgCo2PerKgCng, // caller passes kg, not L
+      FuelTypeHydrogen() => null,
+      FuelTypeElectric() => null,
+      FuelTypeAll() => null,
+    };
+  }
+
+  /// Compute CO2 emissions (kg) for a given volume of fuel.
+  ///
+  /// Negative [liters] is clamped to zero. Unknown or unsupported fuel
+  /// types (electric, hydrogen, all) return 0 — callers wanting to
+  /// distinguish "unsupported" from "zero emissions" should check
+  /// [emissionFactorFor] first.
+  static double co2ForLiters(double liters, FuelType fuelType) {
+    if (liters <= 0) return 0;
+    final factor = emissionFactorFor(fuelType);
+    if (factor == null) return 0;
+    return liters * factor;
+  }
+
+  /// Compute CO2 emissions (kg) for a single [FillUp].
+  static double co2ForFillUp(FillUp fillUp) =>
+      co2ForLiters(fillUp.liters, fillUp.fuelType);
+
+  /// Sum CO2 emissions (kg) across a list of fill-ups.
+  static double cumulativeCo2(List<FillUp> fillUps) {
+    double total = 0;
+    for (final f in fillUps) {
+      total += co2ForFillUp(f);
+    }
+    return total;
+  }
+
+  /// Compute CO2 emissions per kilometer (kg CO2 / km) for a fill-up,
+  /// given the distance [km] driven on that tank.
+  ///
+  /// Returns `null` when [km] is non-positive (distance unknown or zero)
+  /// so callers can distinguish "no data" from "zero".
+  static double? co2PerKm(FillUp fillUp, double km) {
+    if (km <= 0) return null;
+    final co2 = co2ForFillUp(fillUp);
+    if (co2 == 0) return null;
+    return co2 / km;
+  }
+}

--- a/lib/features/consumption/domain/entities/consumption_stats.dart
+++ b/lib/features/consumption/domain/entities/consumption_stats.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../../core/services/co2_calculator.dart';
 import 'fill_up.dart';
 
 part 'consumption_stats.freezed.dart';
@@ -18,9 +19,11 @@ abstract class ConsumptionStats with _$ConsumptionStats {
     required double totalLiters,
     required double totalSpent,
     required double totalDistanceKm,
+    @Default(0) double totalCo2Kg,
     double? avgConsumptionL100km,
     double? avgCostPerKm,
     double? avgPricePerLiter,
+    double? avgCo2PerKm,
     DateTime? periodStart,
     DateTime? periodEnd,
   }) = _ConsumptionStats;
@@ -31,6 +34,7 @@ abstract class ConsumptionStats with _$ConsumptionStats {
     totalLiters: 0,
     totalSpent: 0,
     totalDistanceKm: 0,
+    totalCo2Kg: 0,
   );
 
   /// Compute aggregated stats from a list of fill-ups.
@@ -50,6 +54,7 @@ abstract class ConsumptionStats with _$ConsumptionStats {
         sorted.fold<double>(0, (sum, f) => sum + f.liters);
     final totalSpent =
         sorted.fold<double>(0, (sum, f) => sum + f.totalCost);
+    final totalCo2 = Co2Calculator.cumulativeCo2(sorted);
 
     final firstOdo = sorted.first.odometerKm;
     final lastOdo = sorted.last.odometerKm;
@@ -58,6 +63,7 @@ abstract class ConsumptionStats with _$ConsumptionStats {
 
     double? avgL100;
     double? avgCostKm;
+    double? avgCo2Km;
     if (sorted.length >= 2 && totalDistance > 0) {
       // Liters used between first and last fill-up — exclude the first
       // tank since its prior distance is unknown.
@@ -70,6 +76,12 @@ abstract class ConsumptionStats with _$ConsumptionStats {
           .skip(1)
           .fold<double>(0, (sum, f) => sum + f.totalCost);
       avgCostKm = costBetween / totalDistance;
+
+      // CO2 per km — also excludes the first tank for the same reason.
+      final co2Between = Co2Calculator.cumulativeCo2(sorted.skip(1).toList());
+      if (co2Between > 0) {
+        avgCo2Km = co2Between / totalDistance;
+      }
     }
 
     final avgPriceLiter = totalLiters > 0 ? totalSpent / totalLiters : null;
@@ -79,9 +91,11 @@ abstract class ConsumptionStats with _$ConsumptionStats {
       totalLiters: totalLiters,
       totalSpent: totalSpent,
       totalDistanceKm: totalDistance,
+      totalCo2Kg: totalCo2,
       avgConsumptionL100km: avgL100,
       avgCostPerKm: avgCostKm,
       avgPricePerLiter: avgPriceLiter,
+      avgCo2PerKm: avgCo2Km,
       periodStart: sorted.first.date,
       periodEnd: sorted.last.date,
     );

--- a/lib/features/consumption/domain/entities/consumption_stats.freezed.dart
+++ b/lib/features/consumption/domain/entities/consumption_stats.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ConsumptionStats {
 
- int get fillUpCount; double get totalLiters; double get totalSpent; double get totalDistanceKm; double? get avgConsumptionL100km; double? get avgCostPerKm; double? get avgPricePerLiter; DateTime? get periodStart; DateTime? get periodEnd;
+ int get fillUpCount; double get totalLiters; double get totalSpent; double get totalDistanceKm; double get totalCo2Kg; double? get avgConsumptionL100km; double? get avgCostPerKm; double? get avgPricePerLiter; double? get avgCo2PerKm; DateTime? get periodStart; DateTime? get periodEnd;
 /// Create a copy of ConsumptionStats
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $ConsumptionStatsCopyWith<ConsumptionStats> get copyWith => _$ConsumptionStatsCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConsumptionStats&&(identical(other.fillUpCount, fillUpCount) || other.fillUpCount == fillUpCount)&&(identical(other.totalLiters, totalLiters) || other.totalLiters == totalLiters)&&(identical(other.totalSpent, totalSpent) || other.totalSpent == totalSpent)&&(identical(other.totalDistanceKm, totalDistanceKm) || other.totalDistanceKm == totalDistanceKm)&&(identical(other.avgConsumptionL100km, avgConsumptionL100km) || other.avgConsumptionL100km == avgConsumptionL100km)&&(identical(other.avgCostPerKm, avgCostPerKm) || other.avgCostPerKm == avgCostPerKm)&&(identical(other.avgPricePerLiter, avgPricePerLiter) || other.avgPricePerLiter == avgPricePerLiter)&&(identical(other.periodStart, periodStart) || other.periodStart == periodStart)&&(identical(other.periodEnd, periodEnd) || other.periodEnd == periodEnd));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConsumptionStats&&(identical(other.fillUpCount, fillUpCount) || other.fillUpCount == fillUpCount)&&(identical(other.totalLiters, totalLiters) || other.totalLiters == totalLiters)&&(identical(other.totalSpent, totalSpent) || other.totalSpent == totalSpent)&&(identical(other.totalDistanceKm, totalDistanceKm) || other.totalDistanceKm == totalDistanceKm)&&(identical(other.totalCo2Kg, totalCo2Kg) || other.totalCo2Kg == totalCo2Kg)&&(identical(other.avgConsumptionL100km, avgConsumptionL100km) || other.avgConsumptionL100km == avgConsumptionL100km)&&(identical(other.avgCostPerKm, avgCostPerKm) || other.avgCostPerKm == avgCostPerKm)&&(identical(other.avgPricePerLiter, avgPricePerLiter) || other.avgPricePerLiter == avgPricePerLiter)&&(identical(other.avgCo2PerKm, avgCo2PerKm) || other.avgCo2PerKm == avgCo2PerKm)&&(identical(other.periodStart, periodStart) || other.periodStart == periodStart)&&(identical(other.periodEnd, periodEnd) || other.periodEnd == periodEnd));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,fillUpCount,totalLiters,totalSpent,totalDistanceKm,avgConsumptionL100km,avgCostPerKm,avgPricePerLiter,periodStart,periodEnd);
+int get hashCode => Object.hash(runtimeType,fillUpCount,totalLiters,totalSpent,totalDistanceKm,totalCo2Kg,avgConsumptionL100km,avgCostPerKm,avgPricePerLiter,avgCo2PerKm,periodStart,periodEnd);
 
 @override
 String toString() {
-  return 'ConsumptionStats(fillUpCount: $fillUpCount, totalLiters: $totalLiters, totalSpent: $totalSpent, totalDistanceKm: $totalDistanceKm, avgConsumptionL100km: $avgConsumptionL100km, avgCostPerKm: $avgCostPerKm, avgPricePerLiter: $avgPricePerLiter, periodStart: $periodStart, periodEnd: $periodEnd)';
+  return 'ConsumptionStats(fillUpCount: $fillUpCount, totalLiters: $totalLiters, totalSpent: $totalSpent, totalDistanceKm: $totalDistanceKm, totalCo2Kg: $totalCo2Kg, avgConsumptionL100km: $avgConsumptionL100km, avgCostPerKm: $avgCostPerKm, avgPricePerLiter: $avgPricePerLiter, avgCo2PerKm: $avgCo2PerKm, periodStart: $periodStart, periodEnd: $periodEnd)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $ConsumptionStatsCopyWith<$Res>  {
   factory $ConsumptionStatsCopyWith(ConsumptionStats value, $Res Function(ConsumptionStats) _then) = _$ConsumptionStatsCopyWithImpl;
 @useResult
 $Res call({
- int fillUpCount, double totalLiters, double totalSpent, double totalDistanceKm, double? avgConsumptionL100km, double? avgCostPerKm, double? avgPricePerLiter, DateTime? periodStart, DateTime? periodEnd
+ int fillUpCount, double totalLiters, double totalSpent, double totalDistanceKm, double totalCo2Kg, double? avgConsumptionL100km, double? avgCostPerKm, double? avgPricePerLiter, double? avgCo2PerKm, DateTime? periodStart, DateTime? periodEnd
 });
 
 
@@ -62,15 +62,17 @@ class _$ConsumptionStatsCopyWithImpl<$Res>
 
 /// Create a copy of ConsumptionStats
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? fillUpCount = null,Object? totalLiters = null,Object? totalSpent = null,Object? totalDistanceKm = null,Object? avgConsumptionL100km = freezed,Object? avgCostPerKm = freezed,Object? avgPricePerLiter = freezed,Object? periodStart = freezed,Object? periodEnd = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? fillUpCount = null,Object? totalLiters = null,Object? totalSpent = null,Object? totalDistanceKm = null,Object? totalCo2Kg = null,Object? avgConsumptionL100km = freezed,Object? avgCostPerKm = freezed,Object? avgPricePerLiter = freezed,Object? avgCo2PerKm = freezed,Object? periodStart = freezed,Object? periodEnd = freezed,}) {
   return _then(_self.copyWith(
 fillUpCount: null == fillUpCount ? _self.fillUpCount : fillUpCount // ignore: cast_nullable_to_non_nullable
 as int,totalLiters: null == totalLiters ? _self.totalLiters : totalLiters // ignore: cast_nullable_to_non_nullable
 as double,totalSpent: null == totalSpent ? _self.totalSpent : totalSpent // ignore: cast_nullable_to_non_nullable
 as double,totalDistanceKm: null == totalDistanceKm ? _self.totalDistanceKm : totalDistanceKm // ignore: cast_nullable_to_non_nullable
+as double,totalCo2Kg: null == totalCo2Kg ? _self.totalCo2Kg : totalCo2Kg // ignore: cast_nullable_to_non_nullable
 as double,avgConsumptionL100km: freezed == avgConsumptionL100km ? _self.avgConsumptionL100km : avgConsumptionL100km // ignore: cast_nullable_to_non_nullable
 as double?,avgCostPerKm: freezed == avgCostPerKm ? _self.avgCostPerKm : avgCostPerKm // ignore: cast_nullable_to_non_nullable
 as double?,avgPricePerLiter: freezed == avgPricePerLiter ? _self.avgPricePerLiter : avgPricePerLiter // ignore: cast_nullable_to_non_nullable
+as double?,avgCo2PerKm: freezed == avgCo2PerKm ? _self.avgCo2PerKm : avgCo2PerKm // ignore: cast_nullable_to_non_nullable
 as double?,periodStart: freezed == periodStart ? _self.periodStart : periodStart // ignore: cast_nullable_to_non_nullable
 as DateTime?,periodEnd: freezed == periodEnd ? _self.periodEnd : periodEnd // ignore: cast_nullable_to_non_nullable
 as DateTime?,
@@ -158,10 +160,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int fillUpCount,  double totalLiters,  double totalSpent,  double totalDistanceKm,  double? avgConsumptionL100km,  double? avgCostPerKm,  double? avgPricePerLiter,  DateTime? periodStart,  DateTime? periodEnd)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int fillUpCount,  double totalLiters,  double totalSpent,  double totalDistanceKm,  double totalCo2Kg,  double? avgConsumptionL100km,  double? avgCostPerKm,  double? avgPricePerLiter,  double? avgCo2PerKm,  DateTime? periodStart,  DateTime? periodEnd)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ConsumptionStats() when $default != null:
-return $default(_that.fillUpCount,_that.totalLiters,_that.totalSpent,_that.totalDistanceKm,_that.avgConsumptionL100km,_that.avgCostPerKm,_that.avgPricePerLiter,_that.periodStart,_that.periodEnd);case _:
+return $default(_that.fillUpCount,_that.totalLiters,_that.totalSpent,_that.totalDistanceKm,_that.totalCo2Kg,_that.avgConsumptionL100km,_that.avgCostPerKm,_that.avgPricePerLiter,_that.avgCo2PerKm,_that.periodStart,_that.periodEnd);case _:
   return orElse();
 
 }
@@ -179,10 +181,10 @@ return $default(_that.fillUpCount,_that.totalLiters,_that.totalSpent,_that.total
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int fillUpCount,  double totalLiters,  double totalSpent,  double totalDistanceKm,  double? avgConsumptionL100km,  double? avgCostPerKm,  double? avgPricePerLiter,  DateTime? periodStart,  DateTime? periodEnd)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int fillUpCount,  double totalLiters,  double totalSpent,  double totalDistanceKm,  double totalCo2Kg,  double? avgConsumptionL100km,  double? avgCostPerKm,  double? avgPricePerLiter,  double? avgCo2PerKm,  DateTime? periodStart,  DateTime? periodEnd)  $default,) {final _that = this;
 switch (_that) {
 case _ConsumptionStats():
-return $default(_that.fillUpCount,_that.totalLiters,_that.totalSpent,_that.totalDistanceKm,_that.avgConsumptionL100km,_that.avgCostPerKm,_that.avgPricePerLiter,_that.periodStart,_that.periodEnd);case _:
+return $default(_that.fillUpCount,_that.totalLiters,_that.totalSpent,_that.totalDistanceKm,_that.totalCo2Kg,_that.avgConsumptionL100km,_that.avgCostPerKm,_that.avgPricePerLiter,_that.avgCo2PerKm,_that.periodStart,_that.periodEnd);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -199,10 +201,10 @@ return $default(_that.fillUpCount,_that.totalLiters,_that.totalSpent,_that.total
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int fillUpCount,  double totalLiters,  double totalSpent,  double totalDistanceKm,  double? avgConsumptionL100km,  double? avgCostPerKm,  double? avgPricePerLiter,  DateTime? periodStart,  DateTime? periodEnd)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int fillUpCount,  double totalLiters,  double totalSpent,  double totalDistanceKm,  double totalCo2Kg,  double? avgConsumptionL100km,  double? avgCostPerKm,  double? avgPricePerLiter,  double? avgCo2PerKm,  DateTime? periodStart,  DateTime? periodEnd)?  $default,) {final _that = this;
 switch (_that) {
 case _ConsumptionStats() when $default != null:
-return $default(_that.fillUpCount,_that.totalLiters,_that.totalSpent,_that.totalDistanceKm,_that.avgConsumptionL100km,_that.avgCostPerKm,_that.avgPricePerLiter,_that.periodStart,_that.periodEnd);case _:
+return $default(_that.fillUpCount,_that.totalLiters,_that.totalSpent,_that.totalDistanceKm,_that.totalCo2Kg,_that.avgConsumptionL100km,_that.avgCostPerKm,_that.avgPricePerLiter,_that.avgCo2PerKm,_that.periodStart,_that.periodEnd);case _:
   return null;
 
 }
@@ -214,16 +216,18 @@ return $default(_that.fillUpCount,_that.totalLiters,_that.totalSpent,_that.total
 
 
 class _ConsumptionStats extends ConsumptionStats {
-  const _ConsumptionStats({required this.fillUpCount, required this.totalLiters, required this.totalSpent, required this.totalDistanceKm, this.avgConsumptionL100km, this.avgCostPerKm, this.avgPricePerLiter, this.periodStart, this.periodEnd}): super._();
+  const _ConsumptionStats({required this.fillUpCount, required this.totalLiters, required this.totalSpent, required this.totalDistanceKm, this.totalCo2Kg = 0, this.avgConsumptionL100km, this.avgCostPerKm, this.avgPricePerLiter, this.avgCo2PerKm, this.periodStart, this.periodEnd}): super._();
   
 
 @override final  int fillUpCount;
 @override final  double totalLiters;
 @override final  double totalSpent;
 @override final  double totalDistanceKm;
+@override@JsonKey() final  double totalCo2Kg;
 @override final  double? avgConsumptionL100km;
 @override final  double? avgCostPerKm;
 @override final  double? avgPricePerLiter;
+@override final  double? avgCo2PerKm;
 @override final  DateTime? periodStart;
 @override final  DateTime? periodEnd;
 
@@ -237,16 +241,16 @@ _$ConsumptionStatsCopyWith<_ConsumptionStats> get copyWith => __$ConsumptionStat
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ConsumptionStats&&(identical(other.fillUpCount, fillUpCount) || other.fillUpCount == fillUpCount)&&(identical(other.totalLiters, totalLiters) || other.totalLiters == totalLiters)&&(identical(other.totalSpent, totalSpent) || other.totalSpent == totalSpent)&&(identical(other.totalDistanceKm, totalDistanceKm) || other.totalDistanceKm == totalDistanceKm)&&(identical(other.avgConsumptionL100km, avgConsumptionL100km) || other.avgConsumptionL100km == avgConsumptionL100km)&&(identical(other.avgCostPerKm, avgCostPerKm) || other.avgCostPerKm == avgCostPerKm)&&(identical(other.avgPricePerLiter, avgPricePerLiter) || other.avgPricePerLiter == avgPricePerLiter)&&(identical(other.periodStart, periodStart) || other.periodStart == periodStart)&&(identical(other.periodEnd, periodEnd) || other.periodEnd == periodEnd));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ConsumptionStats&&(identical(other.fillUpCount, fillUpCount) || other.fillUpCount == fillUpCount)&&(identical(other.totalLiters, totalLiters) || other.totalLiters == totalLiters)&&(identical(other.totalSpent, totalSpent) || other.totalSpent == totalSpent)&&(identical(other.totalDistanceKm, totalDistanceKm) || other.totalDistanceKm == totalDistanceKm)&&(identical(other.totalCo2Kg, totalCo2Kg) || other.totalCo2Kg == totalCo2Kg)&&(identical(other.avgConsumptionL100km, avgConsumptionL100km) || other.avgConsumptionL100km == avgConsumptionL100km)&&(identical(other.avgCostPerKm, avgCostPerKm) || other.avgCostPerKm == avgCostPerKm)&&(identical(other.avgPricePerLiter, avgPricePerLiter) || other.avgPricePerLiter == avgPricePerLiter)&&(identical(other.avgCo2PerKm, avgCo2PerKm) || other.avgCo2PerKm == avgCo2PerKm)&&(identical(other.periodStart, periodStart) || other.periodStart == periodStart)&&(identical(other.periodEnd, periodEnd) || other.periodEnd == periodEnd));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,fillUpCount,totalLiters,totalSpent,totalDistanceKm,avgConsumptionL100km,avgCostPerKm,avgPricePerLiter,periodStart,periodEnd);
+int get hashCode => Object.hash(runtimeType,fillUpCount,totalLiters,totalSpent,totalDistanceKm,totalCo2Kg,avgConsumptionL100km,avgCostPerKm,avgPricePerLiter,avgCo2PerKm,periodStart,periodEnd);
 
 @override
 String toString() {
-  return 'ConsumptionStats(fillUpCount: $fillUpCount, totalLiters: $totalLiters, totalSpent: $totalSpent, totalDistanceKm: $totalDistanceKm, avgConsumptionL100km: $avgConsumptionL100km, avgCostPerKm: $avgCostPerKm, avgPricePerLiter: $avgPricePerLiter, periodStart: $periodStart, periodEnd: $periodEnd)';
+  return 'ConsumptionStats(fillUpCount: $fillUpCount, totalLiters: $totalLiters, totalSpent: $totalSpent, totalDistanceKm: $totalDistanceKm, totalCo2Kg: $totalCo2Kg, avgConsumptionL100km: $avgConsumptionL100km, avgCostPerKm: $avgCostPerKm, avgPricePerLiter: $avgPricePerLiter, avgCo2PerKm: $avgCo2PerKm, periodStart: $periodStart, periodEnd: $periodEnd)';
 }
 
 
@@ -257,7 +261,7 @@ abstract mixin class _$ConsumptionStatsCopyWith<$Res> implements $ConsumptionSta
   factory _$ConsumptionStatsCopyWith(_ConsumptionStats value, $Res Function(_ConsumptionStats) _then) = __$ConsumptionStatsCopyWithImpl;
 @override @useResult
 $Res call({
- int fillUpCount, double totalLiters, double totalSpent, double totalDistanceKm, double? avgConsumptionL100km, double? avgCostPerKm, double? avgPricePerLiter, DateTime? periodStart, DateTime? periodEnd
+ int fillUpCount, double totalLiters, double totalSpent, double totalDistanceKm, double totalCo2Kg, double? avgConsumptionL100km, double? avgCostPerKm, double? avgPricePerLiter, double? avgCo2PerKm, DateTime? periodStart, DateTime? periodEnd
 });
 
 
@@ -274,15 +278,17 @@ class __$ConsumptionStatsCopyWithImpl<$Res>
 
 /// Create a copy of ConsumptionStats
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? fillUpCount = null,Object? totalLiters = null,Object? totalSpent = null,Object? totalDistanceKm = null,Object? avgConsumptionL100km = freezed,Object? avgCostPerKm = freezed,Object? avgPricePerLiter = freezed,Object? periodStart = freezed,Object? periodEnd = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? fillUpCount = null,Object? totalLiters = null,Object? totalSpent = null,Object? totalDistanceKm = null,Object? totalCo2Kg = null,Object? avgConsumptionL100km = freezed,Object? avgCostPerKm = freezed,Object? avgPricePerLiter = freezed,Object? avgCo2PerKm = freezed,Object? periodStart = freezed,Object? periodEnd = freezed,}) {
   return _then(_ConsumptionStats(
 fillUpCount: null == fillUpCount ? _self.fillUpCount : fillUpCount // ignore: cast_nullable_to_non_nullable
 as int,totalLiters: null == totalLiters ? _self.totalLiters : totalLiters // ignore: cast_nullable_to_non_nullable
 as double,totalSpent: null == totalSpent ? _self.totalSpent : totalSpent // ignore: cast_nullable_to_non_nullable
 as double,totalDistanceKm: null == totalDistanceKm ? _self.totalDistanceKm : totalDistanceKm // ignore: cast_nullable_to_non_nullable
+as double,totalCo2Kg: null == totalCo2Kg ? _self.totalCo2Kg : totalCo2Kg // ignore: cast_nullable_to_non_nullable
 as double,avgConsumptionL100km: freezed == avgConsumptionL100km ? _self.avgConsumptionL100km : avgConsumptionL100km // ignore: cast_nullable_to_non_nullable
 as double?,avgCostPerKm: freezed == avgCostPerKm ? _self.avgCostPerKm : avgCostPerKm // ignore: cast_nullable_to_non_nullable
 as double?,avgPricePerLiter: freezed == avgPricePerLiter ? _self.avgPricePerLiter : avgPricePerLiter // ignore: cast_nullable_to_non_nullable
+as double?,avgCo2PerKm: freezed == avgCo2PerKm ? _self.avgCo2PerKm : avgCo2PerKm // ignore: cast_nullable_to_non_nullable
 as double?,periodStart: freezed == periodStart ? _self.periodStart : periodStart // ignore: cast_nullable_to_non_nullable
 as DateTime?,periodEnd: freezed == periodEnd ? _self.periodEnd : periodEnd // ignore: cast_nullable_to_non_nullable
 as DateTime?,

--- a/lib/features/consumption/domain/entities/fill_up.dart
+++ b/lib/features/consumption/domain/entities/fill_up.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../../core/services/co2_calculator.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 
 part 'fill_up.freezed.dart';
@@ -30,4 +31,11 @@ abstract class FillUp with _$FillUp {
 extension FillUpX on FillUp {
   /// Price per liter in the store currency (e.g. EUR/L).
   double get pricePerLiter => liters > 0 ? totalCost / liters : 0;
+
+  /// Estimated CO2 emissions for this fill-up, in kilograms.
+  ///
+  /// Computed from fuel type and volume via [Co2Calculator]. Returns 0
+  /// for fuel types without a per-liter emission factor (electric,
+  /// hydrogen, all).
+  double get co2Kg => Co2Calculator.co2ForFillUp(this);
 }

--- a/test/core/services/co2_calculator_test.dart
+++ b/test/core/services/co2_calculator_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/co2_calculator.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+FillUp _f({
+  double liters = 50,
+  FuelType fuelType = FuelType.e10,
+}) =>
+    FillUp(
+      id: 'x',
+      date: DateTime(2026, 1, 1),
+      liters: liters,
+      totalCost: 80,
+      odometerKm: 10000,
+      fuelType: fuelType,
+    );
+
+void main() {
+  group('Co2Calculator.emissionFactorFor', () {
+    test('returns E5 factor for E5', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.e5),
+          Co2Calculator.kgCo2PerLiterE5);
+    });
+
+    test('returns E10 factor for E10', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.e10),
+          Co2Calculator.kgCo2PerLiterE10);
+    });
+
+    test('returns E98 factor for E98', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.e98),
+          Co2Calculator.kgCo2PerLiterE98);
+    });
+
+    test('returns diesel factor for diesel', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.diesel),
+          Co2Calculator.kgCo2PerLiterDiesel);
+    });
+
+    test('returns diesel factor for diesel premium', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.dieselPremium),
+          Co2Calculator.kgCo2PerLiterDieselPremium);
+    });
+
+    test('returns E85 factor for E85 (lower due to ethanol)', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.e85),
+          Co2Calculator.kgCo2PerLiterE85);
+      // Sanity: E85 should be materially lower than diesel/E5.
+      expect(
+          Co2Calculator.kgCo2PerLiterE85, lessThan(Co2Calculator.kgCo2PerLiterE5));
+      expect(Co2Calculator.kgCo2PerLiterE85,
+          lessThan(Co2Calculator.kgCo2PerLiterDiesel));
+    });
+
+    test('returns LPG factor for LPG', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.lpg),
+          Co2Calculator.kgCo2PerLiterLpg);
+    });
+
+    test('returns null for electric', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.electric), isNull);
+    });
+
+    test('returns null for hydrogen', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.hydrogen), isNull);
+    });
+
+    test('returns null for all/meta', () {
+      expect(Co2Calculator.emissionFactorFor(FuelType.all), isNull);
+    });
+  });
+
+  group('Co2Calculator.co2ForLiters', () {
+    test('computes diesel CO2 for 50 L', () {
+      expect(
+        Co2Calculator.co2ForLiters(50, FuelType.diesel),
+        closeTo(50 * Co2Calculator.kgCo2PerLiterDiesel, 0.0001),
+      );
+    });
+
+    test('computes E10 CO2 for 40 L', () {
+      expect(
+        Co2Calculator.co2ForLiters(40, FuelType.e10),
+        closeTo(40 * Co2Calculator.kgCo2PerLiterE10, 0.0001),
+      );
+    });
+
+    test('zero liters returns zero', () {
+      expect(Co2Calculator.co2ForLiters(0, FuelType.diesel), 0);
+    });
+
+    test('negative liters clamped to zero', () {
+      expect(Co2Calculator.co2ForLiters(-10, FuelType.diesel), 0);
+    });
+
+    test('unsupported fuel type (electric) returns zero', () {
+      expect(Co2Calculator.co2ForLiters(50, FuelType.electric), 0);
+    });
+
+    test('unsupported fuel type (hydrogen) returns zero', () {
+      expect(Co2Calculator.co2ForLiters(50, FuelType.hydrogen), 0);
+    });
+
+    test('unsupported fuel type (all) returns zero', () {
+      expect(Co2Calculator.co2ForLiters(50, FuelType.all), 0);
+    });
+  });
+
+  group('Co2Calculator.co2ForFillUp', () {
+    test('computes CO2 for a diesel fill-up', () {
+      final fillUp = _f(liters: 50, fuelType: FuelType.diesel);
+      expect(
+        Co2Calculator.co2ForFillUp(fillUp),
+        closeTo(50 * Co2Calculator.kgCo2PerLiterDiesel, 0.0001),
+      );
+    });
+
+    test('FillUp.co2Kg extension matches calculator', () {
+      final fillUp = _f(liters: 42, fuelType: FuelType.e5);
+      expect(fillUp.co2Kg, closeTo(Co2Calculator.co2ForFillUp(fillUp), 0.0001));
+    });
+
+    test('electric fill-up has zero CO2 (no per-liter factor)', () {
+      final fillUp = _f(liters: 30, fuelType: FuelType.electric);
+      expect(Co2Calculator.co2ForFillUp(fillUp), 0);
+      expect(fillUp.co2Kg, 0);
+    });
+  });
+
+  group('Co2Calculator.cumulativeCo2', () {
+    test('empty list returns 0', () {
+      expect(Co2Calculator.cumulativeCo2(const []), 0);
+    });
+
+    test('sums CO2 across multiple fill-ups of same fuel type', () {
+      final fills = [
+        _f(liters: 50, fuelType: FuelType.diesel),
+        _f(liters: 40, fuelType: FuelType.diesel),
+        _f(liters: 30, fuelType: FuelType.diesel),
+      ];
+      expect(
+        Co2Calculator.cumulativeCo2(fills),
+        closeTo(120 * Co2Calculator.kgCo2PerLiterDiesel, 0.0001),
+      );
+    });
+
+    test('sums CO2 across mixed fuel types', () {
+      final fills = [
+        _f(liters: 50, fuelType: FuelType.diesel),
+        _f(liters: 40, fuelType: FuelType.e10),
+        _f(liters: 30, fuelType: FuelType.e85),
+      ];
+      final expected = 50 * Co2Calculator.kgCo2PerLiterDiesel +
+          40 * Co2Calculator.kgCo2PerLiterE10 +
+          30 * Co2Calculator.kgCo2PerLiterE85;
+      expect(Co2Calculator.cumulativeCo2(fills), closeTo(expected, 0.0001));
+    });
+
+    test('ignores electric entries in cumulative sum', () {
+      final fills = [
+        _f(liters: 50, fuelType: FuelType.diesel),
+        _f(liters: 30, fuelType: FuelType.electric),
+      ];
+      expect(
+        Co2Calculator.cumulativeCo2(fills),
+        closeTo(50 * Co2Calculator.kgCo2PerLiterDiesel, 0.0001),
+      );
+    });
+  });
+
+  group('Co2Calculator.co2PerKm', () {
+    test('computes kg CO2 per km for a known tank', () {
+      // 50 L diesel @ 2.65 = 132.5 kg CO2 over 1000 km = 0.1325 kg/km
+      final fillUp = _f(liters: 50, fuelType: FuelType.diesel);
+      expect(
+        Co2Calculator.co2PerKm(fillUp, 1000),
+        closeTo(50 * Co2Calculator.kgCo2PerLiterDiesel / 1000, 0.0001),
+      );
+    });
+
+    test('returns null for zero distance (no divide-by-zero)', () {
+      final fillUp = _f(liters: 50, fuelType: FuelType.diesel);
+      expect(Co2Calculator.co2PerKm(fillUp, 0), isNull);
+    });
+
+    test('returns null for negative distance', () {
+      final fillUp = _f(liters: 50, fuelType: FuelType.diesel);
+      expect(Co2Calculator.co2PerKm(fillUp, -100), isNull);
+    });
+
+    test('returns null for electric fill-up (no CO2 factor)', () {
+      final fillUp = _f(liters: 30, fuelType: FuelType.electric);
+      expect(Co2Calculator.co2PerKm(fillUp, 500), isNull);
+    });
+  });
+}

--- a/test/features/consumption/domain/consumption_stats_test.dart
+++ b/test/features/consumption/domain/consumption_stats_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/co2_calculator.dart';
 import 'package:tankstellen/features/consumption/domain/entities/consumption_stats.dart';
 import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
@@ -27,8 +28,10 @@ void main() {
       expect(stats.fillUpCount, 0);
       expect(stats.totalLiters, 0);
       expect(stats.totalSpent, 0);
+      expect(stats.totalCo2Kg, 0);
       expect(stats.avgConsumptionL100km, isNull);
       expect(stats.avgCostPerKm, isNull);
+      expect(stats.avgCo2PerKm, isNull);
     });
 
     test('single fill-up reports totals but no consumption', () {
@@ -122,6 +125,78 @@ void main() {
       expect(stats.avgConsumptionL100km, isNull);
       expect(stats.avgCostPerKm, isNull);
       expect(stats.totalLiters, 20);
+    });
+
+    test('totalCo2Kg aggregates across all fill-ups', () {
+      final stats = ConsumptionStats.fromFillUps([
+        _f(
+          id: '1',
+          date: DateTime(2026, 1, 1),
+          liters: 40,
+          cost: 60,
+          odo: 10000,
+          fuelType: FuelType.diesel,
+        ),
+        _f(
+          id: '2',
+          date: DateTime(2026, 1, 15),
+          liters: 50,
+          cost: 80,
+          odo: 11000,
+          fuelType: FuelType.diesel,
+        ),
+      ]);
+      // 90 L diesel * 2.65 kg/L
+      expect(stats.totalCo2Kg,
+          closeTo(90 * Co2Calculator.kgCo2PerLiterDiesel, 0.0001));
+    });
+
+    test('avgCo2PerKm excludes first tank like L/100km', () {
+      // first tank 40 L (odo 10000) ignored for per-km math
+      // second tank 50 L diesel over 1000 km
+      final stats = ConsumptionStats.fromFillUps([
+        _f(
+          id: '1',
+          date: DateTime(2026, 1, 1),
+          liters: 40,
+          cost: 60,
+          odo: 10000,
+          fuelType: FuelType.diesel,
+        ),
+        _f(
+          id: '2',
+          date: DateTime(2026, 1, 15),
+          liters: 50,
+          cost: 80,
+          odo: 11000,
+          fuelType: FuelType.diesel,
+        ),
+      ]);
+      const expectedCo2PerKm =
+          50 * Co2Calculator.kgCo2PerLiterDiesel / 1000;
+      expect(stats.avgCo2PerKm, closeTo(expectedCo2PerKm, 0.0001));
+    });
+
+    test('avgCo2PerKm is null when distance is zero', () {
+      final stats = ConsumptionStats.fromFillUps([
+        _f(
+          id: '1',
+          date: DateTime(2026, 1, 1),
+          liters: 10,
+          cost: 15,
+          odo: 10000,
+          fuelType: FuelType.diesel,
+        ),
+        _f(
+          id: '2',
+          date: DateTime(2026, 1, 2),
+          liters: 10,
+          cost: 15,
+          odo: 10000,
+          fuelType: FuelType.diesel,
+        ),
+      ]);
+      expect(stats.avgCo2PerKm, isNull);
     });
 
     test('three fill-ups: excludes first tank from L/100km', () {


### PR DESCRIPTION
## What

Adds a pure CO2 calculation engine (`Co2Calculator`) that estimates well-to-wheel carbon emissions per fill-up based on fuel type and volume, using EU JEC WTW v5 emission factors. Integrates into the existing fill-up log data model from #148 and extends `ConsumptionStats` with cumulative and per-km CO2 metrics.

**Engine only — no UI changes.** The dashboard UI (#180, #181) will consume this engine in follow-up PRs.

## Why

Part of the Carbon and Expense Tracker epic (#178). Environmental awareness is a growing concern and a unique differentiator vs competing fuel apps. This PR lays the pure-function foundation so subsequent UI work can focus on visualisation.

## Changes

- `lib/core/services/co2_calculator.dart` — new pure utility with emission factor constants:
  - E5/E98: 2.31, E10: 2.27, Diesel/DieselPremium: 2.65, LPG: 1.61, E85: 1.40, CNG: 2.54 kg/kg
  - `emissionFactorFor(FuelType)`, `co2ForLiters`, `co2ForFillUp`, `cumulativeCo2`, `co2PerKm`
  - Returns `null`/0 for unsupported types (electric, hydrogen, all) so callers can distinguish
- `FillUp.co2Kg` extension getter for ergonomic per-record access
- `ConsumptionStats` gains `totalCo2Kg` and `avgCo2PerKm`, computed with the same "skip the first tank" rule used for L/100km so distance-based aggregates stay consistent

## Testing

- 22 new unit tests in `test/core/services/co2_calculator_test.dart` covering:
  - All supported fuel types + unsupported types (electric, hydrogen, all)
  - Edge cases: zero/negative liters, zero/negative distance
  - Cumulative math with mixed fuel types and electric mixed in
  - Sanity: E85 factor is materially lower than E5/diesel
- Extended `consumption_stats_test.dart` with 3 new tests covering `totalCo2Kg`, `avgCo2PerKm`, and zero-distance null behaviour
- `flutter analyze --no-fatal-infos` — no new warnings
- `flutter test` — all tests pass (Argentina connectivity test is the known flaky)

Closes #179