### PR TITLE
fix(ci): stop regenerating golden files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,6 @@ jobs:
           restore-keys: ${{ runner.os }}-pub-
       - run: flutter pub get
       - run: dart run build_runner build --delete-conflicting-outputs
-      - name: Regenerate golden files for this platform
-        run: flutter test --update-goldens test/goldens/
       - run: flutter test --coverage
       - name: Check coverage threshold
         run: bash scripts/check_coverage.sh

--- a/test/goldens/flutter_test_config.dart
+++ b/test/goldens/flutter_test_config.dart
@@ -15,9 +15,11 @@ class TolerantGoldenFileComparator extends LocalFileComparator {
   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
     try {
       return await super.compare(imageBytes, golden);
-    } on TestFailure catch (e) {
-      // Extract percentage from message like "0.14%, 687px diff detected"
-      final match = RegExp(r'(\d+\.\d+)%').firstMatch(e.message ?? '');
+    } catch (e) {
+      // Flutter 3.29+ throws FlutterError; older versions throw TestFailure.
+      // Both stringify to a message like:
+      //   'Pixel test failed, 0.15%, 744px diff detected.'
+      final match = RegExp(r'(\d+\.\d+)%').firstMatch(e.toString());
       if (match != null) {
         final diffPercent = double.parse(match.group(1)!) / 100;
         if (diffPercent <= _tolerance) {


### PR DESCRIPTION
## Summary
- Remove the `flutter test --update-goldens test/goldens/` step from CI. It regenerated golden baselines right before running tests, so any visual regression was silently overwritten.
- Rely on the existing `TolerantGoldenFileComparator` (0.5% tolerance) in `test/goldens/flutter_test_config.dart` to absorb cross-platform font rendering differences.

## Why
Audit finding #391. Golden tests only work if you compare against a trusted committed baseline — regenerating first is equivalent to disabling them.

## Test plan
- [x] `flutter test test/goldens/` — all 18 goldens pass locally on Windows
- [ ] Watch CI: if Linux rendering exceeds 0.5% tolerance, bump it in a follow-up

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)