### PR TITLE
refactor: remove data/ imports from presentation layer

### DIFF
--- a/lib/features/alerts/domain/entities/price_alert.dart
+++ b/lib/features/alerts/domain/entities/price_alert.dart
@@ -1,0 +1,9 @@
+/// Domain entity re-export for PriceAlert.
+///
+/// Presentation and cross-feature consumers must import this path instead of
+/// reaching into `data/models/`. The underlying class lives in the data layer
+/// because it is persisted via Hive/Supabase, but its shape is a pure domain
+/// concept and is safe to expose as an entity.
+library;
+
+export '../../data/models/price_alert.dart';

--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -5,7 +5,7 @@ import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../data/models/price_alert.dart';
+import '../../domain/entities/price_alert.dart';
 import '../../providers/alert_provider.dart';
 import '../widgets/alert_statistics_card.dart';
 

--- a/lib/features/alerts/presentation/widgets/create_alert_dialog.dart
+++ b/lib/features/alerts/presentation/widgets/create_alert_dialog.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
-import '../../data/models/price_alert.dart';
+import '../../domain/entities/price_alert.dart';
 
 /// Dialog for creating a new price alert from the station detail screen.
 ///

--- a/lib/features/price_history/data/repositories/price_history_repository.dart
+++ b/lib/features/price_history/data/repositories/price_history_repository.dart
@@ -1,27 +1,13 @@
 import 'package:flutter/foundation.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../../core/data/storage_repository.dart';
+import '../../domain/entities/price_stats.dart';
 import '../models/price_record.dart';
 
-/// Trend direction for a fuel price over a time window.
-enum PriceTrend { up, down, stable }
-
-/// Aggregate statistics for a single fuel type at a station.
-class PriceStats {
-  final double? min;
-  final double? max;
-  final double? avg;
-  final double? current;
-  final PriceTrend trend;
-
-  const PriceStats({
-    this.min,
-    this.max,
-    this.avg,
-    this.current,
-    this.trend = PriceTrend.stable,
-  });
-}
+// Re-export PriceStats / PriceTrend so existing `price_history_repository.dart`
+// consumers continue to compile. New code should import directly from
+// `domain/entities/price_stats.dart`.
+export '../../domain/entities/price_stats.dart';
 
 /// Persists price snapshots per station via [PriceHistoryStorage] and provides
 /// query/aggregation methods for price history analysis.

--- a/lib/features/price_history/domain/entities/price_prediction.dart
+++ b/lib/features/price_history/domain/entities/price_prediction.dart
@@ -1,0 +1,8 @@
+/// Domain entity re-export for PricePrediction and its supporting value types.
+///
+/// Presentation and cross-feature consumers must import this path instead of
+/// reaching into `data/models/`. PricePrediction is a pure computed result
+/// with no persistence concerns, so it is a first-class domain entity.
+library;
+
+export '../../data/models/price_prediction.dart';

--- a/lib/features/price_history/domain/entities/price_record.dart
+++ b/lib/features/price_history/domain/entities/price_record.dart
@@ -1,0 +1,9 @@
+/// Domain entity re-export for PriceRecord.
+///
+/// Presentation and cross-feature consumers must import this path instead of
+/// reaching into `data/models/`. The underlying class lives in the data layer
+/// because it is persisted via Hive, but its shape is a pure domain concept
+/// and is safe to expose as an entity.
+library;
+
+export '../../data/models/price_record.dart';

--- a/lib/features/price_history/domain/entities/price_stats.dart
+++ b/lib/features/price_history/domain/entities/price_stats.dart
@@ -1,0 +1,22 @@
+/// Trend direction for a fuel price over a time window.
+enum PriceTrend { up, down, stable }
+
+/// Aggregate statistics for a single fuel type at a station.
+///
+/// Pure value object with no persistence concerns — safe to import from the
+/// presentation layer.
+class PriceStats {
+  final double? min;
+  final double? max;
+  final double? avg;
+  final double? current;
+  final PriceTrend trend;
+
+  const PriceStats({
+    this.min,
+    this.max,
+    this.avg,
+    this.current,
+    this.trend = PriceTrend.stable,
+  });
+}

