### PR TITLE
fix(favorites): support EV charging stations in favorites

### DIFF
--- a/lib/core/data/storage_repository.dart
+++ b/lib/core/data/storage_repository.dart
@@ -20,6 +20,20 @@ abstract class FavoriteStorage {
   Future<void> removeFavoriteStationData(String stationId);
 }
 
+/// EV charging station favorite storage.
+abstract class EvFavoriteStorage {
+  List<String> getEvFavoriteIds();
+  Future<void> setEvFavoriteIds(List<String> ids);
+  Future<void> addEvFavorite(String id);
+  Future<void> removeEvFavorite(String id);
+  bool isEvFavorite(String id);
+  int get evFavoriteCount;
+
+  Future<void> saveEvFavoriteStationData(String stationId, Map<String, dynamic> data);
+  Map<String, dynamic>? getEvFavoriteStationData(String stationId);
+  Future<void> removeEvFavoriteStationData(String stationId);
+}
+
 /// Ignored station storage.
 abstract class IgnoredStorage {
   List<String> getIgnoredIds();
@@ -110,9 +124,9 @@ abstract class CacheStorage {
 /// Used for DI — providers and services receive [StorageRepository],
 /// but can narrow to specific interfaces in their type signatures.
 abstract class StorageRepository implements
-    FavoriteStorage, IgnoredStorage, RatingStorage, SettingsStorage,
-    ApiKeyStorage, ProfileStorage, PriceHistoryStorage, AlertStorage,
-    ItineraryStorage, CacheStorage {
+    FavoriteStorage, EvFavoriteStorage, IgnoredStorage, RatingStorage,
+    SettingsStorage, ApiKeyStorage, ProfileStorage, PriceHistoryStorage,
+    AlertStorage, ItineraryStorage, CacheStorage {
   /// Estimated storage size across all data domains (bytes).
   ({int settings, int profiles, int favorites, int cache, int priceHistory, int alerts, int total})
       get storageStats;

--- a/lib/core/storage/hive_storage.dart
+++ b/lib/core/storage/hive_storage.dart
@@ -127,6 +127,33 @@ class HiveStorage implements StorageRepository {
       _favorites.removeFavoriteStationData(stationId);
 
   // ---------------------------------------------------------------------------
+  // EvFavoriteStorage
+  // ---------------------------------------------------------------------------
+  @override
+  List<String> getEvFavoriteIds() => _favorites.getEvFavoriteIds();
+  @override
+  Future<void> setEvFavoriteIds(List<String> ids) =>
+      _favorites.setEvFavoriteIds(ids);
+  @override
+  Future<void> addEvFavorite(String id) => _favorites.addEvFavorite(id);
+  @override
+  Future<void> removeEvFavorite(String id) => _favorites.removeEvFavorite(id);
+  @override
+  bool isEvFavorite(String id) => _favorites.isEvFavorite(id);
+  @override
+  int get evFavoriteCount => _favorites.evFavoriteCount;
+  @override
+  Future<void> saveEvFavoriteStationData(
+          String stationId, Map<String, dynamic> data) =>
+      _favorites.saveEvFavoriteStationData(stationId, data);
+  @override
+  Map<String, dynamic>? getEvFavoriteStationData(String stationId) =>
+      _favorites.getEvFavoriteStationData(stationId);
+  @override
+  Future<void> removeEvFavoriteStationData(String stationId) =>
+      _favorites.removeEvFavoriteStationData(stationId);
+
+  // ---------------------------------------------------------------------------
   // IgnoredStorage
   // ---------------------------------------------------------------------------
   @override

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -24,4 +24,6 @@ class StorageKeys {
   static const String activeVehicleProfileId = 'active_vehicle_profile_id';
   static const String evStationsCache = 'ev_stations_cache';
   static const String evShowOnMap = 'ev_show_on_map';
+  static const String evFavoriteStationIds = 'ev_favorite_station_ids';
+  static const String evFavoriteStationData = 'ev_favorite_station_data';
 }

--- a/lib/core/storage/storage_providers.dart
+++ b/lib/core/storage/storage_providers.dart
@@ -24,6 +24,10 @@ SettingsStorage settingsStorage(Ref ref) => ref.watch(storageRepositoryProvider)
 @Riverpod(keepAlive: true)
 FavoriteStorage favoriteStorage(Ref ref) => ref.watch(storageRepositoryProvider);
 
+/// Narrow provider for EV favorite storage operations.
+@Riverpod(keepAlive: true)
+EvFavoriteStorage evFavoriteStorage(Ref ref) => ref.watch(storageRepositoryProvider);
+
 /// Narrow provider for ignored station operations.
 @Riverpod(keepAlive: true)
 IgnoredStorage ignoredStorage(Ref ref) => ref.watch(storageRepositoryProvider);

--- a/lib/core/storage/storage_providers.g.dart
+++ b/lib/core/storage/storage_providers.g.dart
@@ -212,6 +212,58 @@ final class FavoriteStorageProvider
 
 String _$favoriteStorageHash() => r'2518dc2862ef2bac8cfe2283fe3ccc9dafab909e';
 
+/// Narrow provider for EV favorite storage operations.
+
+@ProviderFor(evFavoriteStorage)
+final evFavoriteStorageProvider = EvFavoriteStorageProvider._();
+
+/// Narrow provider for EV favorite storage operations.
+
+final class EvFavoriteStorageProvider
+    extends
+        $FunctionalProvider<
+          EvFavoriteStorage,
+          EvFavoriteStorage,
+          EvFavoriteStorage
+        >
+    with $Provider<EvFavoriteStorage> {
+  /// Narrow provider for EV favorite storage operations.
+  EvFavoriteStorageProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'evFavoriteStorageProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$evFavoriteStorageHash();
+
+  @$internal
+  @override
+  $ProviderElement<EvFavoriteStorage> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EvFavoriteStorage create(Ref ref) {
+    return evFavoriteStorage(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EvFavoriteStorage value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EvFavoriteStorage>(value),
+    );
+  }
+}
+
+String _$evFavoriteStorageHash() => r'dd725c080adee2a6615812134a580c29471be85e';
+
 /// Narrow provider for ignored station operations.
 
 @ProviderFor(ignoredStorage)

--- a/lib/core/storage/stores/favorites_hive_store.dart
+++ b/lib/core/storage/stores/favorites_hive_store.dart
@@ -9,7 +9,7 @@ import '../storage_keys.dart';
 /// Manages favorite station IDs, persisted station data for offline access,
 /// ignored station IDs, and station ratings.
 class FavoritesHiveStore
-    implements FavoriteStorage, IgnoredStorage, RatingStorage {
+    implements FavoriteStorage, EvFavoriteStorage, IgnoredStorage, RatingStorage {
   Box get _favorites => Hive.box(HiveBoxes.favorites);
 
   // Favorites
@@ -75,6 +75,68 @@ class FavoritesHiveStore
 
   Map<String, dynamic> _getFavoriteStationDataRaw() {
     final raw = _favorites.get(StorageKeys.favoriteStationData);
+    if (raw is Map) return Map<String, dynamic>.from(raw);
+    return {};
+  }
+
+  // EV Favorites
+  @override
+  List<String> getEvFavoriteIds() {
+    final ids = _favorites.get(StorageKeys.evFavoriteStationIds);
+    if (ids == null) return [];
+    return List<String>.from(ids as List);
+  }
+
+  @override
+  Future<void> setEvFavoriteIds(List<String> ids) =>
+      _favorites.put(StorageKeys.evFavoriteStationIds, ids);
+
+  @override
+  Future<void> addEvFavorite(String id) async {
+    final ids = getEvFavoriteIds();
+    if (!ids.contains(id)) {
+      ids.add(id);
+      await setEvFavoriteIds(ids);
+    }
+  }
+
+  @override
+  Future<void> removeEvFavorite(String id) async {
+    final ids = getEvFavoriteIds();
+    ids.remove(id);
+    await setEvFavoriteIds(ids);
+  }
+
+  @override
+  bool isEvFavorite(String id) => getEvFavoriteIds().contains(id);
+
+  @override
+  int get evFavoriteCount => getEvFavoriteIds().length;
+
+  @override
+  Future<void> saveEvFavoriteStationData(
+      String stationId, Map<String, dynamic> data) async {
+    final all = _getEvFavoriteStationDataRaw();
+    all[stationId] = data;
+    await _favorites.put(StorageKeys.evFavoriteStationData, all);
+  }
+
+  @override
+  Map<String, dynamic>? getEvFavoriteStationData(String stationId) {
+    final raw = _getEvFavoriteStationDataRaw()[stationId];
+    if (raw is Map) return Map<String, dynamic>.from(raw);
+    return null;
+  }
+
+  @override
+  Future<void> removeEvFavoriteStationData(String stationId) async {
+    final all = _getEvFavoriteStationDataRaw();
+    all.remove(stationId);
+    await _favorites.put(StorageKeys.evFavoriteStationData, all);
+  }
+
+  Map<String, dynamic> _getEvFavoriteStationDataRaw() {
+    final raw = _favorites.get(StorageKeys.evFavoriteStationData);
     if (raw is Map) return Map<String, dynamic>.from(raw);
     return {};
   }

--- a/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
@@ -1,29 +1,51 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../favorites/providers/ev_favorites_provider.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart'
     show ConnectorType;
 import '../../domain/entities/charging_station.dart';
 
-/// Read-only detail view for a single [ChargingStation].
+/// Detail view for a single [ChargingStation] with favorite toggle.
 ///
 /// Shows all connectors, status badges, operator/address metadata, and
-/// the last-update timestamp. Tariff breakdown is stubbed for now — the
-/// detail includes a placeholder row when the connector references a
-/// tariff id we don't yet resolve client-side.
-class EvStationDetailScreen extends StatelessWidget {
+/// the last-update timestamp.
+class EvStationDetailScreen extends ConsumerWidget {
   final ChargingStation station;
 
   const EvStationDetailScreen({super.key, required this.station});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
+    final isFav = ref.watch(isEvFavoriteProvider(station.id));
 
     return Scaffold(
       appBar: AppBar(
         title: Text(station.name),
+        actions: [
+          IconButton(
+            icon: Icon(
+              isFav ? Icons.star : Icons.star_border,
+              color: isFav ? Colors.amber : null,
+            ),
+            tooltip: isFav
+                ? (l10n?.removeFavorite ?? 'Remove from favorites')
+                : (l10n?.addFavorite ?? 'Add to favorites'),
+            onPressed: () {
+              ref
+                  .read(evFavoritesProvider.notifier)
+                  .toggle(station.id, stationData: station);
+              final msg = isFav
+                  ? (l10n?.removedFromFavorites ?? 'Removed from favorites')
+                  : (l10n?.addedToFavorites ?? 'Added to favorites');
+              SnackBarHelper.show(context, msg);
+            },
+          ),
+        ],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),

--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -13,8 +13,11 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/presentation/widgets/station_card.dart';
 import '../../../profile/providers/profile_provider.dart';
+import '../../../ev/domain/entities/charging_station.dart';
+import '../../providers/ev_favorites_provider.dart';
 import '../../providers/favorites_provider.dart';
 import '../widgets/alerts_tab.dart';
+import '../widgets/ev_favorite_card.dart';
 import '../widgets/favorites_loading_view.dart';
 import '../widgets/swipe_tutorial_banner.dart';
 
@@ -96,7 +99,10 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
     List<String> favoriteIds,
     AsyncValue<ServiceResult<List<Station>>> stationsState,
   ) {
-    if (favoriteIds.isEmpty) {
+    final evStations = ref.watch(evFavoriteStationsProvider);
+    final hasEvFavorites = evStations.isNotEmpty;
+
+    if (favoriteIds.isEmpty && !hasEvFavorites) {
       return Semantics(
         label:
             'No favorites yet. Tap the star on a station to save it as a favorite.',
@@ -112,9 +118,14 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
       );
     }
 
+    // If only EV favorites (no fuel), show them directly
+    if (favoriteIds.isEmpty && hasEvFavorites) {
+      return _buildEvFavoritesSection(context, l10n, evStations);
+    }
+
     return stationsState.when(
       data: (result) {
-        if (result.data.isEmpty) {
+        if (result.data.isEmpty && !hasEvFavorites) {
           return const FavoritesLoadingView();
         }
         return RefreshIndicator(
@@ -123,100 +134,120 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
           },
           child: Column(
             children: [
-              ServiceStatusBanner(result: result),
+              if (result.data.isNotEmpty)
+                ServiceStatusBanner(result: result),
               const SwipeTutorialBanner(),
               Expanded(
-                child: ListView.builder(
-                  itemCount: result.data.length,
-                  itemBuilder: (context, index) {
-                    final station = result.data[index];
-                    final label = station.displayName;
-                    // Swipe right -> navigate, swipe left -> remove favorite
-                    return Dismissible(
-                      key: ValueKey('fav-${station.id}'),
-                      confirmDismiss: (direction) async {
-                        if (direction == DismissDirection.startToEnd) {
-                          _openStationInMaps(station.lat, station.lng, label);
-                          return false;
-                        } else {
-                          // Remove favorite
-                          ref
-                              .read(favoritesProvider.notifier)
-                              .remove(station.id);
-                          final l10nSnack = AppLocalizations.of(context);
-                          SnackBarHelper.showWithUndo(
-                            context,
-                            l10nSnack?.removedFromFavoritesName(label) ??
-                                '$label removed from favorites',
-                            undoLabel: l10nSnack?.undo ?? 'Undo',
-                            onUndo: () => ref
+                child: ListView(
+                  children: [
+                    // EV favorites section
+                    if (hasEvFavorites) ...[
+                      _buildEvSectionHeader(context),
+                      ...evStations.map((ev) => EvFavoriteCard(
+                            key: ValueKey('ev-${ev.id}'),
+                            station: ev,
+                            onTap: () => context.push('/ev-station', extra: ev),
+                            onFavoriteTap: () {
+                              ref.read(evFavoritesProvider.notifier).remove(ev.id);
+                              SnackBarHelper.show(
+                                context,
+                                l10n?.removedFromFavorites ?? 'Removed from favorites',
+                              );
+                            },
+                          )),
+                      if (result.data.isNotEmpty)
+                        _buildFuelSectionHeader(context),
+                    ],
+                    // Fuel favorites
+                    ...result.data.map((station) {
+                      final label = station.displayName;
+                      return Dismissible(
+                        key: ValueKey('fav-${station.id}'),
+                        confirmDismiss: (direction) async {
+                          if (direction == DismissDirection.startToEnd) {
+                            _openStationInMaps(station.lat, station.lng, label);
+                            return false;
+                          } else {
+                            ref
                                 .read(favoritesProvider.notifier)
-                                .add(station.id, stationData: station),
-                          );
-                          return true;
-                        }
-                      },
-                      background: Semantics(
-                        label: 'Navigate to $label',
-                        child: Container(
-                          alignment: Alignment.centerLeft,
-                          padding: const EdgeInsets.only(left: 24),
-                          color: Theme.of(context).colorScheme.primary,
-                          child: const Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(Icons.navigation,
-                                  color: Colors.white, size: 20),
-                              SizedBox(width: 8),
-                              Text('Navigate',
-                                  style: TextStyle(
-                                      color: Colors.white,
-                                      fontWeight: FontWeight.bold)),
-                            ],
-                          ),
-                        ),
-                      ),
-                      secondaryBackground: Semantics(
-                        label: 'Remove $label from favorites',
-                        child: Container(
-                          alignment: Alignment.centerRight,
-                          padding: const EdgeInsets.only(right: 24),
-                          color: Colors.red,
-                          child: const Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text('Remove',
-                                  style: TextStyle(
-                                      color: Colors.white,
-                                      fontWeight: FontWeight.bold)),
-                              SizedBox(width: 8),
-                              Icon(Icons.delete, color: Colors.white, size: 20),
-                            ],
-                          ),
-                        ),
-                      ),
-                      child: StationCard(
-                        key: ValueKey(station.id),
-                        station: station,
-                        selectedFuelType: FuelType.all,
-                        isFavorite: true,
-                        profileFuelType: ref.watch(activeProfileProvider)?.preferredFuelType,
-                        onTap: () => context.push('/station/${station.id}'),
-                        onFavoriteTap: () {
-                          ref
-                              .read(favoritesProvider.notifier)
-                              .remove(station.id);
+                                .remove(station.id);
+                            final l10nSnack = AppLocalizations.of(context);
+                            SnackBarHelper.showWithUndo(
+                              context,
+                              l10nSnack?.removedFromFavoritesName(label) ??
+                                  '$label removed from favorites',
+                              undoLabel: l10nSnack?.undo ?? 'Undo',
+                              onUndo: () => ref
+                                  .read(favoritesProvider.notifier)
+                                  .add(station.id, stationData: station),
+                            );
+                            return true;
+                          }
                         },
-                      ),
-                    );
-                  },
+                        background: Semantics(
+                          label: 'Navigate to $label',
+                          child: Container(
+                            alignment: Alignment.centerLeft,
+                            padding: const EdgeInsets.only(left: 24),
+                            color: Theme.of(context).colorScheme.primary,
+                            child: const Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.navigation,
+                                    color: Colors.white, size: 20),
+                                SizedBox(width: 8),
+                                Text('Navigate',
+                                    style: TextStyle(
+                                        color: Colors.white,
+                                        fontWeight: FontWeight.bold)),
+                              ],
+                            ),
+                          ),
+                        ),
+                        secondaryBackground: Semantics(
+                          label: 'Remove $label from favorites',
+                          child: Container(
+                            alignment: Alignment.centerRight,
+                            padding: const EdgeInsets.only(right: 24),
+                            color: Colors.red,
+                            child: const Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text('Remove',
+                                    style: TextStyle(
+                                        color: Colors.white,
+                                        fontWeight: FontWeight.bold)),
+                                SizedBox(width: 8),
+                                Icon(Icons.delete, color: Colors.white, size: 20),
+                              ],
+                            ),
+                          ),
+                        ),
+                        child: StationCard(
+                          key: ValueKey(station.id),
+                          station: station,
+                          selectedFuelType: FuelType.all,
+                          isFavorite: true,
+                          profileFuelType: ref.watch(activeProfileProvider)?.preferredFuelType,
+                          onTap: () => context.push('/station/${station.id}'),
+                          onFavoriteTap: () {
+                            ref
+                                .read(favoritesProvider.notifier)
+                                .remove(station.id);
+                          },
+                        ),
+                      );
+                    }),
+                  ],
                 ),
               ),
             ],
           ),
         );
       },
-      loading: () => const FavoritesLoadingView(),
+      loading: () => hasEvFavorites
+          ? _buildEvFavoritesSection(context, l10n, evStations)
+          : const FavoritesLoadingView(),
       error: (error, _) => Semantics(
         label: 'Error loading favorites: ${error.toString()}',
         child: Center(
@@ -237,6 +268,58 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildEvSectionHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Row(
+        children: [
+          Icon(Icons.ev_station, size: 16,
+              color: Theme.of(context).colorScheme.primary),
+          const SizedBox(width: 8),
+          Text('EV Charging', style: Theme.of(context).textTheme.titleSmall),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFuelSectionHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Row(
+        children: [
+          Icon(Icons.local_gas_station, size: 16,
+              color: Theme.of(context).colorScheme.primary),
+          const SizedBox(width: 8),
+          Text('Fuel Stations', style: Theme.of(context).textTheme.titleSmall),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEvFavoritesSection(
+    BuildContext context,
+    AppLocalizations? l10n,
+    List<ChargingStation> evStations,
+  ) {
+    return ListView(
+      children: [
+        _buildEvSectionHeader(context),
+        ...evStations.map((ev) => EvFavoriteCard(
+              key: ValueKey('ev-${ev.id}'),
+              station: ev,
+              onTap: () => context.push('/ev-station', extra: ev),
+              onFavoriteTap: () {
+                ref.read(evFavoritesProvider.notifier).remove(ev.id);
+                SnackBarHelper.show(
+                  context,
+                  l10n?.removedFromFavorites ?? 'Removed from favorites',
+                );
+              },
+            )),
+      ],
     );
   }
 }

--- a/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
+++ b/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../ev/domain/entities/charging_station.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+
+/// Compact card for an EV charging station in the favorites list.
+class EvFavoriteCard extends StatelessWidget {
+  final ChargingStation station;
+  final VoidCallback? onTap;
+  final VoidCallback? onFavoriteTap;
+
+  const EvFavoriteCard({
+    super.key,
+    required this.station,
+    this.onTap,
+    this.onFavoriteTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final available = station.connectors
+        .where((c) => c.status == ConnectorStatus.available)
+        .length;
+    final total = station.connectors.length;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              Icon(Icons.ev_station, size: 32, color: theme.colorScheme.primary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      station.name,
+                      style: theme.textTheme.titleSmall,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (station.operator != null)
+                      Text(
+                        station.operator!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        Icon(Icons.bolt, size: 14,
+                            color: theme.colorScheme.onSurfaceVariant),
+                        const SizedBox(width: 4),
+                        Text(
+                          '${station.maxPowerKw.round()} kW',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                        const SizedBox(width: 12),
+                        if (total > 0) ...[
+                          Icon(
+                            Icons.power,
+                            size: 14,
+                            color: available > 0 ? Colors.green : Colors.grey,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            '$available/$total ${l10n?.evStatusAvailable ?? 'available'}',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: available > 0 ? Colors.green : null,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    if (station.connectors.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Wrap(
+                          spacing: 4,
+                          children: station.connectors
+                              .map((c) => c.type)
+                              .toSet()
+                              .map((type) => Chip(
+                                    label: Text(_connectorLabel(type),
+                                        style: const TextStyle(fontSize: 10)),
+                                    materialTapTargetSize:
+                                        MaterialTapTargetSize.shrinkWrap,
+                                    visualDensity: VisualDensity.compact,
+                                    padding: EdgeInsets.zero,
+                                    labelPadding: const EdgeInsets.symmetric(
+                                        horizontal: 6),
+                                  ))
+                              .toList(),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                width: 32,
+                height: 32,
+                child: IconButton(
+                  padding: EdgeInsets.zero,
+                  icon: const Icon(Icons.star, color: Colors.amber, size: 22),
+                  onPressed: onFavoriteTap,
+                  tooltip: l10n?.removeFavorite ?? 'Remove from favorites',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _connectorLabel(ConnectorType type) {
+    return switch (type) {
+      ConnectorType.type2 => 'Type 2',
+      ConnectorType.ccs => 'CCS',
+      ConnectorType.chademo => 'CHAdeMO',
+      ConnectorType.tesla => 'Tesla',
+      ConnectorType.schuko => 'Schuko',
+      ConnectorType.type1 => 'Type 1',
+      ConnectorType.threePin => '3-pin',
+    };
+  }
+}

--- a/lib/features/favorites/providers/ev_favorites_provider.dart
+++ b/lib/features/favorites/providers/ev_favorites_provider.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../../../core/storage/storage_providers.dart';
+import '../../ev/domain/entities/charging_station.dart';
+
+part 'ev_favorites_provider.g.dart';
+
+/// Manages the user's list of favorite EV charging station IDs.
+///
+/// Mirrors [Favorites] but for [ChargingStation] entities.
+@Riverpod(keepAlive: true)
+class EvFavorites extends _$EvFavorites {
+  @override
+  List<String> build() {
+    final storage = ref.watch(storageRepositoryProvider);
+    return storage.getEvFavoriteIds();
+  }
+
+  Future<void> add(String stationId, {ChargingStation? stationData}) async {
+    final storage = ref.read(storageRepositoryProvider);
+    await storage.addEvFavorite(stationId);
+
+    if (stationData != null) {
+      await storage.saveEvFavoriteStationData(
+          stationId, stationData.toJson());
+    }
+
+    state = storage.getEvFavoriteIds();
+  }
+
+  Future<void> remove(String stationId) async {
+    final storage = ref.read(storageRepositoryProvider);
+    await storage.removeEvFavorite(stationId);
+    await storage.removeEvFavoriteStationData(stationId);
+    state = storage.getEvFavoriteIds();
+  }
+
+  Future<void> toggle(String stationId, {ChargingStation? stationData}) async {
+    if (state.contains(stationId)) {
+      await remove(stationId);
+    } else {
+      await add(stationId, stationData: stationData);
+    }
+  }
+}
+
+/// Whether a specific EV station is favorited.
+@riverpod
+bool isEvFavorite(Ref ref, String stationId) {
+  final favorites = ref.watch(evFavoritesProvider);
+  return favorites.contains(stationId);
+}
+
+/// Loads persisted EV station data for favorites.
+@riverpod
+class EvFavoriteStations extends _$EvFavoriteStations {
+  @override
+  List<ChargingStation> build() {
+    final favoriteIds = ref.watch(evFavoritesProvider);
+    if (favoriteIds.isEmpty) return const [];
+
+    final storage = ref.read(storageRepositoryProvider);
+    final stations = <ChargingStation>[];
+
+    for (final id in favoriteIds) {
+      final data = storage.getEvFavoriteStationData(id);
+      if (data != null) {
+        try {
+          stations.add(ChargingStation.fromJson(data));
+        } catch (e) {
+          debugPrint('EvFavoriteStations: parse error for $id: $e');
+        }
+      }
+    }
+
+    return stations;
+  }
+}

--- a/lib/features/favorites/providers/ev_favorites_provider.g.dart
+++ b/lib/features/favorites/providers/ev_favorites_provider.g.dart
@@ -1,0 +1,219 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ev_favorites_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Manages the user's list of favorite EV charging station IDs.
+///
+/// Mirrors [Favorites] but for [ChargingStation] entities.
+
+@ProviderFor(EvFavorites)
+final evFavoritesProvider = EvFavoritesProvider._();
+
+/// Manages the user's list of favorite EV charging station IDs.
+///
+/// Mirrors [Favorites] but for [ChargingStation] entities.
+final class EvFavoritesProvider
+    extends $NotifierProvider<EvFavorites, List<String>> {
+  /// Manages the user's list of favorite EV charging station IDs.
+  ///
+  /// Mirrors [Favorites] but for [ChargingStation] entities.
+  EvFavoritesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'evFavoritesProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$evFavoritesHash();
+
+  @$internal
+  @override
+  EvFavorites create() => EvFavorites();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<String>>(value),
+    );
+  }
+}
+
+String _$evFavoritesHash() => r'1e16aec6b6db0f3dee062687b33f5e29c66935df';
+
+/// Manages the user's list of favorite EV charging station IDs.
+///
+/// Mirrors [Favorites] but for [ChargingStation] entities.
+
+abstract class _$EvFavorites extends $Notifier<List<String>> {
+  List<String> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<List<String>, List<String>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<List<String>, List<String>>,
+              List<String>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+/// Whether a specific EV station is favorited.
+
+@ProviderFor(isEvFavorite)
+final isEvFavoriteProvider = IsEvFavoriteFamily._();
+
+/// Whether a specific EV station is favorited.
+
+final class IsEvFavoriteProvider extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// Whether a specific EV station is favorited.
+  IsEvFavoriteProvider._({
+    required IsEvFavoriteFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'isEvFavoriteProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$isEvFavoriteHash();
+
+  @override
+  String toString() {
+    return r'isEvFavoriteProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    final argument = this.argument as String;
+    return isEvFavorite(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is IsEvFavoriteProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$isEvFavoriteHash() => r'36fb646620e239f6189455f792f4b3217007fed9';
+
+/// Whether a specific EV station is favorited.
+
+final class IsEvFavoriteFamily extends $Family
+    with $FunctionalFamilyOverride<bool, String> {
+  IsEvFavoriteFamily._()
+    : super(
+        retry: null,
+        name: r'isEvFavoriteProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Whether a specific EV station is favorited.
+
+  IsEvFavoriteProvider call(String stationId) =>
+      IsEvFavoriteProvider._(argument: stationId, from: this);
+
+  @override
+  String toString() => r'isEvFavoriteProvider';
+}
+
+/// Loads persisted EV station data for favorites.
+
+@ProviderFor(EvFavoriteStations)
+final evFavoriteStationsProvider = EvFavoriteStationsProvider._();
+
+/// Loads persisted EV station data for favorites.
+final class EvFavoriteStationsProvider
+    extends $NotifierProvider<EvFavoriteStations, List<ChargingStation>> {
+  /// Loads persisted EV station data for favorites.
+  EvFavoriteStationsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'evFavoriteStationsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$evFavoriteStationsHash();
+
+  @$internal
+  @override
+  EvFavoriteStations create() => EvFavoriteStations();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<ChargingStation> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<ChargingStation>>(value),
+    );
+  }
+}
+
+String _$evFavoriteStationsHash() =>
+    r'5f94bec82bdf6fdfe0827fb5a05da110a2d66206';
+
+/// Loads persisted EV station data for favorites.
+
+abstract class _$EvFavoriteStations extends $Notifier<List<ChargingStation>> {
+  List<ChargingStation> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<List<ChargingStation>, List<ChargingStation>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<List<ChargingStation>, List<ChargingStation>>,
+              List<ChargingStation>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/core/data/storage_repository_test.dart
+++ b/test/core/data/storage_repository_test.dart
@@ -74,6 +74,19 @@ class _MockStorageRepository implements StorageRepository {
   @override Map<String, dynamic> getAllFavoriteStationData() => Map.from(_favoriteStationData);
   @override Future<void> removeFavoriteStationData(String id) async => _favoriteStationData.remove(id);
 
+  // EV Favorites
+  final _evFavorites = <String>[];
+  final _evFavoriteData = <String, Map<String, dynamic>>{};
+  @override List<String> getEvFavoriteIds() => List.from(_evFavorites);
+  @override Future<void> setEvFavoriteIds(List<String> ids) async { _evFavorites..clear()..addAll(ids); }
+  @override Future<void> addEvFavorite(String id) async => _evFavorites.add(id);
+  @override Future<void> removeEvFavorite(String id) async => _evFavorites.remove(id);
+  @override bool isEvFavorite(String id) => _evFavorites.contains(id);
+  @override int get evFavoriteCount => _evFavorites.length;
+  @override Future<void> saveEvFavoriteStationData(String id, Map<String, dynamic> data) async => _evFavoriteData[id] = data;
+  @override Map<String, dynamic>? getEvFavoriteStationData(String id) => _evFavoriteData[id];
+  @override Future<void> removeEvFavoriteStationData(String id) async => _evFavoriteData.remove(id);
+
   @override List<String> getIgnoredIds() => List.from(_ignored);
   @override Future<void> setIgnoredIds(List<String> ids) async { _ignored..clear()..addAll(ids); }
   @override Future<void> addIgnored(String id) async => _ignored.add(id);

--- a/test/core/storage/storage_repository_provider_test.dart
+++ b/test/core/storage/storage_repository_provider_test.dart
@@ -248,6 +248,19 @@ class _InMemoryStorageRepository implements StorageRepository {
   @override Map<String, dynamic> getAllFavoriteStationData() => Map.from(_favoriteData);
   @override Future<void> removeFavoriteStationData(String id) async => _favoriteData.remove(id);
 
+  // EvFavoriteStorage
+  final _evFavorites = <String>[];
+  final _evFavoriteData = <String, Map<String, dynamic>>{};
+  @override List<String> getEvFavoriteIds() => List.from(_evFavorites);
+  @override Future<void> setEvFavoriteIds(List<String> ids) async { _evFavorites..clear()..addAll(ids); }
+  @override Future<void> addEvFavorite(String id) async { if (!_evFavorites.contains(id)) _evFavorites.add(id); }
+  @override Future<void> removeEvFavorite(String id) async => _evFavorites.remove(id);
+  @override bool isEvFavorite(String id) => _evFavorites.contains(id);
+  @override int get evFavoriteCount => _evFavorites.length;
+  @override Future<void> saveEvFavoriteStationData(String id, Map<String, dynamic> data) async => _evFavoriteData[id] = data;
+  @override Map<String, dynamic>? getEvFavoriteStationData(String id) => _evFavoriteData[id];
+  @override Future<void> removeEvFavoriteStationData(String id) async => _evFavoriteData.remove(id);
+
   // IgnoredStorage
   @override List<String> getIgnoredIds() => List.from(_ignored);
   @override Future<void> setIgnoredIds(List<String> ids) async { _ignored..clear()..addAll(ids); }

--- a/test/features/favorites/providers/ev_favorites_provider_test.dart
+++ b/test/features/favorites/providers/ev_favorites_provider_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/favorites/providers/ev_favorites_provider.dart';
+
+import '../../../mocks/mocks.dart';
+
+void main() {
+  late MockHiveStorage mockStorage;
+  late ProviderContainer container;
+
+  setUp(() {
+    mockStorage = MockHiveStorage();
+    when(() => mockStorage.getEvFavoriteIds()).thenReturn([]);
+    when(() => mockStorage.addEvFavorite(any())).thenAnswer((_) async {});
+    when(() => mockStorage.removeEvFavorite(any())).thenAnswer((_) async {});
+    when(() => mockStorage.saveEvFavoriteStationData(any(), any()))
+        .thenAnswer((_) async {});
+    when(() => mockStorage.removeEvFavoriteStationData(any()))
+        .thenAnswer((_) async {});
+    when(() => mockStorage.getEvFavoriteStationData(any())).thenReturn(null);
+
+    container = ProviderContainer(
+      overrides: [hiveStorageProvider.overrideWithValue(mockStorage)],
+    );
+  });
+
+  tearDown(() => container.dispose());
+
+  group('EvFavorites', () {
+    test('initial state is empty', () {
+      final favorites = container.read(evFavoritesProvider);
+      expect(favorites, isEmpty);
+    });
+
+    test('add adds station ID to favorites', () async {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn(['ev-1']);
+
+      await container.read(evFavoritesProvider.notifier).add('ev-1');
+
+      verify(() => mockStorage.addEvFavorite('ev-1')).called(1);
+      expect(container.read(evFavoritesProvider), ['ev-1']);
+    });
+
+    test('add persists station data when provided', () async {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn(['ev-1']);
+
+      const station = ChargingStation(
+        id: 'ev-1',
+        name: 'Test Charger',
+        latitude: 48.0,
+        longitude: 2.0,
+      );
+
+      await container
+          .read(evFavoritesProvider.notifier)
+          .add('ev-1', stationData: station);
+
+      verify(() => mockStorage.saveEvFavoriteStationData('ev-1', any()))
+          .called(1);
+    });
+
+    test('remove removes station ID and data', () async {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn([]);
+
+      await container.read(evFavoritesProvider.notifier).remove('ev-1');
+
+      verify(() => mockStorage.removeEvFavorite('ev-1')).called(1);
+      verify(() => mockStorage.removeEvFavoriteStationData('ev-1')).called(1);
+    });
+
+    test('toggle adds when not favorited', () async {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn([]);
+      container.read(evFavoritesProvider); // initialize empty
+
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn(['ev-1']);
+      await container.read(evFavoritesProvider.notifier).toggle('ev-1');
+
+      verify(() => mockStorage.addEvFavorite('ev-1')).called(1);
+    });
+
+    test('toggle removes when already favorited', () async {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn(['ev-1']);
+      container.read(evFavoritesProvider); // initialize with ev-1
+
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn([]);
+      await container.read(evFavoritesProvider.notifier).toggle('ev-1');
+
+      verify(() => mockStorage.removeEvFavorite('ev-1')).called(1);
+    });
+  });
+
+  group('isEvFavorite', () {
+    test('returns true when station is favorited', () {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn(['ev-1']);
+      expect(container.read(isEvFavoriteProvider('ev-1')), isTrue);
+    });
+
+    test('returns false when station is not favorited', () {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn([]);
+      expect(container.read(isEvFavoriteProvider('ev-1')), isFalse);
+    });
+  });
+
+  group('EvFavoriteStations', () {
+    test('returns empty list when no favorites', () {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn([]);
+      final stations = container.read(evFavoriteStationsProvider);
+      expect(stations, isEmpty);
+    });
+
+    test('loads persisted station data', () {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn(['ev-1']);
+      when(() => mockStorage.getEvFavoriteStationData('ev-1')).thenReturn({
+        'id': 'ev-1',
+        'name': 'Test Charger',
+        'latitude': 48.0,
+        'longitude': 2.0,
+        'connectors': <dynamic>[],
+        'amenities': <dynamic>[],
+      });
+
+      final stations = container.read(evFavoriteStationsProvider);
+      expect(stations, hasLength(1));
+      expect(stations.first.name, 'Test Charger');
+    });
+
+    test('skips stations with no persisted data', () {
+      when(() => mockStorage.getEvFavoriteIds()).thenReturn(['ev-1', 'ev-2']);
+      when(() => mockStorage.getEvFavoriteStationData('ev-1')).thenReturn({
+        'id': 'ev-1',
+        'name': 'Test Charger',
+        'latitude': 48.0,
+        'longitude': 2.0,
+        'connectors': <dynamic>[],
+        'amenities': <dynamic>[],
+      });
+      when(() => mockStorage.getEvFavoriteStationData('ev-2'))
+          .thenReturn(null);
+
+      final stations = container.read(evFavoriteStationsProvider);
+      expect(stations, hasLength(1));
+    });
+  });
+}

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -1,3 +1,4 @@
+import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/country/country_config.dart';
 import 'package:tankstellen/core/country/country_provider.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
@@ -16,6 +17,9 @@ import '../mocks/mocks.dart';
 /// Returns both the override and the mock so callers can configure stubs.
 ({Object override, MockStorageRepository mock}) mockStorageRepositoryOverride() {
   final mock = MockStorageRepository();
+  // Default stubs for EV favorites (avoid null returns from Mock)
+  when(() => mock.getEvFavoriteIds()).thenReturn([]);
+  when(() => mock.getEvFavoriteStationData(any())).thenReturn(null);
   return (
     override: storageRepositoryProvider.overrideWithValue(mock),
     mock: mock,


### PR DESCRIPTION
## Summary
- Add `EvFavoriteStorage` interface with Hive implementation (separate storage bucket from fuel favorites)
- Create `EvFavorites` and `EvFavoriteStations` Riverpod providers
- Add star/favorite button to EV station detail screen
- Show EV favorites section in favorites screen (above fuel favorites when both exist)
- New `EvFavoriteCard` widget with connector type chips and availability status
- Backward compatible: existing fuel favorites unchanged

## Test plan
- [x] 11 unit tests: add/remove/toggle, isFavorite, station data persistence
- [x] All 53 existing favorites tests still pass
- [x] All 147 core storage tests pass
- [x] `flutter analyze` — zero warnings

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)