### PR TITLE
fix(search): Prix-Carburants postal-code path includes neighboring postal codes

### DIFF
--- a/lib/core/services/impl/prix_carburants_station_service.dart
+++ b/lib/core/services/impl/prix_carburants_station_service.dart
@@ -38,15 +38,33 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     List<Map<String, dynamic>> allResults = [];
 
     final hasPostalCode = params.postalCode != null && params.postalCode!.isNotEmpty;
+    final hasValidCoords = params.lat != 0 && params.lng != 0;
 
     if (hasPostalCode) {
-      // Postal code search: use native CP filter first (100% accurate),
-      // fall back to geo only if CP returns empty (e.g., invalid code).
-      // This avoids relying on Nominatim geocoding which returns inaccurate
-      // coordinates for French postal codes (especially Paris arrondissements).
-      allResults = await _queryByPostalCode(params.postalCode!, cancelToken: cancelToken);
-      if (allResults.isEmpty) {
-        allResults = await _queryByGeo(params.lat, params.lng, params.radiusKm, cancelToken: cancelToken);
+      // Postal code search strategy:
+      // 1. Run the native CP filter first — fast, 100% accurate for the
+      //    target postal code, and returns stations even when geocoding
+      //    is unreliable (e.g., Paris arrondissements).
+      // 2. ALSO run the geo query when valid coordinates are present, so
+      //    that neighboring postal codes are included when the user picks
+      //    a wider radius. Without this, a GPS search from a rural village
+      //    (which auto-attaches its postal code via reverse geocoding) would
+      //    cap results at the village's own ~5 stations regardless of
+      //    radius — bug #315.
+      // 3. Merge and dedupe by station id.
+      final cpResults = await _queryByPostalCode(params.postalCode!, cancelToken: cancelToken);
+
+      if (hasValidCoords) {
+        final geoResults = await _queryByGeo(params.lat, params.lng, params.radiusKm, cancelToken: cancelToken);
+        allResults = _mergeById(cpResults, geoResults);
+      } else {
+        allResults = cpResults;
+      }
+
+      // Final fallback: if both queries returned nothing (e.g., invalid CP
+      // and no coordinates), give up gracefully.
+      if (allResults.isEmpty && !hasValidCoords) {
+        allResults = const [];
       }
     } else {
       // GPS / coordinate search: geo query is the only option
@@ -125,6 +143,33 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
       debugPrint('Prix-Carburants geo fetch failed: $e');
       return [];
     }
+  }
+
+  /// Merge two raw API result lists, deduplicating by station id.
+  /// Stations from [primary] win when an id collides.
+  List<Map<String, dynamic>> _mergeById(
+    List<Map<String, dynamic>> primary,
+    List<Map<String, dynamic>> secondary,
+  ) {
+    final seen = <String>{};
+    final merged = <Map<String, dynamic>>[];
+    for (final r in primary) {
+      final id = r['id']?.toString() ?? '';
+      if (id.isNotEmpty && seen.add(id)) {
+        merged.add(r);
+      } else if (id.isEmpty) {
+        merged.add(r);
+      }
+    }
+    for (final r in secondary) {
+      final id = r['id']?.toString() ?? '';
+      if (id.isNotEmpty && seen.add(id)) {
+        merged.add(r);
+      } else if (id.isEmpty) {
+        merged.add(r);
+      }
+    }
+    return merged;
   }
 
   List<Map<String, dynamic>> _extractResults(dynamic data) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 11 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 4.3.0+4030
+version: 4.3.0+4040
 
 environment:
   sdk: ^3.11.3

--- a/test/core/services/impl/prix_carburants_station_service_test.dart
+++ b/test/core/services/impl/prix_carburants_station_service_test.dart
@@ -606,6 +606,8 @@ void main() {
       final adapter = _TrackingMockAdapter();
       // First request (CP query) returns results
       adapter.addResponse(_makeApiResponse('75012', 3));
+      // Second request (geo follow-up for neighboring postal codes — #315)
+      adapter.addResponse({'results': const []});
 
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
@@ -615,9 +617,13 @@ void main() {
       );
       final result = await svc.searchStations(params);
 
-      // Should have made exactly 1 request (CP query), not a geo query
-      expect(adapter.requestCount, 1);
-      expect(adapter.lastRequestUri, contains('cp%3D%2775012%27'));
+      // Per #315, the postal-code path now ALSO calls the geo query so that
+      // neighboring postal codes are included when the user picks a wider radius.
+      expect(adapter.requestCount, 2);
+      expect(adapter.requestUris[0], contains('cp%3D%2775012%27'),
+          reason: 'first call must be the postal-code query');
+      expect(adapter.requestUris[1], contains('within_distance'),
+          reason: 'second call must be the geo query (#315)');
       expect(result.data, hasLength(3));
       expect(result.data.first.postCode, '75012');
     });
