### PR TITLE
fix(i18n): localize data transparency and sync cards (batch 3)

### DIFF
--- a/lib/features/sync/presentation/screens/data_transparency_screen.dart
+++ b/lib/features/sync/presentation/screens/data_transparency_screen.dart
@@ -26,7 +26,7 @@ class DataTransparencyScreen extends ConsumerWidget {
     await showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Raw data (JSON)'),
+        title: Text(AppLocalizations.of(context)?.rawDataJson ?? 'Raw data (JSON)'),
         content: SizedBox(
           width: double.maxFinite,
           child: SingleChildScrollView(
@@ -39,7 +39,7 @@ class DataTransparencyScreen extends ConsumerWidget {
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: const Text('Close'),
+            child: Text(AppLocalizations.of(context)?.close ?? 'Close'),
           ),
         ],
       ),
@@ -72,21 +72,20 @@ class DataTransparencyScreen extends ConsumerWidget {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Delete all server data?'),
-        content: const Text(
+        title: Text(AppLocalizations.of(context)?.deleteServerDataConfirm ?? 'Delete all server data?'),
+        content: Text(AppLocalizations.of(context)?.deleteAccountBody ??
           'This will permanently remove all your favorites, alerts, push '
           'tokens, and price reports from the server. Your local data will '
-          'not be affected.\n\nThis action cannot be undone.',
-        ),
+          'not be affected.\n\nThis action cannot be undone.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
+            child: Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
           ),
           FilledButton(
             style: FilledButton.styleFrom(backgroundColor: Colors.red),
             onPressed: () => Navigator.pop(context, true),
-            child: const Text('Delete everything'),
+            child: Text(AppLocalizations.of(context)?.deleteEverything ?? 'Delete everything'),
           ),
         ],
       ),
@@ -106,19 +105,18 @@ class DataTransparencyScreen extends ConsumerWidget {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Disconnect TankSync?'),
-        content: const Text(
+        title: Text(AppLocalizations.of(context)?.disconnectTitle ?? 'Disconnect TankSync?'),
+        content: Text(AppLocalizations.of(context)?.disconnectBody ??
           'You will be signed out from cloud sync. Your local data remains '
-          'intact. You can reconnect at any time.',
-        ),
+          'intact. You can reconnect at any time.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
+            child: Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            child: const Text('Disconnect'),
+            child: Text(AppLocalizations.of(context)?.disconnectAction ?? 'Disconnect'),
           ),
         ],
       ),
@@ -137,7 +135,7 @@ class DataTransparencyScreen extends ConsumerWidget {
     final theme = Theme.of(context);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('My server data')),
+      appBar: AppBar(title: Text(AppLocalizations.of(context)?.myServerData ?? 'My server data')),
       body: uiState.loading
           ? const Center(child: CircularProgressIndicator())
           : uiState.error != null

--- a/lib/features/sync/presentation/widgets/data_transparency_cards.dart
+++ b/lib/features/sync/presentation/widgets/data_transparency_cards.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../core/sync/sync_config.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../l10n/app_localizations.dart';
 
 /// Account info card showing UUID and server URL.
 class AccountInfoCard extends StatelessWidget {
@@ -14,16 +15,17 @@ class AccountInfoCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Account', style: theme.textTheme.titleMedium),
+            Text(l?.account ?? 'Account', style: theme.textTheme.titleMedium),
             const SizedBox(height: 8),
-            InfoRow(label: 'Anonymous UUID', value: syncConfig.userId ?? 'Unknown'),
-            InfoRow(label: 'Server', value: syncConfig.supabaseUrl ?? 'Unknown'),
+            InfoRow(label: l?.anonymousUuid ?? 'Anonymous UUID', value: syncConfig.userId ?? 'Unknown'),
+            InfoRow(label: l?.server ?? 'Server', value: syncConfig.supabaseUrl ?? 'Unknown'),
           ],
         ),
       ),
@@ -56,21 +58,22 @@ class SyncedDataCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Synced data', style: theme.textTheme.titleMedium),
+            Text(l?.syncedData ?? 'Synced data', style: theme.textTheme.titleMedium),
             const SizedBox(height: 8),
-            InfoRow(label: 'Favorites', value: '${(data['favorites'] as List?)?.length ?? 0}'),
-            InfoRow(label: 'Alerts', value: '${(data['alerts'] as List?)?.length ?? 0}'),
-            InfoRow(label: 'Push tokens', value: '${(data['push_tokens'] as List?)?.length ?? 0}'),
-            InfoRow(label: 'Price reports', value: '${(data['reports'] as List?)?.length ?? 0}'),
+            InfoRow(label: l?.favorites ?? 'Favorites', value: '${(data['favorites'] as List?)?.length ?? 0}'),
+            InfoRow(label: l?.priceAlerts ?? 'Alerts', value: '${(data['alerts'] as List?)?.length ?? 0}'),
+            InfoRow(label: l?.pushTokens ?? 'Push tokens', value: '${(data['push_tokens'] as List?)?.length ?? 0}'),
+            InfoRow(label: l?.priceReports ?? 'Price reports', value: '${(data['reports'] as List?)?.length ?? 0}'),
             const Divider(height: 24),
