### PR TITLE
fix(ui): faster favorites loading, translate Fuel/EV toggle, remove '1 L' chip

### DIFF
--- a/lib/features/favorites/providers/favorites_provider.dart
+++ b/lib/features/favorites/providers/favorites_provider.dart
@@ -118,8 +118,6 @@ class FavoriteStations extends _$FavoriteStations {
       return;
     }
 
-    state = const AsyncValue.loading();
-
     try {
       final storage = ref.read(storageRepositoryProvider);
 
@@ -143,6 +141,16 @@ class FavoriteStations extends _$FavoriteStations {
 
       debugPrint('FavoriteStations: loaded ${stations.length}/${favoriteIds.length} from storage'
           '${missingIds.isNotEmpty ? ', ${missingIds.length} missing' : ''}');
+
+      // Show cached data immediately (no shimmer wait)
+      if (stations.isNotEmpty) {
+        state = AsyncValue.data(ServiceResult(
+          data: List.from(stations),
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+          isStale: true,
+        ));
+      }
 
       // Step 2: Check connectivity
       final connectivity = await Connectivity().checkConnectivity();

--- a/lib/features/search/presentation/widgets/search_summary_bar.dart
+++ b/lib/features/search/presentation/widgets/search_summary_bar.dart
@@ -67,12 +67,6 @@ class SearchSummaryBar extends ConsumerWidget {
                           label: _fuelLabel(context, fuelType),
                         ),
                         const SizedBox(width: 6),
-                        // Quantity chip (fixed 1L default for now)
-                        const _SummaryChip(
-                          icon: Icon(Icons.local_gas_station, size: 16),
-                          label: '1 L',
-                        ),
-                        const SizedBox(width: 6),
                         // Radius badge
                         _SummaryChip(
                           icon: const Icon(Icons.radar, size: 16),

--- a/lib/features/search/presentation/widgets/station_type_toggle.dart
+++ b/lib/features/search/presentation/widgets/station_type_toggle.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/station_type_filter.dart';
 import '../../providers/station_type_filter_provider.dart';
 
@@ -10,20 +11,21 @@ class StationTypeToggle extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final filter = ref.watch(activeStationTypeFilterProvider);
+    final l = AppLocalizations.of(context);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       child: SegmentedButton<StationTypeFilter>(
-        segments: const [
+        segments: [
           ButtonSegment(
             value: StationTypeFilter.fuel,
-            icon: Icon(Icons.local_gas_station, size: 18),
-            label: Text('Fuel'),
+            icon: const Icon(Icons.local_gas_station, size: 18),
+            label: Text(l?.stationTypeFuel ?? 'Fuel'),
           ),
           ButtonSegment(
             value: StationTypeFilter.ev,
-            icon: Icon(Icons.ev_station, size: 18),
-            label: Text('EV'),
+            icon: const Icon(Icons.ev_station, size: 18),
+            label: Text(l?.stationTypeEv ?? 'EV'),
           ),
         ],
         selected: {filter},

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -813,5 +813,7 @@
   "onboardingLandingTitle": "Startbildschirm",
   "onboardingLandingHint": "Wählen Sie, welcher Bildschirm beim Start der App angezeigt wird.",
   "scanReceipt": "Beleg scannen",
-  "obdConnect": "OBD-II"
+  "obdConnect": "OBD-II",
+  "stationTypeFuel": "Kraftstoff",
+  "stationTypeEv": "Elektro"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -813,5 +813,7 @@
   "onboardingLandingTitle": "Home screen",
   "onboardingLandingHint": "Choose which screen opens when you launch the app.",
   "scanReceipt": "Scan receipt",
-  "obdConnect": "OBD-II"
+  "obdConnect": "OBD-II",
+  "stationTypeFuel": "Fuel",
+  "stationTypeEv": "EV"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -478,5 +478,7 @@
   "onboardingLandingTitle": "Écran d'accueil",
   "onboardingLandingHint": "Choisissez l'écran qui s'ouvre au lancement de l'application.",
   "scanReceipt": "Scanner le reçu",
-  "obdConnect": "OBD-II"
+  "obdConnect": "OBD-II",
+  "stationTypeFuel": "Carburant",
+  "stationTypeEv": "Recharge"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3550,6 +3550,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'OBD-II'**
   String get obdConnect;
+
+  /// No description provided for @stationTypeFuel.
+  ///
+  /// In en, this message translates to:
+  /// **'Fuel'**
+  String get stationTypeFuel;
+
+  /// No description provided for @stationTypeEv.
+  ///
+  /// In en, this message translates to:
+  /// **'EV'**
+  String get stationTypeEv;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Kraftstoff';
+
+  @override
+  String get stationTypeEv => 'Elektro';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Carburant';
+
+  @override
+  String get stationTypeEv => 'Recharge';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1778,4 +1778,10 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get obdConnect => 'OBD-II';
+
+  @override
+  String get stationTypeFuel => 'Fuel';
+
+  @override
+  String get stationTypeEv => 'EV';
 }


### PR DESCRIPTION
## Summary
- **Favorites loading**: show cached stations immediately from Hive (no shimmer wait), then refresh prices in background
- **Fuel/EV toggle**: translate labels — "Carburant / Recharge" in French, "Kraftstoff / Elektro" in German
- **Remove '1 L' chip**: placeholder quantity chip in search summary bar was confusing — removed

## Test plan
- [x] All 53 favorites tests pass
- [x] `flutter analyze` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)