--- a/lib/features/price_history/presentation/widgets/best_time_banner.dart
+++ b/lib/features/price_history/presentation/widgets/best_time_banner.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../search/domain/entities/fuel_type.dart';
-import '../../data/models/price_prediction.dart';
+import '../../domain/entities/price_prediction.dart';
 import '../../providers/price_prediction_provider.dart';
 
 /// A compact banner that shows the "best time to fill" recommendation.

--- a/lib/features/price_history/presentation/widgets/hourly_price_chart.dart
+++ b/lib/features/price_history/presentation/widgets/hourly_price_chart.dart
@@ -2,7 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
-import '../../data/models/price_prediction.dart';
+import '../../domain/entities/price_prediction.dart';
 
 /// A vertical bar chart showing average price by hour of day (0-23).
 ///

--- a/lib/features/price_history/presentation/widgets/price_chart.dart
+++ b/lib/features/price_history/presentation/widgets/price_chart.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../search/domain/entities/fuel_type.dart';
-import '../../data/models/price_record.dart';
+import '../../domain/entities/price_record.dart';
 
 /// A simple line chart that renders price history using [CustomPainter].
 ///

--- a/lib/features/price_history/presentation/widgets/price_stats_card.dart
+++ b/lib/features/price_history/presentation/widgets/price_stats_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
-import '../../data/repositories/price_history_repository.dart';
+import '../../domain/entities/price_stats.dart';
 
 /// Displays aggregate price statistics (min, max, avg, current) with
 /// a trend indicator arrow.

--- a/lib/features/profile/domain/entities/user_profile.dart
+++ b/lib/features/profile/domain/entities/user_profile.dart
@@ -1,0 +1,9 @@
+/// Domain entity re-export for UserProfile.
+///
+/// Presentation and cross-feature consumers must import this path instead of
+/// reaching into `data/models/`. The underlying class lives in the data layer
+/// because it is persisted via Hive, but its shape is a pure domain concept
+/// and is safe to expose as an entity.
+library;
+
+export '../../data/models/user_profile.dart';

--- a/lib/features/profile/presentation/widgets/location_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/location_section_widget.dart
@@ -5,7 +5,6 @@ import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../data/repositories/profile_repository.dart';
 import '../../providers/profile_provider.dart';
 
 /// GPS position management section for the profile/settings screen.

--- a/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
@@ -5,7 +5,7 @@ import '../../../../core/country/country_config.dart';
 import '../../../../core/language/language_provider.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
-import '../../data/models/user_profile.dart';
+import '../../domain/entities/user_profile.dart';
 import '../../providers/profile_edit_provider.dart';
 
 /// Profile edit bottom sheet. Form state (fuel, radius, rating mode, etc.)

--- a/lib/features/profile/presentation/widgets/profile_list_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_list_section.dart
@@ -4,8 +4,7 @@ import '../../../../core/country/country_config.dart';
 import '../../../../core/language/language_provider.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../data/models/user_profile.dart';
-import '../../data/repositories/profile_repository.dart';
+import '../../domain/entities/user_profile.dart';
 import '../../providers/profile_provider.dart';
 import 'profile_edit_sheet.dart';
 

--- a/lib/features/profile/providers/profile_provider.dart
+++ b/lib/features/profile/providers/profile_provider.dart
@@ -1,6 +1,11 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import '../data/models/user_profile.dart';
+import '../domain/entities/user_profile.dart';
 import '../data/repositories/profile_repository.dart';
+
+// Re-export the generated repository provider so presentation code can read
+// it via the providers/ layer without reaching into data/. The repository
+// class itself stays internal to the data layer.
+export '../data/repositories/profile_repository.dart' show profileRepositoryProvider;
 
 part 'profile_provider.g.dart';
 

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -30,7 +30,7 @@ import '../../domain/entities/search_mode.dart';
 import '../../domain/entities/search_result_item.dart';
 import '../../domain/entities/station.dart';
 import '../widgets/ev_station_card.dart';
