### PR TITLE
refactor: eliminate final setState calls in profile widgets (batch 5)

### DIFF
--- a/lib/features/profile/presentation/widgets/location_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/location_section_widget.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/location/user_position_provider.dart';
-import '../../../../core/storage/storage_providers.dart';
-import '../../../../core/storage/storage_keys.dart';
+import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/profile_provider.dart';
@@ -11,18 +10,11 @@ import '../../providers/profile_provider.dart';
 ///
 /// Displays the current GPS position status, allows manual GPS updates,
 /// and provides toggles for auto-update and auto-switch profile.
-class LocationSectionWidget extends ConsumerStatefulWidget {
+class LocationSectionWidget extends ConsumerWidget {
   const LocationSectionWidget({super.key});
 
   @override
-  ConsumerState<LocationSectionWidget> createState() =>
-      _LocationSectionWidgetState();
-}
-
-class _LocationSectionWidgetState
-    extends ConsumerState<LocationSectionWidget> {
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final activeProfile = ref.watch(activeProfileProvider);
     final l = AppLocalizations.of(context);
@@ -33,18 +25,19 @@ class _LocationSectionWidgetState
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _buildGpsStatus(theme, l),
+            _buildGpsStatus(context, ref, theme, l),
             const SizedBox(height: 12),
-            _buildAutoUpdateToggle(theme, activeProfile, l),
+            _buildAutoUpdateToggle(ref, theme, activeProfile, l),
             const Divider(),
-            _buildAutoSwitchToggle(theme, l),
+            _buildAutoSwitchToggle(ref, theme, l),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildGpsStatus(ThemeData theme, AppLocalizations? l) {
+  Widget _buildGpsStatus(BuildContext context, WidgetRef ref, ThemeData theme,
+      AppLocalizations? l) {
     final userPos = ref.watch(userPositionProvider);
 
     if (userPos != null) {
@@ -65,7 +58,7 @@ class _LocationSectionWidgetState
           ),
           IconButton(
             icon: const Icon(Icons.delete_outline, size: 20),
-            onPressed: () => _confirmClearGps(l),
+            onPressed: () => _confirmClearGps(context, ref, l),
             tooltip: l?.delete ?? 'Clear',
           ),
         ],
@@ -76,7 +69,7 @@ class _LocationSectionWidgetState
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         InkWell(
-          onTap: () => _updateGps(),
+          onTap: () => _updateGps(context, ref),
           borderRadius: BorderRadius.circular(8),
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 4),
@@ -107,8 +100,8 @@ class _LocationSectionWidgetState
     );
   }
 
-  Widget _buildAutoUpdateToggle(
-      ThemeData theme, dynamic activeProfile, AppLocalizations? l) {
+  Widget _buildAutoUpdateToggle(WidgetRef ref, ThemeData theme,
+      dynamic activeProfile, AppLocalizations? l) {
     return SwitchListTile(
       contentPadding: EdgeInsets.zero,
       title: Text(
@@ -133,10 +126,9 @@ class _LocationSectionWidgetState
     );
   }
 
-  Widget _buildAutoSwitchToggle(ThemeData theme, AppLocalizations? l) {
-    final settings = ref.read(settingsStorageProvider);
-    final autoSwitch =
-        settings.getSetting(StorageKeys.autoSwitchProfile) as bool? ?? false;
+  Widget _buildAutoSwitchToggle(
+      WidgetRef ref, ThemeData theme, AppLocalizations? l) {
+    final autoSwitch = ref.watch(autoSwitchProfileProvider);
 
     return SwitchListTile(
       contentPadding: EdgeInsets.zero,
@@ -153,15 +145,13 @@ class _LocationSectionWidgetState
       ),
       value: autoSwitch,
       onChanged: (value) {
-        ref
-            .read(settingsStorageProvider)
-            .putSetting(StorageKeys.autoSwitchProfile, value);
-        setState(() {});
+        ref.read(autoSwitchProfileProvider.notifier).set(value);
       },
     );
   }
 
-  Future<void> _confirmClearGps(AppLocalizations? l) async {
+  Future<void> _confirmClearGps(
+      BuildContext context, WidgetRef ref, AppLocalizations? l) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -187,13 +177,14 @@ class _LocationSectionWidgetState
     }
   }
 
-  Future<void> _updateGps() async {
+  Future<void> _updateGps(BuildContext context, WidgetRef ref) async {
     try {
       await ref.read(userPositionProvider.notifier).updateFromGps();
     } catch (e) {
-      if (mounted) {
+      if (context.mounted) {
         final l10n = AppLocalizations.of(context);
-        SnackBarHelper.showError(context, '${l10n?.gpsError ?? "GPS error"}: $e');
+        SnackBarHelper.showError(
+            context, '${l10n?.gpsError ?? "GPS error"}: $e');
       }
     }
   }

--- a/lib/features/profile/presentation/widgets/storage_section.dart
+++ b/lib/features/profile/presentation/widgets/storage_section.dart
@@ -8,17 +8,12 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import 'storage_bar.dart';
 
-class StorageSection extends ConsumerStatefulWidget {
+class StorageSection extends ConsumerWidget {
   const StorageSection({super.key});
 
   @override
-  ConsumerState<StorageSection> createState() => _StorageSectionState();
-}
-
-class _StorageSectionState extends ConsumerState<StorageSection> {
-  @override
-  Widget build(BuildContext context) {
-    final storageMgmt = ref.read(storageManagementProvider);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final storageMgmt = ref.watch(storageManagementProvider);
     final stats = storageMgmt.storageStats;
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
@@ -159,7 +154,7 @@ class _StorageSectionState extends ConsumerState<StorageSection> {
                 Expanded(
                   child: OutlinedButton.icon(
                     onPressed: storageMgmt.cacheEntryCount > 0
-                        ? () => _clearCache(context)
+                        ? () => _clearCache(context, ref)
                         : null,
                     icon: const Icon(Icons.delete_sweep),
                     label: Text(
@@ -176,7 +171,7 @@ class _StorageSectionState extends ConsumerState<StorageSection> {
               children: [
                 Expanded(
                   child: OutlinedButton.icon(
-                    onPressed: () => _clearAllData(context),
+                    onPressed: () => _clearAllData(context, ref),
                     style: OutlinedButton.styleFrom(
                       foregroundColor: theme.colorScheme.error,
                     ),
@@ -192,7 +187,7 @@ class _StorageSectionState extends ConsumerState<StorageSection> {
     );
   }
 
-  Future<void> _clearCache(BuildContext ctx) async {
+  Future<void> _clearCache(BuildContext ctx, WidgetRef ref) async {
     final confirmed = await showDialog<bool>(
       context: ctx,
       builder: (context) => AlertDialog(
@@ -220,14 +215,15 @@ class _StorageSectionState extends ConsumerState<StorageSection> {
     if (confirmed == true) {
       final cache = ref.read(cacheManagerProvider);
       await cache.clearAll();
-      if (mounted) {
-        setState(() {});
-        SnackBarHelper.show(context, AppLocalizations.of(context)?.cacheCleared ?? 'Cache cleared.');
+      ref.invalidate(storageManagementProvider);
+      if (ctx.mounted) {
+        SnackBarHelper.show(
+            ctx, AppLocalizations.of(ctx)?.cacheCleared ?? 'Cache cleared.');
       }
     }
   }
 
-  Future<void> _clearAllData(BuildContext ctx) async {
+  Future<void> _clearAllData(BuildContext ctx, WidgetRef ref) async {
     final confirmed = await showDialog<bool>(
       context: ctx,
       builder: (context) => AlertDialog(
@@ -269,8 +265,9 @@ class _StorageSectionState extends ConsumerState<StorageSection> {
         final box = Hive.box(boxName);
         await box.clear();
       }
-      if (mounted) {
-        context.go('/setup');
+      ref.invalidate(storageManagementProvider);
+      if (ctx.mounted) {
+        ctx.go('/setup');
       }
     }
   }


### PR DESCRIPTION
## Summary
Final batch of the setState->Riverpod refactor (#57). Converts the last two widgets still using `setState(() {})` as a hack to force rebuilds after writing directly to Hive.

- **storage_section**: `StatefulWidget` -> `ConsumerWidget`. Now watches `storageManagementProvider` and calls `ref.invalidate()` after clear-cache / delete-all, removing the empty `setState(() {})`.
- **location_section_widget**: `StatefulWidget` -> `ConsumerWidget`. Uses the existing `autoSwitchProfileProvider` notifier instead of writing to settings storage directly and forcing a rebuild.

## Why
Empty `setState(() {})` is a code smell - the state is actually living in Hive, not in the widget. These conversions make the data flow reactive and testable.

## Remaining setState calls
~30 setState calls remain across 15 files. **All are intentional local UI state** per Flutter/Riverpod best practice:

| Category | Files |
|---|---|
| Form field values | `add_fill_up_screen`, `edit_vehicle_screen`, `create_alert_dialog`, `api_key_step` |
| Loading/refreshing indicators | `setup_screen`, `ev_station_detail_screen`, `city_autocomplete_field` |
| Tab / view-mode toggles | `route_results_view`, `route_map_view` |
| Ephemeral selection sets | `route_map_view` |
| Animation visibility flags | `swipe_tutorial_banner` |
| One-shot fetch flags | `price_history_section` |
| Lock toggles | `driving_mode_screen` |

These are screen-scoped, ephemeral, have no cross-widget consumers, and should NOT be lifted into providers.

## Testing
- [x] `flutter analyze` - zero warnings / errors
- [x] `flutter test` - all tests pass (one pre-existing Argentina CSV network timeout, unrelated)
- [x] `storage_section_test` - 8/8 pass

Closes #57

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>