### PR TITLE
feat(ev): OCPI charging data model and price calculation engine

### DIFF
--- a/lib/features/ev/domain/entities/charging_station.dart
+++ b/lib/features/ev/domain/entities/charging_station.dart
@@ -1,0 +1,142 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+import 'opening_hours.dart';
+
+part 'charging_station.freezed.dart';
+part 'charging_station.g.dart';
+
+/// Real-time status of an individual [EvConnector].
+enum ConnectorStatus {
+  available('available'),
+  occupied('occupied'),
+  outOfOrder('out_of_order'),
+  unknown('unknown');
+
+  final String key;
+  const ConnectorStatus(this.key);
+
+  static ConnectorStatus fromKey(String? value) {
+    if (value == null) return ConnectorStatus.unknown;
+    for (final v in ConnectorStatus.values) {
+      if (v.key == value) return v;
+    }
+    return ConnectorStatus.unknown;
+  }
+}
+
+/// A single physical connector attached to a [ChargingStation].
+@freezed
+abstract class EvConnector with _$EvConnector {
+  const factory EvConnector({
+    required String id,
+    @ConnectorTypeJsonConverter() required ConnectorType type,
+    @Default(0) double maxPowerKw,
+    @ConnectorStatusJsonConverter()
+    @Default(ConnectorStatus.unknown)
+    ConnectorStatus status,
+    String? tariffId,
+  }) = _EvConnector;
+
+  factory EvConnector.fromJson(Map<String, dynamic> json) =>
+      _$EvConnectorFromJson(json);
+}
+
+/// An EV charging station, typically sourced from OCPI / DATEX II /
+/// OpenChargeMap / Bundesnetzagentur.
+///
+/// The tariff data itself lives in separate [charging_tariff.dart] models;
+/// a station holds only `tariffId` references on each connector so that
+/// multiple connectors can share the same tariff description.
+@freezed
+abstract class ChargingStation with _$ChargingStation {
+  const ChargingStation._();
+
+  const factory ChargingStation({
+    required String id,
+    required String name,
+    String? operator,
+    required double latitude,
+    required double longitude,
+    String? address,
+    @Default(<EvConnector>[])
+    @EvConnectorListConverter()
+    List<EvConnector> connectors,
+    @Default(<String>[]) List<String> amenities,
+    @OpeningHoursNullableConverter() OpeningHours? openingHours,
+    DateTime? lastUpdate,
+  }) = _ChargingStation;
+
+  factory ChargingStation.fromJson(Map<String, dynamic> json) =>
+      _$ChargingStationFromJson(json);
+
+  /// Whether any connector is currently reported as `available`.
+  bool get hasAvailableConnector => connectors
+      .any((c) => c.status == ConnectorStatus.available);
+
+  /// Highest advertised max power across all connectors.
+  double get maxPowerKw => connectors.isEmpty
+      ? 0
+      : connectors
+          .map((c) => c.maxPowerKw)
+          .reduce((a, b) => a > b ? a : b);
+}
+
+// ---------------------------------------------------------------------------
+// JSON converters
+// ---------------------------------------------------------------------------
+
+/// Serializes [ConnectorType] from `vehicle_profile.dart` as its string key.
+class ConnectorTypeJsonConverter
+    implements JsonConverter<ConnectorType, String> {
+  const ConnectorTypeJsonConverter();
+
+  @override
+  ConnectorType fromJson(String json) =>
+      ConnectorType.fromKey(json) ?? ConnectorType.type2;
+
+  @override
+  String toJson(ConnectorType object) => object.key;
+}
+
+/// Serializes [ConnectorStatus] as its string key.
+class ConnectorStatusJsonConverter
+    implements JsonConverter<ConnectorStatus, String> {
+  const ConnectorStatusJsonConverter();
+
+  @override
+  ConnectorStatus fromJson(String json) => ConnectorStatus.fromKey(json);
+
+  @override
+  String toJson(ConnectorStatus object) => object.key;
+}
+
+/// Serializes a list of [EvConnector] as plain JSON maps.
+class EvConnectorListConverter
+    implements JsonConverter<List<EvConnector>, List<dynamic>> {
+  const EvConnectorListConverter();
+
+  @override
+  List<EvConnector> fromJson(List<dynamic> json) => json
+      .whereType<Map<dynamic, dynamic>>()
+      .map((e) => EvConnector.fromJson(Map<String, dynamic>.from(e)))
+      .toList();
+
+  @override
+  List<Map<String, dynamic>> toJson(List<EvConnector> object) =>
+      object.map((c) => c.toJson()).toList();
+}
+
+/// Serializes a nullable [OpeningHours] as a plain JSON map.
+class OpeningHoursNullableConverter
+    implements JsonConverter<OpeningHours?, Map<String, dynamic>?> {
+  const OpeningHoursNullableConverter();
+
+  @override
+  OpeningHours? fromJson(Map<String, dynamic>? json) =>
+      json == null ? null : OpeningHours.fromJson(json);
+
+  @override
+  Map<String, dynamic>? toJson(OpeningHours? object) => object?.toJson();
+}

