### PR TITLE
feat(consumption): OBD-II protocol parser and service with ELM327 support

### DIFF
--- a/lib/features/consumption/data/obd2/elm327_protocol.dart
+++ b/lib/features/consumption/data/obd2/elm327_protocol.dart
@@ -1,0 +1,147 @@
+/// ELM327 OBD-II command builder and response parser.
+///
+/// The ELM327 is an OBD-to-serial interpreter chip. Commands are ASCII
+/// strings sent over serial/Bluetooth/TCP. Responses are hex-encoded
+/// bytes terminated by '>'.
+///
+/// This module is transport-agnostic — it only builds command strings
+/// and parses response strings. The actual I/O is handled by
+/// [Obd2Transport].
+class Elm327Protocol {
+  const Elm327Protocol();
+
+  // ---------------------------------------------------------------------------
+  // AT (adapter configuration) commands
+  // ---------------------------------------------------------------------------
+
+  /// Reset the ELM327 to factory defaults.
+  static const resetCommand = 'ATZ\r';
+
+  /// Turn echo off (cleaner responses).
+  static const echoOffCommand = 'ATE0\r';
+
+  /// Set protocol to automatic detection.
+  static const autoProtocolCommand = 'ATSP0\r';
+
+  /// Turn off line feeds.
+  static const lineFeedsOffCommand = 'ATL0\r';
+
+  /// Turn off headers in responses.
+  static const headersOffCommand = 'ATH0\r';
+
+  /// Standard initialization sequence for a new connection.
+  static const initCommands = [
+    resetCommand,
+    echoOffCommand,
+    lineFeedsOffCommand,
+    headersOffCommand,
+    autoProtocolCommand,
+  ];
+
+  // ---------------------------------------------------------------------------
+  // OBD-II Mode 01 PID commands
+  // ---------------------------------------------------------------------------
+
+  /// Request vehicle speed (km/h). Mode 01, PID 0D.
+  static const vehicleSpeedCommand = '010D\r';
+
+  /// Request engine RPM. Mode 01, PID 0C.
+  static const engineRpmCommand = '010C\r';
+
+  /// Request distance since DTC cleared (km). Mode 01, PID 31.
+  static const distanceSinceDtcClearedCommand = '0131\r';
+
+  /// Request odometer (km). Mode 01, PID A6.
+  /// Note: Not supported by all vehicles.
+  static const odometerCommand = '01A6\r';
+
+  // ---------------------------------------------------------------------------
+  // Response parsing
+  // ---------------------------------------------------------------------------
+
+  /// Parse a raw ELM327 response string into usable data.
+  ///
+  /// Strips whitespace, '>', echo, and extracts the hex payload.
+  /// Returns null if the response indicates an error or no data.
+  static String? cleanResponse(String raw) {
+    final cleaned = raw
+        .replaceAll('>', '')
+        .replaceAll('\r', ' ')
+        .replaceAll('\n', ' ')
+        .trim();
+
+    if (cleaned.isEmpty ||
+        cleaned.contains('NO DATA') ||
+        cleaned.contains('UNABLE TO CONNECT') ||
+        cleaned.contains('ERROR') ||
+        cleaned.contains('?')) {
+      return null;
+    }
+
+    // Remove echo (command echo before response)
+    // Response starts with "41" for Mode 01 responses
+    final idx = cleaned.indexOf('41');
+    if (idx >= 0) return cleaned.substring(idx).trim();
+
+    return cleaned;
+  }
+
+  /// Parse vehicle speed from Mode 01 PID 0D response.
+  /// Response format: "41 0D XX" where XX is speed in km/h.
+  static int? parseVehicleSpeed(String raw) {
+    final clean = cleanResponse(raw);
+    if (clean == null) return null;
+
+    final bytes = _parseHexBytes(clean);
+    if (bytes.length < 3 || bytes[0] != 0x41 || bytes[1] != 0x0D) return null;
+
+    return bytes[2]; // Speed in km/h (0-255)
+  }
+
+  /// Parse engine RPM from Mode 01 PID 0C response.
+  /// Response format: "41 0C XX YY" where RPM = ((XX * 256) + YY) / 4.
+  static double? parseEngineRpm(String raw) {
+    final clean = cleanResponse(raw);
+    if (clean == null) return null;
+
+    final bytes = _parseHexBytes(clean);
+    if (bytes.length < 4 || bytes[0] != 0x41 || bytes[1] != 0x0C) return null;
+
+    return ((bytes[2] * 256) + bytes[3]) / 4.0;
+  }
+
+  /// Parse distance since DTC cleared from Mode 01 PID 31 response.
+  /// Response format: "41 31 XX YY" where distance = (XX * 256) + YY km.
+  static int? parseDistanceSinceDtcCleared(String raw) {
+    final clean = cleanResponse(raw);
+    if (clean == null) return null;
+
+    final bytes = _parseHexBytes(clean);
+    if (bytes.length < 4 || bytes[0] != 0x41 || bytes[1] != 0x31) return null;
+
+    return (bytes[2] * 256) + bytes[3];
+  }
+
+  /// Parse odometer from Mode 01 PID A6 response.
+  /// Response format: "41 A6 XX YY ZZ WW" where odometer = value / 10 km.
+  static double? parseOdometer(String raw) {
+    final clean = cleanResponse(raw);
+    if (clean == null) return null;
+
+    final bytes = _parseHexBytes(clean);
+    if (bytes.length < 6 || bytes[0] != 0x41 || bytes[1] != 0xA6) return null;
+
+    final value = (bytes[2] << 24) | (bytes[3] << 16) | (bytes[4] << 8) | bytes[5];
+    return value / 10.0; // Odometer in km (1/10 km resolution)
+  }
+
+  /// Parse hex string "41 0D FF" into list of byte values [0x41, 0x0D, 0xFF].
+  static List<int> _parseHexBytes(String hex) {
+    return hex
+        .split(RegExp(r'\s+'))
+        .where((s) => s.isNotEmpty)
+        .map((s) => int.tryParse(s, radix: 16))
+        .whereType<int>()
+        .toList();
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/foundation.dart';
+
+import 'elm327_protocol.dart';
+import 'obd2_transport.dart';
+
+/// High-level OBD-II service for reading vehicle data.
+///
+/// Wraps [Obd2Transport] and [Elm327Protocol] to provide a clean API
+/// for reading odometer, speed, and other vehicle parameters.
+class Obd2Service {
+  final Obd2Transport _transport;
+
+  Obd2Service(this._transport);
+
+  bool get isConnected => _transport.isConnected;
+
+  /// Connect and initialize the ELM327 adapter.
+  Future<bool> connect() async {
+    try {
+      await _transport.connect();
+
+      // Run initialization sequence
+      for (final cmd in Elm327Protocol.initCommands) {
+        await _transport.sendCommand(cmd);
+        // Brief delay between init commands
+        await Future.delayed(const Duration(milliseconds: 100));
+      }
+
+      return true;
+    } catch (e) {
+      debugPrint('OBD2 connect failed: $e');
+      return false;
+    }
+  }
+
+  /// Read the odometer value in km.
+  ///
+  /// Tries PID A6 (direct odometer) first, then falls back to PID 31
+  /// (distance since DTC cleared) if not supported.
+  Future<double?> readOdometerKm() async {
+    if (!_transport.isConnected) return null;
+
+    try {
+      // Try direct odometer first (PID A6)
+      final odometerResponse =
+          await _transport.sendCommand(Elm327Protocol.odometerCommand);
+      final odometer = Elm327Protocol.parseOdometer(odometerResponse);
+      if (odometer != null) return odometer;
+
+      // Fallback: distance since DTC cleared (PID 31)
+      final distResponse = await _transport.sendCommand(
+          Elm327Protocol.distanceSinceDtcClearedCommand);
+      final distance = Elm327Protocol.parseDistanceSinceDtcCleared(distResponse);
+      if (distance != null) return distance.toDouble();
+
+      return null;
+    } catch (e) {
+      debugPrint('OBD2 readOdometer failed: $e');
+      return null;
+    }
+  }
+
+  /// Read current vehicle speed in km/h.
+  Future<int?> readSpeedKmh() async {
+    if (!_transport.isConnected) return null;
+
+    try {
+      final response =
+          await _transport.sendCommand(Elm327Protocol.vehicleSpeedCommand);
+      return Elm327Protocol.parseVehicleSpeed(response);
+    } catch (e) {
+      debugPrint('OBD2 readSpeed failed: $e');
+      return null;
+    }
+  }
+
+  /// Read current engine RPM.
+  Future<double?> readRpm() async {
+    if (!_transport.isConnected) return null;
+
+    try {
+      final response =
+          await _transport.sendCommand(Elm327Protocol.engineRpmCommand);
+      return Elm327Protocol.parseEngineRpm(response);
+    } catch (e) {
+      debugPrint('OBD2 readRpm failed: $e');
+      return null;
+    }
+  }
+
+  Future<void> disconnect() async {
+    await _transport.disconnect();
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/obd2_transport.dart
@@ -1,0 +1,43 @@
+/// Abstract transport layer for OBD-II communication.
+///
+/// Implementations handle the actual I/O (Bluetooth, TCP, serial).
+/// The [Elm327Protocol] builds commands and parses responses;
+/// transport just moves bytes.
+abstract class Obd2Transport {
+  /// Connect to the OBD-II adapter.
+  Future<void> connect();
+
+  /// Send a command and wait for the response (terminated by '>').
+  Future<String> sendCommand(String command);
+
+  /// Disconnect from the adapter.
+  Future<void> disconnect();
+
+  /// Whether currently connected.
+  bool get isConnected;
+}
+
+/// A fake transport for testing that returns pre-configured responses.
+class FakeObd2Transport implements Obd2Transport {
+  final Map<String, String> _responses;
+  bool _connected = false;
+
+  FakeObd2Transport([Map<String, String>? responses])
+      : _responses = responses ?? {};
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    return _responses[cmd] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async => _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+}

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -6,6 +6,8 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
+import '../../data/obd2/obd2_service.dart';
+import '../../data/obd2/obd2_transport.dart';
 import '../../data/receipt_scan_service.dart';
 import '../../domain/entities/fill_up.dart';
 import '../../providers/consumption_providers.dart';
@@ -31,6 +33,7 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
   DateTime _date = DateTime.now();
   FuelType _fuelType = FuelType.e10;
   bool _scanning = false;
+  bool _obdReading = false;
   ReceiptScanService? _scanService;
 
   @override
@@ -80,6 +83,45 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     }
   }
 
+  Future<void> _readObd() async {
+    setState(() => _obdReading = true);
+    try {
+      // TODO: Replace FakeObd2Transport with BluetoothObd2Transport
+      // when flutter_blue_plus is integrated and tested on real hardware.
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        '01A6': 'NO DATA>',
+        '0131': '41 31 4E 20>',
+      });
+      final service = Obd2Service(transport);
+      final connected = await service.connect();
+      if (!connected || !mounted) return;
+
+      final km = await service.readOdometerKm();
+      await service.disconnect();
+
+      if (km != null && mounted) {
+        setState(() {
+          _odoCtrl.text = km.round().toString();
+        });
+        SnackBarHelper.showSuccess(context,
+            'Odometer read: ${km.round()} km');
+      } else if (mounted) {
+        SnackBarHelper.show(context, 'Could not read odometer');
+      }
+    } catch (e) {
+      if (mounted) {
+        SnackBarHelper.showError(context, 'OBD-II error: $e');
+      }
+    } finally {
+      if (mounted) setState(() => _obdReading = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
@@ -99,17 +141,37 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [
-            // Scan receipt button
-            OutlinedButton.icon(
-              onPressed: _scanning ? null : _scanReceipt,
-              icon: _scanning
-                  ? const SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.document_scanner),
-              label: Text(l?.scanReceipt ?? 'Scan receipt'),
+            // Scan receipt + OBD buttons
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _scanning ? null : _scanReceipt,
+                    icon: _scanning
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.document_scanner),
+                    label: Text(l?.scanReceipt ?? 'Scan receipt'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _obdReading ? null : _readObd,
+                    icon: _obdReading
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.bluetooth),
+                    label: Text(l?.obdConnect ?? 'OBD-II'),
+                  ),
+                ),
+              ],
             ),
             const SizedBox(height: 12),
             if (widget.stationName != null) ...[

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -812,5 +812,6 @@
   "onboardingPrivacy": "Diese Einstellungen werden nur auf Ihrem Gerät gespeichert und niemals geteilt.",
   "onboardingLandingTitle": "Startbildschirm",
   "onboardingLandingHint": "Wählen Sie, welcher Bildschirm beim Start der App angezeigt wird.",
-  "scanReceipt": "Beleg scannen"
+  "scanReceipt": "Beleg scannen",
+  "obdConnect": "OBD-II"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -812,5 +812,6 @@
   "onboardingPrivacy": "These settings are stored only on your device and never shared.",
   "onboardingLandingTitle": "Home screen",
   "onboardingLandingHint": "Choose which screen opens when you launch the app.",
-  "scanReceipt": "Scan receipt"
+  "scanReceipt": "Scan receipt",
+  "obdConnect": "OBD-II"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -477,5 +477,6 @@
   "onboardingPrivacy": "Ces paramètres sont stockés uniquement sur votre appareil et ne sont jamais partagés.",
   "onboardingLandingTitle": "Écran d'accueil",
   "onboardingLandingHint": "Choisissez l'écran qui s'ouvre au lancement de l'application.",
-  "scanReceipt": "Scanner le reçu"
+  "scanReceipt": "Scanner le reçu",
+  "obdConnect": "OBD-II"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -83,8 +83,7 @@ import 'app_localizations_sv.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -92,8 +91,7 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate =
-      _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -105,13 +103,12 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -137,7 +134,7 @@ abstract class AppLocalizations {
     Locale('ro'),
     Locale('sk'),
     Locale('sl'),
-    Locale('sv'),
+    Locale('sv')
   ];
 
   /// No description provided for @appTitle.
@@ -2724,12 +2721,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{station}, {distance} kilometers ahead, {fuelType} {price}'**
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  );
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price);
 
   /// No description provided for @voiceAnnouncementProximityRadius.
   ///
@@ -3552,10 +3544,15 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Scan receipt'**
   String get scanReceipt;
+
+  /// No description provided for @obdConnect.
+  ///
+  /// In en, this message translates to:
+  /// **'OBD-II'**
+  String get obdConnect;
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -3564,91 +3561,46 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) => <String>[
-    'bg',
-    'cs',
-    'da',
-    'de',
-    'el',
-    'en',
-    'es',
-    'et',
-    'fi',
-    'fr',
-    'hr',
-    'hu',
-    'it',
-    'lt',
-    'lv',
-    'nb',
-    'nl',
-    'pl',
-    'pt',
-    'ro',
-    'sk',
-    'sl',
-    'sv',
-  ].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['bg', 'cs', 'da', 'de', 'el', 'en', 'es', 'et', 'fi', 'fr', 'hr', 'hu', 'it', 'lt', 'lv', 'nb', 'nl', 'pl', 'pt', 'ro', 'sk', 'sl', 'sv'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'bg':
-      return AppLocalizationsBg();
-    case 'cs':
-      return AppLocalizationsCs();
-    case 'da':
-      return AppLocalizationsDa();
-    case 'de':
-      return AppLocalizationsDe();
-    case 'el':
-      return AppLocalizationsEl();
-    case 'en':
-      return AppLocalizationsEn();
-    case 'es':
-      return AppLocalizationsEs();
-    case 'et':
-      return AppLocalizationsEt();
-    case 'fi':
-      return AppLocalizationsFi();
-    case 'fr':
-      return AppLocalizationsFr();
-    case 'hr':
-      return AppLocalizationsHr();
-    case 'hu':
-      return AppLocalizationsHu();
-    case 'it':
-      return AppLocalizationsIt();
-    case 'lt':
-      return AppLocalizationsLt();
-    case 'lv':
-      return AppLocalizationsLv();
-    case 'nb':
-      return AppLocalizationsNb();
-    case 'nl':
-      return AppLocalizationsNl();
-    case 'pl':
-      return AppLocalizationsPl();
-    case 'pt':
-      return AppLocalizationsPt();
-    case 'ro':
-      return AppLocalizationsRo();
-    case 'sk':
-      return AppLocalizationsSk();
-    case 'sl':
-      return AppLocalizationsSl();
-    case 'sv':
-      return AppLocalizationsSv();
+    case 'bg': return AppLocalizationsBg();
+    case 'cs': return AppLocalizationsCs();
+    case 'da': return AppLocalizationsDa();
+    case 'de': return AppLocalizationsDe();
+    case 'el': return AppLocalizationsEl();
+    case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
+    case 'et': return AppLocalizationsEt();
+    case 'fi': return AppLocalizationsFi();
+    case 'fr': return AppLocalizationsFr();
+    case 'hr': return AppLocalizationsHr();
+    case 'hu': return AppLocalizationsHu();
+    case 'it': return AppLocalizationsIt();
+    case 'lt': return AppLocalizationsLt();
+    case 'lv': return AppLocalizationsLv();
+    case 'nb': return AppLocalizationsNb();
+    case 'nl': return AppLocalizationsNl();
+    case 'pl': return AppLocalizationsPl();
+    case 'pt': return AppLocalizationsPt();
+    case 'ro': return AppLocalizationsRo();
+    case 'sk': return AppLocalizationsSk();
+    case 'sl': return AppLocalizationsSl();
+    case 'sv': return AppLocalizationsSv();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
+    'that was used.'
   );
 }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -103,8 +103,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get apiKeySetup => 'API ключ';
 
   @override
-  String get apiKeyDescription =>
-      'Регистрирайте се веднъж за безплатен API ключ.';
+  String get apiKeyDescription => 'Регистрирайте се веднъж за безплатен API ключ.';
 
   @override
   String get apiKeyLabel => 'API ключ';
@@ -173,8 +172,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noFavorites => 'Няма любими';
 
   @override
-  String get noFavoritesHint =>
-      'Докоснете звездата на бензиностанция, за да я запазите в любими.';
+  String get noFavoritesHint => 'Докоснете звездата на бензиностанция, за да я запазите в любими.';
 
   @override
   String get language => 'Език';
@@ -224,29 +222,25 @@ class AppLocalizationsBg extends AppLocalizations {
   String get gpsCoordinates => 'GPS координати';
 
   @override
-  String get gpsReason =>
-      'Изпращат се при всяко търсене за намиране на близки станции.';
+  String get gpsReason => 'Изпращат се при всяко търсене за намиране на близки станции.';
 
   @override
   String get postalCodeData => 'Пощенски код';
 
   @override
-  String get postalReason =>
-      'Преобразува се в координати чрез услуга за геокодиране.';
+  String get postalReason => 'Преобразува се в координати чрез услуга за геокодиране.';
 
   @override
   String get mapViewport => 'Изглед на картата';
 
   @override
-  String get mapReason =>
-      'Плочките на картата се зареждат от сървъра. Не се предават лични данни.';
+  String get mapReason => 'Плочките на картата се зареждат от сървъра. Не се предават лични данни.';
 
   @override
   String get apiKeyData => 'API ключ';
 
   @override
-  String get apiKeyReason =>
-      'Вашият личен ключ се изпраща с всяка API заявка. Свързан е с вашия имейл.';
+  String get apiKeyReason => 'Вашият личен ключ се изпраща с всяка API заявка. Свързан е с вашия имейл.';
 
   @override
   String get notShared => 'НЕ се споделя:';
@@ -267,8 +261,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get usageData => 'Данни за използване';
 
   @override
-  String get privacyBanner =>
-      'Това приложение няма сървър. Всички данни остават на вашето устройство. Без анализи, проследяване или реклами.';
+  String get privacyBanner => 'Това приложение няма сървър. Всички данни остават на вашето устройство. Без анализи, проследяване или реклами.';
 
   @override
   String get storageUsage => 'Използване на паметта на това устройство';
@@ -292,8 +285,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get cacheManagement => 'Управление на кеша';
 
   @override
-  String get cacheDescription =>
-      'Кешът съхранява API отговори за по-бързо зареждане и офлайн достъп.';
+  String get cacheDescription => 'Кешът съхранява API отговори за по-бързо зареждане и офлайн достъп.';
 
   @override
   String get stationSearch => 'Търсене на станции';
@@ -321,8 +313,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get clearCacheTitle => 'Изчистване на кеша?';
 
   @override
-  String get clearCacheBody =>
-      'Кешираните резултати от търсене и цени ще бъдат изтрити. Профилите, любимите и настройките се запазват.';
+  String get clearCacheBody => 'Кешираните резултати от търсене и цени ще бъдат изтрити. Профилите, любимите и настройките се запазват.';
 
   @override
   String get clearCacheButton => 'Изчисти кеша';
@@ -331,8 +322,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleteAllTitle => 'Изтриване на всички данни?';
 
   @override
-  String get deleteAllBody =>
-      'Това ще изтрие завинаги всички профили, любими, API ключ, настройки и кеш. Приложението ще се нулира.';
+  String get deleteAllBody => 'Това ще изтрие завинаги всички профили, любими, API ключ, настройки и кеш. Приложението ще се нулира.';
 
   @override
   String get deleteAllButton => 'Изтрий всичко';
@@ -347,19 +337,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noStorage => 'Няма използвана памет';
 
   @override
-  String get apiKeyNote =>
-      'Безплатна регистрация. Данни от държавни агенции за ценова прозрачност.';
+  String get apiKeyNote => 'Безплатна регистрация. Данни от държавни агенции за ценова прозрачност.';
 
   @override
-  String get apiKeyFormatError =>
-      'Невалиден формат — очакван UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Невалиден формат — очакван UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Подкрепете този проект';
 
   @override
-  String get supportDescription =>
-      'Това приложение е безплатно, с отворен код и без реклами. Ако го намирате за полезно, помислете да подкрепите разработчика.';
+  String get supportDescription => 'Това приложение е безплатно, с отворен код и без реклами. Ако го намирате за полезно, помислете да подкрепите разработчика.';
 
   @override
   String get reportBug => 'Докладване на грешка / Предложение за функция';
@@ -395,8 +382,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get station => 'Бензиностанция';
 
   @override
-  String get locationDenied =>
-      'Разрешението за местоположение е отказано. Можете да търсите по пощенски код.';
+  String get locationDenied => 'Разрешението за местоположение е отказано. Можете да търсите по пощенски код.';
 
   @override
   String get demoModeBanner => 'Демо режим. Настройте API ключа в настройките.';
@@ -425,8 +411,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Зареждане на любими...\nПърво потърсете станции, за да запазите данни.';
+  String get loadingFavorites => 'Зареждане на любими...\nПърво потърсете станции, за да запазите данни.';
 
   @override
   String get reportPrice => 'Докладване на цена';
@@ -462,8 +447,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get autoUpdatePosition => 'Автоматично обновяване на позицията';
 
   @override
-  String get autoUpdateDescription =>
-      'Обновяване на GPS позицията преди всяко търсене';
+  String get autoUpdateDescription => 'Обновяване на GPS позицията преди всяко търсене';
 
   @override
   String get location => 'Местоположение';
@@ -493,8 +477,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get autoSwitchProfile => 'Автоматично превключване на профил';
 
   @override
-  String get autoSwitchDescription =>
-      'Автоматично превключване на профила при преминаване на граница';
+  String get autoSwitchDescription => 'Автоматично превключване на профила при преминаване на граница';
 
   @override
   String get switchProfile => 'Превключи';
@@ -521,8 +504,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noPriceAlerts => 'Няма ценови сигнали';
 
   @override
-  String get noPriceAlertsHint =>
-      'Създайте сигнал от страницата с детайли на станция.';
+  String get noPriceAlertsHint => 'Създайте сигнал от страницата с детайли на станция.';
 
   @override
   String alertDeleted(String name) {
@@ -606,8 +588,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get evUsageCost => 'Разходи за ползване';
 
   @override
-  String get evPricingUnavailable =>
-      'Ценова информация не е налична от доставчика';
+  String get evPricingUnavailable => 'Ценова информация не е налична от доставчика';
 
   @override
   String get evLastUpdated => 'Последна актуализация';
@@ -619,8 +600,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get evDataAttribution => 'Данни от OpenChargeMap (обществен източник)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Състоянието може да не отразява наличността в реално време. Натиснете обновяване за най-новите данни.';
+  String get evStatusDisclaimer => 'Състоянието може да не отразява наличността в реално време. Натиснете обновяване за най-новите данни.';
 
   @override
   String get evNavigateToStation => 'Навигация към станцията';
@@ -632,8 +612,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get evStatusUpdated => 'Състоянието е обновено';
 
   @override
-  String get evStationNotFound =>
-      'Не може да се обнови — станцията не е намерена наблизо';
+  String get evStationNotFound => 'Не може да се обнови — станцията не е намерена наблизо';
 
   @override
   String get addedToFavorites => 'Добавено в любими';
@@ -702,8 +681,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Цени на горива (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Необходим за търсене на цени на горива в Германия';
+  String get requiredForFuelSearch => 'Необходим за търсене на цени на горива в Германия';
 
   @override
   String get evChargingOpenChargeMap => 'EV зареждане (OpenChargeMap)';
@@ -715,12 +693,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get appDefaultKey => 'Ключ по подразбиране на приложението';
 
   @override
-  String get optionalOverrideKey =>
-      'По избор: заменете вградения ключ с ваш собствен';
+  String get optionalOverrideKey => 'По избор: заменете вградения ключ с ваш собствен';
 
   @override
-  String get requiredForEvSearch =>
-      'Необходим за търсене на EV зарядни станции';
+  String get requiredForEvSearch => 'Необходим за търсене на EV зарядни станции';
 
   @override
   String get edit => 'Редактиране';
@@ -749,26 +725,22 @@ class AppLocalizationsBg extends AppLocalizations {
   String get avoidHighways => 'Избягвай магистрали';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Изчисляването на маршрута избягва платени пътища и магистрали';
+  String get avoidHighwaysDesc => 'Изчисляването на маршрута избягва платени пътища и магистрали';
 
   @override
   String get showFuelStations => 'Показвай бензиностанции';
 
   @override
-  String get showFuelStationsDesc =>
-      'Включи бензинови, дизелови, LPG, CNG станции';
+  String get showFuelStationsDesc => 'Включи бензинови, дизелови, LPG, CNG станции';
 
   @override
   String get showEvStations => 'Показвай зарядни станции';
 
   @override
-  String get showEvStationsDesc =>
-      'Включи електрически зарядни станции в резултатите';
+  String get showEvStationsDesc => 'Включи електрически зарядни станции в резултатите';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Не са намерени станции по този маршрут.';
+  String get noStationsAlongThisRoute => 'Не са намерени станции по този маршрут.';
 
   @override
   String get fuelCostCalculator => 'Калкулатор за разход на гориво';
@@ -792,8 +764,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get totalCost => 'Общ разход';
 
   @override
-  String get enterCalcValues =>
-      'Въведете разстояние, разход и цена за изчисляване на разхода за пътуването';
+  String get enterCalcValues => 'Въведете разстояние, разход и цена за изчисляване на разхода за пътуването';
 
   @override
   String get priceHistory => 'Ценова история';
@@ -835,19 +806,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get viewMyData => 'Преглед на моите данни';
 
   @override
-  String get optionalCloudSync =>
-      'По избор облачна синхронизация за сигнали, любими и push известия';
+  String get optionalCloudSync => 'По избор облачна синхронизация за сигнали, любими и push известия';
 
   @override
   String get tapToUpdateGps => 'Натиснете за обновяване на GPS позицията';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS позицията се получава автоматично при търсене. Можете също да я обновите ръчно тук.';
+  String get gpsAutoUpdateHint => 'GPS позицията се получава автоматично при търсене. Можете също да я обновите ръчно тук.';
 
   @override
-  String get clearGpsConfirm =>
-      'Изтриване на запазената GPS позиция? Можете да я обновите отново по всяко време.';
+  String get clearGpsConfirm => 'Изтриване на запазената GPS позиция? Можете да я обновите отново по всяко време.';
 
   @override
   String get pageNotFound => 'Страницата не е намерена';
@@ -931,8 +899,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -957,8 +924,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -982,12 +948,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1002,15 +966,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1061,44 +1023,37 @@ class AppLocalizationsBg extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1107,8 +1062,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1173,8 +1127,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1238,8 +1191,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1260,8 +1212,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1297,8 +1248,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1307,8 +1257,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1332,8 +1281,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1387,8 +1335,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1397,8 +1344,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1409,12 +1355,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1428,8 +1369,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get nearestStations => 'Nai-blizki stantsii';
 
   @override
-  String get nearestStationsHint =>
-      'Namerete nai-blizkite stantsii chrez vashata aktualna pozitsiya';
+  String get nearestStationsHint => 'Namerete nai-blizkite stantsii chrez vashata aktualna pozitsiya';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1438,8 +1378,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1451,8 +1390,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1503,8 +1441,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1584,12 +1521,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1755,15 +1690,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1787,8 +1720,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1797,33 +1729,28 @@ class AppLocalizationsBg extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1838,16 +1765,17 @@ class AppLocalizationsBg extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -103,8 +103,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get apiKeySetup => 'Klíč API';
 
   @override
-  String get apiKeyDescription =>
-      'Zaregistrujte se jednou pro bezplatný klíč API.';
+  String get apiKeyDescription => 'Zaregistrujte se jednou pro bezplatný klíč API.';
 
   @override
   String get apiKeyLabel => 'Klíč API';
@@ -173,8 +172,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get noFavorites => 'Žádné oblíbené';
 
   @override
-  String get noFavoritesHint =>
-      'Klepněte na hvězdičku u stanice, abyste ji uložili do oblíbených.';
+  String get noFavoritesHint => 'Klepněte na hvězdičku u stanice, abyste ji uložili do oblíbených.';
 
   @override
   String get language => 'Jazyk';
@@ -224,29 +222,25 @@ class AppLocalizationsCs extends AppLocalizations {
   String get gpsCoordinates => 'Souřadnice GPS';
 
   @override
-  String get gpsReason =>
-      'Odesílány s každým vyhledáváním pro nalezení blízkých stanic.';
+  String get gpsReason => 'Odesílány s každým vyhledáváním pro nalezení blízkých stanic.';
 
   @override
   String get postalCodeData => 'PSČ';
 
   @override
-  String get postalReason =>
-      'Převedeno na souřadnice prostřednictvím geokódovací služby.';
+  String get postalReason => 'Převedeno na souřadnice prostřednictvím geokódovací služby.';
 
   @override
   String get mapViewport => 'Výřez mapy';
 
   @override
-  String get mapReason =>
-      'Mapové dlaždice se načítají ze serveru. Žádné osobní údaje se nepřenášejí.';
+  String get mapReason => 'Mapové dlaždice se načítají ze serveru. Žádné osobní údaje se nepřenášejí.';
 
   @override
   String get apiKeyData => 'Klíč API';
 
   @override
-  String get apiKeyReason =>
-      'Váš osobní klíč se odesílá s každým požadavkem API. Je spojen s vaším e-mailem.';
+  String get apiKeyReason => 'Váš osobní klíč se odesílá s každým požadavkem API. Je spojen s vaším e-mailem.';
 
   @override
   String get notShared => 'NESDÍLÍ se:';
@@ -267,8 +261,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get usageData => 'Údaje o používání';
 
   @override
-  String get privacyBanner =>
-      'Tato aplikace nemá server. Všechna data zůstávají na vašem zařízení. Žádná analytika, žádné sledování, žádné reklamy.';
+  String get privacyBanner => 'Tato aplikace nemá server. Všechna data zůstávají na vašem zařízení. Žádná analytika, žádné sledování, žádné reklamy.';
 
   @override
   String get storageUsage => 'Využití úložiště na tomto zařízení';
@@ -292,8 +285,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get cacheManagement => 'Správa mezipaměti';
 
   @override
-  String get cacheDescription =>
-      'Mezipaměť ukládá odpovědi API pro rychlejší načítání a offline přístup.';
+  String get cacheDescription => 'Mezipaměť ukládá odpovědi API pro rychlejší načítání a offline přístup.';
 
   @override
   String get stationSearch => 'Vyhledávání stanic';
@@ -321,8 +313,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get clearCacheTitle => 'Vymazat mezipaměť?';
 
   @override
-  String get clearCacheBody =>
-      'Uložené výsledky hledání a ceny budou smazány. Profily, oblíbené a nastavení zůstanou zachovány.';
+  String get clearCacheBody => 'Uložené výsledky hledání a ceny budou smazány. Profily, oblíbené a nastavení zůstanou zachovány.';
 
   @override
   String get clearCacheButton => 'Vymazat mezipaměť';
@@ -331,8 +322,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleteAllTitle => 'Smazat všechna data?';
 
   @override
-  String get deleteAllBody =>
-      'Tím trvale smažete všechny profily, oblíbené, klíč API, nastavení a mezipaměť. Aplikace bude resetována.';
+  String get deleteAllBody => 'Tím trvale smažete všechny profily, oblíbené, klíč API, nastavení a mezipaměť. Aplikace bude resetována.';
 
   @override
   String get deleteAllButton => 'Smazat vše';
@@ -347,19 +337,16 @@ class AppLocalizationsCs extends AppLocalizations {
   String get noStorage => 'Žádné využité úložiště';
 
   @override
-  String get apiKeyNote =>
-      'Bezplatná registrace. Data od vládních agentur pro cenovou transparentnost.';
+  String get apiKeyNote => 'Bezplatná registrace. Data od vládních agentur pro cenovou transparentnost.';
 
   @override
-  String get apiKeyFormatError =>
-      'Neplatný formát — očekáváno UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Neplatný formát — očekáváno UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Podpořte tento projekt';
 
   @override
-  String get supportDescription =>
-      'Tato aplikace je zdarma, s otevřeným zdrojovým kódem a bez reklam. Pokud ji považujete za užitečnou, zvažte podporu vývojáře.';
+  String get supportDescription => 'Tato aplikace je zdarma, s otevřeným zdrojovým kódem a bez reklam. Pokud ji považujete za užitečnou, zvažte podporu vývojáře.';
 
   @override
   String get reportBug => 'Nahlásit chybu / Navrhnout funkci';
@@ -395,8 +382,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get station => 'Čerpací stanice';
 
   @override
-  String get locationDenied =>
-      'Oprávnění k poloze zamítnuto. Můžete hledat podle PSČ.';
+  String get locationDenied => 'Oprávnění k poloze zamítnuto. Můžete hledat podle PSČ.';
 
   @override
   String get demoModeBanner => 'Demo režim. Nastavte klíč API v nastavení.';
@@ -425,8 +411,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Načítání oblíbených...\nNejprve vyhledejte stanice pro uložení dat.';
+  String get loadingFavorites => 'Načítání oblíbených...\nNejprve vyhledejte stanice pro uložení dat.';
 
   @override
   String get reportPrice => 'Nahlásit cenu';
@@ -462,8 +447,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get autoUpdatePosition => 'Automaticky aktualizovat polohu';
 
   @override
-  String get autoUpdateDescription =>
-      'Aktualizovat polohu GPS před každým hledáním';
+  String get autoUpdateDescription => 'Aktualizovat polohu GPS před každým hledáním';
 
   @override
   String get location => 'Poloha';
@@ -493,8 +477,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get autoSwitchProfile => 'Automatické přepnutí profilu';
 
   @override
-  String get autoSwitchDescription =>
-      'Automaticky přepnout profil při překročení hranic';
+  String get autoSwitchDescription => 'Automaticky přepnout profil při překročení hranic';
 
   @override
   String get switchProfile => 'Přepnout';
@@ -521,8 +504,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get noPriceAlerts => 'Žádné cenové výstrahy';
 
   @override
-  String get noPriceAlertsHint =>
-      'Vytvořte výstrahu na stránce s podrobnostmi stanice.';
+  String get noPriceAlertsHint => 'Vytvořte výstrahu na stránce s podrobnostmi stanice.';
 
   @override
   String alertDeleted(String name) {
@@ -586,8 +568,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get openInMaps => 'Otevřít v Mapách';
 
   @override
-  String get noStationsAlongRoute =>
-      'Podél trasy nebyly nalezeny žádné stanice';
+  String get noStationsAlongRoute => 'Podél trasy nebyly nalezeny žádné stanice';
 
   @override
   String get evOperational => 'V provozu';
@@ -619,8 +600,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get evDataAttribution => 'Data z OpenChargeMap (komunitní zdroj)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Stav nemusí odrážet dostupnost v reálném čase. Klepněte na aktualizovat pro získání nejnovějších dat.';
+  String get evStatusDisclaimer => 'Stav nemusí odrážet dostupnost v reálném čase. Klepněte na aktualizovat pro získání nejnovějších dat.';
 
   @override
   String get evNavigateToStation => 'Navigovat na stanici';
@@ -632,8 +612,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get evStatusUpdated => 'Stav aktualizován';
 
   @override
-  String get evStationNotFound =>
-      'Nelze aktualizovat — stanice nenalezena v okolí';
+  String get evStationNotFound => 'Nelze aktualizovat — stanice nenalezena v okolí';
 
   @override
   String get addedToFavorites => 'Přidáno do oblíbených';
@@ -702,8 +681,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Ceny paliv (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Vyžadováno pro vyhledávání cen paliv v Německu';
+  String get requiredForFuelSearch => 'Vyžadováno pro vyhledávání cen paliv v Německu';
 
   @override
   String get evChargingOpenChargeMap => 'Nabíjení EV (OpenChargeMap)';
@@ -715,12 +693,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get appDefaultKey => 'Výchozí klíč aplikace';
 
   @override
-  String get optionalOverrideKey =>
-      'Volitelné: nahradit vestavěný klíč aplikace vlastním';
+  String get optionalOverrideKey => 'Volitelné: nahradit vestavěný klíč aplikace vlastním';
 
   @override
-  String get requiredForEvSearch =>
-      'Vyžadováno pro vyhledávání nabíjecích stanic EV';
+  String get requiredForEvSearch => 'Vyžadováno pro vyhledávání nabíjecích stanic EV';
 
   @override
   String get edit => 'Upravit';
@@ -749,26 +725,22 @@ class AppLocalizationsCs extends AppLocalizations {
   String get avoidHighways => 'Vyhnout se dálnicím';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Výpočet trasy se vyhýbá placeným silnicím a dálnicím';
+  String get avoidHighwaysDesc => 'Výpočet trasy se vyhýbá placeným silnicím a dálnicím';
 
   @override
   String get showFuelStations => 'Zobrazit čerpací stanice';
 
   @override
-  String get showFuelStationsDesc =>
-      'Zahrnout benzínové, naftové, LPG, CNG stanice';
+  String get showFuelStationsDesc => 'Zahrnout benzínové, naftové, LPG, CNG stanice';
 
   @override
   String get showEvStations => 'Zobrazit nabíjecí stanice';
 
   @override
-  String get showEvStationsDesc =>
-      'Zahrnout elektrické nabíjecí stanice ve výsledcích';
+  String get showEvStationsDesc => 'Zahrnout elektrické nabíjecí stanice ve výsledcích';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Podél této trasy nebyly nalezeny žádné stanice.';
+  String get noStationsAlongThisRoute => 'Podél této trasy nebyly nalezeny žádné stanice.';
 
   @override
   String get fuelCostCalculator => 'Kalkulačka nákladů na palivo';
@@ -792,8 +764,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get totalCost => 'Celkové náklady';
 
   @override
-  String get enterCalcValues =>
-      'Zadejte vzdálenost, spotřebu a cenu pro výpočet nákladů na cestu';
+  String get enterCalcValues => 'Zadejte vzdálenost, spotřebu a cenu pro výpočet nákladů na cestu';
 
   @override
   String get priceHistory => 'Historie cen';
@@ -835,19 +806,16 @@ class AppLocalizationsCs extends AppLocalizations {
   String get viewMyData => 'Zobrazit moje data';
 
   @override
-  String get optionalCloudSync =>
-      'Volitelná cloudová synchronizace pro výstrahy, oblíbené a push notifikace';
+  String get optionalCloudSync => 'Volitelná cloudová synchronizace pro výstrahy, oblíbené a push notifikace';
 
   @override
   String get tapToUpdateGps => 'Klepněte pro aktualizaci polohy GPS';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'Poloha GPS se získává automaticky při hledání. Můžete ji také aktualizovat ručně zde.';
+  String get gpsAutoUpdateHint => 'Poloha GPS se získává automaticky při hledání. Můžete ji také aktualizovat ručně zde.';
 
   @override
-  String get clearGpsConfirm =>
-      'Vymazat uloženou polohu GPS? Můžete ji kdykoli znovu aktualizovat.';
+  String get clearGpsConfirm => 'Vymazat uloženou polohu GPS? Můžete ji kdykoli znovu aktualizovat.';
 
   @override
   String get pageNotFound => 'Stránka nenalezena';
@@ -931,8 +899,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -957,8 +924,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -982,12 +948,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1002,15 +966,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1061,44 +1023,37 @@ class AppLocalizationsCs extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1107,8 +1062,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1173,8 +1127,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1238,8 +1191,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1260,8 +1212,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1297,8 +1248,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1307,8 +1257,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1332,8 +1281,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1387,8 +1335,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1397,8 +1344,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1409,12 +1355,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1428,8 +1369,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get nearestStations => 'Nejblizsi stanice';
 
   @override
-  String get nearestStationsHint =>
-      'Najdete nejblizsi stanice pomoci vasi aktualni polohy';
+  String get nearestStationsHint => 'Najdete nejblizsi stanice pomoci vasi aktualni polohy';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1438,8 +1378,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1451,8 +1390,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1503,8 +1441,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1584,12 +1521,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1755,15 +1690,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1787,8 +1720,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1797,33 +1729,28 @@ class AppLocalizationsCs extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1838,16 +1765,17 @@ class AppLocalizationsCs extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -103,8 +103,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get apiKeySetup => 'API-nøgle';
 
   @override
-  String get apiKeyDescription =>
-      'Registrer dig én gang for at få en gratis API-nøgle.';
+  String get apiKeyDescription => 'Registrer dig én gang for at få en gratis API-nøgle.';
 
   @override
   String get apiKeyLabel => 'API-nøgle';
@@ -173,8 +172,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get noFavorites => 'Ingen favoritter endnu';
 
   @override
-  String get noFavoritesHint =>
-      'Tryk på stjernen ved en tankstation for at gemme den som favorit.';
+  String get noFavoritesHint => 'Tryk på stjernen ved en tankstation for at gemme den som favorit.';
 
   @override
   String get language => 'Sprog';
@@ -224,29 +222,25 @@ class AppLocalizationsDa extends AppLocalizations {
   String get gpsCoordinates => 'GPS-koordinater';
 
   @override
-  String get gpsReason =>
-      'Sendes med hver søgning for at finde nærliggende stationer.';
+  String get gpsReason => 'Sendes med hver søgning for at finde nærliggende stationer.';
 
   @override
   String get postalCodeData => 'Postnummer';
 
   @override
-  String get postalReason =>
-      'Konverteres til koordinater via geokodningstjenesten.';
+  String get postalReason => 'Konverteres til koordinater via geokodningstjenesten.';
 
   @override
   String get mapViewport => 'Kortudsnit';
 
   @override
-  String get mapReason =>
-      'Kortfliser indlæses fra serveren. Ingen personlige data overføres.';
+  String get mapReason => 'Kortfliser indlæses fra serveren. Ingen personlige data overføres.';
 
   @override
   String get apiKeyData => 'API-nøgle';
 
   @override
-  String get apiKeyReason =>
-      'Din personlige nøgle sendes med hver API-anmodning. Den er knyttet til din e-mail.';
+  String get apiKeyReason => 'Din personlige nøgle sendes med hver API-anmodning. Den er knyttet til din e-mail.';
 
   @override
   String get notShared => 'Deles IKKE:';
@@ -267,8 +261,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get usageData => 'Brugsdata';
 
   @override
-  String get privacyBanner =>
-      'Denne app har ingen server. Alle data forbliver på din enhed. Ingen analyse, ingen sporing, ingen reklamer.';
+  String get privacyBanner => 'Denne app har ingen server. Alle data forbliver på din enhed. Ingen analyse, ingen sporing, ingen reklamer.';
 
   @override
   String get storageUsage => 'Lagringsforbrug på denne enhed';
@@ -292,8 +285,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get cacheManagement => 'Cacheadministration';
 
   @override
-  String get cacheDescription =>
-      'Cachen gemmer API-svar for hurtigere indlæsning og offline adgang.';
+  String get cacheDescription => 'Cachen gemmer API-svar for hurtigere indlæsning og offline adgang.';
 
   @override
   String get stationSearch => 'Stationssøgning';
@@ -321,8 +313,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get clearCacheTitle => 'Ryd cache?';
 
   @override
-  String get clearCacheBody =>
-      'Cachelagrede søgeresultater og priser slettes. Profiler, favoritter og indstillinger bevares.';
+  String get clearCacheBody => 'Cachelagrede søgeresultater og priser slettes. Profiler, favoritter og indstillinger bevares.';
 
   @override
   String get clearCacheButton => 'Ryd cache';
@@ -331,8 +322,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteAllTitle => 'Slet alle data?';
 
   @override
-  String get deleteAllBody =>
-      'Dette sletter permanent alle profiler, favoritter, API-nøgle, indstillinger og cache. Appen nulstilles.';
+  String get deleteAllBody => 'Dette sletter permanent alle profiler, favoritter, API-nøgle, indstillinger og cache. Appen nulstilles.';
 
   @override
   String get deleteAllButton => 'Slet alt';
@@ -347,19 +337,16 @@ class AppLocalizationsDa extends AppLocalizations {
   String get noStorage => 'Ingen lagring brugt';
 
   @override
-  String get apiKeyNote =>
-      'Gratis registrering. Data fra statslige pristransparensorganer.';
+  String get apiKeyNote => 'Gratis registrering. Data fra statslige pristransparensorganer.';
 
   @override
-  String get apiKeyFormatError =>
-      'Ugyldigt format — forventet UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Ugyldigt format — forventet UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Støt dette projekt';
 
   @override
-  String get supportDescription =>
-      'Denne app er gratis, open source og uden reklamer. Hvis du finder den nyttig, overvej at støtte udvikleren.';
+  String get supportDescription => 'Denne app er gratis, open source og uden reklamer. Hvis du finder den nyttig, overvej at støtte udvikleren.';
 
   @override
   String get reportBug => 'Rapportér fejl / Foreslå funktion';
@@ -395,12 +382,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get station => 'Tankstation';
 
   @override
-  String get locationDenied =>
-      'Placeringstilladelse nægtet. Du kan søge efter postnummer.';
+  String get locationDenied => 'Placeringstilladelse nægtet. Du kan søge efter postnummer.';
 
   @override
-  String get demoModeBanner =>
-      'Demo-tilstand. Konfigurer API-nøgle i indstillinger.';
+  String get demoModeBanner => 'Demo-tilstand. Konfigurer API-nøgle i indstillinger.';
 
   @override
   String get sortDistance => 'Afstand';
@@ -426,8 +411,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Indlæser favoritter...\nSøg først efter stationer for at gemme data.';
+  String get loadingFavorites => 'Indlæser favoritter...\nSøg først efter stationer for at gemme data.';
 
   @override
   String get reportPrice => 'Rapportér pris';
@@ -493,8 +477,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get autoSwitchProfile => 'Automatisk profilskift';
 
   @override
-  String get autoSwitchDescription =>
-      'Skift profil automatisk ved grænseoverskridelse';
+  String get autoSwitchDescription => 'Skift profil automatisk ved grænseoverskridelse';
 
   @override
   String get switchProfile => 'Skift';
@@ -617,8 +600,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get evDataAttribution => 'Data fra OpenChargeMap (community-kilde)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Status afspejler muligvis ikke tilgængeligheden i realtid. Tryk på opdater for at hente de seneste data.';
+  String get evStatusDisclaimer => 'Status afspejler muligvis ikke tilgængeligheden i realtid. Tryk på opdater for at hente de seneste data.';
 
   @override
   String get evNavigateToStation => 'Navigér til station';
@@ -630,8 +612,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get evStatusUpdated => 'Status opdateret';
 
   @override
-  String get evStationNotFound =>
-      'Kunne ikke opdatere — station ikke fundet i nærheden';
+  String get evStationNotFound => 'Kunne ikke opdatere — station ikke fundet i nærheden';
 
   @override
   String get addedToFavorites => 'Tilføjet til favoritter';
@@ -700,8 +681,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Brændstofpriser (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Påkrævet til brændstofprissøgning i Tyskland';
+  String get requiredForFuelSearch => 'Påkrævet til brændstofprissøgning i Tyskland';
 
   @override
   String get evChargingOpenChargeMap => 'EV-opladning (OpenChargeMap)';
@@ -713,12 +693,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get appDefaultKey => 'App-standardnøgle';
 
   @override
-  String get optionalOverrideKey =>
-      'Valgfrit: erstat den indbyggede app-nøgle med din egen';
+  String get optionalOverrideKey => 'Valgfrit: erstat den indbyggede app-nøgle med din egen';
 
   @override
-  String get requiredForEvSearch =>
-      'Påkrævet til søgning efter EV-ladestationer';
+  String get requiredForEvSearch => 'Påkrævet til søgning efter EV-ladestationer';
 
   @override
   String get edit => 'Rediger';
@@ -747,26 +725,22 @@ class AppLocalizationsDa extends AppLocalizations {
   String get avoidHighways => 'Undgå motorveje';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Ruteberegning undgår betalingsveje og motorveje';
+  String get avoidHighwaysDesc => 'Ruteberegning undgår betalingsveje og motorveje';
 
   @override
   String get showFuelStations => 'Vis tankstationer';
 
   @override
-  String get showFuelStationsDesc =>
-      'Inkluder benzin-, diesel-, LPG-, CNG-stationer';
+  String get showFuelStationsDesc => 'Inkluder benzin-, diesel-, LPG-, CNG-stationer';
 
   @override
   String get showEvStations => 'Vis ladestationer';
 
   @override
-  String get showEvStationsDesc =>
-      'Inkluder elektriske ladestationer i søgeresultater';
+  String get showEvStationsDesc => 'Inkluder elektriske ladestationer i søgeresultater';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Ingen stationer fundet langs denne rute.';
+  String get noStationsAlongThisRoute => 'Ingen stationer fundet langs denne rute.';
 
   @override
   String get fuelCostCalculator => 'Brændstofomkostningsberegner';
@@ -790,8 +764,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get totalCost => 'Samlede omkostninger';
 
   @override
-  String get enterCalcValues =>
-      'Indtast afstand, forbrug og pris for at beregne turomkostningen';
+  String get enterCalcValues => 'Indtast afstand, forbrug og pris for at beregne turomkostningen';
 
   @override
   String get priceHistory => 'Prishistorik';
@@ -833,19 +806,16 @@ class AppLocalizationsDa extends AppLocalizations {
   String get viewMyData => 'Se mine data';
 
   @override
-  String get optionalCloudSync =>
-      'Valgfri cloudsynkronisering for alarmer, favoritter og push-notifikationer';
+  String get optionalCloudSync => 'Valgfri cloudsynkronisering for alarmer, favoritter og push-notifikationer';
 
   @override
   String get tapToUpdateGps => 'Tryk for at opdatere GPS-position';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS-positionen hentes automatisk ved søgning. Du kan også opdatere den manuelt her.';
+  String get gpsAutoUpdateHint => 'GPS-positionen hentes automatisk ved søgning. Du kan også opdatere den manuelt her.';
 
   @override
-  String get clearGpsConfirm =>
-      'Ryd den gemte GPS-position? Du kan opdatere den igen når som helst.';
+  String get clearGpsConfirm => 'Ryd den gemte GPS-position? Du kan opdatere den igen når som helst.';
 
   @override
   String get pageNotFound => 'Side ikke fundet';
@@ -929,8 +899,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -955,8 +924,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -980,12 +948,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1000,15 +966,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1059,44 +1023,37 @@ class AppLocalizationsDa extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1105,8 +1062,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1171,8 +1127,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1236,8 +1191,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1258,8 +1212,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1295,8 +1248,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1305,8 +1257,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1330,8 +1281,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1385,8 +1335,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1395,8 +1344,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1407,12 +1355,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1426,8 +1369,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get nearestStations => 'Naermeste stationer';
 
   @override
-  String get nearestStationsHint =>
-      'Find de naermeste stationer med din aktuelle position';
+  String get nearestStationsHint => 'Find de naermeste stationer med din aktuelle position';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1436,8 +1378,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1449,8 +1390,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1501,8 +1441,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1582,12 +1521,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1753,15 +1690,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1785,8 +1720,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1795,33 +1729,28 @@ class AppLocalizationsDa extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1836,16 +1765,17 @@ class AppLocalizationsDa extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -103,8 +103,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get apiKeySetup => 'API-Schlüssel einrichten';
 
   @override
-  String get apiKeyDescription =>
-      'Registrieren Sie sich einmalig für einen kostenlosen API-Schlüssel.';
+  String get apiKeyDescription => 'Registrieren Sie sich einmalig für einen kostenlosen API-Schlüssel.';
 
   @override
   String get apiKeyLabel => 'API-Schlüssel';
@@ -119,8 +118,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get welcome => 'Tankstellen';
 
   @override
-  String get welcomeSubtitle =>
-      'Finden Sie die günstigsten Kraftstoffpreise in Ihrer Nähe.';
+  String get welcomeSubtitle => 'Finden Sie die günstigsten Kraftstoffpreise in Ihrer Nähe.';
 
   @override
   String get profileName => 'Profilname';
@@ -174,8 +172,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noFavorites => 'Noch keine Favoriten';
 
   @override
-  String get noFavoritesHint =>
-      'Tippen Sie auf den Stern bei einer Tankstelle, um sie als Favorit zu speichern.';
+  String get noFavoritesHint => 'Tippen Sie auf den Stern bei einer Tankstelle, um sie als Favorit zu speichern.';
 
   @override
   String get language => 'Sprache';
@@ -225,8 +222,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get gpsCoordinates => 'GPS-Koordinaten';
 
   @override
-  String get gpsReason =>
-      'Wird bei jeder Standort-Suche gesendet, um Tankstellen in der Nähe zu finden.';
+  String get gpsReason => 'Wird bei jeder Standort-Suche gesendet, um Tankstellen in der Nähe zu finden.';
 
   @override
   String get postalCodeData => 'Postleitzahl';
@@ -238,15 +234,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mapViewport => 'Kartenausschnitt';
 
   @override
-  String get mapReason =>
-      'Beim Öffnen der Karte werden Kartenkacheln geladen. Keine persönlichen Daten werden übertragen.';
+  String get mapReason => 'Beim Öffnen der Karte werden Kartenkacheln geladen. Keine persönlichen Daten werden übertragen.';
 
   @override
   String get apiKeyData => 'API-Schlüssel';
 
   @override
-  String get apiKeyReason =>
-      'Ihr persönlicher Schlüssel wird bei jeder API-Anfrage mitgesendet.';
+  String get apiKeyReason => 'Ihr persönlicher Schlüssel wird bei jeder API-Anfrage mitgesendet.';
 
   @override
   String get notShared => 'Wird NICHT geteilt:';
@@ -267,8 +261,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get usageData => 'App-Nutzungsdaten';
 
   @override
-  String get privacyBanner =>
-      'Diese App hat keinen eigenen Server. Alle Daten bleiben auf Ihrem Gerät. Keine Analyse, kein Tracking, keine Werbung.';
+  String get privacyBanner => 'Diese App hat keinen eigenen Server. Alle Daten bleiben auf Ihrem Gerät. Keine Analyse, kein Tracking, keine Werbung.';
 
   @override
   String get storageUsage => 'Speichernutzung auf diesem Gerät';
@@ -292,8 +285,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cacheManagement => 'Cache-Verwaltung';
 
   @override
-  String get cacheDescription =>
-      'Der Cache speichert API-Antworten für schnellere Ladezeiten und Offline-Zugriff.';
+  String get cacheDescription => 'Der Cache speichert API-Antworten für schnellere Ladezeiten und Offline-Zugriff.';
 
   @override
   String get stationSearch => 'Tankstellen-Suche';
@@ -321,8 +313,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get clearCacheTitle => 'Cache leeren?';
 
   @override
-  String get clearCacheBody =>
-      'Zwischengespeicherte Suchergebnisse und Preise werden gelöscht. Profile, Favoriten und Einstellungen bleiben erhalten.';
+  String get clearCacheBody => 'Zwischengespeicherte Suchergebnisse und Preise werden gelöscht. Profile, Favoriten und Einstellungen bleiben erhalten.';
 
   @override
   String get clearCacheButton => 'Cache leeren';
@@ -331,8 +322,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteAllTitle => 'Alle Daten löschen?';
 
   @override
-  String get deleteAllBody =>
-      'Dies löscht unwiderruflich alle Profile, Favoriten, den API-Schlüssel, alle Einstellungen und den gesamten Cache.';
+  String get deleteAllBody => 'Dies löscht unwiderruflich alle Profile, Favoriten, den API-Schlüssel, alle Einstellungen und den gesamten Cache.';
 
   @override
   String get deleteAllButton => 'Alles löschen';
@@ -347,19 +337,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noStorage => 'Kein Speicher belegt';
 
   @override
-  String get apiKeyNote =>
-      'Kostenlose Registrierung. Daten von den Markttransparenzstellen.';
+  String get apiKeyNote => 'Kostenlose Registrierung. Daten von den Markttransparenzstellen.';
 
   @override
-  String get apiKeyFormatError =>
-      'Ungültiges Format — UUID erwartet (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Ungültiges Format — UUID erwartet (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Dieses Projekt unterstützen';
 
   @override
-  String get supportDescription =>
-      'Diese App ist kostenlos, Open Source und ohne Werbung. Wenn Sie sie nützlich finden, unterstützen Sie den Entwickler.';
+  String get supportDescription => 'Diese App ist kostenlos, Open Source und ohne Werbung. Wenn Sie sie nützlich finden, unterstützen Sie den Entwickler.';
 
   @override
   String get reportBug => 'Fehler melden / Funktion vorschlagen';
@@ -395,12 +382,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get station => 'Tankstelle';
 
   @override
-  String get locationDenied =>
-      'Standortfreigabe abgelehnt. Sie können per PLZ suchen.';
+  String get locationDenied => 'Standortfreigabe abgelehnt. Sie können per PLZ suchen.';
 
   @override
-  String get demoModeBanner =>
-      'Demo-Modus. API-Schlüssel in den Einstellungen eingeben.';
+  String get demoModeBanner => 'Demo-Modus. API-Schlüssel in den Einstellungen eingeben.';
 
   @override
   String get sortDistance => 'Entfernung';
@@ -426,8 +411,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Favoriten werden geladen...\nSuchen Sie zuerst Tankstellen, um Daten zu speichern.';
+  String get loadingFavorites => 'Favoriten werden geladen...\nSuchen Sie zuerst Tankstellen, um Daten zu speichern.';
 
   @override
   String get reportPrice => 'Preis melden';
@@ -463,8 +447,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoUpdatePosition => 'Position automatisch aktualisieren';
 
   @override
-  String get autoUpdateDescription =>
-      'GPS-Position vor jeder Suche aktualisieren';
+  String get autoUpdateDescription => 'GPS-Position vor jeder Suche aktualisieren';
 
   @override
   String get location => 'Standort';
@@ -494,8 +477,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoSwitchProfile => 'Profil automatisch wechseln';
 
   @override
-  String get autoSwitchDescription =>
-      'Profil beim Grenzübertritt automatisch wechseln';
+  String get autoSwitchDescription => 'Profil beim Grenzübertritt automatisch wechseln';
 
   @override
   String get switchProfile => 'Wechseln';
@@ -522,8 +504,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noPriceAlerts => 'Keine Preisalarme';
 
   @override
-  String get noPriceAlertsHint =>
-      'Erstellen Sie einen Alarm auf der Detailseite einer Tankstelle.';
+  String get noPriceAlertsHint => 'Erstellen Sie einen Alarm auf der Detailseite einer Tankstelle.';
 
   @override
   String alertDeleted(String name) {
@@ -587,8 +568,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get openInMaps => 'In Karten öffnen';
 
   @override
-  String get noStationsAlongRoute =>
-      'Keine Stationen entlang der Route gefunden';
+  String get noStationsAlongRoute => 'Keine Stationen entlang der Route gefunden';
 
   @override
   String get evOperational => 'In Betrieb';
@@ -620,8 +600,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get evDataAttribution => 'Daten von OpenChargeMap (Community-basiert)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Der Status spiegelt möglicherweise nicht die Echtzeit-Verfügbarkeit wider. Tippen Sie auf Aktualisieren, um die neuesten Daten abzurufen.';
+  String get evStatusDisclaimer => 'Der Status spiegelt möglicherweise nicht die Echtzeit-Verfügbarkeit wider. Tippen Sie auf Aktualisieren, um die neuesten Daten abzurufen.';
 
   @override
   String get evNavigateToStation => 'Zur Station navigieren';
@@ -633,8 +612,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get evStatusUpdated => 'Status aktualisiert';
 
   @override
-  String get evStationNotFound =>
-      'Aktualisierung fehlgeschlagen — Station nicht in der Nähe gefunden';
+  String get evStationNotFound => 'Aktualisierung fehlgeschlagen — Station nicht in der Nähe gefunden';
 
   @override
   String get addedToFavorites => 'Zu Favoriten hinzugefügt';
@@ -703,8 +681,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Kraftstoffpreise (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Erforderlich für die Kraftstoffpreissuche in Deutschland';
+  String get requiredForFuelSearch => 'Erforderlich für die Kraftstoffpreissuche in Deutschland';
 
   @override
   String get evChargingOpenChargeMap => 'E-Laden (OpenChargeMap)';
@@ -716,12 +693,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appDefaultKey => 'Standard-App-Schlüssel';
 
   @override
-  String get optionalOverrideKey =>
-      'Optional: den integrierten App-Schlüssel mit Ihrem eigenen überschreiben';
+  String get optionalOverrideKey => 'Optional: den integrierten App-Schlüssel mit Ihrem eigenen überschreiben';
 
   @override
-  String get requiredForEvSearch =>
-      'Erforderlich für die Suche nach E-Ladestationen';
+  String get requiredForEvSearch => 'Erforderlich für die Suche nach E-Ladestationen';
 
   @override
   String get edit => 'Bearbeiten';
@@ -750,26 +725,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get avoidHighways => 'Autobahnen vermeiden';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Routenberechnung vermeidet Mautstraßen und Autobahnen';
+  String get avoidHighwaysDesc => 'Routenberechnung vermeidet Mautstraßen und Autobahnen';
 
   @override
   String get showFuelStations => 'Tankstellen anzeigen';
 
   @override
-  String get showFuelStationsDesc =>
-      'Benzin-, Diesel-, LPG-, CNG-Stationen einbeziehen';
+  String get showFuelStationsDesc => 'Benzin-, Diesel-, LPG-, CNG-Stationen einbeziehen';
 
   @override
   String get showEvStations => 'E-Ladestationen anzeigen';
 
   @override
-  String get showEvStationsDesc =>
-      'Elektrische Ladestationen in Suchergebnissen einbeziehen';
+  String get showEvStationsDesc => 'Elektrische Ladestationen in Suchergebnissen einbeziehen';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Keine Stationen entlang dieser Route gefunden.';
+  String get noStationsAlongThisRoute => 'Keine Stationen entlang dieser Route gefunden.';
 
   @override
   String get fuelCostCalculator => 'Kraftstoffkostenrechner';
@@ -793,8 +764,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get totalCost => 'Gesamtkosten';
 
   @override
-  String get enterCalcValues =>
-      'Geben Sie Entfernung, Verbrauch und Preis ein, um die Fahrtkosten zu berechnen';
+  String get enterCalcValues => 'Geben Sie Entfernung, Verbrauch und Preis ein, um die Fahrtkosten zu berechnen';
 
   @override
   String get priceHistory => 'Preisverlauf';
@@ -836,19 +806,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get viewMyData => 'Meine Daten anzeigen';
 
   @override
-  String get optionalCloudSync =>
-      'Optionale Cloud-Synchronisierung für Alarme, Favoriten und Push-Benachrichtigungen';
+  String get optionalCloudSync => 'Optionale Cloud-Synchronisierung für Alarme, Favoriten und Push-Benachrichtigungen';
 
   @override
   String get tapToUpdateGps => 'Tippen, um GPS-Position zu aktualisieren';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'Die GPS-Position wird automatisch bei der Suche ermittelt. Sie können sie auch hier manuell aktualisieren.';
+  String get gpsAutoUpdateHint => 'Die GPS-Position wird automatisch bei der Suche ermittelt. Sie können sie auch hier manuell aktualisieren.';
 
   @override
-  String get clearGpsConfirm =>
-      'Gespeicherte GPS-Position löschen? Sie können sie jederzeit erneut aktualisieren.';
+  String get clearGpsConfirm => 'Gespeicherte GPS-Position löschen? Sie können sie jederzeit erneut aktualisieren.';
 
   @override
   String get pageNotFound => 'Seite nicht gefunden';
@@ -932,8 +899,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noSavedRoutes => 'Keine gespeicherten Routen';
 
   @override
-  String get noSavedRoutesHint =>
-      'Suche entlang einer Route und speichere sie fuer schnellen Zugriff.';
+  String get noSavedRoutesHint => 'Suche entlang einer Route und speichere sie fuer schnellen Zugriff.';
 
   @override
   String get saveRoute => 'Route speichern';
@@ -952,15 +918,13 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get refreshFailed =>
-      'Aktualisierung fehlgeschlagen. Bitte erneut versuchen.';
+  String get refreshFailed => 'Aktualisierung fehlgeschlagen. Bitte erneut versuchen.';
 
   @override
   String get deleteProfileTitle => 'Profil löschen?';
 
   @override
-  String get deleteProfileBody =>
-      'Dieses Profil und seine Einstellungen werden unwiderruflich gelöscht.';
+  String get deleteProfileBody => 'Dieses Profil und seine Einstellungen werden unwiderruflich gelöscht.';
 
   @override
   String get deleteProfileConfirm => 'Profil löschen';
@@ -978,23 +942,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get errorNoConnection => 'Keine Internetverbindung.';
 
   @override
-  String get errorApiKey =>
-      'Ungültiger API-Schlüssel. Überprüfe deine Einstellungen.';
+  String get errorApiKey => 'Ungültiger API-Schlüssel. Überprüfe deine Einstellungen.';
 
   @override
   String get errorLocation => 'Standort konnte nicht ermittelt werden.';
 
   @override
-  String get errorNoApiKey =>
-      'Kein API-Schlüssel konfiguriert. In Einstellungen hinzufügen.';
+  String get errorNoApiKey => 'Kein API-Schlüssel konfiguriert. In Einstellungen hinzufügen.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Daten konnten nicht geladen werden. Verbindung prüfen.';
+  String get errorAllServicesFailed => 'Daten konnten nicht geladen werden. Verbindung prüfen.';
 
   @override
-  String get errorCache =>
-      'Lokaler Datenfehler. Cache leeren und erneut versuchen.';
+  String get errorCache => 'Lokaler Datenfehler. Cache leeren und erneut versuchen.';
 
   @override
   String get errorCancelled => 'Anfrage wurde abgebrochen.';
@@ -1003,19 +963,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get errorUnknown => 'Ein unerwarteter Fehler ist aufgetreten.';
 
   @override
-  String get onboardingWelcomeHint =>
-      'Richten Sie die App in wenigen Schritten ein.';
+  String get onboardingWelcomeHint => 'Richten Sie die App in wenigen Schritten ein.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Registrieren Sie sich für einen kostenlosen API-Schlüssel oder überspringen Sie diesen Schritt für Demo-Daten.';
+  String get onboardingApiKeyDescription => 'Registrieren Sie sich für einen kostenlosen API-Schlüssel oder überspringen Sie diesen Schritt für Demo-Daten.';
 
   @override
   String get onboardingComplete => 'Alles bereit!';
 
   @override
-  String get onboardingCompleteHint =>
-      'Sie können diese Einstellungen jederzeit in Ihrem Profil ändern.';
+  String get onboardingCompleteHint => 'Sie können diese Einstellungen jederzeit in Ihrem Profil ändern.';
 
   @override
   String get onboardingBack => 'Zurück';
@@ -1066,45 +1023,37 @@ class AppLocalizationsDe extends AppLocalizations {
   String get gdprTitle => 'Ihre Privatsphäre';
 
   @override
-  String get gdprSubtitle =>
-      'Diese App respektiert Ihre Privatsphäre. Wählen Sie, welche Daten Sie teilen möchten. Sie können diese Einstellungen jederzeit ändern.';
+  String get gdprSubtitle => 'Diese App respektiert Ihre Privatsphäre. Wählen Sie, welche Daten Sie teilen möchten. Sie können diese Einstellungen jederzeit ändern.';
 
   @override
   String get gdprLocationTitle => 'Standortzugriff';
 
   @override
-  String get gdprLocationDescription =>
-      'Ihre Koordinaten werden an die Kraftstoffpreis-API gesendet, um Tankstellen in der Nähe zu finden. Standortdaten werden nie auf einem Server gespeichert und nicht für Tracking verwendet.';
+  String get gdprLocationDescription => 'Ihre Koordinaten werden an die Kraftstoffpreis-API gesendet, um Tankstellen in der Nähe zu finden. Standortdaten werden nie auf einem Server gespeichert und nicht für Tracking verwendet.';
 
   @override
-  String get gdprLocationShort =>
-      'Tankstellen in der Nähe über Ihren Standort finden';
+  String get gdprLocationShort => 'Tankstellen in der Nähe über Ihren Standort finden';
 
   @override
   String get gdprErrorReportingTitle => 'Fehlermeldungen';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonyme Absturzberichte helfen, die App zu verbessern. Keine persönlichen Daten enthalten. Berichte werden nur bei Konfiguration über Sentry gesendet.';
+  String get gdprErrorReportingDescription => 'Anonyme Absturzberichte helfen, die App zu verbessern. Keine persönlichen Daten enthalten. Berichte werden nur bei Konfiguration über Sentry gesendet.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Anonyme Absturzberichte zur Verbesserung der App senden';
+  String get gdprErrorReportingShort => 'Anonyme Absturzberichte zur Verbesserung der App senden';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud-Synchronisierung';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Favoriten und Preisalarme geräteübergreifend über TankSync synchronisieren. Verwendet anonyme Authentifizierung. Ihre Daten werden verschlüsselt übertragen.';
+  String get gdprCloudSyncDescription => 'Favoriten und Preisalarme geräteübergreifend über TankSync synchronisieren. Verwendet anonyme Authentifizierung. Ihre Daten werden verschlüsselt übertragen.';
 
   @override
-  String get gdprCloudSyncShort =>
-      'Favoriten und Alarme geräteübergreifend synchronisieren';
+  String get gdprCloudSyncShort => 'Favoriten und Alarme geräteübergreifend synchronisieren';
 
   @override
-  String get gdprLegalBasis =>
-      'Rechtsgrundlage: Art. 6 Abs. 1 lit. a DSGVO (Einwilligung). Sie können Ihre Einwilligung jederzeit in den Einstellungen widerrufen.';
+  String get gdprLegalBasis => 'Rechtsgrundlage: Art. 6 Abs. 1 lit. a DSGVO (Einwilligung). Sie können Ihre Einwilligung jederzeit in den Einstellungen widerrufen.';
 
   @override
   String get gdprAcceptAll => 'Alle akzeptieren';
@@ -1113,8 +1062,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get gdprAcceptSelected => 'Auswahl akzeptieren';
 
   @override
-  String get gdprSettingsHint =>
-      'Sie können Ihre Datenschutzeinstellungen jederzeit ändern.';
+  String get gdprSettingsHint => 'Sie können Ihre Datenschutzeinstellungen jederzeit ändern.';
 
   @override
   String get routeSaved => 'Route gespeichert!';
@@ -1146,12 +1094,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get testNotificationSent => 'Testbenachrichtigung gesendet!';
 
   @override
-  String get testNotificationFailed =>
-      'Testbenachrichtigung konnte nicht gesendet werden';
+  String get testNotificationFailed => 'Testbenachrichtigung konnte nicht gesendet werden';
 
   @override
-  String get pushUpdateFailed =>
-      'Push-Benachrichtigungseinstellung konnte nicht aktualisiert werden';
+  String get pushUpdateFailed => 'Push-Benachrichtigungseinstellung konnte nicht aktualisiert werden';
 
   @override
   String get connectedAsGuest => 'Als Gast verbunden';
@@ -1181,15 +1127,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get invalidQrCode => 'Ungültiges QR-Code-Format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Ungültiger QR-Code — TankSync-Format erwartet';
+  String get invalidQrCodeTankSync => 'Ungültiger QR-Code — TankSync-Format erwartet';
 
   @override
   String get tankSyncConnected => 'TankSync verbunden!';
 
   @override
-  String get syncCompleted =>
-      'Synchronisierung abgeschlossen — Daten aktualisiert';
+  String get syncCompleted => 'Synchronisierung abgeschlossen — Daten aktualisiert';
 
   @override
   String get deviceCodeCopied => 'Gerätecode kopiert';
@@ -1247,8 +1191,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get brandFilterNoHighway => 'Keine Autobahn';
 
   @override
-  String get swipeTutorialMessage =>
-      'Nach rechts wischen zum Navigieren, nach links zum Entfernen';
+  String get swipeTutorialMessage => 'Nach rechts wischen zum Navigieren, nach links zum Entfernen';
 
   @override
   String get swipeTutorialDismiss => 'Verstanden';
@@ -1266,12 +1209,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get privacyDashboardTitle => 'Datenschutz-Dashboard';
 
   @override
-  String get privacyDashboardSubtitle =>
-      'Daten anzeigen, exportieren oder löschen';
+  String get privacyDashboardSubtitle => 'Daten anzeigen, exportieren oder löschen';
 
   @override
-  String get privacyDashboardBanner =>
-      'Ihre Daten gehören Ihnen. Hier sehen Sie alles, was diese App speichert, und können es exportieren oder löschen.';
+  String get privacyDashboardBanner => 'Ihre Daten gehören Ihnen. Hier sehen Sie alles, was diese App speichert, und können es exportieren oder löschen.';
 
   @override
   String get privacyLocalData => 'Daten auf diesem Gerät';
@@ -1307,8 +1248,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get privacySyncedData => 'Cloud-Sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud-Sync ist deaktiviert. Alle Daten bleiben nur auf diesem Gerät.';
+  String get privacySyncDisabled => 'Cloud-Sync ist deaktiviert. Alle Daten bleiben nur auf diesem Gerät.';
 
   @override
   String get privacySyncMode => 'Sync-Modus';
@@ -1317,8 +1257,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get privacySyncUserId => 'Benutzer-ID';
 
   @override
-  String get privacySyncDescription =>
-      'Bei aktiviertem Sync werden Favoriten, Alarme, ausgeblendete Stationen und Bewertungen auch auf dem TankSync-Server gespeichert.';
+  String get privacySyncDescription => 'Bei aktiviertem Sync werden Favoriten, Alarme, ausgeblendete Stationen und Bewertungen auch auf dem TankSync-Server gespeichert.';
 
   @override
   String get privacyViewServerData => 'Serverdaten anzeigen';
@@ -1333,8 +1272,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get privacyExportCsvButton => 'Alle Daten als CSV exportieren';
 
   @override
-  String get privacyExportCsvSuccess =>
-      'CSV-Daten in die Zwischenablage exportiert';
+  String get privacyExportCsvSuccess => 'CSV-Daten in die Zwischenablage exportiert';
 
   @override
   String get privacyDeleteButton => 'Alle Daten löschen';
@@ -1343,8 +1281,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get privacyDeleteTitle => 'Alle Daten löschen?';
 
   @override
-  String get privacyDeleteBody =>
-      'Dies löscht unwiderruflich:\n\n- Alle Favoriten und Stationsdaten\n- Alle Suchprofile\n- Alle Preisalarme\n- Allen Preisverlauf\n- Alle zwischengespeicherten Daten\n- Ihren API-Schlüssel\n- Alle App-Einstellungen\n\nDie App wird auf den Ausgangszustand zurückgesetzt. Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get privacyDeleteBody => 'Dies löscht unwiderruflich:\n\n- Alle Favoriten und Stationsdaten\n- Alle Suchprofile\n- Alle Preisalarme\n- Allen Preisverlauf\n- Alle zwischengespeicherten Daten\n- Ihren API-Schlüssel\n- Alle App-Einstellungen\n\nDie App wird auf den Ausgangszustand zurückgesetzt. Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get privacyDeleteConfirm => 'Alles löschen';
@@ -1398,8 +1335,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get drivingSafetyTitle => 'Sicherheitshinweis';
 
   @override
-  String get drivingSafetyMessage =>
-      'Bedienen Sie die App nicht während der Fahrt. Halten Sie an einem sicheren Ort an, bevor Sie den Bildschirm bedienen. Der Fahrer ist jederzeit für die sichere Führung des Fahrzeugs verantwortlich.';
+  String get drivingSafetyMessage => 'Bedienen Sie die App nicht während der Fahrt. Halten Sie an einem sicheren Ort an, bevor Sie den Bildschirm bedienen. Der Fahrer ist jederzeit für die sichere Führung des Fahrzeugs verantwortlich.';
 
   @override
   String get drivingSafetyAccept => 'Verstanden';
@@ -1408,8 +1344,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Sprachansagen';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Günstige Tankstellen beim Fahren ansagen';
+  String get voiceAnnouncementsDescription => 'Günstige Tankstellen beim Fahren ansagen';
 
   @override
   String get voiceAnnouncementsEnabled => 'Sprachansagen aktivieren';
@@ -1420,12 +1355,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance Kilometer voraus, $fuelType $price';
   }
 
@@ -1439,8 +1369,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get nearestStations => 'Nächste Tankstellen';
 
   @override
-  String get nearestStationsHint =>
-      'Die nächstgelegenen Tankstellen über Ihren Standort finden';
+  String get nearestStationsHint => 'Die nächstgelegenen Tankstellen über Ihren Standort finden';
 
   @override
   String get consumptionLogTitle => 'Verbrauch';
@@ -1449,8 +1378,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Verbrauchs-Log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Tankvorgänge erfassen und L/100km berechnen';
+  String get consumptionLogMenuSubtitle => 'Tankvorgänge erfassen und L/100km berechnen';
 
   @override
   String get consumptionStatsTitle => 'Verbrauchsstatistik';
@@ -1462,8 +1390,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noFillUpsTitle => 'Noch keine Tankvorgänge';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Erfassen Sie Ihren ersten Tankvorgang, um den Verbrauch zu verfolgen.';
+  String get noFillUpsSubtitle => 'Erfassen Sie Ihren ersten Tankvorgang, um den Verbrauch zu verfolgen.';
 
   @override
   String get fillUpDate => 'Datum';
@@ -1514,8 +1441,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get carbonEmptyTitle => 'Noch keine Daten';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Erfasse Tankvorgänge, um deine CO2-Übersicht zu sehen.';
+  String get carbonEmptySubtitle => 'Erfasse Tankvorgänge, um deine CO2-Übersicht zu sehen.';
 
   @override
   String get carbonSummaryTotalCost => 'Gesamtkosten';
@@ -1598,8 +1524,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get vehiclesMenuSubtitle => 'Batterie, Anschlüsse, Ladevorlieben';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Fügen Sie Ihr Fahrzeug hinzu, um nach Anschlüssen zu filtern und Ladekosten zu schätzen.';
+  String get vehiclesEmptyMessage => 'Fügen Sie Ihr Fahrzeug hinzu, um nach Anschlüssen zu filtern und Ladekosten zu schätzen.';
 
   @override
   String get vehicleAdd => 'Fahrzeug hinzufügen';
@@ -1733,8 +1658,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get configAndPrivacy => 'Konfiguration & Datenschutz';
 
   @override
-  String get searchToSeeMap =>
-      'Suchen Sie, um Tankstellen auf der Karte zu sehen';
+  String get searchToSeeMap => 'Suchen Sie, um Tankstellen auf der Karte zu sehen';
 
   @override
   String get evPowerAny => 'Alle';
@@ -1766,15 +1690,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get switchToEmail => 'Zu E-Mail wechseln';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Daten behalten, Anmeldung von anderen Geräten';
+  String get switchToEmailSubtitle => 'Daten behalten, Anmeldung von anderen Geräten';
 
   @override
   String get switchToAnonymousAction => 'Zu anonym wechseln';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Lokale Daten behalten, neue anonyme Sitzung';
+  String get switchToAnonymousSubtitle => 'Lokale Daten behalten, neue anonyme Sitzung';
 
   @override
   String get linkDevice => 'Gerät verknüpfen';
@@ -1786,8 +1708,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get disconnectAction => 'Trennen';
 
   @override
-  String get disconnectSubtitle =>
-      'Synchronisierung stoppen (lokale Daten bleiben)';
+  String get disconnectSubtitle => 'Synchronisierung stoppen (lokale Daten bleiben)';
 
   @override
   String get deleteAccountAction => 'Konto löschen';
@@ -1799,8 +1720,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get localOnly => 'Nur lokal';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: Favoriten, Alarme und Bewertungen geräteübergreifend synchronisieren';
+  String get localOnlySubtitle => 'Optional: Favoriten, Alarme und Bewertungen geräteübergreifend synchronisieren';
 
   @override
   String get setupCloudSync => 'Cloud-Sync einrichten';
@@ -1809,33 +1729,28 @@ class AppLocalizationsDe extends AppLocalizations {
   String get disconnectTitle => 'TankSync trennen?';
 
   @override
-  String get disconnectBody =>
-      'Cloud-Synchronisierung wird deaktiviert. Ihre lokalen Daten (Favoriten, Alarme, Verlauf) bleiben auf diesem Gerät erhalten. Serverdaten werden nicht gelöscht.';
+  String get disconnectBody => 'Cloud-Synchronisierung wird deaktiviert. Ihre lokalen Daten (Favoriten, Alarme, Verlauf) bleiben auf diesem Gerät erhalten. Serverdaten werden nicht gelöscht.';
 
   @override
   String get deleteAccountTitle => 'Konto löschen?';
 
   @override
-  String get deleteAccountBody =>
-      'Alle Ihre Daten werden dauerhaft vom Server gelöscht (Favoriten, Alarme, Bewertungen, Routen). Lokale Daten auf diesem Gerät bleiben erhalten.\n\nDies kann nicht rückgängig gemacht werden.';
+  String get deleteAccountBody => 'Alle Ihre Daten werden dauerhaft vom Server gelöscht (Favoriten, Alarme, Bewertungen, Routen). Lokale Daten auf diesem Gerät bleiben erhalten.\n\nDies kann nicht rückgängig gemacht werden.';
 
   @override
   String get switchToAnonymousTitle => 'Zu anonym wechseln?';
 
   @override
-  String get switchToAnonymousBody =>
-      'Sie werden von Ihrem E-Mail-Konto abgemeldet und mit einer neuen anonymen Sitzung fortfahren.\n\nIhre lokalen Daten (Favoriten, Alarme) bleiben auf diesem Gerät und werden mit dem neuen anonymen Konto synchronisiert.';
+  String get switchToAnonymousBody => 'Sie werden von Ihrem E-Mail-Konto abgemeldet und mit einer neuen anonymen Sitzung fortfahren.\n\nIhre lokalen Daten (Favoriten, Alarme) bleiben auf diesem Gerät und werden mit dem neuen anonymen Konto synchronisiert.';
 
   @override
   String get switchAction => 'Wechseln';
 
   @override
-  String get helpBannerCriteria =>
-      'Ihre Profil-Standardwerte sind vorausgefüllt. Passen Sie die Kriterien unten an, um Ihre Suche zu verfeinern.';
+  String get helpBannerCriteria => 'Ihre Profil-Standardwerte sind vorausgefüllt. Passen Sie die Kriterien unten an, um Ihre Suche zu verfeinern.';
 
   @override
-  String get helpBannerAlerts =>
-      'Legen Sie einen Preisgrenzwert für eine Station fest. Sie werden benachrichtigt, wenn die Preise darunter fallen. Prüfungen laufen alle 30 Minuten.';
+  String get helpBannerAlerts => 'Legen Sie einen Preisgrenzwert für eine Station fest. Sie werden benachrichtigt, wenn die Preise darunter fallen. Prüfungen laufen alle 30 Minuten.';
 
   @override
   String get syncNow => 'Jetzt synchronisieren';
@@ -1844,23 +1759,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get onboardingPreferencesTitle => 'Ihre Einstellungen';
 
   @override
-  String get onboardingZipHelper =>
-      'Wird verwendet, wenn GPS nicht verfügbar ist';
+  String get onboardingZipHelper => 'Wird verwendet, wenn GPS nicht verfügbar ist';
 
   @override
   String get onboardingRadiusHelper => 'Größerer Radius = mehr Ergebnisse';
 
   @override
-  String get onboardingPrivacy =>
-      'Diese Einstellungen werden nur auf Ihrem Gerät gespeichert und niemals geteilt.';
+  String get onboardingPrivacy => 'Diese Einstellungen werden nur auf Ihrem Gerät gespeichert und niemals geteilt.';
 
   @override
   String get onboardingLandingTitle => 'Startbildschirm';
 
   @override
-  String get onboardingLandingHint =>
-      'Wählen Sie, welcher Bildschirm beim Start der App angezeigt wird.';
+  String get onboardingLandingHint => 'Wählen Sie, welcher Bildschirm beim Start der App angezeigt wird.';
 
   @override
   String get scanReceipt => 'Beleg scannen';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -172,8 +172,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noFavorites => 'Χωρίς αγαπημένα';
 
   @override
-  String get noFavoritesHint =>
-      'Πατήστε το αστέρι σε ένα βενζινάδικο για να το αποθηκεύσετε στα αγαπημένα.';
+  String get noFavoritesHint => 'Πατήστε το αστέρι σε ένα βενζινάδικο για να το αποθηκεύσετε στα αγαπημένα.';
 
   @override
   String get language => 'Γλώσσα';
@@ -223,29 +222,25 @@ class AppLocalizationsEl extends AppLocalizations {
   String get gpsCoordinates => 'Συντεταγμένες GPS';
 
   @override
-  String get gpsReason =>
-      'Αποστέλλονται με κάθε αναζήτηση για εύρεση κοντινών σταθμών.';
+  String get gpsReason => 'Αποστέλλονται με κάθε αναζήτηση για εύρεση κοντινών σταθμών.';
 
   @override
   String get postalCodeData => 'Ταχυδρομικός κώδικας';
 
   @override
-  String get postalReason =>
-      'Μετατρέπεται σε συντεταγμένες μέσω υπηρεσίας γεωκωδικοποίησης.';
+  String get postalReason => 'Μετατρέπεται σε συντεταγμένες μέσω υπηρεσίας γεωκωδικοποίησης.';
 
   @override
   String get mapViewport => 'Προβολή χάρτη';
 
   @override
-  String get mapReason =>
-      'Τα πλακίδια χάρτη φορτώνονται από τον διακομιστή. Δεν μεταδίδονται προσωπικά δεδομένα.';
+  String get mapReason => 'Τα πλακίδια χάρτη φορτώνονται από τον διακομιστή. Δεν μεταδίδονται προσωπικά δεδομένα.';
 
   @override
   String get apiKeyData => 'Κλειδί API';
 
   @override
-  String get apiKeyReason =>
-      'Το προσωπικό σας κλειδί αποστέλλεται με κάθε αίτημα API. Συνδέεται με το e-mail σας.';
+  String get apiKeyReason => 'Το προσωπικό σας κλειδί αποστέλλεται με κάθε αίτημα API. Συνδέεται με το e-mail σας.';
 
   @override
   String get notShared => 'ΔΕΝ κοινοποιείται:';
@@ -266,8 +261,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get usageData => 'Δεδομένα χρήσης';
 
   @override
-  String get privacyBanner =>
-      'Αυτή η εφαρμογή δεν έχει διακομιστή. Όλα τα δεδομένα παραμένουν στη συσκευή σας. Χωρίς αναλύσεις, παρακολούθηση ή διαφημίσεις.';
+  String get privacyBanner => 'Αυτή η εφαρμογή δεν έχει διακομιστή. Όλα τα δεδομένα παραμένουν στη συσκευή σας. Χωρίς αναλύσεις, παρακολούθηση ή διαφημίσεις.';
 
   @override
   String get storageUsage => 'Χρήση αποθηκευτικού χώρου σε αυτή τη συσκευή';
@@ -291,8 +285,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get cacheManagement => 'Διαχείριση προσωρινής μνήμης';
 
   @override
-  String get cacheDescription =>
-      'Η προσωρινή μνήμη αποθηκεύει απαντήσεις API για ταχύτερη φόρτωση και πρόσβαση εκτός σύνδεσης.';
+  String get cacheDescription => 'Η προσωρινή μνήμη αποθηκεύει απαντήσεις API για ταχύτερη φόρτωση και πρόσβαση εκτός σύνδεσης.';
 
   @override
   String get stationSearch => 'Αναζήτηση σταθμών';
@@ -320,8 +313,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get clearCacheTitle => 'Εκκαθάριση προσωρινής μνήμης;';
 
   @override
-  String get clearCacheBody =>
-      'Τα αποθηκευμένα αποτελέσματα αναζήτησης και τιμές θα διαγραφούν. Τα προφίλ, αγαπημένα και ρυθμίσεις διατηρούνται.';
+  String get clearCacheBody => 'Τα αποθηκευμένα αποτελέσματα αναζήτησης και τιμές θα διαγραφούν. Τα προφίλ, αγαπημένα και ρυθμίσεις διατηρούνται.';
 
   @override
   String get clearCacheButton => 'Εκκαθάριση';
@@ -330,8 +322,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteAllTitle => 'Διαγραφή όλων των δεδομένων;';
 
   @override
-  String get deleteAllBody =>
-      'Αυτό θα διαγράψει μόνιμα όλα τα προφίλ, αγαπημένα, κλειδί API, ρυθμίσεις και προσωρινή μνήμη. Η εφαρμογή θα επαναφερθεί.';
+  String get deleteAllBody => 'Αυτό θα διαγράψει μόνιμα όλα τα προφίλ, αγαπημένα, κλειδί API, ρυθμίσεις και προσωρινή μνήμη. Η εφαρμογή θα επαναφερθεί.';
 
   @override
   String get deleteAllButton => 'Διαγραφή όλων';
@@ -346,19 +337,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noStorage => 'Χωρίς χρησιμοποιούμενο χώρο';
 
   @override
-  String get apiKeyNote =>
-      'Δωρεάν εγγραφή. Δεδομένα από κρατικούς φορείς διαφάνειας τιμών.';
+  String get apiKeyNote => 'Δωρεάν εγγραφή. Δεδομένα από κρατικούς φορείς διαφάνειας τιμών.';
 
   @override
-  String get apiKeyFormatError =>
-      'Μη έγκυρη μορφή — αναμενόμενο UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Μη έγκυρη μορφή — αναμενόμενο UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Υποστηρίξτε αυτό το έργο';
 
   @override
-  String get supportDescription =>
-      'Αυτή η εφαρμογή είναι δωρεάν, ανοιχτού κώδικα και χωρίς διαφημίσεις. Αν τη βρίσκετε χρήσιμη, σκεφτείτε να υποστηρίξετε τον προγραμματιστή.';
+  String get supportDescription => 'Αυτή η εφαρμογή είναι δωρεάν, ανοιχτού κώδικα και χωρίς διαφημίσεις. Αν τη βρίσκετε χρήσιμη, σκεφτείτε να υποστηρίξετε τον προγραμματιστή.';
 
   @override
   String get reportBug => 'Αναφορά σφάλματος / Πρόταση λειτουργίας';
@@ -394,12 +382,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get station => 'Βενζινάδικο';
 
   @override
-  String get locationDenied =>
-      'Η άδεια τοποθεσίας απορρίφθηκε. Μπορείτε να αναζητήσετε με Τ.Κ.';
+  String get locationDenied => 'Η άδεια τοποθεσίας απορρίφθηκε. Μπορείτε να αναζητήσετε με Τ.Κ.';
 
   @override
-  String get demoModeBanner =>
-      'Λειτουργία επίδειξης. Ρυθμίστε το κλειδί API στις ρυθμίσεις.';
+  String get demoModeBanner => 'Λειτουργία επίδειξης. Ρυθμίστε το κλειδί API στις ρυθμίσεις.';
 
   @override
   String get sortDistance => 'Απόσταση';
@@ -425,8 +411,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Φόρτωση αγαπημένων...\nΑναζητήστε πρώτα σταθμούς για αποθήκευση δεδομένων.';
+  String get loadingFavorites => 'Φόρτωση αγαπημένων...\nΑναζητήστε πρώτα σταθμούς για αποθήκευση δεδομένων.';
 
   @override
   String get reportPrice => 'Αναφορά τιμής';
@@ -462,8 +447,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoUpdatePosition => 'Αυτόματη ενημέρωση θέσης';
 
   @override
-  String get autoUpdateDescription =>
-      'Ενημέρωση θέσης GPS πριν από κάθε αναζήτηση';
+  String get autoUpdateDescription => 'Ενημέρωση θέσης GPS πριν από κάθε αναζήτηση';
 
   @override
   String get location => 'Τοποθεσία';
@@ -493,8 +477,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoSwitchProfile => 'Αυτόματη εναλλαγή προφίλ';
 
   @override
-  String get autoSwitchDescription =>
-      'Αυτόματη εναλλαγή προφίλ κατά τη διέλευση συνόρων';
+  String get autoSwitchDescription => 'Αυτόματη εναλλαγή προφίλ κατά τη διέλευση συνόρων';
 
   @override
   String get switchProfile => 'Εναλλαγή';
@@ -521,8 +504,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noPriceAlerts => 'Χωρίς ειδοποιήσεις τιμών';
 
   @override
-  String get noPriceAlertsHint =>
-      'Δημιουργήστε ειδοποίηση από τη σελίδα λεπτομερειών ενός σταθμού.';
+  String get noPriceAlertsHint => 'Δημιουργήστε ειδοποίηση από τη σελίδα λεπτομερειών ενός σταθμού.';
 
   @override
   String alertDeleted(String name) {
@@ -586,8 +568,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get openInMaps => 'Άνοιγμα στους Χάρτες';
 
   @override
-  String get noStationsAlongRoute =>
-      'Δεν βρέθηκαν σταθμοί κατά μήκος της διαδρομής';
+  String get noStationsAlongRoute => 'Δεν βρέθηκαν σταθμοί κατά μήκος της διαδρομής';
 
   @override
   String get evOperational => 'Σε λειτουργία';
@@ -619,8 +600,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get evDataAttribution => 'Δεδομένα από OpenChargeMap (κοινοτική πηγή)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Η κατάσταση μπορεί να μην αντικατοπτρίζει τη διαθεσιμότητα σε πραγματικό χρόνο. Πατήστε ανανέωση για τα τελευταία δεδομένα.';
+  String get evStatusDisclaimer => 'Η κατάσταση μπορεί να μην αντικατοπτρίζει τη διαθεσιμότητα σε πραγματικό χρόνο. Πατήστε ανανέωση για τα τελευταία δεδομένα.';
 
   @override
   String get evNavigateToStation => 'Πλοήγηση στον σταθμό';
@@ -632,8 +612,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get evStatusUpdated => 'Κατάσταση ενημερώθηκε';
 
   @override
-  String get evStationNotFound =>
-      'Δεν ήταν δυνατή η ανανέωση — ο σταθμός δεν βρέθηκε κοντά';
+  String get evStationNotFound => 'Δεν ήταν δυνατή η ανανέωση — ο σταθμός δεν βρέθηκε κοντά';
 
   @override
   String get addedToFavorites => 'Προστέθηκε στα αγαπημένα';
@@ -654,8 +633,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get gpsError => 'Σφάλμα GPS';
 
   @override
-  String get couldNotResolve =>
-      'Δεν ήταν δυνατός ο προσδιορισμός αφετηρίας ή προορισμού';
+  String get couldNotResolve => 'Δεν ήταν δυνατός ο προσδιορισμός αφετηρίας ή προορισμού';
 
   @override
   String get start => 'Αφετηρία';
@@ -703,8 +681,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Τιμές καυσίμων (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Απαιτείται για αναζήτηση τιμών καυσίμων στη Γερμανία';
+  String get requiredForFuelSearch => 'Απαιτείται για αναζήτηση τιμών καυσίμων στη Γερμανία';
 
   @override
   String get evChargingOpenChargeMap => 'Φόρτιση EV (OpenChargeMap)';
@@ -716,12 +693,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get appDefaultKey => 'Προεπιλεγμένο κλειδί εφαρμογής';
 
   @override
-  String get optionalOverrideKey =>
-      'Προαιρετικό: αντικατάσταση του ενσωματωμένου κλειδιού με το δικό σας';
+  String get optionalOverrideKey => 'Προαιρετικό: αντικατάσταση του ενσωματωμένου κλειδιού με το δικό σας';
 
   @override
-  String get requiredForEvSearch =>
-      'Απαιτείται για αναζήτηση σταθμών φόρτισης EV';
+  String get requiredForEvSearch => 'Απαιτείται για αναζήτηση σταθμών φόρτισης EV';
 
   @override
   String get edit => 'Επεξεργασία';
@@ -750,26 +725,22 @@ class AppLocalizationsEl extends AppLocalizations {
   String get avoidHighways => 'Αποφυγή αυτοκινητοδρόμων';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Ο υπολογισμός διαδρομής αποφεύγει δρόμους με διόδια και αυτοκινητοδρόμους';
+  String get avoidHighwaysDesc => 'Ο υπολογισμός διαδρομής αποφεύγει δρόμους με διόδια και αυτοκινητοδρόμους';
 
   @override
   String get showFuelStations => 'Εμφάνιση βενζινάδικων';
 
   @override
-  String get showFuelStationsDesc =>
-      'Συμπερίληψη σταθμών βενζίνης, ντίζελ, LPG, CNG';
+  String get showFuelStationsDesc => 'Συμπερίληψη σταθμών βενζίνης, ντίζελ, LPG, CNG';
 
   @override
   String get showEvStations => 'Εμφάνιση σταθμών φόρτισης';
 
   @override
-  String get showEvStationsDesc =>
-      'Συμπερίληψη ηλεκτρικών σταθμών φόρτισης στα αποτελέσματα';
+  String get showEvStationsDesc => 'Συμπερίληψη ηλεκτρικών σταθμών φόρτισης στα αποτελέσματα';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Δεν βρέθηκαν σταθμοί κατά μήκος αυτής της διαδρομής.';
+  String get noStationsAlongThisRoute => 'Δεν βρέθηκαν σταθμοί κατά μήκος αυτής της διαδρομής.';
 
   @override
   String get fuelCostCalculator => 'Υπολογιστής κόστους καυσίμου';
@@ -793,8 +764,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get totalCost => 'Συνολικό κόστος';
 
   @override
-  String get enterCalcValues =>
-      'Εισάγετε απόσταση, κατανάλωση και τιμή για υπολογισμό κόστους ταξιδιού';
+  String get enterCalcValues => 'Εισάγετε απόσταση, κατανάλωση και τιμή για υπολογισμό κόστους ταξιδιού';
 
   @override
   String get priceHistory => 'Ιστορικό τιμών';
@@ -836,19 +806,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get viewMyData => 'Προβολή δεδομένων μου';
 
   @override
-  String get optionalCloudSync =>
-      'Προαιρετικός συγχρονισμός cloud για ειδοποιήσεις, αγαπημένα και push ειδοποιήσεις';
+  String get optionalCloudSync => 'Προαιρετικός συγχρονισμός cloud για ειδοποιήσεις, αγαπημένα και push ειδοποιήσεις';
 
   @override
   String get tapToUpdateGps => 'Πατήστε για ενημέρωση θέσης GPS';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'Η θέση GPS αποκτάται αυτόματα κατά την αναζήτηση. Μπορείτε επίσης να την ενημερώσετε χειροκίνητα εδώ.';
+  String get gpsAutoUpdateHint => 'Η θέση GPS αποκτάται αυτόματα κατά την αναζήτηση. Μπορείτε επίσης να την ενημερώσετε χειροκίνητα εδώ.';
 
   @override
-  String get clearGpsConfirm =>
-      'Διαγραφή αποθηκευμένης θέσης GPS; Μπορείτε να την ενημερώσετε ξανά ανά πάσα στιγμή.';
+  String get clearGpsConfirm => 'Διαγραφή αποθηκευμένης θέσης GPS; Μπορείτε να την ενημερώσετε ξανά ανά πάσα στιγμή.';
 
   @override
   String get pageNotFound => 'Η σελίδα δεν βρέθηκε';
@@ -857,8 +824,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteAllServerData => 'Διαγραφή όλων των δεδομένων διακομιστή';
 
   @override
-  String get deleteServerDataConfirm =>
-      'Διαγραφή όλων των δεδομένων διακομιστή;';
+  String get deleteServerDataConfirm => 'Διαγραφή όλων των δεδομένων διακομιστή;';
 
   @override
   String get deleteEverything => 'Διαγραφή όλων';
@@ -933,8 +899,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -959,8 +924,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -984,12 +948,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1004,15 +966,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1063,44 +1023,37 @@ class AppLocalizationsEl extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1109,8 +1062,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1175,8 +1127,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1240,8 +1191,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1262,8 +1212,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1299,8 +1248,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1309,8 +1257,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1334,8 +1281,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1389,8 +1335,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1399,8 +1344,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1411,12 +1355,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1430,8 +1369,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get nearestStations => 'Kontinoteroi stathmoi';
 
   @override
-  String get nearestStationsHint =>
-      'Vreite tous kontinoterous stathmous me tin trexousa topothesia sas';
+  String get nearestStationsHint => 'Vreite tous kontinoterous stathmous me tin trexousa topothesia sas';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1440,8 +1378,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1453,8 +1390,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1505,8 +1441,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1586,12 +1521,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1757,15 +1690,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1789,8 +1720,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1799,33 +1729,28 @@ class AppLocalizationsEl extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1840,16 +1765,17 @@ class AppLocalizationsEl extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -172,8 +172,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noFavorites => 'No favorites yet';
 
   @override
-  String get noFavoritesHint =>
-      'Tap the star on a station to save it as a favorite.';
+  String get noFavoritesHint => 'Tap the star on a station to save it as a favorite.';
 
   @override
   String get language => 'Language';
@@ -223,8 +222,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get gpsCoordinates => 'GPS coordinates';
 
   @override
-  String get gpsReason =>
-      'Sent with every location search to find nearby stations.';
+  String get gpsReason => 'Sent with every location search to find nearby stations.';
 
   @override
   String get postalCodeData => 'Postal code';
@@ -236,15 +234,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mapViewport => 'Map viewport';
 
   @override
-  String get mapReason =>
-      'Map tiles are loaded from the tile server. No personal data is transmitted.';
+  String get mapReason => 'Map tiles are loaded from the tile server. No personal data is transmitted.';
 
   @override
   String get apiKeyData => 'API Key';
 
   @override
-  String get apiKeyReason =>
-      'Your personal key is sent with every API request. It is linked to your email.';
+  String get apiKeyReason => 'Your personal key is sent with every API request. It is linked to your email.';
 
   @override
   String get notShared => 'NOT shared:';
@@ -265,8 +261,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get usageData => 'Usage data';
 
   @override
-  String get privacyBanner =>
-      'This app has no server. All data stays on your device. No analytics, no tracking, no ads.';
+  String get privacyBanner => 'This app has no server. All data stays on your device. No analytics, no tracking, no ads.';
 
   @override
   String get storageUsage => 'Storage usage on this device';
@@ -290,8 +285,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cacheManagement => 'Cache management';
 
   @override
-  String get cacheDescription =>
-      'The cache stores API responses for faster loading and offline access.';
+  String get cacheDescription => 'The cache stores API responses for faster loading and offline access.';
 
   @override
   String get stationSearch => 'Station search';
@@ -319,8 +313,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get clearCacheTitle => 'Clear cache?';
 
   @override
-  String get clearCacheBody =>
-      'Cached search results and prices will be deleted. Profiles, favorites and settings are preserved.';
+  String get clearCacheBody => 'Cached search results and prices will be deleted. Profiles, favorites and settings are preserved.';
 
   @override
   String get clearCacheButton => 'Clear cache';
@@ -329,8 +322,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteAllTitle => 'Delete all data?';
 
   @override
-  String get deleteAllBody =>
-      'This permanently deletes all profiles, favorites, API key, settings, and cache. The app will reset.';
+  String get deleteAllBody => 'This permanently deletes all profiles, favorites, API key, settings, and cache. The app will reset.';
 
   @override
   String get deleteAllButton => 'Delete all';
@@ -345,8 +337,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noStorage => 'No storage used';
 
   @override
-  String get apiKeyNote =>
-      'Free registration. Data from government price transparency agencies.';
+  String get apiKeyNote => 'Free registration. Data from government price transparency agencies.';
 
   @override
   String get apiKeyFormatError => 'Invalid format — expected UUID (8-4-4-4-12)';
@@ -355,8 +346,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get supportProject => 'Support this project';
 
   @override
-  String get supportDescription =>
-      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+  String get supportDescription => 'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 
   @override
   String get reportBug => 'Report a bug / Suggest a feature';
@@ -392,12 +382,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get station => 'Station';
 
   @override
-  String get locationDenied =>
-      'Location permission denied. You can search by postal code.';
+  String get locationDenied => 'Location permission denied. You can search by postal code.';
 
   @override
-  String get demoModeBanner =>
-      'Demo mode. Configure API key in settings for live prices.';
+  String get demoModeBanner => 'Demo mode. Configure API key in settings for live prices.';
 
   @override
   String get sortDistance => 'Distance';
@@ -423,8 +411,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Loading favorites...\nSearch for stations first to save data.';
+  String get loadingFavorites => 'Loading favorites...\nSearch for stations first to save data.';
 
   @override
   String get reportPrice => 'Report price';
@@ -490,8 +477,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoSwitchProfile => 'Auto-switch profile';
 
   @override
-  String get autoSwitchDescription =>
-      'Automatically switch profile when crossing borders';
+  String get autoSwitchDescription => 'Automatically switch profile when crossing borders';
 
   @override
   String get switchProfile => 'Switch';
@@ -518,8 +504,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noPriceAlerts => 'No price alerts';
 
   @override
-  String get noPriceAlertsHint =>
-      'Create an alert from a station\'s detail page.';
+  String get noPriceAlertsHint => 'Create an alert from a station\'s detail page.';
 
   @override
   String alertDeleted(String name) {
@@ -615,8 +600,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get evDataAttribution => 'Data from OpenChargeMap (community-sourced)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Status may not reflect real-time availability. Tap refresh to get the latest data.';
+  String get evStatusDisclaimer => 'Status may not reflect real-time availability. Tap refresh to get the latest data.';
 
   @override
   String get evNavigateToStation => 'Navigate to station';
@@ -628,8 +612,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get evStatusUpdated => 'Status updated';
 
   @override
-  String get evStationNotFound =>
-      'Could not refresh — station not found nearby';
+  String get evStationNotFound => 'Could not refresh — station not found nearby';
 
   @override
   String get addedToFavorites => 'Added to favorites';
@@ -698,8 +681,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Fuel prices (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Required for fuel price search in Germany';
+  String get requiredForFuelSearch => 'Required for fuel price search in Germany';
 
   @override
   String get evChargingOpenChargeMap => 'EV Charging (OpenChargeMap)';
@@ -711,8 +693,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appDefaultKey => 'App default key';
 
   @override
-  String get optionalOverrideKey =>
-      'Optional: override the built-in app key with your own';
+  String get optionalOverrideKey => 'Optional: override the built-in app key with your own';
 
   @override
   String get requiredForEvSearch => 'Required for EV charging station search';
@@ -744,8 +725,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get avoidHighways => 'Avoid highways';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Route calculation avoids toll roads and highways';
+  String get avoidHighwaysDesc => 'Route calculation avoids toll roads and highways';
 
   @override
   String get showFuelStations => 'Show fuel stations';
@@ -757,8 +737,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showEvStations => 'Show EV charging stations';
 
   @override
-  String get showEvStationsDesc =>
-      'Include electric charging stations in search results';
+  String get showEvStationsDesc => 'Include electric charging stations in search results';
 
   @override
   String get noStationsAlongThisRoute => 'No stations found along this route.';
@@ -785,8 +764,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get totalCost => 'Total cost';
 
   @override
-  String get enterCalcValues =>
-      'Enter distance, consumption, and price to calculate trip cost';
+  String get enterCalcValues => 'Enter distance, consumption, and price to calculate trip cost';
 
   @override
   String get priceHistory => 'Price History';
@@ -828,19 +806,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get viewMyData => 'View my data';
 
   @override
-  String get optionalCloudSync =>
-      'Optional cloud sync for alerts, favorites, and push notifications';
+  String get optionalCloudSync => 'Optional cloud sync for alerts, favorites, and push notifications';
 
   @override
   String get tapToUpdateGps => 'Tap to update GPS position';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS position is acquired automatically when you search. You can also update it manually here.';
+  String get gpsAutoUpdateHint => 'GPS position is acquired automatically when you search. You can also update it manually here.';
 
   @override
-  String get clearGpsConfirm =>
-      'Clear the stored GPS position? You can update it again at any time.';
+  String get clearGpsConfirm => 'Clear the stored GPS position? You can update it again at any time.';
 
   @override
   String get pageNotFound => 'Page not found';
@@ -924,8 +899,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -950,8 +924,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -975,12 +948,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -995,15 +966,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1054,44 +1023,37 @@ class AppLocalizationsEn extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1100,8 +1062,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1166,8 +1127,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1231,8 +1191,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1253,8 +1212,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1290,8 +1248,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1300,8 +1257,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1325,8 +1281,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1380,8 +1335,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1390,8 +1344,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1402,12 +1355,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1421,8 +1369,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get nearestStations => 'Nearest stations';
 
   @override
-  String get nearestStationsHint =>
-      'Find the closest stations using your current location';
+  String get nearestStationsHint => 'Find the closest stations using your current location';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1431,8 +1378,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1444,8 +1390,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1496,8 +1441,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1577,12 +1521,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1748,15 +1690,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1780,8 +1720,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1790,33 +1729,28 @@ class AppLocalizationsEn extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1831,16 +1765,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -103,8 +103,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get apiKeySetup => 'Clave API';
 
   @override
-  String get apiKeyDescription =>
-      'Regístrate una vez para obtener una clave API gratuita.';
+  String get apiKeyDescription => 'Regístrate una vez para obtener una clave API gratuita.';
 
   @override
   String get apiKeyLabel => 'Clave API';
@@ -119,8 +118,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get welcome => 'Precios Combustible';
 
   @override
-  String get welcomeSubtitle =>
-      'Encuentra el combustible más barato cerca de ti.';
+  String get welcomeSubtitle => 'Encuentra el combustible más barato cerca de ti.';
 
   @override
   String get profileName => 'Nombre del perfil';
@@ -174,8 +172,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noFavorites => 'Sin favoritos';
 
   @override
-  String get noFavoritesHint =>
-      'Toca la estrella de una gasolinera para guardarla como favorita.';
+  String get noFavoritesHint => 'Toca la estrella de una gasolinera para guardarla como favorita.';
 
   @override
   String get language => 'Idioma';
@@ -225,29 +222,25 @@ class AppLocalizationsEs extends AppLocalizations {
   String get gpsCoordinates => 'Coordenadas GPS';
 
   @override
-  String get gpsReason =>
-      'Se envían en cada búsqueda para encontrar las estaciones cercanas.';
+  String get gpsReason => 'Se envían en cada búsqueda para encontrar las estaciones cercanas.';
 
   @override
   String get postalCodeData => 'Código postal';
 
   @override
-  String get postalReason =>
-      'Se convierte en coordenadas mediante el servicio de geocodificación.';
+  String get postalReason => 'Se convierte en coordenadas mediante el servicio de geocodificación.';
 
   @override
   String get mapViewport => 'Vista del mapa';
 
   @override
-  String get mapReason =>
-      'Los mosaicos del mapa se cargan desde el servidor. No se transmiten datos personales.';
+  String get mapReason => 'Los mosaicos del mapa se cargan desde el servidor. No se transmiten datos personales.';
 
   @override
   String get apiKeyData => 'Clave API';
 
   @override
-  String get apiKeyReason =>
-      'Su clave personal se envía con cada solicitud API. Está vinculada a su correo electrónico.';
+  String get apiKeyReason => 'Su clave personal se envía con cada solicitud API. Está vinculada a su correo electrónico.';
 
   @override
   String get notShared => 'NO se comparte:';
@@ -268,8 +261,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get usageData => 'Datos de uso';
 
   @override
-  String get privacyBanner =>
-      'Esta app no tiene servidor. Todos los datos permanecen en su dispositivo. Sin análisis, sin seguimiento, sin publicidad.';
+  String get privacyBanner => 'Esta app no tiene servidor. Todos los datos permanecen en su dispositivo. Sin análisis, sin seguimiento, sin publicidad.';
 
   @override
   String get storageUsage => 'Uso de almacenamiento en este dispositivo';
@@ -293,8 +285,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cacheManagement => 'Gestión de caché';
 
   @override
-  String get cacheDescription =>
-      'La caché almacena respuestas API para una carga más rápida y acceso sin conexión.';
+  String get cacheDescription => 'La caché almacena respuestas API para una carga más rápida y acceso sin conexión.';
 
   @override
   String get stationSearch => 'Búsqueda de estaciones';
@@ -322,8 +313,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get clearCacheTitle => '¿Limpiar caché?';
 
   @override
-  String get clearCacheBody =>
-      'Los resultados de búsqueda y precios en caché se eliminarán. Los perfiles, favoritos y ajustes se conservan.';
+  String get clearCacheBody => 'Los resultados de búsqueda y precios en caché se eliminarán. Los perfiles, favoritos y ajustes se conservan.';
 
   @override
   String get clearCacheButton => 'Limpiar caché';
@@ -332,8 +322,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteAllTitle => '¿Eliminar todos los datos?';
 
   @override
-  String get deleteAllBody =>
-      'Esto elimina permanentemente todos los perfiles, favoritos, clave API, ajustes y caché. La app se reiniciará.';
+  String get deleteAllBody => 'Esto elimina permanentemente todos los perfiles, favoritos, clave API, ajustes y caché. La app se reiniciará.';
 
   @override
   String get deleteAllButton => 'Eliminar todo';
@@ -348,19 +337,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noStorage => 'Sin almacenamiento utilizado';
 
   @override
-  String get apiKeyNote =>
-      'Registro gratuito. Datos de las agencias gubernamentales de transparencia de precios.';
+  String get apiKeyNote => 'Registro gratuito. Datos de las agencias gubernamentales de transparencia de precios.';
 
   @override
-  String get apiKeyFormatError =>
-      'Formato inválido — se espera UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Formato inválido — se espera UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Apoyar este proyecto';
 
   @override
-  String get supportDescription =>
-      'Esta app es gratuita, de código abierto y sin publicidad. Si le resulta útil, considere apoyar al desarrollador.';
+  String get supportDescription => 'Esta app es gratuita, de código abierto y sin publicidad. Si le resulta útil, considere apoyar al desarrollador.';
 
   @override
   String get reportBug => 'Reportar error / Sugerir función';
@@ -396,8 +382,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get station => 'Estación';
 
   @override
-  String get locationDenied =>
-      'Permiso de ubicación denegado. Puede buscar por código postal.';
+  String get locationDenied => 'Permiso de ubicación denegado. Puede buscar por código postal.';
 
   @override
   String get demoModeBanner => 'Modo demo. Configure la clave API en ajustes.';
@@ -426,8 +411,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Cargando favoritos...\nBusque estaciones primero para guardar datos.';
+  String get loadingFavorites => 'Cargando favoritos...\nBusque estaciones primero para guardar datos.';
 
   @override
   String get reportPrice => 'Reportar precio';
@@ -493,8 +477,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoSwitchProfile => 'Cambio automático de perfil';
 
   @override
-  String get autoSwitchDescription =>
-      'Cambiar perfil automáticamente al cruzar fronteras';
+  String get autoSwitchDescription => 'Cambiar perfil automáticamente al cruzar fronteras';
 
   @override
   String get switchProfile => 'Cambiar';
@@ -521,8 +504,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noPriceAlerts => 'Sin alertas de precio';
 
   @override
-  String get noPriceAlertsHint =>
-      'Crea una alerta desde la página de detalle de una gasolinera.';
+  String get noPriceAlertsHint => 'Crea una alerta desde la página de detalle de una gasolinera.';
 
   @override
   String alertDeleted(String name) {
@@ -586,8 +568,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get openInMaps => 'Abrir en Mapas';
 
   @override
-  String get noStationsAlongRoute =>
-      'No se encontraron estaciones a lo largo de la ruta';
+  String get noStationsAlongRoute => 'No se encontraron estaciones a lo largo de la ruta';
 
   @override
   String get evOperational => 'Operativa';
@@ -619,8 +600,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get evDataAttribution => 'Datos de OpenChargeMap (fuente comunitaria)';
 
   @override
-  String get evStatusDisclaimer =>
-      'El estado puede no reflejar la disponibilidad en tiempo real. Toque actualizar para obtener los datos más recientes.';
+  String get evStatusDisclaimer => 'El estado puede no reflejar la disponibilidad en tiempo real. Toque actualizar para obtener los datos más recientes.';
 
   @override
   String get evNavigateToStation => 'Navegar a la estación';
@@ -632,8 +612,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get evStatusUpdated => 'Estado actualizado';
 
   @override
-  String get evStationNotFound =>
-      'No se pudo actualizar — estación no encontrada cerca';
+  String get evStationNotFound => 'No se pudo actualizar — estación no encontrada cerca';
 
   @override
   String get addedToFavorites => 'Añadido a favoritos';
@@ -702,8 +681,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Precios de combustible (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Requerido para buscar precios de combustible en Alemania';
+  String get requiredForFuelSearch => 'Requerido para buscar precios de combustible en Alemania';
 
   @override
   String get evChargingOpenChargeMap => 'Carga EV (OpenChargeMap)';
@@ -715,12 +693,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appDefaultKey => 'Clave predeterminada de la app';
 
   @override
-  String get optionalOverrideKey =>
-      'Opcional: reemplazar la clave integrada con la suya';
+  String get optionalOverrideKey => 'Opcional: reemplazar la clave integrada con la suya';
 
   @override
-  String get requiredForEvSearch =>
-      'Requerido para buscar estaciones de carga EV';
+  String get requiredForEvSearch => 'Requerido para buscar estaciones de carga EV';
 
   @override
   String get edit => 'Editar';
@@ -749,26 +725,22 @@ class AppLocalizationsEs extends AppLocalizations {
   String get avoidHighways => 'Evitar autopistas';
 
   @override
-  String get avoidHighwaysDesc =>
-      'El cálculo de ruta evita carreteras de peaje y autopistas';
+  String get avoidHighwaysDesc => 'El cálculo de ruta evita carreteras de peaje y autopistas';
 
   @override
   String get showFuelStations => 'Mostrar gasolineras';
 
   @override
-  String get showFuelStationsDesc =>
-      'Incluir estaciones de gasolina, diésel, GLP, GNC';
+  String get showFuelStationsDesc => 'Incluir estaciones de gasolina, diésel, GLP, GNC';
 
   @override
   String get showEvStations => 'Mostrar estaciones de carga';
 
   @override
-  String get showEvStationsDesc =>
-      'Incluir estaciones de carga eléctrica en los resultados';
+  String get showEvStationsDesc => 'Incluir estaciones de carga eléctrica en los resultados';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'No se encontraron estaciones a lo largo de esta ruta.';
+  String get noStationsAlongThisRoute => 'No se encontraron estaciones a lo largo de esta ruta.';
 
   @override
   String get fuelCostCalculator => 'Calculadora de coste de combustible';
@@ -792,8 +764,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get totalCost => 'Coste total';
 
   @override
-  String get enterCalcValues =>
-      'Introduzca distancia, consumo y precio para calcular el coste del viaje';
+  String get enterCalcValues => 'Introduzca distancia, consumo y precio para calcular el coste del viaje';
 
   @override
   String get priceHistory => 'Historial de precios';
@@ -835,19 +806,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get viewMyData => 'Ver mis datos';
 
   @override
-  String get optionalCloudSync =>
-      'Sincronización en la nube opcional para alertas, favoritos y notificaciones push';
+  String get optionalCloudSync => 'Sincronización en la nube opcional para alertas, favoritos y notificaciones push';
 
   @override
   String get tapToUpdateGps => 'Toque para actualizar la posición GPS';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'La posición GPS se adquiere automáticamente al buscar. También puede actualizarla manualmente aquí.';
+  String get gpsAutoUpdateHint => 'La posición GPS se adquiere automáticamente al buscar. También puede actualizarla manualmente aquí.';
 
   @override
-  String get clearGpsConfirm =>
-      '¿Borrar la posición GPS almacenada? Puede actualizarla en cualquier momento.';
+  String get clearGpsConfirm => '¿Borrar la posición GPS almacenada? Puede actualizarla en cualquier momento.';
 
   @override
   String get pageNotFound => 'Página no encontrada';
@@ -856,8 +824,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteAllServerData => 'Eliminar todos los datos del servidor';
 
   @override
-  String get deleteServerDataConfirm =>
-      '¿Eliminar todos los datos del servidor?';
+  String get deleteServerDataConfirm => '¿Eliminar todos los datos del servidor?';
 
   @override
   String get deleteEverything => 'Eliminar todo';
@@ -932,8 +899,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noSavedRoutes => 'Sin rutas guardadas';
 
   @override
-  String get noSavedRoutesHint =>
-      'Busca a lo largo de una ruta y guárdala para acceso rápido.';
+  String get noSavedRoutesHint => 'Busca a lo largo de una ruta y guárdala para acceso rápido.';
 
   @override
   String get saveRoute => 'Guardar ruta';
@@ -958,8 +924,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -983,12 +948,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1003,15 +966,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1062,44 +1023,37 @@ class AppLocalizationsEs extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1108,8 +1062,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1174,8 +1127,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1239,8 +1191,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1261,8 +1212,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1298,8 +1248,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1308,8 +1257,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1333,8 +1281,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1388,8 +1335,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1398,8 +1344,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1410,12 +1355,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1429,8 +1369,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get nearestStations => 'Estaciones cercanas';
 
   @override
-  String get nearestStationsHint =>
-      'Encontrar las estaciones mas cercanas con su ubicacion actual';
+  String get nearestStationsHint => 'Encontrar las estaciones mas cercanas con su ubicacion actual';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1439,8 +1378,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1452,8 +1390,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1504,8 +1441,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1585,12 +1521,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1756,15 +1690,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1788,8 +1720,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1798,33 +1729,28 @@ class AppLocalizationsEs extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1839,16 +1765,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -103,8 +103,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get apiKeySetup => 'API võti';
 
   @override
-  String get apiKeyDescription =>
-      'Registreeruge üks kord tasuta API võtme saamiseks.';
+  String get apiKeyDescription => 'Registreeruge üks kord tasuta API võtme saamiseks.';
 
   @override
   String get apiKeyLabel => 'API võti';
@@ -173,8 +172,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get noFavorites => 'Lemmikuid pole';
 
   @override
-  String get noFavoritesHint =>
-      'Puudutage tankla tähte, et salvestada see lemmikuks.';
+  String get noFavoritesHint => 'Puudutage tankla tähte, et salvestada see lemmikuks.';
 
   @override
   String get language => 'Keel';
@@ -224,29 +222,25 @@ class AppLocalizationsEt extends AppLocalizations {
   String get gpsCoordinates => 'GPS koordinaadid';
 
   @override
-  String get gpsReason =>
-      'Saadetakse iga otsinguga lähedalolevate jaamade leidmiseks.';
+  String get gpsReason => 'Saadetakse iga otsinguga lähedalolevate jaamade leidmiseks.';
 
   @override
   String get postalCodeData => 'Postiindeks';
 
   @override
-  String get postalReason =>
-      'Teisendatakse koordinaatideks geokodeerimise teenuse kaudu.';
+  String get postalReason => 'Teisendatakse koordinaatideks geokodeerimise teenuse kaudu.';
 
   @override
   String get mapViewport => 'Kaardi vaade';
 
   @override
-  String get mapReason =>
-      'Kaardi paanid laaditakse serverist. Isikuandmeid ei edastata.';
+  String get mapReason => 'Kaardi paanid laaditakse serverist. Isikuandmeid ei edastata.';
 
   @override
   String get apiKeyData => 'API võti';
 
   @override
-  String get apiKeyReason =>
-      'Teie isiklik võti saadetakse iga API päringuga. See on seotud teie e-postiga.';
+  String get apiKeyReason => 'Teie isiklik võti saadetakse iga API päringuga. See on seotud teie e-postiga.';
 
   @override
   String get notShared => 'EI jagata:';
@@ -267,8 +261,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get usageData => 'Kasutusandmed';
 
   @override
-  String get privacyBanner =>
-      'Sellel rakendusel pole serverit. Kõik andmed jäävad teie seadmesse. Pole analüütikat, jälgimist ega reklaame.';
+  String get privacyBanner => 'Sellel rakendusel pole serverit. Kõik andmed jäävad teie seadmesse. Pole analüütikat, jälgimist ega reklaame.';
 
   @override
   String get storageUsage => 'Salvestusruumi kasutus selles seadmes';
@@ -292,8 +285,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get cacheManagement => 'Vahemälu haldus';
 
   @override
-  String get cacheDescription =>
-      'Vahemälu salvestab API vastuseid kiiremaks laadimiseks ja võrguühenduseta juurdepääsuks.';
+  String get cacheDescription => 'Vahemälu salvestab API vastuseid kiiremaks laadimiseks ja võrguühenduseta juurdepääsuks.';
 
   @override
   String get stationSearch => 'Jaamade otsing';
@@ -321,8 +313,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get clearCacheTitle => 'Tühjenda vahemälu?';
 
   @override
-  String get clearCacheBody =>
-      'Vahemällu salvestatud otsingutulemused ja hinnad kustutatakse. Profiilid, lemmikud ja seaded säilitatakse.';
+  String get clearCacheBody => 'Vahemällu salvestatud otsingutulemused ja hinnad kustutatakse. Profiilid, lemmikud ja seaded säilitatakse.';
 
   @override
   String get clearCacheButton => 'Tühjenda vahemälu';
@@ -331,8 +322,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleteAllTitle => 'Kustuta kõik andmed?';
 
   @override
-  String get deleteAllBody =>
-      'See kustutab jäädavalt kõik profiilid, lemmikud, API võtme, seaded ja vahemälu. Rakendus lähtestatakse.';
+  String get deleteAllBody => 'See kustutab jäädavalt kõik profiilid, lemmikud, API võtme, seaded ja vahemälu. Rakendus lähtestatakse.';
 
   @override
   String get deleteAllButton => 'Kustuta kõik';
@@ -347,8 +337,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get noStorage => 'Salvestusruum pole kasutuses';
 
   @override
-  String get apiKeyNote =>
-      'Tasuta registreerumine. Andmed riiklike hinnaläbipaistvuse asutuste käest.';
+  String get apiKeyNote => 'Tasuta registreerumine. Andmed riiklike hinnaläbipaistvuse asutuste käest.';
 
   @override
   String get apiKeyFormatError => 'Vigane vorming — oodatav UUID (8-4-4-4-12)';
@@ -357,8 +346,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get supportProject => 'Toetage seda projekti';
 
   @override
-  String get supportDescription =>
-      'See rakendus on tasuta, avatud lähtekoodiga ja reklaamivaba. Kui leiate selle kasulikuks, kaaluge arendaja toetamist.';
+  String get supportDescription => 'See rakendus on tasuta, avatud lähtekoodiga ja reklaamivaba. Kui leiate selle kasulikuks, kaaluge arendaja toetamist.';
 
   @override
   String get reportBug => 'Teata veast / Soovita funktsiooni';
@@ -394,8 +382,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get station => 'Tankla';
 
   @override
-  String get locationDenied =>
-      'Asukoha luba keelatud. Saate otsida postiindeksi järgi.';
+  String get locationDenied => 'Asukoha luba keelatud. Saate otsida postiindeksi järgi.';
 
   @override
   String get demoModeBanner => 'Demorežiim. Seadistage API võti seadetes.';
@@ -424,8 +411,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Lemmikute laadimine...\nOtsige kõigepealt tanklasid andmete salvestamiseks.';
+  String get loadingFavorites => 'Lemmikute laadimine...\nOtsige kõigepealt tanklasid andmete salvestamiseks.';
 
   @override
   String get reportPrice => 'Teata hinnast';
@@ -491,8 +477,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get autoSwitchProfile => 'Automaatne profiili vahetamine';
 
   @override
-  String get autoSwitchDescription =>
-      'Vaheta profiili automaatselt piiri ületamisel';
+  String get autoSwitchDescription => 'Vaheta profiili automaatselt piiri ületamisel';
 
   @override
   String get switchProfile => 'Vaheta';
@@ -603,8 +588,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get evUsageCost => 'Kasutuskulu';
 
   @override
-  String get evPricingUnavailable =>
-      'Hinnateave teenusepakkujalt pole saadaval';
+  String get evPricingUnavailable => 'Hinnateave teenusepakkujalt pole saadaval';
 
   @override
   String get evLastUpdated => 'Viimati uuendatud';
@@ -616,8 +600,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get evDataAttribution => 'Andmed OpenChargeMapist (kogukonnaallikas)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Olek ei pruugi kajastada reaalajas saadavust. Puudutage uuenda, et saada uusimaid andmeid.';
+  String get evStatusDisclaimer => 'Olek ei pruugi kajastada reaalajas saadavust. Puudutage uuenda, et saada uusimaid andmeid.';
 
   @override
   String get evNavigateToStation => 'Navigeeri jaama';
@@ -629,8 +612,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get evStatusUpdated => 'Olek uuendatud';
 
   @override
-  String get evStationNotFound =>
-      'Ei saanud uuendada — jaama ei leitud lähedusest';
+  String get evStationNotFound => 'Ei saanud uuendada — jaama ei leitud lähedusest';
 
   @override
   String get addedToFavorites => 'Lisatud lemmikutesse';
@@ -711,8 +693,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get appDefaultKey => 'Rakenduse vaikevõti';
 
   @override
-  String get optionalOverrideKey =>
-      'Valikuline: asendage sisseehitatud rakenduse võti enda omaga';
+  String get optionalOverrideKey => 'Valikuline: asendage sisseehitatud rakenduse võti enda omaga';
 
   @override
   String get requiredForEvSearch => 'Vajalik EV laadimisjaamade otsinguks';
@@ -744,26 +725,22 @@ class AppLocalizationsEt extends AppLocalizations {
   String get avoidHighways => 'Väldi kiirteid';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Marsruudi arvutus väldib tasulisi teid ja kiirteid';
+  String get avoidHighwaysDesc => 'Marsruudi arvutus väldib tasulisi teid ja kiirteid';
 
   @override
   String get showFuelStations => 'Näita tanklasid';
 
   @override
-  String get showFuelStationsDesc =>
-      'Kaasa bensiini-, diisli-, LPG-, CNG-jaamad';
+  String get showFuelStationsDesc => 'Kaasa bensiini-, diisli-, LPG-, CNG-jaamad';
 
   @override
   String get showEvStations => 'Näita laadimisjaamu';
 
   @override
-  String get showEvStationsDesc =>
-      'Kaasa elektrilaadimise jaamad otsingutulemustes';
+  String get showEvStationsDesc => 'Kaasa elektrilaadimise jaamad otsingutulemustes';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Selle marsruudi äärest jaamu ei leitud.';
+  String get noStationsAlongThisRoute => 'Selle marsruudi äärest jaamu ei leitud.';
 
   @override
   String get fuelCostCalculator => 'Kütusekulude kalkulaator';
@@ -787,8 +764,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get totalCost => 'Kogukulu';
 
   @override
-  String get enterCalcValues =>
-      'Sisestage kaugus, tarbimine ja hind reisikulu arvutamiseks';
+  String get enterCalcValues => 'Sisestage kaugus, tarbimine ja hind reisikulu arvutamiseks';
 
   @override
   String get priceHistory => 'Hinnaajalugu';
@@ -830,19 +806,16 @@ class AppLocalizationsEt extends AppLocalizations {
   String get viewMyData => 'Vaata minu andmeid';
 
   @override
-  String get optionalCloudSync =>
-      'Valikuline pilvsünkroniseerimine hoiatuste, lemmikute ja tõuketeadete jaoks';
+  String get optionalCloudSync => 'Valikuline pilvsünkroniseerimine hoiatuste, lemmikute ja tõuketeadete jaoks';
 
   @override
   String get tapToUpdateGps => 'Puudutage GPS asukoha uuendamiseks';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS asukoht hangitakse automaatselt otsimisel. Saate seda ka käsitsi siin uuendada.';
+  String get gpsAutoUpdateHint => 'GPS asukoht hangitakse automaatselt otsimisel. Saate seda ka käsitsi siin uuendada.';
 
   @override
-  String get clearGpsConfirm =>
-      'Kustutada salvestatud GPS asukoht? Saate seda igal ajal uuendada.';
+  String get clearGpsConfirm => 'Kustutada salvestatud GPS asukoht? Saate seda igal ajal uuendada.';
 
   @override
   String get pageNotFound => 'Lehte ei leitud';
@@ -926,8 +899,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -952,8 +924,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -977,12 +948,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -997,15 +966,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1056,44 +1023,37 @@ class AppLocalizationsEt extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1102,8 +1062,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1168,8 +1127,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1233,8 +1191,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1255,8 +1212,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1292,8 +1248,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1302,8 +1257,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1327,8 +1281,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1382,8 +1335,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1392,8 +1344,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1404,12 +1355,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1423,8 +1369,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get nearestStations => 'Lahimad jaamad';
 
   @override
-  String get nearestStationsHint =>
-      'Leidke lahimad jaamad oma praeguse asukoha jargi';
+  String get nearestStationsHint => 'Leidke lahimad jaamad oma praeguse asukoha jargi';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1433,8 +1378,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1446,8 +1390,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1498,8 +1441,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1579,12 +1521,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1750,15 +1690,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1782,8 +1720,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1792,33 +1729,28 @@ class AppLocalizationsEt extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1833,16 +1765,17 @@ class AppLocalizationsEt extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -103,8 +103,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get apiKeySetup => 'API-avain';
 
   @override
-  String get apiKeyDescription =>
-      'Rekisteröidy kerran saadaksesi ilmaisen API-avaimen.';
+  String get apiKeyDescription => 'Rekisteröidy kerran saadaksesi ilmaisen API-avaimen.';
 
   @override
   String get apiKeyLabel => 'API-avain';
@@ -173,8 +172,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get noFavorites => 'Ei suosikkeja vielä';
 
   @override
-  String get noFavoritesHint =>
-      'Napauta aseman tähteä tallentaaksesi sen suosikiksi.';
+  String get noFavoritesHint => 'Napauta aseman tähteä tallentaaksesi sen suosikiksi.';
 
   @override
   String get language => 'Kieli';
@@ -224,29 +222,25 @@ class AppLocalizationsFi extends AppLocalizations {
   String get gpsCoordinates => 'GPS-koordinaatit';
 
   @override
-  String get gpsReason =>
-      'Lähetetään jokaisessa haussa lähellä olevien asemien löytämiseksi.';
+  String get gpsReason => 'Lähetetään jokaisessa haussa lähellä olevien asemien löytämiseksi.';
 
   @override
   String get postalCodeData => 'Postinumero';
 
   @override
-  String get postalReason =>
-      'Muunnetaan koordinaateiksi geokoodauspalvelun kautta.';
+  String get postalReason => 'Muunnetaan koordinaateiksi geokoodauspalvelun kautta.';
 
   @override
   String get mapViewport => 'Karttanäkymä';
 
   @override
-  String get mapReason =>
-      'Karttaruudut ladataan palvelimelta. Henkilötietoja ei lähetetä.';
+  String get mapReason => 'Karttaruudut ladataan palvelimelta. Henkilötietoja ei lähetetä.';
 
   @override
   String get apiKeyData => 'API-avain';
 
   @override
-  String get apiKeyReason =>
-      'Henkilökohtainen avaimesi lähetetään jokaisen API-pyynnön mukana. Se on yhdistetty sähköpostiisi.';
+  String get apiKeyReason => 'Henkilökohtainen avaimesi lähetetään jokaisen API-pyynnön mukana. Se on yhdistetty sähköpostiisi.';
 
   @override
   String get notShared => 'EI jaeta:';
@@ -267,8 +261,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get usageData => 'Käyttötiedot';
 
   @override
-  String get privacyBanner =>
-      'Tällä sovelluksella ei ole palvelinta. Kaikki tiedot pysyvät laitteellasi. Ei analytiikkaa, ei seurantaa, ei mainoksia.';
+  String get privacyBanner => 'Tällä sovelluksella ei ole palvelinta. Kaikki tiedot pysyvät laitteellasi. Ei analytiikkaa, ei seurantaa, ei mainoksia.';
 
   @override
   String get storageUsage => 'Tallennustilan käyttö tällä laitteella';
@@ -292,8 +285,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get cacheManagement => 'Välimuistin hallinta';
 
   @override
-  String get cacheDescription =>
-      'Välimuisti tallentaa API-vastaukset nopeampaa latausta ja offline-käyttöä varten.';
+  String get cacheDescription => 'Välimuisti tallentaa API-vastaukset nopeampaa latausta ja offline-käyttöä varten.';
 
   @override
   String get stationSearch => 'Asemahaku';
@@ -321,8 +313,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get clearCacheTitle => 'Tyhjennä välimuisti?';
 
   @override
-  String get clearCacheBody =>
-      'Välimuistissa olevat hakutulokset ja hinnat poistetaan. Profiilit, suosikit ja asetukset säilytetään.';
+  String get clearCacheBody => 'Välimuistissa olevat hakutulokset ja hinnat poistetaan. Profiilit, suosikit ja asetukset säilytetään.';
 
   @override
   String get clearCacheButton => 'Tyhjennä välimuisti';
@@ -331,8 +322,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deleteAllTitle => 'Poista kaikki tiedot?';
 
   @override
-  String get deleteAllBody =>
-      'Tämä poistaa pysyvästi kaikki profiilit, suosikit, API-avaimen, asetukset ja välimuistin. Sovellus palautetaan.';
+  String get deleteAllBody => 'Tämä poistaa pysyvästi kaikki profiilit, suosikit, API-avaimen, asetukset ja välimuistin. Sovellus palautetaan.';
 
   @override
   String get deleteAllButton => 'Poista kaikki';
@@ -347,19 +337,16 @@ class AppLocalizationsFi extends AppLocalizations {
   String get noStorage => 'Ei tallennustilaa käytössä';
 
   @override
-  String get apiKeyNote =>
-      'Ilmainen rekisteröinti. Tiedot valtion hintatransparenssitoimistoilta.';
+  String get apiKeyNote => 'Ilmainen rekisteröinti. Tiedot valtion hintatransparenssitoimistoilta.';
 
   @override
-  String get apiKeyFormatError =>
-      'Virheellinen muoto — odotettu UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Virheellinen muoto — odotettu UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Tue tätä projektia';
 
   @override
-  String get supportDescription =>
-      'Tämä sovellus on ilmainen, avoimen lähdekoodin ja mainokseton. Jos se on hyödyllinen, harkitse kehittäjän tukemista.';
+  String get supportDescription => 'Tämä sovellus on ilmainen, avoimen lähdekoodin ja mainokseton. Jos se on hyödyllinen, harkitse kehittäjän tukemista.';
 
   @override
   String get reportBug => 'Ilmoita virheestä / Ehdota ominaisuutta';
@@ -395,8 +382,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get station => 'Huoltoasema';
 
   @override
-  String get locationDenied =>
-      'Sijaintilupa evätty. Voit hakea postinumerolla.';
+  String get locationDenied => 'Sijaintilupa evätty. Voit hakea postinumerolla.';
 
   @override
   String get demoModeBanner => 'Demotila. Määritä API-avain asetuksissa.';
@@ -425,8 +411,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Ladataan suosikkeja...\nHae asemia ensin tietojen tallentamiseksi.';
+  String get loadingFavorites => 'Ladataan suosikkeja...\nHae asemia ensin tietojen tallentamiseksi.';
 
   @override
   String get reportPrice => 'Ilmoita hinta';
@@ -462,8 +447,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get autoUpdatePosition => 'Päivitä sijainti automaattisesti';
 
   @override
-  String get autoUpdateDescription =>
-      'Päivitä GPS-sijainti ennen jokaista hakua';
+  String get autoUpdateDescription => 'Päivitä GPS-sijainti ennen jokaista hakua';
 
   @override
   String get location => 'Sijainti';
@@ -493,8 +477,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get autoSwitchProfile => 'Automaattinen profiilivaihto';
 
   @override
-  String get autoSwitchDescription =>
-      'Vaihda profiilia automaattisesti rajan ylittyessä';
+  String get autoSwitchDescription => 'Vaihda profiilia automaattisesti rajan ylittyessä';
 
   @override
   String get switchProfile => 'Vaihda';
@@ -605,8 +588,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get evUsageCost => 'Käyttökustannus';
 
   @override
-  String get evPricingUnavailable =>
-      'Hintatietoa ei saatavilla palveluntarjoajalta';
+  String get evPricingUnavailable => 'Hintatietoa ei saatavilla palveluntarjoajalta';
 
   @override
   String get evLastUpdated => 'Viimeksi päivitetty';
@@ -618,8 +600,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get evDataAttribution => 'Tiedot OpenChargeMapista (yhteisölähde)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Tila ei välttämättä vastaa reaaliaikaista saatavuutta. Napauta päivitä saadaksesi uusimmat tiedot.';
+  String get evStatusDisclaimer => 'Tila ei välttämättä vastaa reaaliaikaista saatavuutta. Napauta päivitä saadaksesi uusimmat tiedot.';
 
   @override
   String get evNavigateToStation => 'Navigoi asemalle';
@@ -631,8 +612,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get evStatusUpdated => 'Tila päivitetty';
 
   @override
-  String get evStationNotFound =>
-      'Päivitys epäonnistui — asemaa ei löytynyt läheltä';
+  String get evStationNotFound => 'Päivitys epäonnistui — asemaa ei löytynyt läheltä';
 
   @override
   String get addedToFavorites => 'Lisätty suosikkeihin';
@@ -653,8 +633,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get gpsError => 'GPS-virhe';
 
   @override
-  String get couldNotResolve =>
-      'Lähtöpaikkaa tai määränpäätä ei voitu selvittää';
+  String get couldNotResolve => 'Lähtöpaikkaa tai määränpäätä ei voitu selvittää';
 
   @override
   String get start => 'Lähtö';
@@ -702,8 +681,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Polttoainehinnat (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Vaaditaan polttoainehintahakuun Saksassa';
+  String get requiredForFuelSearch => 'Vaaditaan polttoainehintahakuun Saksassa';
 
   @override
   String get evChargingOpenChargeMap => 'Sähköauton lataus (OpenChargeMap)';
@@ -715,8 +693,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get appDefaultKey => 'Sovelluksen oletusavain';
 
   @override
-  String get optionalOverrideKey =>
-      'Valinnainen: korvaa sovelluksen sisäänrakennettu avain omallasi';
+  String get optionalOverrideKey => 'Valinnainen: korvaa sovelluksen sisäänrakennettu avain omallasi';
 
   @override
   String get requiredForEvSearch => 'Vaaditaan sähköauton latausasemien hakuun';
@@ -748,22 +725,19 @@ class AppLocalizationsFi extends AppLocalizations {
   String get avoidHighways => 'Vältä moottoriteitä';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Reitinlaskenta välttää maksullisia teitä ja moottoriteitä';
+  String get avoidHighwaysDesc => 'Reitinlaskenta välttää maksullisia teitä ja moottoriteitä';
 
   @override
   String get showFuelStations => 'Näytä huoltoasemat';
 
   @override
-  String get showFuelStationsDesc =>
-      'Sisällytä bensiini-, diesel-, LPG-, CNG-asemat';
+  String get showFuelStationsDesc => 'Sisällytä bensiini-, diesel-, LPG-, CNG-asemat';
 
   @override
   String get showEvStations => 'Näytä latausasemat';
 
   @override
-  String get showEvStationsDesc =>
-      'Sisällytä sähköauton latausasemat hakutuloksiin';
+  String get showEvStationsDesc => 'Sisällytä sähköauton latausasemat hakutuloksiin';
 
   @override
   String get noStationsAlongThisRoute => 'Ei asemia tämän reitin varrella.';
@@ -790,8 +764,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get totalCost => 'Kokonaiskustannus';
 
   @override
-  String get enterCalcValues =>
-      'Syötä matka, kulutus ja hinta laskeaksesi matkan kustannuksen';
+  String get enterCalcValues => 'Syötä matka, kulutus ja hinta laskeaksesi matkan kustannuksen';
 
   @override
   String get priceHistory => 'Hintahistoria';
@@ -833,19 +806,16 @@ class AppLocalizationsFi extends AppLocalizations {
   String get viewMyData => 'Näytä omat tiedot';
 
   @override
-  String get optionalCloudSync =>
-      'Valinnainen pilvisynkronointi hälytyksille, suosikeille ja push-ilmoituksille';
+  String get optionalCloudSync => 'Valinnainen pilvisynkronointi hälytyksille, suosikeille ja push-ilmoituksille';
 
   @override
   String get tapToUpdateGps => 'Napauta päivittääksesi GPS-sijainnin';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS-sijainti haetaan automaattisesti hakiessa. Voit myös päivittää sen manuaalisesti täällä.';
+  String get gpsAutoUpdateHint => 'GPS-sijainti haetaan automaattisesti hakiessa. Voit myös päivittää sen manuaalisesti täällä.';
 
   @override
-  String get clearGpsConfirm =>
-      'Tyhjennä tallennettu GPS-sijainti? Voit päivittää sen uudelleen milloin tahansa.';
+  String get clearGpsConfirm => 'Tyhjennä tallennettu GPS-sijainti? Voit päivittää sen uudelleen milloin tahansa.';
 
   @override
   String get pageNotFound => 'Sivua ei löytynyt';
@@ -929,8 +899,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -955,8 +924,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -980,12 +948,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1000,15 +966,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1059,44 +1023,37 @@ class AppLocalizationsFi extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1105,8 +1062,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1171,8 +1127,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1236,8 +1191,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1258,8 +1212,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1295,8 +1248,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1305,8 +1257,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1330,8 +1281,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1385,8 +1335,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1395,8 +1344,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1407,12 +1355,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1426,8 +1369,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get nearestStations => 'Lahimmat asemat';
 
   @override
-  String get nearestStationsHint =>
-      'Loyda lahimmat asemat nykyisella sijainnillasi';
+  String get nearestStationsHint => 'Loyda lahimmat asemat nykyisella sijainnillasi';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1436,8 +1378,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1449,8 +1390,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1501,8 +1441,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1582,12 +1521,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1753,15 +1690,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1785,8 +1720,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1795,33 +1729,28 @@ class AppLocalizationsFi extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1836,16 +1765,17 @@ class AppLocalizationsFi extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -103,8 +103,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get apiKeySetup => 'Clé API';
 
   @override
-  String get apiKeyDescription =>
-      'Inscrivez-vous une fois pour obtenir une clé API gratuite.';
+  String get apiKeyDescription => 'Inscrivez-vous une fois pour obtenir une clé API gratuite.';
 
   @override
   String get apiKeyLabel => 'Clé API';
@@ -119,8 +118,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get welcome => 'Prix Carburants';
 
   @override
-  String get welcomeSubtitle =>
-      'Trouvez le carburant le moins cher près de chez vous.';
+  String get welcomeSubtitle => 'Trouvez le carburant le moins cher près de chez vous.';
 
   @override
   String get profileName => 'Nom du profil';
@@ -174,8 +172,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noFavorites => 'Pas encore de favoris';
 
   @override
-  String get noFavoritesHint =>
-      'Appuyez sur l\'étoile d\'une station pour l\'ajouter aux favoris.';
+  String get noFavoritesHint => 'Appuyez sur l\'étoile d\'une station pour l\'ajouter aux favoris.';
 
   @override
   String get language => 'Langue';
@@ -225,29 +222,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String get gpsCoordinates => 'Coordonnées GPS';
 
   @override
-  String get gpsReason =>
-      'Envoyées à chaque recherche pour trouver les stations proches.';
+  String get gpsReason => 'Envoyées à chaque recherche pour trouver les stations proches.';
 
   @override
   String get postalCodeData => 'Code postal';
 
   @override
-  String get postalReason =>
-      'Converti en coordonnées via le service de géocodage.';
+  String get postalReason => 'Converti en coordonnées via le service de géocodage.';
 
   @override
   String get mapViewport => 'Zone de carte affichée';
 
   @override
-  String get mapReason =>
-      'Les tuiles de carte sont chargées depuis le serveur. Aucune donnée personnelle n\'est transmise.';
+  String get mapReason => 'Les tuiles de carte sont chargées depuis le serveur. Aucune donnée personnelle n\'est transmise.';
 
   @override
   String get apiKeyData => 'Clé API';
 
   @override
-  String get apiKeyReason =>
-      'Votre clé personnelle est envoyée à chaque requête API. Elle est liée à votre e-mail.';
+  String get apiKeyReason => 'Votre clé personnelle est envoyée à chaque requête API. Elle est liée à votre e-mail.';
 
   @override
   String get notShared => 'NON partagé :';
@@ -268,8 +261,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get usageData => 'Données d\'utilisation';
 
   @override
-  String get privacyBanner =>
-      'Cette application n\'a pas de serveur. Toutes les données restent sur votre appareil. Pas d\'analyse, pas de suivi, pas de publicité.';
+  String get privacyBanner => 'Cette application n\'a pas de serveur. Toutes les données restent sur votre appareil. Pas d\'analyse, pas de suivi, pas de publicité.';
 
   @override
   String get storageUsage => 'Utilisation du stockage sur cet appareil';
@@ -293,8 +285,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cacheManagement => 'Gestion du cache';
 
   @override
-  String get cacheDescription =>
-      'Le cache stocke les réponses API pour un chargement plus rapide et l\'accès hors ligne.';
+  String get cacheDescription => 'Le cache stocke les réponses API pour un chargement plus rapide et l\'accès hors ligne.';
 
   @override
   String get stationSearch => 'Recherche de stations';
@@ -322,8 +313,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get clearCacheTitle => 'Vider le cache ?';
 
   @override
-  String get clearCacheBody =>
-      'Les résultats de recherche et prix en cache seront supprimés. Profils, favoris et paramètres sont conservés.';
+  String get clearCacheBody => 'Les résultats de recherche et prix en cache seront supprimés. Profils, favoris et paramètres sont conservés.';
 
   @override
   String get clearCacheButton => 'Vider le cache';
@@ -332,8 +322,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteAllTitle => 'Supprimer toutes les données ?';
 
   @override
-  String get deleteAllBody =>
-      'Cela supprime définitivement tous les profils, favoris, clé API, paramètres et cache. L\'app sera réinitialisée.';
+  String get deleteAllBody => 'Cela supprime définitivement tous les profils, favoris, clé API, paramètres et cache. L\'app sera réinitialisée.';
 
   @override
   String get deleteAllButton => 'Tout supprimer';
@@ -348,8 +337,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noStorage => 'Aucun stockage utilisé';
 
   @override
-  String get apiKeyNote =>
-      'Inscription gratuite. Données des agences gouvernementales de transparence des prix.';
+  String get apiKeyNote => 'Inscription gratuite. Données des agences gouvernementales de transparence des prix.';
 
   @override
   String get apiKeyFormatError => 'Format invalide — UUID attendu (8-4-4-4-12)';
@@ -358,8 +346,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get supportProject => 'Soutenir ce projet';
 
   @override
-  String get supportDescription =>
-      'Cette application est gratuite, open source et sans publicité. Si vous la trouvez utile, pensez à soutenir le développeur.';
+  String get supportDescription => 'Cette application est gratuite, open source et sans publicité. Si vous la trouvez utile, pensez à soutenir le développeur.';
 
   @override
   String get reportBug => 'Signaler un bug / Suggérer une amélioration';
@@ -395,12 +382,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get station => 'Station';
 
   @override
-  String get locationDenied =>
-      'Autorisation de localisation refusée. Vous pouvez chercher par code postal.';
+  String get locationDenied => 'Autorisation de localisation refusée. Vous pouvez chercher par code postal.';
 
   @override
-  String get demoModeBanner =>
-      'Mode démo. Configurez la clé API dans les paramètres.';
+  String get demoModeBanner => 'Mode démo. Configurez la clé API dans les paramètres.';
 
   @override
   String get sortDistance => 'Distance';
@@ -426,8 +411,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Chargement des favoris...\nRecherchez d\'abord des stations pour enregistrer des données.';
+  String get loadingFavorites => 'Chargement des favoris...\nRecherchez d\'abord des stations pour enregistrer des données.';
 
   @override
   String get reportPrice => 'Signaler un prix';
@@ -463,8 +447,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoUpdatePosition => 'Mise à jour automatique';
 
   @override
-  String get autoUpdateDescription =>
-      'Actualiser la position GPS avant chaque recherche';
+  String get autoUpdateDescription => 'Actualiser la position GPS avant chaque recherche';
 
   @override
   String get location => 'Localisation';
@@ -494,8 +477,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoSwitchProfile => 'Changement automatique de profil';
 
   @override
-  String get autoSwitchDescription =>
-      'Changer de profil automatiquement en traversant une frontière';
+  String get autoSwitchDescription => 'Changer de profil automatiquement en traversant une frontière';
 
   @override
   String get switchProfile => 'Changer';
@@ -522,8 +504,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noPriceAlerts => 'Aucune alerte de prix';
 
   @override
-  String get noPriceAlertsHint =>
-      'Créez une alerte depuis la page détail d\'une station.';
+  String get noPriceAlertsHint => 'Créez une alerte depuis la page détail d\'une station.';
 
   @override
   String alertDeleted(String name) {
@@ -607,8 +588,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get evUsageCost => 'Coût d\'utilisation';
 
   @override
-  String get evPricingUnavailable =>
-      'Tarification non disponible auprès du fournisseur';
+  String get evPricingUnavailable => 'Tarification non disponible auprès du fournisseur';
 
   @override
   String get evLastUpdated => 'Dernière mise à jour';
@@ -617,12 +597,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get evUnknown => 'Inconnu';
 
   @override
-  String get evDataAttribution =>
-      'Données de OpenChargeMap (source communautaire)';
+  String get evDataAttribution => 'Données de OpenChargeMap (source communautaire)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Le statut peut ne pas refléter la disponibilité en temps réel. Appuyez sur actualiser pour obtenir les dernières données.';
+  String get evStatusDisclaimer => 'Le statut peut ne pas refléter la disponibilité en temps réel. Appuyez sur actualiser pour obtenir les dernières données.';
 
   @override
   String get evNavigateToStation => 'Naviguer vers la station';
@@ -634,8 +612,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get evStatusUpdated => 'Statut mis à jour';
 
   @override
-  String get evStationNotFound =>
-      'Impossible d\'actualiser — station introuvable à proximité';
+  String get evStationNotFound => 'Impossible d\'actualiser — station introuvable à proximité';
 
   @override
   String get addedToFavorites => 'Ajouté aux favoris';
@@ -656,8 +633,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get gpsError => 'Erreur GPS';
 
   @override
-  String get couldNotResolve =>
-      'Impossible de résoudre le départ ou la destination';
+  String get couldNotResolve => 'Impossible de résoudre le départ ou la destination';
 
   @override
   String get start => 'Départ';
@@ -705,8 +681,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Prix carburants (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Requis pour la recherche de prix de carburant en Allemagne';
+  String get requiredForFuelSearch => 'Requis pour la recherche de prix de carburant en Allemagne';
 
   @override
   String get evChargingOpenChargeMap => 'Recharge EV (OpenChargeMap)';
@@ -718,12 +693,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appDefaultKey => 'Clé par défaut de l\'app';
 
   @override
-  String get optionalOverrideKey =>
-      'Optionnel : remplacer la clé intégrée par la vôtre';
+  String get optionalOverrideKey => 'Optionnel : remplacer la clé intégrée par la vôtre';
 
   @override
-  String get requiredForEvSearch =>
-      'Requis pour la recherche de bornes de recharge';
+  String get requiredForEvSearch => 'Requis pour la recherche de bornes de recharge';
 
   @override
   String get edit => 'Modifier';
@@ -752,26 +725,22 @@ class AppLocalizationsFr extends AppLocalizations {
   String get avoidHighways => 'Éviter les autoroutes';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Le calcul d\'itinéraire évite les routes à péage et les autoroutes';
+  String get avoidHighwaysDesc => 'Le calcul d\'itinéraire évite les routes à péage et les autoroutes';
 
   @override
   String get showFuelStations => 'Afficher les stations-service';
 
   @override
-  String get showFuelStationsDesc =>
-      'Inclure les stations essence, diesel, GPL, GNC';
+  String get showFuelStationsDesc => 'Inclure les stations essence, diesel, GPL, GNC';
 
   @override
   String get showEvStations => 'Afficher les bornes de recharge';
 
   @override
-  String get showEvStationsDesc =>
-      'Inclure les bornes de recharge électrique dans les résultats';
+  String get showEvStationsDesc => 'Inclure les bornes de recharge électrique dans les résultats';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Aucune station trouvée le long de ce trajet.';
+  String get noStationsAlongThisRoute => 'Aucune station trouvée le long de ce trajet.';
 
   @override
   String get fuelCostCalculator => 'Calculateur de coût carburant';
@@ -795,8 +764,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get totalCost => 'Coût total';
 
   @override
-  String get enterCalcValues =>
-      'Saisissez la distance, la consommation et le prix pour calculer le coût du trajet';
+  String get enterCalcValues => 'Saisissez la distance, la consommation et le prix pour calculer le coût du trajet';
 
   @override
   String get priceHistory => 'Historique des prix';
@@ -838,19 +806,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get viewMyData => 'Voir mes données';
 
   @override
-  String get optionalCloudSync =>
-      'Synchronisation cloud optionnelle pour les alertes, favoris et notifications push';
+  String get optionalCloudSync => 'Synchronisation cloud optionnelle pour les alertes, favoris et notifications push';
 
   @override
   String get tapToUpdateGps => 'Appuyez pour mettre à jour la position GPS';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'La position GPS est acquise automatiquement lors de la recherche. Vous pouvez aussi la mettre à jour manuellement ici.';
+  String get gpsAutoUpdateHint => 'La position GPS est acquise automatiquement lors de la recherche. Vous pouvez aussi la mettre à jour manuellement ici.';
 
   @override
-  String get clearGpsConfirm =>
-      'Effacer la position GPS enregistrée ? Vous pourrez la mettre à jour à tout moment.';
+  String get clearGpsConfirm => 'Effacer la position GPS enregistrée ? Vous pourrez la mettre à jour à tout moment.';
 
   @override
   String get pageNotFound => 'Page introuvable';
@@ -859,8 +824,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteAllServerData => 'Supprimer toutes les données serveur';
 
   @override
-  String get deleteServerDataConfirm =>
-      'Supprimer toutes les données serveur ?';
+  String get deleteServerDataConfirm => 'Supprimer toutes les données serveur ?';
 
   @override
   String get deleteEverything => 'Tout supprimer';
@@ -935,8 +899,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noSavedRoutes => 'Aucun itinéraire enregistré';
 
   @override
-  String get noSavedRoutesHint =>
-      'Recherchez le long d\'un itinéraire et enregistrez-le pour un accès rapide.';
+  String get noSavedRoutesHint => 'Recherchez le long d\'un itinéraire et enregistrez-le pour un accès rapide.';
 
   @override
   String get saveRoute => 'Enregistrer l\'itinéraire';
@@ -961,8 +924,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteProfileTitle => 'Supprimer le profil ?';
 
   @override
-  String get deleteProfileBody =>
-      'Ce profil et ses paramètres seront définitivement supprimés. Cette action est irréversible.';
+  String get deleteProfileBody => 'Ce profil et ses paramètres seront définitivement supprimés. Cette action est irréversible.';
 
   @override
   String get deleteProfileConfirm => 'Supprimer le profil';
@@ -986,16 +948,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get errorLocation => 'Impossible de déterminer votre position.';
 
   @override
-  String get errorNoApiKey =>
-      'Aucune clé API configurée. Allez dans Paramètres.';
+  String get errorNoApiKey => 'Aucune clé API configurée. Allez dans Paramètres.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Impossible de charger les données. Vérifiez votre connexion.';
+  String get errorAllServicesFailed => 'Impossible de charger les données. Vérifiez votre connexion.';
 
   @override
-  String get errorCache =>
-      'Erreur de données locales. Essayez de vider le cache.';
+  String get errorCache => 'Erreur de données locales. Essayez de vider le cache.';
 
   @override
   String get errorCancelled => 'Requête annulée.';
@@ -1007,15 +966,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1066,44 +1023,37 @@ class AppLocalizationsFr extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1112,8 +1062,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1178,8 +1127,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1243,8 +1191,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1265,8 +1212,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1302,8 +1248,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1312,8 +1257,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1337,8 +1281,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1392,8 +1335,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1402,8 +1344,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1414,12 +1355,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1433,8 +1369,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get nearestStations => 'Stations les plus proches';
 
   @override
-  String get nearestStationsHint =>
-      'Trouver les stations les plus proches avec votre position actuelle';
+  String get nearestStationsHint => 'Trouver les stations les plus proches avec votre position actuelle';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1443,8 +1378,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1456,8 +1390,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1508,8 +1441,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1589,12 +1521,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1760,15 +1690,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get switchToEmail => 'Passer à l\'e-mail';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Conserver les données, se connecter depuis d\'autres appareils';
+  String get switchToEmailSubtitle => 'Conserver les données, se connecter depuis d\'autres appareils';
 
   @override
   String get switchToAnonymousAction => 'Passer en anonyme';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Conserver les données locales, nouvelle session anonyme';
+  String get switchToAnonymousSubtitle => 'Conserver les données locales, nouvelle session anonyme';
 
   @override
   String get linkDevice => 'Lier un appareil';
@@ -1780,22 +1708,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get disconnectAction => 'Déconnecter';
 
   @override
-  String get disconnectSubtitle =>
-      'Arrêter la synchronisation (données locales conservées)';
+  String get disconnectSubtitle => 'Arrêter la synchronisation (données locales conservées)';
 
   @override
   String get deleteAccountAction => 'Supprimer le compte';
 
   @override
-  String get deleteAccountSubtitle =>
-      'Supprimer définitivement toutes les données serveur';
+  String get deleteAccountSubtitle => 'Supprimer définitivement toutes les données serveur';
 
   @override
   String get localOnly => 'Local uniquement';
 
   @override
-  String get localOnlySubtitle =>
-      'Optionnel : synchroniser favoris, alertes et notes entre appareils';
+  String get localOnlySubtitle => 'Optionnel : synchroniser favoris, alertes et notes entre appareils';
 
   @override
   String get setupCloudSync => 'Configurer la synchronisation cloud';
@@ -1804,33 +1729,28 @@ class AppLocalizationsFr extends AppLocalizations {
   String get disconnectTitle => 'Déconnecter TankSync ?';
 
   @override
-  String get disconnectBody =>
-      'La synchronisation cloud sera désactivée. Vos données locales (favoris, alertes, historique) sont conservées sur cet appareil. Les données serveur ne sont pas supprimées.';
+  String get disconnectBody => 'La synchronisation cloud sera désactivée. Vos données locales (favoris, alertes, historique) sont conservées sur cet appareil. Les données serveur ne sont pas supprimées.';
 
   @override
   String get deleteAccountTitle => 'Supprimer le compte ?';
 
   @override
-  String get deleteAccountBody =>
-      'Toutes vos données seront définitivement supprimées du serveur (favoris, alertes, notes, itinéraires). Les données locales sur cet appareil sont conservées.\n\nCette action est irréversible.';
+  String get deleteAccountBody => 'Toutes vos données seront définitivement supprimées du serveur (favoris, alertes, notes, itinéraires). Les données locales sur cet appareil sont conservées.\n\nCette action est irréversible.';
 
   @override
   String get switchToAnonymousTitle => 'Passer en anonyme ?';
 
   @override
-  String get switchToAnonymousBody =>
-      'Vous serez déconnecté de votre compte e-mail et continuerez avec une nouvelle session anonyme.\n\nVos données locales (favoris, alertes) restent sur cet appareil et seront synchronisées avec le nouveau compte anonyme.';
+  String get switchToAnonymousBody => 'Vous serez déconnecté de votre compte e-mail et continuerez avec une nouvelle session anonyme.\n\nVos données locales (favoris, alertes) restent sur cet appareil et seront synchronisées avec le nouveau compte anonyme.';
 
   @override
   String get switchAction => 'Changer';
 
   @override
-  String get helpBannerCriteria =>
-      'Vos valeurs par défaut sont pré-remplies. Ajustez les critères ci-dessous pour affiner votre recherche.';
+  String get helpBannerCriteria => 'Vos valeurs par défaut sont pré-remplies. Ajustez les critères ci-dessous pour affiner votre recherche.';
 
   @override
-  String get helpBannerAlerts =>
-      'Définissez un seuil de prix pour une station. Vous serez notifié quand les prix passent en dessous. Vérification toutes les 30 minutes.';
+  String get helpBannerAlerts => 'Définissez un seuil de prix pour une station. Vous serez notifié quand les prix passent en dessous. Vérification toutes les 30 minutes.';
 
   @override
   String get syncNow => 'Synchroniser maintenant';
@@ -1839,23 +1759,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get onboardingPreferencesTitle => 'Vos préférences';
 
   @override
-  String get onboardingZipHelper =>
-      'Utilisé quand le GPS n\'est pas disponible';
+  String get onboardingZipHelper => 'Utilisé quand le GPS n\'est pas disponible';
 
   @override
   String get onboardingRadiusHelper => 'Rayon plus grand = plus de résultats';
 
   @override
-  String get onboardingPrivacy =>
-      'Ces paramètres sont stockés uniquement sur votre appareil et ne sont jamais partagés.';
+  String get onboardingPrivacy => 'Ces paramètres sont stockés uniquement sur votre appareil et ne sont jamais partagés.';
 
   @override
   String get onboardingLandingTitle => 'Écran d\'accueil';
 
   @override
-  String get onboardingLandingHint =>
-      'Choisissez l\'écran qui s\'ouvre au lancement de l\'application.';
+  String get onboardingLandingHint => 'Choisissez l\'écran qui s\'ouvre au lancement de l\'application.';
 
   @override
   String get scanReceipt => 'Scanner le reçu';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -103,8 +103,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get apiKeySetup => 'API ključ';
 
   @override
-  String get apiKeyDescription =>
-      'Registrirajte se jednom za besplatni API ključ.';
+  String get apiKeyDescription => 'Registrirajte se jednom za besplatni API ključ.';
 
   @override
   String get apiKeyLabel => 'API ključ';
@@ -173,8 +172,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get noFavorites => 'Nema favorita';
 
   @override
-  String get noFavoritesHint =>
-      'Dodirnite zvjezdicu na postaji da je spremite kao favorita.';
+  String get noFavoritesHint => 'Dodirnite zvjezdicu na postaji da je spremite kao favorita.';
 
   @override
   String get language => 'Jezik';
@@ -224,8 +222,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get gpsCoordinates => 'GPS koordinate';
 
   @override
-  String get gpsReason =>
-      'Šalju se sa svakom pretragom za pronalaženje obližnjih postaja.';
+  String get gpsReason => 'Šalju se sa svakom pretragom za pronalaženje obližnjih postaja.';
 
   @override
   String get postalCodeData => 'Poštanski broj';
@@ -237,15 +234,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get mapViewport => 'Prikaz karte';
 
   @override
-  String get mapReason =>
-      'Pločice karte učitavaju se s poslužitelja. Osobni podaci se ne prenose.';
+  String get mapReason => 'Pločice karte učitavaju se s poslužitelja. Osobni podaci se ne prenose.';
 
   @override
   String get apiKeyData => 'API ključ';
 
   @override
-  String get apiKeyReason =>
-      'Vaš osobni ključ šalje se sa svakim API zahtjevom. Povezan je s vašom e-poštom.';
+  String get apiKeyReason => 'Vaš osobni ključ šalje se sa svakim API zahtjevom. Povezan je s vašom e-poštom.';
 
   @override
   String get notShared => 'NE dijeli se:';
@@ -266,8 +261,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get usageData => 'Podaci o korištenju';
 
   @override
-  String get privacyBanner =>
-      'Ova aplikacija nema poslužitelj. Svi podaci ostaju na vašem uređaju. Bez analitike, praćenja ili reklama.';
+  String get privacyBanner => 'Ova aplikacija nema poslužitelj. Svi podaci ostaju na vašem uređaju. Bez analitike, praćenja ili reklama.';
 
   @override
   String get storageUsage => 'Korištenje pohrane na ovom uređaju';
@@ -291,8 +285,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get cacheManagement => 'Upravljanje predmemorijom';
 
   @override
-  String get cacheDescription =>
-      'Predmemorija pohranjuje API odgovore za brže učitavanje i offline pristup.';
+  String get cacheDescription => 'Predmemorija pohranjuje API odgovore za brže učitavanje i offline pristup.';
 
   @override
   String get stationSearch => 'Pretraživanje postaja';
@@ -320,8 +313,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get clearCacheTitle => 'Očistiti predmemoriju?';
 
   @override
-  String get clearCacheBody =>
-      'Predmemorirani rezultati pretrage i cijene bit će obrisani. Profili, favoriti i postavke su sačuvani.';
+  String get clearCacheBody => 'Predmemorirani rezultati pretrage i cijene bit će obrisani. Profili, favoriti i postavke su sačuvani.';
 
   @override
   String get clearCacheButton => 'Očisti predmemoriju';
@@ -330,8 +322,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleteAllTitle => 'Obrisati sve podatke?';
 
   @override
-  String get deleteAllBody =>
-      'Ovo trajno briše sve profile, favorite, API ključ, postavke i predmemoriju. Aplikacija će se resetirati.';
+  String get deleteAllBody => 'Ovo trajno briše sve profile, favorite, API ključ, postavke i predmemoriju. Aplikacija će se resetirati.';
 
   @override
   String get deleteAllButton => 'Obriši sve';
@@ -346,19 +337,16 @@ class AppLocalizationsHr extends AppLocalizations {
   String get noStorage => 'Nema korištene pohrane';
 
   @override
-  String get apiKeyNote =>
-      'Besplatna registracija. Podaci od vladinih agencija za transparentnost cijena.';
+  String get apiKeyNote => 'Besplatna registracija. Podaci od vladinih agencija za transparentnost cijena.';
 
   @override
-  String get apiKeyFormatError =>
-      'Nevažeći format — očekivan UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Nevažeći format — očekivan UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Podržite ovaj projekt';
 
   @override
-  String get supportDescription =>
-      'Ova aplikacija je besplatna, otvorenog koda i bez reklama. Ako je smatrate korisnom, razmislite o podršci razvojnom programeru.';
+  String get supportDescription => 'Ova aplikacija je besplatna, otvorenog koda i bez reklama. Ako je smatrate korisnom, razmislite o podršci razvojnom programeru.';
 
   @override
   String get reportBug => 'Prijavi grešku / Predloži značajku';
@@ -394,12 +382,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get station => 'Benzinska postaja';
 
   @override
-  String get locationDenied =>
-      'Dopuštenje lokacije odbijeno. Možete pretraživati po poštanskom broju.';
+  String get locationDenied => 'Dopuštenje lokacije odbijeno. Možete pretraživati po poštanskom broju.';
 
   @override
-  String get demoModeBanner =>
-      'Demo način. Konfigurirajte API ključ u postavkama.';
+  String get demoModeBanner => 'Demo način. Konfigurirajte API ključ u postavkama.';
 
   @override
   String get sortDistance => 'Udaljenost';
@@ -425,8 +411,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Učitavanje favorita...\nNajprije pretražite postaje za spremanje podataka.';
+  String get loadingFavorites => 'Učitavanje favorita...\nNajprije pretražite postaje za spremanje podataka.';
 
   @override
   String get reportPrice => 'Prijavi cijenu';
@@ -462,8 +447,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get autoUpdatePosition => 'Automatsko ažuriranje pozicije';
 
   @override
-  String get autoUpdateDescription =>
-      'Ažuriraj GPS poziciju prije svake pretrage';
+  String get autoUpdateDescription => 'Ažuriraj GPS poziciju prije svake pretrage';
 
   @override
   String get location => 'Lokacija';
@@ -493,8 +477,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get autoSwitchProfile => 'Automatska promjena profila';
 
   @override
-  String get autoSwitchDescription =>
-      'Automatski promijeni profil pri prelasku granice';
+  String get autoSwitchDescription => 'Automatski promijeni profil pri prelasku granice';
 
   @override
   String get switchProfile => 'Prebaci';
@@ -521,8 +504,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get noPriceAlerts => 'Nema cjenovnih obavijesti';
 
   @override
-  String get noPriceAlertsHint =>
-      'Izradite obavijest sa stranice detalja postaje.';
+  String get noPriceAlertsHint => 'Izradite obavijest sa stranice detalja postaje.';
 
   @override
   String alertDeleted(String name) {
@@ -618,8 +600,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get evDataAttribution => 'Podaci iz OpenChargeMap (izvor zajednice)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Status možda ne odražava dostupnost u stvarnom vremenu. Dodirnite osvježi za najnovije podatke.';
+  String get evStatusDisclaimer => 'Status možda ne odražava dostupnost u stvarnom vremenu. Dodirnite osvježi za najnovije podatke.';
 
   @override
   String get evNavigateToStation => 'Navigiraj do postaje';
@@ -631,8 +612,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get evStatusUpdated => 'Status ažuriran';
 
   @override
-  String get evStationNotFound =>
-      'Nije moguće osvježiti — postaja nije pronađena u blizini';
+  String get evStationNotFound => 'Nije moguće osvježiti — postaja nije pronađena u blizini';
 
   @override
   String get addedToFavorites => 'Dodano u favorite';
@@ -701,8 +681,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Cijene goriva (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Potrebno za pretraživanje cijena goriva u Njemačkoj';
+  String get requiredForFuelSearch => 'Potrebno za pretraživanje cijena goriva u Njemačkoj';
 
   @override
   String get evChargingOpenChargeMap => 'EV punjenje (OpenChargeMap)';
@@ -714,12 +693,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get appDefaultKey => 'Zadani ključ aplikacije';
 
   @override
-  String get optionalOverrideKey =>
-      'Neobavezno: zamijenite ugrađeni ključ svojim vlastitim';
+  String get optionalOverrideKey => 'Neobavezno: zamijenite ugrađeni ključ svojim vlastitim';
 
   @override
-  String get requiredForEvSearch =>
-      'Potrebno za pretraživanje EV stanica za punjenje';
+  String get requiredForEvSearch => 'Potrebno za pretraživanje EV stanica za punjenje';
 
   @override
   String get edit => 'Uredi';
@@ -748,8 +725,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get avoidHighways => 'Izbjegavaj autoceste';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Izračun rute izbjegava cestarine i autoceste';
+  String get avoidHighwaysDesc => 'Izračun rute izbjegava cestarine i autoceste';
 
   @override
   String get showFuelStations => 'Prikaži benzinske postaje';
@@ -761,8 +737,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showEvStations => 'Prikaži stanice za punjenje';
 
   @override
-  String get showEvStationsDesc =>
-      'Uključi električne stanice za punjenje u rezultatima';
+  String get showEvStationsDesc => 'Uključi električne stanice za punjenje u rezultatima';
 
   @override
   String get noStationsAlongThisRoute => 'Nisu pronađene postaje duž ove rute.';
@@ -789,8 +764,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get totalCost => 'Ukupni trošak';
 
   @override
-  String get enterCalcValues =>
-      'Unesite udaljenost, potrošnju i cijenu za izračun troška putovanja';
+  String get enterCalcValues => 'Unesite udaljenost, potrošnju i cijenu za izračun troška putovanja';
 
   @override
   String get priceHistory => 'Povijest cijena';
@@ -832,19 +806,16 @@ class AppLocalizationsHr extends AppLocalizations {
   String get viewMyData => 'Pogledaj moje podatke';
 
   @override
-  String get optionalCloudSync =>
-      'Neobavezna sinkronizacija u oblaku za obavijesti, favorite i push obavijesti';
+  String get optionalCloudSync => 'Neobavezna sinkronizacija u oblaku za obavijesti, favorite i push obavijesti';
 
   @override
   String get tapToUpdateGps => 'Dodirnite za ažuriranje GPS pozicije';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS pozicija se automatski dobiva pri pretrazi. Možete je ažurirati i ručno ovdje.';
+  String get gpsAutoUpdateHint => 'GPS pozicija se automatski dobiva pri pretrazi. Možete je ažurirati i ručno ovdje.';
 
   @override
-  String get clearGpsConfirm =>
-      'Obrisati spremljenu GPS poziciju? Možete je ažurirati ponovno u bilo kojem trenutku.';
+  String get clearGpsConfirm => 'Obrisati spremljenu GPS poziciju? Možete je ažurirati ponovno u bilo kojem trenutku.';
 
   @override
   String get pageNotFound => 'Stranica nije pronađena';
@@ -928,8 +899,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -954,8 +924,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -979,12 +948,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -999,15 +966,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1058,44 +1023,37 @@ class AppLocalizationsHr extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1104,8 +1062,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1170,8 +1127,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1235,8 +1191,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1257,8 +1212,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1294,8 +1248,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1304,8 +1257,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1329,8 +1281,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1384,8 +1335,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1394,8 +1344,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1406,12 +1355,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1425,8 +1369,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get nearestStations => 'Najblize postaje';
 
   @override
-  String get nearestStationsHint =>
-      'Pronadite najblize postaje pomocu vase trenutne lokacije';
+  String get nearestStationsHint => 'Pronadite najblize postaje pomocu vase trenutne lokacije';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1435,8 +1378,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1448,8 +1390,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1500,8 +1441,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1581,12 +1521,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1752,15 +1690,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1784,8 +1720,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1794,33 +1729,28 @@ class AppLocalizationsHr extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1835,16 +1765,17 @@ class AppLocalizationsHr extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -103,8 +103,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get apiKeySetup => 'API-kulcs';
 
   @override
-  String get apiKeyDescription =>
-      'Regisztráljon egyszer egy ingyenes API-kulcsért.';
+  String get apiKeyDescription => 'Regisztráljon egyszer egy ingyenes API-kulcsért.';
 
   @override
   String get apiKeyLabel => 'API-kulcs';
@@ -119,8 +118,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get welcome => 'Üzemanyagárak';
 
   @override
-  String get welcomeSubtitle =>
-      'Találja meg a legolcsóbb üzemanyagot a közelben.';
+  String get welcomeSubtitle => 'Találja meg a legolcsóbb üzemanyagot a közelben.';
 
   @override
   String get profileName => 'Profil neve';
@@ -174,8 +172,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noFavorites => 'Nincsenek kedvencek';
 
   @override
-  String get noFavoritesHint =>
-      'Érintse meg a csillagot egy kútnál a kedvencekhez adáshoz.';
+  String get noFavoritesHint => 'Érintse meg a csillagot egy kútnál a kedvencekhez adáshoz.';
 
   @override
   String get language => 'Nyelv';
@@ -225,29 +222,25 @@ class AppLocalizationsHu extends AppLocalizations {
   String get gpsCoordinates => 'GPS-koordináták';
 
   @override
-  String get gpsReason =>
-      'Minden kereséssel elküldve a közeli kutak megtalálásához.';
+  String get gpsReason => 'Minden kereséssel elküldve a közeli kutak megtalálásához.';
 
   @override
   String get postalCodeData => 'Irányítószám';
 
   @override
-  String get postalReason =>
-      'Koordinátákká alakítva a geokódolási szolgáltatáson keresztül.';
+  String get postalReason => 'Koordinátákká alakítva a geokódolási szolgáltatáson keresztül.';
 
   @override
   String get mapViewport => 'Térképnézet';
 
   @override
-  String get mapReason =>
-      'A térképcsempék a szerverről töltődnek be. Személyes adatok nem kerülnek továbbításra.';
+  String get mapReason => 'A térképcsempék a szerverről töltődnek be. Személyes adatok nem kerülnek továbbításra.';
 
   @override
   String get apiKeyData => 'API-kulcs';
 
   @override
-  String get apiKeyReason =>
-      'Személyes kulcsa minden API-kéréssel elküldésre kerül. Az e-mail címéhez van kötve.';
+  String get apiKeyReason => 'Személyes kulcsa minden API-kéréssel elküldésre kerül. Az e-mail címéhez van kötve.';
 
   @override
   String get notShared => 'NEM kerül megosztásra:';
@@ -268,8 +261,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get usageData => 'Használati adatok';
 
   @override
-  String get privacyBanner =>
-      'Ennek az alkalmazásnak nincs szervere. Minden adat az eszközén marad. Nincs elemzés, nyomon követés vagy hirdetés.';
+  String get privacyBanner => 'Ennek az alkalmazásnak nincs szervere. Minden adat az eszközén marad. Nincs elemzés, nyomon követés vagy hirdetés.';
 
   @override
   String get storageUsage => 'Tárhelyhasználat ezen az eszközön';
@@ -293,8 +285,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get cacheManagement => 'Gyorsítótár kezelése';
 
   @override
-  String get cacheDescription =>
-      'A gyorsítótár API-válaszokat tárol a gyorsabb betöltés és offline hozzáférés érdekében.';
+  String get cacheDescription => 'A gyorsítótár API-válaszokat tárol a gyorsabb betöltés és offline hozzáférés érdekében.';
 
   @override
   String get stationSearch => 'Kútkeresés';
@@ -322,8 +313,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get clearCacheTitle => 'Gyorsítótár törlése?';
 
   @override
-  String get clearCacheBody =>
-      'A tárolt keresési eredmények és árak törlődnek. A profilok, kedvencek és beállítások megmaradnak.';
+  String get clearCacheBody => 'A tárolt keresési eredmények és árak törlődnek. A profilok, kedvencek és beállítások megmaradnak.';
 
   @override
   String get clearCacheButton => 'Gyorsítótár törlése';
@@ -332,8 +322,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleteAllTitle => 'Összes adat törlése?';
 
   @override
-  String get deleteAllBody =>
-      'Ez véglegesen törli az összes profilt, kedvencet, API-kulcsot, beállítást és gyorsítótárat. Az alkalmazás visszaáll.';
+  String get deleteAllBody => 'Ez véglegesen törli az összes profilt, kedvencet, API-kulcsot, beállítást és gyorsítótárat. Az alkalmazás visszaáll.';
 
   @override
   String get deleteAllButton => 'Mindent töröl';
@@ -348,19 +337,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noStorage => 'Nincs felhasznált tárhely';
 
   @override
-  String get apiKeyNote =>
-      'Ingyenes regisztráció. Adatok a kormányzati ártranszparencia-ügynökségektől.';
+  String get apiKeyNote => 'Ingyenes regisztráció. Adatok a kormányzati ártranszparencia-ügynökségektől.';
 
   @override
-  String get apiKeyFormatError =>
-      'Érvénytelen formátum — UUID elvárva (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Érvénytelen formátum — UUID elvárva (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Támogassa a projektet';
 
   @override
-  String get supportDescription =>
-      'Ez az alkalmazás ingyenes, nyílt forráskódú és reklámmentes. Ha hasznosnak találja, fontolja meg a fejlesztő támogatását.';
+  String get supportDescription => 'Ez az alkalmazás ingyenes, nyílt forráskódú és reklámmentes. Ha hasznosnak találja, fontolja meg a fejlesztő támogatását.';
 
   @override
   String get reportBug => 'Hiba bejelentése / Funkció javaslata';
@@ -396,12 +382,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get station => 'Benzinkút';
 
   @override
-  String get locationDenied =>
-      'Helymeghatározás megtagadva. Irányítószám alapján kereshet.';
+  String get locationDenied => 'Helymeghatározás megtagadva. Irányítószám alapján kereshet.';
 
   @override
-  String get demoModeBanner =>
-      'Demó mód. Állítsa be az API-kulcsot a beállításokban.';
+  String get demoModeBanner => 'Demó mód. Állítsa be az API-kulcsot a beállításokban.';
 
   @override
   String get sortDistance => 'Távolság';
@@ -427,8 +411,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Kedvencek betöltése...\nElőször keressen kutakat az adatok mentéséhez.';
+  String get loadingFavorites => 'Kedvencek betöltése...\nElőször keressen kutakat az adatok mentéséhez.';
 
   @override
   String get reportPrice => 'Ár bejelentése';
@@ -464,8 +447,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get autoUpdatePosition => 'Pozíció automatikus frissítése';
 
   @override
-  String get autoUpdateDescription =>
-      'GPS-pozíció frissítése minden keresés előtt';
+  String get autoUpdateDescription => 'GPS-pozíció frissítése minden keresés előtt';
 
   @override
   String get location => 'Helyzet';
@@ -495,8 +477,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get autoSwitchProfile => 'Automatikus profilváltás';
 
   @override
-  String get autoSwitchDescription =>
-      'Profil automatikus váltása határátlépéskor';
+  String get autoSwitchDescription => 'Profil automatikus váltása határátlépéskor';
 
   @override
   String get switchProfile => 'Váltás';
@@ -523,8 +504,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noPriceAlerts => 'Nincsenek ár riasztások';
 
   @override
-  String get noPriceAlertsHint =>
-      'Hozzon létre riasztást egy kút részletes oldalán.';
+  String get noPriceAlertsHint => 'Hozzon létre riasztást egy kút részletes oldalán.';
 
   @override
   String alertDeleted(String name) {
@@ -588,8 +568,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get openInMaps => 'Megnyitás Térképben';
 
   @override
-  String get noStationsAlongRoute =>
-      'Nem találhatók állomások az útvonal mentén';
+  String get noStationsAlongRoute => 'Nem találhatók állomások az útvonal mentén';
 
   @override
   String get evOperational => 'Üzemel';
@@ -618,12 +597,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get evUnknown => 'Ismeretlen';
 
   @override
-  String get evDataAttribution =>
-      'Adatok az OpenChargeMap-ból (közösségi forrás)';
+  String get evDataAttribution => 'Adatok az OpenChargeMap-ból (közösségi forrás)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Az állapot nem feltétlenül tükrözi a valós idejű elérhetőséget. Érintse meg a frissítést a legújabb adatokhoz.';
+  String get evStatusDisclaimer => 'Az állapot nem feltétlenül tükrözi a valós idejű elérhetőséget. Érintse meg a frissítést a legújabb adatokhoz.';
 
   @override
   String get evNavigateToStation => 'Navigálás az állomáshoz';
@@ -635,8 +612,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get evStatusUpdated => 'Állapot frissítve';
 
   @override
-  String get evStationNotFound =>
-      'Nem sikerült frissíteni — állomás nem található a közelben';
+  String get evStationNotFound => 'Nem sikerült frissíteni — állomás nem található a közelben';
 
   @override
   String get addedToFavorites => 'Hozzáadva a kedvencekhez';
@@ -657,8 +633,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get gpsError => 'GPS hiba';
 
   @override
-  String get couldNotResolve =>
-      'Nem sikerült feloldani a kiindulást vagy a célt';
+  String get couldNotResolve => 'Nem sikerült feloldani a kiindulást vagy a célt';
 
   @override
   String get start => 'Indulás';
@@ -706,8 +681,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Üzemanyagárak (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Szükséges az üzemanyag-árkereséshez Németországban';
+  String get requiredForFuelSearch => 'Szükséges az üzemanyag-árkereséshez Németországban';
 
   @override
   String get evChargingOpenChargeMap => 'EV töltés (OpenChargeMap)';
@@ -719,8 +693,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get appDefaultKey => 'Alkalmazás alapértelmezett kulcsa';
 
   @override
-  String get optionalOverrideKey =>
-      'Opcionális: a beépített alkalmazáskulcs felülírása sajáttal';
+  String get optionalOverrideKey => 'Opcionális: a beépített alkalmazáskulcs felülírása sajáttal';
 
   @override
   String get requiredForEvSearch => 'Szükséges az EV töltőállomás kereséséhez';
@@ -752,8 +725,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get avoidHighways => 'Autópályák elkerülése';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Az útvonaltervezés elkerüli a fizetős utakat és autópályákat';
+  String get avoidHighwaysDesc => 'Az útvonaltervezés elkerüli a fizetős utakat és autópályákat';
 
   @override
   String get showFuelStations => 'Benzinkutak mutatása';
@@ -765,12 +737,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get showEvStations => 'Töltőállomások mutatása';
 
   @override
-  String get showEvStationsDesc =>
-      'Elektromos töltőállomások bevonása a keresési eredményekbe';
+  String get showEvStationsDesc => 'Elektromos töltőállomások bevonása a keresési eredményekbe';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Nem találhatók állomások ezen útvonal mentén.';
+  String get noStationsAlongThisRoute => 'Nem találhatók állomások ezen útvonal mentén.';
 
   @override
   String get fuelCostCalculator => 'Üzemanyagköltség-kalkulátor';
@@ -794,8 +764,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get totalCost => 'Összköltség';
 
   @override
-  String get enterCalcValues =>
-      'Adja meg a távolságot, fogyasztást és árat az útköltség kiszámításához';
+  String get enterCalcValues => 'Adja meg a távolságot, fogyasztást és árat az útköltség kiszámításához';
 
   @override
   String get priceHistory => 'Ártörténet';
@@ -837,19 +806,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get viewMyData => 'Adataim megtekintése';
 
   @override
-  String get optionalCloudSync =>
-      'Opcionális felhőszinkronizálás riasztásokhoz, kedvencekhez és push értesítésekhez';
+  String get optionalCloudSync => 'Opcionális felhőszinkronizálás riasztásokhoz, kedvencekhez és push értesítésekhez';
 
   @override
   String get tapToUpdateGps => 'Érintse meg a GPS-pozíció frissítéséhez';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'A GPS-pozíció automatikusan lekérdezésre kerül kereséskor. Itt manuálisan is frissítheti.';
+  String get gpsAutoUpdateHint => 'A GPS-pozíció automatikusan lekérdezésre kerül kereséskor. Itt manuálisan is frissítheti.';
 
   @override
-  String get clearGpsConfirm =>
-      'Tárolt GPS-pozíció törlése? Bármikor frissítheti újra.';
+  String get clearGpsConfirm => 'Tárolt GPS-pozíció törlése? Bármikor frissítheti újra.';
 
   @override
   String get pageNotFound => 'Az oldal nem található';
@@ -933,8 +899,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -959,8 +924,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -984,12 +948,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1004,15 +966,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1063,44 +1023,37 @@ class AppLocalizationsHu extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1109,8 +1062,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1175,8 +1127,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1240,8 +1191,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1262,8 +1212,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1299,8 +1248,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1309,8 +1257,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1334,8 +1281,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1389,8 +1335,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1399,8 +1344,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1411,12 +1355,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1430,8 +1369,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get nearestStations => 'Legkozelebbi kutjak';
 
   @override
-  String get nearestStationsHint =>
-      'Talalja meg a legkozelebbi kutjakat a jelenlegi helyzete alapjan';
+  String get nearestStationsHint => 'Talalja meg a legkozelebbi kutjakat a jelenlegi helyzete alapjan';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1440,8 +1378,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1453,8 +1390,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1505,8 +1441,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1586,12 +1521,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1757,15 +1690,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1789,8 +1720,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1799,33 +1729,28 @@ class AppLocalizationsHu extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1840,16 +1765,17 @@ class AppLocalizationsHu extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -103,8 +103,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get apiKeySetup => 'Chiave API';
 
   @override
-  String get apiKeyDescription =>
-      'Registrati una volta per ottenere una chiave API gratuita.';
+  String get apiKeyDescription => 'Registrati una volta per ottenere una chiave API gratuita.';
 
   @override
   String get apiKeyLabel => 'Chiave API';
@@ -119,8 +118,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get welcome => 'Prezzi Carburanti';
 
   @override
-  String get welcomeSubtitle =>
-      'Trova il carburante più economico vicino a te.';
+  String get welcomeSubtitle => 'Trova il carburante più economico vicino a te.';
 
   @override
   String get profileName => 'Nome profilo';
@@ -174,8 +172,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noFavorites => 'Nessun preferito';
 
   @override
-  String get noFavoritesHint =>
-      'Tocca la stella di una stazione per aggiungerla ai preferiti.';
+  String get noFavoritesHint => 'Tocca la stella di una stazione per aggiungerla ai preferiti.';
 
   @override
   String get language => 'Lingua';
@@ -225,29 +222,25 @@ class AppLocalizationsIt extends AppLocalizations {
   String get gpsCoordinates => 'Coordinate GPS';
 
   @override
-  String get gpsReason =>
-      'Inviate a ogni ricerca per trovare le stazioni vicine.';
+  String get gpsReason => 'Inviate a ogni ricerca per trovare le stazioni vicine.';
 
   @override
   String get postalCodeData => 'Codice postale';
 
   @override
-  String get postalReason =>
-      'Convertito in coordinate tramite il servizio di geocodifica.';
+  String get postalReason => 'Convertito in coordinate tramite il servizio di geocodifica.';
 
   @override
   String get mapViewport => 'Area della mappa';
 
   @override
-  String get mapReason =>
-      'Le mappe vengono caricate dal server. Nessun dato personale viene trasmesso.';
+  String get mapReason => 'Le mappe vengono caricate dal server. Nessun dato personale viene trasmesso.';
 
   @override
   String get apiKeyData => 'Chiave API';
 
   @override
-  String get apiKeyReason =>
-      'La tua chiave personale viene inviata con ogni richiesta API. È collegata alla tua email.';
+  String get apiKeyReason => 'La tua chiave personale viene inviata con ogni richiesta API. È collegata alla tua email.';
 
   @override
   String get notShared => 'NON condiviso:';
@@ -268,8 +261,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get usageData => 'Dati di utilizzo';
 
   @override
-  String get privacyBanner =>
-      'Questa app non ha un server. Tutti i dati restano sul tuo dispositivo. Nessuna analisi, nessun tracciamento, nessuna pubblicità.';
+  String get privacyBanner => 'Questa app non ha un server. Tutti i dati restano sul tuo dispositivo. Nessuna analisi, nessun tracciamento, nessuna pubblicità.';
 
   @override
   String get storageUsage => 'Utilizzo dello spazio su questo dispositivo';
@@ -293,8 +285,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cacheManagement => 'Gestione cache';
 
   @override
-  String get cacheDescription =>
-      'La cache memorizza le risposte API per un caricamento più veloce e l\'accesso offline.';
+  String get cacheDescription => 'La cache memorizza le risposte API per un caricamento più veloce e l\'accesso offline.';
 
   @override
   String get stationSearch => 'Ricerca stazioni';
@@ -322,8 +313,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get clearCacheTitle => 'Svuotare la cache?';
 
   @override
-  String get clearCacheBody =>
-      'I risultati di ricerca e i prezzi memorizzati verranno eliminati. Profili, preferiti e impostazioni vengono conservati.';
+  String get clearCacheBody => 'I risultati di ricerca e i prezzi memorizzati verranno eliminati. Profili, preferiti e impostazioni vengono conservati.';
 
   @override
   String get clearCacheButton => 'Svuota cache';
@@ -332,8 +322,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteAllTitle => 'Eliminare tutti i dati?';
 
   @override
-  String get deleteAllBody =>
-      'Questo elimina definitivamente tutti i profili, i preferiti, la chiave API, le impostazioni e la cache. L\'app verrà reimpostata.';
+  String get deleteAllBody => 'Questo elimina definitivamente tutti i profili, i preferiti, la chiave API, le impostazioni e la cache. L\'app verrà reimpostata.';
 
   @override
   String get deleteAllButton => 'Elimina tutto';
@@ -348,19 +337,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noStorage => 'Nessuno spazio utilizzato';
 
   @override
-  String get apiKeyNote =>
-      'Registrazione gratuita. Dati dalle agenzie governative per la trasparenza dei prezzi.';
+  String get apiKeyNote => 'Registrazione gratuita. Dati dalle agenzie governative per la trasparenza dei prezzi.';
 
   @override
-  String get apiKeyFormatError =>
-      'Formato non valido — UUID previsto (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Formato non valido — UUID previsto (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Supporta questo progetto';
 
   @override
-  String get supportDescription =>
-      'Questa app è gratuita, open source e senza pubblicità. Se la trovi utile, considera di supportare lo sviluppatore.';
+  String get supportDescription => 'Questa app è gratuita, open source e senza pubblicità. Se la trovi utile, considera di supportare lo sviluppatore.';
 
   @override
   String get reportBug => 'Segnala un bug / Suggerisci una funzione';
@@ -396,12 +382,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get station => 'Stazione';
 
   @override
-  String get locationDenied =>
-      'Permesso di localizzazione negato. Puoi cercare per codice postale.';
+  String get locationDenied => 'Permesso di localizzazione negato. Puoi cercare per codice postale.';
 
   @override
-  String get demoModeBanner =>
-      'Modalità demo. Configura la chiave API nelle impostazioni.';
+  String get demoModeBanner => 'Modalità demo. Configura la chiave API nelle impostazioni.';
 
   @override
   String get sortDistance => 'Distanza';
@@ -427,8 +411,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Caricamento preferiti...\nCerca prima le stazioni per salvare i dati.';
+  String get loadingFavorites => 'Caricamento preferiti...\nCerca prima le stazioni per salvare i dati.';
 
   @override
   String get reportPrice => 'Segnala prezzo';
@@ -494,8 +477,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoSwitchProfile => 'Cambio automatico profilo';
 
   @override
-  String get autoSwitchDescription =>
-      'Cambia profilo automaticamente attraversando i confini';
+  String get autoSwitchDescription => 'Cambia profilo automaticamente attraversando i confini';
 
   @override
   String get switchProfile => 'Cambia';
@@ -522,8 +504,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noPriceAlerts => 'Nessun avviso prezzo';
 
   @override
-  String get noPriceAlertsHint =>
-      'Crea un avviso dalla pagina dettaglio di una stazione.';
+  String get noPriceAlertsHint => 'Crea un avviso dalla pagina dettaglio di una stazione.';
 
   @override
   String alertDeleted(String name) {
@@ -587,8 +568,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get openInMaps => 'Apri in Mappe';
 
   @override
-  String get noStationsAlongRoute =>
-      'Nessuna stazione trovata lungo il percorso';
+  String get noStationsAlongRoute => 'Nessuna stazione trovata lungo il percorso';
 
   @override
   String get evOperational => 'Operativa';
@@ -620,8 +600,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get evDataAttribution => 'Dati da OpenChargeMap (fonte comunitaria)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Lo stato potrebbe non riflettere la disponibilità in tempo reale. Tocca aggiorna per ottenere i dati più recenti.';
+  String get evStatusDisclaimer => 'Lo stato potrebbe non riflettere la disponibilità in tempo reale. Tocca aggiorna per ottenere i dati più recenti.';
 
   @override
   String get evNavigateToStation => 'Naviga verso la stazione';
@@ -633,8 +612,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get evStatusUpdated => 'Stato aggiornato';
 
   @override
-  String get evStationNotFound =>
-      'Impossibile aggiornare — stazione non trovata nelle vicinanze';
+  String get evStationNotFound => 'Impossibile aggiornare — stazione non trovata nelle vicinanze';
 
   @override
   String get addedToFavorites => 'Aggiunto ai preferiti';
@@ -703,8 +681,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Prezzi carburanti (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Necessario per la ricerca prezzi carburanti in Germania';
+  String get requiredForFuelSearch => 'Necessario per la ricerca prezzi carburanti in Germania';
 
   @override
   String get evChargingOpenChargeMap => 'Ricarica EV (OpenChargeMap)';
@@ -716,12 +693,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get appDefaultKey => 'Chiave predefinita dell\'app';
 
   @override
-  String get optionalOverrideKey =>
-      'Facoltativo: sostituire la chiave integrata con la propria';
+  String get optionalOverrideKey => 'Facoltativo: sostituire la chiave integrata con la propria';
 
   @override
-  String get requiredForEvSearch =>
-      'Necessario per la ricerca di stazioni di ricarica EV';
+  String get requiredForEvSearch => 'Necessario per la ricerca di stazioni di ricarica EV';
 
   @override
   String get edit => 'Modifica';
@@ -750,26 +725,22 @@ class AppLocalizationsIt extends AppLocalizations {
   String get avoidHighways => 'Evita autostrade';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Il calcolo del percorso evita strade a pedaggio e autostrade';
+  String get avoidHighwaysDesc => 'Il calcolo del percorso evita strade a pedaggio e autostrade';
 
   @override
   String get showFuelStations => 'Mostra distributori';
 
   @override
-  String get showFuelStationsDesc =>
-      'Includi stazioni benzina, diesel, GPL, metano';
+  String get showFuelStationsDesc => 'Includi stazioni benzina, diesel, GPL, metano';
 
   @override
   String get showEvStations => 'Mostra stazioni di ricarica';
 
   @override
-  String get showEvStationsDesc =>
-      'Includi stazioni di ricarica elettrica nei risultati';
+  String get showEvStationsDesc => 'Includi stazioni di ricarica elettrica nei risultati';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Nessuna stazione trovata lungo questo percorso.';
+  String get noStationsAlongThisRoute => 'Nessuna stazione trovata lungo questo percorso.';
 
   @override
   String get fuelCostCalculator => 'Calcolatore costi carburante';
@@ -793,8 +764,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get totalCost => 'Costo totale';
 
   @override
-  String get enterCalcValues =>
-      'Inserisci distanza, consumo e prezzo per calcolare il costo del viaggio';
+  String get enterCalcValues => 'Inserisci distanza, consumo e prezzo per calcolare il costo del viaggio';
 
   @override
   String get priceHistory => 'Storico prezzi';
@@ -836,19 +806,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get viewMyData => 'Visualizza i miei dati';
 
   @override
-  String get optionalCloudSync =>
-      'Sincronizzazione cloud opzionale per avvisi, preferiti e notifiche push';
+  String get optionalCloudSync => 'Sincronizzazione cloud opzionale per avvisi, preferiti e notifiche push';
 
   @override
   String get tapToUpdateGps => 'Tocca per aggiornare la posizione GPS';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'La posizione GPS viene acquisita automaticamente durante la ricerca. Puoi aggiornarla manualmente qui.';
+  String get gpsAutoUpdateHint => 'La posizione GPS viene acquisita automaticamente durante la ricerca. Puoi aggiornarla manualmente qui.';
 
   @override
-  String get clearGpsConfirm =>
-      'Cancellare la posizione GPS memorizzata? Puoi aggiornarla in qualsiasi momento.';
+  String get clearGpsConfirm => 'Cancellare la posizione GPS memorizzata? Puoi aggiornarla in qualsiasi momento.';
 
   @override
   String get pageNotFound => 'Pagina non trovata';
@@ -932,8 +899,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noSavedRoutes => 'Nessun percorso salvato';
 
   @override
-  String get noSavedRoutesHint =>
-      'Cerca lungo un percorso e salvalo per un accesso rapido.';
+  String get noSavedRoutesHint => 'Cerca lungo un percorso e salvalo per un accesso rapido.';
 
   @override
   String get saveRoute => 'Salva percorso';
@@ -958,8 +924,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -983,12 +948,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1003,15 +966,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1062,44 +1023,37 @@ class AppLocalizationsIt extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1108,8 +1062,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1174,8 +1127,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1239,8 +1191,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1261,8 +1212,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1298,8 +1248,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1308,8 +1257,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1333,8 +1281,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1388,8 +1335,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1398,8 +1344,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1410,12 +1355,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1429,8 +1369,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get nearestStations => 'Stazioni piu vicine';
 
   @override
-  String get nearestStationsHint =>
-      'Trova le stazioni piu vicine con la tua posizione attuale';
+  String get nearestStationsHint => 'Trova le stazioni piu vicine con la tua posizione attuale';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1439,8 +1378,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1452,8 +1390,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1504,8 +1441,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1585,12 +1521,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1756,15 +1690,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1788,8 +1720,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1798,33 +1729,28 @@ class AppLocalizationsIt extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1839,16 +1765,17 @@ class AppLocalizationsIt extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -103,8 +103,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get apiKeySetup => 'API raktas';
 
   @override
-  String get apiKeyDescription =>
-      'Užsiregistruokite vieną kartą nemokamam API raktui gauti.';
+  String get apiKeyDescription => 'Užsiregistruokite vieną kartą nemokamam API raktui gauti.';
 
   @override
   String get apiKeyLabel => 'API raktas';
@@ -173,8 +172,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noFavorites => 'Nėra mėgstamų';
 
   @override
-  String get noFavoritesHint =>
-      'Bakstelėkite žvaigždutę prie degalinės, kad ją išsaugotumėte kaip mėgstamą.';
+  String get noFavoritesHint => 'Bakstelėkite žvaigždutę prie degalinės, kad ją išsaugotumėte kaip mėgstamą.';
 
   @override
   String get language => 'Kalba';
@@ -224,29 +222,25 @@ class AppLocalizationsLt extends AppLocalizations {
   String get gpsCoordinates => 'GPS koordinatės';
 
   @override
-  String get gpsReason =>
-      'Siunčiamos su kiekviena paieška netoliese esančių stočių radimui.';
+  String get gpsReason => 'Siunčiamos su kiekviena paieška netoliese esančių stočių radimui.';
 
   @override
   String get postalCodeData => 'Pašto kodas';
 
   @override
-  String get postalReason =>
-      'Konvertuojamas į koordinates per geokodavimo paslaugą.';
+  String get postalReason => 'Konvertuojamas į koordinates per geokodavimo paslaugą.';
 
   @override
   String get mapViewport => 'Žemėlapio vaizdas';
 
   @override
-  String get mapReason =>
-      'Žemėlapio plytelės įkeliamos iš serverio. Asmeniniai duomenys neperduodami.';
+  String get mapReason => 'Žemėlapio plytelės įkeliamos iš serverio. Asmeniniai duomenys neperduodami.';
 
   @override
   String get apiKeyData => 'API raktas';
 
   @override
-  String get apiKeyReason =>
-      'Jūsų asmeninis raktas siunčiamas su kiekviena API užklausa. Jis susietas su jūsų el. paštu.';
+  String get apiKeyReason => 'Jūsų asmeninis raktas siunčiamas su kiekviena API užklausa. Jis susietas su jūsų el. paštu.';
 
   @override
   String get notShared => 'NĖRA dalijama:';
@@ -267,8 +261,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get usageData => 'Naudojimo duomenys';
 
   @override
-  String get privacyBanner =>
-      'Ši programa neturi serverio. Visi duomenys lieka jūsų įrenginyje. Jokios analitikos, sekimo ar reklamų.';
+  String get privacyBanner => 'Ši programa neturi serverio. Visi duomenys lieka jūsų įrenginyje. Jokios analitikos, sekimo ar reklamų.';
 
   @override
   String get storageUsage => 'Saugyklos naudojimas šiame įrenginyje';
@@ -292,8 +285,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get cacheManagement => 'Podėlio valdymas';
 
   @override
-  String get cacheDescription =>
-      'Podėlis saugo API atsakymus greitesniam įkėlimui ir prieigai neprisijungus.';
+  String get cacheDescription => 'Podėlis saugo API atsakymus greitesniam įkėlimui ir prieigai neprisijungus.';
 
   @override
   String get stationSearch => 'Stočių paieška';
@@ -321,8 +313,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get clearCacheTitle => 'Išvalyti podėlį?';
 
   @override
-  String get clearCacheBody =>
-      'Podėlyje esantys paieškos rezultatai ir kainos bus ištrinti. Profiliai, mėgstami ir nustatymai išsaugomi.';
+  String get clearCacheBody => 'Podėlyje esantys paieškos rezultatai ir kainos bus ištrinti. Profiliai, mėgstami ir nustatymai išsaugomi.';
 
   @override
   String get clearCacheButton => 'Išvalyti podėlį';
@@ -331,8 +322,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deleteAllTitle => 'Ištrinti visus duomenis?';
 
   @override
-  String get deleteAllBody =>
-      'Tai visam laikui ištrina visus profilius, mėgstamus, API raktą, nustatymus ir podėlį. Programa bus atstatyta.';
+  String get deleteAllBody => 'Tai visam laikui ištrina visus profilius, mėgstamus, API raktą, nustatymus ir podėlį. Programa bus atstatyta.';
 
   @override
   String get deleteAllButton => 'Ištrinti viską';
@@ -347,19 +337,16 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noStorage => 'Saugykla nenaudojama';
 
   @override
-  String get apiKeyNote =>
-      'Nemokama registracija. Duomenys iš vyriausybinių kainų skaidrumo agentūrų.';
+  String get apiKeyNote => 'Nemokama registracija. Duomenys iš vyriausybinių kainų skaidrumo agentūrų.';
 
   @override
-  String get apiKeyFormatError =>
-      'Netinkamas formatas — tikėtinas UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Netinkamas formatas — tikėtinas UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Palaikykite šį projektą';
 
   @override
-  String get supportDescription =>
-      'Ši programa yra nemokama, atviro kodo ir be reklamų. Jei manote, kad ji naudinga, apsvarstykite galimybę paremti kūrėją.';
+  String get supportDescription => 'Ši programa yra nemokama, atviro kodo ir be reklamų. Jei manote, kad ji naudinga, apsvarstykite galimybę paremti kūrėją.';
 
   @override
   String get reportBug => 'Pranešti apie klaidą / Pasiūlyti funkciją';
@@ -395,12 +382,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get station => 'Degalinė';
 
   @override
-  String get locationDenied =>
-      'Vietos leidimas atmestas. Galite ieškoti pagal pašto kodą.';
+  String get locationDenied => 'Vietos leidimas atmestas. Galite ieškoti pagal pašto kodą.';
 
   @override
-  String get demoModeBanner =>
-      'Demo režimas. Nustatykite API raktą nustatymuose.';
+  String get demoModeBanner => 'Demo režimas. Nustatykite API raktą nustatymuose.';
 
   @override
   String get sortDistance => 'Atstumas';
@@ -426,8 +411,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Įkeliami mėgstami...\nPirmiausia ieškokite stočių duomenims išsaugoti.';
+  String get loadingFavorites => 'Įkeliami mėgstami...\nPirmiausia ieškokite stočių duomenims išsaugoti.';
 
   @override
   String get reportPrice => 'Pranešti apie kainą';
@@ -463,8 +447,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get autoUpdatePosition => 'Automatiškai atnaujinti poziciją';
 
   @override
-  String get autoUpdateDescription =>
-      'Atnaujinti GPS poziciją prieš kiekvieną paiešką';
+  String get autoUpdateDescription => 'Atnaujinti GPS poziciją prieš kiekvieną paiešką';
 
   @override
   String get location => 'Vieta';
@@ -494,8 +477,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get autoSwitchProfile => 'Automatinis profilio perjungimas';
 
   @override
-  String get autoSwitchDescription =>
-      'Automatiškai perjungti profilį kertant sieną';
+  String get autoSwitchDescription => 'Automatiškai perjungti profilį kertant sieną';
 
   @override
   String get switchProfile => 'Perjungti';
@@ -522,8 +504,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noPriceAlerts => 'Nėra kainų įspėjimų';
 
   @override
-  String get noPriceAlertsHint =>
-      'Sukurkite įspėjimą iš stoties informacijos puslapio.';
+  String get noPriceAlertsHint => 'Sukurkite įspėjimą iš stoties informacijos puslapio.';
 
   @override
   String alertDeleted(String name) {
@@ -616,12 +597,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get evUnknown => 'Nežinoma';
 
   @override
-  String get evDataAttribution =>
-      'Duomenys iš OpenChargeMap (bendruomenės šaltinis)';
+  String get evDataAttribution => 'Duomenys iš OpenChargeMap (bendruomenės šaltinis)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Būsena gali neatspindėti prieinamumo realiuoju laiku. Bakstelėkite atnaujinti naujausiems duomenims gauti.';
+  String get evStatusDisclaimer => 'Būsena gali neatspindėti prieinamumo realiuoju laiku. Bakstelėkite atnaujinti naujausiems duomenims gauti.';
 
   @override
   String get evNavigateToStation => 'Navigacija iki stoties';
@@ -633,8 +612,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get evStatusUpdated => 'Būsena atnaujinta';
 
   @override
-  String get evStationNotFound =>
-      'Nepavyko atnaujinti — stotis nerasta netoliese';
+  String get evStationNotFound => 'Nepavyko atnaujinti — stotis nerasta netoliese';
 
   @override
   String get addedToFavorites => 'Pridėta prie mėgstamų';
@@ -703,8 +681,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Degalų kainos (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Reikalingas degalų kainų paieškai Vokietijoje';
+  String get requiredForFuelSearch => 'Reikalingas degalų kainų paieškai Vokietijoje';
 
   @override
   String get evChargingOpenChargeMap => 'EV įkrovimas (OpenChargeMap)';
@@ -716,8 +693,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get appDefaultKey => 'Numatytasis programos raktas';
 
   @override
-  String get optionalOverrideKey =>
-      'Pasirinktinai: pakeiskite integruotą programos raktą savu';
+  String get optionalOverrideKey => 'Pasirinktinai: pakeiskite integruotą programos raktą savu';
 
   @override
   String get requiredForEvSearch => 'Reikalingas EV įkrovimo stočių paieškai';
@@ -749,22 +725,19 @@ class AppLocalizationsLt extends AppLocalizations {
   String get avoidHighways => 'Vengti greitkelių';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Maršruto skaičiavimas vengia mokamų kelių ir greitkelių';
+  String get avoidHighwaysDesc => 'Maršruto skaičiavimas vengia mokamų kelių ir greitkelių';
 
   @override
   String get showFuelStations => 'Rodyti degalines';
 
   @override
-  String get showFuelStationsDesc =>
-      'Įtraukti benzino, dyzelino, LPG, CNG stotis';
+  String get showFuelStationsDesc => 'Įtraukti benzino, dyzelino, LPG, CNG stotis';
 
   @override
   String get showEvStations => 'Rodyti įkrovimo stotis';
 
   @override
-  String get showEvStationsDesc =>
-      'Įtraukti elektrinius įkrovimo stotis į rezultatus';
+  String get showEvStationsDesc => 'Įtraukti elektrinius įkrovimo stotis į rezultatus';
 
   @override
   String get noStationsAlongThisRoute => 'Stočių palei šį maršrutą nerasta.';
@@ -791,8 +764,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get totalCost => 'Bendra kaina';
 
   @override
-  String get enterCalcValues =>
-      'Įveskite atstumą, sąnaudas ir kainą kelionės kainos apskaičiavimui';
+  String get enterCalcValues => 'Įveskite atstumą, sąnaudas ir kainą kelionės kainos apskaičiavimui';
 
   @override
   String get priceHistory => 'Kainų istorija';
@@ -834,19 +806,16 @@ class AppLocalizationsLt extends AppLocalizations {
   String get viewMyData => 'Peržiūrėti mano duomenis';
 
   @override
-  String get optionalCloudSync =>
-      'Pasirenkama debesų sinchronizacija įspėjimams, mėgstamiems ir push pranešimams';
+  String get optionalCloudSync => 'Pasirenkama debesų sinchronizacija įspėjimams, mėgstamiems ir push pranešimams';
 
   @override
   String get tapToUpdateGps => 'Bakstelėkite GPS pozicijos atnaujinimui';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS pozicija gaunama automatiškai ieškant. Čia galite ją atnaujinti ir rankiniu būdu.';
+  String get gpsAutoUpdateHint => 'GPS pozicija gaunama automatiškai ieškant. Čia galite ją atnaujinti ir rankiniu būdu.';
 
   @override
-  String get clearGpsConfirm =>
-      'Išvalyti išsaugotą GPS poziciją? Galite ją bet kada atnaujinti iš naujo.';
+  String get clearGpsConfirm => 'Išvalyti išsaugotą GPS poziciją? Galite ją bet kada atnaujinti iš naujo.';
 
   @override
   String get pageNotFound => 'Puslapis nerastas';
@@ -930,8 +899,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -956,8 +924,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -981,12 +948,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1001,15 +966,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1060,44 +1023,37 @@ class AppLocalizationsLt extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1106,8 +1062,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1172,8 +1127,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1237,8 +1191,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1259,8 +1212,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1296,8 +1248,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1306,8 +1257,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1331,8 +1281,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1386,8 +1335,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1396,8 +1344,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1408,12 +1355,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1427,8 +1369,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get nearestStations => 'Artimiausios degalines';
 
   @override
-  String get nearestStationsHint =>
-      'Raskite artimiausias degalines pagal jusu dabartine vieta';
+  String get nearestStationsHint => 'Raskite artimiausias degalines pagal jusu dabartine vieta';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1437,8 +1378,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1450,8 +1390,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1502,8 +1441,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1583,12 +1521,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1754,15 +1690,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1786,8 +1720,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1796,33 +1729,28 @@ class AppLocalizationsLt extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1837,16 +1765,17 @@ class AppLocalizationsLt extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -103,8 +103,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get apiKeySetup => 'API atslēga';
 
   @override
-  String get apiKeyDescription =>
-      'Reģistrējieties vienreiz, lai saņemtu bezmaksas API atslēgu.';
+  String get apiKeyDescription => 'Reģistrējieties vienreiz, lai saņemtu bezmaksas API atslēgu.';
 
   @override
   String get apiKeyLabel => 'API atslēga';
@@ -173,8 +172,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get noFavorites => 'Nav izlases';
 
   @override
-  String get noFavoritesHint =>
-      'Pieskarieties zvaigznītei pie stacijas, lai saglabātu to izlasē.';
+  String get noFavoritesHint => 'Pieskarieties zvaigznītei pie stacijas, lai saglabātu to izlasē.';
 
   @override
   String get language => 'Valoda';
@@ -224,29 +222,25 @@ class AppLocalizationsLv extends AppLocalizations {
   String get gpsCoordinates => 'GPS koordinātas';
 
   @override
-  String get gpsReason =>
-      'Tiek nosūtītas ar katru meklējumu, lai atrastu tuvumā esošās stacijas.';
+  String get gpsReason => 'Tiek nosūtītas ar katru meklējumu, lai atrastu tuvumā esošās stacijas.';
 
   @override
   String get postalCodeData => 'Pasta indekss';
 
   @override
-  String get postalReason =>
-      'Tiek pārveidots koordinātās, izmantojot ģeokodēšanas pakalpojumu.';
+  String get postalReason => 'Tiek pārveidots koordinātās, izmantojot ģeokodēšanas pakalpojumu.';
 
   @override
   String get mapViewport => 'Kartes skats';
 
   @override
-  String get mapReason =>
-      'Kartes flīzes tiek ielādētas no servera. Personas dati netiek pārsūtīti.';
+  String get mapReason => 'Kartes flīzes tiek ielādētas no servera. Personas dati netiek pārsūtīti.';
 
   @override
   String get apiKeyData => 'API atslēga';
 
   @override
-  String get apiKeyReason =>
-      'Jūsu personīgā atslēga tiek nosūtīta ar katru API pieprasījumu. Tā ir saistīta ar jūsu e-pastu.';
+  String get apiKeyReason => 'Jūsu personīgā atslēga tiek nosūtīta ar katru API pieprasījumu. Tā ir saistīta ar jūsu e-pastu.';
 
   @override
   String get notShared => 'NETIEK kopīgots:';
@@ -267,8 +261,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get usageData => 'Lietošanas dati';
 
   @override
-  String get privacyBanner =>
-      'Šai lietotnei nav servera. Visi dati paliek jūsu ierīcē. Bez analītikas, izsekošanas vai reklāmām.';
+  String get privacyBanner => 'Šai lietotnei nav servera. Visi dati paliek jūsu ierīcē. Bez analītikas, izsekošanas vai reklāmām.';
 
   @override
   String get storageUsage => 'Krātuves izmantošana šajā ierīcē';
@@ -292,8 +285,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get cacheManagement => 'Kešatmiņas pārvaldība';
 
   @override
-  String get cacheDescription =>
-      'Kešatmiņa saglabā API atbildes ātrākai ielādei un bezsaistes piekļuvei.';
+  String get cacheDescription => 'Kešatmiņa saglabā API atbildes ātrākai ielādei un bezsaistes piekļuvei.';
 
   @override
   String get stationSearch => 'Staciju meklēšana';
@@ -321,8 +313,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get clearCacheTitle => 'Iztīrīt kešatmiņu?';
 
   @override
-  String get clearCacheBody =>
-      'Kešatmiņā saglabātie meklēšanas rezultāti un cenas tiks dzēsti. Profili, izlase un iestatījumi tiks saglabāti.';
+  String get clearCacheBody => 'Kešatmiņā saglabātie meklēšanas rezultāti un cenas tiks dzēsti. Profili, izlase un iestatījumi tiks saglabāti.';
 
   @override
   String get clearCacheButton => 'Iztīrīt kešatmiņu';
@@ -331,8 +322,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deleteAllTitle => 'Dzēst visus datus?';
 
   @override
-  String get deleteAllBody =>
-      'Tas neatgriezeniski dzēš visus profilus, izlasi, API atslēgu, iestatījumus un kešatmiņu. Lietotne tiks atiestatīta.';
+  String get deleteAllBody => 'Tas neatgriezeniski dzēš visus profilus, izlasi, API atslēgu, iestatījumus un kešatmiņu. Lietotne tiks atiestatīta.';
 
   @override
   String get deleteAllButton => 'Dzēst visu';
@@ -347,19 +337,16 @@ class AppLocalizationsLv extends AppLocalizations {
   String get noStorage => 'Krātuve netiek izmantota';
 
   @override
-  String get apiKeyNote =>
-      'Bezmaksas reģistrācija. Dati no valdības cenu caurredzamības aģentūrām.';
+  String get apiKeyNote => 'Bezmaksas reģistrācija. Dati no valdības cenu caurredzamības aģentūrām.';
 
   @override
-  String get apiKeyFormatError =>
-      'Nederīgs formāts — gaidīts UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Nederīgs formāts — gaidīts UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Atbalstiet šo projektu';
 
   @override
-  String get supportDescription =>
-      'Šī lietotne ir bezmaksas, atvērtā koda un bez reklāmām. Ja tā jums šķiet noderīga, apsveriet iespēju atbalstīt izstrādātāju.';
+  String get supportDescription => 'Šī lietotne ir bezmaksas, atvērtā koda un bez reklāmām. Ja tā jums šķiet noderīga, apsveriet iespēju atbalstīt izstrādātāju.';
 
   @override
   String get reportBug => 'Ziņot par kļūdu / Ieteikt funkciju';
@@ -395,12 +382,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get station => 'Degvielas uzpildes stacija';
 
   @override
-  String get locationDenied =>
-      'Atrašanās vietas atļauja noraidīta. Varat meklēt pēc pasta indeksa.';
+  String get locationDenied => 'Atrašanās vietas atļauja noraidīta. Varat meklēt pēc pasta indeksa.';
 
   @override
-  String get demoModeBanner =>
-      'Demo režīms. Konfigurējiet API atslēgu iestatījumos.';
+  String get demoModeBanner => 'Demo režīms. Konfigurējiet API atslēgu iestatījumos.';
 
   @override
   String get sortDistance => 'Attālums';
@@ -426,8 +411,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Ielādē izlasi...\nVispirms meklējiet stacijas, lai saglabātu datus.';
+  String get loadingFavorites => 'Ielādē izlasi...\nVispirms meklējiet stacijas, lai saglabātu datus.';
 
   @override
   String get reportPrice => 'Ziņot par cenu';
@@ -463,8 +447,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get autoUpdatePosition => 'Automātiski atjaunināt pozīciju';
 
   @override
-  String get autoUpdateDescription =>
-      'Atjaunināt GPS pozīciju pirms katras meklēšanas';
+  String get autoUpdateDescription => 'Atjaunināt GPS pozīciju pirms katras meklēšanas';
 
   @override
   String get location => 'Atrašanās vieta';
@@ -494,8 +477,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get autoSwitchProfile => 'Automātiska profila maiņa';
 
   @override
-  String get autoSwitchDescription =>
-      'Automātiski mainīt profilu, šķērsojot robežu';
+  String get autoSwitchDescription => 'Automātiski mainīt profilu, šķērsojot robežu';
 
   @override
   String get switchProfile => 'Pārslēgt';
@@ -522,8 +504,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get noPriceAlerts => 'Nav cenu brīdinājumu';
 
   @override
-  String get noPriceAlertsHint =>
-      'Izveidojiet brīdinājumu no stacijas detaļu lapas.';
+  String get noPriceAlertsHint => 'Izveidojiet brīdinājumu no stacijas detaļu lapas.';
 
   @override
   String alertDeleted(String name) {
@@ -607,8 +588,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get evUsageCost => 'Lietošanas izmaksas';
 
   @override
-  String get evPricingUnavailable =>
-      'Cenu informācija nav pieejama no pakalpojumu sniedzēja';
+  String get evPricingUnavailable => 'Cenu informācija nav pieejama no pakalpojumu sniedzēja';
 
   @override
   String get evLastUpdated => 'Pēdējoreiz atjaunināts';
@@ -620,8 +600,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get evDataAttribution => 'Dati no OpenChargeMap (kopienas avots)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Statuss var neatspoguļot pieejamību reāllaikā. Pieskarieties atjaunināt, lai iegūtu jaunākos datus.';
+  String get evStatusDisclaimer => 'Statuss var neatspoguļot pieejamību reāllaikā. Pieskarieties atjaunināt, lai iegūtu jaunākos datus.';
 
   @override
   String get evNavigateToStation => 'Navigēt uz staciju';
@@ -633,8 +612,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get evStatusUpdated => 'Statuss atjaunināts';
 
   @override
-  String get evStationNotFound =>
-      'Nevar atjaunināt — stacija nav atrasta tuvumā';
+  String get evStationNotFound => 'Nevar atjaunināt — stacija nav atrasta tuvumā';
 
   @override
   String get addedToFavorites => 'Pievienots izlasei';
@@ -703,8 +681,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Degvielas cenas (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Nepieciešams degvielas cenu meklēšanai Vācijā';
+  String get requiredForFuelSearch => 'Nepieciešams degvielas cenu meklēšanai Vācijā';
 
   @override
   String get evChargingOpenChargeMap => 'EV uzlāde (OpenChargeMap)';
@@ -716,12 +693,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get appDefaultKey => 'Lietotnes noklusējuma atslēga';
 
   @override
-  String get optionalOverrideKey =>
-      'Pēc izvēles: aizstāt iebūvēto lietotnes atslēgu ar savu';
+  String get optionalOverrideKey => 'Pēc izvēles: aizstāt iebūvēto lietotnes atslēgu ar savu';
 
   @override
-  String get requiredForEvSearch =>
-      'Nepieciešams EV uzlādes staciju meklēšanai';
+  String get requiredForEvSearch => 'Nepieciešams EV uzlādes staciju meklēšanai';
 
   @override
   String get edit => 'Rediģēt';
@@ -750,26 +725,22 @@ class AppLocalizationsLv extends AppLocalizations {
   String get avoidHighways => 'Izvairīties no automaģistrālēm';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Maršruta aprēķins izvairās no maksas ceļiem un automaģistrālēm';
+  String get avoidHighwaysDesc => 'Maršruta aprēķins izvairās no maksas ceļiem un automaģistrālēm';
 
   @override
   String get showFuelStations => 'Rādīt degvielas uzpildes stacijas';
 
   @override
-  String get showFuelStationsDesc =>
-      'Iekļaut benzīna, dīzeļa, LPG, CNG stacijas';
+  String get showFuelStationsDesc => 'Iekļaut benzīna, dīzeļa, LPG, CNG stacijas';
 
   @override
   String get showEvStations => 'Rādīt uzlādes stacijas';
 
   @override
-  String get showEvStationsDesc =>
-      'Iekļaut elektriskās uzlādes stacijas meklēšanas rezultātos';
+  String get showEvStationsDesc => 'Iekļaut elektriskās uzlādes stacijas meklēšanas rezultātos';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Stacijas gar šo maršrutu nav atrastas.';
+  String get noStationsAlongThisRoute => 'Stacijas gar šo maršrutu nav atrastas.';
 
   @override
   String get fuelCostCalculator => 'Degvielas izmaksu kalkulators';
@@ -793,8 +764,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get totalCost => 'Kopējās izmaksas';
 
   @override
-  String get enterCalcValues =>
-      'Ievadiet attālumu, patēriņu un cenu, lai aprēķinātu brauciena izmaksas';
+  String get enterCalcValues => 'Ievadiet attālumu, patēriņu un cenu, lai aprēķinātu brauciena izmaksas';
 
   @override
   String get priceHistory => 'Cenu vēsture';
@@ -836,19 +806,16 @@ class AppLocalizationsLv extends AppLocalizations {
   String get viewMyData => 'Skatīt manus datus';
 
   @override
-  String get optionalCloudSync =>
-      'Izvēles mākoņa sinhronizācija brīdinājumiem, izlasei un push paziņojumiem';
+  String get optionalCloudSync => 'Izvēles mākoņa sinhronizācija brīdinājumiem, izlasei un push paziņojumiem';
 
   @override
   String get tapToUpdateGps => 'Pieskarieties, lai atjauninātu GPS pozīciju';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS pozīcija tiek iegūta automātiski, meklējot. Varat to arī manuāli atjaunināt šeit.';
+  String get gpsAutoUpdateHint => 'GPS pozīcija tiek iegūta automātiski, meklējot. Varat to arī manuāli atjaunināt šeit.';
 
   @override
-  String get clearGpsConfirm =>
-      'Notīrīt saglabāto GPS pozīciju? Varat to atjaunināt jebkurā laikā.';
+  String get clearGpsConfirm => 'Notīrīt saglabāto GPS pozīciju? Varat to atjaunināt jebkurā laikā.';
 
   @override
   String get pageNotFound => 'Lapa nav atrasta';
@@ -932,8 +899,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -958,8 +924,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -983,12 +948,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1003,15 +966,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1062,44 +1023,37 @@ class AppLocalizationsLv extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1108,8 +1062,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1174,8 +1127,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1239,8 +1191,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1261,8 +1212,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1298,8 +1248,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1308,8 +1257,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1333,8 +1281,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1388,8 +1335,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1398,8 +1344,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1410,12 +1355,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1429,8 +1369,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get nearestStations => 'Tuvakias degvielas uzpildes stacijas';
 
   @override
-  String get nearestStationsHint =>
-      'Atrodiet tuvakias degvielas uzpildes stacijas pec jusu pasreizejas atrasanas vietas';
+  String get nearestStationsHint => 'Atrodiet tuvakias degvielas uzpildes stacijas pec jusu pasreizejas atrasanas vietas';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1439,8 +1378,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1452,8 +1390,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1504,8 +1441,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1585,12 +1521,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1756,15 +1690,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1788,8 +1720,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1798,33 +1729,28 @@ class AppLocalizationsLv extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1839,16 +1765,17 @@ class AppLocalizationsLv extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -103,8 +103,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get apiKeySetup => 'API-nøkkel';
 
   @override
-  String get apiKeyDescription =>
-      'Registrer deg én gang for å få en gratis API-nøkkel.';
+  String get apiKeyDescription => 'Registrer deg én gang for å få en gratis API-nøkkel.';
 
   @override
   String get apiKeyLabel => 'API-nøkkel';
@@ -173,8 +172,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get noFavorites => 'Ingen favoritter ennå';
 
   @override
-  String get noFavoritesHint =>
-      'Trykk på stjernen ved en bensinstasjon for å lagre den som favoritt.';
+  String get noFavoritesHint => 'Trykk på stjernen ved en bensinstasjon for å lagre den som favoritt.';
 
   @override
   String get language => 'Språk';
@@ -224,29 +222,25 @@ class AppLocalizationsNb extends AppLocalizations {
   String get gpsCoordinates => 'GPS-koordinater';
 
   @override
-  String get gpsReason =>
-      'Sendes med hvert søk for å finne nærliggende stasjoner.';
+  String get gpsReason => 'Sendes med hvert søk for å finne nærliggende stasjoner.';
 
   @override
   String get postalCodeData => 'Postnummer';
 
   @override
-  String get postalReason =>
-      'Konverteres til koordinater via geokodingstjenesten.';
+  String get postalReason => 'Konverteres til koordinater via geokodingstjenesten.';
 
   @override
   String get mapViewport => 'Kartutsnitt';
 
   @override
-  String get mapReason =>
-      'Kartfliser lastes fra serveren. Ingen personlige data overføres.';
+  String get mapReason => 'Kartfliser lastes fra serveren. Ingen personlige data overføres.';
 
   @override
   String get apiKeyData => 'API-nøkkel';
 
   @override
-  String get apiKeyReason =>
-      'Din personlige nøkkel sendes med hver API-forespørsel. Den er knyttet til din e-post.';
+  String get apiKeyReason => 'Din personlige nøkkel sendes med hver API-forespørsel. Den er knyttet til din e-post.';
 
   @override
   String get notShared => 'Deles IKKE:';
@@ -267,8 +261,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get usageData => 'Bruksdata';
 
   @override
-  String get privacyBanner =>
-      'Denne appen har ingen server. Alle data forblir på enheten din. Ingen analyse, sporing eller reklame.';
+  String get privacyBanner => 'Denne appen har ingen server. Alle data forblir på enheten din. Ingen analyse, sporing eller reklame.';
 
   @override
   String get storageUsage => 'Lagringsbruk på denne enheten';
@@ -292,8 +285,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get cacheManagement => 'Hurtigbufferadministrasjon';
 
   @override
-  String get cacheDescription =>
-      'Hurtigbufferen lagrer API-svar for raskere lasting og frakoblet tilgang.';
+  String get cacheDescription => 'Hurtigbufferen lagrer API-svar for raskere lasting og frakoblet tilgang.';
 
   @override
   String get stationSearch => 'Stasjonssøk';
@@ -321,8 +313,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get clearCacheTitle => 'Tøm hurtigbuffer?';
 
   @override
-  String get clearCacheBody =>
-      'Hurtigbufrede søkeresultater og priser slettes. Profiler, favoritter og innstillinger beholdes.';
+  String get clearCacheBody => 'Hurtigbufrede søkeresultater og priser slettes. Profiler, favoritter og innstillinger beholdes.';
 
   @override
   String get clearCacheButton => 'Tøm hurtigbuffer';
@@ -331,8 +322,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get deleteAllTitle => 'Slette alle data?';
 
   @override
-  String get deleteAllBody =>
-      'Dette sletter permanent alle profiler, favoritter, API-nøkkel, innstillinger og hurtigbuffer. Appen tilbakestilles.';
+  String get deleteAllBody => 'Dette sletter permanent alle profiler, favoritter, API-nøkkel, innstillinger og hurtigbuffer. Appen tilbakestilles.';
 
   @override
   String get deleteAllButton => 'Slett alt';
@@ -347,19 +337,16 @@ class AppLocalizationsNb extends AppLocalizations {
   String get noStorage => 'Ingen lagring brukt';
 
   @override
-  String get apiKeyNote =>
-      'Gratis registrering. Data fra statlige pristransparensorganer.';
+  String get apiKeyNote => 'Gratis registrering. Data fra statlige pristransparensorganer.';
 
   @override
-  String get apiKeyFormatError =>
-      'Ugyldig format — forventet UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Ugyldig format — forventet UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Støtt dette prosjektet';
 
   @override
-  String get supportDescription =>
-      'Denne appen er gratis, åpen kildekode og uten reklame. Hvis du finner den nyttig, vurder å støtte utvikleren.';
+  String get supportDescription => 'Denne appen er gratis, åpen kildekode og uten reklame. Hvis du finner den nyttig, vurder å støtte utvikleren.';
 
   @override
   String get reportBug => 'Rapporter feil / Foreslå funksjon';
@@ -395,12 +382,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get station => 'Bensinstasjon';
 
   @override
-  String get locationDenied =>
-      'Plasseringstillatelse nektet. Du kan søke etter postnummer.';
+  String get locationDenied => 'Plasseringstillatelse nektet. Du kan søke etter postnummer.';
 
   @override
-  String get demoModeBanner =>
-      'Demomodus. Konfigurer API-nøkkel i innstillinger.';
+  String get demoModeBanner => 'Demomodus. Konfigurer API-nøkkel i innstillinger.';
 
   @override
   String get sortDistance => 'Avstand';
@@ -426,8 +411,7 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Laster favoritter...\nSøk etter stasjoner først for å lagre data.';
+  String get loadingFavorites => 'Laster favoritter...\nSøk etter stasjoner først for å lagre data.';
 
   @override
   String get reportPrice => 'Rapporter pris';
@@ -493,8 +477,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get autoSwitchProfile => 'Automatisk profilbytte';
 
   @override
-  String get autoSwitchDescription =>
-      'Bytt profil automatisk ved grensepassering';
+  String get autoSwitchDescription => 'Bytt profil automatisk ved grensepassering';
 
   @override
   String get switchProfile => 'Bytt';
@@ -521,8 +504,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get noPriceAlerts => 'Ingen prisalarmer';
 
   @override
-  String get noPriceAlertsHint =>
-      'Opprett en alarm fra en stasjons detaljside.';
+  String get noPriceAlertsHint => 'Opprett en alarm fra en stasjons detaljside.';
 
   @override
   String alertDeleted(String name) {
@@ -618,8 +600,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get evDataAttribution => 'Data fra OpenChargeMap (felleskilde)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Status gjenspeiler kanskje ikke tilgjengelighet i sanntid. Trykk oppdater for å hente siste data.';
+  String get evStatusDisclaimer => 'Status gjenspeiler kanskje ikke tilgjengelighet i sanntid. Trykk oppdater for å hente siste data.';
 
   @override
   String get evNavigateToStation => 'Naviger til stasjon';
@@ -631,8 +612,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get evStatusUpdated => 'Status oppdatert';
 
   @override
-  String get evStationNotFound =>
-      'Kunne ikke oppdatere — stasjon ikke funnet i nærheten';
+  String get evStationNotFound => 'Kunne ikke oppdatere — stasjon ikke funnet i nærheten';
 
   @override
   String get addedToFavorites => 'Lagt til i favoritter';
@@ -713,8 +693,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get appDefaultKey => 'Standard app-nøkkel';
 
   @override
-  String get optionalOverrideKey =>
-      'Valgfritt: erstatt den innebygde app-nøkkelen med din egen';
+  String get optionalOverrideKey => 'Valgfritt: erstatt den innebygde app-nøkkelen med din egen';
 
   @override
   String get requiredForEvSearch => 'Påkrevd for søk etter EV-ladestasjoner';
@@ -746,26 +725,22 @@ class AppLocalizationsNb extends AppLocalizations {
   String get avoidHighways => 'Unngå motorveier';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Ruteberegning unngår bompenger og motorveier';
+  String get avoidHighwaysDesc => 'Ruteberegning unngår bompenger og motorveier';
 
   @override
   String get showFuelStations => 'Vis bensinstasjoner';
 
   @override
-  String get showFuelStationsDesc =>
-      'Inkluder bensin-, diesel-, LPG-, CNG-stasjoner';
+  String get showFuelStationsDesc => 'Inkluder bensin-, diesel-, LPG-, CNG-stasjoner';
 
   @override
   String get showEvStations => 'Vis ladestasjoner';
 
   @override
-  String get showEvStationsDesc =>
-      'Inkluder elektriske ladestasjoner i søkeresultater';
+  String get showEvStationsDesc => 'Inkluder elektriske ladestasjoner i søkeresultater';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Ingen stasjoner funnet langs denne ruten.';
+  String get noStationsAlongThisRoute => 'Ingen stasjoner funnet langs denne ruten.';
 
   @override
   String get fuelCostCalculator => 'Drivstoffkostnadsberegner';
@@ -789,8 +764,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get totalCost => 'Totalkostnad';
 
   @override
-  String get enterCalcValues =>
-      'Oppgi avstand, forbruk og pris for å beregne turkostnaden';
+  String get enterCalcValues => 'Oppgi avstand, forbruk og pris for å beregne turkostnaden';
 
   @override
   String get priceHistory => 'Prishistorikk';
@@ -832,19 +806,16 @@ class AppLocalizationsNb extends AppLocalizations {
   String get viewMyData => 'Se mine data';
 
   @override
-  String get optionalCloudSync =>
-      'Valgfri skysynkronisering for alarmer, favoritter og push-varsler';
+  String get optionalCloudSync => 'Valgfri skysynkronisering for alarmer, favoritter og push-varsler';
 
   @override
   String get tapToUpdateGps => 'Trykk for å oppdatere GPS-posisjon';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS-posisjonen hentes automatisk ved søk. Du kan også oppdatere den manuelt her.';
+  String get gpsAutoUpdateHint => 'GPS-posisjonen hentes automatisk ved søk. Du kan også oppdatere den manuelt her.';
 
   @override
-  String get clearGpsConfirm =>
-      'Tøm lagret GPS-posisjon? Du kan oppdatere den igjen når som helst.';
+  String get clearGpsConfirm => 'Tøm lagret GPS-posisjon? Du kan oppdatere den igjen når som helst.';
 
   @override
   String get pageNotFound => 'Siden ble ikke funnet';
@@ -928,8 +899,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -954,8 +924,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -979,12 +948,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -999,15 +966,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1058,44 +1023,37 @@ class AppLocalizationsNb extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1104,8 +1062,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1170,8 +1127,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1235,8 +1191,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1257,8 +1212,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1294,8 +1248,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1304,8 +1257,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1329,8 +1281,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1384,8 +1335,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1394,8 +1344,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1406,12 +1355,7 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1425,8 +1369,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get nearestStations => 'Naermeste stasjoner';
 
   @override
-  String get nearestStationsHint =>
-      'Finn de naermeste stasjonene med din navaerende posisjon';
+  String get nearestStationsHint => 'Finn de naermeste stasjonene med din navaerende posisjon';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1435,8 +1378,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1448,8 +1390,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1500,8 +1441,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1581,12 +1521,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1752,15 +1690,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1784,8 +1720,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1794,33 +1729,28 @@ class AppLocalizationsNb extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1835,16 +1765,17 @@ class AppLocalizationsNb extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -103,8 +103,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get apiKeySetup => 'API-sleutel';
 
   @override
-  String get apiKeyDescription =>
-      'Registreer eenmalig voor een gratis API-sleutel.';
+  String get apiKeyDescription => 'Registreer eenmalig voor een gratis API-sleutel.';
 
   @override
   String get apiKeyLabel => 'API-sleutel';
@@ -119,8 +118,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get welcome => 'Brandstofprijzen';
 
   @override
-  String get welcomeSubtitle =>
-      'Vind de goedkoopste brandstof bij jou in de buurt.';
+  String get welcomeSubtitle => 'Vind de goedkoopste brandstof bij jou in de buurt.';
 
   @override
   String get profileName => 'Profielnaam';
@@ -174,8 +172,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get noFavorites => 'Nog geen favorieten';
 
   @override
-  String get noFavoritesHint =>
-      'Tik op de ster bij een tankstation om het als favoriet op te slaan.';
+  String get noFavoritesHint => 'Tik op de ster bij een tankstation om het als favoriet op te slaan.';
 
   @override
   String get language => 'Taal';
@@ -225,29 +222,25 @@ class AppLocalizationsNl extends AppLocalizations {
   String get gpsCoordinates => 'GPS-coördinaten';
 
   @override
-  String get gpsReason =>
-      'Worden bij elke zoekopdracht verstuurd om nabijgelegen stations te vinden.';
+  String get gpsReason => 'Worden bij elke zoekopdracht verstuurd om nabijgelegen stations te vinden.';
 
   @override
   String get postalCodeData => 'Postcode';
 
   @override
-  String get postalReason =>
-      'Wordt omgezet in coördinaten via de geocoderingsservice.';
+  String get postalReason => 'Wordt omgezet in coördinaten via de geocoderingsservice.';
 
   @override
   String get mapViewport => 'Kaartweergave';
 
   @override
-  String get mapReason =>
-      'Kaarttegels worden geladen vanaf de server. Er worden geen persoonlijke gegevens verzonden.';
+  String get mapReason => 'Kaarttegels worden geladen vanaf de server. Er worden geen persoonlijke gegevens verzonden.';
 
   @override
   String get apiKeyData => 'API-sleutel';
 
   @override
-  String get apiKeyReason =>
-      'Uw persoonlijke sleutel wordt bij elke API-aanvraag meegezonden. Deze is gekoppeld aan uw e-mail.';
+  String get apiKeyReason => 'Uw persoonlijke sleutel wordt bij elke API-aanvraag meegezonden. Deze is gekoppeld aan uw e-mail.';
 
   @override
   String get notShared => 'Wordt NIET gedeeld:';
@@ -268,8 +261,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get usageData => 'Gebruiksgegevens';
 
   @override
-  String get privacyBanner =>
-      'Deze app heeft geen server. Alle gegevens blijven op uw apparaat. Geen analyse, geen tracking, geen advertenties.';
+  String get privacyBanner => 'Deze app heeft geen server. Alle gegevens blijven op uw apparaat. Geen analyse, geen tracking, geen advertenties.';
 
   @override
   String get storageUsage => 'Opslaggebruik op dit apparaat';
@@ -293,8 +285,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get cacheManagement => 'Cachebeheer';
 
   @override
-  String get cacheDescription =>
-      'De cache slaat API-antwoorden op voor sneller laden en offline toegang.';
+  String get cacheDescription => 'De cache slaat API-antwoorden op voor sneller laden en offline toegang.';
 
   @override
   String get stationSearch => 'Stations zoeken';
@@ -322,8 +313,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get clearCacheTitle => 'Cache wissen?';
 
   @override
-  String get clearCacheBody =>
-      'Gecachte zoekresultaten en prijzen worden verwijderd. Profielen, favorieten en instellingen blijven bewaard.';
+  String get clearCacheBody => 'Gecachte zoekresultaten en prijzen worden verwijderd. Profielen, favorieten en instellingen blijven bewaard.';
 
   @override
   String get clearCacheButton => 'Cache wissen';
@@ -332,8 +322,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteAllTitle => 'Alle gegevens verwijderen?';
 
   @override
-  String get deleteAllBody =>
-      'Dit verwijdert permanent alle profielen, favorieten, API-sleutel, instellingen en cache. De app wordt gereset.';
+  String get deleteAllBody => 'Dit verwijdert permanent alle profielen, favorieten, API-sleutel, instellingen en cache. De app wordt gereset.';
 
   @override
   String get deleteAllButton => 'Alles verwijderen';
@@ -348,19 +337,16 @@ class AppLocalizationsNl extends AppLocalizations {
   String get noStorage => 'Geen opslag gebruikt';
 
   @override
-  String get apiKeyNote =>
-      'Gratis registratie. Gegevens van overheidsinstanties voor prijstransparantie.';
+  String get apiKeyNote => 'Gratis registratie. Gegevens van overheidsinstanties voor prijstransparantie.';
 
   @override
-  String get apiKeyFormatError =>
-      'Ongeldig formaat — UUID verwacht (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Ongeldig formaat — UUID verwacht (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Steun dit project';
 
   @override
-  String get supportDescription =>
-      'Deze app is gratis, open source en zonder advertenties. Als u het nuttig vindt, overweeg de ontwikkelaar te steunen.';
+  String get supportDescription => 'Deze app is gratis, open source en zonder advertenties. Als u het nuttig vindt, overweeg de ontwikkelaar te steunen.';
 
   @override
   String get reportBug => 'Bug melden / Functie voorstellen';
@@ -396,12 +382,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get station => 'Tankstation';
 
   @override
-  String get locationDenied =>
-      'Locatietoestemming geweigerd. U kunt zoeken op postcode.';
+  String get locationDenied => 'Locatietoestemming geweigerd. U kunt zoeken op postcode.';
 
   @override
-  String get demoModeBanner =>
-      'Demomodus. Configureer API-sleutel in instellingen.';
+  String get demoModeBanner => 'Demomodus. Configureer API-sleutel in instellingen.';
 
   @override
   String get sortDistance => 'Afstand';
@@ -427,8 +411,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Favorieten laden...\nZoek eerst naar stations om gegevens op te slaan.';
+  String get loadingFavorites => 'Favorieten laden...\nZoek eerst naar stations om gegevens op te slaan.';
 
   @override
   String get reportPrice => 'Prijs melden';
@@ -464,8 +447,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get autoUpdatePosition => 'Positie automatisch bijwerken';
 
   @override
-  String get autoUpdateDescription =>
-      'GPS-positie bijwerken voor elke zoekopdracht';
+  String get autoUpdateDescription => 'GPS-positie bijwerken voor elke zoekopdracht';
 
   @override
   String get location => 'Locatie';
@@ -495,8 +477,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get autoSwitchProfile => 'Automatisch profiel wisselen';
 
   @override
-  String get autoSwitchDescription =>
-      'Profiel automatisch wisselen bij grensovergang';
+  String get autoSwitchDescription => 'Profiel automatisch wisselen bij grensovergang';
 
   @override
   String get switchProfile => 'Wisselen';
@@ -523,8 +504,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get noPriceAlerts => 'Geen prijswaarschuwingen';
 
   @override
-  String get noPriceAlertsHint =>
-      'Maak een waarschuwing aan vanaf de detailpagina van een station.';
+  String get noPriceAlertsHint => 'Maak een waarschuwing aan vanaf de detailpagina van een station.';
 
   @override
   String alertDeleted(String name) {
@@ -608,8 +588,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get evUsageCost => 'Gebruikskosten';
 
   @override
-  String get evPricingUnavailable =>
-      'Prijsinformatie niet beschikbaar van aanbieder';
+  String get evPricingUnavailable => 'Prijsinformatie niet beschikbaar van aanbieder';
 
   @override
   String get evLastUpdated => 'Laatst bijgewerkt';
@@ -621,8 +600,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get evDataAttribution => 'Gegevens van OpenChargeMap (community-bron)';
 
   @override
-  String get evStatusDisclaimer =>
-      'De status weerspiegelt mogelijk niet de real-time beschikbaarheid. Tik op vernieuwen voor de laatste gegevens.';
+  String get evStatusDisclaimer => 'De status weerspiegelt mogelijk niet de real-time beschikbaarheid. Tik op vernieuwen voor de laatste gegevens.';
 
   @override
   String get evNavigateToStation => 'Navigeer naar station';
@@ -634,8 +612,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get evStatusUpdated => 'Status bijgewerkt';
 
   @override
-  String get evStationNotFound =>
-      'Kan niet vernieuwen — station niet in de buurt gevonden';
+  String get evStationNotFound => 'Kan niet vernieuwen — station niet in de buurt gevonden';
 
   @override
   String get addedToFavorites => 'Toegevoegd aan favorieten';
@@ -704,8 +681,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Brandstofprijzen (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Vereist voor brandstofprijzen zoeken in Duitsland';
+  String get requiredForFuelSearch => 'Vereist voor brandstofprijzen zoeken in Duitsland';
 
   @override
   String get evChargingOpenChargeMap => 'EV-laden (OpenChargeMap)';
@@ -717,12 +693,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get appDefaultKey => 'Standaard app-sleutel';
 
   @override
-  String get optionalOverrideKey =>
-      'Optioneel: de ingebouwde app-sleutel vervangen door uw eigen';
+  String get optionalOverrideKey => 'Optioneel: de ingebouwde app-sleutel vervangen door uw eigen';
 
   @override
-  String get requiredForEvSearch =>
-      'Vereist voor het zoeken naar EV-laadstations';
+  String get requiredForEvSearch => 'Vereist voor het zoeken naar EV-laadstations';
 
   @override
   String get edit => 'Bewerken';
@@ -751,26 +725,22 @@ class AppLocalizationsNl extends AppLocalizations {
   String get avoidHighways => 'Snelwegen vermijden';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Routeberekening vermijdt tolwegen en snelwegen';
+  String get avoidHighwaysDesc => 'Routeberekening vermijdt tolwegen en snelwegen';
 
   @override
   String get showFuelStations => 'Tankstations tonen';
 
   @override
-  String get showFuelStationsDesc =>
-      'Inclusief benzine-, diesel-, LPG-, CNG-stations';
+  String get showFuelStationsDesc => 'Inclusief benzine-, diesel-, LPG-, CNG-stations';
 
   @override
   String get showEvStations => 'Laadstations tonen';
 
   @override
-  String get showEvStationsDesc =>
-      'Elektrische laadstations opnemen in zoekresultaten';
+  String get showEvStationsDesc => 'Elektrische laadstations opnemen in zoekresultaten';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Geen stations gevonden langs deze route.';
+  String get noStationsAlongThisRoute => 'Geen stations gevonden langs deze route.';
 
   @override
   String get fuelCostCalculator => 'Brandstofkostencalculator';
@@ -794,8 +764,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get totalCost => 'Totale kosten';
 
   @override
-  String get enterCalcValues =>
-      'Voer afstand, verbruik en prijs in om de ritkosten te berekenen';
+  String get enterCalcValues => 'Voer afstand, verbruik en prijs in om de ritkosten te berekenen';
 
   @override
   String get priceHistory => 'Prijsgeschiedenis';
@@ -837,19 +806,16 @@ class AppLocalizationsNl extends AppLocalizations {
   String get viewMyData => 'Mijn gegevens bekijken';
 
   @override
-  String get optionalCloudSync =>
-      'Optionele cloudsynchronisatie voor waarschuwingen, favorieten en pushmeldingen';
+  String get optionalCloudSync => 'Optionele cloudsynchronisatie voor waarschuwingen, favorieten en pushmeldingen';
 
   @override
   String get tapToUpdateGps => 'Tik om GPS-positie bij te werken';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'De GPS-positie wordt automatisch verkregen bij het zoeken. U kunt deze hier ook handmatig bijwerken.';
+  String get gpsAutoUpdateHint => 'De GPS-positie wordt automatisch verkregen bij het zoeken. U kunt deze hier ook handmatig bijwerken.';
 
   @override
-  String get clearGpsConfirm =>
-      'Opgeslagen GPS-positie wissen? U kunt deze op elk moment opnieuw bijwerken.';
+  String get clearGpsConfirm => 'Opgeslagen GPS-positie wissen? U kunt deze op elk moment opnieuw bijwerken.';
 
   @override
   String get pageNotFound => 'Pagina niet gevonden';
@@ -933,8 +899,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -959,8 +924,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -984,12 +948,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1004,15 +966,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1063,44 +1023,37 @@ class AppLocalizationsNl extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1109,8 +1062,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1175,8 +1127,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1240,8 +1191,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1262,8 +1212,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1299,8 +1248,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1309,8 +1257,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1334,8 +1281,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1389,8 +1335,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1399,8 +1344,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1411,12 +1355,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1430,8 +1369,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get nearestStations => 'Dichtstbijzijnde stations';
 
   @override
-  String get nearestStationsHint =>
-      'Vind de dichtstbijzijnde stations met uw huidige locatie';
+  String get nearestStationsHint => 'Vind de dichtstbijzijnde stations met uw huidige locatie';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1440,8 +1378,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1453,8 +1390,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1505,8 +1441,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1586,12 +1521,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1757,15 +1690,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1789,8 +1720,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1799,33 +1729,28 @@ class AppLocalizationsNl extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1840,16 +1765,17 @@ class AppLocalizationsNl extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -103,8 +103,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get apiKeySetup => 'Klucz API';
 
   @override
-  String get apiKeyDescription =>
-      'Zarejestruj się raz, aby uzyskać bezpłatny klucz API.';
+  String get apiKeyDescription => 'Zarejestruj się raz, aby uzyskać bezpłatny klucz API.';
 
   @override
   String get apiKeyLabel => 'Klucz API';
@@ -173,8 +172,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get noFavorites => 'Brak ulubionych';
 
   @override
-  String get noFavoritesHint =>
-      'Dotknij gwiazdki przy stacji, aby zapisać ją jako ulubioną.';
+  String get noFavoritesHint => 'Dotknij gwiazdki przy stacji, aby zapisać ją jako ulubioną.';
 
   @override
   String get language => 'Język';
@@ -224,29 +222,25 @@ class AppLocalizationsPl extends AppLocalizations {
   String get gpsCoordinates => 'Współrzędne GPS';
 
   @override
-  String get gpsReason =>
-      'Wysyłane przy każdym wyszukiwaniu, aby znaleźć pobliskie stacje.';
+  String get gpsReason => 'Wysyłane przy każdym wyszukiwaniu, aby znaleźć pobliskie stacje.';
 
   @override
   String get postalCodeData => 'Kod pocztowy';
 
   @override
-  String get postalReason =>
-      'Konwertowany na współrzędne przez usługę geokodowania.';
+  String get postalReason => 'Konwertowany na współrzędne przez usługę geokodowania.';
 
   @override
   String get mapViewport => 'Widok mapy';
 
   @override
-  String get mapReason =>
-      'Kafelki mapy są ładowane z serwera. Żadne dane osobowe nie są przesyłane.';
+  String get mapReason => 'Kafelki mapy są ładowane z serwera. Żadne dane osobowe nie są przesyłane.';
 
   @override
   String get apiKeyData => 'Klucz API';
 
   @override
-  String get apiKeyReason =>
-      'Twój osobisty klucz jest wysyłany z każdym żądaniem API. Jest powiązany z Twoim adresem e-mail.';
+  String get apiKeyReason => 'Twój osobisty klucz jest wysyłany z każdym żądaniem API. Jest powiązany z Twoim adresem e-mail.';
 
   @override
   String get notShared => 'NIE jest udostępniane:';
@@ -267,8 +261,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get usageData => 'Dane o użytkowaniu';
 
   @override
-  String get privacyBanner =>
-      'Ta aplikacja nie ma serwera. Wszystkie dane pozostają na Twoim urządzeniu. Bez analityki, bez śledzenia, bez reklam.';
+  String get privacyBanner => 'Ta aplikacja nie ma serwera. Wszystkie dane pozostają na Twoim urządzeniu. Bez analityki, bez śledzenia, bez reklam.';
 
   @override
   String get storageUsage => 'Wykorzystanie pamięci na tym urządzeniu';
@@ -292,8 +285,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get cacheManagement => 'Zarządzanie pamięcią podręczną';
 
   @override
-  String get cacheDescription =>
-      'Pamięć podręczna przechowuje odpowiedzi API dla szybszego ładowania i dostępu offline.';
+  String get cacheDescription => 'Pamięć podręczna przechowuje odpowiedzi API dla szybszego ładowania i dostępu offline.';
 
   @override
   String get stationSearch => 'Wyszukiwanie stacji';
@@ -321,8 +313,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get clearCacheTitle => 'Wyczyścić pamięć podręczną?';
 
   @override
-  String get clearCacheBody =>
-      'Zapisane wyniki wyszukiwania i ceny zostaną usunięte. Profile, ulubione i ustawienia zostaną zachowane.';
+  String get clearCacheBody => 'Zapisane wyniki wyszukiwania i ceny zostaną usunięte. Profile, ulubione i ustawienia zostaną zachowane.';
 
   @override
   String get clearCacheButton => 'Wyczyść pamięć podręczną';
@@ -331,8 +322,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteAllTitle => 'Usunąć wszystkie dane?';
 
   @override
-  String get deleteAllBody =>
-      'To trwale usunie wszystkie profile, ulubione, klucz API, ustawienia i pamięć podręczną. Aplikacja zostanie zresetowana.';
+  String get deleteAllBody => 'To trwale usunie wszystkie profile, ulubione, klucz API, ustawienia i pamięć podręczną. Aplikacja zostanie zresetowana.';
 
   @override
   String get deleteAllButton => 'Usuń wszystko';
@@ -347,19 +337,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get noStorage => 'Brak wykorzystanej pamięci';
 
   @override
-  String get apiKeyNote =>
-      'Bezpłatna rejestracja. Dane od rządowych agencji przejrzystości cen.';
+  String get apiKeyNote => 'Bezpłatna rejestracja. Dane od rządowych agencji przejrzystości cen.';
 
   @override
-  String get apiKeyFormatError =>
-      'Nieprawidłowy format — oczekiwany UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Nieprawidłowy format — oczekiwany UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Wesprzyj ten projekt';
 
   @override
-  String get supportDescription =>
-      'Ta aplikacja jest darmowa, open source i bez reklam. Jeśli jest przydatna, rozważ wsparcie dewelopera.';
+  String get supportDescription => 'Ta aplikacja jest darmowa, open source i bez reklam. Jeśli jest przydatna, rozważ wsparcie dewelopera.';
 
   @override
   String get reportBug => 'Zgłoś błąd / Zaproponuj funkcję';
@@ -395,12 +382,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get station => 'Stacja paliw';
 
   @override
-  String get locationDenied =>
-      'Odmowa dostępu do lokalizacji. Możesz szukać po kodzie pocztowym.';
+  String get locationDenied => 'Odmowa dostępu do lokalizacji. Możesz szukać po kodzie pocztowym.';
 
   @override
-  String get demoModeBanner =>
-      'Tryb demo. Skonfiguruj klucz API w ustawieniach.';
+  String get demoModeBanner => 'Tryb demo. Skonfiguruj klucz API w ustawieniach.';
 
   @override
   String get sortDistance => 'Odległość';
@@ -426,8 +411,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Ładowanie ulubionych...\nNajpierw wyszukaj stacje, aby zapisać dane.';
+  String get loadingFavorites => 'Ładowanie ulubionych...\nNajpierw wyszukaj stacje, aby zapisać dane.';
 
   @override
   String get reportPrice => 'Zgłoś cenę';
@@ -463,8 +447,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get autoUpdatePosition => 'Aktualizuj pozycję automatycznie';
 
   @override
-  String get autoUpdateDescription =>
-      'Aktualizuj GPS przed każdym wyszukiwaniem';
+  String get autoUpdateDescription => 'Aktualizuj GPS przed każdym wyszukiwaniem';
 
   @override
   String get location => 'Lokalizacja';
@@ -494,8 +477,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get autoSwitchProfile => 'Automatyczna zmiana profilu';
 
   @override
-  String get autoSwitchDescription =>
-      'Automatycznie zmień profil po przekroczeniu granicy';
+  String get autoSwitchDescription => 'Automatycznie zmień profil po przekroczeniu granicy';
 
   @override
   String get switchProfile => 'Zmień';
@@ -615,12 +597,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get evUnknown => 'Nieznany';
 
   @override
-  String get evDataAttribution =>
-      'Dane z OpenChargeMap (źródło społecznościowe)';
+  String get evDataAttribution => 'Dane z OpenChargeMap (źródło społecznościowe)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Status może nie odzwierciedlać dostępności w czasie rzeczywistym. Dotknij odśwież, aby pobrać najnowsze dane.';
+  String get evStatusDisclaimer => 'Status może nie odzwierciedlać dostępności w czasie rzeczywistym. Dotknij odśwież, aby pobrać najnowsze dane.';
 
   @override
   String get evNavigateToStation => 'Nawiguj do stacji';
@@ -632,8 +612,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get evStatusUpdated => 'Status zaktualizowany';
 
   @override
-  String get evStationNotFound =>
-      'Nie udało się odświeżyć — stacja nie znaleziona w pobliżu';
+  String get evStationNotFound => 'Nie udało się odświeżyć — stacja nie znaleziona w pobliżu';
 
   @override
   String get addedToFavorites => 'Dodano do ulubionych';
@@ -702,8 +681,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Ceny paliw (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Wymagane do wyszukiwania cen paliw w Niemczech';
+  String get requiredForFuelSearch => 'Wymagane do wyszukiwania cen paliw w Niemczech';
 
   @override
   String get evChargingOpenChargeMap => 'Ładowanie EV (OpenChargeMap)';
@@ -715,12 +693,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get appDefaultKey => 'Domyślny klucz aplikacji';
 
   @override
-  String get optionalOverrideKey =>
-      'Opcjonalnie: zastąp wbudowany klucz aplikacji własnym';
+  String get optionalOverrideKey => 'Opcjonalnie: zastąp wbudowany klucz aplikacji własnym';
 
   @override
-  String get requiredForEvSearch =>
-      'Wymagane do wyszukiwania stacji ładowania EV';
+  String get requiredForEvSearch => 'Wymagane do wyszukiwania stacji ładowania EV';
 
   @override
   String get edit => 'Edytuj';
@@ -749,26 +725,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get avoidHighways => 'Unikaj autostrad';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Obliczanie trasy omija drogi płatne i autostrady';
+  String get avoidHighwaysDesc => 'Obliczanie trasy omija drogi płatne i autostrady';
 
   @override
   String get showFuelStations => 'Pokaż stacje paliw';
 
   @override
-  String get showFuelStationsDesc =>
-      'Uwzględnij stacje benzynowe, diesel, LPG, CNG';
+  String get showFuelStationsDesc => 'Uwzględnij stacje benzynowe, diesel, LPG, CNG';
 
   @override
   String get showEvStations => 'Pokaż stacje ładowania';
 
   @override
-  String get showEvStationsDesc =>
-      'Uwzględnij stacje ładowania w wynikach wyszukiwania';
+  String get showEvStationsDesc => 'Uwzględnij stacje ładowania w wynikach wyszukiwania';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Nie znaleziono stacji wzdłuż tej trasy.';
+  String get noStationsAlongThisRoute => 'Nie znaleziono stacji wzdłuż tej trasy.';
 
   @override
   String get fuelCostCalculator => 'Kalkulator kosztów paliwa';
@@ -792,8 +764,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get totalCost => 'Koszt całkowity';
 
   @override
-  String get enterCalcValues =>
-      'Wprowadź odległość, zużycie i cenę, aby obliczyć koszt podróży';
+  String get enterCalcValues => 'Wprowadź odległość, zużycie i cenę, aby obliczyć koszt podróży';
 
   @override
   String get priceHistory => 'Historia cen';
@@ -835,19 +806,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get viewMyData => 'Zobacz moje dane';
 
   @override
-  String get optionalCloudSync =>
-      'Opcjonalna synchronizacja w chmurze dla alertów, ulubionych i powiadomień push';
+  String get optionalCloudSync => 'Opcjonalna synchronizacja w chmurze dla alertów, ulubionych i powiadomień push';
 
   @override
   String get tapToUpdateGps => 'Dotknij, aby zaktualizować pozycję GPS';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'Pozycja GPS jest pobierana automatycznie podczas wyszukiwania. Możesz ją też zaktualizować ręcznie tutaj.';
+  String get gpsAutoUpdateHint => 'Pozycja GPS jest pobierana automatycznie podczas wyszukiwania. Możesz ją też zaktualizować ręcznie tutaj.';
 
   @override
-  String get clearGpsConfirm =>
-      'Wyczyścić zapisaną pozycję GPS? Możesz ją zaktualizować ponownie w dowolnym momencie.';
+  String get clearGpsConfirm => 'Wyczyścić zapisaną pozycję GPS? Możesz ją zaktualizować ponownie w dowolnym momencie.';
 
   @override
   String get pageNotFound => 'Strona nie znaleziona';
@@ -931,8 +899,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -957,8 +924,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -982,12 +948,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1002,15 +966,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1061,44 +1023,37 @@ class AppLocalizationsPl extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1107,8 +1062,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1173,8 +1127,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1238,8 +1191,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1260,8 +1212,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1297,8 +1248,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1307,8 +1257,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1332,8 +1281,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1387,8 +1335,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1397,8 +1344,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1409,12 +1355,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1428,8 +1369,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get nearestStations => 'Najblizsze stacje';
 
   @override
-  String get nearestStationsHint =>
-      'Znajdz najblizsze stacje na podstawie Twojej lokalizacji';
+  String get nearestStationsHint => 'Znajdz najblizsze stacje na podstawie Twojej lokalizacji';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1438,8 +1378,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1451,8 +1390,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1503,8 +1441,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1584,12 +1521,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1755,15 +1690,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1787,8 +1720,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1797,33 +1729,28 @@ class AppLocalizationsPl extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1838,16 +1765,17 @@ class AppLocalizationsPl extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -103,8 +103,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get apiKeySetup => 'Chave API';
 
   @override
-  String get apiKeyDescription =>
-      'Registe-se uma vez para obter uma chave API gratuita.';
+  String get apiKeyDescription => 'Registe-se uma vez para obter uma chave API gratuita.';
 
   @override
   String get apiKeyLabel => 'Chave API';
@@ -119,8 +118,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get welcome => 'Preços de Combustível';
 
   @override
-  String get welcomeSubtitle =>
-      'Encontre o combustível mais barato perto de si.';
+  String get welcomeSubtitle => 'Encontre o combustível mais barato perto de si.';
 
   @override
   String get profileName => 'Nome do perfil';
@@ -174,8 +172,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noFavorites => 'Sem favoritos';
 
   @override
-  String get noFavoritesHint =>
-      'Toque na estrela de um posto para o guardar como favorito.';
+  String get noFavoritesHint => 'Toque na estrela de um posto para o guardar como favorito.';
 
   @override
   String get language => 'Idioma';
@@ -225,29 +222,25 @@ class AppLocalizationsPt extends AppLocalizations {
   String get gpsCoordinates => 'Coordenadas GPS';
 
   @override
-  String get gpsReason =>
-      'Enviadas em cada pesquisa para encontrar postos próximos.';
+  String get gpsReason => 'Enviadas em cada pesquisa para encontrar postos próximos.';
 
   @override
   String get postalCodeData => 'Código postal';
 
   @override
-  String get postalReason =>
-      'Convertido em coordenadas através do serviço de geocodificação.';
+  String get postalReason => 'Convertido em coordenadas através do serviço de geocodificação.';
 
   @override
   String get mapViewport => 'Área do mapa';
 
   @override
-  String get mapReason =>
-      'Os mosaicos do mapa são carregados do servidor. Nenhum dado pessoal é transmitido.';
+  String get mapReason => 'Os mosaicos do mapa são carregados do servidor. Nenhum dado pessoal é transmitido.';
 
   @override
   String get apiKeyData => 'Chave API';
 
   @override
-  String get apiKeyReason =>
-      'A sua chave pessoal é enviada com cada pedido API. Está ligada ao seu e-mail.';
+  String get apiKeyReason => 'A sua chave pessoal é enviada com cada pedido API. Está ligada ao seu e-mail.';
 
   @override
   String get notShared => 'NÃO partilhado:';
@@ -268,8 +261,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get usageData => 'Dados de utilização';
 
   @override
-  String get privacyBanner =>
-      'Esta app não tem servidor. Todos os dados ficam no seu dispositivo. Sem análises, sem rastreamento, sem publicidade.';
+  String get privacyBanner => 'Esta app não tem servidor. Todos os dados ficam no seu dispositivo. Sem análises, sem rastreamento, sem publicidade.';
 
   @override
   String get storageUsage => 'Utilização de armazenamento neste dispositivo';
@@ -293,8 +285,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get cacheManagement => 'Gestão de cache';
 
   @override
-  String get cacheDescription =>
-      'A cache armazena respostas API para carregamento mais rápido e acesso offline.';
+  String get cacheDescription => 'A cache armazena respostas API para carregamento mais rápido e acesso offline.';
 
   @override
   String get stationSearch => 'Pesquisa de postos';
@@ -322,8 +313,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get clearCacheTitle => 'Limpar cache?';
 
   @override
-  String get clearCacheBody =>
-      'Os resultados de pesquisa e preços em cache serão eliminados. Perfis, favoritos e definições são preservados.';
+  String get clearCacheBody => 'Os resultados de pesquisa e preços em cache serão eliminados. Perfis, favoritos e definições são preservados.';
 
   @override
   String get clearCacheButton => 'Limpar cache';
@@ -332,8 +322,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteAllTitle => 'Eliminar todos os dados?';
 
   @override
-  String get deleteAllBody =>
-      'Isto elimina permanentemente todos os perfis, favoritos, chave API, definições e cache. A app será reiniciada.';
+  String get deleteAllBody => 'Isto elimina permanentemente todos os perfis, favoritos, chave API, definições e cache. A app será reiniciada.';
 
   @override
   String get deleteAllButton => 'Eliminar tudo';
@@ -348,19 +337,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noStorage => 'Sem armazenamento utilizado';
 
   @override
-  String get apiKeyNote =>
-      'Registo gratuito. Dados de agências governamentais de transparência de preços.';
+  String get apiKeyNote => 'Registo gratuito. Dados de agências governamentais de transparência de preços.';
 
   @override
-  String get apiKeyFormatError =>
-      'Formato inválido — UUID esperado (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Formato inválido — UUID esperado (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Apoiar este projeto';
 
   @override
-  String get supportDescription =>
-      'Esta app é gratuita, de código aberto e sem publicidade. Se a achar útil, considere apoiar o programador.';
+  String get supportDescription => 'Esta app é gratuita, de código aberto e sem publicidade. Se a achar útil, considere apoiar o programador.';
 
   @override
   String get reportBug => 'Reportar erro / Sugerir funcionalidade';
@@ -396,12 +382,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get station => 'Posto';
 
   @override
-  String get locationDenied =>
-      'Permissão de localização negada. Pode pesquisar por código postal.';
+  String get locationDenied => 'Permissão de localização negada. Pode pesquisar por código postal.';
 
   @override
-  String get demoModeBanner =>
-      'Modo de demonstração. Configure a chave API nas definições.';
+  String get demoModeBanner => 'Modo de demonstração. Configure a chave API nas definições.';
 
   @override
   String get sortDistance => 'Distância';
@@ -427,8 +411,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'A carregar favoritos...\nPesquise postos primeiro para guardar dados.';
+  String get loadingFavorites => 'A carregar favoritos...\nPesquise postos primeiro para guardar dados.';
 
   @override
   String get reportPrice => 'Reportar preço';
@@ -464,8 +447,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoUpdatePosition => 'Atualizar posição automaticamente';
 
   @override
-  String get autoUpdateDescription =>
-      'Atualizar posição GPS antes de cada pesquisa';
+  String get autoUpdateDescription => 'Atualizar posição GPS antes de cada pesquisa';
 
   @override
   String get location => 'Localização';
@@ -495,8 +477,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoSwitchProfile => 'Mudança automática de perfil';
 
   @override
-  String get autoSwitchDescription =>
-      'Mudar perfil automaticamente ao cruzar fronteiras';
+  String get autoSwitchDescription => 'Mudar perfil automaticamente ao cruzar fronteiras';
 
   @override
   String get switchProfile => 'Mudar';
@@ -523,8 +504,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noPriceAlerts => 'Sem alertas de preço';
 
   @override
-  String get noPriceAlertsHint =>
-      'Crie um alerta a partir da página de detalhes de um posto.';
+  String get noPriceAlertsHint => 'Crie um alerta a partir da página de detalhes de um posto.';
 
   @override
   String alertDeleted(String name) {
@@ -620,8 +600,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get evDataAttribution => 'Dados do OpenChargeMap (fonte comunitária)';
 
   @override
-  String get evStatusDisclaimer =>
-      'O estado pode não refletir a disponibilidade em tempo real. Toque em atualizar para obter os dados mais recentes.';
+  String get evStatusDisclaimer => 'O estado pode não refletir a disponibilidade em tempo real. Toque em atualizar para obter os dados mais recentes.';
 
   @override
   String get evNavigateToStation => 'Navegar para o posto';
@@ -633,8 +612,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get evStatusUpdated => 'Estado atualizado';
 
   @override
-  String get evStationNotFound =>
-      'Não foi possível atualizar — posto não encontrado nas proximidades';
+  String get evStationNotFound => 'Não foi possível atualizar — posto não encontrado nas proximidades';
 
   @override
   String get addedToFavorites => 'Adicionado aos favoritos';
@@ -703,8 +681,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Preços de combustível (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Necessário para pesquisa de preços de combustível na Alemanha';
+  String get requiredForFuelSearch => 'Necessário para pesquisa de preços de combustível na Alemanha';
 
   @override
   String get evChargingOpenChargeMap => 'Carregamento EV (OpenChargeMap)';
@@ -716,12 +693,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appDefaultKey => 'Chave predefinida da app';
 
   @override
-  String get optionalOverrideKey =>
-      'Opcional: substituir a chave integrada pela sua';
+  String get optionalOverrideKey => 'Opcional: substituir a chave integrada pela sua';
 
   @override
-  String get requiredForEvSearch =>
-      'Necessário para pesquisa de postos de carregamento EV';
+  String get requiredForEvSearch => 'Necessário para pesquisa de postos de carregamento EV';
 
   @override
   String get edit => 'Editar';
@@ -750,26 +725,22 @@ class AppLocalizationsPt extends AppLocalizations {
   String get avoidHighways => 'Evitar autoestradas';
 
   @override
-  String get avoidHighwaysDesc =>
-      'O cálculo da rota evita portagens e autoestradas';
+  String get avoidHighwaysDesc => 'O cálculo da rota evita portagens e autoestradas';
 
   @override
   String get showFuelStations => 'Mostrar postos de combustível';
 
   @override
-  String get showFuelStationsDesc =>
-      'Incluir postos de gasolina, gasóleo, GPL, GNC';
+  String get showFuelStationsDesc => 'Incluir postos de gasolina, gasóleo, GPL, GNC';
 
   @override
   String get showEvStations => 'Mostrar postos de carregamento';
 
   @override
-  String get showEvStationsDesc =>
-      'Incluir postos de carregamento elétrico nos resultados';
+  String get showEvStationsDesc => 'Incluir postos de carregamento elétrico nos resultados';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Nenhum posto encontrado ao longo desta rota.';
+  String get noStationsAlongThisRoute => 'Nenhum posto encontrado ao longo desta rota.';
 
   @override
   String get fuelCostCalculator => 'Calculadora de custo de combustível';
@@ -793,8 +764,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get totalCost => 'Custo total';
 
   @override
-  String get enterCalcValues =>
-      'Introduza distância, consumo e preço para calcular o custo da viagem';
+  String get enterCalcValues => 'Introduza distância, consumo e preço para calcular o custo da viagem';
 
   @override
   String get priceHistory => 'Histórico de preços';
@@ -836,19 +806,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get viewMyData => 'Ver os meus dados';
 
   @override
-  String get optionalCloudSync =>
-      'Sincronização na nuvem opcional para alertas, favoritos e notificações push';
+  String get optionalCloudSync => 'Sincronização na nuvem opcional para alertas, favoritos e notificações push';
 
   @override
   String get tapToUpdateGps => 'Toque para atualizar a posição GPS';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'A posição GPS é obtida automaticamente ao pesquisar. Também pode atualizá-la manualmente aqui.';
+  String get gpsAutoUpdateHint => 'A posição GPS é obtida automaticamente ao pesquisar. Também pode atualizá-la manualmente aqui.';
 
   @override
-  String get clearGpsConfirm =>
-      'Limpar a posição GPS guardada? Pode atualizá-la novamente a qualquer momento.';
+  String get clearGpsConfirm => 'Limpar a posição GPS guardada? Pode atualizá-la novamente a qualquer momento.';
 
   @override
   String get pageNotFound => 'Página não encontrada';
@@ -932,8 +899,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -958,8 +924,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -983,12 +948,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1003,15 +966,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1062,44 +1023,37 @@ class AppLocalizationsPt extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1108,8 +1062,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1174,8 +1127,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1239,8 +1191,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1261,8 +1212,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1298,8 +1248,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1308,8 +1257,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1333,8 +1281,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1388,8 +1335,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1398,8 +1344,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1410,12 +1355,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1429,8 +1369,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get nearestStations => 'Postos mais proximos';
 
   @override
-  String get nearestStationsHint =>
-      'Encontre os postos mais proximos com a sua localizacao atual';
+  String get nearestStationsHint => 'Encontre os postos mais proximos com a sua localizacao atual';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1439,8 +1378,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1452,8 +1390,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1504,8 +1441,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1585,12 +1521,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1756,15 +1690,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1788,8 +1720,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1798,33 +1729,28 @@ class AppLocalizationsPt extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1839,16 +1765,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -103,8 +103,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get apiKeySetup => 'Cheie API';
 
   @override
-  String get apiKeyDescription =>
-      'Înregistrați-vă o dată pentru o cheie API gratuită.';
+  String get apiKeyDescription => 'Înregistrați-vă o dată pentru o cheie API gratuită.';
 
   @override
   String get apiKeyLabel => 'Cheie API';
@@ -119,8 +118,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get welcome => 'Prețuri Carburanți';
 
   @override
-  String get welcomeSubtitle =>
-      'Găsiți cel mai ieftin carburant în apropierea dvs.';
+  String get welcomeSubtitle => 'Găsiți cel mai ieftin carburant în apropierea dvs.';
 
   @override
   String get profileName => 'Numele profilului';
@@ -174,8 +172,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noFavorites => 'Fără favorite';
 
   @override
-  String get noFavoritesHint =>
-      'Atingeți steaua la o benzinărie pentru a o salva ca favorită.';
+  String get noFavoritesHint => 'Atingeți steaua la o benzinărie pentru a o salva ca favorită.';
 
   @override
   String get language => 'Limbă';
@@ -225,29 +222,25 @@ class AppLocalizationsRo extends AppLocalizations {
   String get gpsCoordinates => 'Coordonate GPS';
 
   @override
-  String get gpsReason =>
-      'Trimise la fiecare căutare pentru a găsi benzinării în apropiere.';
+  String get gpsReason => 'Trimise la fiecare căutare pentru a găsi benzinării în apropiere.';
 
   @override
   String get postalCodeData => 'Cod poștal';
 
   @override
-  String get postalReason =>
-      'Convertit în coordonate prin serviciul de geocodificare.';
+  String get postalReason => 'Convertit în coordonate prin serviciul de geocodificare.';
 
   @override
   String get mapViewport => 'Zona hărții';
 
   @override
-  String get mapReason =>
-      'Plăcile hărții sunt încărcate de pe server. Nu se transmit date personale.';
+  String get mapReason => 'Plăcile hărții sunt încărcate de pe server. Nu se transmit date personale.';
 
   @override
   String get apiKeyData => 'Cheie API';
 
   @override
-  String get apiKeyReason =>
-      'Cheia dvs. personală este trimisă cu fiecare cerere API. Este legată de e-mailul dvs.';
+  String get apiKeyReason => 'Cheia dvs. personală este trimisă cu fiecare cerere API. Este legată de e-mailul dvs.';
 
   @override
   String get notShared => 'NU se partajează:';
@@ -268,8 +261,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get usageData => 'Date de utilizare';
 
   @override
-  String get privacyBanner =>
-      'Această aplicație nu are server. Toate datele rămân pe dispozitivul dvs. Fără analiză, fără urmărire, fără reclame.';
+  String get privacyBanner => 'Această aplicație nu are server. Toate datele rămân pe dispozitivul dvs. Fără analiză, fără urmărire, fără reclame.';
 
   @override
   String get storageUsage => 'Utilizare stocare pe acest dispozitiv';
@@ -293,8 +285,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get cacheManagement => 'Gestionare cache';
 
   @override
-  String get cacheDescription =>
-      'Cache-ul stochează răspunsuri API pentru încărcare mai rapidă și acces offline.';
+  String get cacheDescription => 'Cache-ul stochează răspunsuri API pentru încărcare mai rapidă și acces offline.';
 
   @override
   String get stationSearch => 'Căutare benzinării';
@@ -322,8 +313,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get clearCacheTitle => 'Golești cache-ul?';
 
   @override
-  String get clearCacheBody =>
-      'Rezultatele căutărilor și prețurile din cache vor fi șterse. Profilurile, favoritele și setările sunt păstrate.';
+  String get clearCacheBody => 'Rezultatele căutărilor și prețurile din cache vor fi șterse. Profilurile, favoritele și setările sunt păstrate.';
 
   @override
   String get clearCacheButton => 'Golește cache';
@@ -332,8 +322,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteAllTitle => 'Ștergi toate datele?';
 
   @override
-  String get deleteAllBody =>
-      'Aceasta șterge permanent toate profilurile, favoritele, cheia API, setările și cache-ul. Aplicația va fi resetată.';
+  String get deleteAllBody => 'Aceasta șterge permanent toate profilurile, favoritele, cheia API, setările și cache-ul. Aplicația va fi resetată.';
 
   @override
   String get deleteAllButton => 'Șterge tot';
@@ -348,8 +337,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noStorage => 'Fără stocare utilizată';
 
   @override
-  String get apiKeyNote =>
-      'Înregistrare gratuită. Date de la agențiile guvernamentale de transparență a prețurilor.';
+  String get apiKeyNote => 'Înregistrare gratuită. Date de la agențiile guvernamentale de transparență a prețurilor.';
 
   @override
   String get apiKeyFormatError => 'Format invalid — UUID așteptat (8-4-4-4-12)';
@@ -358,8 +346,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get supportProject => 'Susțineți acest proiect';
 
   @override
-  String get supportDescription =>
-      'Această aplicație este gratuită, open source și fără reclame. Dacă o găsiți utilă, luați în considerare susținerea dezvoltatorului.';
+  String get supportDescription => 'Această aplicație este gratuită, open source și fără reclame. Dacă o găsiți utilă, luați în considerare susținerea dezvoltatorului.';
 
   @override
   String get reportBug => 'Raportează eroare / Sugerează funcție';
@@ -395,8 +382,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get station => 'Benzinărie';
 
   @override
-  String get locationDenied =>
-      'Permisiunea de localizare refuzată. Puteți căuta după cod poștal.';
+  String get locationDenied => 'Permisiunea de localizare refuzată. Puteți căuta după cod poștal.';
 
   @override
   String get demoModeBanner => 'Mod demo. Configurați cheia API în setări.';
@@ -425,8 +411,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Se încarcă favoritele...\nCăutați benzinării mai întâi pentru a salva date.';
+  String get loadingFavorites => 'Se încarcă favoritele...\nCăutați benzinării mai întâi pentru a salva date.';
 
   @override
   String get reportPrice => 'Raportează preț';
@@ -462,8 +447,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoUpdatePosition => 'Actualizare automată a poziției';
 
   @override
-  String get autoUpdateDescription =>
-      'Actualizează poziția GPS înainte de fiecare căutare';
+  String get autoUpdateDescription => 'Actualizează poziția GPS înainte de fiecare căutare';
 
   @override
   String get location => 'Locație';
@@ -493,8 +477,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoSwitchProfile => 'Comutare automată a profilului';
 
   @override
-  String get autoSwitchDescription =>
-      'Comută profilul automat la trecerea frontierei';
+  String get autoSwitchDescription => 'Comută profilul automat la trecerea frontierei';
 
   @override
   String get switchProfile => 'Comută';
@@ -521,8 +504,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noPriceAlerts => 'Fără alerte de preț';
 
   @override
-  String get noPriceAlertsHint =>
-      'Creați o alertă din pagina de detalii a unei benzinării.';
+  String get noPriceAlertsHint => 'Creați o alertă din pagina de detalii a unei benzinării.';
 
   @override
   String alertDeleted(String name) {
@@ -618,8 +600,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get evDataAttribution => 'Date de la OpenChargeMap (sursă comunitară)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Starea poate să nu reflecte disponibilitatea în timp real. Atingeți actualizare pentru cele mai recente date.';
+  String get evStatusDisclaimer => 'Starea poate să nu reflecte disponibilitatea în timp real. Atingeți actualizare pentru cele mai recente date.';
 
   @override
   String get evNavigateToStation => 'Navigare la stație';
@@ -631,8 +612,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get evStatusUpdated => 'Stare actualizată';
 
   @override
-  String get evStationNotFound =>
-      'Nu s-a putut actualiza — stație negăsită în apropiere';
+  String get evStationNotFound => 'Nu s-a putut actualiza — stație negăsită în apropiere';
 
   @override
   String get addedToFavorites => 'Adăugat la favorite';
@@ -653,8 +633,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get gpsError => 'Eroare GPS';
 
   @override
-  String get couldNotResolve =>
-      'Nu s-a putut determina punctul de plecare sau destinația';
+  String get couldNotResolve => 'Nu s-a putut determina punctul de plecare sau destinația';
 
   @override
   String get start => 'Start';
@@ -702,8 +681,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Prețuri carburanți (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Necesar pentru căutarea prețurilor de carburanți în Germania';
+  String get requiredForFuelSearch => 'Necesar pentru căutarea prețurilor de carburanți în Germania';
 
   @override
   String get evChargingOpenChargeMap => 'Încărcare EV (OpenChargeMap)';
@@ -715,12 +693,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get appDefaultKey => 'Cheie implicită a aplicației';
 
   @override
-  String get optionalOverrideKey =>
-      'Opțional: înlocuiți cheia încorporată cu a dvs.';
+  String get optionalOverrideKey => 'Opțional: înlocuiți cheia încorporată cu a dvs.';
 
   @override
-  String get requiredForEvSearch =>
-      'Necesar pentru căutarea stațiilor de încărcare EV';
+  String get requiredForEvSearch => 'Necesar pentru căutarea stațiilor de încărcare EV';
 
   @override
   String get edit => 'Editare';
@@ -749,26 +725,22 @@ class AppLocalizationsRo extends AppLocalizations {
   String get avoidHighways => 'Evită autostrăzile';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Calculul rutei evită drumurile cu taxă și autostrăzile';
+  String get avoidHighwaysDesc => 'Calculul rutei evită drumurile cu taxă și autostrăzile';
 
   @override
   String get showFuelStations => 'Arată benzinăriile';
 
   @override
-  String get showFuelStationsDesc =>
-      'Include stații de benzină, motorină, GPL, GNC';
+  String get showFuelStationsDesc => 'Include stații de benzină, motorină, GPL, GNC';
 
   @override
   String get showEvStations => 'Arată stații de încărcare';
 
   @override
-  String get showEvStationsDesc =>
-      'Include stații de încărcare electrică în rezultate';
+  String get showEvStationsDesc => 'Include stații de încărcare electrică în rezultate';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Nu s-au găsit stații de-a lungul acestei rute.';
+  String get noStationsAlongThisRoute => 'Nu s-au găsit stații de-a lungul acestei rute.';
 
   @override
   String get fuelCostCalculator => 'Calculator cost carburant';
@@ -792,8 +764,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get totalCost => 'Cost total';
 
   @override
-  String get enterCalcValues =>
-      'Introduceți distanța, consumul și prețul pentru a calcula costul călătoriei';
+  String get enterCalcValues => 'Introduceți distanța, consumul și prețul pentru a calcula costul călătoriei';
 
   @override
   String get priceHistory => 'Istoric prețuri';
@@ -835,19 +806,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get viewMyData => 'Vezi datele mele';
 
   @override
-  String get optionalCloudSync =>
-      'Sincronizare cloud opțională pentru alerte, favorite și notificări push';
+  String get optionalCloudSync => 'Sincronizare cloud opțională pentru alerte, favorite și notificări push';
 
   @override
   String get tapToUpdateGps => 'Atingeți pentru a actualiza poziția GPS';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'Poziția GPS este obținută automat la căutare. O puteți actualiza și manual aici.';
+  String get gpsAutoUpdateHint => 'Poziția GPS este obținută automat la căutare. O puteți actualiza și manual aici.';
 
   @override
-  String get clearGpsConfirm =>
-      'Ștergeți poziția GPS stocată? O puteți actualiza oricând.';
+  String get clearGpsConfirm => 'Ștergeți poziția GPS stocată? O puteți actualiza oricând.';
 
   @override
   String get pageNotFound => 'Pagină negăsită';
@@ -931,8 +899,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -957,8 +924,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -982,12 +948,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1002,15 +966,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1061,44 +1023,37 @@ class AppLocalizationsRo extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1107,8 +1062,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1173,8 +1127,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1238,8 +1191,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1260,8 +1212,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1297,8 +1248,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1307,8 +1257,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1332,8 +1281,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1387,8 +1335,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1397,8 +1344,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1409,12 +1355,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1428,8 +1369,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get nearestStations => 'Cele mai apropiate statii';
 
   @override
-  String get nearestStationsHint =>
-      'Gasiti cele mai apropiate statii cu locatia dvs. actuala';
+  String get nearestStationsHint => 'Gasiti cele mai apropiate statii cu locatia dvs. actuala';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1438,8 +1378,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1451,8 +1390,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1503,8 +1441,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1584,12 +1521,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1755,15 +1690,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1787,8 +1720,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1797,33 +1729,28 @@ class AppLocalizationsRo extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1838,16 +1765,17 @@ class AppLocalizationsRo extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -103,8 +103,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get apiKeySetup => 'Kľúč API';
 
   @override
-  String get apiKeyDescription =>
-      'Zaregistrujte sa raz pre bezplatný kľúč API.';
+  String get apiKeyDescription => 'Zaregistrujte sa raz pre bezplatný kľúč API.';
 
   @override
   String get apiKeyLabel => 'Kľúč API';
@@ -173,8 +172,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noFavorites => 'Žiadne obľúbené';
 
   @override
-  String get noFavoritesHint =>
-      'Ťuknite na hviezdičku pri stanici, aby ste ju uložili do obľúbených.';
+  String get noFavoritesHint => 'Ťuknite na hviezdičku pri stanici, aby ste ju uložili do obľúbených.';
 
   @override
   String get language => 'Jazyk';
@@ -224,29 +222,25 @@ class AppLocalizationsSk extends AppLocalizations {
   String get gpsCoordinates => 'Súradnice GPS';
 
   @override
-  String get gpsReason =>
-      'Odosielané s každým vyhľadávaním na nájdenie blízkych staníc.';
+  String get gpsReason => 'Odosielané s každým vyhľadávaním na nájdenie blízkych staníc.';
 
   @override
   String get postalCodeData => 'PSČ';
 
   @override
-  String get postalReason =>
-      'Prevedené na súradnice prostredníctvom geokódovacej služby.';
+  String get postalReason => 'Prevedené na súradnice prostredníctvom geokódovacej služby.';
 
   @override
   String get mapViewport => 'Výrez mapy';
 
   @override
-  String get mapReason =>
-      'Mapové dlaždice sa načítavajú zo servera. Žiadne osobné údaje sa neprenášajú.';
+  String get mapReason => 'Mapové dlaždice sa načítavajú zo servera. Žiadne osobné údaje sa neprenášajú.';
 
   @override
   String get apiKeyData => 'Kľúč API';
 
   @override
-  String get apiKeyReason =>
-      'Váš osobný kľúč sa odosiela s každou API požiadavkou. Je prepojený s vaším e-mailom.';
+  String get apiKeyReason => 'Váš osobný kľúč sa odosiela s každou API požiadavkou. Je prepojený s vaším e-mailom.';
 
   @override
   String get notShared => 'NEZDIEĽA sa:';
@@ -267,8 +261,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get usageData => 'Údaje o používaní';
 
   @override
-  String get privacyBanner =>
-      'Táto aplikácia nemá server. Všetky údaje zostávajú na vašom zariadení. Žiadna analytika, sledovanie ani reklamy.';
+  String get privacyBanner => 'Táto aplikácia nemá server. Všetky údaje zostávajú na vašom zariadení. Žiadna analytika, sledovanie ani reklamy.';
 
   @override
   String get storageUsage => 'Využitie úložiska na tomto zariadení';
@@ -292,8 +285,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get cacheManagement => 'Správa vyrovnávacej pamäte';
 
   @override
-  String get cacheDescription =>
-      'Vyrovnávacia pamäť ukladá odpovede API pre rýchlejšie načítanie a offline prístup.';
+  String get cacheDescription => 'Vyrovnávacia pamäť ukladá odpovede API pre rýchlejšie načítanie a offline prístup.';
 
   @override
   String get stationSearch => 'Vyhľadávanie staníc';
@@ -321,8 +313,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get clearCacheTitle => 'Vymazať vyrovnávaciu pamäť?';
 
   @override
-  String get clearCacheBody =>
-      'Uložené výsledky hľadania a ceny budú vymazané. Profily, obľúbené a nastavenia zostanú zachované.';
+  String get clearCacheBody => 'Uložené výsledky hľadania a ceny budú vymazané. Profily, obľúbené a nastavenia zostanú zachované.';
 
   @override
   String get clearCacheButton => 'Vymazať vyrovnávaciu pamäť';
@@ -331,8 +322,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleteAllTitle => 'Vymazať všetky údaje?';
 
   @override
-  String get deleteAllBody =>
-      'Toto natrvalo vymaže všetky profily, obľúbené, kľúč API, nastavenia a vyrovnávaciu pamäť. Aplikácia sa resetuje.';
+  String get deleteAllBody => 'Toto natrvalo vymaže všetky profily, obľúbené, kľúč API, nastavenia a vyrovnávaciu pamäť. Aplikácia sa resetuje.';
 
   @override
   String get deleteAllButton => 'Vymazať všetko';
@@ -347,19 +337,16 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noStorage => 'Žiadne využité úložisko';
 
   @override
-  String get apiKeyNote =>
-      'Bezplatná registrácia. Údaje od vládnych agentúr pre cenovú transparentnosť.';
+  String get apiKeyNote => 'Bezplatná registrácia. Údaje od vládnych agentúr pre cenovú transparentnosť.';
 
   @override
-  String get apiKeyFormatError =>
-      'Neplatný formát — očakávané UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Neplatný formát — očakávané UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Podporte tento projekt';
 
   @override
-  String get supportDescription =>
-      'Táto aplikácia je bezplatná, s otvoreným zdrojovým kódom a bez reklám. Ak ju považujete za užitočnú, zvážte podporu vývojára.';
+  String get supportDescription => 'Táto aplikácia je bezplatná, s otvoreným zdrojovým kódom a bez reklám. Ak ju považujete za užitočnú, zvážte podporu vývojára.';
 
   @override
   String get reportBug => 'Nahlásiť chybu / Navrhnúť funkciu';
@@ -395,8 +382,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get station => 'Čerpacia stanica';
 
   @override
-  String get locationDenied =>
-      'Povolenie polohy zamietnuté. Môžete hľadať podľa PSČ.';
+  String get locationDenied => 'Povolenie polohy zamietnuté. Môžete hľadať podľa PSČ.';
 
   @override
   String get demoModeBanner => 'Demo režim. Nastavte kľúč API v nastaveniach.';
@@ -425,8 +411,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Načítavanie obľúbených...\nNajprv vyhľadajte stanice na uloženie údajov.';
+  String get loadingFavorites => 'Načítavanie obľúbených...\nNajprv vyhľadajte stanice na uloženie údajov.';
 
   @override
   String get reportPrice => 'Nahlásiť cenu';
@@ -462,8 +447,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get autoUpdatePosition => 'Automaticky aktualizovať polohu';
 
   @override
-  String get autoUpdateDescription =>
-      'Aktualizovať polohu GPS pred každým hľadaním';
+  String get autoUpdateDescription => 'Aktualizovať polohu GPS pred každým hľadaním';
 
   @override
   String get location => 'Poloha';
@@ -493,8 +477,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get autoSwitchProfile => 'Automatické prepnutie profilu';
 
   @override
-  String get autoSwitchDescription =>
-      'Automaticky prepnúť profil pri prekročení hraníc';
+  String get autoSwitchDescription => 'Automaticky prepnúť profil pri prekročení hraníc';
 
   @override
   String get switchProfile => 'Prepnúť';
@@ -521,8 +504,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noPriceAlerts => 'Žiadne cenové upozornenia';
 
   @override
-  String get noPriceAlertsHint =>
-      'Vytvorte upozornenie zo stránky s podrobnosťami stanice.';
+  String get noPriceAlertsHint => 'Vytvorte upozornenie zo stránky s podrobnosťami stanice.';
 
   @override
   String alertDeleted(String name) {
@@ -586,8 +568,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get openInMaps => 'Otvoriť v Mapách';
 
   @override
-  String get noStationsAlongRoute =>
-      'Pozdĺž trasy neboli nájdené žiadne stanice';
+  String get noStationsAlongRoute => 'Pozdĺž trasy neboli nájdené žiadne stanice';
 
   @override
   String get evOperational => 'V prevádzke';
@@ -607,8 +588,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get evUsageCost => 'Náklady na použitie';
 
   @override
-  String get evPricingUnavailable =>
-      'Ceny nie sú k dispozícii od poskytovateľa';
+  String get evPricingUnavailable => 'Ceny nie sú k dispozícii od poskytovateľa';
 
   @override
   String get evLastUpdated => 'Naposledy aktualizované';
@@ -620,8 +600,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get evDataAttribution => 'Údaje z OpenChargeMap (komunitný zdroj)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Stav nemusí odrážať dostupnosť v reálnom čase. Ťuknite na aktualizovať pre najnovšie údaje.';
+  String get evStatusDisclaimer => 'Stav nemusí odrážať dostupnosť v reálnom čase. Ťuknite na aktualizovať pre najnovšie údaje.';
 
   @override
   String get evNavigateToStation => 'Navigovať na stanicu';
@@ -633,8 +612,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get evStatusUpdated => 'Stav aktualizovaný';
 
   @override
-  String get evStationNotFound =>
-      'Nie je možné aktualizovať — stanica nenájdená v okolí';
+  String get evStationNotFound => 'Nie je možné aktualizovať — stanica nenájdená v okolí';
 
   @override
   String get addedToFavorites => 'Pridané do obľúbených';
@@ -703,8 +681,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get fuelPricesTankerkoenig => 'Ceny palív (Tankerkoenig)';
 
   @override
-  String get requiredForFuelSearch =>
-      'Vyžadované pre vyhľadávanie cien palív v Nemecku';
+  String get requiredForFuelSearch => 'Vyžadované pre vyhľadávanie cien palív v Nemecku';
 
   @override
   String get evChargingOpenChargeMap => 'Nabíjanie EV (OpenChargeMap)';
@@ -716,12 +693,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get appDefaultKey => 'Predvolený kľúč aplikácie';
 
   @override
-  String get optionalOverrideKey =>
-      'Voliteľné: nahradiť vstavaný kľúč aplikácie vlastným';
+  String get optionalOverrideKey => 'Voliteľné: nahradiť vstavaný kľúč aplikácie vlastným';
 
   @override
-  String get requiredForEvSearch =>
-      'Vyžadované pre vyhľadávanie nabíjacích staníc EV';
+  String get requiredForEvSearch => 'Vyžadované pre vyhľadávanie nabíjacích staníc EV';
 
   @override
   String get edit => 'Upraviť';
@@ -750,26 +725,22 @@ class AppLocalizationsSk extends AppLocalizations {
   String get avoidHighways => 'Vyhnúť sa diaľniciam';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Výpočet trasy sa vyhýba spoplatneným cestám a diaľniciam';
+  String get avoidHighwaysDesc => 'Výpočet trasy sa vyhýba spoplatneným cestám a diaľniciam';
 
   @override
   String get showFuelStations => 'Zobraziť čerpacie stanice';
 
   @override
-  String get showFuelStationsDesc =>
-      'Zahrnúť benzínové, naftové, LPG, CNG stanice';
+  String get showFuelStationsDesc => 'Zahrnúť benzínové, naftové, LPG, CNG stanice';
 
   @override
   String get showEvStations => 'Zobraziť nabíjacie stanice';
 
   @override
-  String get showEvStationsDesc =>
-      'Zahrnúť elektrické nabíjacie stanice vo výsledkoch';
+  String get showEvStationsDesc => 'Zahrnúť elektrické nabíjacie stanice vo výsledkoch';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Pozdĺž tejto trasy neboli nájdené žiadne stanice.';
+  String get noStationsAlongThisRoute => 'Pozdĺž tejto trasy neboli nájdené žiadne stanice.';
 
   @override
   String get fuelCostCalculator => 'Kalkulačka nákladov na palivo';
@@ -793,8 +764,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get totalCost => 'Celkové náklady';
 
   @override
-  String get enterCalcValues =>
-      'Zadajte vzdialenosť, spotrebu a cenu pre výpočet nákladov na cestu';
+  String get enterCalcValues => 'Zadajte vzdialenosť, spotrebu a cenu pre výpočet nákladov na cestu';
 
   @override
   String get priceHistory => 'História cien';
@@ -836,19 +806,16 @@ class AppLocalizationsSk extends AppLocalizations {
   String get viewMyData => 'Zobraziť moje údaje';
 
   @override
-  String get optionalCloudSync =>
-      'Voliteľná cloudová synchronizácia pre upozornenia, obľúbené a push notifikácie';
+  String get optionalCloudSync => 'Voliteľná cloudová synchronizácia pre upozornenia, obľúbené a push notifikácie';
 
   @override
   String get tapToUpdateGps => 'Ťuknite pre aktualizáciu polohy GPS';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'Poloha GPS sa získava automaticky pri hľadaní. Môžete ju tiež aktualizovať manuálne tu.';
+  String get gpsAutoUpdateHint => 'Poloha GPS sa získava automaticky pri hľadaní. Môžete ju tiež aktualizovať manuálne tu.';
 
   @override
-  String get clearGpsConfirm =>
-      'Vymazať uloženú polohu GPS? Môžete ju kedykoľvek znova aktualizovať.';
+  String get clearGpsConfirm => 'Vymazať uloženú polohu GPS? Môžete ju kedykoľvek znova aktualizovať.';
 
   @override
   String get pageNotFound => 'Stránka nenájdená';
@@ -932,8 +899,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -958,8 +924,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -983,12 +948,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1003,15 +966,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1062,44 +1023,37 @@ class AppLocalizationsSk extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1108,8 +1062,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1174,8 +1127,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1239,8 +1191,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1261,8 +1212,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1298,8 +1248,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1308,8 +1257,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1333,8 +1281,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1388,8 +1335,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1398,8 +1344,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1410,12 +1355,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1429,8 +1369,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get nearestStations => 'Najblizsie stanice';
 
   @override
-  String get nearestStationsHint =>
-      'Najdite najblizsie stanice podla vasej aktualnej polohy';
+  String get nearestStationsHint => 'Najdite najblizsie stanice podla vasej aktualnej polohy';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1439,8 +1378,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1452,8 +1390,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1504,8 +1441,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1585,12 +1521,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1756,15 +1690,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1788,8 +1720,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1798,33 +1729,28 @@ class AppLocalizationsSk extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1839,16 +1765,17 @@ class AppLocalizationsSk extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -103,8 +103,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get apiKeySetup => 'API ključ';
 
   @override
-  String get apiKeyDescription =>
-      'Registrirajte se enkrat za brezplačni API ključ.';
+  String get apiKeyDescription => 'Registrirajte se enkrat za brezplačni API ključ.';
 
   @override
   String get apiKeyLabel => 'API ključ';
@@ -173,8 +172,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get noFavorites => 'Ni priljubljenih';
 
   @override
-  String get noFavoritesHint =>
-      'Tapnite zvezdico pri postaji, da jo dodate med priljubljene.';
+  String get noFavoritesHint => 'Tapnite zvezdico pri postaji, da jo dodate med priljubljene.';
 
   @override
   String get language => 'Jezik';
@@ -224,29 +222,25 @@ class AppLocalizationsSl extends AppLocalizations {
   String get gpsCoordinates => 'GPS koordinate';
 
   @override
-  String get gpsReason =>
-      'Pošljejo se z vsakim iskanjem za iskanje bližnjih postaj.';
+  String get gpsReason => 'Pošljejo se z vsakim iskanjem za iskanje bližnjih postaj.';
 
   @override
   String get postalCodeData => 'Poštna številka';
 
   @override
-  String get postalReason =>
-      'Pretvori se v koordinate prek geokodirne storitve.';
+  String get postalReason => 'Pretvori se v koordinate prek geokodirne storitve.';
 
   @override
   String get mapViewport => 'Prikaz zemljevida';
 
   @override
-  String get mapReason =>
-      'Ploščice zemljevida se naložijo s strežnika. Osebni podatki se ne prenašajo.';
+  String get mapReason => 'Ploščice zemljevida se naložijo s strežnika. Osebni podatki se ne prenašajo.';
 
   @override
   String get apiKeyData => 'API ključ';
 
   @override
-  String get apiKeyReason =>
-      'Vaš osebni ključ se pošlje z vsako API zahtevo. Povezan je z vašim e-naslovom.';
+  String get apiKeyReason => 'Vaš osebni ključ se pošlje z vsako API zahtevo. Povezan je z vašim e-naslovom.';
 
   @override
   String get notShared => 'SE NE deli:';
@@ -267,8 +261,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get usageData => 'Podatki o uporabi';
 
   @override
-  String get privacyBanner =>
-      'Ta aplikacija nima strežnika. Vsi podatki ostanejo na vaši napravi. Brez analitike, sledenja ali oglasov.';
+  String get privacyBanner => 'Ta aplikacija nima strežnika. Vsi podatki ostanejo na vaši napravi. Brez analitike, sledenja ali oglasov.';
 
   @override
   String get storageUsage => 'Poraba shrambe na tej napravi';
@@ -292,8 +285,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get cacheManagement => 'Upravljanje predpomnilnika';
 
   @override
-  String get cacheDescription =>
-      'Predpomnilnik shranjuje API odgovore za hitrejše nalaganje in dostop brez povezave.';
+  String get cacheDescription => 'Predpomnilnik shranjuje API odgovore za hitrejše nalaganje in dostop brez povezave.';
 
   @override
   String get stationSearch => 'Iskanje postaj';
@@ -321,8 +313,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get clearCacheTitle => 'Počistiti predpomnilnik?';
 
   @override
-  String get clearCacheBody =>
-      'Predpomnjeni rezultati iskanja in cene bodo izbrisani. Profili, priljubljene in nastavitve so ohranjeni.';
+  String get clearCacheBody => 'Predpomnjeni rezultati iskanja in cene bodo izbrisani. Profili, priljubljene in nastavitve so ohranjeni.';
 
   @override
   String get clearCacheButton => 'Počisti predpomnilnik';
@@ -331,8 +322,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleteAllTitle => 'Izbrisati vse podatke?';
 
   @override
-  String get deleteAllBody =>
-      'To trajno izbriše vse profile, priljubljene, API ključ, nastavitve in predpomnilnik. Aplikacija se ponastavi.';
+  String get deleteAllBody => 'To trajno izbriše vse profile, priljubljene, API ključ, nastavitve in predpomnilnik. Aplikacija se ponastavi.';
 
   @override
   String get deleteAllButton => 'Izbriši vse';
@@ -347,19 +337,16 @@ class AppLocalizationsSl extends AppLocalizations {
   String get noStorage => 'Ni uporabljene shrambe';
 
   @override
-  String get apiKeyNote =>
-      'Brezplačna registracija. Podatki od vladnih agencij za cenovno preglednost.';
+  String get apiKeyNote => 'Brezplačna registracija. Podatki od vladnih agencij za cenovno preglednost.';
 
   @override
-  String get apiKeyFormatError =>
-      'Neveljavna oblika — pričakovan UUID (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Neveljavna oblika — pričakovan UUID (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Podprite ta projekt';
 
   @override
-  String get supportDescription =>
-      'Ta aplikacija je brezplačna, odprtokodna in brez oglasov. Če jo smatrate za koristno, razmislite o podpori razvijalcu.';
+  String get supportDescription => 'Ta aplikacija je brezplačna, odprtokodna in brez oglasov. Če jo smatrate za koristno, razmislite o podpori razvijalcu.';
 
   @override
   String get reportBug => 'Prijavi napako / Predlagaj funkcijo';
@@ -395,8 +382,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get station => 'Bencinska postaja';
 
   @override
-  String get locationDenied =>
-      'Dovoljenje za lokacijo zavrnjeno. Iščete lahko po poštni številki.';
+  String get locationDenied => 'Dovoljenje za lokacijo zavrnjeno. Iščete lahko po poštni številki.';
 
   @override
   String get demoModeBanner => 'Demo način. Nastavite API ključ v nastavitvah.';
@@ -425,8 +411,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Nalaganje priljubljenih...\nNajprej poiščite postaje za shranjevanje podatkov.';
+  String get loadingFavorites => 'Nalaganje priljubljenih...\nNajprej poiščite postaje za shranjevanje podatkov.';
 
   @override
   String get reportPrice => 'Prijavi ceno';
@@ -462,8 +447,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get autoUpdatePosition => 'Samodejno posodobi pozicijo';
 
   @override
-  String get autoUpdateDescription =>
-      'Posodobi GPS pozicijo pred vsakim iskanjem';
+  String get autoUpdateDescription => 'Posodobi GPS pozicijo pred vsakim iskanjem';
 
   @override
   String get location => 'Lokacija';
@@ -493,8 +477,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get autoSwitchProfile => 'Samodejna zamenjava profila';
 
   @override
-  String get autoSwitchDescription =>
-      'Samodejno zamenjaj profil ob prečkanju meje';
+  String get autoSwitchDescription => 'Samodejno zamenjaj profil ob prečkanju meje';
 
   @override
   String get switchProfile => 'Zamenjaj';
@@ -521,8 +504,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get noPriceAlerts => 'Ni cenovnih opozoril';
 
   @override
-  String get noPriceAlertsHint =>
-      'Ustvarite opozorilo s strani s podrobnostmi postaje.';
+  String get noPriceAlertsHint => 'Ustvarite opozorilo s strani s podrobnostmi postaje.';
 
   @override
   String alertDeleted(String name) {
@@ -618,8 +600,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get evDataAttribution => 'Podatki iz OpenChargeMap (skupnostni vir)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Status morda ne odraža razpoložljivosti v realnem času. Tapnite osveži za najnovejše podatke.';
+  String get evStatusDisclaimer => 'Status morda ne odraža razpoložljivosti v realnem času. Tapnite osveži za najnovejše podatke.';
 
   @override
   String get evNavigateToStation => 'Navigiraj do postaje';
@@ -631,8 +612,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get evStatusUpdated => 'Status posodobljen';
 
   @override
-  String get evStationNotFound =>
-      'Ni mogoče osvežiti — postaja ni najdena v bližini';
+  String get evStationNotFound => 'Ni mogoče osvežiti — postaja ni najdena v bližini';
 
   @override
   String get addedToFavorites => 'Dodano med priljubljene';
@@ -713,8 +693,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get appDefaultKey => 'Privzeti ključ aplikacije';
 
   @override
-  String get optionalOverrideKey =>
-      'Neobvezno: zamenjajte vgrajeni ključ s svojim';
+  String get optionalOverrideKey => 'Neobvezno: zamenjajte vgrajeni ključ s svojim';
 
   @override
   String get requiredForEvSearch => 'Potrebno za iskanje EV polnilnih postaj';
@@ -746,8 +725,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get avoidHighways => 'Izogibaj se avtocestam';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Izračun poti se izogiba cestninjenim cestam in avtocestam';
+  String get avoidHighwaysDesc => 'Izračun poti se izogiba cestninjenim cestam in avtocestam';
 
   @override
   String get showFuelStations => 'Prikaži bencinske postaje';
@@ -759,8 +737,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get showEvStations => 'Prikaži polnilne postaje';
 
   @override
-  String get showEvStationsDesc =>
-      'Vključi električne polnilne postaje v rezultatih';
+  String get showEvStationsDesc => 'Vključi električne polnilne postaje v rezultatih';
 
   @override
   String get noStationsAlongThisRoute => 'Vzdolž te poti ni najdenih postaj.';
@@ -787,8 +764,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get totalCost => 'Skupni stroški';
 
   @override
-  String get enterCalcValues =>
-      'Vnesite razdaljo, porabo in ceno za izračun stroškov potovanja';
+  String get enterCalcValues => 'Vnesite razdaljo, porabo in ceno za izračun stroškov potovanja';
 
   @override
   String get priceHistory => 'Zgodovina cen';
@@ -830,19 +806,16 @@ class AppLocalizationsSl extends AppLocalizations {
   String get viewMyData => 'Ogled mojih podatkov';
 
   @override
-  String get optionalCloudSync =>
-      'Neobvezna oblačna sinhronizacija za opozorila, priljubljene in push obvestila';
+  String get optionalCloudSync => 'Neobvezna oblačna sinhronizacija za opozorila, priljubljene in push obvestila';
 
   @override
   String get tapToUpdateGps => 'Tapnite za posodobitev GPS pozicije';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS pozicija se samodejno pridobi ob iskanju. Tukaj jo lahko tudi ročno posodobite.';
+  String get gpsAutoUpdateHint => 'GPS pozicija se samodejno pridobi ob iskanju. Tukaj jo lahko tudi ročno posodobite.';
 
   @override
-  String get clearGpsConfirm =>
-      'Počistiti shranjeno GPS pozicijo? Kadar koli jo lahko znova posodobite.';
+  String get clearGpsConfirm => 'Počistiti shranjeno GPS pozicijo? Kadar koli jo lahko znova posodobite.';
 
   @override
   String get pageNotFound => 'Stran ni najdena';
@@ -926,8 +899,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -952,8 +924,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -977,12 +948,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -997,15 +966,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1056,44 +1023,37 @@ class AppLocalizationsSl extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1102,8 +1062,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1168,8 +1127,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1233,8 +1191,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1255,8 +1212,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1292,8 +1248,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1302,8 +1257,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1327,8 +1281,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1382,8 +1335,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1392,8 +1344,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1404,12 +1355,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1423,8 +1369,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get nearestStations => 'Najblizje postaje';
 
   @override
-  String get nearestStationsHint =>
-      'Poiscite najblizje postaje z vaso trenutno lokacijo';
+  String get nearestStationsHint => 'Poiscite najblizje postaje z vaso trenutno lokacijo';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1433,8 +1378,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1446,8 +1390,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1498,8 +1441,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1579,12 +1521,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1750,15 +1690,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1782,8 +1720,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1792,33 +1729,28 @@ class AppLocalizationsSl extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1833,16 +1765,17 @@ class AppLocalizationsSl extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -103,8 +103,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get apiKeySetup => 'API-nyckel';
 
   @override
-  String get apiKeyDescription =>
-      'Registrera dig en gång för att få en gratis API-nyckel.';
+  String get apiKeyDescription => 'Registrera dig en gång för att få en gratis API-nyckel.';
 
   @override
   String get apiKeyLabel => 'API-nyckel';
@@ -173,8 +172,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noFavorites => 'Inga favoriter ännu';
 
   @override
-  String get noFavoritesHint =>
-      'Tryck på stjärnan vid en bensinstation för att spara den som favorit.';
+  String get noFavoritesHint => 'Tryck på stjärnan vid en bensinstation för att spara den som favorit.';
 
   @override
   String get language => 'Språk';
@@ -224,29 +222,25 @@ class AppLocalizationsSv extends AppLocalizations {
   String get gpsCoordinates => 'GPS-koordinater';
 
   @override
-  String get gpsReason =>
-      'Skickas med varje sökning för att hitta närliggande stationer.';
+  String get gpsReason => 'Skickas med varje sökning för att hitta närliggande stationer.';
 
   @override
   String get postalCodeData => 'Postnummer';
 
   @override
-  String get postalReason =>
-      'Konverteras till koordinater via geokodarens tjänst.';
+  String get postalReason => 'Konverteras till koordinater via geokodarens tjänst.';
 
   @override
   String get mapViewport => 'Kartvy';
 
   @override
-  String get mapReason =>
-      'Kartplattor laddas från servern. Inga personuppgifter överförs.';
+  String get mapReason => 'Kartplattor laddas från servern. Inga personuppgifter överförs.';
 
   @override
   String get apiKeyData => 'API-nyckel';
 
   @override
-  String get apiKeyReason =>
-      'Din personliga nyckel skickas med varje API-förfrågan. Den är kopplad till din e-post.';
+  String get apiKeyReason => 'Din personliga nyckel skickas med varje API-förfrågan. Den är kopplad till din e-post.';
 
   @override
   String get notShared => 'Delas INTE:';
@@ -267,8 +261,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get usageData => 'Användningsdata';
 
   @override
-  String get privacyBanner =>
-      'Denna app har ingen server. All data stannar på din enhet. Ingen analys, ingen spårning, ingen reklam.';
+  String get privacyBanner => 'Denna app har ingen server. All data stannar på din enhet. Ingen analys, ingen spårning, ingen reklam.';
 
   @override
   String get storageUsage => 'Lagringsanvändning på denna enhet';
@@ -292,8 +285,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get cacheManagement => 'Cachehantering';
 
   @override
-  String get cacheDescription =>
-      'Cachen lagrar API-svar för snabbare laddning och offlineåtkomst.';
+  String get cacheDescription => 'Cachen lagrar API-svar för snabbare laddning och offlineåtkomst.';
 
   @override
   String get stationSearch => 'Stationssökning';
@@ -321,8 +313,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get clearCacheTitle => 'Rensa cache?';
 
   @override
-  String get clearCacheBody =>
-      'Cachade sökresultat och priser raderas. Profiler, favoriter och inställningar bevaras.';
+  String get clearCacheBody => 'Cachade sökresultat och priser raderas. Profiler, favoriter och inställningar bevaras.';
 
   @override
   String get clearCacheButton => 'Rensa cache';
@@ -331,8 +322,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteAllTitle => 'Ta bort all data?';
 
   @override
-  String get deleteAllBody =>
-      'Detta raderar permanent alla profiler, favoriter, API-nyckel, inställningar och cache. Appen återställs.';
+  String get deleteAllBody => 'Detta raderar permanent alla profiler, favoriter, API-nyckel, inställningar och cache. Appen återställs.';
 
   @override
   String get deleteAllButton => 'Ta bort allt';
@@ -347,19 +337,16 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noStorage => 'Ingen lagring använd';
 
   @override
-  String get apiKeyNote =>
-      'Gratis registrering. Data från statliga pristransparensorgan.';
+  String get apiKeyNote => 'Gratis registrering. Data från statliga pristransparensorgan.';
 
   @override
-  String get apiKeyFormatError =>
-      'Ogiltigt format — UUID förväntat (8-4-4-4-12)';
+  String get apiKeyFormatError => 'Ogiltigt format — UUID förväntat (8-4-4-4-12)';
 
   @override
   String get supportProject => 'Stöd detta projekt';
 
   @override
-  String get supportDescription =>
-      'Denna app är gratis, öppen källkod och utan reklam. Om du tycker den är användbar, överväg att stödja utvecklaren.';
+  String get supportDescription => 'Denna app är gratis, öppen källkod och utan reklam. Om du tycker den är användbar, överväg att stödja utvecklaren.';
 
   @override
   String get reportBug => 'Rapportera fel / Föreslå funktion';
@@ -395,12 +382,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get station => 'Bensinstation';
 
   @override
-  String get locationDenied =>
-      'Platstillstånd nekades. Du kan söka med postnummer.';
+  String get locationDenied => 'Platstillstånd nekades. Du kan söka med postnummer.';
 
   @override
-  String get demoModeBanner =>
-      'Demoläge. Konfigurera API-nyckel i inställningar.';
+  String get demoModeBanner => 'Demoläge. Konfigurera API-nyckel i inställningar.';
 
   @override
   String get sortDistance => 'Avstånd';
@@ -426,8 +411,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get loadingFavorites =>
-      'Laddar favoriter...\nSök efter stationer först för att spara data.';
+  String get loadingFavorites => 'Laddar favoriter...\nSök efter stationer först för att spara data.';
 
   @override
   String get reportPrice => 'Rapportera pris';
@@ -463,8 +447,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get autoUpdatePosition => 'Uppdatera position automatiskt';
 
   @override
-  String get autoUpdateDescription =>
-      'Uppdatera GPS-position före varje sökning';
+  String get autoUpdateDescription => 'Uppdatera GPS-position före varje sökning';
 
   @override
   String get location => 'Plats';
@@ -494,8 +477,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get autoSwitchProfile => 'Automatiskt profilbyte';
 
   @override
-  String get autoSwitchDescription =>
-      'Byt profil automatiskt vid gränsöverskridande';
+  String get autoSwitchDescription => 'Byt profil automatiskt vid gränsöverskridande';
 
   @override
   String get switchProfile => 'Byt';
@@ -522,8 +504,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noPriceAlerts => 'Inga prisvarningar';
 
   @override
-  String get noPriceAlertsHint =>
-      'Skapa en varning från en stations detaljsida.';
+  String get noPriceAlertsHint => 'Skapa en varning från en stations detaljsida.';
 
   @override
   String alertDeleted(String name) {
@@ -607,8 +588,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get evUsageCost => 'Användningskostnad';
 
   @override
-  String get evPricingUnavailable =>
-      'Prissättning inte tillgänglig från leverantören';
+  String get evPricingUnavailable => 'Prissättning inte tillgänglig från leverantören';
 
   @override
   String get evLastUpdated => 'Senast uppdaterad';
@@ -620,8 +600,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get evDataAttribution => 'Data från OpenChargeMap (community-källa)';
 
   @override
-  String get evStatusDisclaimer =>
-      'Status kanske inte återspeglar tillgänglighet i realtid. Tryck på uppdatera för att hämta senaste data.';
+  String get evStatusDisclaimer => 'Status kanske inte återspeglar tillgänglighet i realtid. Tryck på uppdatera för att hämta senaste data.';
 
   @override
   String get evNavigateToStation => 'Navigera till station';
@@ -633,8 +612,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get evStatusUpdated => 'Status uppdaterad';
 
   @override
-  String get evStationNotFound =>
-      'Kunde inte uppdatera — station hittades inte i närheten';
+  String get evStationNotFound => 'Kunde inte uppdatera — station hittades inte i närheten';
 
   @override
   String get addedToFavorites => 'Tillagd i favoriter';
@@ -715,8 +693,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get appDefaultKey => 'App-standardnyckel';
 
   @override
-  String get optionalOverrideKey =>
-      'Valfritt: ersätt den inbyggda appnyckeln med din egen';
+  String get optionalOverrideKey => 'Valfritt: ersätt den inbyggda appnyckeln med din egen';
 
   @override
   String get requiredForEvSearch => 'Krävs för sökning efter EV-laddstationer';
@@ -748,26 +725,22 @@ class AppLocalizationsSv extends AppLocalizations {
   String get avoidHighways => 'Undvik motorvägar';
 
   @override
-  String get avoidHighwaysDesc =>
-      'Ruttberäkning undviker avgiftsvägar och motorvägar';
+  String get avoidHighwaysDesc => 'Ruttberäkning undviker avgiftsvägar och motorvägar';
 
   @override
   String get showFuelStations => 'Visa bensinstationer';
 
   @override
-  String get showFuelStationsDesc =>
-      'Inkludera bensin-, diesel-, LPG-, CNG-stationer';
+  String get showFuelStationsDesc => 'Inkludera bensin-, diesel-, LPG-, CNG-stationer';
 
   @override
   String get showEvStations => 'Visa laddstationer';
 
   @override
-  String get showEvStationsDesc =>
-      'Inkludera elektriska laddstationer i sökresultat';
+  String get showEvStationsDesc => 'Inkludera elektriska laddstationer i sökresultat';
 
   @override
-  String get noStationsAlongThisRoute =>
-      'Inga stationer hittades längs denna rutt.';
+  String get noStationsAlongThisRoute => 'Inga stationer hittades längs denna rutt.';
 
   @override
   String get fuelCostCalculator => 'Bränslekostnadskalkylator';
@@ -791,8 +764,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get totalCost => 'Total kostnad';
 
   @override
-  String get enterCalcValues =>
-      'Ange avstånd, förbrukning och pris för att beräkna resekostnaden';
+  String get enterCalcValues => 'Ange avstånd, förbrukning och pris för att beräkna resekostnaden';
 
   @override
   String get priceHistory => 'Prishistorik';
@@ -834,19 +806,16 @@ class AppLocalizationsSv extends AppLocalizations {
   String get viewMyData => 'Visa mina data';
 
   @override
-  String get optionalCloudSync =>
-      'Valfri molnsynkronisering för varningar, favoriter och push-notiser';
+  String get optionalCloudSync => 'Valfri molnsynkronisering för varningar, favoriter och push-notiser';
 
   @override
   String get tapToUpdateGps => 'Tryck för att uppdatera GPS-position';
 
   @override
-  String get gpsAutoUpdateHint =>
-      'GPS-positionen hämtas automatiskt vid sökning. Du kan också uppdatera den manuellt här.';
+  String get gpsAutoUpdateHint => 'GPS-positionen hämtas automatiskt vid sökning. Du kan också uppdatera den manuellt här.';
 
   @override
-  String get clearGpsConfirm =>
-      'Rensa den sparade GPS-positionen? Du kan uppdatera den igen när som helst.';
+  String get clearGpsConfirm => 'Rensa den sparade GPS-positionen? Du kan uppdatera den igen när som helst.';
 
   @override
   String get pageNotFound => 'Sidan hittades inte';
@@ -930,8 +899,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noSavedRoutes => 'No saved routes';
 
   @override
-  String get noSavedRoutesHint =>
-      'Search along a route and save it for quick access later.';
+  String get noSavedRoutesHint => 'Search along a route and save it for quick access later.';
 
   @override
   String get saveRoute => 'Save route';
@@ -956,8 +924,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteProfileTitle => 'Delete profile?';
 
   @override
-  String get deleteProfileBody =>
-      'This profile and its settings will be permanently deleted. This cannot be undone.';
+  String get deleteProfileBody => 'This profile and its settings will be permanently deleted. This cannot be undone.';
 
   @override
   String get deleteProfileConfirm => 'Delete profile';
@@ -981,12 +948,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get errorLocation => 'Could not determine your location.';
 
   @override
-  String get errorNoApiKey =>
-      'No API key configured. Go to Settings to add one.';
+  String get errorNoApiKey => 'No API key configured. Go to Settings to add one.';
 
   @override
-  String get errorAllServicesFailed =>
-      'Could not load data. Check your connection and try again.';
+  String get errorAllServicesFailed => 'Could not load data. Check your connection and try again.';
 
   @override
   String get errorCache => 'Local data error. Try clearing the cache.';
@@ -1001,15 +966,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get onboardingWelcomeHint => 'Set up the app in a few quick steps.';
 
   @override
-  String get onboardingApiKeyDescription =>
-      'Register for a free API key, or skip to explore the app with demo data.';
+  String get onboardingApiKeyDescription => 'Register for a free API key, or skip to explore the app with demo data.';
 
   @override
   String get onboardingComplete => 'All set!';
 
   @override
-  String get onboardingCompleteHint =>
-      'You can change these settings anytime in your profile.';
+  String get onboardingCompleteHint => 'You can change these settings anytime in your profile.';
 
   @override
   String get onboardingBack => 'Back';
@@ -1060,44 +1023,37 @@ class AppLocalizationsSv extends AppLocalizations {
   String get gdprTitle => 'Your Privacy';
 
   @override
-  String get gdprSubtitle =>
-      'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
+  String get gdprSubtitle => 'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.';
 
   @override
   String get gdprLocationTitle => 'Location Access';
 
   @override
-  String get gdprLocationDescription =>
-      'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
+  String get gdprLocationDescription => 'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.';
 
   @override
-  String get gdprLocationShort =>
-      'Find nearby fuel stations using your location';
+  String get gdprLocationShort => 'Find nearby fuel stations using your location';
 
   @override
   String get gdprErrorReportingTitle => 'Error Reporting';
 
   @override
-  String get gdprErrorReportingDescription =>
-      'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
+  String get gdprErrorReportingDescription => 'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.';
 
   @override
-  String get gdprErrorReportingShort =>
-      'Send anonymous crash reports to improve the app';
+  String get gdprErrorReportingShort => 'Send anonymous crash reports to improve the app';
 
   @override
   String get gdprCloudSyncTitle => 'Cloud Sync';
 
   @override
-  String get gdprCloudSyncDescription =>
-      'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
+  String get gdprCloudSyncDescription => 'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.';
 
   @override
   String get gdprCloudSyncShort => 'Sync favorites and alerts across devices';
 
   @override
-  String get gdprLegalBasis =>
-      'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
+  String get gdprLegalBasis => 'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.';
 
   @override
   String get gdprAcceptAll => 'Accept All';
@@ -1106,8 +1062,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get gdprAcceptSelected => 'Accept Selected';
 
   @override
-  String get gdprSettingsHint =>
-      'You can change your privacy choices at any time.';
+  String get gdprSettingsHint => 'You can change your privacy choices at any time.';
 
   @override
   String get routeSaved => 'Route saved!';
@@ -1172,8 +1127,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get invalidQrCode => 'Invalid QR code format';
 
   @override
-  String get invalidQrCodeTankSync =>
-      'Invalid QR code — expected TankSync format';
+  String get invalidQrCodeTankSync => 'Invalid QR code — expected TankSync format';
 
   @override
   String get tankSyncConnected => 'TankSync connected!';
@@ -1237,8 +1191,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get brandFilterNoHighway => 'No highway';
 
   @override
-  String get swipeTutorialMessage =>
-      'Swipe right to navigate, swipe left to remove';
+  String get swipeTutorialMessage => 'Swipe right to navigate, swipe left to remove';
 
   @override
   String get swipeTutorialDismiss => 'Got it';
@@ -1259,8 +1212,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
 
   @override
-  String get privacyDashboardBanner =>
-      'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
+  String get privacyDashboardBanner => 'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.';
 
   @override
   String get privacyLocalData => 'Data on this device';
@@ -1296,8 +1248,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get privacySyncedData => 'Cloud sync (TankSync)';
 
   @override
-  String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+  String get privacySyncDisabled => 'Cloud sync is disabled. All data stays on this device only.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1306,8 +1257,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get privacySyncUserId => 'User ID';
 
   @override
-  String get privacySyncDescription =>
-      'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
+  String get privacySyncDescription => 'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.';
 
   @override
   String get privacyViewServerData => 'View server data';
@@ -1331,8 +1281,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override
-  String get privacyDeleteBody =>
-      'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
+  String get privacyDeleteBody => 'This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.';
 
   @override
   String get privacyDeleteConfirm => 'Delete everything';
@@ -1386,8 +1335,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get drivingSafetyTitle => 'Safety Notice';
 
   @override
-  String get drivingSafetyMessage =>
-      'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
+  String get drivingSafetyMessage => 'Do not operate the app while driving. Pull over to a safe location before interacting with the screen. The driver is responsible for safe operation of the vehicle at all times.';
 
   @override
   String get drivingSafetyAccept => 'I understand';
@@ -1396,8 +1344,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get voiceAnnouncementsTitle => 'Voice Announcements';
 
   @override
-  String get voiceAnnouncementsDescription =>
-      'Announce nearby cheap stations while driving';
+  String get voiceAnnouncementsDescription => 'Announce nearby cheap stations while driving';
 
   @override
   String get voiceAnnouncementsEnabled => 'Enable voice announcements';
@@ -1408,12 +1355,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String voiceAnnouncementCheapFuel(
-    String station,
-    String distance,
-    String fuelType,
-    String price,
-  ) {
+  String voiceAnnouncementCheapFuel(String station, String distance, String fuelType, String price) {
     return '$station, $distance kilometers ahead, $fuelType $price';
   }
 
@@ -1427,8 +1369,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get nearestStations => 'Narmaste stationer';
 
   @override
-  String get nearestStationsHint =>
-      'Hitta de narmaste stationerna med din nuvarande position';
+  String get nearestStationsHint => 'Hitta de narmaste stationerna med din nuvarande position';
 
   @override
   String get consumptionLogTitle => 'Fuel consumption';
@@ -1437,8 +1378,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get consumptionLogMenuTitle => 'Consumption log';
 
   @override
-  String get consumptionLogMenuSubtitle =>
-      'Track fill-ups and calculate L/100km';
+  String get consumptionLogMenuSubtitle => 'Track fill-ups and calculate L/100km';
 
   @override
   String get consumptionStatsTitle => 'Consumption stats';
@@ -1450,8 +1390,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noFillUpsTitle => 'No fill-ups yet';
 
   @override
-  String get noFillUpsSubtitle =>
-      'Log your first fill-up to start tracking consumption.';
+  String get noFillUpsSubtitle => 'Log your first fill-up to start tracking consumption.';
 
   @override
   String get fillUpDate => 'Date';
@@ -1502,8 +1441,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get carbonEmptyTitle => 'No data yet';
 
   @override
-  String get carbonEmptySubtitle =>
-      'Log fill-ups to see your carbon dashboard.';
+  String get carbonEmptySubtitle => 'Log fill-ups to see your carbon dashboard.';
 
   @override
   String get carbonSummaryTotalCost => 'Total cost';
@@ -1583,12 +1521,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get vehiclesMenuTitle => 'My vehicles';
 
   @override
-  String get vehiclesMenuSubtitle =>
-      'Battery, connectors, charging preferences';
+  String get vehiclesMenuSubtitle => 'Battery, connectors, charging preferences';
 
   @override
-  String get vehiclesEmptyMessage =>
-      'Add your car to filter by connector and estimate charging costs.';
+  String get vehiclesEmptyMessage => 'Add your car to filter by connector and estimate charging costs.';
 
   @override
   String get vehicleAdd => 'Add vehicle';
@@ -1754,15 +1690,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get switchToEmail => 'Switch to email';
 
   @override
-  String get switchToEmailSubtitle =>
-      'Keep data, add sign-in from other devices';
+  String get switchToEmailSubtitle => 'Keep data, add sign-in from other devices';
 
   @override
   String get switchToAnonymousAction => 'Switch to anonymous';
 
   @override
-  String get switchToAnonymousSubtitle =>
-      'Keep local data, use new anonymous session';
+  String get switchToAnonymousSubtitle => 'Keep local data, use new anonymous session';
 
   @override
   String get linkDevice => 'Link device';
@@ -1786,8 +1720,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get localOnly => 'Local only';
 
   @override
-  String get localOnlySubtitle =>
-      'Optional: sync favorites, alerts, and ratings across devices';
+  String get localOnlySubtitle => 'Optional: sync favorites, alerts, and ratings across devices';
 
   @override
   String get setupCloudSync => 'Set up cloud sync';
@@ -1796,33 +1729,28 @@ class AppLocalizationsSv extends AppLocalizations {
   String get disconnectTitle => 'Disconnect TankSync?';
 
   @override
-  String get disconnectBody =>
-      'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
+  String get disconnectBody => 'Cloud sync will be disabled. Your local data (favorites, alerts, history) is preserved on this device. Server data is not deleted.';
 
   @override
   String get deleteAccountTitle => 'Delete account?';
 
   @override
-  String get deleteAccountBody =>
-      'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
+  String get deleteAccountBody => 'This permanently deletes all your data from the server (favorites, alerts, ratings, routes). Local data on this device is preserved.\n\nThis cannot be undone.';
 
   @override
   String get switchToAnonymousTitle => 'Switch to anonymous?';
 
   @override
-  String get switchToAnonymousBody =>
-      'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
+  String get switchToAnonymousBody => 'You will be signed out of your email account and continue with a new anonymous session.\n\nYour local data (favorites, alerts) is kept on this device and will be synced to the new anonymous account.';
 
   @override
   String get switchAction => 'Switch';
 
   @override
-  String get helpBannerCriteria =>
-      'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
+  String get helpBannerCriteria => 'Your profile defaults are pre-filled. Adjust criteria below to refine your search.';
 
   @override
-  String get helpBannerAlerts =>
-      'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
+  String get helpBannerAlerts => 'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.';
 
   @override
   String get syncNow => 'Sync now';
@@ -1837,16 +1765,17 @@ class AppLocalizationsSv extends AppLocalizations {
   String get onboardingRadiusHelper => 'Larger radius = more results';
 
   @override
-  String get onboardingPrivacy =>
-      'These settings are stored only on your device and never shared.';
+  String get onboardingPrivacy => 'These settings are stored only on your device and never shared.';
 
   @override
   String get onboardingLandingTitle => 'Home screen';
 
   @override
-  String get onboardingLandingHint =>
-      'Choose which screen opens when you launch the app.';
+  String get onboardingLandingHint => 'Choose which screen opens when you launch the app.';
 
   @override
   String get scanReceipt => 'Scan receipt';
+
+  @override
+  String get obdConnect => 'OBD-II';
 }

--- a/test/features/consumption/data/obd2/elm327_protocol_test.dart
+++ b/test/features/consumption/data/obd2/elm327_protocol_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
+
+void main() {
+  group('Elm327Protocol', () {
+    group('cleanResponse', () {
+      test('strips > prompt', () {
+        expect(Elm327Protocol.cleanResponse('41 0D 50>'), '41 0D 50');
+      });
+
+      test('returns null for NO DATA', () {
+        expect(Elm327Protocol.cleanResponse('NO DATA>'), isNull);
+      });
+
+      test('returns null for UNABLE TO CONNECT', () {
+        expect(Elm327Protocol.cleanResponse('UNABLE TO CONNECT>'), isNull);
+      });
+
+      test('returns null for ERROR', () {
+        expect(Elm327Protocol.cleanResponse('ERROR>'), isNull);
+      });
+
+      test('strips echo and finds 41 response', () {
+        expect(Elm327Protocol.cleanResponse('010D\r41 0D 50>'), '41 0D 50');
+      });
+    });
+
+    group('parseVehicleSpeed', () {
+      test('parses 80 km/h', () {
+        expect(Elm327Protocol.parseVehicleSpeed('41 0D 50>'), 80);
+      });
+
+      test('parses 0 km/h', () {
+        expect(Elm327Protocol.parseVehicleSpeed('41 0D 00>'), 0);
+      });
+
+      test('parses 255 km/h (max)', () {
+        expect(Elm327Protocol.parseVehicleSpeed('41 0D FF>'), 255);
+      });
+
+      test('returns null for NO DATA', () {
+        expect(Elm327Protocol.parseVehicleSpeed('NO DATA>'), isNull);
+      });
+
+      test('returns null for wrong PID', () {
+        expect(Elm327Protocol.parseVehicleSpeed('41 0C 50>'), isNull);
+      });
+    });
+
+    group('parseEngineRpm', () {
+      test('parses 1000 RPM', () {
+        // 1000 RPM = 4000 / 4 → (4000 >> 8) = 0x0F, (4000 & 0xFF) = 0xA0
+        expect(
+            Elm327Protocol.parseEngineRpm('41 0C 0F A0>'), closeTo(1000, 0.5));
+      });
+
+      test('parses idle ~800 RPM', () {
+        // 800 RPM = 3200 / 4 → 3200 = 0x0C80
+        expect(
+            Elm327Protocol.parseEngineRpm('41 0C 0C 80>'), closeTo(800, 0.5));
+      });
+
+      test('returns null for NO DATA', () {
+        expect(Elm327Protocol.parseEngineRpm('NO DATA>'), isNull);
+      });
+    });
+
+    group('parseDistanceSinceDtcCleared', () {
+      test('parses 20000 km', () {
+        // 20000 = 0x4E20
+        expect(Elm327Protocol.parseDistanceSinceDtcCleared('41 31 4E 20>'),
+            20000);
+      });
+
+      test('parses 0 km', () {
+        expect(
+            Elm327Protocol.parseDistanceSinceDtcCleared('41 31 00 00>'), 0);
+      });
+
+      test('parses 65535 km (max)', () {
+        expect(Elm327Protocol.parseDistanceSinceDtcCleared('41 31 FF FF>'),
+            65535);
+      });
+
+      test('returns null for NO DATA', () {
+        expect(
+            Elm327Protocol.parseDistanceSinceDtcCleared('NO DATA>'), isNull);
+      });
+    });
+
+    group('parseOdometer', () {
+      test('parses 123456.7 km', () {
+        // 1234567 / 10 = 123456.7 → 1234567 = 0x0012D687
+        expect(Elm327Protocol.parseOdometer('41 A6 00 12 D6 87>'),
+            closeTo(123456.7, 0.1));
+      });
+
+      test('returns null for NO DATA', () {
+        expect(Elm327Protocol.parseOdometer('NO DATA>'), isNull);
+      });
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+
+void main() {
+  group('Obd2Service', () {
+    test('connect initializes ELM327 adapter', () async {
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+      });
+      final service = Obd2Service(transport);
+
+      final connected = await service.connect();
+
+      expect(connected, isTrue);
+      expect(service.isConnected, isTrue);
+    });
+
+    test('readOdometerKm returns odometer from PID A6', () async {
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        '01A6': '41 A6 00 12 D6 87>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final km = await service.readOdometerKm();
+
+      expect(km, closeTo(123456.7, 0.1));
+    });
+
+    test('readOdometerKm falls back to PID 31 when A6 not supported',
+        () async {
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        '01A6': 'NO DATA>',
+        '0131': '41 31 4E 20>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final km = await service.readOdometerKm();
+
+      expect(km, 20000.0);
+    });
+
+    test('readOdometerKm returns null when not connected', () async {
+      final transport = FakeObd2Transport();
+      final service = Obd2Service(transport);
+
+      final km = await service.readOdometerKm();
+
+      expect(km, isNull);
+    });
+
+    test('readSpeedKmh returns current speed', () async {
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        '010D': '41 0D 50>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final speed = await service.readSpeedKmh();
+
+      expect(speed, 80);
+    });
+
+    test('readRpm returns engine RPM', () async {
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        '010C': '41 0C 0F A0>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final rpm = await service.readRpm();
+
+      expect(rpm, closeTo(1000, 0.5));
+    });
+
+    test('disconnect works', () async {
+      final transport = FakeObd2Transport({
+        'ATZ': 'OK>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+      expect(service.isConnected, isTrue);
+
+      await service.disconnect();
+      expect(service.isConnected, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **Elm327Protocol**: command builder + hex response parser for PIDs 0C (RPM), 0D (speed), 31 (distance), A6 (odometer)
- **Obd2Transport**: abstract transport with `FakeObd2Transport` for testing
- **Obd2Service**: high-level API with automatic PID A6→31 fallback for odometer
- OBD-II button on Add Fill-Up screen (placeholder transport until Bluetooth wired)

Transport-agnostic: ready for Bluetooth (flutter_blue_plus) or TCP (com0com + ELM327-emulator).

## Test plan
- [x] 19 protocol parser tests (cleanResponse, speed, RPM, distance, odometer)
- [x] 7 service tests (connect, read odometer with fallback, speed, RPM, disconnect)
- [x] `flutter analyze` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)