-            InfoRow(label: 'Total items', value: '${_countItems()}'),
-            InfoRow(label: 'Estimated size', value: _estimateSize()),
+            InfoRow(label: l?.totalItems ?? 'Total items', value: '${_countItems()}'),
+            InfoRow(label: l?.estimatedSize ?? 'Estimated size', value: _estimateSize()),
           ],
         ),
       ),
@@ -101,25 +104,26 @@ class DataActionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         FilledButton.icon(
           onPressed: loading ? null : onSync,
           icon: const Icon(Icons.sync),
-          label: const Text('Sync now'),
+          label: Text(l?.syncNow ?? 'Sync now'),
         ),
         const SizedBox(height: 8),
         OutlinedButton.icon(
           onPressed: onViewRawJson,
           icon: const Icon(Icons.code),
-          label: const Text('View raw data as JSON'),
+          label: Text(l?.viewRawJson ?? 'View raw data as JSON'),
         ),
         const SizedBox(height: 8),
         OutlinedButton.icon(
           onPressed: onExportJson,
           icon: const Icon(Icons.copy),
-          label: const Text('Export as JSON (clipboard)'),
+          label: Text(l?.exportJson ?? 'Export as JSON (clipboard)'),
         ),
         const SizedBox(height: 24),
 
@@ -150,14 +154,14 @@ class DataActionButtons extends StatelessWidget {
             style: FilledButton.styleFrom(backgroundColor: Colors.red),
             onPressed: onDeleteAll,
             icon: const Icon(Icons.delete_forever),
-            label: const Text('Delete all server data'),
+            label: Text(l?.deleteAllServerData ?? 'Delete all server data'),
           ),
           const SizedBox(height: 8),
         ],
         OutlinedButton.icon(
           onPressed: onDisconnect,
           icon: const Icon(Icons.link_off),
-          label: const Text('Disconnect TankSync'),
+          label: Text(l?.disconnectTankSync ?? 'Disconnect TankSync'),
         ),
       ],
     );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -804,5 +804,6 @@
   "switchToAnonymousBody": "Sie werden von Ihrem E-Mail-Konto abgemeldet und mit einer neuen anonymen Sitzung fortfahren.\n\nIhre lokalen Daten (Favoriten, Alarme) bleiben auf diesem Gerät und werden mit dem neuen anonymen Konto synchronisiert.",
   "switchAction": "Wechseln",
   "helpBannerCriteria": "Ihre Profil-Standardwerte sind vorausgefüllt. Passen Sie die Kriterien unten an, um Ihre Suche zu verfeinern.",
-  "helpBannerAlerts": "Legen Sie einen Preisgrenzwert für eine Station fest. Sie werden benachrichtigt, wenn die Preise darunter fallen. Prüfungen laufen alle 30 Minuten."
+  "helpBannerAlerts": "Legen Sie einen Preisgrenzwert für eine Station fest. Sie werden benachrichtigt, wenn die Preise darunter fallen. Prüfungen laufen alle 30 Minuten.",
+  "syncNow": "Jetzt synchronisieren"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -804,5 +804,6 @@
   "switchToAnonymousBody": "You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.",
   "switchAction": "Switch",
   "helpBannerCriteria": "Your profile defaults are pre-filled. Adjust criteria below to refine your search.",
-  "helpBannerAlerts": "Set a price threshold for a station. You'll be notified when prices drop below it. Checks run every 30 minutes."
+  "helpBannerAlerts": "Set a price threshold for a station. You'll be notified when prices drop below it. Checks run every 30 minutes.",
+  "syncNow": "Sync now"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -469,5 +469,6 @@
   "switchToAnonymousBody": "Vous serez déconnecté de votre compte e-mail et continuerez avec une nouvelle session anonyme.\n\nVos données locales (favoris, alertes) restent sur cet appareil et seront synchronisées avec le nouveau compte anonyme.",
   "switchAction": "Changer",
   "helpBannerCriteria": "Vos valeurs par défaut sont pré-remplies. Ajustez les critères ci-dessous pour affiner votre recherche.",
-  "helpBannerAlerts": "Définissez un seuil de prix pour une station. Vous serez notifié quand les prix passent en dessous. Vérification toutes les 30 minutes."
+  "helpBannerAlerts": "Définissez un seuil de prix pour une station. Vous serez notifié quand les prix passent en dessous. Vérification toutes les 30 minutes.",
+  "syncNow": "Synchroniser maintenant"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3496,6 +3496,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.'**
   String get helpBannerAlerts;
+
+  /// No description provided for @syncNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync now'**
+  String get syncNow;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Legen Sie einen Preisgrenzwert für eine Station fest. Sie werden benachrichtigt, wenn die Preise darunter fallen. Prüfungen laufen alle 30 Minuten.';
+
+  @override
+  String get syncNow => 'Jetzt synchronisieren';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Définissez un seuil de prix pour une station. Vous serez notifié quand les prix passent en dessous. Vérification toutes les 30 minutes.';
+
+  @override
+  String get syncNow => 'Synchroniser maintenant';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1751,4 +1751,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+
+  @override
+  String get syncNow => 'Sync now';
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded strings in `data_transparency_screen.dart` and `data_transparency_cards.dart` with existing AppLocalizations keys
- Add 1 new key (`syncNow`) with EN/DE/FR translations
- Most keys already existed in ARB files but weren't being used

## Test plan
- [x] `flutter analyze` — zero warnings
- [x] All 98 sync + lint tests pass

Partial fix for #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)