--- a/lib/features/ev/domain/entities/charging_station.freezed.dart
+++ b/lib/features/ev/domain/entities/charging_station.freezed.dart
@@ -1,0 +1,615 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'charging_station.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EvConnector {
+
+ String get id;@ConnectorTypeJsonConverter() ConnectorType get type; double get maxPowerKw;@ConnectorStatusJsonConverter() ConnectorStatus get status; String? get tariffId;
+/// Create a copy of EvConnector
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EvConnectorCopyWith<EvConnector> get copyWith => _$EvConnectorCopyWithImpl<EvConnector>(this as EvConnector, _$identity);
+
+  /// Serializes this EvConnector to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EvConnector&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.maxPowerKw, maxPowerKw) || other.maxPowerKw == maxPowerKw)&&(identical(other.status, status) || other.status == status)&&(identical(other.tariffId, tariffId) || other.tariffId == tariffId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,type,maxPowerKw,status,tariffId);
+
+@override
+String toString() {
+  return 'EvConnector(id: $id, type: $type, maxPowerKw: $maxPowerKw, status: $status, tariffId: $tariffId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EvConnectorCopyWith<$Res>  {
+  factory $EvConnectorCopyWith(EvConnector value, $Res Function(EvConnector) _then) = _$EvConnectorCopyWithImpl;
+@useResult
+$Res call({
+ String id,@ConnectorTypeJsonConverter() ConnectorType type, double maxPowerKw,@ConnectorStatusJsonConverter() ConnectorStatus status, String? tariffId
+});
+
+
+
+
+}
+/// @nodoc
+class _$EvConnectorCopyWithImpl<$Res>
+    implements $EvConnectorCopyWith<$Res> {
+  _$EvConnectorCopyWithImpl(this._self, this._then);
+
+  final EvConnector _self;
+  final $Res Function(EvConnector) _then;
+
+/// Create a copy of EvConnector
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = null,Object? maxPowerKw = null,Object? status = null,Object? tariffId = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as ConnectorType,maxPowerKw: null == maxPowerKw ? _self.maxPowerKw : maxPowerKw // ignore: cast_nullable_to_non_nullable
+as double,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as ConnectorStatus,tariffId: freezed == tariffId ? _self.tariffId : tariffId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EvConnector].
+extension EvConnectorPatterns on EvConnector {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EvConnector value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EvConnector() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EvConnector value)  $default,){
+final _that = this;
+switch (_that) {
+case _EvConnector():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EvConnector value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EvConnector() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @ConnectorTypeJsonConverter()  ConnectorType type,  double maxPowerKw, @ConnectorStatusJsonConverter()  ConnectorStatus status,  String? tariffId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EvConnector() when $default != null:
+return $default(_that.id,_that.type,_that.maxPowerKw,_that.status,_that.tariffId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @ConnectorTypeJsonConverter()  ConnectorType type,  double maxPowerKw, @ConnectorStatusJsonConverter()  ConnectorStatus status,  String? tariffId)  $default,) {final _that = this;
+switch (_that) {
+case _EvConnector():
+return $default(_that.id,_that.type,_that.maxPowerKw,_that.status,_that.tariffId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @ConnectorTypeJsonConverter()  ConnectorType type,  double maxPowerKw, @ConnectorStatusJsonConverter()  ConnectorStatus status,  String? tariffId)?  $default,) {final _that = this;
+switch (_that) {
+case _EvConnector() when $default != null:
+return $default(_that.id,_that.type,_that.maxPowerKw,_that.status,_that.tariffId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _EvConnector implements EvConnector {
+  const _EvConnector({required this.id, @ConnectorTypeJsonConverter() required this.type, this.maxPowerKw = 0, @ConnectorStatusJsonConverter() this.status = ConnectorStatus.unknown, this.tariffId});
+  factory _EvConnector.fromJson(Map<String, dynamic> json) => _$EvConnectorFromJson(json);
+
+@override final  String id;
+@override@ConnectorTypeJsonConverter() final  ConnectorType type;
+@override@JsonKey() final  double maxPowerKw;
+@override@JsonKey()@ConnectorStatusJsonConverter() final  ConnectorStatus status;
+@override final  String? tariffId;
+
+/// Create a copy of EvConnector
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EvConnectorCopyWith<_EvConnector> get copyWith => __$EvConnectorCopyWithImpl<_EvConnector>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EvConnectorToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EvConnector&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.maxPowerKw, maxPowerKw) || other.maxPowerKw == maxPowerKw)&&(identical(other.status, status) || other.status == status)&&(identical(other.tariffId, tariffId) || other.tariffId == tariffId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,type,maxPowerKw,status,tariffId);
+
+@override
+String toString() {
+  return 'EvConnector(id: $id, type: $type, maxPowerKw: $maxPowerKw, status: $status, tariffId: $tariffId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EvConnectorCopyWith<$Res> implements $EvConnectorCopyWith<$Res> {
+  factory _$EvConnectorCopyWith(_EvConnector value, $Res Function(_EvConnector) _then) = __$EvConnectorCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@ConnectorTypeJsonConverter() ConnectorType type, double maxPowerKw,@ConnectorStatusJsonConverter() ConnectorStatus status, String? tariffId
+});
+
+
+
+
+}
+/// @nodoc
+class __$EvConnectorCopyWithImpl<$Res>
+    implements _$EvConnectorCopyWith<$Res> {
+  __$EvConnectorCopyWithImpl(this._self, this._then);
+
+  final _EvConnector _self;
+  final $Res Function(_EvConnector) _then;
+
+/// Create a copy of EvConnector
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? type = null,Object? maxPowerKw = null,Object? status = null,Object? tariffId = freezed,}) {
+  return _then(_EvConnector(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as ConnectorType,maxPowerKw: null == maxPowerKw ? _self.maxPowerKw : maxPowerKw // ignore: cast_nullable_to_non_nullable
+as double,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as ConnectorStatus,tariffId: freezed == tariffId ? _self.tariffId : tariffId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$ChargingStation {
+
+ String get id; String get name; String? get operator; double get latitude; double get longitude; String? get address;@EvConnectorListConverter() List<EvConnector> get connectors; List<String> get amenities;@OpeningHoursNullableConverter() OpeningHours? get openingHours; DateTime? get lastUpdate;
+/// Create a copy of ChargingStation
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChargingStationCopyWith<ChargingStation> get copyWith => _$ChargingStationCopyWithImpl<ChargingStation>(this as ChargingStation, _$identity);
+
+  /// Serializes this ChargingStation to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChargingStation&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.operator, operator) || other.operator == operator)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude)&&(identical(other.address, address) || other.address == address)&&const DeepCollectionEquality().equals(other.connectors, connectors)&&const DeepCollectionEquality().equals(other.amenities, amenities)&&(identical(other.openingHours, openingHours) || other.openingHours == openingHours)&&(identical(other.lastUpdate, lastUpdate) || other.lastUpdate == lastUpdate));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,operator,latitude,longitude,address,const DeepCollectionEquality().hash(connectors),const DeepCollectionEquality().hash(amenities),openingHours,lastUpdate);
+
+@override
+String toString() {
+  return 'ChargingStation(id: $id, name: $name, operator: $operator, latitude: $latitude, longitude: $longitude, address: $address, connectors: $connectors, amenities: $amenities, openingHours: $openingHours, lastUpdate: $lastUpdate)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChargingStationCopyWith<$Res>  {
+  factory $ChargingStationCopyWith(ChargingStation value, $Res Function(ChargingStation) _then) = _$ChargingStationCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name, String? operator, double latitude, double longitude, String? address,@EvConnectorListConverter() List<EvConnector> connectors, List<String> amenities,@OpeningHoursNullableConverter() OpeningHours? openingHours, DateTime? lastUpdate
+});
+
+
+$OpeningHoursCopyWith<$Res>? get openingHours;
+
+}
+/// @nodoc
+class _$ChargingStationCopyWithImpl<$Res>
+    implements $ChargingStationCopyWith<$Res> {
+  _$ChargingStationCopyWithImpl(this._self, this._then);
+
+  final ChargingStation _self;
+  final $Res Function(ChargingStation) _then;
+
+/// Create a copy of ChargingStation
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? operator = freezed,Object? latitude = null,Object? longitude = null,Object? address = freezed,Object? connectors = null,Object? amenities = null,Object? openingHours = freezed,Object? lastUpdate = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,operator: freezed == operator ? _self.operator : operator // ignore: cast_nullable_to_non_nullable
+as String?,latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,address: freezed == address ? _self.address : address // ignore: cast_nullable_to_non_nullable
+as String?,connectors: null == connectors ? _self.connectors : connectors // ignore: cast_nullable_to_non_nullable
+as List<EvConnector>,amenities: null == amenities ? _self.amenities : amenities // ignore: cast_nullable_to_non_nullable
+as List<String>,openingHours: freezed == openingHours ? _self.openingHours : openingHours // ignore: cast_nullable_to_non_nullable
+as OpeningHours?,lastUpdate: freezed == lastUpdate ? _self.lastUpdate : lastUpdate // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+/// Create a copy of ChargingStation
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$OpeningHoursCopyWith<$Res>? get openingHours {
+    if (_self.openingHours == null) {
+    return null;
+  }
+
+  return $OpeningHoursCopyWith<$Res>(_self.openingHours!, (value) {
+    return _then(_self.copyWith(openingHours: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [ChargingStation].
+extension ChargingStationPatterns on ChargingStation {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChargingStation value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChargingStation() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChargingStation value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChargingStation():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChargingStation value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChargingStation() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String? operator,  double latitude,  double longitude,  String? address, @EvConnectorListConverter()  List<EvConnector> connectors,  List<String> amenities, @OpeningHoursNullableConverter()  OpeningHours? openingHours,  DateTime? lastUpdate)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChargingStation() when $default != null:
+return $default(_that.id,_that.name,_that.operator,_that.latitude,_that.longitude,_that.address,_that.connectors,_that.amenities,_that.openingHours,_that.lastUpdate);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String? operator,  double latitude,  double longitude,  String? address, @EvConnectorListConverter()  List<EvConnector> connectors,  List<String> amenities, @OpeningHoursNullableConverter()  OpeningHours? openingHours,  DateTime? lastUpdate)  $default,) {final _that = this;
+switch (_that) {
+case _ChargingStation():
+return $default(_that.id,_that.name,_that.operator,_that.latitude,_that.longitude,_that.address,_that.connectors,_that.amenities,_that.openingHours,_that.lastUpdate);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String? operator,  double latitude,  double longitude,  String? address, @EvConnectorListConverter()  List<EvConnector> connectors,  List<String> amenities, @OpeningHoursNullableConverter()  OpeningHours? openingHours,  DateTime? lastUpdate)?  $default,) {final _that = this;
+switch (_that) {
+case _ChargingStation() when $default != null:
+return $default(_that.id,_that.name,_that.operator,_that.latitude,_that.longitude,_that.address,_that.connectors,_that.amenities,_that.openingHours,_that.lastUpdate);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ChargingStation extends ChargingStation {
+  const _ChargingStation({required this.id, required this.name, this.operator, required this.latitude, required this.longitude, this.address, @EvConnectorListConverter() final  List<EvConnector> connectors = const <EvConnector>[], final  List<String> amenities = const <String>[], @OpeningHoursNullableConverter() this.openingHours, this.lastUpdate}): _connectors = connectors,_amenities = amenities,super._();
+  factory _ChargingStation.fromJson(Map<String, dynamic> json) => _$ChargingStationFromJson(json);
+
+@override final  String id;
+@override final  String name;
+@override final  String? operator;
+@override final  double latitude;
+@override final  double longitude;
+@override final  String? address;
+ final  List<EvConnector> _connectors;
+@override@JsonKey()@EvConnectorListConverter() List<EvConnector> get connectors {
+  if (_connectors is EqualUnmodifiableListView) return _connectors;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_connectors);
+}
+
+ final  List<String> _amenities;
+@override@JsonKey() List<String> get amenities {
+  if (_amenities is EqualUnmodifiableListView) return _amenities;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_amenities);
+}
+
+@override@OpeningHoursNullableConverter() final  OpeningHours? openingHours;
+@override final  DateTime? lastUpdate;
+
+/// Create a copy of ChargingStation
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChargingStationCopyWith<_ChargingStation> get copyWith => __$ChargingStationCopyWithImpl<_ChargingStation>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ChargingStationToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChargingStation&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.operator, operator) || other.operator == operator)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude)&&(identical(other.address, address) || other.address == address)&&const DeepCollectionEquality().equals(other._connectors, _connectors)&&const DeepCollectionEquality().equals(other._amenities, _amenities)&&(identical(other.openingHours, openingHours) || other.openingHours == openingHours)&&(identical(other.lastUpdate, lastUpdate) || other.lastUpdate == lastUpdate));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,operator,latitude,longitude,address,const DeepCollectionEquality().hash(_connectors),const DeepCollectionEquality().hash(_amenities),openingHours,lastUpdate);
+
+@override
+String toString() {
+  return 'ChargingStation(id: $id, name: $name, operator: $operator, latitude: $latitude, longitude: $longitude, address: $address, connectors: $connectors, amenities: $amenities, openingHours: $openingHours, lastUpdate: $lastUpdate)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChargingStationCopyWith<$Res> implements $ChargingStationCopyWith<$Res> {
+  factory _$ChargingStationCopyWith(_ChargingStation value, $Res Function(_ChargingStation) _then) = __$ChargingStationCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name, String? operator, double latitude, double longitude, String? address,@EvConnectorListConverter() List<EvConnector> connectors, List<String> amenities,@OpeningHoursNullableConverter() OpeningHours? openingHours, DateTime? lastUpdate
+});
+
+
+@override $OpeningHoursCopyWith<$Res>? get openingHours;
+
+}
+/// @nodoc
+class __$ChargingStationCopyWithImpl<$Res>
+    implements _$ChargingStationCopyWith<$Res> {
+  __$ChargingStationCopyWithImpl(this._self, this._then);
+
+  final _ChargingStation _self;
+  final $Res Function(_ChargingStation) _then;
+
+/// Create a copy of ChargingStation
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? operator = freezed,Object? latitude = null,Object? longitude = null,Object? address = freezed,Object? connectors = null,Object? amenities = null,Object? openingHours = freezed,Object? lastUpdate = freezed,}) {
+  return _then(_ChargingStation(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,operator: freezed == operator ? _self.operator : operator // ignore: cast_nullable_to_non_nullable
+as String?,latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,address: freezed == address ? _self.address : address // ignore: cast_nullable_to_non_nullable
+as String?,connectors: null == connectors ? _self._connectors : connectors // ignore: cast_nullable_to_non_nullable
+as List<EvConnector>,amenities: null == amenities ? _self._amenities : amenities // ignore: cast_nullable_to_non_nullable
+as List<String>,openingHours: freezed == openingHours ? _self.openingHours : openingHours // ignore: cast_nullable_to_non_nullable
+as OpeningHours?,lastUpdate: freezed == lastUpdate ? _self.lastUpdate : lastUpdate // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+/// Create a copy of ChargingStation
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$OpeningHoursCopyWith<$Res>? get openingHours {
+    if (_self.openingHours == null) {
+    return null;
+  }
+
+  return $OpeningHoursCopyWith<$Res>(_self.openingHours!, (value) {
+    return _then(_self.copyWith(openingHours: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/ev/domain/entities/charging_station.g.dart
+++ b/lib/features/ev/domain/entities/charging_station.g.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'charging_station.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EvConnector _$EvConnectorFromJson(Map<String, dynamic> json) => _EvConnector(
+  id: json['id'] as String,
+  type: const ConnectorTypeJsonConverter().fromJson(json['type'] as String),
+  maxPowerKw: (json['maxPowerKw'] as num?)?.toDouble() ?? 0,
+  status: json['status'] == null
+      ? ConnectorStatus.unknown
+      : const ConnectorStatusJsonConverter().fromJson(json['status'] as String),
+  tariffId: json['tariffId'] as String?,
+);
+
+Map<String, dynamic> _$EvConnectorToJson(_EvConnector instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': const ConnectorTypeJsonConverter().toJson(instance.type),
+      'maxPowerKw': instance.maxPowerKw,
+      'status': const ConnectorStatusJsonConverter().toJson(instance.status),
+      'tariffId': instance.tariffId,
+    };
+
+_ChargingStation _$ChargingStationFromJson(
+  Map<String, dynamic> json,
+) => _ChargingStation(
+  id: json['id'] as String,
+  name: json['name'] as String,
+  operator: json['operator'] as String?,
+  latitude: (json['latitude'] as num).toDouble(),
+  longitude: (json['longitude'] as num).toDouble(),
+  address: json['address'] as String?,
+  connectors: json['connectors'] == null
+      ? const <EvConnector>[]
+      : const EvConnectorListConverter().fromJson(json['connectors'] as List),
+  amenities:
+      (json['amenities'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+      const <String>[],
+  openingHours: const OpeningHoursNullableConverter().fromJson(
+    json['openingHours'] as Map<String, dynamic>?,
+  ),
+  lastUpdate: json['lastUpdate'] == null
+      ? null
+      : DateTime.parse(json['lastUpdate'] as String),
+);
+
+Map<String, dynamic> _$ChargingStationToJson(
+  _ChargingStation instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'name': instance.name,
+  'operator': instance.operator,
+  'latitude': instance.latitude,
+  'longitude': instance.longitude,
+  'address': instance.address,
+  'connectors': const EvConnectorListConverter().toJson(instance.connectors),
+  'amenities': instance.amenities,
+  'openingHours': const OpeningHoursNullableConverter().toJson(
+    instance.openingHours,
+  ),
+  'lastUpdate': instance.lastUpdate?.toIso8601String(),
+};

--- a/lib/features/ev/domain/entities/charging_tariff.dart
+++ b/lib/features/ev/domain/entities/charging_tariff.dart
@@ -1,0 +1,220 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'charging_tariff.freezed.dart';
+part 'charging_tariff.g.dart';
+
+/// OCPI-style tariff type.
+///
+/// Mirrors the OCPI 2.2.1 `TariffType` enum loosely, reduced to the
+/// categories that actually appear in the sources we ingest.
+enum TariffType {
+  regular('regular'),
+  adHocPayment('ad_hoc_payment'),
+  profileCheap('profile_cheap'),
+  profileFast('profile_fast'),
+  profileGreen('profile_green');
+
+  final String key;
+  const TariffType(this.key);
+
+  static TariffType fromKey(String? value) {
+    if (value == null) return TariffType.regular;
+    for (final v in TariffType.values) {
+      if (v.key == value) return v;
+    }
+    return TariffType.regular;
+  }
+}
+
+/// Type of a single price component inside a tariff element.
+///
+/// Matches the OCPI 2.2.1 `PriceComponent.type` enumeration:
+/// - [energy] — price per kWh delivered
+/// - [flat] — fixed session fee, charged once
+/// - [time] — price per second of charging (we expose it per-minute)
+/// - [parkingTime] — price per second of parking while not charging
+/// - [blockingTime] — price per second after charging completes
+enum PriceComponentType {
+  energy('energy'),
+  flat('flat'),
+  time('time'),
+  parkingTime('parking_time'),
+  blockingTime('blocking_time');
+
+  final String key;
+  const PriceComponentType(this.key);
+
+  static PriceComponentType fromKey(String? value) {
+    if (value == null) return PriceComponentType.energy;
+    for (final v in PriceComponentType.values) {
+      if (v.key == value) return v;
+    }
+    return PriceComponentType.energy;
+  }
+}
+
+/// A single OCPI price component inside a [TariffElement].
+///
+/// `price` is denominated in the parent [ChargingTariff.currency]. `stepSize`
+/// is the billing granularity in the unit of the component type (Wh for
+/// energy, seconds for time/parkingTime/blockingTime, 1 for flat).
+@freezed
+abstract class TariffComponent with _$TariffComponent {
+  const factory TariffComponent({
+    @PriceComponentTypeJsonConverter()
+    @Default(PriceComponentType.energy)
+    PriceComponentType type,
+    @Default(0) double price,
+    @Default(1) int stepSize,
+  }) = _TariffComponent;
+
+  factory TariffComponent.fromJson(Map<String, dynamic> json) =>
+      _$TariffComponentFromJson(json);
+}
+
+/// Restrictions that may limit when a [TariffElement] applies.
+///
+/// All fields are optional. An element with no restrictions always applies.
+/// Time fields use 24h `HH:mm` local time; weekday is 1 (Mon) - 7 (Sun).
+@freezed
+abstract class TariffRestriction with _$TariffRestriction {
+  const factory TariffRestriction({
+    String? startTime,
+    String? endTime,
+    @Default(<int>[]) List<int> daysOfWeek,
+    double? minKwh,
+    double? maxKwh,
+  }) = _TariffRestriction;
+
+  factory TariffRestriction.fromJson(Map<String, dynamic> json) =>
+      _$TariffRestrictionFromJson(json);
+}
+
+/// A tariff element bundles [TariffComponent]s that share the same
+/// [TariffRestriction]. A [ChargingTariff] may contain multiple elements
+/// so that time-of-day pricing can switch between them.
+@freezed
+abstract class TariffElement with _$TariffElement {
+  const factory TariffElement({
+    @Default(<TariffComponent>[])
+    @TariffComponentListConverter()
+    List<TariffComponent> priceComponents,
+    @TariffRestrictionNullableConverter()
+    TariffRestriction? restrictions,
+  }) = _TariffElement;
+
+  factory TariffElement.fromJson(Map<String, dynamic> json) =>
+      _$TariffElementFromJson(json);
+}
+
+/// OCPI charging tariff.
+///
+/// A tariff groups one or more [TariffElement]s that together describe how
+/// a charging session is priced. The calculator in
+/// `EvPriceCalculator` picks the right element based on
+/// [TariffRestriction]s and sums the resulting component costs.
+@freezed
+abstract class ChargingTariff with _$ChargingTariff {
+  const ChargingTariff._();
+
+  const factory ChargingTariff({
+    required String id,
+    @Default('EUR') String currency,
+    @TariffTypeJsonConverter() @Default(TariffType.regular) TariffType type,
+    @Default(<TariffElement>[])
+    @TariffElementListConverter()
+    List<TariffElement> elements,
+    DateTime? validFrom,
+    DateTime? validTo,
+  }) = _ChargingTariff;
+
+  factory ChargingTariff.fromJson(Map<String, dynamic> json) =>
+      _$ChargingTariffFromJson(json);
+
+  /// Headline price used for map marker display: the first energy component
+  /// we find, regardless of restrictions. Returns `null` if the tariff has
+  /// no energy component (e.g. free or time-only).
+  double? get headlinePricePerKwh {
+    for (final element in elements) {
+      for (final component in element.priceComponents) {
+        if (component.type == PriceComponentType.energy) {
+          return component.price;
+        }
+      }
+    }
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON converters
+// ---------------------------------------------------------------------------
+
+/// Serializes [PriceComponentType] as its string key.
+class PriceComponentTypeJsonConverter
+    implements JsonConverter<PriceComponentType, String> {
+  const PriceComponentTypeJsonConverter();
+
+  @override
+  PriceComponentType fromJson(String json) => PriceComponentType.fromKey(json);
+
+  @override
+  String toJson(PriceComponentType object) => object.key;
+}
+
+/// Serializes [TariffType] as its string key.
+class TariffTypeJsonConverter implements JsonConverter<TariffType, String> {
+  const TariffTypeJsonConverter();
+
+  @override
+  TariffType fromJson(String json) => TariffType.fromKey(json);
+
+  @override
+  String toJson(TariffType object) => object.key;
+}
+
+/// Serializes a list of [TariffComponent] as plain JSON maps so that the
+/// parent freezed class does not embed the object instances directly.
+class TariffComponentListConverter
+    implements JsonConverter<List<TariffComponent>, List<dynamic>> {
+  const TariffComponentListConverter();
+
+  @override
+  List<TariffComponent> fromJson(List<dynamic> json) => json
+      .whereType<Map<dynamic, dynamic>>()
+      .map((e) => TariffComponent.fromJson(Map<String, dynamic>.from(e)))
+      .toList();
+
+  @override
+  List<Map<String, dynamic>> toJson(List<TariffComponent> object) =>
+      object.map((c) => c.toJson()).toList();
+}
+
+/// Serializes a list of [TariffElement] as plain JSON maps.
+class TariffElementListConverter
+    implements JsonConverter<List<TariffElement>, List<dynamic>> {
+  const TariffElementListConverter();
+
+  @override
+  List<TariffElement> fromJson(List<dynamic> json) => json
+      .whereType<Map<dynamic, dynamic>>()
+      .map((e) => TariffElement.fromJson(Map<String, dynamic>.from(e)))
+      .toList();
+
+  @override
+  List<Map<String, dynamic>> toJson(List<TariffElement> object) =>
+      object.map((c) => c.toJson()).toList();
+}
+
+/// Serializes a nullable [TariffRestriction] as a plain JSON map.
+class TariffRestrictionNullableConverter
+    implements JsonConverter<TariffRestriction?, Map<String, dynamic>?> {
+  const TariffRestrictionNullableConverter();
+
+  @override
+  TariffRestriction? fromJson(Map<String, dynamic>? json) =>
+      json == null ? null : TariffRestriction.fromJson(json);
+
+  @override
+  Map<String, dynamic>? toJson(TariffRestriction? object) => object?.toJson();
+}

--- a/lib/features/ev/domain/entities/charging_tariff.freezed.dart
+++ b/lib/features/ev/domain/entities/charging_tariff.freezed.dart
@@ -1,0 +1,1144 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'charging_tariff.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$TariffComponent {
+
+@PriceComponentTypeJsonConverter() PriceComponentType get type; double get price; int get stepSize;
+/// Create a copy of TariffComponent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TariffComponentCopyWith<TariffComponent> get copyWith => _$TariffComponentCopyWithImpl<TariffComponent>(this as TariffComponent, _$identity);
+
+  /// Serializes this TariffComponent to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TariffComponent&&(identical(other.type, type) || other.type == type)&&(identical(other.price, price) || other.price == price)&&(identical(other.stepSize, stepSize) || other.stepSize == stepSize));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,price,stepSize);
+
+@override
+String toString() {
+  return 'TariffComponent(type: $type, price: $price, stepSize: $stepSize)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TariffComponentCopyWith<$Res>  {
+  factory $TariffComponentCopyWith(TariffComponent value, $Res Function(TariffComponent) _then) = _$TariffComponentCopyWithImpl;
+@useResult
+$Res call({
+@PriceComponentTypeJsonConverter() PriceComponentType type, double price, int stepSize
+});
+
+
+
+
+}
+/// @nodoc
+class _$TariffComponentCopyWithImpl<$Res>
+    implements $TariffComponentCopyWith<$Res> {
+  _$TariffComponentCopyWithImpl(this._self, this._then);
+
+  final TariffComponent _self;
+  final $Res Function(TariffComponent) _then;
+
+/// Create a copy of TariffComponent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? price = null,Object? stepSize = null,}) {
+  return _then(_self.copyWith(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as PriceComponentType,price: null == price ? _self.price : price // ignore: cast_nullable_to_non_nullable
+as double,stepSize: null == stepSize ? _self.stepSize : stepSize // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TariffComponent].
+extension TariffComponentPatterns on TariffComponent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TariffComponent value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TariffComponent() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TariffComponent value)  $default,){
+final _that = this;
+switch (_that) {
+case _TariffComponent():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TariffComponent value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TariffComponent() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@PriceComponentTypeJsonConverter()  PriceComponentType type,  double price,  int stepSize)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TariffComponent() when $default != null:
+return $default(_that.type,_that.price,_that.stepSize);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@PriceComponentTypeJsonConverter()  PriceComponentType type,  double price,  int stepSize)  $default,) {final _that = this;
+switch (_that) {
+case _TariffComponent():
+return $default(_that.type,_that.price,_that.stepSize);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@PriceComponentTypeJsonConverter()  PriceComponentType type,  double price,  int stepSize)?  $default,) {final _that = this;
+switch (_that) {
+case _TariffComponent() when $default != null:
+return $default(_that.type,_that.price,_that.stepSize);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TariffComponent implements TariffComponent {
+  const _TariffComponent({@PriceComponentTypeJsonConverter() this.type = PriceComponentType.energy, this.price = 0, this.stepSize = 1});
+  factory _TariffComponent.fromJson(Map<String, dynamic> json) => _$TariffComponentFromJson(json);
+
+@override@JsonKey()@PriceComponentTypeJsonConverter() final  PriceComponentType type;
+@override@JsonKey() final  double price;
+@override@JsonKey() final  int stepSize;
+
+/// Create a copy of TariffComponent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TariffComponentCopyWith<_TariffComponent> get copyWith => __$TariffComponentCopyWithImpl<_TariffComponent>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TariffComponentToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TariffComponent&&(identical(other.type, type) || other.type == type)&&(identical(other.price, price) || other.price == price)&&(identical(other.stepSize, stepSize) || other.stepSize == stepSize));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,price,stepSize);
+
+@override
+String toString() {
+  return 'TariffComponent(type: $type, price: $price, stepSize: $stepSize)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TariffComponentCopyWith<$Res> implements $TariffComponentCopyWith<$Res> {
+  factory _$TariffComponentCopyWith(_TariffComponent value, $Res Function(_TariffComponent) _then) = __$TariffComponentCopyWithImpl;
+@override @useResult
+$Res call({
+@PriceComponentTypeJsonConverter() PriceComponentType type, double price, int stepSize
+});
+
+
+
+
+}
+/// @nodoc
+class __$TariffComponentCopyWithImpl<$Res>
+    implements _$TariffComponentCopyWith<$Res> {
+  __$TariffComponentCopyWithImpl(this._self, this._then);
+
+  final _TariffComponent _self;
+  final $Res Function(_TariffComponent) _then;
+
+/// Create a copy of TariffComponent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? price = null,Object? stepSize = null,}) {
+  return _then(_TariffComponent(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as PriceComponentType,price: null == price ? _self.price : price // ignore: cast_nullable_to_non_nullable
+as double,stepSize: null == stepSize ? _self.stepSize : stepSize // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$TariffRestriction {
+
+ String? get startTime; String? get endTime; List<int> get daysOfWeek; double? get minKwh; double? get maxKwh;
+/// Create a copy of TariffRestriction
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TariffRestrictionCopyWith<TariffRestriction> get copyWith => _$TariffRestrictionCopyWithImpl<TariffRestriction>(this as TariffRestriction, _$identity);
+
+  /// Serializes this TariffRestriction to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TariffRestriction&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&const DeepCollectionEquality().equals(other.daysOfWeek, daysOfWeek)&&(identical(other.minKwh, minKwh) || other.minKwh == minKwh)&&(identical(other.maxKwh, maxKwh) || other.maxKwh == maxKwh));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,startTime,endTime,const DeepCollectionEquality().hash(daysOfWeek),minKwh,maxKwh);
+
+@override
+String toString() {
+  return 'TariffRestriction(startTime: $startTime, endTime: $endTime, daysOfWeek: $daysOfWeek, minKwh: $minKwh, maxKwh: $maxKwh)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TariffRestrictionCopyWith<$Res>  {
+  factory $TariffRestrictionCopyWith(TariffRestriction value, $Res Function(TariffRestriction) _then) = _$TariffRestrictionCopyWithImpl;
+@useResult
+$Res call({
+ String? startTime, String? endTime, List<int> daysOfWeek, double? minKwh, double? maxKwh
+});
+
+
+
+
+}
+/// @nodoc
+class _$TariffRestrictionCopyWithImpl<$Res>
+    implements $TariffRestrictionCopyWith<$Res> {
+  _$TariffRestrictionCopyWithImpl(this._self, this._then);
+
+  final TariffRestriction _self;
+  final $Res Function(TariffRestriction) _then;
+
+/// Create a copy of TariffRestriction
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? startTime = freezed,Object? endTime = freezed,Object? daysOfWeek = null,Object? minKwh = freezed,Object? maxKwh = freezed,}) {
+  return _then(_self.copyWith(
+startTime: freezed == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as String?,endTime: freezed == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as String?,daysOfWeek: null == daysOfWeek ? _self.daysOfWeek : daysOfWeek // ignore: cast_nullable_to_non_nullable
+as List<int>,minKwh: freezed == minKwh ? _self.minKwh : minKwh // ignore: cast_nullable_to_non_nullable
+as double?,maxKwh: freezed == maxKwh ? _self.maxKwh : maxKwh // ignore: cast_nullable_to_non_nullable
+as double?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TariffRestriction].
+extension TariffRestrictionPatterns on TariffRestriction {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TariffRestriction value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TariffRestriction() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TariffRestriction value)  $default,){
+final _that = this;
+switch (_that) {
+case _TariffRestriction():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TariffRestriction value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TariffRestriction() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? startTime,  String? endTime,  List<int> daysOfWeek,  double? minKwh,  double? maxKwh)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TariffRestriction() when $default != null:
+return $default(_that.startTime,_that.endTime,_that.daysOfWeek,_that.minKwh,_that.maxKwh);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? startTime,  String? endTime,  List<int> daysOfWeek,  double? minKwh,  double? maxKwh)  $default,) {final _that = this;
+switch (_that) {
+case _TariffRestriction():
+return $default(_that.startTime,_that.endTime,_that.daysOfWeek,_that.minKwh,_that.maxKwh);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? startTime,  String? endTime,  List<int> daysOfWeek,  double? minKwh,  double? maxKwh)?  $default,) {final _that = this;
+switch (_that) {
+case _TariffRestriction() when $default != null:
+return $default(_that.startTime,_that.endTime,_that.daysOfWeek,_that.minKwh,_that.maxKwh);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TariffRestriction implements TariffRestriction {
+  const _TariffRestriction({this.startTime, this.endTime, final  List<int> daysOfWeek = const <int>[], this.minKwh, this.maxKwh}): _daysOfWeek = daysOfWeek;
+  factory _TariffRestriction.fromJson(Map<String, dynamic> json) => _$TariffRestrictionFromJson(json);
+
+@override final  String? startTime;
+@override final  String? endTime;
+ final  List<int> _daysOfWeek;
+@override@JsonKey() List<int> get daysOfWeek {
+  if (_daysOfWeek is EqualUnmodifiableListView) return _daysOfWeek;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_daysOfWeek);
+}
+
+@override final  double? minKwh;
+@override final  double? maxKwh;
+
+/// Create a copy of TariffRestriction
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TariffRestrictionCopyWith<_TariffRestriction> get copyWith => __$TariffRestrictionCopyWithImpl<_TariffRestriction>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TariffRestrictionToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TariffRestriction&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&const DeepCollectionEquality().equals(other._daysOfWeek, _daysOfWeek)&&(identical(other.minKwh, minKwh) || other.minKwh == minKwh)&&(identical(other.maxKwh, maxKwh) || other.maxKwh == maxKwh));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,startTime,endTime,const DeepCollectionEquality().hash(_daysOfWeek),minKwh,maxKwh);
+
+@override
+String toString() {
+  return 'TariffRestriction(startTime: $startTime, endTime: $endTime, daysOfWeek: $daysOfWeek, minKwh: $minKwh, maxKwh: $maxKwh)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TariffRestrictionCopyWith<$Res> implements $TariffRestrictionCopyWith<$Res> {
+  factory _$TariffRestrictionCopyWith(_TariffRestriction value, $Res Function(_TariffRestriction) _then) = __$TariffRestrictionCopyWithImpl;
+@override @useResult
+$Res call({
+ String? startTime, String? endTime, List<int> daysOfWeek, double? minKwh, double? maxKwh
+});
+
+
+
+
+}
+/// @nodoc
+class __$TariffRestrictionCopyWithImpl<$Res>
+    implements _$TariffRestrictionCopyWith<$Res> {
+  __$TariffRestrictionCopyWithImpl(this._self, this._then);
+
+  final _TariffRestriction _self;
+  final $Res Function(_TariffRestriction) _then;
+
+/// Create a copy of TariffRestriction
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? startTime = freezed,Object? endTime = freezed,Object? daysOfWeek = null,Object? minKwh = freezed,Object? maxKwh = freezed,}) {
+  return _then(_TariffRestriction(
+startTime: freezed == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as String?,endTime: freezed == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as String?,daysOfWeek: null == daysOfWeek ? _self._daysOfWeek : daysOfWeek // ignore: cast_nullable_to_non_nullable
+as List<int>,minKwh: freezed == minKwh ? _self.minKwh : minKwh // ignore: cast_nullable_to_non_nullable
+as double?,maxKwh: freezed == maxKwh ? _self.maxKwh : maxKwh // ignore: cast_nullable_to_non_nullable
+as double?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$TariffElement {
+
+@TariffComponentListConverter() List<TariffComponent> get priceComponents;@TariffRestrictionNullableConverter() TariffRestriction? get restrictions;
+/// Create a copy of TariffElement
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TariffElementCopyWith<TariffElement> get copyWith => _$TariffElementCopyWithImpl<TariffElement>(this as TariffElement, _$identity);
+
+  /// Serializes this TariffElement to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TariffElement&&const DeepCollectionEquality().equals(other.priceComponents, priceComponents)&&(identical(other.restrictions, restrictions) || other.restrictions == restrictions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(priceComponents),restrictions);
+
+@override
+String toString() {
+  return 'TariffElement(priceComponents: $priceComponents, restrictions: $restrictions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TariffElementCopyWith<$Res>  {
+  factory $TariffElementCopyWith(TariffElement value, $Res Function(TariffElement) _then) = _$TariffElementCopyWithImpl;
+@useResult
+$Res call({
+@TariffComponentListConverter() List<TariffComponent> priceComponents,@TariffRestrictionNullableConverter() TariffRestriction? restrictions
+});
+
+
+$TariffRestrictionCopyWith<$Res>? get restrictions;
+
+}
+/// @nodoc
+class _$TariffElementCopyWithImpl<$Res>
+    implements $TariffElementCopyWith<$Res> {
+  _$TariffElementCopyWithImpl(this._self, this._then);
+
+  final TariffElement _self;
+  final $Res Function(TariffElement) _then;
+
+/// Create a copy of TariffElement
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? priceComponents = null,Object? restrictions = freezed,}) {
+  return _then(_self.copyWith(
+priceComponents: null == priceComponents ? _self.priceComponents : priceComponents // ignore: cast_nullable_to_non_nullable
+as List<TariffComponent>,restrictions: freezed == restrictions ? _self.restrictions : restrictions // ignore: cast_nullable_to_non_nullable
+as TariffRestriction?,
+  ));
+}
+/// Create a copy of TariffElement
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TariffRestrictionCopyWith<$Res>? get restrictions {
+    if (_self.restrictions == null) {
+    return null;
+  }
+
+  return $TariffRestrictionCopyWith<$Res>(_self.restrictions!, (value) {
+    return _then(_self.copyWith(restrictions: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [TariffElement].
+extension TariffElementPatterns on TariffElement {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TariffElement value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TariffElement() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TariffElement value)  $default,){
+final _that = this;
+switch (_that) {
+case _TariffElement():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TariffElement value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TariffElement() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@TariffComponentListConverter()  List<TariffComponent> priceComponents, @TariffRestrictionNullableConverter()  TariffRestriction? restrictions)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TariffElement() when $default != null:
+return $default(_that.priceComponents,_that.restrictions);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@TariffComponentListConverter()  List<TariffComponent> priceComponents, @TariffRestrictionNullableConverter()  TariffRestriction? restrictions)  $default,) {final _that = this;
+switch (_that) {
+case _TariffElement():
+return $default(_that.priceComponents,_that.restrictions);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@TariffComponentListConverter()  List<TariffComponent> priceComponents, @TariffRestrictionNullableConverter()  TariffRestriction? restrictions)?  $default,) {final _that = this;
+switch (_that) {
+case _TariffElement() when $default != null:
+return $default(_that.priceComponents,_that.restrictions);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TariffElement implements TariffElement {
+  const _TariffElement({@TariffComponentListConverter() final  List<TariffComponent> priceComponents = const <TariffComponent>[], @TariffRestrictionNullableConverter() this.restrictions}): _priceComponents = priceComponents;
+  factory _TariffElement.fromJson(Map<String, dynamic> json) => _$TariffElementFromJson(json);
+
+ final  List<TariffComponent> _priceComponents;
+@override@JsonKey()@TariffComponentListConverter() List<TariffComponent> get priceComponents {
+  if (_priceComponents is EqualUnmodifiableListView) return _priceComponents;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_priceComponents);
+}
+
+@override@TariffRestrictionNullableConverter() final  TariffRestriction? restrictions;
+
+/// Create a copy of TariffElement
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TariffElementCopyWith<_TariffElement> get copyWith => __$TariffElementCopyWithImpl<_TariffElement>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TariffElementToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TariffElement&&const DeepCollectionEquality().equals(other._priceComponents, _priceComponents)&&(identical(other.restrictions, restrictions) || other.restrictions == restrictions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_priceComponents),restrictions);
+
+@override
+String toString() {
+  return 'TariffElement(priceComponents: $priceComponents, restrictions: $restrictions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TariffElementCopyWith<$Res> implements $TariffElementCopyWith<$Res> {
+  factory _$TariffElementCopyWith(_TariffElement value, $Res Function(_TariffElement) _then) = __$TariffElementCopyWithImpl;
+@override @useResult
+$Res call({
+@TariffComponentListConverter() List<TariffComponent> priceComponents,@TariffRestrictionNullableConverter() TariffRestriction? restrictions
+});
+
+
+@override $TariffRestrictionCopyWith<$Res>? get restrictions;
+
+}
+/// @nodoc
+class __$TariffElementCopyWithImpl<$Res>
+    implements _$TariffElementCopyWith<$Res> {
+  __$TariffElementCopyWithImpl(this._self, this._then);
+
+  final _TariffElement _self;
+  final $Res Function(_TariffElement) _then;
+
+/// Create a copy of TariffElement
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? priceComponents = null,Object? restrictions = freezed,}) {
+  return _then(_TariffElement(
+priceComponents: null == priceComponents ? _self._priceComponents : priceComponents // ignore: cast_nullable_to_non_nullable
+as List<TariffComponent>,restrictions: freezed == restrictions ? _self.restrictions : restrictions // ignore: cast_nullable_to_non_nullable
+as TariffRestriction?,
+  ));
+}
+
+/// Create a copy of TariffElement
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TariffRestrictionCopyWith<$Res>? get restrictions {
+    if (_self.restrictions == null) {
+    return null;
+  }
+
+  return $TariffRestrictionCopyWith<$Res>(_self.restrictions!, (value) {
+    return _then(_self.copyWith(restrictions: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$ChargingTariff {
+
+ String get id; String get currency;@TariffTypeJsonConverter() TariffType get type;@TariffElementListConverter() List<TariffElement> get elements; DateTime? get validFrom; DateTime? get validTo;
+/// Create a copy of ChargingTariff
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChargingTariffCopyWith<ChargingTariff> get copyWith => _$ChargingTariffCopyWithImpl<ChargingTariff>(this as ChargingTariff, _$identity);
+
+  /// Serializes this ChargingTariff to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChargingTariff&&(identical(other.id, id) || other.id == id)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other.elements, elements)&&(identical(other.validFrom, validFrom) || other.validFrom == validFrom)&&(identical(other.validTo, validTo) || other.validTo == validTo));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,currency,type,const DeepCollectionEquality().hash(elements),validFrom,validTo);
+
+@override
+String toString() {
+  return 'ChargingTariff(id: $id, currency: $currency, type: $type, elements: $elements, validFrom: $validFrom, validTo: $validTo)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChargingTariffCopyWith<$Res>  {
+  factory $ChargingTariffCopyWith(ChargingTariff value, $Res Function(ChargingTariff) _then) = _$ChargingTariffCopyWithImpl;
+@useResult
+$Res call({
+ String id, String currency,@TariffTypeJsonConverter() TariffType type,@TariffElementListConverter() List<TariffElement> elements, DateTime? validFrom, DateTime? validTo
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChargingTariffCopyWithImpl<$Res>
+    implements $ChargingTariffCopyWith<$Res> {
+  _$ChargingTariffCopyWithImpl(this._self, this._then);
+
+  final ChargingTariff _self;
+  final $Res Function(ChargingTariff) _then;
+
+/// Create a copy of ChargingTariff
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? currency = null,Object? type = null,Object? elements = null,Object? validFrom = freezed,Object? validTo = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as TariffType,elements: null == elements ? _self.elements : elements // ignore: cast_nullable_to_non_nullable
+as List<TariffElement>,validFrom: freezed == validFrom ? _self.validFrom : validFrom // ignore: cast_nullable_to_non_nullable
+as DateTime?,validTo: freezed == validTo ? _self.validTo : validTo // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ChargingTariff].
+extension ChargingTariffPatterns on ChargingTariff {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChargingTariff value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChargingTariff() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChargingTariff value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChargingTariff():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChargingTariff value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChargingTariff() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String currency, @TariffTypeJsonConverter()  TariffType type, @TariffElementListConverter()  List<TariffElement> elements,  DateTime? validFrom,  DateTime? validTo)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChargingTariff() when $default != null:
+return $default(_that.id,_that.currency,_that.type,_that.elements,_that.validFrom,_that.validTo);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String currency, @TariffTypeJsonConverter()  TariffType type, @TariffElementListConverter()  List<TariffElement> elements,  DateTime? validFrom,  DateTime? validTo)  $default,) {final _that = this;
+switch (_that) {
+case _ChargingTariff():
+return $default(_that.id,_that.currency,_that.type,_that.elements,_that.validFrom,_that.validTo);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String currency, @TariffTypeJsonConverter()  TariffType type, @TariffElementListConverter()  List<TariffElement> elements,  DateTime? validFrom,  DateTime? validTo)?  $default,) {final _that = this;
+switch (_that) {
+case _ChargingTariff() when $default != null:
+return $default(_that.id,_that.currency,_that.type,_that.elements,_that.validFrom,_that.validTo);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ChargingTariff extends ChargingTariff {
+  const _ChargingTariff({required this.id, this.currency = 'EUR', @TariffTypeJsonConverter() this.type = TariffType.regular, @TariffElementListConverter() final  List<TariffElement> elements = const <TariffElement>[], this.validFrom, this.validTo}): _elements = elements,super._();
+  factory _ChargingTariff.fromJson(Map<String, dynamic> json) => _$ChargingTariffFromJson(json);
+
+@override final  String id;
+@override@JsonKey() final  String currency;
+@override@JsonKey()@TariffTypeJsonConverter() final  TariffType type;
+ final  List<TariffElement> _elements;
+@override@JsonKey()@TariffElementListConverter() List<TariffElement> get elements {
+  if (_elements is EqualUnmodifiableListView) return _elements;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_elements);
+}
+
+@override final  DateTime? validFrom;
+@override final  DateTime? validTo;
+
+/// Create a copy of ChargingTariff
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChargingTariffCopyWith<_ChargingTariff> get copyWith => __$ChargingTariffCopyWithImpl<_ChargingTariff>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ChargingTariffToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChargingTariff&&(identical(other.id, id) || other.id == id)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other._elements, _elements)&&(identical(other.validFrom, validFrom) || other.validFrom == validFrom)&&(identical(other.validTo, validTo) || other.validTo == validTo));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,currency,type,const DeepCollectionEquality().hash(_elements),validFrom,validTo);
+
+@override
+String toString() {
+  return 'ChargingTariff(id: $id, currency: $currency, type: $type, elements: $elements, validFrom: $validFrom, validTo: $validTo)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChargingTariffCopyWith<$Res> implements $ChargingTariffCopyWith<$Res> {
+  factory _$ChargingTariffCopyWith(_ChargingTariff value, $Res Function(_ChargingTariff) _then) = __$ChargingTariffCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String currency,@TariffTypeJsonConverter() TariffType type,@TariffElementListConverter() List<TariffElement> elements, DateTime? validFrom, DateTime? validTo
+});
+
+
+
+
+}
+/// @nodoc
+class __$ChargingTariffCopyWithImpl<$Res>
+    implements _$ChargingTariffCopyWith<$Res> {
+  __$ChargingTariffCopyWithImpl(this._self, this._then);
+
+  final _ChargingTariff _self;
+  final $Res Function(_ChargingTariff) _then;
+
+/// Create a copy of ChargingTariff
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? currency = null,Object? type = null,Object? elements = null,Object? validFrom = freezed,Object? validTo = freezed,}) {
+  return _then(_ChargingTariff(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as TariffType,elements: null == elements ? _self._elements : elements // ignore: cast_nullable_to_non_nullable
+as List<TariffElement>,validFrom: freezed == validFrom ? _self.validFrom : validFrom // ignore: cast_nullable_to_non_nullable
+as DateTime?,validTo: freezed == validTo ? _self.validTo : validTo // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/ev/domain/entities/charging_tariff.g.dart
+++ b/lib/features/ev/domain/entities/charging_tariff.g.dart
@@ -1,0 +1,99 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'charging_tariff.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_TariffComponent _$TariffComponentFromJson(Map<String, dynamic> json) =>
+    _TariffComponent(
+      type: json['type'] == null
+          ? PriceComponentType.energy
+          : const PriceComponentTypeJsonConverter().fromJson(
+              json['type'] as String,
+            ),
+      price: (json['price'] as num?)?.toDouble() ?? 0,
+      stepSize: (json['stepSize'] as num?)?.toInt() ?? 1,
+    );
+
+Map<String, dynamic> _$TariffComponentToJson(_TariffComponent instance) =>
+    <String, dynamic>{
+      'type': const PriceComponentTypeJsonConverter().toJson(instance.type),
+      'price': instance.price,
+      'stepSize': instance.stepSize,
+    };
+
+_TariffRestriction _$TariffRestrictionFromJson(Map<String, dynamic> json) =>
+    _TariffRestriction(
+      startTime: json['startTime'] as String?,
+      endTime: json['endTime'] as String?,
+      daysOfWeek:
+          (json['daysOfWeek'] as List<dynamic>?)
+              ?.map((e) => (e as num).toInt())
+              .toList() ??
+          const <int>[],
+      minKwh: (json['minKwh'] as num?)?.toDouble(),
+      maxKwh: (json['maxKwh'] as num?)?.toDouble(),
+    );
+
+Map<String, dynamic> _$TariffRestrictionToJson(_TariffRestriction instance) =>
+    <String, dynamic>{
+      'startTime': instance.startTime,
+      'endTime': instance.endTime,
+      'daysOfWeek': instance.daysOfWeek,
+      'minKwh': instance.minKwh,
+      'maxKwh': instance.maxKwh,
+    };
+
+_TariffElement _$TariffElementFromJson(Map<String, dynamic> json) =>
+    _TariffElement(
+      priceComponents: json['priceComponents'] == null
+          ? const <TariffComponent>[]
+          : const TariffComponentListConverter().fromJson(
+              json['priceComponents'] as List,
+            ),
+      restrictions: const TariffRestrictionNullableConverter().fromJson(
+        json['restrictions'] as Map<String, dynamic>?,
+      ),
+    );
+
+Map<String, dynamic> _$TariffElementToJson(_TariffElement instance) =>
+    <String, dynamic>{
+      'priceComponents': const TariffComponentListConverter().toJson(
+        instance.priceComponents,
+      ),
+      'restrictions': const TariffRestrictionNullableConverter().toJson(
+        instance.restrictions,
+      ),
+    };
+
+_ChargingTariff _$ChargingTariffFromJson(Map<String, dynamic> json) =>
+    _ChargingTariff(
+      id: json['id'] as String,
+      currency: json['currency'] as String? ?? 'EUR',
+      type: json['type'] == null
+          ? TariffType.regular
+          : const TariffTypeJsonConverter().fromJson(json['type'] as String),
+      elements: json['elements'] == null
+          ? const <TariffElement>[]
+          : const TariffElementListConverter().fromJson(
+              json['elements'] as List,
+            ),
+      validFrom: json['validFrom'] == null
+          ? null
+          : DateTime.parse(json['validFrom'] as String),
+      validTo: json['validTo'] == null
+          ? null
+          : DateTime.parse(json['validTo'] as String),
+    );
+
+Map<String, dynamic> _$ChargingTariffToJson(_ChargingTariff instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'currency': instance.currency,
+      'type': const TariffTypeJsonConverter().toJson(instance.type),
+      'elements': const TariffElementListConverter().toJson(instance.elements),
+      'validFrom': instance.validFrom?.toIso8601String(),
+      'validTo': instance.validTo?.toIso8601String(),
+    };

--- a/lib/features/ev/domain/entities/opening_hours.dart
+++ b/lib/features/ev/domain/entities/opening_hours.dart
@@ -1,0 +1,55 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'opening_hours.freezed.dart';
+part 'opening_hours.g.dart';
+
+/// A single opening period on one weekday.
+///
+/// `weekday` is 1 (Monday) through 7 (Sunday) to match ISO 8601 and
+/// `DateTime.weekday`. `periodBegin` / `periodEnd` use 24h local `HH:mm`
+/// strings as in OCPI.
+@freezed
+abstract class RegularHours with _$RegularHours {
+  const factory RegularHours({
+    required int weekday,
+    required String periodBegin,
+    required String periodEnd,
+  }) = _RegularHours;
+
+  factory RegularHours.fromJson(Map<String, dynamic> json) =>
+      _$RegularHoursFromJson(json);
+}
+
+/// Station opening hours, OCPI-style.
+///
+/// Either [twentyFourSeven] is true and [regularHours] is ignored, or the
+/// station advertises a list of weekday windows in [regularHours].
+@freezed
+abstract class OpeningHours with _$OpeningHours {
+  const factory OpeningHours({
+    @Default(false) bool twentyFourSeven,
+    @Default(<RegularHours>[])
+    @RegularHoursListConverter()
+    List<RegularHours> regularHours,
+  }) = _OpeningHours;
+
+  factory OpeningHours.fromJson(Map<String, dynamic> json) =>
+      _$OpeningHoursFromJson(json);
+}
+
+/// Serializes a list of [RegularHours] as plain JSON maps so the parent
+/// does not embed object instances directly in its `toJson` output.
+class RegularHoursListConverter
+    implements JsonConverter<List<RegularHours>, List<dynamic>> {
+  const RegularHoursListConverter();
+
+  @override
+  List<RegularHours> fromJson(List<dynamic> json) => json
+      .whereType<Map<dynamic, dynamic>>()
+      .map((e) => RegularHours.fromJson(Map<String, dynamic>.from(e)))
+      .toList();
+
+  @override
+  List<Map<String, dynamic>> toJson(List<RegularHours> object) =>
+      object.map((c) => c.toJson()).toList();
+}

--- a/lib/features/ev/domain/entities/opening_hours.freezed.dart
+++ b/lib/features/ev/domain/entities/opening_hours.freezed.dart
@@ -1,0 +1,555 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'opening_hours.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RegularHours {
+
+ int get weekday; String get periodBegin; String get periodEnd;
+/// Create a copy of RegularHours
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RegularHoursCopyWith<RegularHours> get copyWith => _$RegularHoursCopyWithImpl<RegularHours>(this as RegularHours, _$identity);
+
+  /// Serializes this RegularHours to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RegularHours&&(identical(other.weekday, weekday) || other.weekday == weekday)&&(identical(other.periodBegin, periodBegin) || other.periodBegin == periodBegin)&&(identical(other.periodEnd, periodEnd) || other.periodEnd == periodEnd));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,weekday,periodBegin,periodEnd);
+
+@override
+String toString() {
+  return 'RegularHours(weekday: $weekday, periodBegin: $periodBegin, periodEnd: $periodEnd)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RegularHoursCopyWith<$Res>  {
+  factory $RegularHoursCopyWith(RegularHours value, $Res Function(RegularHours) _then) = _$RegularHoursCopyWithImpl;
+@useResult
+$Res call({
+ int weekday, String periodBegin, String periodEnd
+});
+
+
+
+
+}
+/// @nodoc
+class _$RegularHoursCopyWithImpl<$Res>
+    implements $RegularHoursCopyWith<$Res> {
+  _$RegularHoursCopyWithImpl(this._self, this._then);
+
+  final RegularHours _self;
+  final $Res Function(RegularHours) _then;
+
+/// Create a copy of RegularHours
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? weekday = null,Object? periodBegin = null,Object? periodEnd = null,}) {
+  return _then(_self.copyWith(
+weekday: null == weekday ? _self.weekday : weekday // ignore: cast_nullable_to_non_nullable
+as int,periodBegin: null == periodBegin ? _self.periodBegin : periodBegin // ignore: cast_nullable_to_non_nullable
+as String,periodEnd: null == periodEnd ? _self.periodEnd : periodEnd // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RegularHours].
+extension RegularHoursPatterns on RegularHours {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RegularHours value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RegularHours() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RegularHours value)  $default,){
+final _that = this;
+switch (_that) {
+case _RegularHours():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RegularHours value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RegularHours() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int weekday,  String periodBegin,  String periodEnd)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RegularHours() when $default != null:
+return $default(_that.weekday,_that.periodBegin,_that.periodEnd);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int weekday,  String periodBegin,  String periodEnd)  $default,) {final _that = this;
+switch (_that) {
+case _RegularHours():
+return $default(_that.weekday,_that.periodBegin,_that.periodEnd);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int weekday,  String periodBegin,  String periodEnd)?  $default,) {final _that = this;
+switch (_that) {
+case _RegularHours() when $default != null:
+return $default(_that.weekday,_that.periodBegin,_that.periodEnd);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _RegularHours implements RegularHours {
+  const _RegularHours({required this.weekday, required this.periodBegin, required this.periodEnd});
+  factory _RegularHours.fromJson(Map<String, dynamic> json) => _$RegularHoursFromJson(json);
+
+@override final  int weekday;
+@override final  String periodBegin;
+@override final  String periodEnd;
+
+/// Create a copy of RegularHours
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RegularHoursCopyWith<_RegularHours> get copyWith => __$RegularHoursCopyWithImpl<_RegularHours>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RegularHoursToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RegularHours&&(identical(other.weekday, weekday) || other.weekday == weekday)&&(identical(other.periodBegin, periodBegin) || other.periodBegin == periodBegin)&&(identical(other.periodEnd, periodEnd) || other.periodEnd == periodEnd));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,weekday,periodBegin,periodEnd);
+
+@override
+String toString() {
+  return 'RegularHours(weekday: $weekday, periodBegin: $periodBegin, periodEnd: $periodEnd)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RegularHoursCopyWith<$Res> implements $RegularHoursCopyWith<$Res> {
+  factory _$RegularHoursCopyWith(_RegularHours value, $Res Function(_RegularHours) _then) = __$RegularHoursCopyWithImpl;
+@override @useResult
+$Res call({
+ int weekday, String periodBegin, String periodEnd
+});
+
+
+
+
+}
+/// @nodoc
+class __$RegularHoursCopyWithImpl<$Res>
+    implements _$RegularHoursCopyWith<$Res> {
+  __$RegularHoursCopyWithImpl(this._self, this._then);
+
+  final _RegularHours _self;
+  final $Res Function(_RegularHours) _then;
+
+/// Create a copy of RegularHours
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? weekday = null,Object? periodBegin = null,Object? periodEnd = null,}) {
+  return _then(_RegularHours(
+weekday: null == weekday ? _self.weekday : weekday // ignore: cast_nullable_to_non_nullable
+as int,periodBegin: null == periodBegin ? _self.periodBegin : periodBegin // ignore: cast_nullable_to_non_nullable
+as String,periodEnd: null == periodEnd ? _self.periodEnd : periodEnd // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$OpeningHours {
+
+ bool get twentyFourSeven;@RegularHoursListConverter() List<RegularHours> get regularHours;
+/// Create a copy of OpeningHours
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$OpeningHoursCopyWith<OpeningHours> get copyWith => _$OpeningHoursCopyWithImpl<OpeningHours>(this as OpeningHours, _$identity);
+
+  /// Serializes this OpeningHours to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is OpeningHours&&(identical(other.twentyFourSeven, twentyFourSeven) || other.twentyFourSeven == twentyFourSeven)&&const DeepCollectionEquality().equals(other.regularHours, regularHours));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,twentyFourSeven,const DeepCollectionEquality().hash(regularHours));
+
+@override
+String toString() {
+  return 'OpeningHours(twentyFourSeven: $twentyFourSeven, regularHours: $regularHours)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $OpeningHoursCopyWith<$Res>  {
+  factory $OpeningHoursCopyWith(OpeningHours value, $Res Function(OpeningHours) _then) = _$OpeningHoursCopyWithImpl;
+@useResult
+$Res call({
+ bool twentyFourSeven,@RegularHoursListConverter() List<RegularHours> regularHours
+});
+
+
+
+
+}
+/// @nodoc
+class _$OpeningHoursCopyWithImpl<$Res>
+    implements $OpeningHoursCopyWith<$Res> {
+  _$OpeningHoursCopyWithImpl(this._self, this._then);
+
+  final OpeningHours _self;
+  final $Res Function(OpeningHours) _then;
+
+/// Create a copy of OpeningHours
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? twentyFourSeven = null,Object? regularHours = null,}) {
+  return _then(_self.copyWith(
+twentyFourSeven: null == twentyFourSeven ? _self.twentyFourSeven : twentyFourSeven // ignore: cast_nullable_to_non_nullable
+as bool,regularHours: null == regularHours ? _self.regularHours : regularHours // ignore: cast_nullable_to_non_nullable
+as List<RegularHours>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [OpeningHours].
+extension OpeningHoursPatterns on OpeningHours {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _OpeningHours value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _OpeningHours() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _OpeningHours value)  $default,){
+final _that = this;
+switch (_that) {
+case _OpeningHours():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _OpeningHours value)?  $default,){
+final _that = this;
+switch (_that) {
+case _OpeningHours() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool twentyFourSeven, @RegularHoursListConverter()  List<RegularHours> regularHours)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _OpeningHours() when $default != null:
+return $default(_that.twentyFourSeven,_that.regularHours);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool twentyFourSeven, @RegularHoursListConverter()  List<RegularHours> regularHours)  $default,) {final _that = this;
+switch (_that) {
+case _OpeningHours():
+return $default(_that.twentyFourSeven,_that.regularHours);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool twentyFourSeven, @RegularHoursListConverter()  List<RegularHours> regularHours)?  $default,) {final _that = this;
+switch (_that) {
+case _OpeningHours() when $default != null:
+return $default(_that.twentyFourSeven,_that.regularHours);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _OpeningHours implements OpeningHours {
+  const _OpeningHours({this.twentyFourSeven = false, @RegularHoursListConverter() final  List<RegularHours> regularHours = const <RegularHours>[]}): _regularHours = regularHours;
+  factory _OpeningHours.fromJson(Map<String, dynamic> json) => _$OpeningHoursFromJson(json);
+
+@override@JsonKey() final  bool twentyFourSeven;
+ final  List<RegularHours> _regularHours;
+@override@JsonKey()@RegularHoursListConverter() List<RegularHours> get regularHours {
+  if (_regularHours is EqualUnmodifiableListView) return _regularHours;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_regularHours);
+}
+
+
+/// Create a copy of OpeningHours
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$OpeningHoursCopyWith<_OpeningHours> get copyWith => __$OpeningHoursCopyWithImpl<_OpeningHours>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$OpeningHoursToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _OpeningHours&&(identical(other.twentyFourSeven, twentyFourSeven) || other.twentyFourSeven == twentyFourSeven)&&const DeepCollectionEquality().equals(other._regularHours, _regularHours));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,twentyFourSeven,const DeepCollectionEquality().hash(_regularHours));
+
+@override
+String toString() {
+  return 'OpeningHours(twentyFourSeven: $twentyFourSeven, regularHours: $regularHours)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$OpeningHoursCopyWith<$Res> implements $OpeningHoursCopyWith<$Res> {
+  factory _$OpeningHoursCopyWith(_OpeningHours value, $Res Function(_OpeningHours) _then) = __$OpeningHoursCopyWithImpl;
+@override @useResult
+$Res call({
+ bool twentyFourSeven,@RegularHoursListConverter() List<RegularHours> regularHours
+});
+
+
+
+
+}
+/// @nodoc
+class __$OpeningHoursCopyWithImpl<$Res>
+    implements _$OpeningHoursCopyWith<$Res> {
+  __$OpeningHoursCopyWithImpl(this._self, this._then);
+
+  final _OpeningHours _self;
+  final $Res Function(_OpeningHours) _then;
+
+/// Create a copy of OpeningHours
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? twentyFourSeven = null,Object? regularHours = null,}) {
+  return _then(_OpeningHours(
+twentyFourSeven: null == twentyFourSeven ? _self.twentyFourSeven : twentyFourSeven // ignore: cast_nullable_to_non_nullable
+as bool,regularHours: null == regularHours ? _self._regularHours : regularHours // ignore: cast_nullable_to_non_nullable
+as List<RegularHours>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/ev/domain/entities/opening_hours.g.dart
+++ b/lib/features/ev/domain/entities/opening_hours.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'opening_hours.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RegularHours _$RegularHoursFromJson(Map<String, dynamic> json) =>
+    _RegularHours(
+      weekday: (json['weekday'] as num).toInt(),
+      periodBegin: json['periodBegin'] as String,
+      periodEnd: json['periodEnd'] as String,
+    );
+
+Map<String, dynamic> _$RegularHoursToJson(_RegularHours instance) =>
+    <String, dynamic>{
+      'weekday': instance.weekday,
+      'periodBegin': instance.periodBegin,
+      'periodEnd': instance.periodEnd,
+    };
+
+_OpeningHours _$OpeningHoursFromJson(Map<String, dynamic> json) =>
+    _OpeningHours(
+      twentyFourSeven: json['twentyFourSeven'] as bool? ?? false,
+      regularHours: json['regularHours'] == null
+          ? const <RegularHours>[]
+          : const RegularHoursListConverter().fromJson(
+              json['regularHours'] as List,
+            ),
+    );
+
+Map<String, dynamic> _$OpeningHoursToJson(_OpeningHours instance) =>
+    <String, dynamic>{
+      'twentyFourSeven': instance.twentyFourSeven,
+      'regularHours': const RegularHoursListConverter().toJson(
+        instance.regularHours,
+      ),
+    };

--- a/lib/features/ev/domain/services/ev_price_calculator.dart
+++ b/lib/features/ev/domain/services/ev_price_calculator.dart
@@ -1,0 +1,276 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../entities/charging_tariff.dart';
+
+part 'ev_price_calculator.freezed.dart';
+part 'ev_price_calculator.g.dart';
+
+/// Detailed breakdown of a single charging session cost.
+///
+/// All monetary fields are denominated in [currency]. `totalCost` is always
+/// the exact sum of the component fields and is never computed with rounding
+/// so that UI code can display it without re-summing.
+@freezed
+abstract class ChargingCostBreakdown with _$ChargingCostBreakdown {
+  const ChargingCostBreakdown._();
+
+  const factory ChargingCostBreakdown({
+    required double totalCost,
+    @Default(0) double energyCost,
+    @Default(0) double timeCost,
+    @Default(0) double flatFee,
+    @Default(0) double parkingCost,
+    @Default(0) double blockingCost,
+    @Default(0) double kwhDelivered,
+    @Default('EUR') String currency,
+  }) = _ChargingCostBreakdown;
+
+  factory ChargingCostBreakdown.fromJson(Map<String, dynamic> json) =>
+      _$ChargingCostBreakdownFromJson(json);
+
+  /// Effective price per kWh, including every fee. Returns `null` if no
+  /// energy was delivered (e.g. pure parking session).
+  double? get effectivePricePerKwh =>
+      kwhDelivered > 0 ? totalCost / kwhDelivered : null;
+}
+
+/// Comparison entry returned by [EvPriceCalculator.compareTariffs].
+@freezed
+abstract class TariffComparisonEntry with _$TariffComparisonEntry {
+  const factory TariffComparisonEntry({
+    required String tariffId,
+    required double totalCost,
+    required String currency,
+  }) = _TariffComparisonEntry;
+
+  factory TariffComparisonEntry.fromJson(Map<String, dynamic> json) =>
+      _$TariffComparisonEntryFromJson(json);
+}
+
+/// Pure utility for deriving session costs from OCPI-style tariffs.
+///
+/// The calculator is stateless; every method is a static function. It is
+/// safe to call from providers, widgets, or background isolates alike.
+class EvPriceCalculator {
+  const EvPriceCalculator._();
+
+  /// Sum every applicable [TariffComponent] from every [TariffElement] in
+  /// [tariff] for the given session metrics.
+  ///
+  /// Time-based components ([PriceComponentType.time],
+  /// [PriceComponentType.blockingTime], [PriceComponentType.parkingTime]) are
+  /// stored per-second in OCPI. We interpret the `price` field as cost per
+  /// minute here because that is what the UI and the tests in this
+  /// codebase already show. `stepSize` is respected for rounding: energy
+  /// components use Wh step sizes, time components use second step sizes,
+  /// flat components are applied as-is.
+  ///
+  /// When [tariff] has multiple elements, the first matching element per
+  /// component type wins — later elements only contribute component types
+  /// that earlier elements did not carry. This mirrors how real providers
+  /// express "cheaper at night" as a separate element rather than nested
+  /// tiers.
+  ///
+  /// Missing components simply produce `0` cost — the caller must decide
+  /// whether a tariff without any components is usable.
+  static ChargingCostBreakdown calculateChargingCost(
+    ChargingTariff tariff,
+    double kwhDelivered,
+    Duration duration, {
+    Duration parkingTime = Duration.zero,
+    Duration blockingTime = Duration.zero,
+    DateTime? startTime,
+  }) {
+    final kwh = kwhDelivered < 0 ? 0.0 : kwhDelivered;
+    final minutes = duration.inSeconds < 0 ? 0.0 : duration.inSeconds / 60.0;
+    final parkingMinutes = parkingTime.inSeconds < 0
+        ? 0.0
+        : parkingTime.inSeconds / 60.0;
+    final blockingMinutes = blockingTime.inSeconds < 0
+        ? 0.0
+        : blockingTime.inSeconds / 60.0;
+
+    double energyCost = 0;
+    double timeCost = 0;
+    double flatFee = 0;
+    double parkingCost = 0;
+    double blockingCost = 0;
+    final seenTypes = <PriceComponentType>{};
+
+    for (final element in tariff.elements) {
+      if (!_restrictionApplies(element.restrictions, startTime, kwh)) {
+        continue;
+      }
+      for (final component in element.priceComponents) {
+        if (seenTypes.contains(component.type)) continue;
+        seenTypes.add(component.type);
+        switch (component.type) {
+          case PriceComponentType.energy:
+            energyCost += _energyCostFor(component, kwh);
+            break;
+          case PriceComponentType.flat:
+            flatFee += component.price;
+            break;
+          case PriceComponentType.time:
+            timeCost += _timeCostFor(component, minutes);
+            break;
+          case PriceComponentType.parkingTime:
+            parkingCost += _timeCostFor(component, parkingMinutes);
+            break;
+          case PriceComponentType.blockingTime:
+            blockingCost += _timeCostFor(component, blockingMinutes);
+            break;
+        }
+      }
+    }
+
+    final total =
+        energyCost + timeCost + flatFee + parkingCost + blockingCost;
+
+    return ChargingCostBreakdown(
+      totalCost: total,
+      energyCost: energyCost,
+      timeCost: timeCost,
+      flatFee: flatFee,
+      parkingCost: parkingCost,
+      blockingCost: blockingCost,
+      kwhDelivered: kwh,
+      currency: tariff.currency,
+    );
+  }
+
+  /// Estimate the cost of charging [vehicle] from [startSoc] to [targetSoc]
+  /// (both in percent, 0-100). Uses the vehicle's [VehicleProfile.batteryKwh]
+  /// and the vehicle's [VehicleProfile.maxChargingKw] to derive duration.
+  ///
+  /// Returns `null` when the vehicle profile is missing battery information
+  /// or when [targetSoc] is not greater than [startSoc].
+  static ChargingCostBreakdown? estimateChargeCost(
+    ChargingTariff tariff,
+    VehicleProfile vehicle, {
+    required double startSoc,
+    required double targetSoc,
+    DateTime? startTime,
+  }) {
+    final battery = vehicle.batteryKwh;
+    if (battery == null || battery <= 0) return null;
+    if (targetSoc <= startSoc) return null;
+
+    final clampedStart = startSoc.clamp(0.0, 100.0);
+    final clampedTarget = targetSoc.clamp(0.0, 100.0);
+    final kwh = battery * (clampedTarget - clampedStart) / 100.0;
+
+    // Rough duration estimate: assume the vehicle charges at 70% of its
+    // rated max to account for tapering above ~80% SoC. When max power is
+    // unknown, assume a conservative 11 kW AC rate.
+    final ratedKw = (vehicle.maxChargingKw ?? 11).toDouble();
+    final effectiveKw = ratedKw <= 0 ? 11.0 : ratedKw * 0.7;
+    final hours = kwh / effectiveKw;
+    final duration = Duration(seconds: (hours * 3600).round());
+
+    return calculateChargingCost(
+      tariff,
+      kwh,
+      duration,
+      startTime: startTime,
+    );
+  }
+
+  /// Evaluate every tariff against the same session profile and return the
+  /// results sorted from cheapest to most expensive.
+  ///
+  /// Tariffs whose currencies differ are still returned in the same list;
+  /// cross-currency comparisons are the caller's responsibility.
+  static List<TariffComparisonEntry> compareTariffs(
+    List<ChargingTariff> tariffs,
+    double kwhDelivered, {
+    Duration duration = Duration.zero,
+    Duration parkingTime = Duration.zero,
+    DateTime? startTime,
+  }) {
+    final entries = <TariffComparisonEntry>[];
+    for (final tariff in tariffs) {
+      final breakdown = calculateChargingCost(
+        tariff,
+        kwhDelivered,
+        duration,
+        parkingTime: parkingTime,
+        startTime: startTime,
+      );
+      entries.add(
+        TariffComparisonEntry(
+          tariffId: tariff.id,
+          totalCost: breakdown.totalCost,
+          currency: breakdown.currency,
+        ),
+      );
+    }
+    entries.sort((a, b) => a.totalCost.compareTo(b.totalCost));
+    return entries;
+  }
+
+  // ---------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------
+
+  static double _energyCostFor(TariffComponent component, double kwh) {
+    if (kwh <= 0 || component.price <= 0) return 0;
+    // stepSize for energy components is in Wh; round up to the next step.
+    final step = component.stepSize <= 0 ? 1 : component.stepSize;
+    final wh = kwh * 1000.0;
+    final steps = (wh / step).ceil();
+    final billedKwh = (steps * step) / 1000.0;
+    return billedKwh * component.price;
+  }
+
+  static double _timeCostFor(TariffComponent component, double minutes) {
+    if (minutes <= 0 || component.price <= 0) return 0;
+    // stepSize for time components is in seconds; round up to the next step.
+    final step = component.stepSize <= 0 ? 1 : component.stepSize;
+    final seconds = minutes * 60.0;
+    final steps = (seconds / step).ceil();
+    final billedMinutes = (steps * step) / 60.0;
+    return billedMinutes * component.price;
+  }
+
+  static bool _restrictionApplies(
+    TariffRestriction? restriction,
+    DateTime? startTime,
+    double kwh,
+  ) {
+    if (restriction == null) return true;
+
+    if (restriction.minKwh != null && kwh < restriction.minKwh!) return false;
+    if (restriction.maxKwh != null && kwh > restriction.maxKwh!) return false;
+
+    if (startTime != null) {
+      if (restriction.daysOfWeek.isNotEmpty &&
+          !restriction.daysOfWeek.contains(startTime.weekday)) {
+        return false;
+      }
+      final start = _parseHhMm(restriction.startTime);
+      final end = _parseHhMm(restriction.endTime);
+      if (start != null && end != null) {
+        final minutes = startTime.hour * 60 + startTime.minute;
+        if (start <= end) {
+          if (minutes < start || minutes >= end) return false;
+        } else {
+          // Window wraps midnight (e.g. 22:00 - 06:00).
+          if (minutes < start && minutes >= end) return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  static int? _parseHhMm(String? value) {
+    if (value == null) return null;
+    final parts = value.split(':');
+    if (parts.length != 2) return null;
+    final h = int.tryParse(parts[0]);
+    final m = int.tryParse(parts[1]);
+    if (h == null || m == null) return null;
+    return h * 60 + m;
+  }
+}

--- a/lib/features/ev/domain/services/ev_price_calculator.freezed.dart
+++ b/lib/features/ev/domain/services/ev_price_calculator.freezed.dart
@@ -1,0 +1,567 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'ev_price_calculator.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChargingCostBreakdown {
+
+ double get totalCost; double get energyCost; double get timeCost; double get flatFee; double get parkingCost; double get blockingCost; double get kwhDelivered; String get currency;
+/// Create a copy of ChargingCostBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChargingCostBreakdownCopyWith<ChargingCostBreakdown> get copyWith => _$ChargingCostBreakdownCopyWithImpl<ChargingCostBreakdown>(this as ChargingCostBreakdown, _$identity);
+
+  /// Serializes this ChargingCostBreakdown to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChargingCostBreakdown&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.energyCost, energyCost) || other.energyCost == energyCost)&&(identical(other.timeCost, timeCost) || other.timeCost == timeCost)&&(identical(other.flatFee, flatFee) || other.flatFee == flatFee)&&(identical(other.parkingCost, parkingCost) || other.parkingCost == parkingCost)&&(identical(other.blockingCost, blockingCost) || other.blockingCost == blockingCost)&&(identical(other.kwhDelivered, kwhDelivered) || other.kwhDelivered == kwhDelivered)&&(identical(other.currency, currency) || other.currency == currency));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,totalCost,energyCost,timeCost,flatFee,parkingCost,blockingCost,kwhDelivered,currency);
+
+@override
+String toString() {
+  return 'ChargingCostBreakdown(totalCost: $totalCost, energyCost: $energyCost, timeCost: $timeCost, flatFee: $flatFee, parkingCost: $parkingCost, blockingCost: $blockingCost, kwhDelivered: $kwhDelivered, currency: $currency)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChargingCostBreakdownCopyWith<$Res>  {
+  factory $ChargingCostBreakdownCopyWith(ChargingCostBreakdown value, $Res Function(ChargingCostBreakdown) _then) = _$ChargingCostBreakdownCopyWithImpl;
+@useResult
+$Res call({
+ double totalCost, double energyCost, double timeCost, double flatFee, double parkingCost, double blockingCost, double kwhDelivered, String currency
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChargingCostBreakdownCopyWithImpl<$Res>
+    implements $ChargingCostBreakdownCopyWith<$Res> {
+  _$ChargingCostBreakdownCopyWithImpl(this._self, this._then);
+
+  final ChargingCostBreakdown _self;
+  final $Res Function(ChargingCostBreakdown) _then;
+
+/// Create a copy of ChargingCostBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? totalCost = null,Object? energyCost = null,Object? timeCost = null,Object? flatFee = null,Object? parkingCost = null,Object? blockingCost = null,Object? kwhDelivered = null,Object? currency = null,}) {
+  return _then(_self.copyWith(
+totalCost: null == totalCost ? _self.totalCost : totalCost // ignore: cast_nullable_to_non_nullable
+as double,energyCost: null == energyCost ? _self.energyCost : energyCost // ignore: cast_nullable_to_non_nullable
+as double,timeCost: null == timeCost ? _self.timeCost : timeCost // ignore: cast_nullable_to_non_nullable
+as double,flatFee: null == flatFee ? _self.flatFee : flatFee // ignore: cast_nullable_to_non_nullable
+as double,parkingCost: null == parkingCost ? _self.parkingCost : parkingCost // ignore: cast_nullable_to_non_nullable
+as double,blockingCost: null == blockingCost ? _self.blockingCost : blockingCost // ignore: cast_nullable_to_non_nullable
+as double,kwhDelivered: null == kwhDelivered ? _self.kwhDelivered : kwhDelivered // ignore: cast_nullable_to_non_nullable
+as double,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ChargingCostBreakdown].
+extension ChargingCostBreakdownPatterns on ChargingCostBreakdown {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChargingCostBreakdown value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChargingCostBreakdown() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChargingCostBreakdown value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChargingCostBreakdown():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChargingCostBreakdown value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChargingCostBreakdown() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double totalCost,  double energyCost,  double timeCost,  double flatFee,  double parkingCost,  double blockingCost,  double kwhDelivered,  String currency)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChargingCostBreakdown() when $default != null:
+return $default(_that.totalCost,_that.energyCost,_that.timeCost,_that.flatFee,_that.parkingCost,_that.blockingCost,_that.kwhDelivered,_that.currency);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double totalCost,  double energyCost,  double timeCost,  double flatFee,  double parkingCost,  double blockingCost,  double kwhDelivered,  String currency)  $default,) {final _that = this;
+switch (_that) {
+case _ChargingCostBreakdown():
+return $default(_that.totalCost,_that.energyCost,_that.timeCost,_that.flatFee,_that.parkingCost,_that.blockingCost,_that.kwhDelivered,_that.currency);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double totalCost,  double energyCost,  double timeCost,  double flatFee,  double parkingCost,  double blockingCost,  double kwhDelivered,  String currency)?  $default,) {final _that = this;
+switch (_that) {
+case _ChargingCostBreakdown() when $default != null:
+return $default(_that.totalCost,_that.energyCost,_that.timeCost,_that.flatFee,_that.parkingCost,_that.blockingCost,_that.kwhDelivered,_that.currency);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ChargingCostBreakdown extends ChargingCostBreakdown {
+  const _ChargingCostBreakdown({required this.totalCost, this.energyCost = 0, this.timeCost = 0, this.flatFee = 0, this.parkingCost = 0, this.blockingCost = 0, this.kwhDelivered = 0, this.currency = 'EUR'}): super._();
+  factory _ChargingCostBreakdown.fromJson(Map<String, dynamic> json) => _$ChargingCostBreakdownFromJson(json);
+
+@override final  double totalCost;
+@override@JsonKey() final  double energyCost;
+@override@JsonKey() final  double timeCost;
+@override@JsonKey() final  double flatFee;
+@override@JsonKey() final  double parkingCost;
+@override@JsonKey() final  double blockingCost;
+@override@JsonKey() final  double kwhDelivered;
+@override@JsonKey() final  String currency;
+
+/// Create a copy of ChargingCostBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChargingCostBreakdownCopyWith<_ChargingCostBreakdown> get copyWith => __$ChargingCostBreakdownCopyWithImpl<_ChargingCostBreakdown>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ChargingCostBreakdownToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChargingCostBreakdown&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.energyCost, energyCost) || other.energyCost == energyCost)&&(identical(other.timeCost, timeCost) || other.timeCost == timeCost)&&(identical(other.flatFee, flatFee) || other.flatFee == flatFee)&&(identical(other.parkingCost, parkingCost) || other.parkingCost == parkingCost)&&(identical(other.blockingCost, blockingCost) || other.blockingCost == blockingCost)&&(identical(other.kwhDelivered, kwhDelivered) || other.kwhDelivered == kwhDelivered)&&(identical(other.currency, currency) || other.currency == currency));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,totalCost,energyCost,timeCost,flatFee,parkingCost,blockingCost,kwhDelivered,currency);
+
+@override
+String toString() {
+  return 'ChargingCostBreakdown(totalCost: $totalCost, energyCost: $energyCost, timeCost: $timeCost, flatFee: $flatFee, parkingCost: $parkingCost, blockingCost: $blockingCost, kwhDelivered: $kwhDelivered, currency: $currency)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChargingCostBreakdownCopyWith<$Res> implements $ChargingCostBreakdownCopyWith<$Res> {
+  factory _$ChargingCostBreakdownCopyWith(_ChargingCostBreakdown value, $Res Function(_ChargingCostBreakdown) _then) = __$ChargingCostBreakdownCopyWithImpl;
+@override @useResult
+$Res call({
+ double totalCost, double energyCost, double timeCost, double flatFee, double parkingCost, double blockingCost, double kwhDelivered, String currency
+});
+
+
+
+
+}
+/// @nodoc
+class __$ChargingCostBreakdownCopyWithImpl<$Res>
+    implements _$ChargingCostBreakdownCopyWith<$Res> {
+  __$ChargingCostBreakdownCopyWithImpl(this._self, this._then);
+
+  final _ChargingCostBreakdown _self;
+  final $Res Function(_ChargingCostBreakdown) _then;
+
+/// Create a copy of ChargingCostBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? totalCost = null,Object? energyCost = null,Object? timeCost = null,Object? flatFee = null,Object? parkingCost = null,Object? blockingCost = null,Object? kwhDelivered = null,Object? currency = null,}) {
+  return _then(_ChargingCostBreakdown(
+totalCost: null == totalCost ? _self.totalCost : totalCost // ignore: cast_nullable_to_non_nullable
+as double,energyCost: null == energyCost ? _self.energyCost : energyCost // ignore: cast_nullable_to_non_nullable
+as double,timeCost: null == timeCost ? _self.timeCost : timeCost // ignore: cast_nullable_to_non_nullable
+as double,flatFee: null == flatFee ? _self.flatFee : flatFee // ignore: cast_nullable_to_non_nullable
+as double,parkingCost: null == parkingCost ? _self.parkingCost : parkingCost // ignore: cast_nullable_to_non_nullable
+as double,blockingCost: null == blockingCost ? _self.blockingCost : blockingCost // ignore: cast_nullable_to_non_nullable
+as double,kwhDelivered: null == kwhDelivered ? _self.kwhDelivered : kwhDelivered // ignore: cast_nullable_to_non_nullable
+as double,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$TariffComparisonEntry {
+
+ String get tariffId; double get totalCost; String get currency;
+/// Create a copy of TariffComparisonEntry
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TariffComparisonEntryCopyWith<TariffComparisonEntry> get copyWith => _$TariffComparisonEntryCopyWithImpl<TariffComparisonEntry>(this as TariffComparisonEntry, _$identity);
+
+  /// Serializes this TariffComparisonEntry to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TariffComparisonEntry&&(identical(other.tariffId, tariffId) || other.tariffId == tariffId)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.currency, currency) || other.currency == currency));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,tariffId,totalCost,currency);
+
+@override
+String toString() {
+  return 'TariffComparisonEntry(tariffId: $tariffId, totalCost: $totalCost, currency: $currency)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TariffComparisonEntryCopyWith<$Res>  {
+  factory $TariffComparisonEntryCopyWith(TariffComparisonEntry value, $Res Function(TariffComparisonEntry) _then) = _$TariffComparisonEntryCopyWithImpl;
+@useResult
+$Res call({
+ String tariffId, double totalCost, String currency
+});
+
+
+
+
+}
+/// @nodoc
+class _$TariffComparisonEntryCopyWithImpl<$Res>
+    implements $TariffComparisonEntryCopyWith<$Res> {
+  _$TariffComparisonEntryCopyWithImpl(this._self, this._then);
+
+  final TariffComparisonEntry _self;
+  final $Res Function(TariffComparisonEntry) _then;
+
+/// Create a copy of TariffComparisonEntry
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? tariffId = null,Object? totalCost = null,Object? currency = null,}) {
+  return _then(_self.copyWith(
+tariffId: null == tariffId ? _self.tariffId : tariffId // ignore: cast_nullable_to_non_nullable
+as String,totalCost: null == totalCost ? _self.totalCost : totalCost // ignore: cast_nullable_to_non_nullable
+as double,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TariffComparisonEntry].
+extension TariffComparisonEntryPatterns on TariffComparisonEntry {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TariffComparisonEntry value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TariffComparisonEntry() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TariffComparisonEntry value)  $default,){
+final _that = this;
+switch (_that) {
+case _TariffComparisonEntry():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TariffComparisonEntry value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TariffComparisonEntry() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String tariffId,  double totalCost,  String currency)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TariffComparisonEntry() when $default != null:
+return $default(_that.tariffId,_that.totalCost,_that.currency);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String tariffId,  double totalCost,  String currency)  $default,) {final _that = this;
+switch (_that) {
+case _TariffComparisonEntry():
+return $default(_that.tariffId,_that.totalCost,_that.currency);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String tariffId,  double totalCost,  String currency)?  $default,) {final _that = this;
+switch (_that) {
+case _TariffComparisonEntry() when $default != null:
+return $default(_that.tariffId,_that.totalCost,_that.currency);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TariffComparisonEntry implements TariffComparisonEntry {
+  const _TariffComparisonEntry({required this.tariffId, required this.totalCost, required this.currency});
+  factory _TariffComparisonEntry.fromJson(Map<String, dynamic> json) => _$TariffComparisonEntryFromJson(json);
+
+@override final  String tariffId;
+@override final  double totalCost;
+@override final  String currency;
+
+/// Create a copy of TariffComparisonEntry
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TariffComparisonEntryCopyWith<_TariffComparisonEntry> get copyWith => __$TariffComparisonEntryCopyWithImpl<_TariffComparisonEntry>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TariffComparisonEntryToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TariffComparisonEntry&&(identical(other.tariffId, tariffId) || other.tariffId == tariffId)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.currency, currency) || other.currency == currency));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,tariffId,totalCost,currency);
+
+@override
+String toString() {
+  return 'TariffComparisonEntry(tariffId: $tariffId, totalCost: $totalCost, currency: $currency)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TariffComparisonEntryCopyWith<$Res> implements $TariffComparisonEntryCopyWith<$Res> {
+  factory _$TariffComparisonEntryCopyWith(_TariffComparisonEntry value, $Res Function(_TariffComparisonEntry) _then) = __$TariffComparisonEntryCopyWithImpl;
+@override @useResult
+$Res call({
+ String tariffId, double totalCost, String currency
+});
+
+
+
+
+}
+/// @nodoc
+class __$TariffComparisonEntryCopyWithImpl<$Res>
+    implements _$TariffComparisonEntryCopyWith<$Res> {
+  __$TariffComparisonEntryCopyWithImpl(this._self, this._then);
+
+  final _TariffComparisonEntry _self;
+  final $Res Function(_TariffComparisonEntry) _then;
+
+/// Create a copy of TariffComparisonEntry
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? tariffId = null,Object? totalCost = null,Object? currency = null,}) {
+  return _then(_TariffComparisonEntry(
+tariffId: null == tariffId ? _self.tariffId : tariffId // ignore: cast_nullable_to_non_nullable
+as String,totalCost: null == totalCost ? _self.totalCost : totalCost // ignore: cast_nullable_to_non_nullable
+as double,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/ev/domain/services/ev_price_calculator.g.dart
+++ b/lib/features/ev/domain/services/ev_price_calculator.g.dart
@@ -1,0 +1,49 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ev_price_calculator.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChargingCostBreakdown _$ChargingCostBreakdownFromJson(
+  Map<String, dynamic> json,
+) => _ChargingCostBreakdown(
+  totalCost: (json['totalCost'] as num).toDouble(),
+  energyCost: (json['energyCost'] as num?)?.toDouble() ?? 0,
+  timeCost: (json['timeCost'] as num?)?.toDouble() ?? 0,
+  flatFee: (json['flatFee'] as num?)?.toDouble() ?? 0,
+  parkingCost: (json['parkingCost'] as num?)?.toDouble() ?? 0,
+  blockingCost: (json['blockingCost'] as num?)?.toDouble() ?? 0,
+  kwhDelivered: (json['kwhDelivered'] as num?)?.toDouble() ?? 0,
+  currency: json['currency'] as String? ?? 'EUR',
+);
+
+Map<String, dynamic> _$ChargingCostBreakdownToJson(
+  _ChargingCostBreakdown instance,
+) => <String, dynamic>{
+  'totalCost': instance.totalCost,
+  'energyCost': instance.energyCost,
+  'timeCost': instance.timeCost,
+  'flatFee': instance.flatFee,
+  'parkingCost': instance.parkingCost,
+  'blockingCost': instance.blockingCost,
+  'kwhDelivered': instance.kwhDelivered,
+  'currency': instance.currency,
+};
+
+_TariffComparisonEntry _$TariffComparisonEntryFromJson(
+  Map<String, dynamic> json,
+) => _TariffComparisonEntry(
+  tariffId: json['tariffId'] as String,
+  totalCost: (json['totalCost'] as num).toDouble(),
+  currency: json['currency'] as String,
+);
+
+Map<String, dynamic> _$TariffComparisonEntryToJson(
+  _TariffComparisonEntry instance,
+) => <String, dynamic>{
+  'tariffId': instance.tariffId,
+  'totalCost': instance.totalCost,
+  'currency': instance.currency,
+};

--- a/test/features/ev/domain/charging_station_test.dart
+++ b/test/features/ev/domain/charging_station_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/ev/domain/entities/opening_hours.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+
+void main() {
+  group('ChargingStation', () {
+    ChargingStation sample() => ChargingStation(
+          id: 'station-1',
+          name: 'Ionity Strasbourg',
+          operator: 'Ionity',
+          latitude: 48.5734,
+          longitude: 7.7521,
+          address: '67000 Strasbourg, France',
+          connectors: const [
+            EvConnector(
+              id: 'c1',
+              type: ConnectorType.ccs,
+              maxPowerKw: 350,
+              status: ConnectorStatus.available,
+              tariffId: 'tariff-1',
+            ),
+            EvConnector(
+              id: 'c2',
+              type: ConnectorType.type2,
+              maxPowerKw: 22,
+              status: ConnectorStatus.occupied,
+            ),
+          ],
+          amenities: const ['restroom', 'cafe'],
+          openingHours: const OpeningHours(twentyFourSeven: true),
+          lastUpdate: DateTime.utc(2026, 4, 8, 10, 0),
+        );
+
+    test('JSON round-trip preserves every field', () {
+      final original = sample();
+      final json = original.toJson();
+      final restored = ChargingStation.fromJson(json);
+      expect(restored, original);
+    });
+
+    test('hasAvailableConnector reflects connector status', () {
+      expect(sample().hasAvailableConnector, isTrue);
+      final none = sample().copyWith(
+        connectors: const [
+          EvConnector(
+            id: 'c',
+            type: ConnectorType.ccs,
+            maxPowerKw: 50,
+            status: ConnectorStatus.outOfOrder,
+          ),
+        ],
+      );
+      expect(none.hasAvailableConnector, isFalse);
+    });
+
+    test('maxPowerKw returns the highest connector rating', () {
+      expect(sample().maxPowerKw, 350);
+    });
+
+    test('maxPowerKw returns 0 for empty connectors', () {
+      final empty = sample().copyWith(connectors: const []);
+      expect(empty.maxPowerKw, 0);
+    });
+
+    test('connector without tariffId round-trips', () {
+      const conn = EvConnector(
+        id: 'x',
+        type: ConnectorType.chademo,
+        maxPowerKw: 50,
+      );
+      final restored = EvConnector.fromJson(conn.toJson());
+      expect(restored, conn);
+      expect(restored.status, ConnectorStatus.unknown);
+    });
+
+    test('openingHours with regular hours round-trips', () {
+      const hours = OpeningHours(
+        regularHours: [
+          RegularHours(
+            weekday: 1,
+            periodBegin: '06:00',
+            periodEnd: '22:00',
+          ),
+          RegularHours(
+            weekday: 7,
+            periodBegin: '08:00',
+            periodEnd: '20:00',
+          ),
+        ],
+      );
+      final restored = OpeningHours.fromJson(hours.toJson());
+      expect(restored, hours);
+    });
+
+    test('ConnectorStatus.fromKey handles unknown values', () {
+      expect(ConnectorStatus.fromKey(null), ConnectorStatus.unknown);
+      expect(ConnectorStatus.fromKey('bogus'), ConnectorStatus.unknown);
+      expect(
+        ConnectorStatus.fromKey('out_of_order'),
+        ConnectorStatus.outOfOrder,
+      );
+    });
+  });
+}

--- a/test/features/ev/domain/charging_tariff_test.dart
+++ b/test/features/ev/domain/charging_tariff_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_tariff.dart';
+
+void main() {
+  group('ChargingTariff', () {
+    const energyOnly = ChargingTariff(
+      id: 'tariff-1',
+      currency: 'EUR',
+      elements: [
+        TariffElement(
+          priceComponents: [
+            TariffComponent(
+              type: PriceComponentType.energy,
+              price: 0.39,
+              stepSize: 1,
+            ),
+          ],
+        ),
+      ],
+    );
+
+    test('energy-only tariff round-trips through JSON', () {
+      final restored = ChargingTariff.fromJson(energyOnly.toJson());
+      expect(restored, energyOnly);
+    });
+
+    test('complex tariff with restrictions round-trips through JSON', () {
+      const tariff = ChargingTariff(
+        id: 'tariff-complex',
+        currency: 'EUR',
+        type: TariffType.adHocPayment,
+        elements: [
+          TariffElement(
+            priceComponents: [
+              TariffComponent(
+                type: PriceComponentType.energy,
+                price: 0.79,
+                stepSize: 1000,
+              ),
+              TariffComponent(
+                type: PriceComponentType.flat,
+                price: 1.0,
+              ),
+              TariffComponent(
+                type: PriceComponentType.time,
+                price: 0.1,
+                stepSize: 60,
+              ),
+              TariffComponent(
+                type: PriceComponentType.parkingTime,
+                price: 0.05,
+                stepSize: 60,
+              ),
+              TariffComponent(
+                type: PriceComponentType.blockingTime,
+                price: 0.2,
+                stepSize: 60,
+              ),
+            ],
+            restrictions: TariffRestriction(
+              startTime: '22:00',
+              endTime: '06:00',
+              daysOfWeek: [1, 2, 3, 4, 5],
+              minKwh: 1.0,
+              maxKwh: 200.0,
+            ),
+          ),
+        ],
+      );
+      final restored = ChargingTariff.fromJson(tariff.toJson());
+      expect(restored, tariff);
+    });
+
+    test('headlinePricePerKwh picks the first energy component', () {
+      expect(energyOnly.headlinePricePerKwh, 0.39);
+
+      const multi = ChargingTariff(
+        id: 't',
+        elements: [
+          TariffElement(
+            priceComponents: [
+              TariffComponent(type: PriceComponentType.flat, price: 0.5),
+            ],
+          ),
+          TariffElement(
+            priceComponents: [
+              TariffComponent(
+                type: PriceComponentType.energy,
+                price: 0.42,
+              ),
+            ],
+          ),
+        ],
+      );
+      expect(multi.headlinePricePerKwh, 0.42);
+    });
+
+    test('headlinePricePerKwh returns null when no energy component exists', () {
+      const timeOnly = ChargingTariff(
+        id: 't',
+        elements: [
+          TariffElement(
+            priceComponents: [
+              TariffComponent(type: PriceComponentType.time, price: 0.1),
+            ],
+          ),
+        ],
+      );
+      expect(timeOnly.headlinePricePerKwh, isNull);
+    });
+
+    test('enum.fromKey falls back to defaults on unknown input', () {
+      expect(
+        PriceComponentType.fromKey('bogus'),
+        PriceComponentType.energy,
+      );
+      expect(TariffType.fromKey(null), TariffType.regular);
+    });
+  });
+}

--- a/test/features/ev/domain/services/ev_price_calculator_test.dart
+++ b/test/features/ev/domain/services/ev_price_calculator_test.dart
@@ -1,0 +1,435 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_tariff.dart';
+import 'package:tankstellen/features/ev/domain/services/ev_price_calculator.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+/// Builds a single-element tariff from a flat list of components.
+ChargingTariff _tariff(
+  List<TariffComponent> components, {
+  String id = 't',
+  String currency = 'EUR',
+  TariffRestriction? restrictions,
+}) =>
+    ChargingTariff(
+      id: id,
+      currency: currency,
+      elements: [
+        TariffElement(
+          priceComponents: components,
+          restrictions: restrictions,
+        ),
+      ],
+    );
+
+void main() {
+  group('EvPriceCalculator.calculateChargingCost', () {
+    test('energy-only tariff bills kWh at the component price', () {
+      final tariff = _tariff(const [
+        TariffComponent(
+          type: PriceComponentType.energy,
+          price: 0.39,
+        ),
+      ]);
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        40.0,
+        const Duration(minutes: 45),
+      );
+      expect(cost.energyCost, closeTo(15.60, 1e-9));
+      expect(cost.totalCost, closeTo(15.60, 1e-9));
+      expect(cost.timeCost, 0);
+      expect(cost.flatFee, 0);
+      expect(cost.currency, 'EUR');
+      expect(cost.kwhDelivered, 40.0);
+      expect(cost.effectivePricePerKwh, closeTo(0.39, 1e-9));
+    });
+
+    test('time-only tariff bills duration per minute', () {
+      final tariff = _tariff(const [
+        TariffComponent(type: PriceComponentType.time, price: 0.10),
+      ]);
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        0,
+        const Duration(minutes: 30),
+      );
+      expect(cost.timeCost, closeTo(3.0, 1e-9));
+      expect(cost.totalCost, closeTo(3.0, 1e-9));
+      expect(cost.effectivePricePerKwh, isNull);
+    });
+
+    test('flat fee is charged exactly once', () {
+      final tariff = _tariff(const [
+        TariffComponent(type: PriceComponentType.flat, price: 1.0),
+      ]);
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        10,
+        const Duration(minutes: 20),
+      );
+      expect(cost.flatFee, 1.0);
+      expect(cost.totalCost, 1.0);
+    });
+
+    test('combined energy + time + flat tariff sums all components', () {
+      final tariff = _tariff(const [
+        TariffComponent(type: PriceComponentType.energy, price: 0.45),
+        TariffComponent(type: PriceComponentType.time, price: 0.10),
+        TariffComponent(type: PriceComponentType.flat, price: 1.0),
+      ]);
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        40.0,
+        const Duration(minutes: 45),
+      );
+      expect(cost.energyCost, closeTo(18.0, 1e-9));
+      expect(cost.timeCost, closeTo(4.5, 1e-9));
+      expect(cost.flatFee, 1.0);
+      expect(cost.totalCost, closeTo(23.5, 1e-9));
+    });
+
+    test('parking fee is billed per parking minute only', () {
+      final tariff = _tariff(const [
+        TariffComponent(type: PriceComponentType.energy, price: 0.30),
+        TariffComponent(type: PriceComponentType.parkingTime, price: 0.20),
+      ]);
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        20,
+        const Duration(minutes: 30),
+        parkingTime: const Duration(minutes: 15),
+      );
+      expect(cost.energyCost, closeTo(6.0, 1e-9));
+      expect(cost.parkingCost, closeTo(3.0, 1e-9));
+      expect(cost.totalCost, closeTo(9.0, 1e-9));
+    });
+
+    test('blocking fee is billed per blocking minute only', () {
+      final tariff = _tariff(const [
+        TariffComponent(type: PriceComponentType.blockingTime, price: 0.50),
+      ]);
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        0,
+        Duration.zero,
+        blockingTime: const Duration(minutes: 10),
+      );
+      expect(cost.blockingCost, closeTo(5.0, 1e-9));
+      expect(cost.totalCost, closeTo(5.0, 1e-9));
+    });
+
+    test('zero kwh + zero duration returns zero cost', () {
+      final tariff = _tariff(const [
+        TariffComponent(type: PriceComponentType.energy, price: 0.39),
+        TariffComponent(type: PriceComponentType.time, price: 0.10),
+      ]);
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        0,
+        Duration.zero,
+      );
+      expect(cost.totalCost, 0);
+      expect(cost.effectivePricePerKwh, isNull);
+    });
+
+    test('negative inputs are clamped to zero', () {
+      final tariff = _tariff(const [
+        TariffComponent(type: PriceComponentType.energy, price: 0.39),
+      ]);
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        -5,
+        const Duration(seconds: -10),
+      );
+      expect(cost.totalCost, 0);
+      expect(cost.kwhDelivered, 0);
+    });
+
+    test('tariff with no components produces zero cost', () {
+      final tariff = _tariff(const []);
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        40,
+        const Duration(minutes: 30),
+      );
+      expect(cost.totalCost, 0);
+    });
+
+    test('completely empty tariff with no elements produces zero cost', () {
+      const tariff = ChargingTariff(id: 'empty');
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        10,
+        const Duration(minutes: 10),
+      );
+      expect(cost.totalCost, 0);
+    });
+
+    test('energy stepSize rounds up to whole Wh increments', () {
+      final tariff = _tariff(const [
+        TariffComponent(
+          type: PriceComponentType.energy,
+          price: 1.0,
+          stepSize: 1000, // 1 kWh increments
+        ),
+      ]);
+      // 40.3 kWh -> billed as 41 kWh
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        40.3,
+        const Duration(minutes: 30),
+      );
+      expect(cost.energyCost, closeTo(41.0, 1e-9));
+    });
+
+    test('time stepSize rounds up to whole seconds', () {
+      final tariff = _tariff(const [
+        TariffComponent(
+          type: PriceComponentType.time,
+          price: 0.60,
+          stepSize: 900, // 15 minute blocks
+        ),
+      ]);
+      // 16 minutes -> billed as 30 minutes (two blocks)
+      final cost = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        0,
+        const Duration(minutes: 16),
+      );
+      expect(cost.timeCost, closeTo(18.0, 1e-9));
+    });
+
+    test('first matching element wins for a given component type', () {
+      const tariff = ChargingTariff(
+        id: 'tiered',
+        elements: [
+          TariffElement(
+            priceComponents: [
+              TariffComponent(
+                type: PriceComponentType.energy,
+                price: 0.20,
+              ),
+            ],
+            restrictions: TariffRestriction(minKwh: 50),
+          ),
+          TariffElement(
+            priceComponents: [
+              TariffComponent(
+                type: PriceComponentType.energy,
+                price: 0.39,
+              ),
+            ],
+          ),
+        ],
+      );
+      // 10 kWh -> first element skipped (min 50), second matches
+      final cheap = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        10,
+        const Duration(minutes: 10),
+      );
+      expect(cheap.energyCost, closeTo(3.9, 1e-9));
+
+      // 100 kWh -> first element wins (0.20/kWh)
+      final bulk = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        100,
+        const Duration(minutes: 60),
+      );
+      expect(bulk.energyCost, closeTo(20.0, 1e-9));
+    });
+
+    test('time-of-day restriction filters element when startTime is outside',
+        () {
+      const tariff = ChargingTariff(
+        id: 'night',
+        elements: [
+          TariffElement(
+            priceComponents: [
+              TariffComponent(
+                type: PriceComponentType.energy,
+                price: 0.20,
+              ),
+            ],
+            restrictions:
+                TariffRestriction(startTime: '22:00', endTime: '06:00'),
+          ),
+          TariffElement(
+            priceComponents: [
+              TariffComponent(
+                type: PriceComponentType.energy,
+                price: 0.45,
+              ),
+            ],
+          ),
+        ],
+      );
+      final day = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        10,
+        const Duration(minutes: 20),
+        startTime: DateTime(2026, 4, 8, 14, 0),
+      );
+      expect(day.energyCost, closeTo(4.5, 1e-9));
+
+      final night = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        10,
+        const Duration(minutes: 20),
+        startTime: DateTime(2026, 4, 8, 23, 30),
+      );
+      expect(night.energyCost, closeTo(2.0, 1e-9));
+    });
+
+    test('day-of-week restriction filters element', () {
+      const tariff = ChargingTariff(
+        id: 'weekday',
+        elements: [
+          TariffElement(
+            priceComponents: [
+              TariffComponent(
+                type: PriceComponentType.energy,
+                price: 0.25,
+              ),
+            ],
+            restrictions: TariffRestriction(daysOfWeek: [1, 2, 3, 4, 5]),
+          ),
+          TariffElement(
+            priceComponents: [
+              TariffComponent(
+                type: PriceComponentType.energy,
+                price: 0.50,
+              ),
+            ],
+          ),
+        ],
+      );
+      // 2026-04-08 is a Wednesday -> weekday rate
+      final wed = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        10,
+        Duration.zero,
+        startTime: DateTime(2026, 4, 8, 12, 0),
+      );
+      expect(wed.energyCost, closeTo(2.5, 1e-9));
+
+      // 2026-04-11 is a Saturday -> fallback rate
+      final sat = EvPriceCalculator.calculateChargingCost(
+        tariff,
+        10,
+        Duration.zero,
+        startTime: DateTime(2026, 4, 11, 12, 0),
+      );
+      expect(sat.energyCost, closeTo(5.0, 1e-9));
+    });
+  });
+
+  group('EvPriceCalculator.estimateChargeCost', () {
+    const vehicle = VehicleProfile(
+      id: 'v1',
+      name: 'Zoe',
+      type: VehicleType.ev,
+      batteryKwh: 52.0,
+      maxChargingKw: 50.0,
+      supportedConnectors: {ConnectorType.ccs, ConnectorType.type2},
+    );
+
+    final tariff = _tariff(const [
+      TariffComponent(type: PriceComponentType.energy, price: 0.40),
+    ]);
+
+    test('estimates kWh from SoC delta and battery capacity', () {
+      final cost = EvPriceCalculator.estimateChargeCost(
+        tariff,
+        vehicle,
+        startSoc: 20,
+        targetSoc: 80,
+      );
+      expect(cost, isNotNull);
+      // 60% of 52 kWh = 31.2 kWh @ 0.40 = 12.48
+      expect(cost!.kwhDelivered, closeTo(31.2, 1e-9));
+      expect(cost.totalCost, closeTo(12.48, 1e-6));
+    });
+
+    test('returns null when battery capacity is unknown', () {
+      final noBattery = vehicle.copyWith(batteryKwh: null);
+      expect(
+        EvPriceCalculator.estimateChargeCost(
+          tariff,
+          noBattery,
+          startSoc: 20,
+          targetSoc: 80,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null when targetSoc is not greater than startSoc', () {
+      expect(
+        EvPriceCalculator.estimateChargeCost(
+          tariff,
+          vehicle,
+          startSoc: 80,
+          targetSoc: 80,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('EvPriceCalculator.compareTariffs', () {
+    test('returns entries sorted by total cost ascending', () {
+      final a = _tariff(
+        const [
+          TariffComponent(type: PriceComponentType.energy, price: 0.45),
+          TariffComponent(type: PriceComponentType.flat, price: 1.0),
+        ],
+        id: 'a',
+      );
+      final b = _tariff(
+        const [
+          TariffComponent(type: PriceComponentType.energy, price: 0.39),
+        ],
+        id: 'b',
+      );
+      final c = _tariff(
+        const [
+          TariffComponent(type: PriceComponentType.energy, price: 0.60),
+        ],
+        id: 'c',
+      );
+
+      final entries = EvPriceCalculator.compareTariffs(
+        [a, b, c],
+        40,
+        duration: const Duration(minutes: 30),
+      );
+      expect(entries.map((e) => e.tariffId).toList(), ['b', 'a', 'c']);
+      expect(entries.first.totalCost, closeTo(15.6, 1e-9));
+      expect(entries.last.totalCost, closeTo(24.0, 1e-9));
+    });
+
+    test('returns an empty list when no tariffs are provided', () {
+      expect(EvPriceCalculator.compareTariffs(const [], 10), isEmpty);
+    });
+  });
+
+  group('ChargingCostBreakdown JSON', () {
+    test('round-trips through JSON', () {
+      const breakdown = ChargingCostBreakdown(
+        totalCost: 23.5,
+        energyCost: 18.0,
+        timeCost: 4.5,
+        flatFee: 1.0,
+        parkingCost: 0,
+        blockingCost: 0,
+        kwhDelivered: 40,
+        currency: 'EUR',
+      );
+      final restored =
+          ChargingCostBreakdown.fromJson(breakdown.toJson());
+      expect(restored, breakdown);
+      expect(restored.effectivePricePerKwh, closeTo(0.5875, 1e-9));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Foundational EV domain layer for epic #171. Pure models plus a stateless price calculator — no UI, no services, no providers.

- **ChargingStation / EvConnector / OpeningHours** — station model with OCPI-aligned connector status, amenities, and opening hours (24/7 or weekday windows).
- **ChargingTariff / TariffElement / TariffComponent / TariffRestriction** — OCPI 2.2.1 tariff structure supporting `energy`, `flat`, `time`, `parking_time`, and `blocking_time` components with optional time-of-day, day-of-week, and min/max kWh restrictions. Exposes `headlinePricePerKwh` for map markers.
- **EvPriceCalculator** — stateless utility:
  - `calculateChargingCost` sums applicable components, respects `stepSize` (Wh for energy, seconds for time), picks the first matching element per component type via restrictions
  - `estimateChargeCost` derives kWh + duration from a `VehicleProfile` SoC delta
  - `compareTariffs` ranks tariffs cheapest-first

All freezed classes serialize nested structures via explicit `JsonConverter`s to keep Hive round-trips safe (see #176 gotcha).

## Why

EV charging costs are multi-component (energy + flat + time + parking + blocking) with time-of-day restrictions. The data model has to mirror OCPI so future ingestion from DATEX II / OCPI / OpenChargeMap / Bundesnetzagentur maps cleanly. The calculator is needed by the upcoming EV map client (#177) to compute headline and detailed prices.

## Test plan

- [x] 33 new unit tests, all green
- [x] JSON round-trip for every entity (station, connector, tariff, restrictions, opening hours, cost breakdown)
- [x] Headline price extraction (present, absent, multi-element)
- [x] Every `PriceComponentType` variant billed correctly
- [x] `stepSize` rounding for energy (Wh) and time (seconds) components
- [x] Restriction filtering: time-of-day (including midnight wrap), day-of-week, min/max kWh
- [x] First-matching-element semantics for tiered pricing
- [x] Vehicle-based estimate with SoC delta and battery capacity
- [x] Edge cases: negative inputs, empty tariff, no components, zero kWh, cross-tariff comparison
- [x] `flutter analyze --no-fatal-infos` — no warnings
- [x] `flutter test` — 3073 pass (1 known-flaky Argentina network test unrelated to this PR)

Closes #172
Closes #175

Part of epic #171.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>