### PR TITLE
fix(ui): landing screen works on cold start + translate rating labels

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -100,26 +100,22 @@ GoRouter router(Ref ref) {
 
       // Step 2: Setup (onboarding) must be complete before main app
       if (!isReady && !isSetup && !isConsent) return '/setup';
-      if (isReady && isSetup) {
+      if (isReady && (isSetup || state.matchedLocation == '/')) {
         // Route to profile landing screen preference
         final profileId = storage.getActiveProfileId();
         if (profileId != null) {
           final profile = storage.getProfile(profileId);
           final landing = profile?['landingScreen']?.toString();
-          // json_serializable stores enum as name: "map", "favorites", etc.
-          // Also handle legacy format "LandingScreen.map"
           switch (landing) {
             case 'favorites':
             case 'LandingScreen.favorites':
-              return '/favorites';
+              if (state.matchedLocation != '/favorites') return '/favorites';
             case 'map':
             case 'LandingScreen.map':
-              return '/map';
-            // 'cheapest', 'nearest', 'search' all go to search screen
-            // (cheapest/nearest trigger auto-search via SearchScreen.initState)
+              if (state.matchedLocation != '/map') return '/map';
           }
         }
-        return '/';
+        if (isSetup) return '/';
       }
       return null;
     },

--- a/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
@@ -202,13 +202,13 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
               ),
               // Rating sharing mode
               const SizedBox(height: 16),
