### PR TITLE
fix(i18n): localize hardcoded strings in core screens (batch 1)

### DIFF
--- a/lib/features/carbon/presentation/widgets/monthly_bar_chart.dart
+++ b/lib/features/carbon/presentation/widgets/monthly_bar_chart.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+import '../../../../l10n/app_localizations.dart';
 import '../../domain/monthly_summary.dart';
 
 /// A minimal bar chart rendered via [CustomPainter].
@@ -34,9 +35,10 @@ class MonthlyBarChart extends StatelessWidget {
   Widget build(BuildContext context) {
     final onSurface = Theme.of(context).colorScheme.onSurface;
     if (summaries.isEmpty) {
-      return const SizedBox(
+      final l = AppLocalizations.of(context);
+      return SizedBox(
         height: 180,
-        child: Center(child: Text('No data')),
+        child: Center(child: Text(l?.noDataAvailable ?? 'No data')),
       );
     }
     return SizedBox(

--- a/lib/features/ev/presentation/widgets/ev_filter_chips.dart
+++ b/lib/features/ev/presentation/widgets/ev_filter_chips.dart
@@ -83,13 +83,13 @@ class _PowerDropdown extends StatelessWidget {
     return DropdownButton<double>(
       value: value,
       hint: Text(l10n?.evMinPower ?? 'Min power'),
-      items: const [
-        DropdownMenuItem(value: 0, child: Text('Any')),
-        DropdownMenuItem(value: 11, child: Text('11 kW+')),
-        DropdownMenuItem(value: 22, child: Text('22 kW+')),
-        DropdownMenuItem(value: 50, child: Text('50 kW+')),
-        DropdownMenuItem(value: 150, child: Text('150 kW+')),
-        DropdownMenuItem(value: 300, child: Text('300 kW+')),
+      items: [
+        DropdownMenuItem(value: 0, child: Text(l10n?.evPowerAny ?? 'Any')),
+        DropdownMenuItem(value: 11, child: Text(l10n?.evPowerKw(11) ?? '11 kW+')),
+        DropdownMenuItem(value: 22, child: Text(l10n?.evPowerKw(22) ?? '22 kW+')),
+        DropdownMenuItem(value: 50, child: Text(l10n?.evPowerKw(50) ?? '50 kW+')),
+        DropdownMenuItem(value: 150, child: Text(l10n?.evPowerKw(150) ?? '150 kW+')),
+        DropdownMenuItem(value: 300, child: Text(l10n?.evPowerKw(300) ?? '300 kW+')),
       ],
       onChanged: (v) {
         if (v != null) onChanged(v);

--- a/lib/features/favorites/presentation/widgets/favorites_loading_view.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_loading_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/widgets/shimmer_placeholder.dart';
+import '../../../../l10n/app_localizations.dart';
 
 /// Professional loading view with shimmer skeleton + pulsing fuel icon + reassuring text.
 ///
@@ -39,6 +40,7 @@ class _FavoritesLoadingViewState extends State<FavoritesLoadingView>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
 
     return Column(
       children: [
@@ -65,11 +67,11 @@ class _FavoritesLoadingViewState extends State<FavoritesLoadingView>
                       style: theme.textTheme.titleSmall!.copyWith(
                         color: theme.colorScheme.onSurface,
                       ),
-                      child: const Text('Updating your favorites...'),
+                      child: Text(l?.updatingFavorites ?? 'Updating your favorites...'),
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      'Fetching the latest prices',
+                      l?.fetchingLatestPrices ?? 'Fetching the latest prices',
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                       ),

--- a/lib/features/map/presentation/widgets/inline_map.dart
+++ b/lib/features/map/presentation/widgets/inline_map.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/widgets/empty_state.dart';
+import '../../../../l10n/app_localizations.dart';
 import '../../../search/providers/search_provider.dart';
 import 'station_map_layers.dart';
 
@@ -40,9 +41,9 @@ class _InlineMapState extends ConsumerState<InlineMap> {
         final stations = result.data;
 
         if (stations.isEmpty) {
-          return const EmptyState(
+          return EmptyState(
             icon: Icons.map_outlined,
-            title: 'Search to see stations on the map',
+            title: AppLocalizations.of(context)?.searchToSeeMap ?? 'Search to see stations on the map',
           );
         }
 

--- a/lib/features/price_history/presentation/widgets/hourly_price_chart.dart
+++ b/lib/features/price_history/presentation/widgets/hourly_price_chart.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/price_prediction.dart';
 
 /// A vertical bar chart showing average price by hour of day (0-23).
@@ -17,9 +18,10 @@ class HourlyPriceChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (hourlyAverages.isEmpty) {
-      return const SizedBox(
+      final l = AppLocalizations.of(context);
+      return SizedBox(
         height: 140,
-        child: Center(child: Text('No hourly data')),
+        child: Center(child: Text(l?.noHourlyData ?? 'No hourly data')),
       );
     }
     return SizedBox(

--- a/lib/features/price_history/presentation/widgets/price_chart.dart
+++ b/lib/features/price_history/presentation/widgets/price_chart.dart
@@ -4,6 +4,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/fuel_colors.dart';
+import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/price_record.dart';
 
@@ -20,9 +21,10 @@ class PriceChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (records.isEmpty) {
-      return const SizedBox(
+      final l = AppLocalizations.of(context);
+      return SizedBox(
         height: 120,
-        child: Center(child: Text('No price history yet')),
+        child: Center(child: Text(l?.noPriceHistory ?? 'No price history yet')),
       );
     }
     return SizedBox(

--- a/lib/features/price_history/presentation/widgets/price_stats_card.dart
+++ b/lib/features/price_history/presentation/widgets/price_stats_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/price_stats.dart';
 
 /// Displays aggregate price statistics (min, max, avg, current) with
@@ -20,9 +21,10 @@ class PriceStatsCard extends StatelessWidget {
     final theme = Theme.of(context);
 
     if (stats.current == null && stats.min == null) {
-      return const Padding(
-        padding: EdgeInsets.all(16),
-        child: Text('No statistics available'),
+      final l = AppLocalizations.of(context);
+      return Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(l?.noStatistics ?? 'No statistics available'),
       );
     }
 

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -32,13 +32,13 @@ class ProfileScreen extends ConsumerWidget {
         padding: const EdgeInsets.all(16),
         children: [
           // Profiles
-          const _SectionHeader(icon: Icons.person, title: 'Profile'),
+          _SectionHeader(icon: Icons.person, title: l?.sectionProfile ?? 'Profile'),
           const SizedBox(height: 8),
           const ProfileListSection(),
           const SizedBox(height: 32),
 
           // Location
-          const _SectionHeader(icon: Icons.my_location, title: 'Location'),
+          _SectionHeader(icon: Icons.my_location, title: l?.sectionLocation ?? 'Location'),
           const SizedBox(height: 8),
           const LocationSectionWidget(),
           const SizedBox(height: 32),
@@ -150,9 +150,9 @@ class ProfileScreen extends ConsumerWidget {
           const SizedBox(height: 8),
 
           // Configuration Verification
-          const _SectionHeader(
+          _SectionHeader(
             icon: Icons.verified_user,
-            title: 'Configuration & Privacy',
+            title: l?.configAndPrivacy ?? 'Configuration & Privacy',
           ),
           const SizedBox(height: 8),
           const ConfigVerificationWidget(),

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -140,7 +140,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
         title: Text(l10n?.searchCriteriaTitle ?? 'Search criteria'),
         leading: IconButton(
           icon: const Icon(Icons.close),
-          tooltip: 'Close',
+          tooltip: AppLocalizations.of(context)?.tooltipClose ?? 'Close',
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),

--- a/lib/features/search/presentation/widgets/demo_mode_banner.dart
+++ b/lib/features/search/presentation/widgets/demo_mode_banner.dart
@@ -26,7 +26,7 @@ class DemoModeBanner extends ConsumerWidget {
         actions: [
           TextButton(
             onPressed: () => context.go('/profile'),
-            child: const Text('Setup'),
+            child: Text(l10n?.apiKeySetup ?? 'Setup'),
           ),
         ],
       );

--- a/lib/features/search/presentation/widgets/location_input.dart
+++ b/lib/features/search/presentation/widgets/location_input.dart
@@ -170,7 +170,7 @@ class _LocationInputState extends ConsumerState<LocationInput> {
                       if (_controller.text.isNotEmpty)
                         IconButton(
                           icon: const Icon(Icons.clear, size: 18),
-                          tooltip: 'Clear search input',
+                          tooltip: AppLocalizations.of(context)?.tooltipClearSearch ?? 'Clear search input',
                           padding: const EdgeInsets.all(4),
                           constraints: const BoxConstraints(
                               minWidth: 32, minHeight: 32),
@@ -181,7 +181,7 @@ class _LocationInputState extends ConsumerState<LocationInput> {
                         ),
                       IconButton(
                         icon: const Icon(Icons.my_location, size: 18),
-                        tooltip: 'Use GPS location',
+                        tooltip: AppLocalizations.of(context)?.tooltipUseGps ?? 'Use GPS location',
                         padding: const EdgeInsets.all(4),
                         constraints: const BoxConstraints(
                             minWidth: 32, minHeight: 32),

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -42,7 +42,7 @@ class StationDetailScreen extends ConsumerWidget {
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () => context.pop(),
-          tooltip: 'Back',
+          tooltip: AppLocalizations.of(context)?.tooltipBack ?? 'Back',
         ),
         actions: [
           IconButton(

--- a/lib/features/station_detail/presentation/widgets/price_history_section.dart
+++ b/lib/features/station_detail/presentation/widgets/price_history_section.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/sync/sync_service.dart';
+import '../../../../l10n/app_localizations.dart';
 import '../../../price_history/domain/entities/price_record.dart';
 import '../../../price_history/presentation/widgets/price_chart.dart';
 import '../../../price_history/presentation/widgets/price_stats_card.dart';
@@ -118,7 +119,7 @@ class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
           alignment: Alignment.centerRight,
           child: TextButton(
             onPressed: () => GoRouter.of(context).push('/station/${widget.stationId}/history'),
-            child: const Text('Show all fuel types'),
+            child: Text(AppLocalizations.of(context)?.showAllFuelTypes ?? 'Show all fuel types'),
           ),
         ),
       ],

--- a/lib/features/station_detail/presentation/widgets/station_info_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_info_section.dart
@@ -52,7 +52,7 @@ class StationInfoSection extends StatelessWidget {
         if (station.is24h)
           ListTile(
             leading: Icon(Icons.schedule, color: DarkModeColors.success(context)),
-            title: const Text('24h/24 — Automate'),
+            title: Text(l10n?.automate24h ?? '24h/24 — Automate'),
           )
         else if (station.openingHoursText != null && station.openingHoursText!.isNotEmpty)
           ...station.openingHoursText!.split('\n').map((line) => ListTile(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -762,5 +762,25 @@
   "openOnlyFilter": "Nur geöffnete",
   "saveAsDefaults": "Als Standard speichern",
   "criteriaSavedToProfile": "Als Standard gespeichert",
-  "profileNotFound": "Kein aktives Profil"
+  "profileNotFound": "Kein aktives Profil",
+  "updatingFavorites": "Favoriten werden aktualisiert…",
+  "fetchingLatestPrices": "Neueste Preise werden geladen",
+  "noDataAvailable": "Keine Daten",
+  "configAndPrivacy": "Konfiguration & Datenschutz",
+  "searchToSeeMap": "Suchen Sie, um Tankstellen auf der Karte zu sehen",
+  "evPowerAny": "Alle",
+  "evPowerKw": "{kw} kW+",
+  "@evPowerKw": {
+    "placeholders": {
+      "kw": {
+        "type": "int"
+      }
+    }
+  },
+  "sectionProfile": "Profil",
+  "sectionLocation": "Standort",
+  "tooltipBack": "Zurück",
+  "tooltipClose": "Schließen",
+  "tooltipClearSearch": "Sucheingabe löschen",
+  "tooltipUseGps": "GPS-Standort verwenden"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -762,5 +762,25 @@
   "openOnlyFilter": "Open only",
   "saveAsDefaults": "Save as my defaults",
   "criteriaSavedToProfile": "Saved as defaults",
-  "profileNotFound": "No active profile"
+  "profileNotFound": "No active profile",
+  "updatingFavorites": "Updating your favorites...",
+  "fetchingLatestPrices": "Fetching the latest prices",
+  "noDataAvailable": "No data",
+  "configAndPrivacy": "Configuration & Privacy",
+  "searchToSeeMap": "Search to see stations on the map",
+  "evPowerAny": "Any",
+  "evPowerKw": "{kw} kW+",
+  "@evPowerKw": {
+    "placeholders": {
+      "kw": {
+        "type": "int"
+      }
+    }
+  },
+  "sectionProfile": "Profile",
+  "sectionLocation": "Location",
+  "tooltipBack": "Back",
+  "tooltipClose": "Close",
+  "tooltipClearSearch": "Clear search input",
+  "tooltipUseGps": "Use GPS location"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -427,5 +427,25 @@
   "openOnlyFilter": "Ouvertes uniquement",
   "saveAsDefaults": "Enregistrer comme valeurs par défaut",
   "criteriaSavedToProfile": "Enregistré comme valeurs par défaut",
-  "profileNotFound": "Aucun profil actif"
+  "profileNotFound": "Aucun profil actif",
+  "updatingFavorites": "Mise à jour de vos favoris…",
+  "fetchingLatestPrices": "Récupération des derniers prix",
+  "noDataAvailable": "Pas de données",
+  "configAndPrivacy": "Configuration & Confidentialité",
+  "searchToSeeMap": "Recherchez pour voir les stations sur la carte",
+  "evPowerAny": "Tous",
+  "evPowerKw": "{kw} kW+",
+  "@evPowerKw": {
+    "placeholders": {
+      "kw": {
+        "type": "int"
+      }
+    }
+  },
+  "sectionProfile": "Profil",
+  "sectionLocation": "Localisation",
+  "tooltipBack": "Retour",
+  "tooltipClose": "Fermer",
+  "tooltipClearSearch": "Effacer la recherche",
+  "tooltipUseGps": "Utiliser la position GPS"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3294,6 +3294,84 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No active profile'**
   String get profileNotFound;
+
+  /// No description provided for @updatingFavorites.
+  ///
+  /// In en, this message translates to:
+  /// **'Updating your favorites...'**
+  String get updatingFavorites;
+
+  /// No description provided for @fetchingLatestPrices.
+  ///
+  /// In en, this message translates to:
+  /// **'Fetching the latest prices'**
+  String get fetchingLatestPrices;
+
+  /// No description provided for @noDataAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'No data'**
+  String get noDataAvailable;
+
+  /// No description provided for @configAndPrivacy.
+  ///
+  /// In en, this message translates to:
+  /// **'Configuration & Privacy'**
+  String get configAndPrivacy;
+
+  /// No description provided for @searchToSeeMap.
+  ///
+  /// In en, this message translates to:
+  /// **'Search to see stations on the map'**
+  String get searchToSeeMap;
+
+  /// No description provided for @evPowerAny.
+  ///
+  /// In en, this message translates to:
+  /// **'Any'**
+  String get evPowerAny;
+
+  /// No description provided for @evPowerKw.
+  ///
+  /// In en, this message translates to:
+  /// **'{kw} kW+'**
+  String evPowerKw(int kw);
+
+  /// No description provided for @sectionProfile.
+  ///
+  /// In en, this message translates to:
+  /// **'Profile'**
+  String get sectionProfile;
+
+  /// No description provided for @sectionLocation.
+  ///
+  /// In en, this message translates to:
+  /// **'Location'**
+  String get sectionLocation;
+
+  /// No description provided for @tooltipBack.
+  ///
+  /// In en, this message translates to:
+  /// **'Back'**
+  String get tooltipBack;
+
+  /// No description provided for @tooltipClose.
+  ///
+  /// In en, this message translates to:
+  /// **'Close'**
+  String get tooltipClose;
+
+  /// No description provided for @tooltipClearSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear search input'**
+  String get tooltipClearSearch;
+
+  /// No description provided for @tooltipUseGps.
+  ///
+  /// In en, this message translates to:
+  /// **'Use GPS location'**
+  String get tooltipUseGps;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1709,4 +1709,45 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1709,4 +1709,45 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1707,4 +1707,45 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1719,4 +1719,46 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get profileNotFound => 'Kein aktives Profil';
+
+  @override
+  String get updatingFavorites => 'Favoriten werden aktualisiert…';
+
+  @override
+  String get fetchingLatestPrices => 'Neueste Preise werden geladen';
+
+  @override
+  String get noDataAvailable => 'Keine Daten';
+
+  @override
+  String get configAndPrivacy => 'Konfiguration & Datenschutz';
+
+  @override
+  String get searchToSeeMap =>
+      'Suchen Sie, um Tankstellen auf der Karte zu sehen';
+
+  @override
+  String get evPowerAny => 'Alle';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profil';
+
+  @override
+  String get sectionLocation => 'Standort';
+
+  @override
+  String get tooltipBack => 'Zurück';
+
+  @override
+  String get tooltipClose => 'Schließen';
+
+  @override
+  String get tooltipClearSearch => 'Sucheingabe löschen';
+
+  @override
+  String get tooltipUseGps => 'GPS-Standort verwenden';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1711,4 +1711,45 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1702,4 +1702,45 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1710,4 +1710,45 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1704,4 +1704,45 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1707,4 +1707,45 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1714,4 +1714,45 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get profileNotFound => 'Aucun profil actif';
+
+  @override
+  String get updatingFavorites => 'Mise à jour de vos favoris…';
+
+  @override
+  String get fetchingLatestPrices => 'Récupération des derniers prix';
+
+  @override
+  String get noDataAvailable => 'Pas de données';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Confidentialité';
+
+  @override
+  String get searchToSeeMap => 'Recherchez pour voir les stations sur la carte';
+
+  @override
+  String get evPowerAny => 'Tous';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profil';
+
+  @override
+  String get sectionLocation => 'Localisation';
+
+  @override
+  String get tooltipBack => 'Retour';
+
+  @override
+  String get tooltipClose => 'Fermer';
+
+  @override
+  String get tooltipClearSearch => 'Effacer la recherche';
+
+  @override
+  String get tooltipUseGps => 'Utiliser la position GPS';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1706,4 +1706,45 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1711,4 +1711,45 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1710,4 +1710,45 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1708,4 +1708,45 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1710,4 +1710,45 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1706,4 +1706,45 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1711,4 +1711,45 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1709,4 +1709,45 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1710,4 +1710,45 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1709,4 +1709,45 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1710,4 +1710,45 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1704,4 +1704,45 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1708,4 +1708,45 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get profileNotFound => 'No active profile';
+
+  @override
+  String get updatingFavorites => 'Updating your favorites...';
+
+  @override
+  String get fetchingLatestPrices => 'Fetching the latest prices';
+
+  @override
+  String get noDataAvailable => 'No data';
+
+  @override
+  String get configAndPrivacy => 'Configuration & Privacy';
+
+  @override
+  String get searchToSeeMap => 'Search to see stations on the map';
+
+  @override
+  String get evPowerAny => 'Any';
+
+  @override
+  String evPowerKw(int kw) {
+    return '$kw kW+';
+  }
+
+  @override
+  String get sectionProfile => 'Profile';
+
+  @override
+  String get sectionLocation => 'Location';
+
+  @override
+  String get tooltipBack => 'Back';
+
+  @override
+  String get tooltipClose => 'Close';
+
+  @override
+  String get tooltipClearSearch => 'Clear search input';
+
+  @override
+  String get tooltipUseGps => 'Use GPS location';
 }

--- a/test/lint/no_hardcoded_ui_strings_test.dart
+++ b/test/lint/no_hardcoded_ui_strings_test.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards against hardcoded user-facing strings in presentation code.
+///
+/// Detects `Text('literal')` and `Text("literal")` patterns in widget files
+/// that should use `AppLocalizations.of(context)?.key ?? 'fallback'` instead.
+///
+/// A baseline count is maintained so existing violations don't break CI,
+/// but new ones are caught.
+void main() {
+  test('hardcoded Text() count does not increase', () {
+    final featuresDir = Directory('lib/features');
+    expect(featuresDir.existsSync(), isTrue);
+
+    // Matches: Text('literal'), Text("literal"), title: 'literal', etc.
+    // Excludes: patterns with ?? (already using l10n fallback),
+    //           patterns with $ (string interpolation with variables),
+    //           patterns that reference l10n/l/AppLocalizations
+    final hardcodedTextPattern = RegExp(
+      r"""(?:const\s+)?Text\(\s*['"][A-Z][^'"$]*['"]\s*\)"""
+      r"""|(?:const\s+)?Text\(\s*['"][a-z][^'"$]{3,}['"]\s*\)""",
+    );
+
+    final violations = <String>[];
+
+    for (final entity in featuresDir.listSync(recursive: true)) {
+      if (entity is! File) continue;
+      final path = entity.path.replaceAll(r'\', '/');
+      if (!path.endsWith('.dart')) continue;
+      if (path.endsWith('.g.dart')) continue;
+      if (path.endsWith('.freezed.dart')) continue;
+      if (!path.contains('/presentation/')) continue;
+
+      final lines = entity.readAsLinesSync();
+      for (int i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        // Skip lines that already use l10n pattern
+        if (line.contains('??') || line.contains('l10n') || line.contains('AppLocalizations')) continue;
+        // Skip comments
+        if (line.trimLeft().startsWith('//')) continue;
+
+        for (final match in hardcodedTextPattern.allMatches(line)) {
+          final text = match.group(0)!;
+          // Skip very short strings (likely identifiers, not UI text)
+          if (text.length < 12) continue;
+          violations.add('$path:${i + 1}: $text');
+        }
+      }
+    }
+
+    // Baseline: number of known hardcoded strings as of 2026-04-12.
+    // This number should only go DOWN over time as strings are localized.
+    // If this test fails, you added a new hardcoded string — use l10n instead.
+    const baseline = 120;
+
+    expect(
+      violations.length,
+      lessThanOrEqualTo(baseline),
+      reason: 'Hardcoded user-facing strings increased! '
+          'Found ${violations.length} (baseline: $baseline).\n'
+          'New violations:\n${violations.take(20).join('\n')}\n'
+          'Use AppLocalizations.of(context)?.key ?? \'fallback\' instead.',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings with `AppLocalizations` keys in 14 presentation files across the most visible screens (search, favorites, station detail, profile, price history, EV filters, map)
- Add 13 new l10n keys (`updatingFavorites`, `fetchingLatestPrices`, `noDataAvailable`, `configAndPrivacy`, `searchToSeeMap`, `evPowerAny`, `evPowerKw`, `sectionProfile`, `sectionLocation`, `tooltipBack`, `tooltipClose`, `tooltipClearSearch`, `tooltipUseGps`) with EN/DE/FR translations
- Add CI lint test (`no_hardcoded_ui_strings_test`) that fails if hardcoded string count increases

## Remaining (tracked in #329)
Sync wizard, TankSync section, calculator, vehicle, and config verification widget still have hardcoded strings — will be addressed in batch 2.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero warnings
- [x] All profile/favorites/search/price_history/lint tests pass
- [x] New lint test passes with baseline of 120

Partial fix for #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)