### PR TITLE
fix(core): locale-aware PriceFormatter — correct decimals per country

### DIFF
--- a/lib/core/country/country_provider.dart
+++ b/lib/core/country/country_provider.dart
@@ -4,6 +4,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../features/profile/providers/profile_provider.dart';
 import '../../features/profile/data/repositories/profile_repository.dart';
 import '../storage/storage_providers.dart';
+import '../utils/price_formatter.dart';
 import 'country_config.dart';
 
 part 'country_provider.g.dart';
@@ -18,17 +19,23 @@ class ActiveCountry extends _$ActiveCountry {
     final profile = ref.watch(activeProfileProvider);
     if (profile?.countryCode != null) {
       final fromProfile = Countries.byCode(profile!.countryCode!);
-      if (fromProfile != null) return fromProfile;
+      if (fromProfile != null) return _applyCountry(fromProfile);
     }
 
     // Priority 2: persisted setting (legacy / migration)
     final storage = ref.watch(storageRepositoryProvider);
     final savedCode = storage.getSetting(_storageKey) as String?;
     if (savedCode != null) {
-      return Countries.byCode(savedCode) ?? _detectFromLocale();
+      return _applyCountry(Countries.byCode(savedCode) ?? _detectFromLocale());
     }
 
-    return _detectFromLocale();
+    return _applyCountry(_detectFromLocale());
+  }
+
+  /// Apply country to price formatter when country changes.
+  CountryConfig _applyCountry(CountryConfig config) {
+    PriceFormatter.setCountry(config.code);
+    return config;
   }
 
   /// Auto-detect country from system locale.

--- a/lib/core/utils/price_formatter.dart
+++ b/lib/core/utils/price_formatter.dart
@@ -4,14 +4,72 @@ import 'package:intl/intl.dart';
 class PriceFormatter {
   PriceFormatter._();
 
-  static final _fullFormat = NumberFormat('0.000', 'de_DE');
-  static final _distanceFormat = NumberFormat('0.0', 'de_DE');
+  /// Country code → locale mapping for number formatting.
+  /// Comma-decimal countries (most of Europe) use 'de_DE'.
+  /// Period-decimal countries use 'en_US'.
+  static const _localeMap = <String, String>{
+    'DE': 'de_DE',
+    'FR': 'fr_FR',
+    'AT': 'de_AT',
+    'ES': 'es_ES',
+    'IT': 'it_IT',
+    'PT': 'pt_PT',
+    'BE': 'fr_BE',
+    'LU': 'fr_LU',
+    'DK': 'da_DK',
+    'GB': 'en_GB',
+    'AU': 'en_AU',
+    'MX': 'es_MX',
+    'AR': 'es_AR',
+  };
 
-  /// Format price as plain string (e.g., "1,459 EUR").
-  /// For UI with superscript, use [priceTextSpan] instead.
+  /// Currency symbols per country.
+  static const _currencyMap = <String, String>{
+    'DE': '€',
+    'FR': '€',
+    'AT': '€',
+    'ES': '€',
+    'IT': '€',
+    'PT': '€',
+    'BE': '€',
+    'LU': '€',
+    'DK': 'kr',
+    'GB': '£',
+    'AU': '\$',
+    'MX': '\$',
+    'AR': '\$',
+  };
+
+  /// Active country code. Set by the app on country change.
+  static String _activeCountry = 'FR';
+
+  /// Set the active country for price formatting.
+  static void setCountry(String countryCode) {
+    _activeCountry = countryCode.toUpperCase();
+    _cachedFullFormat = null;
+    _cachedDistanceFormat = null;
+  }
+
+  static String get _locale =>
+      _localeMap[_activeCountry] ?? 'en_US';
+
+  static String get currency =>
+      _currencyMap[_activeCountry] ?? '€';
+
+  // Lazy-initialized formatters that reset when country changes.
+  static NumberFormat? _cachedFullFormat;
+  static NumberFormat? _cachedDistanceFormat;
+
+  static NumberFormat get _fullFormat =>
+      _cachedFullFormat ??= NumberFormat('0.000', _locale);
+
+  static NumberFormat get _distanceFormat =>
+      _cachedDistanceFormat ??= NumberFormat('0.0', _locale);
+
+  /// Format price as plain string (e.g., "1,459 €" or "1.459 £").
   static String formatPrice(double? price) {
     if (price == null || price <= 0) return '--';
-    return '${_fullFormat.format(price)} \u20ac';
+    return '${_fullFormat.format(price)} $currency';
   }
 
   /// Format price without currency symbol for compact display.
@@ -21,22 +79,20 @@ class PriceFormatter {
   }
 
   /// Build a TextSpan with the 9/10ths digit in superscript.
-  /// Example: 1,45⁹ € — the standard European fuel price display.
-  ///
-  /// Returns [baseStyle] for "1,45" and a smaller raised style for "9".
+  /// Example: 1,45⁹ € — the standard fuel price display.
   static TextSpan priceTextSpan(
     double? price, {
     required TextStyle baseStyle,
-    String currency = '\u20ac',
+    String? currencyOverride,
   }) {
     if (price == null || price <= 0) {
       return TextSpan(text: '--', style: baseStyle);
     }
 
-    // Split: 1.459 → base "1,45", superscript "9"
-    final full = _fullFormat.format(price); // "1,459"
-    final base = full.substring(0, full.length - 1); // "1,45"
-    final tenths = full.substring(full.length - 1); // "9"
+    final cur = currencyOverride ?? currency;
+    final full = _fullFormat.format(price);
+    final base = full.substring(0, full.length - 1);
+    final tenths = full.substring(full.length - 1);
 
     final superStyle = baseStyle.copyWith(
       fontSize: (baseStyle.fontSize ?? 14) * 0.65,
@@ -53,12 +109,12 @@ class PriceFormatter {
             child: Text(tenths, style: superStyle),
           ),
         ),
-        TextSpan(text: ' $currency', style: baseStyle),
+        TextSpan(text: ' $cur', style: baseStyle),
       ],
     );
   }
 
