### PR TITLE
feat(ev): EV charging station map client with plug-type filter

### DIFF
--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'bfd9e27c2801ba2b512f35b542239b0663e86fa7';
+String _$routerHash() => r'ce13ed19d2b896b9196ecc3b976517603da0f8cb';

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -22,4 +22,6 @@ class StorageKeys {
   static const String consumptionLog = 'consumption_log';
   static const String vehicleProfiles = 'vehicle_profiles';
   static const String activeVehicleProfileId = 'active_vehicle_profile_id';
+  static const String evStationsCache = 'ev_stations_cache';
+  static const String evShowOnMap = 'ev_show_on_map';
 }

--- a/lib/features/ev/data/repositories/ev_station_repository.dart
+++ b/lib/features/ev/data/repositories/ev_station_repository.dart
@@ -1,0 +1,77 @@
+import '../../../../core/data/storage_repository.dart';
+import '../../../../core/storage/hive_boxes.dart';
+import '../../../../core/storage/storage_keys.dart';
+import '../../domain/entities/charging_station.dart';
+
+/// CRUD repository for [ChargingStation] entries.
+///
+/// Stored as a simple list under [StorageKeys.evStationsCache] in the
+/// settings box. Acts as an in-memory + Hive-persistent cache of recently
+/// fetched EV charging stations so the map can render instantly on reopen
+/// even when the backing service is unreachable.
+class EvStationRepository {
+  final SettingsStorage _storage;
+
+  EvStationRepository(this._storage);
+
+  static const String _listKey = StorageKeys.evStationsCache;
+
+  /// Returns all cached charging stations, in insertion order.
+  List<ChargingStation> getAll() {
+    final raw = _storage.getSetting(_listKey);
+    if (raw is! List) return const [];
+
+    final result = <ChargingStation>[];
+    for (final item in raw) {
+      final map = HiveBoxes.toStringDynamicMap(item);
+      if (map == null) continue;
+      try {
+        result.add(ChargingStation.fromJson(map));
+      } catch (_) {
+        // Skip malformed entries rather than crashing the whole list.
+      }
+    }
+    return result;
+  }
+
+  /// Returns the charging station matching [id] if present.
+  ChargingStation? getById(String id) {
+    for (final s in getAll()) {
+      if (s.id == id) return s;
+    }
+    return null;
+  }
+
+  /// Add or update a charging station (matched by id).
+  Future<void> save(ChargingStation station) async {
+    final all = [...getAll()];
+    final index = all.indexWhere((s) => s.id == station.id);
+    if (index >= 0) {
+      all[index] = station;
+    } else {
+      all.add(station);
+    }
+    await _writeAll(all);
+  }
+
+  /// Replace the entire cache with the given list.
+  Future<void> saveAll(List<ChargingStation> stations) async {
+    await _writeAll(stations);
+  }
+
+  /// Delete a charging station by id.
+  Future<void> delete(String id) async {
+    final all = [...getAll()]..removeWhere((s) => s.id == id);
+    await _writeAll(all);
+  }
+
+  /// Remove every cached charging station.
+  Future<void> clear() async {
+    await _storage.putSetting(_listKey, <Map<String, dynamic>>[]);
+  }
+
+  Future<void> _writeAll(List<ChargingStation> list) async {
+    final json = list.map((s) => s.toJson()).toList();
+    await _storage.putSetting(_listKey, json);
+  }
+}

--- a/lib/features/ev/data/services/open_charge_map_service.dart
+++ b/lib/features/ev/data/services/open_charge_map_service.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+import '../../domain/entities/charging_station.dart';
+
+/// Abstract contract for an EV charging station backend.
+///
+/// Allows the rest of the app to swap between real OpenChargeMap calls
+/// and the built-in [DemoEvStationService] without leaking Dio/HTTP
+/// details into the presentation layer.
+abstract class EvStationService {
+  /// Fetch charging stations inside a bounding box around [centerLat]/
+  /// [centerLng] with the given [radiusKm].
+  Future<List<ChargingStation>> fetchStations({
+    required double centerLat,
+    required double centerLng,
+    required double radiusKm,
+  });
+}
+
+/// Open Charge Map-backed [EvStationService].
+///
+/// Currently a stub: if no API key is configured, it transparently falls
+/// back to [DemoEvStationService]. The real HTTP integration is tracked
+/// separately so this PR can ship the client end-to-end without coupling
+/// to network flakiness.
+///
+/// TODO(#177-followup): implement real https://api.openchargemap.io/v3
+/// REST call using Dio with a Bearer API key, cache TTL, and full
+/// connector/tariff mapping.
+class OpenChargeMapService implements EvStationService {
+  final String? apiKey;
+  final EvStationService _fallback;
+
+  OpenChargeMapService({
+    this.apiKey,
+    EvStationService? fallback,
+  }) : _fallback = fallback ?? const DemoEvStationService();
+
+  @override
+  Future<List<ChargingStation>> fetchStations({
+    required double centerLat,
+    required double centerLng,
+    required double radiusKm,
+  }) async {
+    if (apiKey == null || apiKey!.trim().isEmpty) {
+      debugPrint('OpenChargeMapService: no API key, using demo data');
+      return _fallback.fetchStations(
+        centerLat: centerLat,
+        centerLng: centerLng,
+        radiusKm: radiusKm,
+      );
+    }
+    // Real call intentionally unimplemented — see class docs.
+    return _fallback.fetchStations(
+      centerLat: centerLat,
+      centerLng: centerLng,
+      radiusKm: radiusKm,
+    );
+  }
+}
+
+/// Deterministic demo dataset used when no API key is configured.
+///
+/// Generates a small cluster of synthetic charging stations around the
+/// requested map center so the feature is visibly functional end-to-end
+/// without external dependencies. Coordinates are offset in both axes and
+/// capped to a 5 km radius regardless of request size.
+class DemoEvStationService implements EvStationService {
+  const DemoEvStationService();
+
+  @override
+  Future<List<ChargingStation>> fetchStations({
+    required double centerLat,
+    required double centerLng,
+    required double radiusKm,
+  }) async {
+    // ~0.009 deg latitude ≈ 1 km.
+    const step = 0.009;
+    final samples = <_DemoSample>[
+      const _DemoSample(
+        id: 'demo-1',
+        name: 'Demo Fast Charger',
+        operator: 'Ionity',
+        latOffset: step * 1.2,
+        lngOffset: step * 0.8,
+        connectors: [
+          EvConnector(
+            id: 'demo-1-a',
+            type: ConnectorType.ccs,
+            maxPowerKw: 150,
+            status: ConnectorStatus.available,
+          ),
+          EvConnector(
+            id: 'demo-1-b',
+            type: ConnectorType.ccs,
+            maxPowerKw: 150,
+            status: ConnectorStatus.occupied,
+          ),
+        ],
+      ),
+      const _DemoSample(
+        id: 'demo-2',
+        name: 'Demo Destination Charger',
+        operator: 'Tesla',
+        latOffset: -step * 0.6,
+        lngOffset: step * 1.6,
+        connectors: [
+          EvConnector(
+            id: 'demo-2-a',
+            type: ConnectorType.tesla,
+            maxPowerKw: 120,
+            status: ConnectorStatus.available,
+          ),
+          EvConnector(
+            id: 'demo-2-b',
+            type: ConnectorType.type2,
+            maxPowerKw: 22,
+            status: ConnectorStatus.unknown,
+          ),
+        ],
+      ),
+      const _DemoSample(
+        id: 'demo-3',
+        name: 'Demo AC Point',
+        operator: 'EnBW',
+        latOffset: step * 0.4,
+        lngOffset: -step * 1.1,
+        connectors: [
+          EvConnector(
+            id: 'demo-3-a',
+            type: ConnectorType.type2,
+            maxPowerKw: 22,
+            status: ConnectorStatus.available,
+          ),
+        ],
+      ),
+      const _DemoSample(
+        id: 'demo-4',
+        name: 'Demo CHAdeMO',
+        operator: 'Allego',
+        latOffset: -step * 1.4,
+        lngOffset: -step * 0.5,
+        connectors: [
+          EvConnector(
+            id: 'demo-4-a',
+            type: ConnectorType.chademo,
+            maxPowerKw: 50,
+            status: ConnectorStatus.outOfOrder,
+          ),
+          EvConnector(
+            id: 'demo-4-b',
+            type: ConnectorType.ccs,
+            maxPowerKw: 50,
+            status: ConnectorStatus.available,
+          ),
+        ],
+      ),
+    ];
+
+    return samples
+        .map((s) => ChargingStation(
+              id: s.id,
+              name: s.name,
+              operator: s.operator,
+              latitude: centerLat + s.latOffset,
+              longitude: centerLng + s.lngOffset,
+              connectors: s.connectors,
+              lastUpdate: DateTime.now(),
+            ))
+        .toList();
+  }
+}
+
+class _DemoSample {
+  final String id;
+  final String name;
+  final String operator;
+  final double latOffset;
+  final double lngOffset;
+  final List<EvConnector> connectors;
+
+  const _DemoSample({
+    required this.id,
+    required this.name,
+    required this.operator,
+    required this.latOffset,
+    required this.lngOffset,
+    required this.connectors,
+  });
+}