@@ -663,9 +669,14 @@ void main() {
       expect(result.data, hasLength(4));
     });
 
-    test('does not call geo when postal code query succeeds', () async {
+    test('always calls geo as well when postal code + valid coords are present (#315)',
+        () async {
+      // Per #315, the cp-only path missed neighboring postal codes within the
+      // requested radius. The fix is to ALWAYS run the geo query in addition
+      // to the cp query when valid coordinates are present.
       final adapter = _TrackingMockAdapter();
       adapter.addResponse(_makeApiResponse('34120', 5));
+      adapter.addResponse({'results': const []}); // geo follow-up
 
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
@@ -675,8 +686,9 @@ void main() {
       );
       final result = await svc.searchStations(params);
 
-      expect(adapter.requestCount, 1);
-      expect(adapter.lastRequestUri, isNot(contains('within_distance')));
+      expect(adapter.requestCount, 2);
+      expect(adapter.requestUris[0], contains('cp%3D%2734120%27'));
+      expect(adapter.requestUris[1], contains('within_distance'));
       expect(result.data, hasLength(5));
     });
 
@@ -750,7 +762,8 @@ void main() {
 
     test('postal-code path filters stations by radius (regression #298)', () async {
       final adapter = _TrackingMockAdapter()
-        ..addResponse(scatteredStations('34120'));
+        ..addResponse(scatteredStations('34120'))
+        ..addResponse({'results': const []}); // geo follow-up returns nothing extra
 
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
@@ -760,7 +773,8 @@ void main() {
         lat: 43.45, lng: 3.42, radiusKm: 2.0, postalCode: '34120',
       ));
 
-      expect(adapter.lastRequestUri, contains('cp%3D%2734120%27'),
+      // First request must be the postal-code query
+      expect(adapter.requestUris.first, contains('cp%3D%2734120%27'),
           reason: 'should have taken the postal-code path');
       expect(result.data.map((s) => s.id).toList(), ['3412001', '3412002'],
           reason: 'only stations within 2 km should remain');
@@ -772,7 +786,9 @@ void main() {
     test('postal-code path with different radii returns different result counts (#298)', () async {
       final adapter = _TrackingMockAdapter()
         ..addResponse(scatteredStations('34120'))
-        ..addResponse(scatteredStations('34120'));
+        ..addResponse({'results': const []}) // geo follow-up for narrow
+        ..addResponse(scatteredStations('34120'))
+        ..addResponse({'results': const []}); // geo follow-up for wide
 
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
@@ -825,6 +841,227 @@ void main() {
 
       expect(adapter.lastRequestUri, contains('within_distance'));
       expect(result.data.map((s) => s.id).toList(), ['3412001', '3412002']);
+    });
+
+    // -------- #315: postal-code search must include neighboring postal codes --------
+
+    test('postal-code path also queries geo to include neighboring postal codes (#315)',
+        () async {
+      // 2 stations in postal code 34120 (the user's village, both very close),
+      // plus 3 stations in neighboring postal codes returned by the geo query.
+      final cpResults = {
+        'results': [
+          {
+            'id': '3412001',
+            'adresse': 'Local A',
+            'cp': '34120',
+            'geom': {'lat': 43.45 + (0.3 / 111), 'lon': 3.42},
+            'sp95_prix': 1.80,
+          },
+          {
+            'id': '3412002',
+            'adresse': 'Local B',
+            'cp': '34120',
+            'geom': {'lat': 43.45 + (1.5 / 111), 'lon': 3.42},
+            'sp95_prix': 1.82,
+          },
+        ],
+      };
+      final geoResults = {
+        'results': [
+          // Same village stations also visible to geo (will be deduped)
+          {
+            'id': '3412001',
+            'adresse': 'Local A',
+            'cp': '34120',
+            'geom': {'lat': 43.45 + (0.3 / 111), 'lon': 3.42},
+            'sp95_prix': 1.80,
+          },
+          // Pézenas (5 km away) — different postal code
+          {
+            'id': '3412003',
+            'adresse': 'Pézenas Total',
+            'cp': '34120',
+            'geom': {'lat': 43.45 + (5.0 / 111), 'lon': 3.42},
+            'sp95_prix': 1.78,
+          },
+          // Mèze (12 km) — different postal code
+          {
+            'id': '3414001',
+            'adresse': 'Mèze Esso',
+            'cp': '34140',
+            'geom': {'lat': 43.45 + (12.0 / 111), 'lon': 3.42},
+            'sp95_prix': 1.76,
+          },
+          // Agde (20 km) — different postal code
+          {
+            'id': '3430001',
+            'adresse': 'Agde Carrefour',
+            'cp': '34300',
+            'geom': {'lat': 43.45 + (20.0 / 111), 'lon': 3.42},
+            'sp95_prix': 1.79,
+          },
+        ],
+      };
+
+      final adapter = _TrackingMockAdapter()
+        ..addResponse(cpResults)
+        ..addResponse(geoResults);
+
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      final result = await svc.searchStations(const SearchParams(
+        lat: 43.45, lng: 3.42, radiusKm: 25.0, postalCode: '34120',
+      ));
+
+      // Both API calls must happen
+      expect(adapter.requestCount, 2,
+          reason: 'postal-code path must call BOTH cp and geo queries when valid coords are present');
+      expect(adapter.requestUris[0], contains('cp%3D%2734120%27'),
+          reason: 'first call is the postal-code query');
+      expect(adapter.requestUris[1], contains('within_distance'),
+          reason: 'second call is the geo query for neighboring postal codes');
+
+      // Should return 5 unique stations (2 local + 3 neighbors), deduped
+      expect(result.data.length, 5,
+          reason: 'merged set should include local + neighboring stations');
+      expect(result.data.map((s) => s.id).toSet(), {
+        '3412001', '3412002', '3412003', '3414001', '3430001',
+      });
+    });
+
+    test('postal-code search: 5km vs 25km returns different counts when neighbors exist (#315)',
+        () async {
+      // The exact bug the user reported in Castelnau-de-Guers: small radius
+      // returns local stations, large radius returns local + neighboring.
+      Map<String, dynamic> cpFixture() => {
+            'results': [
+              {
+                'id': 'local1',
+                'adresse': 'Local 1',
+                'cp': '34120',
+                'geom': {'lat': 43.45 + (0.5 / 111), 'lon': 3.42},
+                'sp95_prix': 1.80,
+              },
+              {
+                'id': 'local2',
+                'adresse': 'Local 2',
+                'cp': '34120',
+                'geom': {'lat': 43.45 + (2.0 / 111), 'lon': 3.42},
+                'sp95_prix': 1.82,
+              },
+            ],
+          };
+      Map<String, dynamic> geoFixtureNarrow() => {
+            'results': [
+              // Same as cp results (within 5km)
+              {
+                'id': 'local1',
+                'adresse': 'Local 1',
+                'cp': '34120',
+                'geom': {'lat': 43.45 + (0.5 / 111), 'lon': 3.42},
+                'sp95_prix': 1.80,
+              },
+              {
+                'id': 'local2',
+                'adresse': 'Local 2',
+                'cp': '34120',
+                'geom': {'lat': 43.45 + (2.0 / 111), 'lon': 3.42},
+                'sp95_prix': 1.82,
+              },
+            ],
+          };
+      Map<String, dynamic> geoFixtureWide() => {
+            'results': [
+              // Local (5km radius would already include these)
+              {
+                'id': 'local1',
+                'adresse': 'Local 1',
+                'cp': '34120',
+                'geom': {'lat': 43.45 + (0.5 / 111), 'lon': 3.42},
+                'sp95_prix': 1.80,
+              },
+              {
+                'id': 'local2',
+                'adresse': 'Local 2',
+                'cp': '34120',
+                'geom': {'lat': 43.45 + (2.0 / 111), 'lon': 3.42},
+                'sp95_prix': 1.82,
+              },
+              // Neighbors (only visible at 25km)
+              {
+                'id': 'neighbor1',
+                'adresse': 'Pézenas',
+                'cp': '34120',
+                'geom': {'lat': 43.45 + (8.0 / 111), 'lon': 3.42},
+                'sp95_prix': 1.78,
+              },
+              {
+                'id': 'neighbor2',
+                'adresse': 'Mèze',
+                'cp': '34140',
+                'geom': {'lat': 43.45 + (15.0 / 111), 'lon': 3.42},
+                'sp95_prix': 1.76,
+              },
+              {
+                'id': 'neighbor3',
+                'adresse': 'Agde',
+                'cp': '34300',
+                'geom': {'lat': 43.45 + (22.0 / 111), 'lon': 3.42},
+                'sp95_prix': 1.79,
+              },
+            ],
+          };
+
+      final adapter = _TrackingMockAdapter()
+        ..addResponse(cpFixture())
+        ..addResponse(geoFixtureNarrow())
+        ..addResponse(cpFixture())
+        ..addResponse(geoFixtureWide());
+
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      final small = await svc.searchStations(const SearchParams(
+        lat: 43.45, lng: 3.42, radiusKm: 5.0, postalCode: '34120',
+      ));
+      final large = await svc.searchStations(const SearchParams(
+        lat: 43.45, lng: 3.42, radiusKm: 25.0, postalCode: '34120',
+      ));
+
+      // Bug #315 contract: large radius MUST return strictly more stations
+      // than small radius when neighboring postal codes are populated.
+      expect(small.data.length, 2,
+          reason: 'only the 2 local stations within 5 km');
+      expect(large.data.length, 5,
+          reason: 'local + 3 neighbors within 25 km');
+      expect(large.data.length, greaterThan(small.data.length),
+          reason: 'BUG #315: 25 km must return more stations than 5 km');
+    });
+
+    test('postal-code path falls back to cp-only when coords are invalid (#315)',
+        () async {
+      // No valid GPS coords (lat=0, lng=0): only the cp query runs.
+      // This preserves the original Paris-arrondissement use case where
+      // Nominatim coords are unreliable.
+      final adapter = _TrackingMockAdapter()
+        ..addResponse(scatteredStations('75001'));
+
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      final result = await svc.searchStations(const SearchParams(
+        lat: 0, lng: 0, radiusKm: 25.0, postalCode: '75001',
+      ));
+
+      expect(adapter.requestCount, 1,
+          reason: 'only cp query runs when coords are 0,0');
+      expect(adapter.requestUris.first, contains('cp%3D%2775001%27'));
+      // All 5 fixture stations are at (lat = 43.45 + offset, lng = 3.42)
+      // Distances from (0,0) are huge → filterByRadius fallback triggers,
+      // returning the 20 nearest. We just verify the call shape.
+      expect(result.data, isNotEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary
GPS search from a small French village (e.g., Castelnau-de-Guers) was returning the same stations regardless of the radius slider — 5 km and 25 km gave identical results.

Root cause: reverse geocoding attaches the village's postal code (34120) to the search params, which forced the service into a `cp='34120'`-only query path. That query returns the village's ~5 stations and never queries neighboring postal codes (Pézenas, Mèze, Agde, etc.). PR #300 fixed the post-filter for the cp path, but the deeper issue was that the API never returned the neighbors in the first place.

## Fix
When the postal-code path runs AND valid coordinates are present, also call the geo `within_distance` query, merge results deduped by station id, and apply the existing `filterByRadius` post-filter.

The cp-only path is preserved for the `(lat=0, lng=0)` case, keeping the Paris-arrondissement use case (typed postal code, no GPS) working.

## Test plan
- [x] New: `postal-code path also queries geo to include neighboring postal codes (#315)`
- [x] New: `postal-code search: 5km vs 25km returns different counts when neighbors exist (#315)` — the exact user repro
- [x] New: `postal-code path falls back to cp-only when coords are invalid (#315)` — Paris arrondissement guard
- [x] Updated existing #298 tests to provide the geo follow-up response
- [x] Radius contract test (#299) still green
- [x] All 54 prix_carburants tests pass
- [x] `flutter analyze --no-fatal-infos` clean

Closes #315