### PR TITLE
feat: vehicle profile — battery, connectors, and charging preferences

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -27,6 +27,8 @@ import '../features/sync/presentation/screens/auth_screen.dart';
 import '../features/sync/presentation/screens/data_transparency_screen.dart';
 import '../features/sync/presentation/screens/link_device_screen.dart';
 import '../features/sync/presentation/screens/sync_setup_screen.dart';
+import '../features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import '../features/vehicle/presentation/screens/vehicle_list_screen.dart';
 import 'shell_screen.dart';
 import 'station_id_validator.dart';
 
@@ -178,6 +180,18 @@ GoRouter router(Ref ref) {
       GoRoute(
         path: '/carbon',
         builder: (context, state) => const CarbonDashboardScreen(),
+      ),
+      GoRoute(
+        path: '/vehicles',
+        builder: (context, state) => const VehicleListScreen(),
+      ),
+      GoRoute(
+        path: '/vehicles/edit',
+        builder: (context, state) {
+          final extra = state.extra;
+          final vehicleId = extra is String ? extra : null;
+          return EditVehicleScreen(vehicleId: vehicleId);
+        },
       ),
       GoRoute(
         path: '/consumption/add',

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'b06ed435e2e92487050e2e991fc5de486a10976a';
+String _$routerHash() => r'bfd9e27c2801ba2b512f35b542239b0663e86fa7';

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -20,4 +20,6 @@ class StorageKeys {
   static const String consentCloudSync = 'consent_cloud_sync';
   static const String swipeTutorialShown = 'swipe_tutorial_shown';
   static const String consumptionLog = 'consumption_log';
+  static const String vehicleProfiles = 'vehicle_profiles';
+  static const String activeVehicleProfileId = 'active_vehicle_profile_id';
 }

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -60,6 +60,28 @@ class ProfileScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
 
+          // My vehicles
+          Card(
+            margin: EdgeInsets.zero,
+            child: ListTile(
+              leading: const Icon(Icons.directions_car, size: 20),
+              title: Text(
+                l?.vehiclesMenuTitle ?? 'My vehicles',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              subtitle: Text(
+                l?.vehiclesMenuSubtitle ??
+                    'Battery, connectors, charging preferences',
+                style: theme.textTheme.bodySmall,
+              ),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => context.push('/vehicles'),
+            ),
+          ),
+          const SizedBox(height: 8),
+
           // Fuel consumption log
           Card(
             margin: EdgeInsets.zero,

--- a/lib/features/vehicle/data/repositories/vehicle_profile_repository.dart
+++ b/lib/features/vehicle/data/repositories/vehicle_profile_repository.dart
@@ -1,0 +1,102 @@
+import '../../../../core/data/storage_repository.dart';
+import '../../../../core/storage/hive_boxes.dart';
+import '../../../../core/storage/storage_keys.dart';
+import '../../domain/entities/vehicle_profile.dart';
+
+/// CRUD repository for [VehicleProfile] entries.
+///
+/// Stored as a simple list under [StorageKeys.vehicleProfiles] and the
+/// active profile id under [StorageKeys.activeVehicleProfileId] in the
+/// settings box. No dedicated Hive box is needed — the list is small
+/// (typically 1-3 profiles per household).
+class VehicleProfileRepository {
+  final SettingsStorage _storage;
+
+  VehicleProfileRepository(this._storage);
+
+  static const String _listKey = StorageKeys.vehicleProfiles;
+  static const String _activeKey = StorageKeys.activeVehicleProfileId;
+
+  /// Returns all stored vehicle profiles, in insertion order.
+  List<VehicleProfile> getAll() {
+    final raw = _storage.getSetting(_listKey);
+    if (raw is! List) return const [];
+
+    final result = <VehicleProfile>[];
+    for (final item in raw) {
+      final map = HiveBoxes.toStringDynamicMap(item);
+      if (map == null) continue;
+      try {
+        result.add(VehicleProfile.fromJson(map));
+      } catch (_) {
+        // Skip malformed entries rather than crashing the whole list.
+      }
+    }
+    return result;
+  }
+
+  /// Returns the profile matching [id] if present.
+  VehicleProfile? getById(String id) {
+    for (final v in getAll()) {
+      if (v.id == id) return v;
+    }
+    return null;
+  }
+
+  /// Returns the active vehicle profile, or `null` if none is stored.
+  VehicleProfile? getActive() {
+    final id = _storage.getSetting(_activeKey) as String?;
+    if (id == null) return null;
+    return getById(id);
+  }
+
+  /// Add or update a vehicle profile (matched by id).
+  Future<void> save(VehicleProfile profile) async {
+    final all = [...getAll()];
+    final index = all.indexWhere((v) => v.id == profile.id);
+    if (index >= 0) {
+      all[index] = profile;
+    } else {
+      all.add(profile);
+    }
+    await _writeAll(all);
+
+    // Auto-activate the first vehicle so the UI always has one selected.
+    if (_storage.getSetting(_activeKey) == null && all.isNotEmpty) {
+      await _storage.putSetting(_activeKey, all.first.id);
+    }
+  }
+
+  /// Delete a vehicle profile by id.
+  ///
+  /// If the deleted profile was the active one, the active selection
+  /// switches to the first remaining profile (or clears if none).
+  Future<void> delete(String id) async {
+    final all = [...getAll()]..removeWhere((v) => v.id == id);
+    await _writeAll(all);
+
+    if (_storage.getSetting(_activeKey) == id) {
+      if (all.isNotEmpty) {
+        await _storage.putSetting(_activeKey, all.first.id);
+      } else {
+        await _storage.putSetting(_activeKey, null);
+      }
+    }
+  }
+
+  /// Set the active vehicle profile by id.
+  Future<void> setActive(String id) async {
+    await _storage.putSetting(_activeKey, id);
+  }
+
+  /// Remove all stored vehicle profiles.
+  Future<void> clear() async {
+    await _storage.putSetting(_listKey, <Map<String, dynamic>>[]);
+    await _storage.putSetting(_activeKey, null);
+  }
+
+  Future<void> _writeAll(List<VehicleProfile> list) async {
+    final json = list.map((v) => v.toJson()).toList();
+    await _storage.putSetting(_listKey, json);
+  }
+}

--- a/lib/features/vehicle/domain/entities/vehicle_profile.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.dart
@@ -1,0 +1,151 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'vehicle_profile.freezed.dart';
+part 'vehicle_profile.g.dart';
+
+/// Powertrain type for a stored vehicle.
+enum VehicleType {
+  combustion('combustion'),
+  hybrid('hybrid'),
+  ev('ev');
+
+  final String key;
+  const VehicleType(this.key);
+
+  static VehicleType fromKey(String? value) {
+    if (value == null) return VehicleType.combustion;
+    for (final v in VehicleType.values) {
+      if (v.key == value) return v;
+    }
+    return VehicleType.combustion;
+  }
+}
+
+/// Common EV connector standards used in Europe.
+///
+/// Stored as part of [VehicleProfile.supportedConnectors] so the app can
+/// filter charging stations by compatibility with the user's vehicle.
+enum ConnectorType {
+  type2('type2', 'Type 2'),
+  ccs('ccs', 'CCS'),
+  chademo('chademo', 'CHAdeMO'),
+  tesla('tesla', 'Tesla'),
+  schuko('schuko', 'Schuko'),
+  type1('type1', 'Type 1'),
+  threePin('three_pin', '3-pin');
+
+  final String key;
+  final String label;
+  const ConnectorType(this.key, this.label);
+
+  static ConnectorType? fromKey(String? value) {
+    if (value == null) return null;
+    for (final c in ConnectorType.values) {
+      if (c.key == value) return c;
+    }
+    return null;
+  }
+}
+
+/// User preferences for how a vehicle should be charged.
+///
+/// Independent of the [VehicleProfile] model because the values are
+/// relevant only for EVs / hybrids and may be edited separately.
+@freezed
+abstract class ChargingPreferences with _$ChargingPreferences {
+  const factory ChargingPreferences({
+    @Default(20) int minSocPercent,
+    @Default(80) int maxSocPercent,
+    @Default(<String>[]) List<String> preferredNetworks,
+  }) = _ChargingPreferences;
+
+  factory ChargingPreferences.fromJson(Map<String, dynamic> json) =>
+      _$ChargingPreferencesFromJson(json);
+}
+
+/// Persistent data for one of the user's vehicles.
+///
+/// A single profile may describe a combustion car (tank capacity, preferred
+/// fuel) or an EV (battery, supported connectors, charging preferences).
+/// Hybrids may carry either or both sets of fields.
+@freezed
+abstract class VehicleProfile with _$VehicleProfile {
+  const VehicleProfile._();
+
+  const factory VehicleProfile({
+    required String id,
+    required String name,
+    @Default(VehicleType.combustion)
+    @VehicleTypeJsonConverter()
+    VehicleType type,
+
+    // EV fields
+    double? batteryKwh,
+    double? maxChargingKw,
+    @Default(<ConnectorType>{})
+    @ConnectorTypeSetConverter()
+    Set<ConnectorType> supportedConnectors,
+    @Default(ChargingPreferences())
+    @ChargingPreferencesJsonConverter()
+    ChargingPreferences chargingPreferences,
+
+    // Combustion fields
+    double? tankCapacityL,
+    String? preferredFuelType,
+  }) = _VehicleProfile;
+
+  factory VehicleProfile.fromJson(Map<String, dynamic> json) =>
+      _$VehicleProfileFromJson(json);
+
+  bool get isEv => type == VehicleType.ev || type == VehicleType.hybrid;
+  bool get isCombustion =>
+      type == VehicleType.combustion || type == VehicleType.hybrid;
+}
+
+/// Serializes [VehicleType] as its string key.
+class VehicleTypeJsonConverter
+    implements JsonConverter<VehicleType, String> {
+  const VehicleTypeJsonConverter();
+
+  @override
+  VehicleType fromJson(String json) => VehicleType.fromKey(json);
+
+  @override
+  String toJson(VehicleType object) => object.key;
+}
+
+/// Serializes [ChargingPreferences] as a plain map so json_serializable
+/// does not store the nested object instance directly in the parent's
+/// `toJson` output (which would break round-trips through Hive).
+class ChargingPreferencesJsonConverter
+    implements JsonConverter<ChargingPreferences, Map<String, dynamic>> {
+  const ChargingPreferencesJsonConverter();
+
+  @override
+  ChargingPreferences fromJson(Map<String, dynamic> json) =>
+      ChargingPreferences.fromJson(json);
+
+  @override
+  Map<String, dynamic> toJson(ChargingPreferences object) => object.toJson();
+}
+
+/// Serializes a `Set<ConnectorType>` as a list of string keys so it
+/// survives Hive's `Map<String, dynamic>` storage.
+class ConnectorTypeSetConverter
+    implements JsonConverter<Set<ConnectorType>, List<dynamic>> {
+  const ConnectorTypeSetConverter();
+
+  @override
+  Set<ConnectorType> fromJson(List<dynamic> json) {
+    final result = <ConnectorType>{};
+    for (final value in json) {
+      final c = ConnectorType.fromKey(value?.toString());
+      if (c != null) result.add(c);
+    }
+    return result;
+  }
+
+  @override
+  List<String> toJson(Set<ConnectorType> object) =>
+      object.map((c) => c.key).toList();
+}

--- a/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
@@ -1,0 +1,604 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'vehicle_profile.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChargingPreferences {
+
+ int get minSocPercent; int get maxSocPercent; List<String> get preferredNetworks;
+/// Create a copy of ChargingPreferences
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChargingPreferencesCopyWith<ChargingPreferences> get copyWith => _$ChargingPreferencesCopyWithImpl<ChargingPreferences>(this as ChargingPreferences, _$identity);
+
+  /// Serializes this ChargingPreferences to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChargingPreferences&&(identical(other.minSocPercent, minSocPercent) || other.minSocPercent == minSocPercent)&&(identical(other.maxSocPercent, maxSocPercent) || other.maxSocPercent == maxSocPercent)&&const DeepCollectionEquality().equals(other.preferredNetworks, preferredNetworks));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,minSocPercent,maxSocPercent,const DeepCollectionEquality().hash(preferredNetworks));
+
+@override
+String toString() {
+  return 'ChargingPreferences(minSocPercent: $minSocPercent, maxSocPercent: $maxSocPercent, preferredNetworks: $preferredNetworks)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChargingPreferencesCopyWith<$Res>  {
+  factory $ChargingPreferencesCopyWith(ChargingPreferences value, $Res Function(ChargingPreferences) _then) = _$ChargingPreferencesCopyWithImpl;
+@useResult
+$Res call({
+ int minSocPercent, int maxSocPercent, List<String> preferredNetworks
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChargingPreferencesCopyWithImpl<$Res>
+    implements $ChargingPreferencesCopyWith<$Res> {
+  _$ChargingPreferencesCopyWithImpl(this._self, this._then);
+
+  final ChargingPreferences _self;
+  final $Res Function(ChargingPreferences) _then;
+
+/// Create a copy of ChargingPreferences
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? minSocPercent = null,Object? maxSocPercent = null,Object? preferredNetworks = null,}) {
+  return _then(_self.copyWith(
+minSocPercent: null == minSocPercent ? _self.minSocPercent : minSocPercent // ignore: cast_nullable_to_non_nullable
+as int,maxSocPercent: null == maxSocPercent ? _self.maxSocPercent : maxSocPercent // ignore: cast_nullable_to_non_nullable
+as int,preferredNetworks: null == preferredNetworks ? _self.preferredNetworks : preferredNetworks // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ChargingPreferences].
+extension ChargingPreferencesPatterns on ChargingPreferences {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChargingPreferences value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChargingPreferences() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChargingPreferences value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChargingPreferences():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChargingPreferences value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChargingPreferences() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int minSocPercent,  int maxSocPercent,  List<String> preferredNetworks)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChargingPreferences() when $default != null:
+return $default(_that.minSocPercent,_that.maxSocPercent,_that.preferredNetworks);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int minSocPercent,  int maxSocPercent,  List<String> preferredNetworks)  $default,) {final _that = this;
+switch (_that) {
+case _ChargingPreferences():
+return $default(_that.minSocPercent,_that.maxSocPercent,_that.preferredNetworks);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int minSocPercent,  int maxSocPercent,  List<String> preferredNetworks)?  $default,) {final _that = this;
+switch (_that) {
+case _ChargingPreferences() when $default != null:
+return $default(_that.minSocPercent,_that.maxSocPercent,_that.preferredNetworks);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ChargingPreferences implements ChargingPreferences {
+  const _ChargingPreferences({this.minSocPercent = 20, this.maxSocPercent = 80, final  List<String> preferredNetworks = const <String>[]}): _preferredNetworks = preferredNetworks;
+  factory _ChargingPreferences.fromJson(Map<String, dynamic> json) => _$ChargingPreferencesFromJson(json);
+
+@override@JsonKey() final  int minSocPercent;
+@override@JsonKey() final  int maxSocPercent;
+ final  List<String> _preferredNetworks;
+@override@JsonKey() List<String> get preferredNetworks {
+  if (_preferredNetworks is EqualUnmodifiableListView) return _preferredNetworks;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_preferredNetworks);
+}
+
+
+/// Create a copy of ChargingPreferences
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChargingPreferencesCopyWith<_ChargingPreferences> get copyWith => __$ChargingPreferencesCopyWithImpl<_ChargingPreferences>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ChargingPreferencesToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChargingPreferences&&(identical(other.minSocPercent, minSocPercent) || other.minSocPercent == minSocPercent)&&(identical(other.maxSocPercent, maxSocPercent) || other.maxSocPercent == maxSocPercent)&&const DeepCollectionEquality().equals(other._preferredNetworks, _preferredNetworks));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,minSocPercent,maxSocPercent,const DeepCollectionEquality().hash(_preferredNetworks));
+
+@override
+String toString() {
+  return 'ChargingPreferences(minSocPercent: $minSocPercent, maxSocPercent: $maxSocPercent, preferredNetworks: $preferredNetworks)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChargingPreferencesCopyWith<$Res> implements $ChargingPreferencesCopyWith<$Res> {
+  factory _$ChargingPreferencesCopyWith(_ChargingPreferences value, $Res Function(_ChargingPreferences) _then) = __$ChargingPreferencesCopyWithImpl;
+@override @useResult
+$Res call({
+ int minSocPercent, int maxSocPercent, List<String> preferredNetworks
+});
+
+
+
+
+}
+/// @nodoc
+class __$ChargingPreferencesCopyWithImpl<$Res>
+    implements _$ChargingPreferencesCopyWith<$Res> {
+  __$ChargingPreferencesCopyWithImpl(this._self, this._then);
+
+  final _ChargingPreferences _self;
+  final $Res Function(_ChargingPreferences) _then;
+
+/// Create a copy of ChargingPreferences
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? minSocPercent = null,Object? maxSocPercent = null,Object? preferredNetworks = null,}) {
+  return _then(_ChargingPreferences(
+minSocPercent: null == minSocPercent ? _self.minSocPercent : minSocPercent // ignore: cast_nullable_to_non_nullable
+as int,maxSocPercent: null == maxSocPercent ? _self.maxSocPercent : maxSocPercent // ignore: cast_nullable_to_non_nullable
+as int,preferredNetworks: null == preferredNetworks ? _self._preferredNetworks : preferredNetworks // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$VehicleProfile {
+
+ String get id; String get name;@VehicleTypeJsonConverter() VehicleType get type;// EV fields
+ double? get batteryKwh; double? get maxChargingKw;@ConnectorTypeSetConverter() Set<ConnectorType> get supportedConnectors;@ChargingPreferencesJsonConverter() ChargingPreferences get chargingPreferences;// Combustion fields
+ double? get tankCapacityL; String? get preferredFuelType;
+/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VehicleProfileCopyWith<VehicleProfile> get copyWith => _$VehicleProfileCopyWithImpl<VehicleProfile>(this as VehicleProfile, _$identity);
+
+  /// Serializes this VehicleProfile to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType);
+
+@override
+String toString() {
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VehicleProfileCopyWith<$Res>  {
+  factory $VehicleProfileCopyWith(VehicleProfile value, $Res Function(VehicleProfile) _then) = _$VehicleProfileCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType
+});
+
+
+$ChargingPreferencesCopyWith<$Res> get chargingPreferences;
+
+}
+/// @nodoc
+class _$VehicleProfileCopyWithImpl<$Res>
+    implements $VehicleProfileCopyWith<$Res> {
+  _$VehicleProfileCopyWithImpl(this._self, this._then);
+
+  final VehicleProfile _self;
+  final $Res Function(VehicleProfile) _then;
+
+/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as VehicleType,batteryKwh: freezed == batteryKwh ? _self.batteryKwh : batteryKwh // ignore: cast_nullable_to_non_nullable
+as double?,maxChargingKw: freezed == maxChargingKw ? _self.maxChargingKw : maxChargingKw // ignore: cast_nullable_to_non_nullable
+as double?,supportedConnectors: null == supportedConnectors ? _self.supportedConnectors : supportedConnectors // ignore: cast_nullable_to_non_nullable
+as Set<ConnectorType>,chargingPreferences: null == chargingPreferences ? _self.chargingPreferences : chargingPreferences // ignore: cast_nullable_to_non_nullable
+as ChargingPreferences,tankCapacityL: freezed == tankCapacityL ? _self.tankCapacityL : tankCapacityL // ignore: cast_nullable_to_non_nullable
+as double?,preferredFuelType: freezed == preferredFuelType ? _self.preferredFuelType : preferredFuelType // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ChargingPreferencesCopyWith<$Res> get chargingPreferences {
+  
+  return $ChargingPreferencesCopyWith<$Res>(_self.chargingPreferences, (value) {
+    return _then(_self.copyWith(chargingPreferences: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [VehicleProfile].
+extension VehicleProfilePatterns on VehicleProfile {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _VehicleProfile value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _VehicleProfile() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _VehicleProfile value)  $default,){
+final _that = this;
+switch (_that) {
+case _VehicleProfile():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _VehicleProfile value)?  $default,){
+final _that = this;
+switch (_that) {
+case _VehicleProfile() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _VehicleProfile() when $default != null:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType)  $default,) {final _that = this;
+switch (_that) {
+case _VehicleProfile():
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType)?  $default,) {final _that = this;
+switch (_that) {
+case _VehicleProfile() when $default != null:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _VehicleProfile extends VehicleProfile {
+  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType}): _supportedConnectors = supportedConnectors,super._();
+  factory _VehicleProfile.fromJson(Map<String, dynamic> json) => _$VehicleProfileFromJson(json);
+
+@override final  String id;
+@override final  String name;
+@override@JsonKey()@VehicleTypeJsonConverter() final  VehicleType type;
+// EV fields
+@override final  double? batteryKwh;
+@override final  double? maxChargingKw;
+ final  Set<ConnectorType> _supportedConnectors;
+@override@JsonKey()@ConnectorTypeSetConverter() Set<ConnectorType> get supportedConnectors {
+  if (_supportedConnectors is EqualUnmodifiableSetView) return _supportedConnectors;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableSetView(_supportedConnectors);
+}
+
+@override@JsonKey()@ChargingPreferencesJsonConverter() final  ChargingPreferences chargingPreferences;
+// Combustion fields
+@override final  double? tankCapacityL;
+@override final  String? preferredFuelType;
+
+/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VehicleProfileCopyWith<_VehicleProfile> get copyWith => __$VehicleProfileCopyWithImpl<_VehicleProfile>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$VehicleProfileToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType);
+
+@override
+String toString() {
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$VehicleProfileCopyWith<$Res> implements $VehicleProfileCopyWith<$Res> {
+  factory _$VehicleProfileCopyWith(_VehicleProfile value, $Res Function(_VehicleProfile) _then) = __$VehicleProfileCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType
+});
+
+
+@override $ChargingPreferencesCopyWith<$Res> get chargingPreferences;
+
+}
+/// @nodoc
+class __$VehicleProfileCopyWithImpl<$Res>
+    implements _$VehicleProfileCopyWith<$Res> {
+  __$VehicleProfileCopyWithImpl(this._self, this._then);
+
+  final _VehicleProfile _self;
+  final $Res Function(_VehicleProfile) _then;
+
+/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,}) {
+  return _then(_VehicleProfile(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as VehicleType,batteryKwh: freezed == batteryKwh ? _self.batteryKwh : batteryKwh // ignore: cast_nullable_to_non_nullable
+as double?,maxChargingKw: freezed == maxChargingKw ? _self.maxChargingKw : maxChargingKw // ignore: cast_nullable_to_non_nullable
+as double?,supportedConnectors: null == supportedConnectors ? _self._supportedConnectors : supportedConnectors // ignore: cast_nullable_to_non_nullable
+as Set<ConnectorType>,chargingPreferences: null == chargingPreferences ? _self.chargingPreferences : chargingPreferences // ignore: cast_nullable_to_non_nullable
+as ChargingPreferences,tankCapacityL: freezed == tankCapacityL ? _self.tankCapacityL : tankCapacityL // ignore: cast_nullable_to_non_nullable
+as double?,preferredFuelType: freezed == preferredFuelType ? _self.preferredFuelType : preferredFuelType // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ChargingPreferencesCopyWith<$Res> get chargingPreferences {
+  
+  return $ChargingPreferencesCopyWith<$Res>(_self.chargingPreferences, (value) {
+    return _then(_self.copyWith(chargingPreferences: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vehicle_profile.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChargingPreferences _$ChargingPreferencesFromJson(Map<String, dynamic> json) =>
+    _ChargingPreferences(
+      minSocPercent: (json['minSocPercent'] as num?)?.toInt() ?? 20,
+      maxSocPercent: (json['maxSocPercent'] as num?)?.toInt() ?? 80,
+      preferredNetworks:
+          (json['preferredNetworks'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const <String>[],
+    );
+
+Map<String, dynamic> _$ChargingPreferencesToJson(
+  _ChargingPreferences instance,
+) => <String, dynamic>{
+  'minSocPercent': instance.minSocPercent,
+  'maxSocPercent': instance.maxSocPercent,
+  'preferredNetworks': instance.preferredNetworks,
+};
+
+_VehicleProfile _$VehicleProfileFromJson(Map<String, dynamic> json) =>
+    _VehicleProfile(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      type: json['type'] == null
+          ? VehicleType.combustion
+          : const VehicleTypeJsonConverter().fromJson(json['type'] as String),
+      batteryKwh: (json['batteryKwh'] as num?)?.toDouble(),
+      maxChargingKw: (json['maxChargingKw'] as num?)?.toDouble(),
+      supportedConnectors: json['supportedConnectors'] == null
+          ? const <ConnectorType>{}
+          : const ConnectorTypeSetConverter().fromJson(
+              json['supportedConnectors'] as List,
+            ),
+      chargingPreferences: json['chargingPreferences'] == null
+          ? const ChargingPreferences()
+          : const ChargingPreferencesJsonConverter().fromJson(
+              json['chargingPreferences'] as Map<String, dynamic>,
+            ),
+      tankCapacityL: (json['tankCapacityL'] as num?)?.toDouble(),
+      preferredFuelType: json['preferredFuelType'] as String?,
+    );
+
+Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'type': const VehicleTypeJsonConverter().toJson(instance.type),
+      'batteryKwh': instance.batteryKwh,
+      'maxChargingKw': instance.maxChargingKw,
+      'supportedConnectors': const ConnectorTypeSetConverter().toJson(
+        instance.supportedConnectors,
+      ),
+      'chargingPreferences': const ChargingPreferencesJsonConverter().toJson(
+        instance.chargingPreferences,
+      ),
+      'tankCapacityL': instance.tankCapacityL,
+      'preferredFuelType': instance.preferredFuelType,
+    };

--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -1,0 +1,323 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/vehicle_profile.dart';
+import '../../providers/vehicle_providers.dart';
+
+/// Form for adding or editing a [VehicleProfile].
+///
+/// Pass [vehicleId] to edit an existing profile; omit to create a new one.
+class EditVehicleScreen extends ConsumerStatefulWidget {
+  final String? vehicleId;
+
+  const EditVehicleScreen({super.key, this.vehicleId});
+
+  @override
+  ConsumerState<EditVehicleScreen> createState() => _EditVehicleScreenState();
+}
+
+class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
+  static const _uuid = Uuid();
+
+  final _formKey = GlobalKey<FormState>();
+  final _nameCtrl = TextEditingController();
+  final _batteryCtrl = TextEditingController();
+  final _maxKwCtrl = TextEditingController();
+  final _tankCtrl = TextEditingController();
+  final _fuelTypeCtrl = TextEditingController();
+  final _minSocCtrl = TextEditingController(text: '20');
+  final _maxSocCtrl = TextEditingController(text: '80');
+
+  VehicleType _type = VehicleType.ev;
+  final Set<ConnectorType> _connectors = {};
+  String? _existingId;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.vehicleId != null) {
+      // Load after first frame so we have access to ref.
+      WidgetsBinding.instance.addPostFrameCallback((_) => _loadExisting());
+    }
+  }
+
+  void _loadExisting() {
+    final list = ref.read(vehicleProfileListProvider);
+    final existing = list.where((v) => v.id == widget.vehicleId).firstOrNull;
+    if (existing == null) return;
+    setState(() {
+      _existingId = existing.id;
+      _nameCtrl.text = existing.name;
+      _type = existing.type;
+      _batteryCtrl.text = existing.batteryKwh?.toString() ?? '';
+      _maxKwCtrl.text = existing.maxChargingKw?.toString() ?? '';
+      _tankCtrl.text = existing.tankCapacityL?.toString() ?? '';
+      _fuelTypeCtrl.text = existing.preferredFuelType ?? '';
+      _minSocCtrl.text = existing.chargingPreferences.minSocPercent.toString();
+      _maxSocCtrl.text = existing.chargingPreferences.maxSocPercent.toString();
+      _connectors
+        ..clear()
+        ..addAll(existing.supportedConnectors);
+    });
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _batteryCtrl.dispose();
+    _maxKwCtrl.dispose();
+    _tankCtrl.dispose();
+    _fuelTypeCtrl.dispose();
+    _minSocCtrl.dispose();
+    _maxSocCtrl.dispose();
+    super.dispose();
+  }
+
+  double? _parseDouble(String text) {
+    final trimmed = text.trim().replaceAll(',', '.');
+    if (trimmed.isEmpty) return null;
+    return double.tryParse(trimmed);
+  }
+
+  int _parseIntOr(String text, int fallback) {
+    final parsed = int.tryParse(text.trim());
+    return parsed ?? fallback;
+  }
+
+  Future<void> _save() async {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
+    final profile = VehicleProfile(
+      id: _existingId ?? _uuid.v4(),
+      name: _nameCtrl.text.trim(),
+      type: _type,
+      batteryKwh:
+          _type == VehicleType.combustion ? null : _parseDouble(_batteryCtrl.text),
+      maxChargingKw:
+          _type == VehicleType.combustion ? null : _parseDouble(_maxKwCtrl.text),
+      supportedConnectors:
+          _type == VehicleType.combustion ? <ConnectorType>{} : {..._connectors},
+      tankCapacityL:
+          _type == VehicleType.ev ? null : _parseDouble(_tankCtrl.text),
+      preferredFuelType: _type == VehicleType.ev
+          ? null
+          : (_fuelTypeCtrl.text.trim().isEmpty
+              ? null
+              : _fuelTypeCtrl.text.trim()),
+      chargingPreferences: ChargingPreferences(
+        minSocPercent: _parseIntOr(_minSocCtrl.text, 20).clamp(0, 100),
+        maxSocPercent: _parseIntOr(_maxSocCtrl.text, 80).clamp(0, 100),
+      ),
+    );
+
+    await ref.read(vehicleProfileListProvider.notifier).save(profile);
+    if (!mounted) return;
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final isEdit = _existingId != null || widget.vehicleId != null;
+    final showEv = _type != VehicleType.combustion;
+    final showCombustion = _type != VehicleType.ev;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEdit
+            ? (l?.vehicleEditTitle ?? 'Edit vehicle')
+            : (l?.vehicleAddTitle ?? 'Add vehicle')),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.check),
+            tooltip: l?.save ?? 'Save',
+            onPressed: _save,
+          ),
+        ],
+      ),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            TextFormField(
+              controller: _nameCtrl,
+              decoration: InputDecoration(
+                labelText: l?.vehicleNameLabel ?? 'Name',
+                hintText: l?.vehicleNameHint ?? 'e.g. My Tesla Model 3',
+              ),
+              validator: (v) => (v == null || v.trim().isEmpty)
+                  ? (l?.fieldRequired ?? 'Required')
+                  : null,
+            ),
+            const SizedBox(height: 16),
+            _TypeSelector(
+              selected: _type,
+              onChanged: (t) => setState(() => _type = t),
+            ),
+            const SizedBox(height: 24),
+            if (showEv) ...[
+              Text(
+                l?.vehicleEvSectionTitle ?? 'Electric',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _batteryCtrl,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration: InputDecoration(
+                  labelText: l?.vehicleBatteryLabel ?? 'Battery capacity (kWh)',
+                ),
+                validator: (v) {
+                  if (v == null || v.trim().isEmpty) return null;
+                  return _parseDouble(v) == null
+                      ? (l?.fieldInvalidNumber ?? 'Invalid number')
+                      : null;
+                },
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _maxKwCtrl,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration: InputDecoration(
+                  labelText:
+                      l?.vehicleMaxChargeLabel ?? 'Max charging power (kW)',
+                ),
+                validator: (v) {
+                  if (v == null || v.trim().isEmpty) return null;
+                  return _parseDouble(v) == null
+                      ? (l?.fieldInvalidNumber ?? 'Invalid number')
+                      : null;
+                },
+              ),
+              const SizedBox(height: 16),
+              Text(
+                l?.vehicleConnectorsLabel ?? 'Supported connectors',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: ConnectorType.values.map((c) {
+                  final selected = _connectors.contains(c);
+                  return FilterChip(
+                    label: Text(c.label),
+                    selected: selected,
+                    onSelected: (value) {
+                      setState(() {
+                        if (value) {
+                          _connectors.add(c);
+                        } else {
+                          _connectors.remove(c);
+                        }
+                      });
+                    },
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: _minSocCtrl,
+                      keyboardType: TextInputType.number,
+                      decoration: InputDecoration(
+                        labelText: l?.vehicleMinSocLabel ?? 'Min SoC %',
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: TextFormField(
+                      controller: _maxSocCtrl,
+                      keyboardType: TextInputType.number,
+                      decoration: InputDecoration(
+                        labelText: l?.vehicleMaxSocLabel ?? 'Max SoC %',
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+            ],
+            if (showCombustion) ...[
+              Text(
+                l?.vehicleCombustionSectionTitle ?? 'Combustion',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _tankCtrl,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration: InputDecoration(
+                  labelText: l?.vehicleTankLabel ?? 'Tank capacity (L)',
+                ),
+                validator: (v) {
+                  if (v == null || v.trim().isEmpty) return null;
+                  return _parseDouble(v) == null
+                      ? (l?.fieldInvalidNumber ?? 'Invalid number')
+                      : null;
+                },
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _fuelTypeCtrl,
+                decoration: InputDecoration(
+                  labelText: l?.vehiclePreferredFuelLabel ?? 'Preferred fuel',
+                  hintText: 'e.g. Diesel, E10',
+                ),
+              ),
+            ],
+            const SizedBox(height: 32),
+            FilledButton.icon(
+              onPressed: _save,
+              icon: const Icon(Icons.save),
+              label: Text(l?.save ?? 'Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TypeSelector extends StatelessWidget {
+  final VehicleType selected;
+  final ValueChanged<VehicleType> onChanged;
+
+  const _TypeSelector({required this.selected, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return SegmentedButton<VehicleType>(
+      segments: [
+        ButtonSegment(
+          value: VehicleType.combustion,
+          label: Text(l?.vehicleTypeCombustion ?? 'Combustion'),
+          icon: const Icon(Icons.local_gas_station),
+        ),
+        ButtonSegment(
+          value: VehicleType.hybrid,
+          label: Text(l?.vehicleTypeHybrid ?? 'Hybrid'),
+          icon: const Icon(Icons.directions_car_filled),
+        ),
+        ButtonSegment(
+          value: VehicleType.ev,
+          label: Text(l?.vehicleTypeEv ?? 'Electric'),
+          icon: const Icon(Icons.electric_car),
+        ),
+      ],
+      selected: {selected},
+      onSelectionChanged: (set) => onChanged(set.first),
+    );
+  }
+}

--- a/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
+++ b/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../providers/vehicle_providers.dart';
+import '../widgets/vehicle_card.dart';
+
+/// Screen listing all of the user's vehicle profiles with CRUD actions.
+class VehicleListScreen extends ConsumerWidget {
+  const VehicleListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context);
+    final vehicles = ref.watch(vehicleProfileListProvider);
+    final active = ref.watch(activeVehicleProfileProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l?.vehiclesTitle ?? 'My vehicles'),
+      ),
+      body: vehicles.isEmpty
+          ? _EmptyState(
+              message: l?.vehiclesEmptyMessage ??
+                  'Add your car to filter by connector and estimate charging costs.',
+            )
+          : ListView.separated(
+              padding: EdgeInsets.fromLTRB(
+                16,
+                16,
+                16,
+                MediaQuery.of(context).viewPadding.bottom + 96,
+              ),
+              itemCount: vehicles.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                final v = vehicles[index];
+                return VehicleCard(
+                  vehicle: v,
+                  isActive: v.id == active?.id,
+                  onTap: () => context.push('/vehicles/edit', extra: v.id),
+                  onEdit: () => context.push('/vehicles/edit', extra: v.id),
+                  onSetActive: () => ref
+                      .read(activeVehicleProfileProvider.notifier)
+                      .setActive(v.id),
+                  onDelete: () => _confirmDelete(context, ref, v.id, v.name),
+                );
+              },
+            ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.push('/vehicles/edit'),
+        icon: const Icon(Icons.add),
+        label: Text(l?.vehicleAdd ?? 'Add vehicle'),
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(
+    BuildContext context,
+    WidgetRef ref,
+    String id,
+    String name,
+  ) async {
+    final l = AppLocalizations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l?.vehicleDeleteTitle ?? 'Delete vehicle?'),
+        content: Text(l?.vehicleDeleteMessage(name) ??
+            'Remove "$name" from your profiles?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l?.cancel ?? 'Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(l?.delete ?? 'Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await ref.read(vehicleProfileListProvider.notifier).remove(id);
+    }
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final String message;
+  const _EmptyState({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.directions_car, size: 64),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_card.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_card.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/vehicle_profile.dart';
+
+/// Compact summary card for one [VehicleProfile].
+///
+/// Shows the name, powertrain badge, and a line of key specs. Used in the
+/// [VehicleListScreen] and as a preview in settings.
+class VehicleCard extends StatelessWidget {
+  final VehicleProfile vehicle;
+  final bool isActive;
+  final VoidCallback? onTap;
+  final VoidCallback? onEdit;
+  final VoidCallback? onDelete;
+  final VoidCallback? onSetActive;
+
+  const VehicleCard({
+    super.key,
+    required this.vehicle,
+    this.isActive = false,
+    this.onTap,
+    this.onEdit,
+    this.onDelete,
+    this.onSetActive,
+  });
+
+  IconData _iconForType(VehicleType type) {
+    switch (type) {
+      case VehicleType.ev:
+        return Icons.electric_car;
+      case VehicleType.hybrid:
+        return Icons.directions_car_filled;
+      case VehicleType.combustion:
+        return Icons.local_gas_station;
+    }
+  }
+
+  String _subtitle() {
+    final parts = <String>[];
+    if (vehicle.isEv) {
+      if (vehicle.batteryKwh != null) {
+        parts.add('${vehicle.batteryKwh!.toStringAsFixed(0)} kWh');
+      }
+      if (vehicle.maxChargingKw != null) {
+        parts.add('${vehicle.maxChargingKw!.toStringAsFixed(0)} kW');
+      }
+      if (vehicle.supportedConnectors.isNotEmpty) {
+        parts.add(vehicle.supportedConnectors.map((c) => c.label).join(', '));
+      }
+    }
+    if (vehicle.isCombustion) {
+      if (vehicle.tankCapacityL != null) {
+        parts.add('${vehicle.tankCapacityL!.toStringAsFixed(0)} L');
+      }
+      if (vehicle.preferredFuelType != null) {
+        parts.add(vehicle.preferredFuelType!);
+      }
+    }
+    return parts.join(' • ');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subtitle = _subtitle();
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: isActive
+              ? theme.colorScheme.primaryContainer
+              : theme.colorScheme.surfaceContainerHighest,
+          child: Icon(
+            _iconForType(vehicle.type),
+            color: isActive
+                ? theme.colorScheme.onPrimaryContainer
+                : theme.colorScheme.onSurface,
+          ),
+        ),
+        title: Row(
+          children: [
+            Flexible(
+              child: Text(
+                vehicle.name,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleSmall
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
+            ),
+            if (isActive) ...[
+              const SizedBox(width: 8),
+              Icon(
+                Icons.check_circle,
+                size: 16,
+                color: theme.colorScheme.primary,
+              ),
+            ],
+          ],
+        ),
+        subtitle: subtitle.isEmpty ? null : Text(subtitle),
+        trailing: PopupMenuButton<String>(
+          onSelected: (value) {
+            switch (value) {
+              case 'edit':
+                onEdit?.call();
+                break;
+              case 'delete':
+                onDelete?.call();
+                break;
+              case 'activate':
+                onSetActive?.call();
+                break;
+            }
+          },
+          itemBuilder: (context) => [
+            if (!isActive)
+              const PopupMenuItem(
+                value: 'activate',
+                child: Text('Set active'),
+              ),
+            const PopupMenuItem(value: 'edit', child: Text('Edit')),
+            const PopupMenuItem(value: 'delete', child: Text('Delete')),
+          ],
+        ),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/lib/features/vehicle/providers/vehicle_providers.dart
+++ b/lib/features/vehicle/providers/vehicle_providers.dart
@@ -1,0 +1,63 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/storage/storage_providers.dart';
+import '../data/repositories/vehicle_profile_repository.dart';
+import '../domain/entities/vehicle_profile.dart';
+
+part 'vehicle_providers.g.dart';
+
+/// Repository for reading/writing [VehicleProfile] entries.
+@Riverpod(keepAlive: true)
+VehicleProfileRepository vehicleProfileRepository(Ref ref) {
+  final storage = ref.watch(settingsStorageProvider);
+  return VehicleProfileRepository(storage);
+}
+
+/// Full list of stored vehicle profiles.
+@Riverpod(keepAlive: true)
+class VehicleProfileList extends _$VehicleProfileList {
+  @override
+  List<VehicleProfile> build() {
+    final repo = ref.watch(vehicleProfileRepositoryProvider);
+    return repo.getAll();
+  }
+
+  Future<void> save(VehicleProfile profile) async {
+    final repo = ref.read(vehicleProfileRepositoryProvider);
+    await repo.save(profile);
+    state = repo.getAll();
+    // Nudge the active-profile provider in case it just got auto-set.
+    ref.invalidate(activeVehicleProfileProvider);
+  }
+
+  Future<void> remove(String id) async {
+    final repo = ref.read(vehicleProfileRepositoryProvider);
+    await repo.delete(id);
+    state = repo.getAll();
+    ref.invalidate(activeVehicleProfileProvider);
+  }
+
+  Future<void> clearAll() async {
+    final repo = ref.read(vehicleProfileRepositoryProvider);
+    await repo.clear();
+    state = repo.getAll();
+    ref.invalidate(activeVehicleProfileProvider);
+  }
+}
+
+/// Currently active vehicle profile, or `null` when none is selected.
+@Riverpod(keepAlive: true)
+class ActiveVehicleProfile extends _$ActiveVehicleProfile {
+  @override
+  VehicleProfile? build() {
+    ref.watch(vehicleProfileListProvider);
+    final repo = ref.watch(vehicleProfileRepositoryProvider);
+    return repo.getActive();
+  }
+
+  Future<void> setActive(String id) async {
+    final repo = ref.read(vehicleProfileRepositoryProvider);
+    await repo.setActive(id);
+    state = repo.getActive();
+  }
+}

--- a/lib/features/vehicle/providers/vehicle_providers.g.dart
+++ b/lib/features/vehicle/providers/vehicle_providers.g.dart
@@ -1,0 +1,180 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vehicle_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Repository for reading/writing [VehicleProfile] entries.
+
+@ProviderFor(vehicleProfileRepository)
+final vehicleProfileRepositoryProvider = VehicleProfileRepositoryProvider._();
+
+/// Repository for reading/writing [VehicleProfile] entries.
+
+final class VehicleProfileRepositoryProvider
+    extends
+        $FunctionalProvider<
+          VehicleProfileRepository,
+          VehicleProfileRepository,
+          VehicleProfileRepository
+        >
+    with $Provider<VehicleProfileRepository> {
+  /// Repository for reading/writing [VehicleProfile] entries.
+  VehicleProfileRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'vehicleProfileRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$vehicleProfileRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<VehicleProfileRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  VehicleProfileRepository create(Ref ref) {
+    return vehicleProfileRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(VehicleProfileRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<VehicleProfileRepository>(value),
+    );
+  }
+}
+
+String _$vehicleProfileRepositoryHash() =>
+    r'f466a06a3256a4e33dd5b5844e2952e55fb8b67d';
+
+/// Full list of stored vehicle profiles.
+
+@ProviderFor(VehicleProfileList)
+final vehicleProfileListProvider = VehicleProfileListProvider._();
+
+/// Full list of stored vehicle profiles.
+final class VehicleProfileListProvider
+    extends $NotifierProvider<VehicleProfileList, List<VehicleProfile>> {
+  /// Full list of stored vehicle profiles.
+  VehicleProfileListProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'vehicleProfileListProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$vehicleProfileListHash();
+
+  @$internal
+  @override
+  VehicleProfileList create() => VehicleProfileList();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<VehicleProfile> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<VehicleProfile>>(value),
+    );
+  }
+}
+
+String _$vehicleProfileListHash() =>
+    r'c728b5804706e187f82fd462aa89a9bbeb49f8d6';
+
+/// Full list of stored vehicle profiles.
+
+abstract class _$VehicleProfileList extends $Notifier<List<VehicleProfile>> {
+  List<VehicleProfile> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<List<VehicleProfile>, List<VehicleProfile>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<List<VehicleProfile>, List<VehicleProfile>>,
+              List<VehicleProfile>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+/// Currently active vehicle profile, or `null` when none is selected.
+
+@ProviderFor(ActiveVehicleProfile)
+final activeVehicleProfileProvider = ActiveVehicleProfileProvider._();
+
+/// Currently active vehicle profile, or `null` when none is selected.
+final class ActiveVehicleProfileProvider
+    extends $NotifierProvider<ActiveVehicleProfile, VehicleProfile?> {
+  /// Currently active vehicle profile, or `null` when none is selected.
+  ActiveVehicleProfileProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'activeVehicleProfileProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$activeVehicleProfileHash();
+
+  @$internal
+  @override
+  ActiveVehicleProfile create() => ActiveVehicleProfile();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(VehicleProfile? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<VehicleProfile?>(value),
+    );
+  }
+}
+
+String _$activeVehicleProfileHash() =>
+    r'57bb44897a1e45978f1b026d52cb70d641740354';
+
+/// Currently active vehicle profile, or `null` when none is selected.
+
+abstract class _$ActiveVehicleProfile extends $Notifier<VehicleProfile?> {
+  VehicleProfile? build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<VehicleProfile?, VehicleProfile?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<VehicleProfile?, VehicleProfile?>,
+              VehicleProfile?,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -701,5 +701,42 @@
         "type": "String"
       }
     }
-  }
+  },
+  "vehiclesTitle": "Meine Fahrzeuge",
+  "vehiclesMenuTitle": "Meine Fahrzeuge",
+  "vehiclesMenuSubtitle": "Batterie, Anschlüsse, Ladevorlieben",
+  "vehiclesEmptyMessage": "Fügen Sie Ihr Fahrzeug hinzu, um nach Anschlüssen zu filtern und Ladekosten zu schätzen.",
+  "vehicleAdd": "Fahrzeug hinzufügen",
+  "vehicleAddTitle": "Fahrzeug hinzufügen",
+  "vehicleEditTitle": "Fahrzeug bearbeiten",
+  "vehicleDeleteTitle": "Fahrzeug löschen?",
+  "vehicleDeleteMessage": "„{name}“ aus Ihren Profilen entfernen?",
+  "@vehicleDeleteMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "vehicleNameLabel": "Name",
+  "vehicleNameHint": "z. B. Mein Tesla Model 3",
+  "vehicleTypeCombustion": "Verbrenner",
+  "vehicleTypeHybrid": "Hybrid",
+  "vehicleTypeEv": "Elektro",
+  "vehicleEvSectionTitle": "Elektro",
+  "vehicleCombustionSectionTitle": "Verbrenner",
+  "vehicleBatteryLabel": "Batteriekapazität (kWh)",
+  "vehicleMaxChargeLabel": "Max. Ladeleistung (kW)",
+  "vehicleConnectorsLabel": "Unterstützte Anschlüsse",
+  "vehicleMinSocLabel": "Min. SoC %",
+  "vehicleMaxSocLabel": "Max. SoC %",
+  "vehicleTankLabel": "Tankvolumen (L)",
+  "vehiclePreferredFuelLabel": "Bevorzugter Kraftstoff",
+  "connectorType2": "Typ 2",
+  "connectorCcs": "CCS",
+  "connectorChademo": "CHAdeMO",
+  "connectorTesla": "Tesla",
+  "connectorSchuko": "Schuko",
+  "connectorType1": "Typ 1",
+  "connectorThreePin": "Schuko 3-polig"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -701,5 +701,42 @@
         "type": "String"
       }
     }
-  }
+  },
+  "vehiclesTitle": "My vehicles",
+  "vehiclesMenuTitle": "My vehicles",
+  "vehiclesMenuSubtitle": "Battery, connectors, charging preferences",
+  "vehiclesEmptyMessage": "Add your car to filter by connector and estimate charging costs.",
+  "vehicleAdd": "Add vehicle",
+  "vehicleAddTitle": "Add vehicle",
+  "vehicleEditTitle": "Edit vehicle",
+  "vehicleDeleteTitle": "Delete vehicle?",
+  "vehicleDeleteMessage": "Remove \"{name}\" from your profiles?",
+  "@vehicleDeleteMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "vehicleNameLabel": "Name",
+  "vehicleNameHint": "e.g. My Tesla Model 3",
+  "vehicleTypeCombustion": "Combustion",
+  "vehicleTypeHybrid": "Hybrid",
+  "vehicleTypeEv": "Electric",
+  "vehicleEvSectionTitle": "Electric",
+  "vehicleCombustionSectionTitle": "Combustion",
+  "vehicleBatteryLabel": "Battery capacity (kWh)",
+  "vehicleMaxChargeLabel": "Max charging power (kW)",
+  "vehicleConnectorsLabel": "Supported connectors",
+  "vehicleMinSocLabel": "Min SoC %",
+  "vehicleMaxSocLabel": "Max SoC %",
+  "vehicleTankLabel": "Tank capacity (L)",
+  "vehiclePreferredFuelLabel": "Preferred fuel",
+  "connectorType2": "Type 2",
+  "connectorCcs": "CCS",
+  "connectorChademo": "CHAdeMO",
+  "connectorTesla": "Tesla",
+  "connectorSchuko": "Schuko",
+  "connectorType1": "Type 1",
+  "connectorThreePin": "3-pin"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3012,6 +3012,186 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'I tracked {kg} kg CO2 with Tankstellen.'**
   String shareCo2Message(String kg);
+
+  /// No description provided for @vehiclesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'My vehicles'**
+  String get vehiclesTitle;
+
+  /// No description provided for @vehiclesMenuTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'My vehicles'**
+  String get vehiclesMenuTitle;
+
+  /// No description provided for @vehiclesMenuSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Battery, connectors, charging preferences'**
+  String get vehiclesMenuSubtitle;
+
+  /// No description provided for @vehiclesEmptyMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Add your car to filter by connector and estimate charging costs.'**
+  String get vehiclesEmptyMessage;
+
+  /// No description provided for @vehicleAdd.
+  ///
+  /// In en, this message translates to:
+  /// **'Add vehicle'**
+  String get vehicleAdd;
+
+  /// No description provided for @vehicleAddTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add vehicle'**
+  String get vehicleAddTitle;
+
+  /// No description provided for @vehicleEditTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit vehicle'**
+  String get vehicleEditTitle;
+
+  /// No description provided for @vehicleDeleteTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete vehicle?'**
+  String get vehicleDeleteTitle;
+
+  /// No description provided for @vehicleDeleteMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove \"{name}\" from your profiles?'**
+  String vehicleDeleteMessage(String name);
+
+  /// No description provided for @vehicleNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Name'**
+  String get vehicleNameLabel;
+
+  /// No description provided for @vehicleNameHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. My Tesla Model 3'**
+  String get vehicleNameHint;
+
+  /// No description provided for @vehicleTypeCombustion.
+  ///
+  /// In en, this message translates to:
+  /// **'Combustion'**
+  String get vehicleTypeCombustion;
+
+  /// No description provided for @vehicleTypeHybrid.
+  ///
+  /// In en, this message translates to:
+  /// **'Hybrid'**
+  String get vehicleTypeHybrid;
+
+  /// No description provided for @vehicleTypeEv.
+  ///
+  /// In en, this message translates to:
+  /// **'Electric'**
+  String get vehicleTypeEv;
+
+  /// No description provided for @vehicleEvSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Electric'**
+  String get vehicleEvSectionTitle;
+
+  /// No description provided for @vehicleCombustionSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Combustion'**
+  String get vehicleCombustionSectionTitle;
+
+  /// No description provided for @vehicleBatteryLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Battery capacity (kWh)'**
+  String get vehicleBatteryLabel;
+
+  /// No description provided for @vehicleMaxChargeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Max charging power (kW)'**
+  String get vehicleMaxChargeLabel;
+
+  /// No description provided for @vehicleConnectorsLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Supported connectors'**
+  String get vehicleConnectorsLabel;
+
+  /// No description provided for @vehicleMinSocLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Min SoC %'**
+  String get vehicleMinSocLabel;
+
+  /// No description provided for @vehicleMaxSocLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Max SoC %'**
+  String get vehicleMaxSocLabel;
+
+  /// No description provided for @vehicleTankLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Tank capacity (L)'**
+  String get vehicleTankLabel;
+
+  /// No description provided for @vehiclePreferredFuelLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Preferred fuel'**
+  String get vehiclePreferredFuelLabel;
+
+  /// No description provided for @connectorType2.
+  ///
+  /// In en, this message translates to:
+  /// **'Type 2'**
+  String get connectorType2;
+
+  /// No description provided for @connectorCcs.
+  ///
+  /// In en, this message translates to:
+  /// **'CCS'**
+  String get connectorCcs;
+
+  /// No description provided for @connectorChademo.
+  ///
+  /// In en, this message translates to:
+  /// **'CHAdeMO'**
+  String get connectorChademo;
+
+  /// No description provided for @connectorTesla.
+  ///
+  /// In en, this message translates to:
+  /// **'Tesla'**
+  String get connectorTesla;
+
+  /// No description provided for @connectorSchuko.
+  ///
+  /// In en, this message translates to:
+  /// **'Schuko'**
+  String get connectorSchuko;
+
+  /// No description provided for @connectorType1.
+  ///
+  /// In en, this message translates to:
+  /// **'Type 1'**
+  String get connectorType1;
+
+  /// No description provided for @connectorThreePin.
+  ///
+  /// In en, this message translates to:
+  /// **'3-pin'**
+  String get connectorThreePin;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1562,4 +1562,98 @@ class AppLocalizationsBg extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1562,4 +1562,98 @@ class AppLocalizationsCs extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1560,4 +1560,98 @@ class AppLocalizationsDa extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1573,4 +1573,97 @@ class AppLocalizationsDe extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'Ich habe mit Tankstellen $kg kg CO2 erfasst.';
   }
+
+  @override
+  String get vehiclesTitle => 'Meine Fahrzeuge';
+
+  @override
+  String get vehiclesMenuTitle => 'Meine Fahrzeuge';
+
+  @override
+  String get vehiclesMenuSubtitle => 'Batterie, Anschlüsse, Ladevorlieben';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Fügen Sie Ihr Fahrzeug hinzu, um nach Anschlüssen zu filtern und Ladekosten zu schätzen.';
+
+  @override
+  String get vehicleAdd => 'Fahrzeug hinzufügen';
+
+  @override
+  String get vehicleAddTitle => 'Fahrzeug hinzufügen';
+
+  @override
+  String get vehicleEditTitle => 'Fahrzeug bearbeiten';
+
+  @override
+  String get vehicleDeleteTitle => 'Fahrzeug löschen?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return '„$name“ aus Ihren Profilen entfernen?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'z. B. Mein Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Verbrenner';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Elektro';
+
+  @override
+  String get vehicleEvSectionTitle => 'Elektro';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Verbrenner';
+
+  @override
+  String get vehicleBatteryLabel => 'Batteriekapazität (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max. Ladeleistung (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Unterstützte Anschlüsse';
+
+  @override
+  String get vehicleMinSocLabel => 'Min. SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max. SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tankvolumen (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Bevorzugter Kraftstoff';
+
+  @override
+  String get connectorType2 => 'Typ 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Typ 1';
+
+  @override
+  String get connectorThreePin => 'Schuko 3-polig';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1564,4 +1564,98 @@ class AppLocalizationsEl extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1555,4 +1555,98 @@ class AppLocalizationsEn extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1563,4 +1563,98 @@ class AppLocalizationsEs extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1557,4 +1557,98 @@ class AppLocalizationsEt extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1560,4 +1560,98 @@ class AppLocalizationsFi extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1567,4 +1567,98 @@ class AppLocalizationsFr extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1559,4 +1559,98 @@ class AppLocalizationsHr extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1564,4 +1564,98 @@ class AppLocalizationsHu extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1563,4 +1563,98 @@ class AppLocalizationsIt extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1561,4 +1561,98 @@ class AppLocalizationsLt extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1563,4 +1563,98 @@ class AppLocalizationsLv extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1559,4 +1559,98 @@ class AppLocalizationsNb extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1564,4 +1564,98 @@ class AppLocalizationsNl extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1562,4 +1562,98 @@ class AppLocalizationsPl extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1563,4 +1563,98 @@ class AppLocalizationsPt extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1562,4 +1562,98 @@ class AppLocalizationsRo extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1563,4 +1563,98 @@ class AppLocalizationsSk extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1557,4 +1557,98 @@ class AppLocalizationsSl extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1561,4 +1561,98 @@ class AppLocalizationsSv extends AppLocalizations {
   String shareCo2Message(String kg) {
     return 'I tracked $kg kg CO2 with Tankstellen.';
   }
+
+  @override
+  String get vehiclesTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuTitle => 'My vehicles';
+
+  @override
+  String get vehiclesMenuSubtitle =>
+      'Battery, connectors, charging preferences';
+
+  @override
+  String get vehiclesEmptyMessage =>
+      'Add your car to filter by connector and estimate charging costs.';
+
+  @override
+  String get vehicleAdd => 'Add vehicle';
+
+  @override
+  String get vehicleAddTitle => 'Add vehicle';
+
+  @override
+  String get vehicleEditTitle => 'Edit vehicle';
+
+  @override
+  String get vehicleDeleteTitle => 'Delete vehicle?';
+
+  @override
+  String vehicleDeleteMessage(String name) {
+    return 'Remove \"$name\" from your profiles?';
+  }
+
+  @override
+  String get vehicleNameLabel => 'Name';
+
+  @override
+  String get vehicleNameHint => 'e.g. My Tesla Model 3';
+
+  @override
+  String get vehicleTypeCombustion => 'Combustion';
+
+  @override
+  String get vehicleTypeHybrid => 'Hybrid';
+
+  @override
+  String get vehicleTypeEv => 'Electric';
+
+  @override
+  String get vehicleEvSectionTitle => 'Electric';
+
+  @override
+  String get vehicleCombustionSectionTitle => 'Combustion';
+
+  @override
+  String get vehicleBatteryLabel => 'Battery capacity (kWh)';
+
+  @override
+  String get vehicleMaxChargeLabel => 'Max charging power (kW)';
+
+  @override
+  String get vehicleConnectorsLabel => 'Supported connectors';
+
+  @override
+  String get vehicleMinSocLabel => 'Min SoC %';
+
+  @override
+  String get vehicleMaxSocLabel => 'Max SoC %';
+
+  @override
+  String get vehicleTankLabel => 'Tank capacity (L)';
+
+  @override
+  String get vehiclePreferredFuelLabel => 'Preferred fuel';
+
+  @override
+  String get connectorType2 => 'Type 2';
+
+  @override
+  String get connectorCcs => 'CCS';
+
+  @override
+  String get connectorChademo => 'CHAdeMO';
+
+  @override
+  String get connectorTesla => 'Tesla';
+
+  @override
+  String get connectorSchuko => 'Schuko';
+
+  @override
+  String get connectorType1 => 'Type 1';
+
+  @override
+  String get connectorThreePin => '3-pin';
 }

--- a/test/features/vehicle/data/vehicle_profile_repository_test.dart
+++ b/test/features/vehicle/data/vehicle_profile_repository_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+void main() {
+  group('VehicleProfileRepository', () {
+    late _FakeSettings storage;
+    late VehicleProfileRepository repo;
+
+    setUp(() {
+      storage = _FakeSettings();
+      repo = VehicleProfileRepository(storage);
+    });
+
+    const sample = VehicleProfile(
+      id: 'v1',
+      name: 'Model 3',
+      type: VehicleType.ev,
+      batteryKwh: 60.0,
+      supportedConnectors: {ConnectorType.ccs},
+    );
+
+    test('getAll returns empty when no data stored', () {
+      expect(repo.getAll(), isEmpty);
+    });
+
+    test('save then getAll returns the profile', () async {
+      await repo.save(sample);
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.name, 'Model 3');
+      expect(all.first.supportedConnectors, {ConnectorType.ccs});
+    });
+
+    test('save activates first vehicle automatically', () async {
+      expect(repo.getActive(), isNull);
+      await repo.save(sample);
+      expect(repo.getActive()?.id, 'v1');
+    });
+
+    test('save does not change active when adding a second vehicle',
+        () async {
+      await repo.save(sample);
+      await repo.save(
+        const VehicleProfile(
+          id: 'v2',
+          name: 'Zoe',
+          type: VehicleType.ev,
+        ),
+      );
+      expect(repo.getActive()?.id, 'v1');
+    });
+
+    test('save updates existing entry matched by id', () async {
+      await repo.save(sample);
+      await repo.save(sample.copyWith(name: 'Model 3 Long Range'));
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.name, 'Model 3 Long Range');
+    });
+
+    test('delete removes entry and switches active to remaining', () async {
+      await repo.save(sample);
+      await repo.save(
+        const VehicleProfile(
+          id: 'v2',
+          name: 'Zoe',
+          type: VehicleType.ev,
+        ),
+      );
+      await repo.delete('v1');
+
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.id, 'v2');
+      expect(repo.getActive()?.id, 'v2');
+    });
+
+    test('delete last vehicle clears active', () async {
+      await repo.save(sample);
+      await repo.delete('v1');
+      expect(repo.getAll(), isEmpty);
+      expect(repo.getActive(), isNull);
+    });
+
+    test('setActive changes the active profile', () async {
+      await repo.save(sample);
+      await repo.save(
+        const VehicleProfile(id: 'v2', name: 'Zoe', type: VehicleType.ev),
+      );
+      await repo.setActive('v2');
+      expect(repo.getActive()?.id, 'v2');
+    });
+
+    test('clear removes everything', () async {
+      await repo.save(sample);
+      await repo.clear();
+      expect(repo.getAll(), isEmpty);
+      expect(repo.getActive(), isNull);
+    });
+
+    test('getById returns null when id does not exist', () async {
+      await repo.save(sample);
+      expect(repo.getById('missing'), isNull);
+      expect(repo.getById('v1')?.name, 'Model 3');
+    });
+
+    test('malformed JSON entries are skipped without crashing', () async {
+      storage._data[_listKey] = [
+        sample.toJson(),
+        'not a map',
+        {'id': 'bad'}, // missing name — VehicleProfile.fromJson will throw
+      ];
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.id, 'v1');
+    });
+  });
+}
+
+const _listKey = 'vehicle_profiles';
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/vehicle/domain/vehicle_profile_test.dart
+++ b/test/features/vehicle/domain/vehicle_profile_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+void main() {
+  group('VehicleProfile', () {
+    test('defaults are sensible', () {
+      const v = VehicleProfile(id: 'abc', name: 'Car');
+      expect(v.type, VehicleType.combustion);
+      expect(v.supportedConnectors, isEmpty);
+      expect(v.chargingPreferences.minSocPercent, 20);
+      expect(v.chargingPreferences.maxSocPercent, 80);
+      expect(v.isCombustion, isTrue);
+      expect(v.isEv, isFalse);
+    });
+
+    test('hybrid counts as both EV and combustion', () {
+      const v = VehicleProfile(id: 'h', name: 'Hybrid', type: VehicleType.hybrid);
+      expect(v.isEv, isTrue);
+      expect(v.isCombustion, isTrue);
+    });
+
+    test('ev profile round-trips through JSON with connector set', () {
+      const v = VehicleProfile(
+        id: 'tesla',
+        name: 'Model 3',
+        type: VehicleType.ev,
+        batteryKwh: 60.0,
+        maxChargingKw: 150.0,
+        supportedConnectors: {ConnectorType.ccs, ConnectorType.type2},
+        chargingPreferences: ChargingPreferences(
+          minSocPercent: 10,
+          maxSocPercent: 90,
+          preferredNetworks: ['Tesla Supercharger'],
+        ),
+      );
+
+      final json = v.toJson();
+      final restored = VehicleProfile.fromJson(json);
+
+      expect(restored.id, 'tesla');
+      expect(restored.name, 'Model 3');
+      expect(restored.type, VehicleType.ev);
+      expect(restored.batteryKwh, 60.0);
+      expect(restored.maxChargingKw, 150.0);
+      expect(restored.supportedConnectors,
+          {ConnectorType.ccs, ConnectorType.type2});
+      expect(restored.chargingPreferences.minSocPercent, 10);
+      expect(restored.chargingPreferences.maxSocPercent, 90);
+      expect(restored.chargingPreferences.preferredNetworks,
+          ['Tesla Supercharger']);
+    });
+
+    test('combustion profile round-trips through JSON', () {
+      const v = VehicleProfile(
+        id: 'golf',
+        name: 'Golf',
+        type: VehicleType.combustion,
+        tankCapacityL: 50.0,
+        preferredFuelType: 'Diesel',
+      );
+
+      final restored = VehicleProfile.fromJson(v.toJson());
+      expect(restored.type, VehicleType.combustion);
+      expect(restored.tankCapacityL, 50.0);
+      expect(restored.preferredFuelType, 'Diesel');
+      expect(restored.supportedConnectors, isEmpty);
+    });
+
+    test('unknown connector keys are silently dropped on decode', () {
+      final json = {
+        'id': 'x',
+        'name': 'X',
+        'type': 'ev',
+        'supportedConnectors': ['ccs', 'unknown_plug', 'type2'],
+        'chargingPreferences': const ChargingPreferences().toJson(),
+      };
+      final restored = VehicleProfile.fromJson(json);
+      expect(restored.supportedConnectors,
+          {ConnectorType.ccs, ConnectorType.type2});
+    });
+
+    test('copyWith preserves unspecified fields', () {
+      const v = VehicleProfile(
+        id: 'a',
+        name: 'Old',
+        type: VehicleType.ev,
+        batteryKwh: 60,
+        supportedConnectors: {ConnectorType.ccs},
+      );
+      final copy = v.copyWith(name: 'New');
+      expect(copy.name, 'New');
+      expect(copy.batteryKwh, 60);
+      expect(copy.supportedConnectors, {ConnectorType.ccs});
+    });
+  });
+
+  group('VehicleType.fromKey', () {
+    test('returns matching value', () {
+      expect(VehicleType.fromKey('ev'), VehicleType.ev);
+      expect(VehicleType.fromKey('hybrid'), VehicleType.hybrid);
+      expect(VehicleType.fromKey('combustion'), VehicleType.combustion);
+    });
+
+    test('falls back to combustion for unknown or null', () {
+      expect(VehicleType.fromKey(null), VehicleType.combustion);
+      expect(VehicleType.fromKey('diesel'), VehicleType.combustion);
+    });
+  });
+}

--- a/test/features/vehicle/presentation/vehicle_card_test.dart
+++ b/test/features/vehicle/presentation/vehicle_card_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_card.dart';
+
+import '../../../helpers/pump_app.dart';
+
+void main() {
+  group('VehicleCard', () {
+    const evVehicle = VehicleProfile(
+      id: 'v1',
+      name: 'Model 3',
+      type: VehicleType.ev,
+      batteryKwh: 60,
+      maxChargingKw: 150,
+      supportedConnectors: {ConnectorType.ccs, ConnectorType.type2},
+    );
+
+    const combustionVehicle = VehicleProfile(
+      id: 'v2',
+      name: 'Golf',
+      type: VehicleType.combustion,
+      tankCapacityL: 50,
+      preferredFuelType: 'Diesel',
+    );
+
+    testWidgets('renders EV name and specs', (tester) async {
+      await pumpApp(tester, const VehicleCard(vehicle: evVehicle));
+
+      expect(find.text('Model 3'), findsOneWidget);
+      expect(find.textContaining('60'), findsOneWidget);
+      expect(find.byIcon(Icons.electric_car), findsOneWidget);
+    });
+
+    testWidgets('renders combustion vehicle with tank info', (tester) async {
+      await pumpApp(tester, const VehicleCard(vehicle: combustionVehicle));
+
+      expect(find.text('Golf'), findsOneWidget);
+      expect(find.textContaining('50'), findsOneWidget);
+      expect(find.textContaining('Diesel'), findsOneWidget);
+      expect(find.byIcon(Icons.local_gas_station), findsOneWidget);
+    });
+
+    testWidgets('shows active check when isActive', (tester) async {
+      await pumpApp(
+        tester,
+        const VehicleCard(vehicle: evVehicle, isActive: true),
+      );
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    });
+
+    testWidgets('tapping card invokes onTap', (tester) async {
+      var tapped = false;
+      await pumpApp(
+        tester,
+        VehicleCard(vehicle: evVehicle, onTap: () => tapped = true),
+      );
+      await tester.tap(find.byType(ListTile));
+      await tester.pumpAndSettle();
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('popup menu offers Edit and Delete', (tester) async {
+      await pumpApp(
+        tester,
+        VehicleCard(
+          vehicle: evVehicle,
+          isActive: true,
+          onEdit: () {},
+          onDelete: () {},
+        ),
+      );
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
+      expect(find.text('Edit'), findsOneWidget);
+      expect(find.text('Delete'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/vehicle/providers/vehicle_providers_test.dart
+++ b/test/features/vehicle/providers/vehicle_providers_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+void main() {
+  group('VehicleProfileList provider', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      final repo = VehicleProfileRepository(_FakeSettings());
+      container = ProviderContainer(
+        overrides: [
+          vehicleProfileRepositoryProvider.overrideWithValue(repo),
+        ],
+      );
+      addTearDown(container.dispose);
+    });
+
+    test('starts empty when no stored vehicles', () {
+      expect(container.read(vehicleProfileListProvider), isEmpty);
+      expect(container.read(activeVehicleProfileProvider), isNull);
+    });
+
+    test('save adds vehicle and auto-activates', () async {
+      const v = VehicleProfile(
+        id: 'v1',
+        name: 'Model 3',
+        type: VehicleType.ev,
+        batteryKwh: 60,
+      );
+      await container.read(vehicleProfileListProvider.notifier).save(v);
+
+      expect(container.read(vehicleProfileListProvider), hasLength(1));
+      expect(container.read(activeVehicleProfileProvider)?.id, 'v1');
+    });
+
+    test('remove deletes and updates state', () async {
+      const v = VehicleProfile(id: 'v1', name: 'Car');
+      await container.read(vehicleProfileListProvider.notifier).save(v);
+      await container.read(vehicleProfileListProvider.notifier).remove('v1');
+
+      expect(container.read(vehicleProfileListProvider), isEmpty);
+      expect(container.read(activeVehicleProfileProvider), isNull);
+    });
+
+    test('setActive switches the active vehicle', () async {
+      await container.read(vehicleProfileListProvider.notifier).save(
+            const VehicleProfile(id: 'v1', name: 'A'),
+          );
+      await container.read(vehicleProfileListProvider.notifier).save(
+            const VehicleProfile(id: 'v2', name: 'B'),
+          );
+      await container
+          .read(activeVehicleProfileProvider.notifier)
+          .setActive('v2');
+
+      expect(container.read(activeVehicleProfileProvider)?.id, 'v2');
+    });
+
+    test('clearAll removes everything', () async {
+      await container.read(vehicleProfileListProvider.notifier).save(
+            const VehicleProfile(id: 'v1', name: 'A'),
+          );
+      await container.read(vehicleProfileListProvider.notifier).clearAll();
+      expect(container.read(vehicleProfileListProvider), isEmpty);
+    });
+  });
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}


### PR DESCRIPTION
## Summary

Adds a client-side vehicle profile feature so users can store battery capacity, supported connectors, and charging preferences — used later for filtering charging stations and estimating costs.

- Freezed `VehicleProfile` + `ChargingPreferences` with JSON converters for enum types and the `Set<ConnectorType>` (so it survives Hive round-trips).
- `VehicleProfileRepository` persists profiles as a list under a single settings key, auto-activates the first vehicle, and switches active on delete.
- Riverpod `keepAlive` providers for the vehicle list and active profile.
- `VehicleListScreen` (add/edit/delete/set-active), `EditVehicleScreen` (segmented type control, connector filter chips, EV + combustion sections), and `VehicleCard` widget.
- Routes at `/vehicles` and `/vehicles/edit`, plus a "My vehicles" entry in the Settings screen.
- en/de ARB strings for all labels, connector types, and vehicle types.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — zero warnings/errors
- [x] `flutter test test/features/vehicle` — 29 new tests pass
- [x] `flutter test` — full suite passes (one pre-existing Argentina network test fails on master too)
- [ ] Manual: open Settings → My vehicles, add an EV, verify form, delete, add combustion car, set active

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)