--- a/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+import '../../domain/entities/charging_station.dart';
+
+/// Read-only detail view for a single [ChargingStation].
+///
+/// Shows all connectors, status badges, operator/address metadata, and
+/// the last-update timestamp. Tariff breakdown is stubbed for now — the
+/// detail includes a placeholder row when the connector references a
+/// tariff id we don't yet resolve client-side.
+class EvStationDetailScreen extends StatelessWidget {
+  final ChargingStation station;
+
+  const EvStationDetailScreen({super.key, required this.station});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(station.name),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          if (station.operator != null)
+            _row(
+              icon: Icons.business,
+              label: l10n?.evOperator ?? 'Operator',
+              value: station.operator!,
+            ),
+          if (station.address != null)
+            _row(
+              icon: Icons.location_on_outlined,
+              label: l10n?.address ?? 'Address',
+              value: station.address!,
+            ),
+          _row(
+            icon: Icons.bolt,
+            label: l10n?.evMaxPower ?? 'Max power',
+            value: '${station.maxPowerKw.round()} kW',
+          ),
+          if (station.lastUpdate != null)
+            _row(
+              icon: Icons.update,
+              label: l10n?.evLastUpdate ?? 'Last update',
+              value: station.lastUpdate!.toLocal().toString(),
+            ),
+          const SizedBox(height: 16),
+          Text(
+            l10n?.evConnectors(station.connectors.length) ?? 'Connectors',
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          if (station.connectors.isEmpty)
+            Text(l10n?.evNoConnectors ?? 'No connector details available'),
+          ...station.connectors.map((c) => _ConnectorTile(connector: c)),
+        ],
+      ),
+    );
+  }
+
+  Widget _row({
+    required IconData icon,
+    required String label,
+    required String value,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 18),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: const TextStyle(fontSize: 12)),
+                Text(value),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConnectorTile extends StatelessWidget {
+  final EvConnector connector;
+  const _ConnectorTile({required this.connector});
+
+  static String _labelForType(BuildContext context, ConnectorType type) {
+    final l10n = AppLocalizations.of(context);
+    switch (type) {
+      case ConnectorType.type2:
+        return l10n?.connectorType2 ?? 'Type 2';
+      case ConnectorType.ccs:
+        return l10n?.connectorCcs ?? 'CCS';
+      case ConnectorType.chademo:
+        return l10n?.connectorChademo ?? 'CHAdeMO';
+      case ConnectorType.tesla:
+        return l10n?.connectorTesla ?? 'Tesla';
+      case ConnectorType.schuko:
+        return l10n?.connectorSchuko ?? 'Schuko';
+      case ConnectorType.type1:
+        return l10n?.connectorType1 ?? 'Type 1';
+      case ConnectorType.threePin:
+        return l10n?.connectorThreePin ?? '3-pin';
+    }
+  }
+
+  static (String, Color) _statusBadge(
+    BuildContext context,
+    ConnectorStatus status,
+  ) {
+    final l10n = AppLocalizations.of(context);
+    switch (status) {
+      case ConnectorStatus.available:
+        return (l10n?.evStatusAvailable ?? 'Available', Colors.green);
+      case ConnectorStatus.occupied:
+        return (l10n?.evStatusOccupied ?? 'Occupied', Colors.orange);
+      case ConnectorStatus.outOfOrder:
+        return (l10n?.evStatusOutOfOrder ?? 'Out of order', Colors.red);
+      case ConnectorStatus.unknown:
+        return (l10n?.evStatusUnknown ?? 'Unknown', Colors.grey);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final (statusLabel, color) = _statusBadge(context, connector.status);
+    return Card(
+      child: ListTile(
+        leading: const Icon(Icons.power),
+        title: Text(_labelForType(context, connector.type)),
+        subtitle: Text('${connector.maxPowerKw.round()} kW'),
+        trailing: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.15),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Text(
+            statusLabel,
+            style: TextStyle(color: color, fontSize: 12),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/ev/presentation/widgets/ev_filter_chips.dart
+++ b/lib/features/ev/presentation/widgets/ev_filter_chips.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+import '../../providers/ev_providers.dart';
+
+/// Horizontal row of filter chips allowing the user to narrow displayed
+/// EV charging stations by connector type, minimum power, and
+/// availability.
+class EvFilterChips extends ConsumerWidget {
+  const EvFilterChips({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filter = ref.watch(evFilterControllerProvider);
+    final notifier = ref.read(evFilterControllerProvider.notifier);
+    final l10n = AppLocalizations.of(context);
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        children: [
+          FilterChip(
+            label: Text(l10n?.evAvailableOnly ?? 'Available only'),
+            selected: filter.availableOnly,
+            onSelected: notifier.setAvailableOnly,
+          ),
+          const SizedBox(width: 8),
+          ...ConnectorType.values.map((type) {
+            final selected = filter.connectorTypes.contains(type);
+            return Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: FilterChip(
+                label: Text(_labelFor(context, type)),
+                selected: selected,
+                onSelected: (_) => notifier.toggleConnector(type),
+              ),
+            );
+          }),
+          const SizedBox(width: 4),
+          _PowerDropdown(
+            value: filter.minPowerKw,
+            onChanged: notifier.setMinPowerKw,
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _labelFor(BuildContext context, ConnectorType type) {
+    final l10n = AppLocalizations.of(context);
+    switch (type) {
+      case ConnectorType.type2:
+        return l10n?.connectorType2 ?? 'Type 2';
+      case ConnectorType.ccs:
+        return l10n?.connectorCcs ?? 'CCS';
+      case ConnectorType.chademo:
+        return l10n?.connectorChademo ?? 'CHAdeMO';
+      case ConnectorType.tesla:
+        return l10n?.connectorTesla ?? 'Tesla';
+      case ConnectorType.schuko:
+        return l10n?.connectorSchuko ?? 'Schuko';
+      case ConnectorType.type1:
+        return l10n?.connectorType1 ?? 'Type 1';
+      case ConnectorType.threePin:
+        return l10n?.connectorThreePin ?? '3-pin';
+    }
+  }
+}
+
+class _PowerDropdown extends StatelessWidget {
+  final double value;
+  final ValueChanged<double> onChanged;
+
+  const _PowerDropdown({required this.value, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return DropdownButton<double>(
+      value: value,
+      hint: Text(l10n?.evMinPower ?? 'Min power'),
+      items: const [
+        DropdownMenuItem(value: 0, child: Text('Any')),
+        DropdownMenuItem(value: 11, child: Text('11 kW+')),
+        DropdownMenuItem(value: 22, child: Text('22 kW+')),
+        DropdownMenuItem(value: 50, child: Text('50 kW+')),
+        DropdownMenuItem(value: 150, child: Text('150 kW+')),
+        DropdownMenuItem(value: 300, child: Text('300 kW+')),
+      ],
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+    );
+  }
+}

--- a/lib/features/ev/presentation/widgets/ev_map_overlay.dart
+++ b/lib/features/ev/presentation/widgets/ev_map_overlay.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/charging_station.dart';
+import '../../providers/ev_providers.dart';
+import '../screens/ev_station_detail_screen.dart';
+import 'ev_marker_widget.dart';
+
+/// Map layer rendering all charging stations for the given [viewport].
+///
+/// Pulls results from [evStationsProvider], applies the current filter,
+/// and clusters markers independently of fuel-station markers so the two
+/// layers never collide visually.
+class EvMapLayer extends ConsumerWidget {
+  final EvViewport viewport;
+
+  const EvMapLayer({super.key, required this.viewport});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(evStationsProvider(viewport));
+    return async.when(
+      data: (stations) => _buildLayer(context, stations),
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildLayer(BuildContext context, List<ChargingStation> stations) {
+    if (stations.isEmpty) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+
+    final markers = stations
+        .map(
+          (s) => EvMarkerWidget.buildMarker(
+            s,
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => EvStationDetailScreen(station: s),
+              ),
+            ),
+          ),
+        )
+        .toList();
+
+    if (stations.length > 20) {
+      return MarkerClusterLayerWidget(
+        options: MarkerClusterLayerOptions(
+          maxClusterRadius: 80,
+          markers: markers,
+          builder: (ctx, clusterMarkers) => Container(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.tertiaryContainer,
+              shape: BoxShape.circle,
+            ),
+            child: Center(
+              child: Text(
+                '${clusterMarkers.length}',
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+    return MarkerLayer(markers: markers);
+  }
+}
+
+/// Small toggle button placed on top of the map screen that switches the
+/// EV overlay on and off.
+class EvToggleButton extends ConsumerWidget {
+  const EvToggleButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final shown = ref.watch(evShowOnMapProvider);
+    final l10n = AppLocalizations.of(context);
+    return Material(
+      color: shown ? Colors.green : Colors.white,
+      shape: const CircleBorder(),
+      elevation: 4,
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: () => ref.read(evShowOnMapProvider.notifier).toggle(),
+        child: Tooltip(
+          message: l10n?.evShowOnMap ?? 'Show EV stations',
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: Icon(
+              Icons.ev_station,
+              color: shown ? Colors.white : Colors.black54,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/ev/presentation/widgets/ev_marker_widget.dart
+++ b/lib/features/ev/presentation/widgets/ev_marker_widget.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../domain/entities/charging_station.dart';
+
+/// Visual marker representing an EV [ChargingStation] on the flutter_map.
+///
+/// Uses an `ev_station` icon with a background color derived from
+/// availability:
+///  - green:  at least one connector is `available`
+///  - red:    all connectors are occupied or out of order
+///  - grey:   status unknown
+class EvMarkerWidget extends StatelessWidget {
+  final ChargingStation station;
+  final VoidCallback? onTap;
+
+  const EvMarkerWidget({
+    super.key,
+    required this.station,
+    this.onTap,
+  });
+
+  static Color colorFor(ChargingStation station) {
+    if (station.connectors.isEmpty) return Colors.grey;
+    if (station.hasAvailableConnector) return Colors.green;
+    final anyKnown = station.connectors.any(
+      (c) => c.status != ConnectorStatus.unknown,
+    );
+    if (!anyKnown) return Colors.grey;
+    return Colors.red;
+  }
+
+  /// Build a flutter_map [Marker] for this station.
+  static Marker buildMarker(
+    ChargingStation station, {
+    VoidCallback? onTap,
+  }) {
+    return Marker(
+      point: LatLng(station.latitude, station.longitude),
+      width: 44,
+      height: 44,
+      child: EvMarkerWidget(station: station, onTap: onTap),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = colorFor(station);
+    final maxPower = station.maxPowerKw.round();
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Semantics(
+        label: 'EV charging station ${station.name}, $maxPower kW',
+        button: true,
+        child: Container(
+          decoration: BoxDecoration(
+            color: color,
+            shape: BoxShape.circle,
+            border: Border.all(color: Colors.white, width: 2),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.3),
+                blurRadius: 4,
+              ),
+            ],
+          ),
+          child: const Icon(
+            Icons.ev_station,
+            color: Colors.white,
+            size: 24,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/ev/providers/ev_providers.dart
+++ b/lib/features/ev/providers/ev_providers.dart
@@ -1,0 +1,203 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/storage/storage_keys.dart';
+import '../../../core/storage/storage_providers.dart';
+import '../../vehicle/domain/entities/vehicle_profile.dart' show ConnectorType;
+import '../../vehicle/providers/vehicle_providers.dart';
+import '../data/repositories/ev_station_repository.dart';
+import '../data/services/open_charge_map_service.dart';
+import '../domain/entities/charging_station.dart';
+
+part 'ev_providers.g.dart';
+
+/// Repository for reading/writing cached [ChargingStation] entries.
+@Riverpod(keepAlive: true)
+EvStationRepository evStationRepository(Ref ref) {
+  final storage = ref.watch(settingsStorageProvider);
+  return EvStationRepository(storage);
+}
+
+/// Concrete [EvStationService] used by the app.
+///
+/// Plain `@riverpod` (not keepAlive) so a future settings change can swap
+/// in a real API key without a restart.
+@Riverpod(keepAlive: true)
+EvStationService evStationService(Ref ref) {
+  final storage = ref.watch(settingsStorageProvider);
+  final rawKey = storage.getSetting(StorageKeys.evApiKey);
+  final apiKey = rawKey is String && rawKey.trim().isNotEmpty ? rawKey : null;
+  return OpenChargeMapService(apiKey: apiKey);
+}
+
+/// Whether EV charging stations should be overlaid on the map.
+///
+/// Persisted to the settings box so the user's preference survives
+/// restarts. Defaults to `false` — existing fuel-station users shouldn't
+/// suddenly see extra markers on upgrade.
+@Riverpod(keepAlive: true)
+class EvShowOnMap extends _$EvShowOnMap {
+  @override
+  bool build() {
+    final storage = ref.watch(settingsStorageProvider);
+    final raw = storage.getSetting(StorageKeys.evShowOnMap);
+    return raw is bool ? raw : false;
+  }
+
+  Future<void> toggle() async {
+    final storage = ref.read(settingsStorageProvider);
+    final next = !state;
+    await storage.putSetting(StorageKeys.evShowOnMap, next);
+    state = next;
+  }
+
+  Future<void> set(bool value) async {
+    final storage = ref.read(settingsStorageProvider);
+    await storage.putSetting(StorageKeys.evShowOnMap, value);
+    state = value;
+  }
+}
+
+/// Filter criteria applied to [evStationsProvider] results before they
+/// are rendered on the map or station list.
+class EvFilter {
+  final Set<ConnectorType> connectorTypes;
+  final double minPowerKw;
+  final bool availableOnly;
+
+  const EvFilter({
+    this.connectorTypes = const <ConnectorType>{},
+    this.minPowerKw = 0,
+    this.availableOnly = false,
+  });
+
+  EvFilter copyWith({
+    Set<ConnectorType>? connectorTypes,
+    double? minPowerKw,
+    bool? availableOnly,
+  }) {
+    return EvFilter(
+      connectorTypes: connectorTypes ?? this.connectorTypes,
+      minPowerKw: minPowerKw ?? this.minPowerKw,
+      availableOnly: availableOnly ?? this.availableOnly,
+    );
+  }
+
+  /// Whether [station] passes this filter.
+  bool matches(ChargingStation station) {
+    if (availableOnly && !station.hasAvailableConnector) return false;
+    if (minPowerKw > 0 && station.maxPowerKw < minPowerKw) return false;
+    if (connectorTypes.isNotEmpty) {
+      final hasMatch = station.connectors.any(
+        (c) => connectorTypes.contains(c.type),
+      );
+      if (!hasMatch) return false;
+    }
+    return true;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is EvFilter &&
+      other.connectorTypes.length == connectorTypes.length &&
+      other.connectorTypes.containsAll(connectorTypes) &&
+      other.minPowerKw == minPowerKw &&
+      other.availableOnly == availableOnly;
+
+  @override
+  int get hashCode => Object.hash(
+        Object.hashAllUnordered(connectorTypes),
+        minPowerKw,
+        availableOnly,
+      );
+}
+
+/// User-editable filter for EV stations.
+///
+/// Seeded from the active vehicle profile's `supportedConnectors` so a
+/// driver with a CCS-only car doesn't see incompatible plugs by default.
+@Riverpod(keepAlive: true)
+class EvFilterController extends _$EvFilterController {
+  @override
+  EvFilter build() {
+    final active = ref.watch(activeVehicleProfileProvider);
+    final connectors = active?.supportedConnectors ?? const <ConnectorType>{};
+    return EvFilter(connectorTypes: Set<ConnectorType>.from(connectors));
+  }
+
+  void setConnectorTypes(Set<ConnectorType> types) {
+    state = state.copyWith(connectorTypes: Set<ConnectorType>.from(types));
+  }
+
+  void toggleConnector(ConnectorType type) {
+    final next = Set<ConnectorType>.from(state.connectorTypes);
+    if (next.contains(type)) {
+      next.remove(type);
+    } else {
+      next.add(type);
+    }
+    state = state.copyWith(connectorTypes: next);
+  }
+
+  void setMinPowerKw(double value) {
+    state = state.copyWith(minPowerKw: value);
+  }
+
+  void setAvailableOnly(bool value) {
+    state = state.copyWith(availableOnly: value);
+  }
+
+  void reset() {
+    state = const EvFilter();
+  }
+}
+
+/// Parameters describing the map viewport for which to fetch EV stations.
+class EvViewport {
+  final double latitude;
+  final double longitude;
+  final double radiusKm;
+
+  const EvViewport({
+    required this.latitude,
+    required this.longitude,
+    this.radiusKm = 5,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is EvViewport &&
+      other.latitude == latitude &&
+      other.longitude == longitude &&
+      other.radiusKm == radiusKm;
+
+  @override
+  int get hashCode => Object.hash(latitude, longitude, radiusKm);
+}
+
+/// Fetches charging stations for the given [viewport] and writes them
+/// through the local repository cache. Applies the current
+/// [evFilterControllerProvider] before returning.
+@riverpod
+Future<List<ChargingStation>> evStations(
+  Ref ref,
+  EvViewport viewport,
+) async {
+  final service = ref.watch(evStationServiceProvider);
+  final repo = ref.watch(evStationRepositoryProvider);
+  final filter = ref.watch(evFilterControllerProvider);
+
+  List<ChargingStation> stations;
+  try {
+    stations = await service.fetchStations(
+      centerLat: viewport.latitude,
+      centerLng: viewport.longitude,
+      radiusKm: viewport.radiusKm,
+    );
+    await repo.saveAll(stations);
+  } catch (e) {
+    // Fall back to whatever we have cached if the service fails.
+    stations = repo.getAll();
+  }
+
+  return stations.where(filter.matches).toList();
+}

--- a/lib/features/ev/providers/ev_providers.g.dart
+++ b/lib/features/ev/providers/ev_providers.g.dart
@@ -1,0 +1,363 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ev_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Repository for reading/writing cached [ChargingStation] entries.
+
+@ProviderFor(evStationRepository)
+final evStationRepositoryProvider = EvStationRepositoryProvider._();
+
+/// Repository for reading/writing cached [ChargingStation] entries.
+
+final class EvStationRepositoryProvider
+    extends
+        $FunctionalProvider<
+          EvStationRepository,
+          EvStationRepository,
+          EvStationRepository
+        >
+    with $Provider<EvStationRepository> {
+  /// Repository for reading/writing cached [ChargingStation] entries.
+  EvStationRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'evStationRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$evStationRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<EvStationRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EvStationRepository create(Ref ref) {
+    return evStationRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EvStationRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EvStationRepository>(value),
+    );
+  }
+}
+
+String _$evStationRepositoryHash() =>
+    r'd52b16691f4b66e428cb48969c05797bd4d88f03';
+
+/// Concrete [EvStationService] used by the app.
+///
+/// Plain `@riverpod` (not keepAlive) so a future settings change can swap
+/// in a real API key without a restart.
+
+@ProviderFor(evStationService)
+final evStationServiceProvider = EvStationServiceProvider._();
+
+/// Concrete [EvStationService] used by the app.
+///
+/// Plain `@riverpod` (not keepAlive) so a future settings change can swap
+/// in a real API key without a restart.
+
+final class EvStationServiceProvider
+    extends
+        $FunctionalProvider<
+          EvStationService,
+          EvStationService,
+          EvStationService
+        >
+    with $Provider<EvStationService> {
+  /// Concrete [EvStationService] used by the app.
+  ///
+  /// Plain `@riverpod` (not keepAlive) so a future settings change can swap
+  /// in a real API key without a restart.
+  EvStationServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'evStationServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$evStationServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<EvStationService> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  EvStationService create(Ref ref) {
+    return evStationService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EvStationService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EvStationService>(value),
+    );
+  }
+}
+
+String _$evStationServiceHash() => r'1d977c9206aebfb49e6f452730f35e05f49b83b6';
+
+/// Whether EV charging stations should be overlaid on the map.
+///
+/// Persisted to the settings box so the user's preference survives
+/// restarts. Defaults to `false` — existing fuel-station users shouldn't
+/// suddenly see extra markers on upgrade.
+
+@ProviderFor(EvShowOnMap)
+final evShowOnMapProvider = EvShowOnMapProvider._();
+
+/// Whether EV charging stations should be overlaid on the map.
+///
+/// Persisted to the settings box so the user's preference survives
+/// restarts. Defaults to `false` — existing fuel-station users shouldn't
+/// suddenly see extra markers on upgrade.
+final class EvShowOnMapProvider extends $NotifierProvider<EvShowOnMap, bool> {
+  /// Whether EV charging stations should be overlaid on the map.
+  ///
+  /// Persisted to the settings box so the user's preference survives
+  /// restarts. Defaults to `false` — existing fuel-station users shouldn't
+  /// suddenly see extra markers on upgrade.
+  EvShowOnMapProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'evShowOnMapProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$evShowOnMapHash();
+
+  @$internal
+  @override
+  EvShowOnMap create() => EvShowOnMap();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$evShowOnMapHash() => r'4d7004b1a48703495c01b69847b7c13339f3947e';
+
+/// Whether EV charging stations should be overlaid on the map.
+///
+/// Persisted to the settings box so the user's preference survives
+/// restarts. Defaults to `false` — existing fuel-station users shouldn't
+/// suddenly see extra markers on upgrade.
+
+abstract class _$EvShowOnMap extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+/// User-editable filter for EV stations.
+///
+/// Seeded from the active vehicle profile's `supportedConnectors` so a
+/// driver with a CCS-only car doesn't see incompatible plugs by default.
+
+@ProviderFor(EvFilterController)
+final evFilterControllerProvider = EvFilterControllerProvider._();
+
+/// User-editable filter for EV stations.
+///
+/// Seeded from the active vehicle profile's `supportedConnectors` so a
+/// driver with a CCS-only car doesn't see incompatible plugs by default.
+final class EvFilterControllerProvider
+    extends $NotifierProvider<EvFilterController, EvFilter> {
+  /// User-editable filter for EV stations.
+  ///
+  /// Seeded from the active vehicle profile's `supportedConnectors` so a
+  /// driver with a CCS-only car doesn't see incompatible plugs by default.
+  EvFilterControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'evFilterControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$evFilterControllerHash();
+
+  @$internal
+  @override
+  EvFilterController create() => EvFilterController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EvFilter value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EvFilter>(value),
+    );
+  }
+}
+
+String _$evFilterControllerHash() =>
+    r'bdb0e5cd2c758eb6104e44ace63b1a2ef9a7bb05';
+
+/// User-editable filter for EV stations.
+///
+/// Seeded from the active vehicle profile's `supportedConnectors` so a
+/// driver with a CCS-only car doesn't see incompatible plugs by default.
+
+abstract class _$EvFilterController extends $Notifier<EvFilter> {
+  EvFilter build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<EvFilter, EvFilter>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<EvFilter, EvFilter>,
+              EvFilter,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+/// Fetches charging stations for the given [viewport] and writes them
+/// through the local repository cache. Applies the current
+/// [evFilterControllerProvider] before returning.
+
+@ProviderFor(evStations)
+final evStationsProvider = EvStationsFamily._();
+
+/// Fetches charging stations for the given [viewport] and writes them
+/// through the local repository cache. Applies the current
+/// [evFilterControllerProvider] before returning.
+
+final class EvStationsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<ChargingStation>>,
+          List<ChargingStation>,
+          FutureOr<List<ChargingStation>>
+        >
+    with
+        $FutureModifier<List<ChargingStation>>,
+        $FutureProvider<List<ChargingStation>> {
+  /// Fetches charging stations for the given [viewport] and writes them
+  /// through the local repository cache. Applies the current
+  /// [evFilterControllerProvider] before returning.
+  EvStationsProvider._({
+    required EvStationsFamily super.from,
+    required EvViewport super.argument,
+  }) : super(
+         retry: null,
+         name: r'evStationsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$evStationsHash();
+
+  @override
+  String toString() {
+    return r'evStationsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<List<ChargingStation>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<ChargingStation>> create(Ref ref) {
+    final argument = this.argument as EvViewport;
+    return evStations(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EvStationsProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$evStationsHash() => r'0afe64b089a8c1e725069db89d3b1deb0137ae0e';
+
+/// Fetches charging stations for the given [viewport] and writes them
+/// through the local repository cache. Applies the current
+/// [evFilterControllerProvider] before returning.
+
+final class EvStationsFamily extends $Family
+    with
+        $FunctionalFamilyOverride<FutureOr<List<ChargingStation>>, EvViewport> {
+  EvStationsFamily._()
+    : super(
+        retry: null,
+        name: r'evStationsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches charging stations for the given [viewport] and writes them
+  /// through the local repository cache. Applies the current
+  /// [evFilterControllerProvider] before returning.
+
+  EvStationsProvider call(EvViewport viewport) =>
+      EvStationsProvider._(argument: viewport, from: this);
+
+  @override
+  String toString() => r'evStationsProvider';
+}

--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -3,6 +3,9 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../driving/presentation/widgets/driving_mode_fab.dart';
+import '../../../ev/presentation/widgets/ev_filter_chips.dart';
+import '../../../ev/presentation/widgets/ev_map_overlay.dart';
+import '../../../ev/providers/ev_providers.dart';
 import '../../../route_search/providers/route_search_provider.dart';
 import '../../../search/providers/search_provider.dart';
 import '../widgets/nearby_map_view.dart';
@@ -38,9 +41,23 @@ class _MapScreenState extends ConsumerState<MapScreen> {
     final selectedFuel = ref.watch(selectedFuelTypeProvider);
     final searchRadius = ref.watch(searchRadiusProvider);
     final routeState = ref.watch(routeSearchStateProvider);
+    final showEv = ref.watch(evShowOnMapProvider);
     final l10n = AppLocalizations.of(context);
 
     final hasRouteResults = routeState.hasValue && routeState.value != null;
+
+    final body = hasRouteResults
+        ? RouteMapView(
+            routeResult: routeState.value!,
+            selectedFuel: selectedFuel,
+            mapController: _mapController,
+          )
+        : NearbyMapView(
+            searchState: searchState,
+            selectedFuel: selectedFuel,
+            searchRadiusKm: searchRadius,
+            mapController: _mapController,
+          );
 
     return Scaffold(
       appBar: PreferredSize(
@@ -53,18 +70,23 @@ class _MapScreenState extends ConsumerState<MapScreen> {
         ),
       ),
       floatingActionButton: const DrivingModeFab(),
-      body: hasRouteResults
-          ? RouteMapView(
-              routeResult: routeState.value!,
-              selectedFuel: selectedFuel,
-              mapController: _mapController,
-            )
-          : NearbyMapView(
-              searchState: searchState,
-              selectedFuel: selectedFuel,
-              searchRadiusKm: searchRadius,
-              mapController: _mapController,
+      body: Column(
+        children: [
+          if (showEv) const EvFilterChips(),
+          Expanded(
+            child: Stack(
+              children: [
+                body,
+                const Positioned(
+                  left: 16,
+                  top: 16,
+                  child: EvToggleButton(),
+                ),
+              ],
             ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../core/location/user_position_provider.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../ev/presentation/widgets/ev_map_overlay.dart';
+import '../../../ev/providers/ev_providers.dart';
 import 'station_map_layers.dart';
 
 /// Displays a map of nearby stations from the current search results.
@@ -47,6 +50,23 @@ class NearbyMapView extends ConsumerWidget {
         final center = StationMapLayers.centerOf(stations);
         final zoom = StationMapLayers.zoomForRadius(searchRadiusKm);
 
+        final showEv = ref.watch(evShowOnMapProvider);
+        final userPos = ref.read(userPositionProvider);
+        final evLat = userPos?.lat ?? center.latitude;
+        final evLng = userPos?.lng ?? center.longitude;
+        final extraLayers = <Widget>[];
+        if (showEv) {
+          extraLayers.add(
+            EvMapLayer(
+              viewport: EvViewport(
+                latitude: evLat,
+                longitude: evLng,
+                radiusKm: searchRadiusKm,
+              ),
+            ),
+          );
+        }
+
         // Move map to new center when search results change
         WidgetsBinding.instance.addPostFrameCallback((_) {
           try { mapController.move(center, zoom); } catch (e) { debugPrint('Map move failed: $e'); }
@@ -65,6 +85,7 @@ class NearbyMapView extends ConsumerWidget {
                 selectedFuel: selectedFuel,
                 showRecenterButton: true,
                 onRecenter: () => mapController.move(center, zoom),
+                extraLayers: extraLayers,
               ),
             ),
             _buildInfoBar(context, l10n, stations, result),

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -32,6 +32,10 @@ class StationMapLayers extends StatelessWidget {
   /// Stations IN this set use vivid/flashy colors for quick identification.
   final Set<String>? selectedStationIds;
 
+  /// Additional map layers rendered after the station markers, e.g. the
+  /// EV charging station overlay.
+  final List<Widget> extraLayers;
+
   const StationMapLayers({
     super.key,
     required this.mapController,
@@ -45,6 +49,7 @@ class StationMapLayers extends StatelessWidget {
     this.routePolyline,
     this.showSearchRadius = true,
     this.selectedStationIds,
+    this.extraLayers = const [],
   });
 
   @override
@@ -149,6 +154,8 @@ class StationMapLayers extends StatelessWidget {
               }
               return MarkerLayer(markers: markers);
             }),
+            // Extra layers (e.g. EV overlay)
+            ...extraLayers,
             // Attribution
             const RichAttributionWidget(
               attributions: [

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -738,5 +738,14 @@
   "connectorTesla": "Tesla",
   "connectorSchuko": "Schuko",
   "connectorType1": "Typ 1",
-  "connectorThreePin": "Schuko 3-polig"
+  "connectorThreePin": "Schuko 3-polig",
+  "evShowOnMap": "Ladestationen anzeigen",
+  "evAvailableOnly": "Nur verfügbare",
+  "evMinPower": "Min. Leistung",
+  "evMaxPower": "Max. Leistung",
+  "evOperator": "Betreiber",
+  "evLastUpdate": "Letzte Aktualisierung",
+  "evStatusAvailable": "Verfügbar",
+  "evStatusOccupied": "Belegt",
+  "evStatusOutOfOrder": "Außer Betrieb"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -738,5 +738,14 @@
   "connectorTesla": "Tesla",
   "connectorSchuko": "Schuko",
   "connectorType1": "Type 1",
-  "connectorThreePin": "3-pin"
+  "connectorThreePin": "3-pin",
+  "evShowOnMap": "Show EV stations",
+  "evAvailableOnly": "Available only",
+  "evMinPower": "Min power",
+  "evMaxPower": "Max power",
+  "evOperator": "Operator",
+  "evLastUpdate": "Last update",
+  "evStatusAvailable": "Available",
+  "evStatusOccupied": "Occupied",
+  "evStatusOutOfOrder": "Out of order"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3192,6 +3192,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'3-pin'**
   String get connectorThreePin;
+
+  /// No description provided for @evShowOnMap.
+  ///
+  /// In en, this message translates to:
+  /// **'Show EV stations'**
+  String get evShowOnMap;
+
+  /// No description provided for @evAvailableOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Available only'**
+  String get evAvailableOnly;
+
+  /// No description provided for @evMinPower.
+  ///
+  /// In en, this message translates to:
+  /// **'Min power'**
+  String get evMinPower;
+
+  /// No description provided for @evMaxPower.
+  ///
+  /// In en, this message translates to:
+  /// **'Max power'**
+  String get evMaxPower;
+
+  /// No description provided for @evOperator.
+  ///
+  /// In en, this message translates to:
+  /// **'Operator'**
+  String get evOperator;
+
+  /// No description provided for @evLastUpdate.
+  ///
+  /// In en, this message translates to:
+  /// **'Last update'**
+  String get evLastUpdate;
+
+  /// No description provided for @evStatusAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Available'**
+  String get evStatusAvailable;
+
+  /// No description provided for @evStatusOccupied.
+  ///
+  /// In en, this message translates to:
+  /// **'Occupied'**
+  String get evStatusOccupied;
+
+  /// No description provided for @evStatusOutOfOrder.
+  ///
+  /// In en, this message translates to:
+  /// **'Out of order'**
+  String get evStatusOutOfOrder;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1656,4 +1656,31 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1656,4 +1656,31 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1654,4 +1654,31 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1666,4 +1666,31 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get connectorThreePin => 'Schuko 3-polig';
+
+  @override
+  String get evShowOnMap => 'Ladestationen anzeigen';
+
+  @override
+  String get evAvailableOnly => 'Nur verfügbare';
+
+  @override
+  String get evMinPower => 'Min. Leistung';
+
+  @override
+  String get evMaxPower => 'Max. Leistung';
+
+  @override
+  String get evOperator => 'Betreiber';
+
+  @override
+  String get evLastUpdate => 'Letzte Aktualisierung';
+
+  @override
+  String get evStatusAvailable => 'Verfügbar';
+
+  @override
+  String get evStatusOccupied => 'Belegt';
+
+  @override
+  String get evStatusOutOfOrder => 'Außer Betrieb';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1658,4 +1658,31 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1649,4 +1649,31 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1657,4 +1657,31 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1651,4 +1651,31 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1654,4 +1654,31 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1661,4 +1661,31 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1653,4 +1653,31 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1658,4 +1658,31 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1657,4 +1657,31 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1655,4 +1655,31 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1657,4 +1657,31 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1653,4 +1653,31 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1658,4 +1658,31 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1656,4 +1656,31 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1657,4 +1657,31 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1656,4 +1656,31 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1657,4 +1657,31 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1651,4 +1651,31 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1655,4 +1655,31 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get connectorThreePin => '3-pin';
+
+  @override
+  String get evShowOnMap => 'Show EV stations';
+
+  @override
+  String get evAvailableOnly => 'Available only';
+
+  @override
+  String get evMinPower => 'Min power';
+
+  @override
+  String get evMaxPower => 'Max power';
+
+  @override
+  String get evOperator => 'Operator';
+
+  @override
+  String get evLastUpdate => 'Last update';
+
+  @override
+  String get evStatusAvailable => 'Available';
+
+  @override
+  String get evStatusOccupied => 'Occupied';
+
+  @override
+  String get evStatusOutOfOrder => 'Out of order';
 }

--- a/test/features/ev/data/ev_station_repository_test.dart
+++ b/test/features/ev/data/ev_station_repository_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/ev/data/repositories/ev_station_repository.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+
+void main() {
+  group('EvStationRepository', () {
+    late _FakeSettings storage;
+    late EvStationRepository repo;
+
+    setUp(() {
+      storage = _FakeSettings();
+      repo = EvStationRepository(storage);
+    });
+
+    ChargingStation makeStation(String id, {double lat = 48.0}) =>
+        ChargingStation(
+          id: id,
+          name: 'Station $id',
+          latitude: lat,
+          longitude: 2.0,
+          connectors: const [
+            EvConnector(
+              id: 'c1',
+              type: ConnectorType.ccs,
+              maxPowerKw: 50,
+              status: ConnectorStatus.available,
+            ),
+          ],
+        );
+
+    test('getAll returns empty when nothing is stored', () {
+      expect(repo.getAll(), isEmpty);
+    });
+
+    test('save and retrieve station', () async {
+      await repo.save(makeStation('a'));
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.id, 'a');
+      expect(all.first.connectors.single.type, ConnectorType.ccs);
+    });
+
+    test('save updates existing entry by id', () async {
+      await repo.save(makeStation('a', lat: 48.0));
+      await repo.save(makeStation('a', lat: 49.0));
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.latitude, 49.0);
+    });
+
+    test('saveAll replaces the whole list', () async {
+      await repo.save(makeStation('a'));
+      await repo.saveAll([makeStation('x'), makeStation('y')]);
+      expect(repo.getAll().map((s) => s.id), ['x', 'y']);
+    });
+
+    test('delete removes matching entry', () async {
+      await repo.save(makeStation('a'));
+      await repo.save(makeStation('b'));
+      await repo.delete('a');
+      expect(repo.getAll().single.id, 'b');
+    });
+
+    test('getById returns null for missing id', () async {
+      await repo.save(makeStation('a'));
+      expect(repo.getById('missing'), isNull);
+      expect(repo.getById('a')?.id, 'a');
+    });
+
+    test('clear empties the cache', () async {
+      await repo.save(makeStation('a'));
+      await repo.clear();
+      expect(repo.getAll(), isEmpty);
+    });
+
+    test('malformed entries are skipped gracefully', () async {
+      storage._data['ev_stations_cache'] = [
+        makeStation('ok').toJson(),
+        'not a map',
+        {'id': 'broken'}, // missing required fields
+      ];
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.id, 'ok');
+    });
+  });
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/ev/presentation/ev_filter_chips_test.dart
+++ b/test/features/ev/presentation/ev_filter_chips_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/ev/presentation/widgets/ev_filter_chips.dart';
+import 'package:tankstellen/features/ev/providers/ev_providers.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+import '../../../helpers/pump_app.dart';
+
+void main() {
+  testWidgets('EvFilterChips toggles connector selection via provider',
+      (tester) async {
+    late ProviderContainer capturedContainer;
+
+    await pumpApp(
+      tester,
+      Consumer(
+        builder: (context, ref, _) {
+          capturedContainer = ProviderScope.containerOf(context);
+          return const EvFilterChips();
+        },
+      ),
+      overrides: [
+        vehicleProfileRepositoryProvider.overrideWithValue(
+          VehicleProfileRepository(_FakeSettings()),
+        ),
+      ],
+    );
+
+    expect(
+      capturedContainer.read(evFilterControllerProvider).connectorTypes,
+      isEmpty,
+    );
+
+    // Find the CCS chip and tap it.
+    final ccsChip = find.widgetWithText(FilterChip, 'CCS');
+    expect(ccsChip, findsOneWidget);
+    await tester.ensureVisible(ccsChip);
+    await tester.tap(ccsChip);
+    await tester.pumpAndSettle();
+
+    expect(
+      capturedContainer
+          .read(evFilterControllerProvider)
+          .connectorTypes
+          .contains(ConnectorType.ccs),
+      isTrue,
+    );
+  });
+
+  testWidgets('EvFilterChips exposes an "Available only" toggle',
+      (tester) async {
+    late ProviderContainer capturedContainer;
+
+    await pumpApp(
+      tester,
+      Consumer(
+        builder: (context, ref, _) {
+          capturedContainer = ProviderScope.containerOf(context);
+          return const EvFilterChips();
+        },
+      ),
+      overrides: [
+        vehicleProfileRepositoryProvider.overrideWithValue(
+          VehicleProfileRepository(_FakeSettings()),
+        ),
+      ],
+    );
+
+    final chip = find.widgetWithText(FilterChip, 'Available only');
+    expect(chip, findsOneWidget);
+    await tester.tap(chip);
+    await tester.pumpAndSettle();
+
+    expect(
+      capturedContainer.read(evFilterControllerProvider).availableOnly,
+      isTrue,
+    );
+  });
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/ev/presentation/ev_marker_widget_test.dart
+++ b/test/features/ev/presentation/ev_marker_widget_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/ev/presentation/widgets/ev_marker_widget.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+
+import '../../../helpers/pump_app.dart';
+
+void main() {
+  group('EvMarkerWidget', () {
+    const availableStation = ChargingStation(
+      id: 'a',
+      name: 'Available',
+      latitude: 0,
+      longitude: 0,
+      connectors: [
+        EvConnector(
+          id: 'a1',
+          type: ConnectorType.ccs,
+          maxPowerKw: 50,
+          status: ConnectorStatus.available,
+        ),
+      ],
+    );
+
+    const occupiedStation = ChargingStation(
+      id: 'b',
+      name: 'Occupied',
+      latitude: 0,
+      longitude: 0,
+      connectors: [
+        EvConnector(
+          id: 'b1',
+          type: ConnectorType.ccs,
+          maxPowerKw: 50,
+          status: ConnectorStatus.occupied,
+        ),
+      ],
+    );
+
+    const unknownStation = ChargingStation(
+      id: 'c',
+      name: 'Unknown',
+      latitude: 0,
+      longitude: 0,
+      connectors: [
+        EvConnector(
+          id: 'c1',
+          type: ConnectorType.type2,
+          maxPowerKw: 22,
+        ),
+      ],
+    );
+
+    test('colorFor returns green for available, red for occupied,'
+        ' grey for unknown', () {
+      expect(EvMarkerWidget.colorFor(availableStation), Colors.green);
+      expect(EvMarkerWidget.colorFor(occupiedStation), Colors.red);
+      expect(EvMarkerWidget.colorFor(unknownStation), Colors.grey);
+    });
+
+    testWidgets('renders an ev_station icon and responds to tap',
+        (tester) async {
+      var tapped = 0;
+      await pumpApp(
+        tester,
+        EvMarkerWidget(
+          station: availableStation,
+          onTap: () => tapped++,
+        ),
+      );
+
+      expect(find.byIcon(Icons.ev_station), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.ev_station));
+      expect(tapped, 1);
+    });
+
+    test('buildMarker returns a Marker anchored at station coordinates', () {
+      final marker = EvMarkerWidget.buildMarker(
+        const ChargingStation(
+          id: 'x',
+          name: 'X',
+          latitude: 48.1,
+          longitude: 2.5,
+        ),
+      );
+      expect(marker.point.latitude, 48.1);
+      expect(marker.point.longitude, 2.5);
+      expect(marker.width, 44);
+      expect(marker.height, 44);
+    });
+  });
+}

--- a/test/features/ev/providers/ev_providers_test.dart
+++ b/test/features/ev/providers/ev_providers_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/ev/data/services/open_charge_map_service.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/ev/providers/ev_providers.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+
+void main() {
+  group('EvFilter.matches', () {
+    final stationCcs50Available = ChargingStation(
+      id: 'a',
+      name: 'A',
+      latitude: 0,
+      longitude: 0,
+      connectors: const [
+        EvConnector(
+          id: 'a1',
+          type: ConnectorType.ccs,
+          maxPowerKw: 50,
+          status: ConnectorStatus.available,
+        ),
+      ],
+    );
+    final stationType2Occupied = ChargingStation(
+      id: 'b',
+      name: 'B',
+      latitude: 0,
+      longitude: 0,
+      connectors: const [
+        EvConnector(
+          id: 'b1',
+          type: ConnectorType.type2,
+          maxPowerKw: 22,
+          status: ConnectorStatus.occupied,
+        ),
+      ],
+    );
+
+    test('empty filter matches everything', () {
+      const filter = EvFilter();
+      expect(filter.matches(stationCcs50Available), isTrue);
+      expect(filter.matches(stationType2Occupied), isTrue);
+    });
+
+    test('connector type filter keeps matching plug only', () {
+      const filter = EvFilter(connectorTypes: {ConnectorType.ccs});
+      expect(filter.matches(stationCcs50Available), isTrue);
+      expect(filter.matches(stationType2Occupied), isFalse);
+    });
+
+    test('minPowerKw filters out slow chargers', () {
+      const filter = EvFilter(minPowerKw: 50);
+      expect(filter.matches(stationCcs50Available), isTrue);
+      expect(filter.matches(stationType2Occupied), isFalse);
+    });
+
+    test('availableOnly removes stations without free connectors', () {
+      const filter = EvFilter(availableOnly: true);
+      expect(filter.matches(stationCcs50Available), isTrue);
+      expect(filter.matches(stationType2Occupied), isFalse);
+    });
+
+    test('copyWith preserves untouched fields', () {
+      const base = EvFilter(
+        connectorTypes: {ConnectorType.ccs},
+        minPowerKw: 50,
+        availableOnly: true,
+      );
+      final next = base.copyWith(availableOnly: false);
+      expect(next.connectorTypes, {ConnectorType.ccs});
+      expect(next.minPowerKw, 50);
+      expect(next.availableOnly, isFalse);
+    });
+
+    test('equality compares all fields including sets', () {
+      const a = EvFilter(
+        connectorTypes: {ConnectorType.ccs, ConnectorType.type2},
+        minPowerKw: 22,
+      );
+      const b = EvFilter(
+        connectorTypes: {ConnectorType.type2, ConnectorType.ccs},
+        minPowerKw: 22,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+
+  group('DemoEvStationService', () {
+    test('returns a non-empty list of stations centered near the request',
+        () async {
+      const service = DemoEvStationService();
+      final stations = await service.fetchStations(
+        centerLat: 48.85,
+        centerLng: 2.35,
+        radiusKm: 5,
+      );
+      expect(stations, isNotEmpty);
+      for (final s in stations) {
+        expect((s.latitude - 48.85).abs() < 0.1, isTrue);
+        expect((s.longitude - 2.35).abs() < 0.1, isTrue);
+      }
+    });
+
+    test('OpenChargeMapService without API key falls back to demo data',
+        () async {
+      final service = OpenChargeMapService();
+      final stations = await service.fetchStations(
+        centerLat: 48.85,
+        centerLng: 2.35,
+        radiusKm: 5,
+      );
+      expect(stations, isNotEmpty);
+    });
+  });
+
+  group('evShowOnMapProvider', () {
+    test('defaults to false and can be toggled', () async {
+      final storage = _FakeSettings();
+      final container = ProviderContainer(
+        overrides: [
+          settingsStorageProvider.overrideWithValue(storage),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(container.read(evShowOnMapProvider), isFalse);
+      await container.read(evShowOnMapProvider.notifier).toggle();
+      expect(container.read(evShowOnMapProvider), isTrue);
+      await container.read(evShowOnMapProvider.notifier).set(false);
+      expect(container.read(evShowOnMapProvider), isFalse);
+    });
+  });
+
+  group('evStationsProvider', () {
+    test('fetches from service, caches in repo, applies filter', () async {
+      final storage = _FakeSettings();
+      final container = ProviderContainer(
+        overrides: [
+          settingsStorageProvider.overrideWithValue(storage),
+          evStationServiceProvider.overrideWith(
+            (ref) => const DemoEvStationService(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Narrow the filter to CCS only so we can assert filtering happens.
+      container
+          .read(evFilterControllerProvider.notifier)
+          .setConnectorTypes({ConnectorType.ccs});
+
+      final result = await container.read(
+        evStationsProvider(
+          const EvViewport(latitude: 48.85, longitude: 2.35, radiusKm: 5),
+        ).future,
+      );
+      expect(result, isNotEmpty);
+      for (final s in result) {
+        expect(
+          s.connectors.any((c) => c.type == ConnectorType.ccs),
+          isTrue,
+        );
+      }
+
+      // Repository should now hold the full (unfiltered) list.
+      final repo = container.read(evStationRepositoryProvider);
+      expect(repo.getAll(), isNotEmpty);
+    });
+  });
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/ev/providers/ev_providers_test.dart
+++ b/test/features/ev/providers/ev_providers_test.dart
@@ -10,12 +10,12 @@ import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dar
 
 void main() {
   group('EvFilter.matches', () {
-    final stationCcs50Available = ChargingStation(
+    const stationCcs50Available = ChargingStation(
       id: 'a',
       name: 'A',
       latitude: 0,
       longitude: 0,
-      connectors: const [
+      connectors: [
         EvConnector(
           id: 'a1',
           type: ConnectorType.ccs,
@@ -24,12 +24,12 @@ void main() {
         ),
       ],
     );
-    final stationType2Occupied = ChargingStation(
+    const stationType2Occupied = ChargingStation(
       id: 'b',
       name: 'B',
       latitude: 0,
       longitude: 0,
-      connectors: const [
+      connectors: [
         EvConnector(
           id: 'b1',
           type: ConnectorType.type2,


### PR DESCRIPTION
## Summary
- Adds the Flutter client layer for EV charging stations: repository, Open Charge Map service stub (with deterministic demo fallback), Riverpod providers, marker/filter/detail widgets, and a map toggle.
- Map screen shows an EV toggle button plus a filter chip row above the existing fuel map; the overlay renders clustered markers through the existing StationMapLayers without disturbing fuel search.
- Connector filter is seeded from the active vehicle profile's supportedConnectors, so a CCS-only car won't see incompatible plugs by default.
- l10n: new keys in en and de; existing translations reused for shared strings.

## Notes
- The real Open Charge Map HTTP call is intentionally stubbed in this PR (class-level TODO). When no API key is set we transparently serve the demo dataset so the feature is end-to-end visible without network flakiness.
- Fuel-station flow is untouched; adding the EV layer is opt-in via the toggle.

## Test plan
- [x] EvStationRepository CRUD (8 tests)
- [x] EvFilter logic for connector/power/availability (6 tests)
- [x] DemoEvStationService + OpenChargeMapService fallback
- [x] evShowOnMap persistence via provider
- [x] evStationsProvider fetch + cache + filter pipeline
- [x] EvMarkerWidget color + tap + buildMarker
- [x] EvFilterChips connector toggle + available-only toggle
- [x] flutter analyze: 0 warnings / 0 errors
- [x] flutter test: all EV tests pass; only pre-existing network-dependent Argentina API connectivity test fails (unrelated)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)