### PR TITLE
fix(security): move Supabase anon key to FlutterSecureStorage

### DIFF
--- a/lib/core/data/storage_repository.dart
+++ b/lib/core/data/storage_repository.dart
@@ -71,6 +71,12 @@ abstract class ApiKeyStorage {
   bool hasEvApiKey();
   bool hasCustomEvApiKey();
   Future<void> setEvApiKey(String key);
+
+  /// Supabase anon key — stored in the platform secure enclave, mirrored
+  /// to an in-memory cache so callers can read synchronously.
+  String? getSupabaseAnonKey();
+  Future<void> setSupabaseAnonKey(String key);
+  Future<void> deleteSupabaseAnonKey();
 }
 
 /// User profile storage.

--- a/lib/core/storage/hive_storage.dart
+++ b/lib/core/storage/hive_storage.dart
@@ -95,6 +95,13 @@ class HiveStorage implements StorageRepository {
   bool hasCustomEvApiKey() => _settings.hasCustomEvApiKey();
   @override
   Future<void> setEvApiKey(String key) => _settings.setEvApiKey(key);
+  @override
+  String? getSupabaseAnonKey() => _settings.getSupabaseAnonKey();
+  @override
+  Future<void> setSupabaseAnonKey(String key) =>
+      _settings.setSupabaseAnonKey(key);
+  @override
+  Future<void> deleteSupabaseAnonKey() => _settings.deleteSupabaseAnonKey();
 
   // ---------------------------------------------------------------------------
   // FavoriteStorage

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -28,4 +28,5 @@ class StorageKeys {
   static const String evFavoriteStationData = 'ev_favorite_station_data';
   static const String helpBannerCriteria = 'help_banner_criteria_shown';
   static const String helpBannerAlerts = 'help_banner_alerts_shown';
+  static const String supabaseAnonKey = 'supabase_anon_key';
 }

--- a/lib/core/storage/stores/settings_hive_store.dart
+++ b/lib/core/storage/stores/settings_hive_store.dart
@@ -22,6 +22,7 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
   static Future<void> loadApiKey() async {
     _apiKeyCache = await _secureStorage.read(key: StorageKeys.apiKey);
     await loadEvApiKey();
+    await loadSupabaseAnonKey();
   }
 
   @override
@@ -70,6 +71,43 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
   Future<void> setEvApiKey(String key) async {
     await _secureStorage.write(key: StorageKeys.evApiKey, value: key);
     _evApiKeyCache = key;
+  }
+
+  // Supabase anon key — secure storage with in-memory cache.
+  static String? _supabaseAnonKeyCache;
+
+  /// Load the Supabase anon key into memory and migrate any legacy plain-Hive
+  /// value that pre-dates secure storage (issue #389).
+  static Future<void> loadSupabaseAnonKey() async {
+    _supabaseAnonKeyCache =
+        await _secureStorage.read(key: StorageKeys.supabaseAnonKey);
+    if (_supabaseAnonKeyCache != null) return;
+
+    // One-time migration from plain Hive settings.
+    final box = Hive.box(HiveBoxes.settings);
+    final legacy = box.get(StorageKeys.supabaseAnonKey) as String?;
+    if (legacy != null && legacy.isNotEmpty) {
+      await _secureStorage.write(
+          key: StorageKeys.supabaseAnonKey, value: legacy);
+      _supabaseAnonKeyCache = legacy;
+      await box.delete(StorageKeys.supabaseAnonKey);
+    }
+  }
+
+  @override
+  String? getSupabaseAnonKey() => _supabaseAnonKeyCache;
+
+  @override
+  Future<void> setSupabaseAnonKey(String key) async {
+    await _secureStorage.write(
+        key: StorageKeys.supabaseAnonKey, value: key);
+    _supabaseAnonKeyCache = key;
+  }
+
+  @override
+  Future<void> deleteSupabaseAnonKey() async {
+    await _secureStorage.delete(key: StorageKeys.supabaseAnonKey);
+    _supabaseAnonKeyCache = null;
   }
 
   // Generic settings access

--- a/lib/core/sync/sync_provider.dart
+++ b/lib/core/sync/sync_provider.dart
@@ -30,7 +30,7 @@ class SyncState extends _$SyncState {
     return SyncConfig(
       enabled: storage.getSetting('sync_enabled') as bool? ?? false,
       supabaseUrl: storage.getSetting('supabase_url') as String?,
-      supabaseAnonKey: storage.getSetting('supabase_anon_key') as String?,
+      supabaseAnonKey: storage.getSupabaseAnonKey(),
       userId: storage.getSetting('sync_user_id') as String?,
       userEmail: TankSyncClient.currentEmail,
       mode: _parseMode(modeStr),
@@ -61,7 +61,7 @@ class SyncState extends _$SyncState {
 
       await storage.putSetting('sync_enabled', true);
       await storage.putSetting('supabase_url', cleanUrl);
-      await storage.putSetting('supabase_anon_key', cleanKey);
+      await storage.setSupabaseAnonKey(cleanKey);
       await storage.putSetting('sync_mode', mode.name);
       if (userId != null) {
         await storage.putSetting('sync_user_id', userId);
@@ -190,7 +190,7 @@ class SyncState extends _$SyncState {
 
     await storage.putSetting('sync_enabled', false);
     await storage.putSetting('supabase_url', null);
-    await storage.putSetting('supabase_anon_key', null);
+    await storage.deleteSupabaseAnonKey();
     await storage.putSetting('sync_user_id', null);
     await storage.putSetting('sync_mode', null);
 

--- a/lib/features/sync/presentation/screens/sync_wizard_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_wizard_screen.dart
@@ -230,9 +230,10 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
           userId = await TankSyncClient.signInWithEmail(_emailController.text.trim(), _passwordController.text);
         }
         final settings = ref.read(settingsStorageProvider);
+        final apiKeys = ref.read(apiKeyStorageProvider);
         await settings.putSetting('sync_enabled', true);
         await settings.putSetting('supabase_url', url);
-        await settings.putSetting('supabase_anon_key', key);
+        await apiKeys.setSupabaseAnonKey(key);
         if (userId != null) await settings.putSetting('sync_user_id', userId);
         ref.invalidate(syncStateProvider);
       } else {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -89,7 +89,7 @@ Future<void> main() async {
   final syncEnabled = storage.getSetting('sync_enabled') as bool? ?? false;
   if (syncEnabled) {
     final url = storage.getSetting('supabase_url') as String?;
-    final key = storage.getSetting('supabase_anon_key') as String?;
+    final key = storage.getSupabaseAnonKey();
     if (url != null && key != null) {
       try {
         await Future(() async {

--- a/test/core/data/storage_repository_test.dart
+++ b/test/core/data/storage_repository_test.dart
@@ -49,6 +49,13 @@ void main() {
       // Settings
       await mock.putSetting('key', 'value');
       expect(mock.getSetting('key'), 'value');
+
+      // Supabase anon key (secure storage surface)
+      expect(mock.getSupabaseAnonKey(), isNull);
+      await mock.setSupabaseAnonKey('anon-key-123');
+      expect(mock.getSupabaseAnonKey(), 'anon-key-123');
+      await mock.deleteSupabaseAnonKey();
+      expect(mock.getSupabaseAnonKey(), isNull);
     });
   });
 }
@@ -109,6 +116,14 @@ class _MockStorageRepository implements StorageRepository {
   @override bool hasEvApiKey() => false;
   @override bool hasCustomEvApiKey() => false;
   @override Future<void> setEvApiKey(String key) async {}
+  String? _supabaseAnonKey;
+  @override String? getSupabaseAnonKey() => _supabaseAnonKey;
+  @override Future<void> setSupabaseAnonKey(String key) async {
+    _supabaseAnonKey = key;
+  }
+  @override Future<void> deleteSupabaseAnonKey() async {
+    _supabaseAnonKey = null;
+  }
 
   @override String? getActiveProfileId() => _settings['active_profile_id'] as String?;
   @override Future<void> setActiveProfileId(String id) async => _settings['active_profile_id'] = id;

--- a/test/core/storage/storage_repository_provider_test.dart
+++ b/test/core/storage/storage_repository_provider_test.dart
@@ -291,6 +291,14 @@ class _InMemoryStorageRepository implements StorageRepository {
   @override bool hasEvApiKey() => false;
   @override bool hasCustomEvApiKey() => false;
   @override Future<void> setEvApiKey(String key) async {}
+  String? _supabaseAnonKey;
+  @override String? getSupabaseAnonKey() => _supabaseAnonKey;
+  @override Future<void> setSupabaseAnonKey(String key) async {
+    _supabaseAnonKey = key;
+  }
+  @override Future<void> deleteSupabaseAnonKey() async {
+    _supabaseAnonKey = null;
+  }
 
   // ProfileStorage
   @override String? getActiveProfileId() => _settings['active_profile_id'] as String?;

--- a/test/core/sync/sync_provider_auth_transition_test.dart
+++ b/test/core/sync/sync_provider_auth_transition_test.dart
@@ -38,6 +38,11 @@ void main() {
   void stubStorageDefaults() {
     when(() => mockStorage.getSetting(any())).thenReturn(null);
     when(() => mockStorage.putSetting(any(), any())).thenAnswer((_) async {});
+    when(() => mockStorage.getSupabaseAnonKey()).thenReturn(null);
+    when(() => mockStorage.setSupabaseAnonKey(any()))
+        .thenAnswer((_) async {});
+    when(() => mockStorage.deleteSupabaseAnonKey())
+        .thenAnswer((_) async {});
     when(() => mockStorage.getFavoriteIds()).thenReturn([]);
     when(() => mockStorage.getIgnoredIds()).thenReturn([]);
     when(() => mockStorage.getRatings()).thenReturn({});
@@ -92,7 +97,7 @@ void main() {
       // Verify sync settings are cleared
       verify(() => mockStorage.putSetting('sync_enabled', false)).called(1);
       verify(() => mockStorage.putSetting('supabase_url', null)).called(1);
-      verify(() => mockStorage.putSetting('supabase_anon_key', null)).called(1);
+      verify(() => mockStorage.deleteSupabaseAnonKey()).called(1);
       verify(() => mockStorage.putSetting('sync_user_id', null)).called(1);
       verify(() => mockStorage.putSetting('sync_mode', null)).called(1);
 


### PR DESCRIPTION
## Summary
- Extend \`ApiKeyStorage\` with \`{get,set,delete}SupabaseAnonKey\` backed by \`FlutterSecureStorage\` and an in-memory cache (same pattern as Tankerkoenig and Open Charge Map keys).
- Load the key at startup via \`SettingsHiveStore.loadApiKey\` so reads stay synchronous.
- Transparently migrate any existing plain-Hive \`supabase_anon_key\` entry on first launch after upgrade, then delete the legacy setting.
- Route \`sync_provider.connect / disconnect\`, \`main.dart\` bootstrap, and the sync wizard through the new API.

## Why
Audit finding #389. The Supabase anon key is public by design but still a credential — storing it in the platform secure enclave is defense in depth and matches how the Tankerkoenig key is stored.

## Test plan
- [x] \`flutter analyze\` — 0 errors, 0 warnings
- [x] \`flutter test test/core/sync/ test/core/data/ test/core/storage/ test/features/sync/ test/features/profile/ test/accessibility/\` — all passing
- [x] Interface test (\`storage_repository_test.dart\`) exercises get/set/delete round-trip
- [x] \`sync_provider_auth_transition_test.dart\` updated: disconnect now verifies \`deleteSupabaseAnonKey()\` instead of \`putSetting('supabase_anon_key', null)\`

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)