-import '../../../profile/data/models/user_profile.dart';
+import '../../../profile/domain/entities/user_profile.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../widgets/mode_chip.dart';
 import '../widgets/nearest_shortcut_card.dart';

--- a/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
+++ b/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
@@ -6,7 +6,6 @@ import '../../../../core/language/language_provider.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../profile/data/repositories/profile_repository.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../providers/api_key_validator_provider.dart';
 import '../../providers/onboarding_wizard_provider.dart';

--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -10,7 +10,6 @@ import '../../../../core/language/language_provider.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../profile/data/repositories/profile_repository.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../data/api_key_validator.dart';
 import '../../providers/api_key_validator_provider.dart';

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -8,7 +8,7 @@ import '../../../../core/widgets/brand_logo.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../alerts/data/models/price_alert.dart';
+import '../../../alerts/domain/entities/price_alert.dart';
 import '../../../alerts/presentation/widgets/create_alert_dialog.dart';
 import '../../../alerts/providers/alert_provider.dart';
 import '../../../favorites/providers/favorites_provider.dart';

--- a/lib/features/station_detail/presentation/widgets/price_history_section.dart
+++ b/lib/features/station_detail/presentation/widgets/price_history_section.dart
@@ -5,7 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/sync/sync_service.dart';
-import '../../../price_history/data/models/price_record.dart';
+import '../../../price_history/domain/entities/price_record.dart';
 import '../../../price_history/presentation/widgets/price_chart.dart';
 import '../../../price_history/presentation/widgets/price_stats_card.dart';
 import '../../../price_history/providers/price_history_provider.dart';

--- a/scripts/check_module_boundaries.sh
+++ b/scripts/check_module_boundaries.sh
@@ -103,6 +103,44 @@ for feature in "${FEATURE_NAMES[@]}"; do
   done < <(find "$feature_path" -name "*.dart" -type f 2>/dev/null)
 done
 
+# -----------------------------------------------------------------------------
+# Presentation -> data layer leak check
+#
+# Presentation code must depend only on `domain/` (entities, use cases) and
+# providers. Importing `data/models/`, `data/repositories/`, or `data/dto/`
+# directly from a presentation file re-creates the tight coupling that issue
+# #56 eliminated.
+# -----------------------------------------------------------------------------
+PRESENTATION_VIOLATIONS=0
+PRESENTATION_VIOLATION_LINES=""
+
+while IFS= read -r dart_file; do
+  [ -f "$dart_file" ] || continue
+  [[ "$dart_file" == *.g.dart ]] && continue
+  [[ "$dart_file" == *.freezed.dart ]] && continue
+
+  # Match both relative imports (`../../data/models/foo.dart`,
+  # `../../../feature/data/repositories/bar.dart`) and absolute package
+  # imports (`package:tankstellen/features/<name>/data/models/foo.dart`).
+  while IFS= read -r import_line; do
+    [ -z "$import_line" ] && continue
+    PRESENTATION_VIOLATIONS=$((PRESENTATION_VIOLATIONS + 1))
+    msg="  $dart_file: $import_line"
+    PRESENTATION_VIOLATION_LINES="${PRESENTATION_VIOLATION_LINES}${msg}\n"
+  done < <(grep -nE "^import .*(data/models|data/repositories|data/dto)/" "$dart_file" 2>/dev/null || true)
+done < <(find "$FEATURES_DIR" -type f -name "*.dart" -path "*/presentation/*" 2>/dev/null)
+
+if [ "$PRESENTATION_VIOLATIONS" -gt 0 ]; then
+  echo "::error::Found $PRESENTATION_VIOLATIONS presentation -> data layer import(s):"
+  echo ""
+  echo -e "$PRESENTATION_VIOLATION_LINES"
+  echo ""
+  echo "Presentation code must only depend on domain entities (domain/entities/)."
+  echo "Move or re-export the type via lib/features/<feature>/domain/entities/"
+  echo "and import the domain path from the widget / screen."
+  VIOLATIONS=$((VIOLATIONS + PRESENTATION_VIOLATIONS))
+fi
+
 if [ "$VIOLATIONS" -gt 0 ]; then
   echo "::error::Found $VIOLATIONS cross-feature import violation(s):"
   echo ""

