### PR TITLE
feat(carbon): add carbon dashboard with charts and achievements

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -13,6 +13,7 @@ import '../features/search/presentation/screens/search_screen.dart';
 import '../features/setup/presentation/screens/onboarding_wizard_screen.dart';
 import '../features/alerts/presentation/screens/alerts_screen.dart';
 import '../features/calculator/presentation/screens/calculator_screen.dart';
+import '../features/carbon/presentation/screens/carbon_dashboard_screen.dart';
 import '../features/report/presentation/screens/report_screen.dart';
 import '../features/consumption/presentation/screens/add_fill_up_screen.dart';
 import '../features/consumption/presentation/screens/consumption_screen.dart';
@@ -173,6 +174,10 @@ GoRouter router(Ref ref) {
       GoRoute(
         path: '/consumption',
         builder: (context, state) => const ConsumptionScreen(),
+      ),
+      GoRoute(
+        path: '/carbon',
+        builder: (context, state) => const CarbonDashboardScreen(),
       ),
       GoRoute(
         path: '/consumption/add',

--- a/lib/features/carbon/domain/milestone.dart
+++ b/lib/features/carbon/domain/milestone.dart
@@ -1,0 +1,186 @@
+import '../../consumption/domain/entities/fill_up.dart';
+import 'monthly_summary.dart';
+
+/// A gamification milestone that can be unlocked by the user.
+///
+/// Milestones are pure data — they have no I/O and are cheap to
+/// re-compute on every rebuild. Unlocking is derived from the current
+/// fill-up list, not persisted separately, so there is no drift risk
+/// between "persisted unlocked flag" and "current reality".
+class Milestone {
+  /// Stable identifier, safe to persist and key widgets on.
+  final String id;
+  final MilestoneCategory category;
+  final double target;
+  final String unit;
+
+  const Milestone({
+    required this.id,
+    required this.category,
+    required this.target,
+    required this.unit,
+  });
+}
+
+enum MilestoneCategory {
+  firstFillUp,
+  fillUpsLogged,
+  litersTracked,
+  co2Tracked,
+  distanceDriven,
+  co2SavedVsAvg,
+}
+
+/// Progress towards a specific milestone.
+class MilestoneProgress {
+  final Milestone milestone;
+  final double current;
+  final bool unlocked;
+
+  const MilestoneProgress({
+    required this.milestone,
+    required this.current,
+    required this.unlocked,
+  });
+
+  /// Fraction in [0.0, 1.0]. 0 when target is zero.
+  double get fraction {
+    if (milestone.target <= 0) return 0;
+    final raw = current / milestone.target;
+    if (raw.isNaN || raw.isInfinite) return 0;
+    if (raw < 0) return 0;
+    if (raw > 1) return 1;
+    return raw;
+  }
+}
+
+/// Engine for milestone unlocking.
+class MilestoneEngine {
+  MilestoneEngine._();
+
+  /// Assumed average CO2 per km for a modern EV (kg/km), grid-average
+  /// EU electricity mix. Used for "fuel vs EV" comparison.
+  static const double kgCo2PerKmEv = 0.05;
+
+  /// Canonical milestone catalog. Ordered for display.
+  static const List<Milestone> catalog = [
+    Milestone(
+      id: 'first_fill_up',
+      category: MilestoneCategory.firstFillUp,
+      target: 1,
+      unit: 'fillup',
+    ),
+    Milestone(
+      id: 'ten_fill_ups',
+      category: MilestoneCategory.fillUpsLogged,
+      target: 10,
+      unit: 'fillup',
+    ),
+    Milestone(
+      id: 'fifty_fill_ups',
+      category: MilestoneCategory.fillUpsLogged,
+      target: 50,
+      unit: 'fillup',
+    ),
+    Milestone(
+      id: 'hundred_liters',
+      category: MilestoneCategory.litersTracked,
+      target: 100,
+      unit: 'L',
+    ),
+    Milestone(
+      id: 'thousand_liters',
+      category: MilestoneCategory.litersTracked,
+      target: 1000,
+      unit: 'L',
+    ),
+    Milestone(
+      id: 'hundred_kg_co2',
+      category: MilestoneCategory.co2Tracked,
+      target: 100,
+      unit: 'kg',
+    ),
+    Milestone(
+      id: 'one_tonne_co2',
+      category: MilestoneCategory.co2Tracked,
+      target: 1000,
+      unit: 'kg',
+    ),
+    Milestone(
+      id: 'thousand_km',
+      category: MilestoneCategory.distanceDriven,
+      target: 1000,
+      unit: 'km',
+    ),
+    Milestone(
+      id: 'ten_thousand_km',
+      category: MilestoneCategory.distanceDriven,
+      target: 10000,
+      unit: 'km',
+    ),
+  ];
+
+  /// Computes the distance driven across [fillUps] from odometer
+  /// deltas. Returns 0 when fewer than two readings or when all
+  /// odometer values are non-positive.
+  static double distanceFromOdometer(List<FillUp> fillUps) {
+    final valid = fillUps
+        .where((f) => f.odometerKm > 0)
+        .toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+    if (valid.length < 2) return 0;
+    final first = valid.first.odometerKm;
+    final last = valid.last.odometerKm;
+    final delta = last - first;
+    return delta > 0 ? delta : 0;
+  }
+
+  /// Evaluates [catalog] against the provided fill-up data and returns
+  /// a progress entry for each milestone.
+  static List<MilestoneProgress> evaluate(List<FillUp> fillUps) {
+    final summaries = MonthlyAggregator.byMonth(fillUps);
+    final totalLiters = MonthlyAggregator.totalLiters(summaries);
+    final totalCo2 = MonthlyAggregator.totalCo2(summaries);
+    final distanceKm = distanceFromOdometer(fillUps);
+    final count = fillUps.length.toDouble();
+
+    return [
+      for (final m in catalog)
+        MilestoneProgress(
+          milestone: m,
+          current: _currentFor(m, count, totalLiters, totalCo2, distanceKm),
+          unlocked: _currentFor(m, count, totalLiters, totalCo2, distanceKm) >=
+              m.target,
+        ),
+    ];
+  }
+
+  static double _currentFor(
+    Milestone m,
+    double count,
+    double totalLiters,
+    double totalCo2,
+    double distanceKm,
+  ) {
+    switch (m.category) {
+      case MilestoneCategory.firstFillUp:
+      case MilestoneCategory.fillUpsLogged:
+        return count;
+      case MilestoneCategory.litersTracked:
+        return totalLiters;
+      case MilestoneCategory.co2Tracked:
+        return totalCo2;
+      case MilestoneCategory.distanceDriven:
+        return distanceKm;
+      case MilestoneCategory.co2SavedVsAvg:
+        return 0;
+    }
+  }
+
+  /// CO2 (kg) an EV would have emitted over the same distance,
+  /// using [kgCo2PerKmEv].
+  static double evEquivalentCo2(double distanceKm) {
+    if (distanceKm <= 0) return 0;
+    return distanceKm * kgCo2PerKmEv;
+  }
+}

--- a/lib/features/carbon/domain/monthly_summary.dart
+++ b/lib/features/carbon/domain/monthly_summary.dart
@@ -1,0 +1,103 @@
+import '../../../core/services/co2_calculator.dart';
+import '../../consumption/domain/entities/fill_up.dart';
+
+/// Aggregated totals for a single calendar month.
+///
+/// All fields are in SI / market units: cost in the user's currency
+/// (no FX conversion is performed), liters of fuel, kilograms of CO2.
+class MonthlySummary {
+  /// First day of the month at 00:00 local time.
+  final DateTime month;
+  final double totalCost;
+  final double totalLiters;
+  final double totalCo2Kg;
+  final int fillUpCount;
+
+  const MonthlySummary({
+    required this.month,
+    required this.totalCost,
+    required this.totalLiters,
+    required this.totalCo2Kg,
+    required this.fillUpCount,
+  });
+
+  /// Average price per liter across all fill-ups in this month.
+  double get avgPricePerLiter =>
+      totalLiters > 0 ? totalCost / totalLiters : 0;
+}
+
+/// Pure aggregation helpers for building monthly views from fill-ups.
+class MonthlyAggregator {
+  MonthlyAggregator._();
+
+  /// Groups [fillUps] by calendar month and returns summaries sorted
+  /// oldest first. Months with no fill-ups are omitted.
+  static List<MonthlySummary> byMonth(List<FillUp> fillUps) {
+    if (fillUps.isEmpty) return const [];
+    final buckets = <DateTime, _Bucket>{};
+    for (final f in fillUps) {
+      final key = DateTime(f.date.year, f.date.month);
+      final b = buckets.putIfAbsent(key, _Bucket.new);
+      b.cost += f.totalCost;
+      b.liters += f.liters;
+      b.co2 += Co2Calculator.co2ForFillUp(f);
+      b.count += 1;
+    }
+    final keys = buckets.keys.toList()..sort();
+    return [
+      for (final k in keys)
+        MonthlySummary(
+          month: k,
+          totalCost: buckets[k]!.cost,
+          totalLiters: buckets[k]!.liters,
+          totalCo2Kg: buckets[k]!.co2,
+          fillUpCount: buckets[k]!.count,
+        ),
+    ];
+  }
+
+  /// Returns only the last [months] entries from a full summary list,
+  /// preserving chronological order (oldest first). If fewer summaries
+  /// exist, returns them all.
+  static List<MonthlySummary> lastN(
+    List<MonthlySummary> summaries,
+    int months,
+  ) {
+    if (months <= 0 || summaries.length <= months) return summaries;
+    return summaries.sublist(summaries.length - months);
+  }
+
+  /// Total cost across all summaries.
+  static double totalCost(List<MonthlySummary> summaries) {
+    double sum = 0;
+    for (final s in summaries) {
+      sum += s.totalCost;
+    }
+    return sum;
+  }
+
+  /// Total CO2 across all summaries.
+  static double totalCo2(List<MonthlySummary> summaries) {
+    double sum = 0;
+    for (final s in summaries) {
+      sum += s.totalCo2Kg;
+    }
+    return sum;
+  }
+
+  /// Total liters across all summaries.
+  static double totalLiters(List<MonthlySummary> summaries) {
+    double sum = 0;
+    for (final s in summaries) {
+      sum += s.totalLiters;
+    }
+    return sum;
+  }
+}
+
+class _Bucket {
+  double cost = 0;
+  double liters = 0;
+  double co2 = 0;
+  int count = 0;
+}

--- a/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
+++ b/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/widgets/empty_state.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/providers/consumption_providers.dart';
+import '../../domain/milestone.dart';
+import '../../domain/monthly_summary.dart';
+import '../widgets/fuel_vs_ev_card.dart';
+import '../widgets/milestones_card.dart';
+import '../widgets/monthly_bar_chart.dart';
+
+/// Carbon dashboard: tabbed view of monthly charts (#180) and
+/// gamified achievements (#181). Data is derived entirely from the
+/// existing [fillUpListProvider] — no new storage or providers.
+class CarbonDashboardScreen extends ConsumerWidget {
+  const CarbonDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final fillUps = ref.watch(fillUpListProvider);
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    final summaries = MonthlyAggregator.byMonth(fillUps);
+    final last12 = MonthlyAggregator.lastN(summaries, 12);
+    final milestones = MilestoneEngine.evaluate(fillUps);
+    final distanceKm = MilestoneEngine.distanceFromOdometer(fillUps);
+    final totalCo2 = MonthlyAggregator.totalCo2(summaries);
+    final totalCost = MonthlyAggregator.totalCost(summaries);
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(l?.carbonDashboardTitle ?? 'Carbon dashboard'),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => context.pop(),
+          ),
+          bottomOpacity: 1,
+          bottom: TabBar(
+            tabs: [
+              Tab(text: l?.carbonTabCharts ?? 'Charts'),
+              Tab(text: l?.carbonTabAchievements ?? 'Achievements'),
+            ],
+          ),
+        ),
+        body: fillUps.isEmpty
+            ? EmptyState(
+                icon: Icons.eco_outlined,
+                title: l?.carbonEmptyTitle ?? 'No data yet',
+                subtitle: l?.carbonEmptySubtitle ??
+                    'Log fill-ups to see your carbon dashboard.',
+              )
+            : TabBarView(
+                children: [
+                  _ChartsTab(
+                    summaries: last12,
+                    totalCost: totalCost,
+                    totalCo2: totalCo2,
+                  ),
+                  _AchievementsTab(
+                    milestones: milestones,
+                    fuelCo2Kg: totalCo2,
+                    distanceKm: distanceKm,
+                    theme: theme,
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+class _ChartsTab extends StatelessWidget {
+  final List<MonthlySummary> summaries;
+  final double totalCost;
+  final double totalCo2;
+
+  const _ChartsTab({
+    required this.summaries,
+    required this.totalCost,
+    required this.totalCo2,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return ListView(
+      padding: EdgeInsets.only(
+        top: 16,
+        bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      children: [
+        _SummaryRow(totalCost: totalCost, totalCo2: totalCo2),
+        const SizedBox(height: 8),
+        Card(
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l?.monthlyCostsTitle ?? 'Monthly costs',
+                  style: theme.textTheme.titleMedium,
+                ),
+                const SizedBox(height: 12),
+                MonthlyBarChart(
+                  key: const Key('monthly_cost_chart'),
+                  summaries: summaries,
+                  valueOf: (s) => s.totalCost,
+                  color: theme.colorScheme.primary,
+                  unitLabel: '€',
+                ),
+              ],
+            ),
+          ),
+        ),
+        Card(
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l?.monthlyEmissionsTitle ?? 'Monthly CO2 emissions',
+                  style: theme.textTheme.titleMedium,
+                ),
+                const SizedBox(height: 12),
+                MonthlyBarChart(
+                  key: const Key('monthly_emissions_chart'),
+                  summaries: summaries,
+                  valueOf: (s) => s.totalCo2Kg,
+                  color: theme.colorScheme.tertiary,
+                  unitLabel: 'kg',
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AchievementsTab extends StatelessWidget {
+  final List<MilestoneProgress> milestones;
+  final double fuelCo2Kg;
+  final double distanceKm;
+  final ThemeData theme;
+
+  const _AchievementsTab({
+    required this.milestones,
+    required this.fuelCo2Kg,
+    required this.distanceKm,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: EdgeInsets.only(
+        top: 8,
+        bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      children: [
+        MilestonesCard(progress: milestones),
+        FuelVsEvCard(fuelCo2Kg: fuelCo2Kg, distanceKm: distanceKm),
+      ],
+    );
+  }
+}
+
+class _SummaryRow extends StatelessWidget {
+  final double totalCost;
+  final double totalCo2;
+
+  const _SummaryRow({required this.totalCost, required this.totalCo2});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: Card(
+            margin: const EdgeInsets.only(left: 16, right: 8),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l?.carbonSummaryTotalCost ?? 'Total cost',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${totalCost.toStringAsFixed(0)} €',
+                    style: theme.textTheme.titleLarge,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        Expanded(
+          child: Card(
+            margin: const EdgeInsets.only(left: 8, right: 16),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l?.carbonSummaryTotalCo2 ?? 'Total CO2',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${totalCo2.toStringAsFixed(0)} kg',
+                    style: theme.textTheme.titleLarge,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/carbon/presentation/widgets/fuel_vs_ev_card.dart
+++ b/lib/features/carbon/presentation/widgets/fuel_vs_ev_card.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/milestone.dart';
+
+/// Compares the user's fuel CO2 against an EV equivalent for the same
+/// distance and offers a copy-to-clipboard "share" of the headline
+/// number. Uses [Clipboard] instead of share_plus to stay platform-
+/// agnostic and avoid pulling in another dependency.
+class FuelVsEvCard extends StatelessWidget {
+  final double fuelCo2Kg;
+  final double distanceKm;
+
+  const FuelVsEvCard({
+    super.key,
+    required this.fuelCo2Kg,
+    required this.distanceKm,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final evCo2 = MilestoneEngine.evEquivalentCo2(distanceKm);
+    final diff = fuelCo2Kg - evCo2;
+    final maxVal = fuelCo2Kg > evCo2 ? fuelCo2Kg : evCo2;
+    final fuelFrac = maxVal > 0 ? fuelCo2Kg / maxVal : 0.0;
+    final evFrac = maxVal > 0 ? evCo2 / maxVal : 0.0;
+
+    return Card(
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l?.fuelVsEvTitle ?? 'Fuel vs EV',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              l?.fuelVsEvSubtitle ??
+                  'CO2 comparison for the same distance driven',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _Row(
+              label: l?.fuelVsEvYourFuel ?? 'Your fuel',
+              valueKg: fuelCo2Kg,
+              fraction: fuelFrac,
+              color: theme.colorScheme.error,
+            ),
+            const SizedBox(height: 12),
+            _Row(
+              label: l?.fuelVsEvEquivalent ?? 'Equivalent EV',
+              valueKg: evCo2,
+              fraction: evFrac,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              '${l?.fuelVsEvDistance ?? 'Distance'}: '
+              '${distanceKm.toStringAsFixed(0)} km',
+              style: theme.textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            if (diff > 0)
+              Text(
+                '${l?.fuelVsEvDifference ?? 'Difference'}: '
+                '+${diff.toStringAsFixed(1)} kg CO2',
+                style: theme.textTheme.bodyMedium,
+              ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                key: const Key('carbon_share_button'),
+                onPressed: () => _share(context, l),
+                icon: const Icon(Icons.share),
+                label: Text(l?.shareProgress ?? 'Share'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _share(BuildContext context, AppLocalizations? l) async {
+    // Privacy-respecting: no location, no cost, just CO2 + app name.
+    final text =
+        '${l?.shareCo2Message(fuelCo2Kg.toStringAsFixed(0)) ?? 'I tracked ${fuelCo2Kg.toStringAsFixed(0)} kg CO2 with Tankstellen.'}';
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(l?.shareCopied ?? 'Copied to clipboard'),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+}
+
+class _Row extends StatelessWidget {
+  final String label;
+  final double valueKg;
+  final double fraction;
+  final Color color;
+
+  const _Row({
+    required this.label,
+    required this.valueKg,
+    required this.fraction,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(label, style: theme.textTheme.bodyMedium),
+            Text(
+              '${valueKg.toStringAsFixed(1)} kg',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(3),
+          child: LinearProgressIndicator(
+            value: fraction.clamp(0.0, 1.0),
+            minHeight: 8,
+            valueColor: AlwaysStoppedAnimation<Color>(color),
+            backgroundColor: color.withAlpha(40),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/carbon/presentation/widgets/milestones_card.dart
+++ b/lib/features/carbon/presentation/widgets/milestones_card.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/milestone.dart';
+
+/// Displays the full milestone catalog with progress bars.
+///
+/// Unlocked milestones are shown first with a filled check icon;
+/// in-progress milestones show a linear progress indicator.
+class MilestonesCard extends StatelessWidget {
+  final List<MilestoneProgress> progress;
+
+  const MilestonesCard({super.key, required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final sorted = [...progress]
+      ..sort((a, b) {
+        if (a.unlocked == b.unlocked) return 0;
+        return a.unlocked ? -1 : 1;
+      });
+    return Card(
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l?.milestonesTitle ?? 'Milestones',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            for (final p in sorted) _MilestoneRow(progress: p),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MilestoneRow extends StatelessWidget {
+  final MilestoneProgress progress;
+
+  const _MilestoneRow({required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final label = _labelFor(progress.milestone, l);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        children: [
+          Icon(
+            progress.unlocked
+                ? Icons.check_circle
+                : Icons.radio_button_unchecked,
+            color: progress.unlocked
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurfaceVariant,
+            size: 20,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: theme.textTheme.bodyMedium),
+                const SizedBox(height: 4),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(3),
+                  child: LinearProgressIndicator(
+                    value: progress.fraction,
+                    minHeight: 6,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  '${progress.current.toStringAsFixed(0)} / '
+                  '${progress.milestone.target.toStringAsFixed(0)} '
+                  '${progress.milestone.unit}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _labelFor(Milestone m, AppLocalizations? l) {
+    switch (m.id) {
+      case 'first_fill_up':
+        return l?.milestoneFirstFillUp ?? 'First fill-up logged';
+      case 'ten_fill_ups':
+        return l?.milestoneTenFillUps ?? '10 fill-ups tracked';
+      case 'fifty_fill_ups':
+        return l?.milestoneFiftyFillUps ?? '50 fill-ups tracked';
+      case 'hundred_liters':
+        return l?.milestoneHundredLiters ?? '100 L tracked';
+      case 'thousand_liters':
+        return l?.milestoneThousandLiters ?? '1000 L tracked';
+      case 'hundred_kg_co2':
+        return l?.milestoneHundredKgCo2 ?? '100 kg CO2 tracked';
+      case 'one_tonne_co2':
+        return l?.milestoneOneTonneCo2 ?? '1 tonne CO2 tracked';
+      case 'thousand_km':
+        return l?.milestoneThousandKm ?? '1000 km driven';
+      case 'ten_thousand_km':
+        return l?.milestoneTenThousandKm ?? '10,000 km driven';
+    }
+    return m.id;
+  }
+}

--- a/lib/features/carbon/presentation/widgets/monthly_bar_chart.dart
+++ b/lib/features/carbon/presentation/widgets/monthly_bar_chart.dart
@@ -1,0 +1,190 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../domain/monthly_summary.dart';
+
+/// A minimal bar chart rendered via [CustomPainter].
+///
+/// Consistent with the rest of the project: no external chart library,
+/// pure paint operations, cheap to rebuild. One bar per month, label
+/// at the bottom, max value reference line at the top.
+class MonthlyBarChart extends StatelessWidget {
+  /// The summaries to render, oldest first.
+  final List<MonthlySummary> summaries;
+
+  /// How to extract the numeric value from a summary (e.g. cost, co2).
+  final double Function(MonthlySummary) valueOf;
+
+  /// Bar fill color.
+  final Color color;
+
+  /// Unit suffix shown on the max-value label (e.g. "€", "kg").
+  final String unitLabel;
+
+  const MonthlyBarChart({
+    super.key,
+    required this.summaries,
+    required this.valueOf,
+    required this.color,
+    required this.unitLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final onSurface = Theme.of(context).colorScheme.onSurface;
+    if (summaries.isEmpty) {
+      return const SizedBox(
+        height: 180,
+        child: Center(child: Text('No data')),
+      );
+    }
+    return SizedBox(
+      height: 180,
+      child: CustomPaint(
+        painter: _BarChartPainter(
+          summaries: summaries,
+          valueOf: valueOf,
+          color: color,
+          unitLabel: unitLabel,
+          labelColor: onSurface,
+        ),
+        size: Size.infinite,
+      ),
+    );
+  }
+}
+
+class _BarChartPainter extends CustomPainter {
+  final List<MonthlySummary> summaries;
+  final double Function(MonthlySummary) valueOf;
+  final Color color;
+  final String unitLabel;
+  final Color labelColor;
+
+  _BarChartPainter({
+    required this.summaries,
+    required this.valueOf,
+    required this.color,
+    required this.unitLabel,
+    required this.labelColor,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (summaries.isEmpty) return;
+
+    const leftInset = 8.0;
+    const rightInset = 8.0;
+    const topInset = 18.0;
+    const bottomInset = 24.0;
+
+    final chartWidth = size.width - leftInset - rightInset;
+    final chartHeight = size.height - topInset - bottomInset;
+
+    final values = summaries.map(valueOf).toList();
+    final maxValue = values.reduce(math.max);
+    final effectiveMax = maxValue > 0 ? maxValue : 1.0;
+
+    final barCount = summaries.length;
+    final slot = chartWidth / barCount;
+    final barWidth = math.max(4.0, slot * 0.6);
+
+    final barPaint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+
+    final refPaint = Paint()
+      ..color = color.withAlpha(50)
+      ..strokeWidth = 1;
+    canvas.drawLine(
+      const Offset(leftInset, topInset),
+      Offset(size.width - rightInset, topInset),
+      refPaint,
+    );
+
+    // Max label at top-right.
+    _drawText(
+      canvas,
+      '${maxValue.toStringAsFixed(0)} $unitLabel',
+      Offset(size.width - rightInset, 2),
+      anchorRight: true,
+      color: labelColor.withAlpha(160),
+      fontSize: 10,
+    );
+
+    for (int i = 0; i < barCount; i++) {
+      final v = values[i];
+      final barHeight = effectiveMax > 0
+          ? (v / effectiveMax) * chartHeight
+          : 0.0;
+      final cx = leftInset + slot * i + slot / 2;
+      final left = cx - barWidth / 2;
+      final top = topInset + chartHeight - barHeight;
+      final rect = RRect.fromRectAndCorners(
+        Rect.fromLTWH(left, top, barWidth, barHeight),
+        topLeft: const Radius.circular(3),
+        topRight: const Radius.circular(3),
+      );
+      canvas.drawRRect(rect, barPaint);
+
+      // Month label below the bar.
+      final m = summaries[i].month;
+      _drawText(
+        canvas,
+        _shortMonth(m),
+        Offset(cx, topInset + chartHeight + 4),
+        anchorCenter: true,
+        color: labelColor.withAlpha(160),
+        fontSize: 10,
+      );
+    }
+  }
+
+  void _drawText(
+    Canvas canvas,
+    String text,
+    Offset offset, {
+    bool anchorRight = false,
+    bool anchorCenter = false,
+    Color color = const Color(0xFF000000),
+    double fontSize = 10,
+  }) {
+    final tp = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(color: color, fontSize: fontSize),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    var dx = offset.dx;
+    if (anchorRight) dx -= tp.width;
+    if (anchorCenter) dx -= tp.width / 2;
+    tp.paint(canvas, Offset(dx, offset.dy));
+  }
+
+  String _shortMonth(DateTime d) {
+    const names = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return names[d.month - 1];
+  }
+
+  @override
+  bool shouldRepaint(_BarChartPainter oldDelegate) {
+    return oldDelegate.summaries != summaries ||
+        oldDelegate.color != color ||
+        oldDelegate.unitLabel != unitLabel;
+  }
+}

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -25,6 +25,14 @@ class ConsumptionScreen extends ConsumerWidget {
           icon: const Icon(Icons.arrow_back),
           onPressed: () => context.pop(),
         ),
+        actions: [
+          IconButton(
+            key: const Key('open_carbon_dashboard'),
+            tooltip: l?.carbonDashboardTitle ?? 'Carbon dashboard',
+            icon: const Icon(Icons.eco_outlined),
+            onPressed: () => context.push('/carbon'),
+          ),
+        ],
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => context.push('/consumption/add'),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -666,5 +666,40 @@
   "statTotalSpent": "Gesamt ausgegeben",
   "statFillUpCount": "Tankvorgänge",
   "fieldRequired": "Pflichtfeld",
-  "fieldInvalidNumber": "Ungültige Zahl"
+  "fieldInvalidNumber": "Ungültige Zahl",
+  "carbonDashboardTitle": "CO2-Übersicht",
+  "carbonTabCharts": "Diagramme",
+  "carbonTabAchievements": "Erfolge",
+  "carbonEmptyTitle": "Noch keine Daten",
+  "carbonEmptySubtitle": "Erfasse Tankvorgänge, um deine CO2-Übersicht zu sehen.",
+  "carbonSummaryTotalCost": "Gesamtkosten",
+  "carbonSummaryTotalCo2": "CO2 gesamt",
+  "monthlyCostsTitle": "Monatliche Kosten",
+  "monthlyEmissionsTitle": "Monatliche CO2-Emissionen",
+  "milestonesTitle": "Meilensteine",
+  "milestoneFirstFillUp": "Erster Tankvorgang erfasst",
+  "milestoneTenFillUps": "10 Tankvorgänge erfasst",
+  "milestoneFiftyFillUps": "50 Tankvorgänge erfasst",
+  "milestoneHundredLiters": "100 L erfasst",
+  "milestoneThousandLiters": "1000 L erfasst",
+  "milestoneHundredKgCo2": "100 kg CO2 erfasst",
+  "milestoneOneTonneCo2": "1 Tonne CO2 erfasst",
+  "milestoneThousandKm": "1000 km gefahren",
+  "milestoneTenThousandKm": "10.000 km gefahren",
+  "fuelVsEvTitle": "Sprit vs. E-Auto",
+  "fuelVsEvSubtitle": "CO2-Vergleich für dieselbe gefahrene Strecke",
+  "fuelVsEvYourFuel": "Dein Sprit",
+  "fuelVsEvEquivalent": "E-Auto (äquivalent)",
+  "fuelVsEvDistance": "Strecke",
+  "fuelVsEvDifference": "Differenz",
+  "shareProgress": "Teilen",
+  "shareCopied": "In Zwischenablage kopiert",
+  "shareCo2Message": "Ich habe mit Tankstellen {kg} kg CO2 erfasst.",
+  "@shareCo2Message": {
+    "placeholders": {
+      "kg": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -666,5 +666,40 @@
   "statTotalSpent": "Total spent",
   "statFillUpCount": "Fill-ups",
   "fieldRequired": "Required",
-  "fieldInvalidNumber": "Invalid number"
+  "fieldInvalidNumber": "Invalid number",
+  "carbonDashboardTitle": "Carbon dashboard",
+  "carbonTabCharts": "Charts",
+  "carbonTabAchievements": "Achievements",
+  "carbonEmptyTitle": "No data yet",
+  "carbonEmptySubtitle": "Log fill-ups to see your carbon dashboard.",
+  "carbonSummaryTotalCost": "Total cost",
+  "carbonSummaryTotalCo2": "Total CO2",
+  "monthlyCostsTitle": "Monthly costs",
+  "monthlyEmissionsTitle": "Monthly CO2 emissions",
+  "milestonesTitle": "Milestones",
+  "milestoneFirstFillUp": "First fill-up logged",
+  "milestoneTenFillUps": "10 fill-ups tracked",
+  "milestoneFiftyFillUps": "50 fill-ups tracked",
+  "milestoneHundredLiters": "100 L tracked",
+  "milestoneThousandLiters": "1000 L tracked",
+  "milestoneHundredKgCo2": "100 kg CO2 tracked",
+  "milestoneOneTonneCo2": "1 tonne CO2 tracked",
+  "milestoneThousandKm": "1000 km driven",
+  "milestoneTenThousandKm": "10,000 km driven",
+  "fuelVsEvTitle": "Fuel vs EV",
+  "fuelVsEvSubtitle": "CO2 comparison for the same distance driven",
+  "fuelVsEvYourFuel": "Your fuel",
+  "fuelVsEvEquivalent": "Equivalent EV",
+  "fuelVsEvDistance": "Distance",
+  "fuelVsEvDifference": "Difference",
+  "shareProgress": "Share",
+  "shareCopied": "Copied to clipboard",
+  "shareCo2Message": "I tracked {kg} kg CO2 with Tankstellen.",
+  "@shareCo2Message": {
+    "placeholders": {
+      "kg": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2844,6 +2844,174 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Invalid number'**
   String get fieldInvalidNumber;
+
+  /// No description provided for @carbonDashboardTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Carbon dashboard'**
+  String get carbonDashboardTitle;
+
+  /// No description provided for @carbonTabCharts.
+  ///
+  /// In en, this message translates to:
+  /// **'Charts'**
+  String get carbonTabCharts;
+
+  /// No description provided for @carbonTabAchievements.
+  ///
+  /// In en, this message translates to:
+  /// **'Achievements'**
+  String get carbonTabAchievements;
+
+  /// No description provided for @carbonEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No data yet'**
+  String get carbonEmptyTitle;
+
+  /// No description provided for @carbonEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Log fill-ups to see your carbon dashboard.'**
+  String get carbonEmptySubtitle;
+
+  /// No description provided for @carbonSummaryTotalCost.
+  ///
+  /// In en, this message translates to:
+  /// **'Total cost'**
+  String get carbonSummaryTotalCost;
+
+  /// No description provided for @carbonSummaryTotalCo2.
+  ///
+  /// In en, this message translates to:
+  /// **'Total CO2'**
+  String get carbonSummaryTotalCo2;
+
+  /// No description provided for @monthlyCostsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly costs'**
+  String get monthlyCostsTitle;
+
+  /// No description provided for @monthlyEmissionsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly CO2 emissions'**
+  String get monthlyEmissionsTitle;
+
+  /// No description provided for @milestonesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Milestones'**
+  String get milestonesTitle;
+
+  /// No description provided for @milestoneFirstFillUp.
+  ///
+  /// In en, this message translates to:
+  /// **'First fill-up logged'**
+  String get milestoneFirstFillUp;
+
+  /// No description provided for @milestoneTenFillUps.
+  ///
+  /// In en, this message translates to:
+  /// **'10 fill-ups tracked'**
+  String get milestoneTenFillUps;
+
+  /// No description provided for @milestoneFiftyFillUps.
+  ///
+  /// In en, this message translates to:
+  /// **'50 fill-ups tracked'**
+  String get milestoneFiftyFillUps;
+
+  /// No description provided for @milestoneHundredLiters.
+  ///
+  /// In en, this message translates to:
+  /// **'100 L tracked'**
+  String get milestoneHundredLiters;
+
+  /// No description provided for @milestoneThousandLiters.
+  ///
+  /// In en, this message translates to:
+  /// **'1000 L tracked'**
+  String get milestoneThousandLiters;
+
+  /// No description provided for @milestoneHundredKgCo2.
+  ///
+  /// In en, this message translates to:
+  /// **'100 kg CO2 tracked'**
+  String get milestoneHundredKgCo2;
+
+  /// No description provided for @milestoneOneTonneCo2.
+  ///
+  /// In en, this message translates to:
+  /// **'1 tonne CO2 tracked'**
+  String get milestoneOneTonneCo2;
+
+  /// No description provided for @milestoneThousandKm.
+  ///
+  /// In en, this message translates to:
+  /// **'1000 km driven'**
+  String get milestoneThousandKm;
+
+  /// No description provided for @milestoneTenThousandKm.
+  ///
+  /// In en, this message translates to:
+  /// **'10,000 km driven'**
+  String get milestoneTenThousandKm;
+
+  /// No description provided for @fuelVsEvTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Fuel vs EV'**
+  String get fuelVsEvTitle;
+
+  /// No description provided for @fuelVsEvSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'CO2 comparison for the same distance driven'**
+  String get fuelVsEvSubtitle;
+
+  /// No description provided for @fuelVsEvYourFuel.
+  ///
+  /// In en, this message translates to:
+  /// **'Your fuel'**
+  String get fuelVsEvYourFuel;
+
+  /// No description provided for @fuelVsEvEquivalent.
+  ///
+  /// In en, this message translates to:
+  /// **'Equivalent EV'**
+  String get fuelVsEvEquivalent;
+
+  /// No description provided for @fuelVsEvDistance.
+  ///
+  /// In en, this message translates to:
+  /// **'Distance'**
+  String get fuelVsEvDistance;
+
+  /// No description provided for @fuelVsEvDifference.
+  ///
+  /// In en, this message translates to:
+  /// **'Difference'**
+  String get fuelVsEvDifference;
+
+  /// No description provided for @shareProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'Share'**
+  String get shareProgress;
+
+  /// No description provided for @shareCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'Copied to clipboard'**
+  String get shareCopied;
+
+  /// No description provided for @shareCo2Message.
+  ///
+  /// In en, this message translates to:
+  /// **'I tracked {kg} kg CO2 with Tankstellen.'**
+  String shareCo2Message(String kg);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1475,4 +1475,91 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1475,4 +1475,91 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1473,4 +1473,91 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1486,4 +1486,91 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Ungültige Zahl';
+
+  @override
+  String get carbonDashboardTitle => 'CO2-Übersicht';
+
+  @override
+  String get carbonTabCharts => 'Diagramme';
+
+  @override
+  String get carbonTabAchievements => 'Erfolge';
+
+  @override
+  String get carbonEmptyTitle => 'Noch keine Daten';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Erfasse Tankvorgänge, um deine CO2-Übersicht zu sehen.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Gesamtkosten';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'CO2 gesamt';
+
+  @override
+  String get monthlyCostsTitle => 'Monatliche Kosten';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monatliche CO2-Emissionen';
+
+  @override
+  String get milestonesTitle => 'Meilensteine';
+
+  @override
+  String get milestoneFirstFillUp => 'Erster Tankvorgang erfasst';
+
+  @override
+  String get milestoneTenFillUps => '10 Tankvorgänge erfasst';
+
+  @override
+  String get milestoneFiftyFillUps => '50 Tankvorgänge erfasst';
+
+  @override
+  String get milestoneHundredLiters => '100 L erfasst';
+
+  @override
+  String get milestoneThousandLiters => '1000 L erfasst';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 erfasst';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 Tonne CO2 erfasst';
+
+  @override
+  String get milestoneThousandKm => '1000 km gefahren';
+
+  @override
+  String get milestoneTenThousandKm => '10.000 km gefahren';
+
+  @override
+  String get fuelVsEvTitle => 'Sprit vs. E-Auto';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2-Vergleich für dieselbe gefahrene Strecke';
+
+  @override
+  String get fuelVsEvYourFuel => 'Dein Sprit';
+
+  @override
+  String get fuelVsEvEquivalent => 'E-Auto (äquivalent)';
+
+  @override
+  String get fuelVsEvDistance => 'Strecke';
+
+  @override
+  String get fuelVsEvDifference => 'Differenz';
+
+  @override
+  String get shareProgress => 'Teilen';
+
+  @override
+  String get shareCopied => 'In Zwischenablage kopiert';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'Ich habe mit Tankstellen $kg kg CO2 erfasst.';
+  }
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1477,4 +1477,91 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1468,4 +1468,91 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1476,4 +1476,91 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1470,4 +1470,91 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1473,4 +1473,91 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1480,4 +1480,91 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1472,4 +1472,91 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1477,4 +1477,91 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1476,4 +1476,91 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1474,4 +1474,91 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1476,4 +1476,91 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1472,4 +1472,91 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1477,4 +1477,91 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1475,4 +1475,91 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1476,4 +1476,91 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1475,4 +1475,91 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1476,4 +1476,91 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1470,4 +1470,91 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1474,4 +1474,91 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get fieldInvalidNumber => 'Invalid number';
+
+  @override
+  String get carbonDashboardTitle => 'Carbon dashboard';
+
+  @override
+  String get carbonTabCharts => 'Charts';
+
+  @override
+  String get carbonTabAchievements => 'Achievements';
+
+  @override
+  String get carbonEmptyTitle => 'No data yet';
+
+  @override
+  String get carbonEmptySubtitle =>
+      'Log fill-ups to see your carbon dashboard.';
+
+  @override
+  String get carbonSummaryTotalCost => 'Total cost';
+
+  @override
+  String get carbonSummaryTotalCo2 => 'Total CO2';
+
+  @override
+  String get monthlyCostsTitle => 'Monthly costs';
+
+  @override
+  String get monthlyEmissionsTitle => 'Monthly CO2 emissions';
+
+  @override
+  String get milestonesTitle => 'Milestones';
+
+  @override
+  String get milestoneFirstFillUp => 'First fill-up logged';
+
+  @override
+  String get milestoneTenFillUps => '10 fill-ups tracked';
+
+  @override
+  String get milestoneFiftyFillUps => '50 fill-ups tracked';
+
+  @override
+  String get milestoneHundredLiters => '100 L tracked';
+
+  @override
+  String get milestoneThousandLiters => '1000 L tracked';
+
+  @override
+  String get milestoneHundredKgCo2 => '100 kg CO2 tracked';
+
+  @override
+  String get milestoneOneTonneCo2 => '1 tonne CO2 tracked';
+
+  @override
+  String get milestoneThousandKm => '1000 km driven';
+
+  @override
+  String get milestoneTenThousandKm => '10,000 km driven';
+
+  @override
+  String get fuelVsEvTitle => 'Fuel vs EV';
+
+  @override
+  String get fuelVsEvSubtitle => 'CO2 comparison for the same distance driven';
+
+  @override
+  String get fuelVsEvYourFuel => 'Your fuel';
+
+  @override
+  String get fuelVsEvEquivalent => 'Equivalent EV';
+
+  @override
+  String get fuelVsEvDistance => 'Distance';
+
+  @override
+  String get fuelVsEvDifference => 'Difference';
+
+  @override
+  String get shareProgress => 'Share';
+
+  @override
+  String get shareCopied => 'Copied to clipboard';
+
+  @override
+  String shareCo2Message(String kg) {
+    return 'I tracked $kg kg CO2 with Tankstellen.';
+  }
 }

--- a/test/features/carbon/carbon_dashboard_screen_test.dart
+++ b/test/features/carbon/carbon_dashboard_screen_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/carbon/presentation/screens/carbon_dashboard_screen.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/fuel_vs_ev_card.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/milestones_card.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/monthly_bar_chart.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+import '../../helpers/pump_app.dart';
+
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    _data[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+
+FillUp _f(
+  String id,
+  DateTime date, {
+  double liters = 50,
+  double cost = 80,
+  double odometer = 10000,
+}) =>
+    FillUp(
+      id: id,
+      date: date,
+      liters: liters,
+      totalCost: cost,
+      odometerKm: odometer,
+      fuelType: FuelType.diesel,
+    );
+
+void main() {
+  testWidgets('renders empty state when no fill-ups', (tester) async {
+    await pumpApp(
+      tester,
+      const CarbonDashboardScreen(),
+      overrides: [
+        settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+      ],
+    );
+    expect(find.text('No data yet'), findsOneWidget);
+    expect(find.byType(MonthlyBarChart), findsNothing);
+  });
+
+  testWidgets('renders charts tab with bar charts when data exists',
+      (tester) async {
+    await pumpApp(
+      tester,
+      const CarbonDashboardScreen(),
+      overrides: [
+        settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+        fillUpListProvider.overrideWith(_FakeFillUpList.new),
+      ],
+    );
+    // Two bar charts on the Charts tab
+    expect(find.byType(MonthlyBarChart), findsNWidgets(2));
+    expect(find.text('Monthly costs'), findsOneWidget);
+    expect(find.text('Monthly CO2 emissions'), findsOneWidget);
+  });
+
+  testWidgets('switches to achievements tab showing milestones + EV card',
+      (tester) async {
+    await pumpApp(
+      tester,
+      const CarbonDashboardScreen(),
+      overrides: [
+        settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+        fillUpListProvider.overrideWith(_FakeFillUpList.new),
+      ],
+    );
+    await tester.tap(find.text('Achievements'));
+    await tester.pumpAndSettle();
+    expect(
+      find.byType(MilestonesCard, skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(
+      find.byType(FuelVsEvCard, skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(find.text('Milestones'), findsOneWidget);
+  });
+}
+
+class _FakeFillUpList extends FillUpList {
+  @override
+  List<FillUp> build() {
+    return [
+      _f('1', DateTime(2026, 1, 5), liters: 40, cost: 60, odometer: 10000),
+      _f('2', DateTime(2026, 2, 5), liters: 50, cost: 80, odometer: 11000),
+      _f('3', DateTime(2026, 3, 5), liters: 45, cost: 70, odometer: 12000),
+    ];
+  }
+}

--- a/test/features/carbon/milestone_test.dart
+++ b/test/features/carbon/milestone_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/carbon/domain/milestone.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+FillUp _f({
+  required String id,
+  required DateTime date,
+  double liters = 50,
+  double cost = 80,
+  double odometer = 10000,
+  FuelType? fuelType,
+}) =>
+    FillUp(
+      id: id,
+      date: date,
+      liters: liters,
+      totalCost: cost,
+      odometerKm: odometer,
+      fuelType: fuelType ?? FuelType.diesel,
+    );
+
+void main() {
+  group('MilestoneEngine.evaluate', () {
+    test('empty fill-ups: nothing is unlocked', () {
+      final progress = MilestoneEngine.evaluate(const []);
+      expect(progress.where((p) => p.unlocked), isEmpty);
+      expect(progress.length, MilestoneEngine.catalog.length);
+    });
+
+    test('single fill-up unlocks "first fill-up"', () {
+      final progress = MilestoneEngine.evaluate([
+        _f(id: '1', date: DateTime(2026, 1, 1)),
+      ]);
+      final first = progress.firstWhere(
+        (p) => p.milestone.id == 'first_fill_up',
+      );
+      expect(first.unlocked, isTrue);
+      expect(first.fraction, 1.0);
+    });
+
+    test('ten fill-ups unlocks "ten_fill_ups"', () {
+      final fillUps = [
+        for (int i = 0; i < 10; i++)
+          _f(id: '$i', date: DateTime(2026, 1, i + 1), odometer: 10000.0 + i),
+      ];
+      final progress = MilestoneEngine.evaluate(fillUps);
+      final ten = progress.firstWhere(
+        (p) => p.milestone.id == 'ten_fill_ups',
+      );
+      expect(ten.unlocked, isTrue);
+      final fifty = progress.firstWhere(
+        (p) => p.milestone.id == 'fifty_fill_ups',
+      );
+      expect(fifty.unlocked, isFalse);
+      expect(fifty.fraction, closeTo(10 / 50, 0.0001));
+    });
+
+    test('hundred liters milestone tracks total liters', () {
+      final fillUps = [
+        _f(id: '1', date: DateTime(2026, 1, 1), liters: 60),
+        _f(id: '2', date: DateTime(2026, 1, 2), liters: 60),
+      ];
+      final progress = MilestoneEngine.evaluate(fillUps);
+      final m = progress.firstWhere(
+        (p) => p.milestone.id == 'hundred_liters',
+      );
+      expect(m.unlocked, isTrue);
+      expect(m.current, closeTo(120, 0.0001));
+    });
+
+    test('hundred kg co2 milestone tracks diesel emissions', () {
+      // 40 L diesel ~ 106 kg CO2
+      final fillUps = [
+        _f(
+          id: '1',
+          date: DateTime(2026, 1, 1),
+          liters: 40,
+          fuelType: FuelType.diesel,
+        ),
+      ];
+      final progress = MilestoneEngine.evaluate(fillUps);
+      final m = progress.firstWhere(
+        (p) => p.milestone.id == 'hundred_kg_co2',
+      );
+      expect(m.unlocked, isTrue);
+    });
+
+    test('distance milestone computes odometer delta', () {
+      final fillUps = [
+        _f(id: '1', date: DateTime(2026, 1, 1), odometer: 10000),
+        _f(id: '2', date: DateTime(2026, 2, 1), odometer: 11500),
+      ];
+      final progress = MilestoneEngine.evaluate(fillUps);
+      final m = progress.firstWhere(
+        (p) => p.milestone.id == 'thousand_km',
+      );
+      expect(m.unlocked, isTrue);
+      expect(m.current, closeTo(1500, 0.0001));
+    });
+  });
+
+  group('MilestoneEngine.distanceFromOdometer', () {
+    test('returns 0 for fewer than two readings', () {
+      expect(
+        MilestoneEngine.distanceFromOdometer([
+          _f(id: '1', date: DateTime(2026, 1, 1), odometer: 10000),
+        ]),
+        0,
+      );
+    });
+
+    test('ignores non-positive odometer values', () {
+      final fillUps = [
+        _f(id: '1', date: DateTime(2026, 1, 1), odometer: 0),
+        _f(id: '2', date: DateTime(2026, 2, 1), odometer: 10000),
+        _f(id: '3', date: DateTime(2026, 3, 1), odometer: 10500),
+      ];
+      expect(
+        MilestoneEngine.distanceFromOdometer(fillUps),
+        closeTo(500, 0.0001),
+      );
+    });
+
+    test('negative delta clamps to 0', () {
+      final fillUps = [
+        _f(id: '1', date: DateTime(2026, 1, 1), odometer: 10000),
+        _f(id: '2', date: DateTime(2026, 2, 1), odometer: 9000),
+      ];
+      expect(MilestoneEngine.distanceFromOdometer(fillUps), 0);
+    });
+  });
+
+  group('MilestoneProgress.fraction', () {
+    test('clamps to [0, 1]', () {
+      const m = Milestone(
+        id: 'x',
+        category: MilestoneCategory.fillUpsLogged,
+        target: 10,
+        unit: 'fillup',
+      );
+      expect(
+        const MilestoneProgress(milestone: m, current: 20, unlocked: true)
+            .fraction,
+        1.0,
+      );
+      expect(
+        const MilestoneProgress(milestone: m, current: -5, unlocked: false)
+            .fraction,
+        0.0,
+      );
+      expect(
+        const MilestoneProgress(milestone: m, current: 5, unlocked: false)
+            .fraction,
+        0.5,
+      );
+    });
+
+    test('returns 0 when target is zero', () {
+      const m = Milestone(
+        id: 'x',
+        category: MilestoneCategory.fillUpsLogged,
+        target: 0,
+        unit: 'fillup',
+      );
+      expect(
+        const MilestoneProgress(milestone: m, current: 10, unlocked: true)
+            .fraction,
+        0,
+      );
+    });
+  });
+
+  group('MilestoneEngine.evEquivalentCo2', () {
+    test('returns 0 for non-positive distance', () {
+      expect(MilestoneEngine.evEquivalentCo2(0), 0);
+      expect(MilestoneEngine.evEquivalentCo2(-100), 0);
+    });
+
+    test('applies kgCo2PerKmEv factor', () {
+      expect(
+        MilestoneEngine.evEquivalentCo2(1000),
+        closeTo(1000 * MilestoneEngine.kgCo2PerKmEv, 0.0001),
+      );
+    });
+  });
+}

--- a/test/features/carbon/monthly_summary_test.dart
+++ b/test/features/carbon/monthly_summary_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/carbon/domain/monthly_summary.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+FillUp _f({
+  required String id,
+  required DateTime date,
+  double liters = 50,
+  double cost = 80,
+  double odometer = 10000,
+  FuelType? fuelType,
+}) =>
+    FillUp(
+      id: id,
+      date: date,
+      liters: liters,
+      totalCost: cost,
+      odometerKm: odometer,
+      fuelType: fuelType ?? FuelType.e10,
+    );
+
+void main() {
+  group('MonthlyAggregator.byMonth', () {
+    test('returns empty for empty input', () {
+      expect(MonthlyAggregator.byMonth(const []), isEmpty);
+    });
+
+    test('groups fill-ups by calendar month', () {
+      final fillUps = [
+        _f(id: '1', date: DateTime(2026, 1, 5), liters: 40, cost: 60),
+        _f(id: '2', date: DateTime(2026, 1, 20), liters: 30, cost: 50),
+        _f(id: '3', date: DateTime(2026, 2, 3), liters: 50, cost: 80),
+      ];
+      final summaries = MonthlyAggregator.byMonth(fillUps);
+      expect(summaries.length, 2);
+      expect(summaries[0].month, DateTime(2026, 1));
+      expect(summaries[0].totalLiters, closeTo(70, 0.0001));
+      expect(summaries[0].totalCost, closeTo(110, 0.0001));
+      expect(summaries[0].fillUpCount, 2);
+      expect(summaries[1].month, DateTime(2026, 2));
+      expect(summaries[1].fillUpCount, 1);
+    });
+
+    test('summaries are ordered oldest first', () {
+      final fillUps = [
+        _f(id: '1', date: DateTime(2026, 3, 1)),
+        _f(id: '2', date: DateTime(2026, 1, 1)),
+        _f(id: '3', date: DateTime(2026, 2, 1)),
+      ];
+      final summaries = MonthlyAggregator.byMonth(fillUps);
+      expect(
+        summaries.map((s) => s.month.month).toList(),
+        [1, 2, 3],
+      );
+    });
+
+    test('computes CO2 from fuel type', () {
+      final fillUps = [
+        _f(
+          id: '1',
+          date: DateTime(2026, 1, 1),
+          liters: 100,
+          fuelType: FuelType.diesel,
+        ),
+      ];
+      final summaries = MonthlyAggregator.byMonth(fillUps);
+      // Diesel factor ~2.65 kg/L
+      expect(summaries.single.totalCo2Kg, closeTo(265, 1));
+    });
+  });
+
+  group('MonthlyAggregator.lastN', () {
+    test('returns all when fewer summaries than N', () {
+      final fillUps = [
+        _f(id: '1', date: DateTime(2026, 1, 1)),
+        _f(id: '2', date: DateTime(2026, 2, 1)),
+      ];
+      final summaries = MonthlyAggregator.byMonth(fillUps);
+      expect(MonthlyAggregator.lastN(summaries, 12).length, 2);
+    });
+
+    test('returns last N preserving chronological order', () {
+      final fillUps = [
+        for (int m = 1; m <= 6; m++)
+          _f(id: 'm$m', date: DateTime(2026, m, 1)),
+      ];
+      final summaries = MonthlyAggregator.byMonth(fillUps);
+      final last3 = MonthlyAggregator.lastN(summaries, 3);
+      expect(last3.length, 3);
+      expect(last3.first.month.month, 4);
+      expect(last3.last.month.month, 6);
+    });
+
+    test('non-positive N returns all', () {
+      final fillUps = [_f(id: '1', date: DateTime(2026, 1, 1))];
+      final summaries = MonthlyAggregator.byMonth(fillUps);
+      expect(MonthlyAggregator.lastN(summaries, 0).length, 1);
+    });
+  });
+
+  group('MonthlyAggregator totals', () {
+    test('sum across summaries', () {
+      final fillUps = [
+        _f(
+          id: '1',
+          date: DateTime(2026, 1, 1),
+          liters: 50,
+          cost: 80,
+          fuelType: FuelType.e10,
+        ),
+        _f(
+          id: '2',
+          date: DateTime(2026, 2, 1),
+          liters: 40,
+          cost: 70,
+          fuelType: FuelType.e10,
+        ),
+      ];
+      final summaries = MonthlyAggregator.byMonth(fillUps);
+      expect(MonthlyAggregator.totalCost(summaries), closeTo(150, 0.0001));
+      expect(MonthlyAggregator.totalLiters(summaries), closeTo(90, 0.0001));
+      expect(MonthlyAggregator.totalCo2(summaries), greaterThan(0));
+    });
+  });
+
+  test('avgPricePerLiter is zero when no liters', () {
+    final s = MonthlySummary(
+      month: DateTime(2026, 1),
+      totalCost: 100,
+      totalLiters: 0,
+      totalCo2Kg: 0,
+      fillUpCount: 0,
+    );
+    expect(s.avgPricePerLiter, 0);
+  });
+
+  test('avgPricePerLiter divides cost by liters', () {
+    final s = MonthlySummary(
+      month: DateTime(2026, 1),
+      totalCost: 100,
+      totalLiters: 50,
+      totalCo2Kg: 0,
+      fillUpCount: 1,
+    );
+    expect(s.avgPricePerLiter, closeTo(2.0, 0.0001));
+  });
+}


### PR DESCRIPTION
## Summary

- New `/carbon` route with a two-tab dashboard reachable from the consumption screen app bar.
- **Charts tab** (#180): monthly fuel cost and CO2 emission bar charts rendered via `CustomPainter` (consistent with the existing `PriceChart`), plus summary cards for total cost and CO2.
- **Achievements tab** (#181): 9-milestone catalog (fill-up counts, liters, CO2, km), fuel-vs-EV comparison card (0.05 kg CO2/km baseline), and a clipboard-based share button that stays cross-platform and privacy-respecting (no PII, no cost figures).
- All data derived from the existing `fillUpListProvider` and `Co2Calculator` — no new storage, no new providers, no new dependencies.

## Why

Closes #180 and #181 — both belong to epic #178 and share UI scaffolding (tabs, summary cards, milestone logic reuses `MonthlyAggregator`), so they ship together.

## Testing

- `flutter analyze --no-fatal-infos` — zero warnings introduced
- `flutter test test/features/carbon/` — 26 new tests, all passing
- Full suite run — only pre-existing network-dependent Argentina API test fails (unrelated to this change)

## Test plan

- [x] Unit tests for `MonthlyAggregator` (grouping, ordering, totals, lastN)
- [x] Unit tests for `MilestoneEngine` (unlock logic, odometer deltas, EV equivalent)
- [x] Widget tests for `CarbonDashboardScreen` (empty state, charts tab, achievements tab)

Closes #180
Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)