### PR TITLE
fix(detail): remove redundant fuel type chips section

### DIFF
--- a/lib/features/station_detail/presentation/widgets/station_info_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_info_section.dart
@@ -75,30 +75,6 @@ class StationInfoSection extends StatelessWidget {
           ),
         const SizedBox(height: 24),
 
-        // Available fuels
-        if (station.availableFuels.isNotEmpty) ...[
-          Text(l10n?.fuels ?? 'Fuels', style: theme.textTheme.titleMedium),
-          const SizedBox(height: 8),
-          Wrap(
-            spacing: 6,
-            runSpacing: 4,
-            children: [
-              ...station.availableFuels.map((f) => Chip(
-                    label: Text(f, style: const TextStyle(fontSize: 12)),
-                    visualDensity: VisualDensity.compact,
-                    backgroundColor: DarkModeColors.successSurface(context),
-                    side: BorderSide(color: DarkModeColors.success(context).withValues(alpha: 0.4)),
-                  )),
-              ...station.unavailableFuels.map((f) => Chip(
-                    label: Text(f, style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant, decoration: TextDecoration.lineThrough)),
-                    visualDensity: VisualDensity.compact,
-                    backgroundColor: theme.colorScheme.surfaceContainerHighest,
-                  )),
-            ],
-          ),
-          const SizedBox(height: 24),
-        ],
-
         // Location info
         if (station.department != null || station.region != null) ...[
           Text(l10n?.zone ?? 'Zone', style: theme.textTheme.titleMedium),

--- a/test/features/station_detail/presentation/widgets/station_info_section_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_info_section_test.dart
@@ -103,6 +103,26 @@ void main() {
       expect(amenitiesPos.dy, greaterThan(zonePos.dy));
     });
 
+    testWidgets('does not show fuel type chips section', (tester) async {
+      // Fuel types are already shown in the price list — the chip section
+      // was removed as redundant (issue #321).
+      final stationWithFuels = baseStation.copyWith(
+        availableFuels: ['Super E5', 'Super E10', 'Diesel'],
+      );
+      final detail = StationDetail(station: stationWithFuels);
+
+      await pumpApp(
+        tester,
+        SingleChildScrollView(
+          child: StationInfoSection(
+              station: stationWithFuels, detail: detail),
+        ),
+      );
+
+      // "Fuels" section title should not be present
+      expect(find.text('Fuels'), findsNothing);
+    });
+
     testWidgets('does not show separate last-update ListTile', (tester) async {
       final stationWithUpdate = baseStation.copyWith(
         updatedAt: '2026-03-27T10:00:00+01:00',


### PR DESCRIPTION
## Summary
- Remove "Available fuels" chip section from station detail — fuel types are already visible in the price list above
- Brand logo was already implemented (BrandLogo widget exists)

## Test plan
- [x] Widget test: fuel chips section is NOT in the widget tree
- [x] `flutter analyze` — zero warnings
- [x] All 6 station info section tests pass

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)