--- a/test/lint/presentation_data_imports_test.dart
+++ b/test/lint/presentation_data_imports_test.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the clean-architecture boundary introduced by issue #56.
+///
+/// Presentation code (anything under `lib/features/*/presentation/`) must not
+/// import from `data/models/`, `data/repositories/`, or `data/dto/`. Shared
+/// types belong in `lib/features/*/domain/entities/`, and repositories must be
+/// accessed via providers in `lib/features/*/providers/`.
+///
+/// This test complements `scripts/check_module_boundaries.sh` so the boundary
+/// is also enforced on Windows CI without a bash dependency.
+void main() {
+  test('no presentation file imports from data/models|repositories|dto', () {
+    final featuresDir = Directory('lib/features');
+    expect(featuresDir.existsSync(), isTrue,
+        reason: 'lib/features must exist at project root');
+
+    final violations = <String>[];
+    final dataImportPattern = RegExp(
+      r'''^\s*import\s+['"][^'"]*data/(models|repositories|dto)/''',
+      multiLine: true,
+    );
+
+    for (final entity in featuresDir.listSync(recursive: true)) {
+      if (entity is! File) continue;
+      final path = entity.path.replaceAll(r'\', '/');
+      if (!path.endsWith('.dart')) continue;
+      if (path.endsWith('.g.dart')) continue;
+      if (path.endsWith('.freezed.dart')) continue;
+      if (!path.contains('/presentation/')) continue;
+
+      final contents = entity.readAsStringSync();
+      for (final match in dataImportPattern.allMatches(contents)) {
+        violations.add('$path: ${match.group(0)!.trim()}');
+      }
+    }
+
+    expect(
+      violations,
+      isEmpty,
+      reason: 'Presentation layer must not import data/ types directly.\n'
+          'Move or re-export the type via domain/entities/, and access '
+          'repositories via providers/.\n\nViolations:\n'
+          '${violations.join('\n')}',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Presentation widgets and screens no longer import from `data/models/` or `data/repositories/` — they now depend only on `domain/entities/` and `providers/`.
- Adds a portable Dart lint test (plus a bash check) so new violations fail CI.

## Why
Clean-architecture boundary enforcement. Presentation depending on data-layer DTOs re-created tight coupling, made data refactors cascade into UI code, and risked circular imports. Closes #56.

## What changed
- New `domain/entities/` re-export files for `PriceAlert`, `UserProfile`, `PriceRecord`, `PricePrediction`. The underlying freezed classes stay under `data/models/` so `part`/`.g.dart` generation keeps working, but presentation imports the stable `domain/entities/` path.
- Extracted `PriceStats` / `PriceTrend` into `price_history/domain/entities/price_stats.dart` and re-exported from `price_history_repository.dart` for backward compatibility.
- `profile_provider.dart` now re-exports `profileRepositoryProvider` so presentation accesses the generated Riverpod provider via `providers/`, not `data/repositories/`.
- Dropped unused `data/repositories/profile_repository.dart` imports from `setup_screen`, `onboarding_wizard_screen`, and `location_section_widget`.
- Extended `scripts/check_module_boundaries.sh` with a presentation->data leak check.
- Added `test/lint/presentation_data_imports_test.dart` — Dart-only guard so the boundary is also enforced on Windows CI (no bash dependency).

## Notes
- The issue title said "46 files", but the actual current count was 10 presentation files with `data/models/` imports plus 5 with `data/repositories/` imports — all 15 are fixed in this PR.
- Zero functional changes. All 1040 feature + lint tests pass. Only pre-existing flake is the live-network `api_connectivity_test` for the Argentina CSV endpoint, unrelated to this change.

## Test plan
- [x] `bash scripts/check_module_boundaries.sh` passes
- [x] `flutter analyze --no-fatal-infos` has zero warnings/errors
- [x] `flutter test test/features/ test/lint/` passes (1040 tests)
- [x] New `test/lint/presentation_data_imports_test.dart` asserts zero violations

Closes #56

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>