-              Text('Station ratings', style: Theme.of(context).textTheme.titleSmall),
+              Text(AppLocalizations.of(context)?.privacyRatings ?? 'Station ratings', style: Theme.of(context).textTheme.titleSmall),
               const SizedBox(height: 4),
               SegmentedButton<String>(
-                segments: const [
-                  ButtonSegment(value: 'local', label: Text('Local'), icon: Icon(Icons.phone_android, size: 16)),
-                  ButtonSegment(value: 'private', label: Text('Private'), icon: Icon(Icons.lock, size: 16)),
-                  ButtonSegment(value: 'shared', label: Text('Shared'), icon: Icon(Icons.people, size: 16)),
+                segments: [
+                  ButtonSegment(value: 'local', label: Text(AppLocalizations.of(context)?.ratingModeLocal ?? 'Local'), icon: const Icon(Icons.phone_android, size: 16)),
+                  ButtonSegment(value: 'private', label: Text(AppLocalizations.of(context)?.ratingModePrivate ?? 'Private'), icon: const Icon(Icons.lock, size: 16)),
+                  ButtonSegment(value: 'shared', label: Text(AppLocalizations.of(context)?.ratingModeShared ?? 'Shared'), icon: const Icon(Icons.people, size: 16)),
                 ],
                 selected: {editState.ratingMode},
                 onSelectionChanged: (s) => editCtrl.setRatingMode(s.first),
@@ -217,10 +217,10 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
                 padding: const EdgeInsets.only(left: 4, top: 4),
                 child: Text(
                   editState.ratingMode == 'local'
-                      ? 'Ratings saved on this device only'
+                      ? (AppLocalizations.of(context)?.ratingDescLocal ?? 'Ratings saved on this device only')
                       : editState.ratingMode == 'private'
-                          ? 'Synced with your database (not visible to others)'
-                          : 'Visible to all users of your database',
+                          ? (AppLocalizations.of(context)?.ratingDescPrivate ?? 'Synced with your database (not visible to others)')
+                          : (AppLocalizations.of(context)?.ratingDescShared ?? 'Visible to all users of your database'),
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -816,5 +816,11 @@
   "obdConnect": "OBD-II",
   "stationTypeFuel": "Kraftstoff",
   "stationTypeEv": "Elektro",
-  "brandFilterHighway": "Autobahn"
+  "brandFilterHighway": "Autobahn",
+  "ratingModeLocal": "Lokal",
+  "ratingModePrivate": "Privat",
+  "ratingModeShared": "Geteilt",
+  "ratingDescLocal": "Bewertungen nur auf diesem Gerät gespeichert",
+  "ratingDescPrivate": "Mit Ihrer Datenbank synchronisiert (nicht für andere sichtbar)",
+  "ratingDescShared": "Für alle Nutzer Ihrer Datenbank sichtbar"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -816,5 +816,11 @@
   "obdConnect": "OBD-II",
   "stationTypeFuel": "Fuel",
   "stationTypeEv": "EV",
-  "brandFilterHighway": "Highway"
+  "brandFilterHighway": "Highway",
+  "ratingModeLocal": "Local",
+  "ratingModePrivate": "Private",
+  "ratingModeShared": "Shared",
+  "ratingDescLocal": "Ratings saved on this device only",
+  "ratingDescPrivate": "Synced with your database (not visible to others)",
+  "ratingDescShared": "Visible to all users of your database"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -481,5 +481,11 @@
   "obdConnect": "OBD-II",
   "stationTypeFuel": "Carburant",
   "stationTypeEv": "Recharge",
-  "brandFilterHighway": "Autoroute"
+  "brandFilterHighway": "Autoroute",
+  "ratingModeLocal": "Local",
+  "ratingModePrivate": "Privé",
+  "ratingModeShared": "Partagé",
+  "ratingDescLocal": "Notes enregistrées uniquement sur cet appareil",
+  "ratingDescPrivate": "Synchronisé avec votre base de données (non visible par les autres)",
+  "ratingDescShared": "Visible par tous les utilisateurs de votre base de données"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3568,6 +3568,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Highway'**
   String get brandFilterHighway;
+
+  /// No description provided for @ratingModeLocal.
+  ///
+  /// In en, this message translates to:
+  /// **'Local'**
+  String get ratingModeLocal;
+
+  /// No description provided for @ratingModePrivate.
+  ///
+  /// In en, this message translates to:
+  /// **'Private'**
+  String get ratingModePrivate;
+
+  /// No description provided for @ratingModeShared.
+  ///
+  /// In en, this message translates to:
+  /// **'Shared'**
+  String get ratingModeShared;
+
+  /// No description provided for @ratingDescLocal.
+  ///
+  /// In en, this message translates to:
+  /// **'Ratings saved on this device only'**
+  String get ratingDescLocal;
+
+  /// No description provided for @ratingDescPrivate.
+  ///
+  /// In en, this message translates to:
+  /// **'Synced with your database (not visible to others)'**
+  String get ratingDescPrivate;
+
+  /// No description provided for @ratingDescShared.
+  ///
+  /// In en, this message translates to:
+  /// **'Visible to all users of your database'**
+  String get ratingDescShared;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Autobahn';
+
+  @override
+  String get ratingModeLocal => 'Lokal';
+
+  @override
+  String get ratingModePrivate => 'Privat';
+
+  @override
+  String get ratingModeShared => 'Geteilt';
+
+  @override
+  String get ratingDescLocal => 'Bewertungen nur auf diesem Gerät gespeichert';
+
+  @override
+  String get ratingDescPrivate => 'Mit Ihrer Datenbank synchronisiert (nicht für andere sichtbar)';
+
+  @override
+  String get ratingDescShared => 'Für alle Nutzer Ihrer Datenbank sichtbar';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Autoroute';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Privé';
+
+  @override
+  String get ratingModeShared => 'Partagé';
+
+  @override
+  String get ratingDescLocal => 'Notes enregistrées uniquement sur cet appareil';
+
+  @override
+  String get ratingDescPrivate => 'Synchronisé avec votre base de données (non visible par les autres)';
+
+  @override
+  String get ratingDescShared => 'Visible par tous les utilisateurs de votre base de données';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1787,4 +1787,22 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get brandFilterHighway => 'Highway';
+
+  @override
+  String get ratingModeLocal => 'Local';
+
+  @override
+  String get ratingModePrivate => 'Private';
+
+  @override
+  String get ratingModeShared => 'Shared';
+
+  @override
+  String get ratingDescLocal => 'Ratings saved on this device only';
+
+  @override
+  String get ratingDescPrivate => 'Synced with your database (not visible to others)';
+
+  @override
+  String get ratingDescShared => 'Visible to all users of your database';
 }


### PR DESCRIPTION
## Summary
- Fix router: landing screen preference now works on cold start (not just after onboarding)
- Translate Station ratings labels and descriptions to FR/DE

🤖 Generated with [Claude Code](https://claude.com/claude-code)