-  /// Format distance in km (e.g., "2,3 km").
+  /// Format distance in km (e.g., "2,3 km" or "2.3 km").
   static String formatDistance(double? distanceKm) {
     if (distanceKm == null) return '--';
     if (distanceKm < 1) {

--- a/test/core/utils/price_formatter_test.dart
+++ b/test/core/utils/price_formatter_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
+
+void main() {
+  group('PriceFormatter', () {
+    group('locale-aware formatting', () {
+      test('French locale uses comma decimal separator', () {
+        PriceFormatter.setCountry('FR');
+        final formatted = PriceFormatter.formatPriceCompact(1.459);
+        expect(formatted, contains(','));
+        expect(formatted, isNot(contains('.')));
+      });
+
+      test('UK locale uses period decimal separator', () {
+        PriceFormatter.setCountry('GB');
+        final formatted = PriceFormatter.formatPriceCompact(1.459);
+        expect(formatted, contains('.'));
+      });
+
+      test('Australian locale uses period decimal separator', () {
+        PriceFormatter.setCountry('AU');
+        final formatted = PriceFormatter.formatPriceCompact(1.959);
+        expect(formatted, contains('.'));
+      });
+
+      test('Mexican locale uses period decimal separator', () {
+        PriceFormatter.setCountry('MX');
+        final formatted = PriceFormatter.formatPriceCompact(22.50);
+        expect(formatted, contains('.'));
+      });
+
+      test('German locale uses comma decimal separator', () {
+        PriceFormatter.setCountry('DE');
+        final formatted = PriceFormatter.formatPriceCompact(1.899);
+        expect(formatted, contains(','));
+      });
+    });
+
+    group('currency symbols', () {
+      test('EUR for France', () {
+        PriceFormatter.setCountry('FR');
+        expect(PriceFormatter.currency, '€');
+        expect(PriceFormatter.formatPrice(1.459), contains('€'));
+      });
+
+      test('GBP for UK', () {
+        PriceFormatter.setCountry('GB');
+        expect(PriceFormatter.currency, '£');
+        expect(PriceFormatter.formatPrice(1.459), contains('£'));
+      });
+
+      test('AUD for Australia', () {
+        PriceFormatter.setCountry('AU');
+        expect(PriceFormatter.currency, '\$');
+      });
+
+      test('DKK for Denmark', () {
+        PriceFormatter.setCountry('DK');
+        expect(PriceFormatter.currency, 'kr');
+      });
+    });
+
+    group('null and zero handling', () {
+      test('null price returns --', () {
+        PriceFormatter.setCountry('FR');
+        expect(PriceFormatter.formatPrice(null), '--');
+      });
+
+      test('zero price returns --', () {
+        expect(PriceFormatter.formatPrice(0), '--');
+      });
+
+      test('negative price returns --', () {
+        expect(PriceFormatter.formatPrice(-1.5), '--');
+      });
+    });
+
+    group('distance formatting', () {
+      test('formats km with locale separator', () {
+        PriceFormatter.setCountry('FR');
+        final d = PriceFormatter.formatDistance(2.3);
+        expect(d, contains('km'));
+      });
+
+      test('formats meters for < 1 km', () {
+        PriceFormatter.setCountry('FR');
+        expect(PriceFormatter.formatDistance(0.5), '500 m');
+      });
+
+      test('null distance returns --', () {
+        expect(PriceFormatter.formatDistance(null), '--');
+      });
+    });
+
+    group('setCountry', () {
+      test('case insensitive', () {
+        PriceFormatter.setCountry('gb');
+        expect(PriceFormatter.currency, '£');
+      });
+
+      test('unknown country defaults to USD-style', () {
+        PriceFormatter.setCountry('ZZ');
+        expect(PriceFormatter.currency, '€'); // default
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Fix hardcoded de_DE locale in PriceFormatter. Now uses correct decimal separator and currency per country.

## Test plan
- [x] 17 unit tests (FR comma, UK/AU/MX period, currency symbols, edge cases)
- [x] `flutter analyze` — zero warnings

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)