### PR TITLE
refactor(state): eliminate setState in 3 widgets via Riverpod (batch 3)

### DIFF
--- a/lib/features/search/presentation/widgets/location_input.dart
+++ b/lib/features/search/presentation/widgets/location_input.dart
@@ -9,6 +9,7 @@ import '../../../../core/utils/frame_callbacks.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
+import '../../providers/location_input_provider.dart';
 
 /// Unified location input: auto-detects GPS (empty), ZIP (digits), or city (text).
 /// Replaces the old 3-tab GPS/ZIP/City UI.
@@ -32,10 +33,6 @@ class _LocationInputState extends ConsumerState<LocationInput> {
   final _controller = TextEditingController();
   final _focusNode = FocusNode();
   Timer? _debounce;
-  List<ResolvedLocation> _suggestions = [];
-  ResolvedLocation? _selectedCity;
-  bool _isSearching = false;
-  LocationInputType _inputType = LocationInputType.gps;
 
   @override
   void initState() {
@@ -63,11 +60,7 @@ class _LocationInputState extends ConsumerState<LocationInput> {
     final service = ref.read(locationSearchServiceProvider);
     final type = service.detectInputType(value, country);
 
-    setState(() {
-      _inputType = type;
-      _selectedCity = null;
-      if (type != LocationInputType.city) _suggestions = [];
-    });
+    ref.read(locationInputControllerProvider.notifier).setInputType(type);
 
     if (type == LocationInputType.city) {
       _debounce?.cancel();
@@ -79,26 +72,28 @@ class _LocationInputState extends ConsumerState<LocationInput> {
 
   Future<void> _fetchSuggestions(String query) async {
     if (!mounted) return;
-    setState(() => _isSearching = true);
+    final controller = ref.read(locationInputControllerProvider.notifier);
+    controller.setSearching(true);
     try {
       final service = ref.read(locationSearchServiceProvider);
       final results = await service.searchCities(query);
-      if (mounted) setState(() => _suggestions = results);
+      if (mounted) controller.setSuggestions(results);
     } finally {
-      if (mounted) setState(() => _isSearching = false);
+      if (mounted) controller.setSearching(false);
     }
   }
 
   void _submit() {
     final country = ref.read(activeCountryProvider);
+    final uiState = ref.read(locationInputControllerProvider);
     final text = _controller.text.trim();
 
-    if (_selectedCity != null) {
-      widget.onCitySearch(_selectedCity!);
+    if (uiState.selectedCity != null) {
+      widget.onCitySearch(uiState.selectedCity!);
       return;
     }
 
-    switch (_inputType) {
+    switch (uiState.inputType) {
       case LocationInputType.gps:
         widget.onGpsSearch();
       case LocationInputType.zip:
@@ -108,19 +103,20 @@ class _LocationInputState extends ConsumerState<LocationInput> {
           final l10n = AppLocalizations.of(context);
           SnackBarHelper.showError(
             context,
-            l10n?.invalidPostalCode(country.postalCodeLength.toString(), country.postalCodeLabel) ??
+            l10n?.invalidPostalCode(
+                    country.postalCodeLength.toString(), country.postalCodeLabel) ??
                 'Please enter a valid ${country.postalCodeLength}-digit ${country.postalCodeLabel}',
           );
         }
       case LocationInputType.city:
         // If they typed a city but didn't select a suggestion, search anyway
-        if (_suggestions.isNotEmpty) {
-          widget.onCitySearch(_suggestions.first);
+        if (uiState.suggestions.isNotEmpty) {
+          widget.onCitySearch(uiState.suggestions.first);
         }
     }
   }
 
-  IconData get _prefixIcon => switch (_inputType) {
+  IconData _prefixIcon(LocationInputType type) => switch (type) {
         LocationInputType.gps => Icons.my_location,
         LocationInputType.zip => Icons.pin_drop,
         LocationInputType.city => Icons.location_city,
@@ -133,74 +129,81 @@ class _LocationInputState extends ConsumerState<LocationInput> {
   @override
   Widget build(BuildContext context) {
     final country = ref.watch(activeCountryProvider);
+    final uiState = ref.watch(locationInputControllerProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         SizedBox(
           height: 40,
-          child: TextField(
-            controller: _controller,
-            focusNode: _focusNode,
-            style: const TextStyle(fontSize: 14),
-            decoration: InputDecoration(
-              hintText: _hintText(country),
-              labelText: 'Location search field',
-              floatingLabelBehavior: FloatingLabelBehavior.never,
-              isDense: true,
-              contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              prefixIcon: Icon(_prefixIcon, size: 20),
-              prefixIconConstraints:
-                  const BoxConstraints(minWidth: 36, minHeight: 36),
-              border: const OutlineInputBorder(),
-              suffixIcon: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (_isSearching)
-                    const Padding(
-                      padding: EdgeInsets.all(8),
-                      child: SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+          child: ListenableBuilder(
+            listenable: _controller,
+            builder: (context, _) {
+              return TextField(
+                controller: _controller,
+                focusNode: _focusNode,
+                style: const TextStyle(fontSize: 14),
+                decoration: InputDecoration(
+                  hintText: _hintText(country),
+                  labelText: 'Location search field',
+                  floatingLabelBehavior: FloatingLabelBehavior.never,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 12, vertical: 8),
+                  prefixIcon: Icon(_prefixIcon(uiState.inputType), size: 20),
+                  prefixIconConstraints:
+                      const BoxConstraints(minWidth: 36, minHeight: 36),
+                  border: const OutlineInputBorder(),
+                  suffixIcon: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (uiState.isSearching)
+                        const Padding(
+                          padding: EdgeInsets.all(8),
+                          child: SizedBox(
+                            width: 16,
+                            height: 16,
+                            child:
+                                CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        ),
+                      if (_controller.text.isNotEmpty)
+                        IconButton(
+                          icon: const Icon(Icons.clear, size: 18),
+                          tooltip: 'Clear search input',
+                          padding: const EdgeInsets.all(4),
+                          constraints: const BoxConstraints(
+                              minWidth: 32, minHeight: 32),
+                          onPressed: () {
+                            _controller.clear();
+                            _onChanged('');
+                          },
+                        ),
+                      IconButton(
+                        icon: const Icon(Icons.my_location, size: 18),
+                        tooltip: 'Use GPS location',
+                        padding: const EdgeInsets.all(4),
+                        constraints: const BoxConstraints(
+                            minWidth: 32, minHeight: 32),
+                        onPressed: () {
+                          _controller.clear();
+                          _onChanged('');
+                          widget.onGpsSearch();
+                        },
                       ),
-                    ),
-                  if (_controller.text.isNotEmpty)
-                    IconButton(
-                      icon: const Icon(Icons.clear, size: 18),
-                      tooltip: 'Clear search input',
-                      padding: const EdgeInsets.all(4),
-                      constraints:
-                          const BoxConstraints(minWidth: 32, minHeight: 32),
-                      onPressed: () {
-                        _controller.clear();
-                        _onChanged('');
-                      },
-                    ),
-                  IconButton(
-                    icon: const Icon(Icons.my_location, size: 18),
-                    tooltip: 'Use GPS location',
-                    padding: const EdgeInsets.all(4),
-                    constraints:
-                        const BoxConstraints(minWidth: 32, minHeight: 32),
-                    onPressed: () {
-                      _controller.clear();
-                      _onChanged('');
-                      widget.onGpsSearch();
-                    },
+                    ],
                   ),
-                ],
-              ),
-              suffixIconConstraints:
-                  const BoxConstraints(minWidth: 36, minHeight: 36),
-            ),
-            onChanged: _onChanged,
-            onSubmitted: (_) => _submit(),
+                  suffixIconConstraints:
+                      const BoxConstraints(minWidth: 36, minHeight: 36),
+                ),
+                onChanged: _onChanged,
+                onSubmitted: (_) => _submit(),
+              );
+            },
           ),
         ),
         // City suggestions dropdown
-        if (_suggestions.isNotEmpty)
+        if (uiState.suggestions.isNotEmpty)
           Container(
             constraints: const BoxConstraints(maxHeight: 200),
             margin: const EdgeInsets.only(top: 4),
@@ -212,10 +215,10 @@ class _LocationInputState extends ConsumerState<LocationInput> {
             ),
             child: ListView.builder(
               shrinkWrap: true,
-              itemCount: _suggestions.length,
+              itemCount: uiState.suggestions.length,
               itemBuilder: (ctx, i) {
-                final city = _suggestions[i];
-                final isSelected = _selectedCity == city;
+                final city = uiState.suggestions[i];
+                final isSelected = uiState.selectedCity == city;
                 return ListTile(
                   key: ValueKey('city-${city.lat}-${city.lng}-${city.name}'),
                   dense: true,
@@ -228,11 +231,10 @@ class _LocationInputState extends ConsumerState<LocationInput> {
                           style: const TextStyle(fontSize: 11))
                       : null,
                   onTap: () {
-                    setState(() {
-                      _selectedCity = city;
-                      _controller.text = city.name;
-                      _suggestions = [];
-                    });
+                    _controller.text = city.name;
+                    ref
+                        .read(locationInputControllerProvider.notifier)
+                        .selectCity(city);
                     widget.onCitySearch(city);
                   },
                 );

--- a/lib/features/search/providers/location_input_provider.dart
+++ b/lib/features/search/providers/location_input_provider.dart
@@ -1,0 +1,69 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/services/location_search_service.dart';
+
+part 'location_input_provider.g.dart';
+
+/// UI state for the unified LocationInput widget. Holds the detected
+/// input type, search-in-progress flag, city suggestions and the
+/// user-selected city. The TextEditingController itself stays local
+/// to the widget.
+class LocationInputState {
+  final LocationInputType inputType;
+  final List<ResolvedLocation> suggestions;
+  final ResolvedLocation? selectedCity;
+  final bool isSearching;
+
+  const LocationInputState({
+    this.inputType = LocationInputType.gps,
+    this.suggestions = const [],
+    this.selectedCity,
+    this.isSearching = false,
+  });
+
+  LocationInputState copyWith({
+    LocationInputType? inputType,
+    List<ResolvedLocation>? suggestions,
+    ResolvedLocation? selectedCity,
+    bool clearSelectedCity = false,
+    bool? isSearching,
+  }) {
+    return LocationInputState(
+      inputType: inputType ?? this.inputType,
+      suggestions: suggestions ?? this.suggestions,
+      selectedCity:
+          clearSelectedCity ? null : (selectedCity ?? this.selectedCity),
+      isSearching: isSearching ?? this.isSearching,
+    );
+  }
+}
+
+@riverpod
+class LocationInputController extends _$LocationInputController {
+  @override
+  LocationInputState build() => const LocationInputState();
+
+  void setInputType(LocationInputType type) {
+    state = state.copyWith(
+      inputType: type,
+      clearSelectedCity: true,
+      suggestions: type != LocationInputType.city ? const [] : state.suggestions,
+    );
+  }
+
+  void setSearching(bool value) => state = state.copyWith(isSearching: value);
+
+  void setSuggestions(List<ResolvedLocation> suggestions) =>
+      state = state.copyWith(suggestions: suggestions);
+
+  void selectCity(ResolvedLocation city) {
+    state = state.copyWith(
+      selectedCity: city,
+      suggestions: const [],
+    );
+  }
+
+  void clear() {
+    state = const LocationInputState();
+  }
+}

--- a/lib/features/search/providers/location_input_provider.g.dart
+++ b/lib/features/search/providers/location_input_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'location_input_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(LocationInputController)
+final locationInputControllerProvider = LocationInputControllerProvider._();
+
+final class LocationInputControllerProvider
+    extends $NotifierProvider<LocationInputController, LocationInputState> {
+  LocationInputControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'locationInputControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$locationInputControllerHash();
+
+  @$internal
+  @override
+  LocationInputController create() => LocationInputController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(LocationInputState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<LocationInputState>(value),
+    );
+  }
+}
+
+String _$locationInputControllerHash() =>
+    r'377a0458d3364157b4ee0a59af3c7b5e87241fbb';
+
+abstract class _$LocationInputController extends $Notifier<LocationInputState> {
+  LocationInputState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<LocationInputState, LocationInputState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<LocationInputState, LocationInputState>,
+              LocationInputState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/sync/presentation/screens/data_transparency_screen.dart
+++ b/lib/features/sync/presentation/screens/data_transparency_screen.dart
@@ -4,110 +4,25 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/sync/sync_provider.dart';
-import '../../../../core/sync/sync_service.dart';
-import '../../../alerts/providers/alert_provider.dart';
-import '../../../favorites/providers/favorites_provider.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../providers/data_transparency_provider.dart';
 import '../widgets/data_transparency_cards.dart';
 
 /// Shows all data stored on the server for the current user.
-class DataTransparencyScreen extends ConsumerStatefulWidget {
+class DataTransparencyScreen extends ConsumerWidget {
   const DataTransparencyScreen({super.key});
-
-  @override
-  ConsumerState<DataTransparencyScreen> createState() =>
-      _DataTransparencyScreenState();
-}
-
-class _DataTransparencyScreenState
-    extends ConsumerState<DataTransparencyScreen> {
-  Map<String, dynamic>? _data;
-  bool _loading = true;
-  String? _error;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadData();
-  }
-
-  Future<void> _forceSyncAndReload() async {
-    setState(() => _loading = true);
-
-    try {
-      final favoriteIds = ref.read(favoritesProvider);
-      debugPrint('DataTransparency: forcing sync of ${favoriteIds.length} local favorites');
-      debugPrint('DataTransparency: auth user = ${TankSyncClient.client?.auth.currentUser?.id}');
-      debugPrint('DataTransparency: client initialized = ${TankSyncClient.isConnected}');
-
-      if (!TankSyncClient.isConnected) {
-        debugPrint('DataTransparency: not connected, attempting re-auth...');
-        await TankSyncClient.signInAnonymously();
-        debugPrint('DataTransparency: re-auth result = ${TankSyncClient.client?.auth.currentUser?.id}');
-      } else {
-        final uid = TankSyncClient.client?.auth.currentUser?.id;
-        if (uid != null) {
-          try {
-            await TankSyncClient.client!.from('users').upsert({'id': uid}, onConflict: 'id');
-          } catch (e) {
-            debugPrint('DataTransparency: users upsert failed: $e');
-          }
-        }
-      }
-
-      await SyncService.syncFavorites(favoriteIds);
-
-      final alerts = ref.read(alertProvider);
-      debugPrint('DataTransparency: syncing ${alerts.length} local alerts');
-      await SyncService.syncAlerts(alerts);
-    } catch (e) {
-      debugPrint('DataTransparency: force sync failed: $e');
-    }
-
-    await _loadData();
-    if (mounted) {
-      SnackBarHelper.showSuccess(context, AppLocalizations.of(context)?.syncCompleted ?? 'Sync completed — data refreshed');
-    }
-  }
-
-  Future<void> _loadData() async {
-    final syncConfig = ref.read(syncStateProvider);
-    final storedUserId = syncConfig.userId;
-    final sessionUserId = TankSyncClient.client?.auth.currentUser?.id;
-
-    debugPrint('DataTransparency._loadData: storedUserId=$storedUserId, sessionUserId=$sessionUserId, isConnected=${TankSyncClient.isConnected}');
-
-    if (storedUserId == null && sessionUserId == null) {
-      setState(() {
-        _error = 'No user ID found. Try disconnecting and reconnecting TankSync.';
-        _loading = false;
-      });
-      return;
-    }
-
-    try {
-      final data = await SyncService.fetchAllUserData();
-      if (data.containsKey('error')) {
-        setState(() { _error = data['error'] as String; _loading = false; });
-      } else {
-        setState(() { _data = data; _loading = false; });
-      }
-    } catch (e) {
-      setState(() { _error = e.toString(); _loading = false; });
-    }
-  }
 
   String _prettyJson(Map<String, dynamic> data) {
     return const JsonEncoder.withIndent('  ').convert(data);
   }
 
-  Future<void> _showRawJson() async {
-    if (_data == null) return;
-    final json = _prettyJson(_data!);
-    if (!mounted) return;
+  Future<void> _showRawJson(
+    BuildContext context,
+    Map<String, dynamic> data,
+  ) async {
+    final json = _prettyJson(data);
     await showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -115,27 +30,45 @@ class _DataTransparencyScreenState
         content: SizedBox(
           width: double.maxFinite,
           child: SingleChildScrollView(
-            child: SelectableText(json, style: const TextStyle(fontFamily: 'monospace', fontSize: 12)),
+            child: SelectableText(
+              json,
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+            ),
           ),
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Close')),
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
         ],
       ),
     );
   }
 
-  Future<void> _exportJson() async {
-    if (_data == null) return;
-    await Clipboard.setData(ClipboardData(text: _prettyJson(_data!)));
-    if (!mounted) return;
-    SnackBarHelper.show(context, AppLocalizations.of(context)?.jsonCopied ?? 'JSON copied to clipboard');
+  Future<void> _exportJson(
+    BuildContext context,
+    Map<String, dynamic> data,
+  ) async {
+    await Clipboard.setData(ClipboardData(text: _prettyJson(data)));
+    if (!context.mounted) return;
+    SnackBarHelper.show(
+      context,
+      AppLocalizations.of(context)?.jsonCopied ?? 'JSON copied to clipboard',
+    );
   }
 
-  Future<void> _deleteAllData() async {
-    final syncConfig = ref.read(syncStateProvider);
-    if (syncConfig.userId == null) return;
+  Future<void> _forceSyncAndReload(BuildContext context, WidgetRef ref) async {
+    await ref.read(dataTransparencyControllerProvider.notifier).forceSyncAndReload();
+    if (!context.mounted) return;
+    SnackBarHelper.showSuccess(
+      context,
+      AppLocalizations.of(context)?.syncCompleted ??
+          'Sync completed — data refreshed',
+    );
+  }
 
+  Future<void> _deleteAllData(BuildContext context, WidgetRef ref) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
@@ -146,7 +79,10 @@ class _DataTransparencyScreenState
           'not be affected.\n\nThis action cannot be undone.',
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
           FilledButton(
             style: FilledButton.styleFrom(backgroundColor: Colors.red),
             onPressed: () => Navigator.pop(context, true),
@@ -156,20 +92,17 @@ class _DataTransparencyScreenState
       ),
     );
 
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !context.mounted) return;
 
-    setState(() => _loading = true);
-    try {
-      await SyncService.deleteAllUserData();
-      await _loadData();
-      if (!mounted) return;
-      SnackBarHelper.showSuccess(context, AppLocalizations.of(context)?.allDataDeleted ?? 'All server data deleted');
-    } catch (e) {
-      setState(() { _error = e.toString(); _loading = false; });
-    }
+    await ref.read(dataTransparencyControllerProvider.notifier).deleteAllData();
+    if (!context.mounted) return;
+    SnackBarHelper.showSuccess(
+      context,
+      AppLocalizations.of(context)?.allDataDeleted ?? 'All server data deleted',
+    );
   }
 
-  Future<void> _disconnect() async {
+  Future<void> _disconnect(BuildContext context, WidgetRef ref) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
@@ -179,32 +112,43 @@ class _DataTransparencyScreenState
           'intact. You can reconnect at any time.',
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Disconnect')),
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Disconnect'),
+          ),
         ],
       ),
     );
 
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !context.mounted) return;
     await ref.read(syncStateProvider.notifier).disconnect();
-    if (!mounted) return;
+    if (!context.mounted) return;
     Navigator.pop(context);
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final syncConfig = ref.watch(syncStateProvider);
+    final uiState = ref.watch(dataTransparencyControllerProvider);
     final theme = Theme.of(context);
 
     return Scaffold(
       appBar: AppBar(title: const Text('My server data')),
-      body: _loading
+      body: uiState.loading
           ? const Center(child: CircularProgressIndicator())
-          : _error != null
+          : uiState.error != null
               ? Center(
                   child: Padding(
                     padding: const EdgeInsets.all(24),
-                    child: Text(_error!, style: TextStyle(color: theme.colorScheme.error), textAlign: TextAlign.center),
+                    child: Text(
+                      uiState.error!,
+                      style: TextStyle(color: theme.colorScheme.error),
+                      textAlign: TextAlign.center,
+                    ),
                   ),
                 )
               : ListView(
@@ -212,17 +156,18 @@ class _DataTransparencyScreenState
                   children: [
                     AccountInfoCard(syncConfig: syncConfig),
                     const SizedBox(height: 12),
-                    if (_data != null) ...[
-                      SyncedDataCard(data: _data!),
+                    if (uiState.data != null) ...[
+                      SyncedDataCard(data: uiState.data!),
                       const SizedBox(height: 16),
                       DataActionButtons(
-                        loading: _loading,
+                        loading: uiState.loading,
                         mode: syncConfig.mode,
-                        onSync: _forceSyncAndReload,
-                        onViewRawJson: _showRawJson,
-                        onExportJson: _exportJson,
-                        onDeleteAll: _deleteAllData,
-                        onDisconnect: _disconnect,
+                        onSync: () => _forceSyncAndReload(context, ref),
+                        onViewRawJson: () =>
+                            _showRawJson(context, uiState.data!),
+                        onExportJson: () => _exportJson(context, uiState.data!),
+                        onDeleteAll: () => _deleteAllData(context, ref),
+                        onDisconnect: () => _disconnect(context, ref),
                       ),
                     ],
                   ],

--- a/lib/features/sync/presentation/screens/link_device_screen.dart
+++ b/lib/features/sync/presentation/screens/link_device_screen.dart
@@ -3,12 +3,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/sync/supabase_client.dart';
-import '../../../../core/sync/sync_service.dart';
-import '../../../favorites/providers/favorites_provider.dart';
-import '../../../alerts/providers/alert_provider.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../alerts/data/models/price_alert.dart';
+import '../../providers/link_device_provider.dart';
 
 class LinkDeviceScreen extends ConsumerStatefulWidget {
   const LinkDeviceScreen({super.key});
@@ -18,17 +15,11 @@ class LinkDeviceScreen extends ConsumerStatefulWidget {
 }
 
 class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
+  // Text controller stays local — guideline is to keep controllers in the
+  // widget even after lifting business state into a provider.
   final _codeController = TextEditingController();
-  bool _isLinking = false;
-  String? _result;
 
   String? get _myId => TankSyncClient.client?.auth.currentUser?.id;
-
-  @override
-  void initState() {
-    super.initState();
-    _codeController.addListener(() => setState(() {}));
-  }
 
   @override
   void dispose() {
@@ -36,93 +27,10 @@ class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
     super.dispose();
   }
 
-  Future<void> _linkDevice() async {
-    final otherUserId = _codeController.text.trim();
-    if (otherUserId.isEmpty || otherUserId.length < 10) {
-      setState(() => _result = 'Please enter a valid device code');
-      return;
-    }
-
-    setState(() {
-      _isLinking = true;
-      _result = null;
-    });
-
-    try {
-      final client = TankSyncClient.client;
-      if (client == null) {
-        setState(() => _result = 'Not connected to TankSync');
-        return;
-      }
-
-      // 1. Fetch the other device's favorites
-      final otherFavorites = await client
-          .from('favorites')
-          .select('station_id')
-          .eq('user_id', otherUserId);
-
-      final importedFavIds = (otherFavorites as List)
-          .map((r) => r['station_id'] as String)
-          .toList();
-
-      // 2. Fetch the other device's alerts
-      final otherAlerts = await client
-          .from('alerts')
-          .select()
-          .eq('user_id', otherUserId);
-
-      // 3. Merge favorites locally
-      int addedFavorites = 0;
-      final currentFavs = ref.read(favoritesProvider);
-      for (final stationId in importedFavIds) {
-        if (!currentFavs.contains(stationId)) {
-          await ref.read(favoritesProvider.notifier).add(stationId);
-          addedFavorites++;
-        }
-      }
-
-      // 4. Merge alerts locally
-      int addedAlerts = 0;
-      final currentAlerts = ref.read(alertProvider);
-      final currentAlertIds = currentAlerts.map((a) => a.id).toSet();
-      for (final row in otherAlerts as List) {
-        if (!currentAlertIds.contains(row['id'])) {
-          try {
-            final alert = PriceAlert.fromJson({
-              'id': row['id'],
-              'stationId': row['station_id'],
-              'stationName': row['station_name'] ?? '',
-              'fuelType': row['fuel_type'] ?? 'e10',
-              'targetPrice': (row['target_price'] as num).toDouble(),
-              'isActive': row['is_active'] ?? true,
-              'createdAt': row['created_at'] ?? DateTime.now().toIso8601String(),
-            });
-            await ref.read(alertProvider.notifier).addAlert(alert);
-            addedAlerts++;
-          } catch (e) { debugPrint('Alert import failed: $e'); }
-        }
-      }
-
-      // 5. Sync merged data back to our server account
-      await SyncService.syncFavorites(ref.read(favoritesProvider));
-      await SyncService.syncAlerts(ref.read(alertProvider));
-
-      setState(() {
-        _result =
-            'Linked! Imported $addedFavorites favorites and $addedAlerts alerts.';
-      });
-    } catch (e) {
-      setState(() {
-        _result = 'Link failed: $e';
-      });
-    } finally {
-      setState(() => _isLinking = false);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final uiState = ref.watch(linkDeviceControllerProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -178,7 +86,11 @@ class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
                             tooltip: 'Copy code',
                             onPressed: () {
                               Clipboard.setData(ClipboardData(text: _myId!));
-                              SnackBarHelper.show(context, AppLocalizations.of(context)?.deviceCodeCopied ?? 'Device code copied');
+                              SnackBarHelper.show(
+                                context,
+                                AppLocalizations.of(context)?.deviceCodeCopied ??
+                                    'Device code copied',
+                              );
                             },
                             padding: EdgeInsets.zero,
                             constraints: const BoxConstraints(
@@ -218,39 +130,53 @@ class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
                         ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
                   ),
                   const SizedBox(height: 12),
-                  TextField(
-                    controller: _codeController,
-                    decoration: const InputDecoration(
-                      labelText: 'Device code',
-                      hintText: 'Paste the UUID from other device',
-                      prefixIcon: Icon(Icons.key, size: 18),
-                      isDense: true,
-                      contentPadding:
-                          EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                    ),
+                  // ListenableBuilder so the submit button enables/disables
+                  // based on the local TextEditingController without rebuilding
+                  // the whole screen.
+                  ListenableBuilder(
+                    listenable: _codeController,
+                    builder: (context, _) {
+                      final hasText = _codeController.text.isNotEmpty;
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          TextField(
+                            controller: _codeController,
+                            decoration: const InputDecoration(
+                              labelText: 'Device code',
+                              hintText: 'Paste the UUID from other device',
+                              prefixIcon: Icon(Icons.key, size: 18),
+                              isDense: true,
+                              contentPadding: EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 8),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          FilledButton.icon(
+                            onPressed: (hasText && !uiState.isLinking)
+                                ? () => ref
+                                    .read(linkDeviceControllerProvider.notifier)
+                                    .linkDevice(_codeController.text)
+                                : null,
+                            icon: uiState.isLinking
+                                ? const SizedBox(
+                                    width: 16,
+                                    height: 16,
+                                    child: CircularProgressIndicator(
+                                        strokeWidth: 2, color: Colors.white))
+                                : const Icon(Icons.sync),
+                            label: const Text('Import data'),
+                          ),
+                        ],
+                      );
+                    },
                   ),
-                  const SizedBox(height: 12),
-                  FilledButton.icon(
-                    onPressed: (_codeController.text.isNotEmpty && !_isLinking)
-                        ? _linkDevice
-                        : null,
-                    icon: _isLinking
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(
-                                strokeWidth: 2, color: Colors.white))
-                        : const Icon(Icons.sync),
-                    label: const Text('Import data'),
-                  ),
-                  if (_result != null) ...[
+                  if (uiState.result != null) ...[
                     const SizedBox(height: 12),
                     Text(
-                      _result!,
+                      uiState.result!,
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        color: _result!.startsWith('Link failed')
-                            ? Colors.red
-                            : Colors.green,
+                        color: uiState.isError ? Colors.red : Colors.green,
                       ),
                     ),
                   ],

--- a/lib/features/sync/providers/data_transparency_provider.dart
+++ b/lib/features/sync/providers/data_transparency_provider.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/sync/supabase_client.dart';
+import '../../../core/sync/sync_provider.dart';
+import '../../../core/sync/sync_service.dart';
+import '../../alerts/providers/alert_provider.dart';
+import '../../favorites/providers/favorites_provider.dart';
+
+part 'data_transparency_provider.g.dart';
+
+/// UI state for the "My server data" (data transparency) screen.
+/// Holds the fetched server payload plus loading/error state so the
+/// screen can be a [ConsumerWidget] instead of using setState.
+class DataTransparencyState {
+  final Map<String, dynamic>? data;
+  final bool loading;
+  final String? error;
+
+  const DataTransparencyState({
+    this.data,
+    this.loading = true,
+    this.error,
+  });
+
+  DataTransparencyState copyWith({
+    Map<String, dynamic>? data,
+    bool? loading,
+    String? error,
+    bool clearError = false,
+    bool clearData = false,
+  }) {
+    return DataTransparencyState(
+      data: clearData ? null : (data ?? this.data),
+      loading: loading ?? this.loading,
+      error: clearError ? null : (error ?? this.error),
+    );
+  }
+}
+
+@riverpod
+class DataTransparencyController extends _$DataTransparencyController {
+  @override
+  DataTransparencyState build() {
+    // Kick off initial load.
+    Future.microtask(load);
+    return const DataTransparencyState();
+  }
+
+  Future<void> load() async {
+    final syncConfig = ref.read(syncStateProvider);
+    final storedUserId = syncConfig.userId;
+    final sessionUserId = TankSyncClient.client?.auth.currentUser?.id;
+
+    debugPrint(
+      'DataTransparency.load: storedUserId=$storedUserId, '
+      'sessionUserId=$sessionUserId, isConnected=${TankSyncClient.isConnected}',
+    );
+
+    if (storedUserId == null && sessionUserId == null) {
+      state = state.copyWith(
+        loading: false,
+        error:
+            'No user ID found. Try disconnecting and reconnecting TankSync.',
+      );
+      return;
+    }
+
+    state = state.copyWith(loading: true, clearError: true);
+    try {
+      final data = await SyncService.fetchAllUserData();
+      if (data.containsKey('error')) {
+        state = state.copyWith(
+          loading: false,
+          error: data['error'] as String,
+        );
+      } else {
+        state = DataTransparencyState(data: data, loading: false);
+      }
+    } catch (e) {
+      state = state.copyWith(loading: false, error: e.toString());
+    }
+  }
+
+  Future<void> forceSyncAndReload() async {
+    state = state.copyWith(loading: true, clearError: true);
+    try {
+      final favoriteIds = ref.read(favoritesProvider);
+      debugPrint(
+        'DataTransparency: forcing sync of ${favoriteIds.length} local favorites',
+      );
+      debugPrint(
+        'DataTransparency: auth user = ${TankSyncClient.client?.auth.currentUser?.id}',
+      );
+      debugPrint(
+        'DataTransparency: client initialized = ${TankSyncClient.isConnected}',
+      );
+
+      if (!TankSyncClient.isConnected) {
+        debugPrint('DataTransparency: not connected, attempting re-auth...');
+        await TankSyncClient.signInAnonymously();
+        debugPrint(
+          'DataTransparency: re-auth result = ${TankSyncClient.client?.auth.currentUser?.id}',
+        );
+      } else {
+        final uid = TankSyncClient.client?.auth.currentUser?.id;
+        if (uid != null) {
+          try {
+            await TankSyncClient.client!
+                .from('users')
+                .upsert({'id': uid}, onConflict: 'id');
+          } catch (e) {
+            debugPrint('DataTransparency: users upsert failed: $e');
+          }
+        }
+      }
+
+      await SyncService.syncFavorites(favoriteIds);
+
+      final alerts = ref.read(alertProvider);
+      debugPrint('DataTransparency: syncing ${alerts.length} local alerts');
+      await SyncService.syncAlerts(alerts);
+    } catch (e) {
+      debugPrint('DataTransparency: force sync failed: $e');
+    }
+
+    await load();
+  }
+
+  Future<void> deleteAllData() async {
+    final syncConfig = ref.read(syncStateProvider);
+    if (syncConfig.userId == null) return;
+
+    state = state.copyWith(loading: true, clearError: true);
+    try {
+      await SyncService.deleteAllUserData();
+      await load();
+    } catch (e) {
+      state = state.copyWith(loading: false, error: e.toString());
+    }
+  }
+}

--- a/lib/features/sync/providers/data_transparency_provider.g.dart
+++ b/lib/features/sync/providers/data_transparency_provider.g.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'data_transparency_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(DataTransparencyController)
+final dataTransparencyControllerProvider =
+    DataTransparencyControllerProvider._();
+
+final class DataTransparencyControllerProvider
+    extends
+        $NotifierProvider<DataTransparencyController, DataTransparencyState> {
+  DataTransparencyControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'dataTransparencyControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$dataTransparencyControllerHash();
+
+  @$internal
+  @override
+  DataTransparencyController create() => DataTransparencyController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DataTransparencyState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DataTransparencyState>(value),
+    );
+  }
+}
+
+String _$dataTransparencyControllerHash() =>
+    r'597a78d6a36b719e18b87b268552333bcee2ff63';
+
+abstract class _$DataTransparencyController
+    extends $Notifier<DataTransparencyState> {
+  DataTransparencyState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<DataTransparencyState, DataTransparencyState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<DataTransparencyState, DataTransparencyState>,
+              DataTransparencyState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/sync/providers/link_device_provider.dart
+++ b/lib/features/sync/providers/link_device_provider.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/sync/supabase_client.dart';
+import '../../../core/sync/sync_service.dart';
+import '../../alerts/data/models/price_alert.dart';
+import '../../alerts/providers/alert_provider.dart';
+import '../../favorites/providers/favorites_provider.dart';
+
+part 'link_device_provider.g.dart';
+
+/// UI state for the "Link device" screen. The text controller itself
+/// is owned by the screen; this provider only tracks loading + result.
+class LinkDeviceState {
+  final bool isLinking;
+  final String? result;
+
+  const LinkDeviceState({this.isLinking = false, this.result});
+
+  LinkDeviceState copyWith({
+    bool? isLinking,
+    String? result,
+    bool clearResult = false,
+  }) {
+    return LinkDeviceState(
+      isLinking: isLinking ?? this.isLinking,
+      result: clearResult ? null : (result ?? this.result),
+    );
+  }
+
+  bool get isError => result != null && result!.startsWith('Link failed');
+}
+
+@riverpod
+class LinkDeviceController extends _$LinkDeviceController {
+  @override
+  LinkDeviceState build() => const LinkDeviceState();
+
+  Future<void> linkDevice(String otherUserId) async {
+    final trimmed = otherUserId.trim();
+    if (trimmed.isEmpty || trimmed.length < 10) {
+      state = state.copyWith(result: 'Please enter a valid device code');
+      return;
+    }
+
+    state = const LinkDeviceState(isLinking: true);
+
+    try {
+      final client = TankSyncClient.client;
+      if (client == null) {
+        state = const LinkDeviceState(result: 'Not connected to TankSync');
+        return;
+      }
+
+      // 1. Fetch the other device's favorites
+      final otherFavorites = await client
+          .from('favorites')
+          .select('station_id')
+          .eq('user_id', trimmed);
+
+      final importedFavIds = (otherFavorites as List)
+          .map((r) => r['station_id'] as String)
+          .toList();
+
+      // 2. Fetch the other device's alerts
+      final otherAlerts =
+          await client.from('alerts').select().eq('user_id', trimmed);
+
+      // 3. Merge favorites locally
+      int addedFavorites = 0;
+      final currentFavs = ref.read(favoritesProvider);
+      for (final stationId in importedFavIds) {
+        if (!currentFavs.contains(stationId)) {
+          await ref.read(favoritesProvider.notifier).add(stationId);
+          addedFavorites++;
+        }
+      }
+
+      // 4. Merge alerts locally
+      int addedAlerts = 0;
+      final currentAlerts = ref.read(alertProvider);
+      final currentAlertIds = currentAlerts.map((a) => a.id).toSet();
+      for (final row in otherAlerts as List) {
+        if (!currentAlertIds.contains(row['id'])) {
+          try {
+            final alert = PriceAlert.fromJson({
+              'id': row['id'],
+              'stationId': row['station_id'],
+              'stationName': row['station_name'] ?? '',
+              'fuelType': row['fuel_type'] ?? 'e10',
+              'targetPrice': (row['target_price'] as num).toDouble(),
+              'isActive': row['is_active'] ?? true,
+              'createdAt':
+                  row['created_at'] ?? DateTime.now().toIso8601String(),
+            });
+            await ref.read(alertProvider.notifier).addAlert(alert);
+            addedAlerts++;
+          } catch (e) {
+            debugPrint('Alert import failed: $e');
+          }
+        }
+      }
+
+      // 5. Sync merged data back to our server account
+      await SyncService.syncFavorites(ref.read(favoritesProvider));
+      await SyncService.syncAlerts(ref.read(alertProvider));
+
+      state = LinkDeviceState(
+        result:
+            'Linked! Imported $addedFavorites favorites and $addedAlerts alerts.',
+      );
+    } catch (e) {
+      state = LinkDeviceState(result: 'Link failed: $e');
+    }
+  }
+}

--- a/lib/features/sync/providers/link_device_provider.g.dart
+++ b/lib/features/sync/providers/link_device_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'link_device_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(LinkDeviceController)
+final linkDeviceControllerProvider = LinkDeviceControllerProvider._();
+
+final class LinkDeviceControllerProvider
+    extends $NotifierProvider<LinkDeviceController, LinkDeviceState> {
+  LinkDeviceControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'linkDeviceControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$linkDeviceControllerHash();
+
+  @$internal
+  @override
+  LinkDeviceController create() => LinkDeviceController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(LinkDeviceState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<LinkDeviceState>(value),
+    );
+  }
+}
+
+String _$linkDeviceControllerHash() =>
+    r'675e5a709956096c3db16e0e8b7219a003ef4726';
+
+abstract class _$LinkDeviceController extends $Notifier<LinkDeviceState> {
+  LinkDeviceState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<LinkDeviceState, LinkDeviceState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<LinkDeviceState, LinkDeviceState>,
+              LinkDeviceState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/search/providers/location_input_provider_test.dart
+++ b/test/features/search/providers/location_input_provider_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/location_search_service.dart';
+import 'package:tankstellen/features/search/providers/location_input_provider.dart';
+
+void main() {
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer();
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  const city1 = ResolvedLocation(
+    name: 'Montpellier',
+    lat: 43.6,
+    lng: 3.88,
+    postcode: '34000',
+  );
+  const city2 = ResolvedLocation(
+    name: 'Nimes',
+    lat: 43.83,
+    lng: 4.35,
+    postcode: '30000',
+  );
+
+  group('LocationInputController', () {
+    test('initial state: GPS type, empty suggestions', () {
+      final c = makeContainer();
+      final s = c.read(locationInputControllerProvider);
+      expect(s.inputType, LocationInputType.gps);
+      expect(s.suggestions, isEmpty);
+      expect(s.selectedCity, isNull);
+      expect(s.isSearching, isFalse);
+    });
+
+    test('setInputType(zip) clears suggestions and selected city', () {
+      final c = makeContainer();
+      final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setSuggestions(const [city1, city2]);
+      ctrl.selectCity(city1);
+      ctrl.setInputType(LocationInputType.zip);
+
+      final s = c.read(locationInputControllerProvider);
+      expect(s.inputType, LocationInputType.zip);
+      expect(s.suggestions, isEmpty);
+      expect(s.selectedCity, isNull);
+    });
+
+    test('setInputType(city) keeps existing suggestions', () {
+      final c = makeContainer();
+      final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setSuggestions(const [city1]);
+      ctrl.setInputType(LocationInputType.city);
+
+      expect(
+        c.read(locationInputControllerProvider).suggestions,
+        hasLength(1),
+      );
+    });
+
+    test('selectCity stores city and clears suggestions', () {
+      final c = makeContainer();
+      final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setSuggestions(const [city1, city2]);
+      ctrl.selectCity(city2);
+
+      final s = c.read(locationInputControllerProvider);
+      expect(s.selectedCity, city2);
+      expect(s.suggestions, isEmpty);
+    });
+
+    test('setSearching toggles isSearching flag', () {
+      final c = makeContainer();
+      final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setSearching(true);
+      expect(c.read(locationInputControllerProvider).isSearching, isTrue);
+      ctrl.setSearching(false);
+      expect(c.read(locationInputControllerProvider).isSearching, isFalse);
+    });
+
+    test('clear resets everything to defaults', () {
+      final c = makeContainer();
+      final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setSuggestions(const [city1]);
+      ctrl.selectCity(city1);
+      ctrl.setSearching(true);
+      ctrl.clear();
+
+      final s = c.read(locationInputControllerProvider);
+      expect(s.inputType, LocationInputType.gps);
+      expect(s.suggestions, isEmpty);
+      expect(s.selectedCity, isNull);
+      expect(s.isSearching, isFalse);
+    });
+  });
+}

--- a/test/features/sync/providers/link_device_provider_test.dart
+++ b/test/features/sync/providers/link_device_provider_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/sync/providers/link_device_provider.dart';
+
+void main() {
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer();
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('LinkDeviceState', () {
+    test('default is idle with no result', () {
+      const s = LinkDeviceState();
+      expect(s.isLinking, isFalse);
+      expect(s.result, isNull);
+      expect(s.isError, isFalse);
+    });
+
+    test('isError true when result starts with "Link failed"', () {
+      const s = LinkDeviceState(result: 'Link failed: boom');
+      expect(s.isError, isTrue);
+    });
+
+    test('isError false for success messages', () {
+      const s = LinkDeviceState(result: 'Linked! Imported 2 favorites');
+      expect(s.isError, isFalse);
+    });
+
+    test('copyWith preserves fields, clearResult wipes result', () {
+      const s = LinkDeviceState(isLinking: true, result: 'boom');
+      final cleared = s.copyWith(clearResult: true);
+      expect(cleared.isLinking, isTrue);
+      expect(cleared.result, isNull);
+    });
+  });
+
+  group('LinkDeviceController', () {
+    test('initial state is idle', () {
+      final c = makeContainer();
+      expect(c.read(linkDeviceControllerProvider).isLinking, isFalse);
+      expect(c.read(linkDeviceControllerProvider).result, isNull);
+    });
+
+    test('linkDevice with empty code sets validation error', () async {
+      final c = makeContainer();
+      await c.read(linkDeviceControllerProvider.notifier).linkDevice('');
+      final s = c.read(linkDeviceControllerProvider);
+      expect(s.result, 'Please enter a valid device code');
+      expect(s.isLinking, isFalse);
+    });
+
+    test('linkDevice with too-short code sets validation error', () async {
+      final c = makeContainer();
+      await c.read(linkDeviceControllerProvider.notifier).linkDevice('short');
+      expect(
+        c.read(linkDeviceControllerProvider).result,
+        'Please enter a valid device code',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Converts 3 widgets from StatefulWidget.setState to @riverpod controllers, removing ~19 setState calls:
  - DataTransparencyScreen -> ConsumerWidget + DataTransparencyController (data/loading/error + load / forceSync / deleteAll)
  - LinkDeviceScreen keeps its local TextEditingController; link state (isLinking, result) lifted into LinkDeviceController with ListenableBuilder for the submit button
  - LocationInput keeps controller/focus/debounce local; inputType, suggestions, selectedCity and isSearching lifted into LocationInputController
- Adds unit tests for the two pure controllers (link_device_provider, location_input_provider) — 13 new tests
- Existing widget tests for data_transparency_screen and location_input pass unchanged (public widget API preserved)

## Why
Per the issue, meaningful shared state belongs in Riverpod so rebuild scopes are narrower and logic is unit-testable. UI-only flags (animation, expand/collapse, scroll) are intentionally left as setState per guidance.

## Test plan
- [x] flutter analyze: 0 warnings, 0 errors (info-level only)
- [x] flutter test: 2985 pass, 1 skip, 1 pre-existing network flake (Argentina CSV 20s timeout, unrelated)
- [x] New provider unit tests pass (13/13)
- [x] Pre-existing screen/widget tests pass unchanged

## Remaining setState work (batch 4+)
Larger targets still open: ntfy_setup, auth_form_widget, add_fill_up_screen, report_screen, price_history_section. Long tail of UI-only flags should stay as setState.

refs #57

Generated with Claude Code