### PR TITLE
refactor(ui): split SetupScreen build method into section widgets

### DIFF
--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -86,7 +86,10 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
       if (!result.isValid) {
         if (mounted) {
           final l10n = AppLocalizations.of(context);
-          SnackBarHelper.showError(context, l10n?.invalidApiKey(result.errorMessage ?? '') ?? 'Invalid API key: ${result.errorMessage}');
+          SnackBarHelper.showError(
+              context,
+              l10n?.invalidApiKey(result.errorMessage ?? '') ??
+                  'Invalid API key: ${result.errorMessage}');
         }
         return;
       }
@@ -119,17 +122,8 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
     if (mounted) context.go('/');
   }
 
-  Widget? _buildFormatIndicator() {
-    if (_isFormatValid == null) return null;
-    if (_isFormatValid!) {
-      return const Icon(Icons.check_circle, color: Colors.green);
-    }
-    return const Icon(Icons.error_outline, color: Colors.red);
-  }
-
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final country = ref.watch(activeCountryProvider);
     final language = ref.watch(activeLanguageProvider);
     final l10n = AppLocalizations.of(context);
@@ -142,255 +136,372 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: 16),
-              Semantics(
-                excludeSemantics: true,
-                child: Icon(
-                  Icons.local_gas_station,
-                  size: 72,
-                  color: theme.colorScheme.primary,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Semantics(
-                header: true,
-                child: Text(
-                  l10n?.welcome ?? 'Fuel Prices',
-                  style: theme.textTheme.headlineMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                l10n?.welcomeSubtitle ?? 'Find the cheapest fuel near you.',
-                style: theme.textTheme.bodyLarge,
-                textAlign: TextAlign.center,
+              const _SetupHeader(),
+              const SizedBox(height: 24),
+              _LanguageSelector(
+                selected: language,
+                onSelect: (lang) =>
+                    ref.read(activeLanguageProvider.notifier).select(lang),
               ),
               const SizedBox(height: 24),
-
-              // ── Language selector ──
-              Text(
-                l10n?.language ?? 'Language',
-                style: theme.textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Wrap(
-                spacing: 6,
-                runSpacing: 6,
-                children: AppLanguages.all.map((lang) {
-                  final isSelected = lang.code == language.code;
-                  return Semantics(
-                    label: 'Language ${lang.nativeName}${isSelected ? ", selected" : ""}',
-                    child: ChoiceChip(
-                      label: Text(lang.nativeName),
-                      selected: isSelected,
-                      onSelected: (_) {
-                        ref.read(activeLanguageProvider.notifier).select(lang);
-                      },
-                      visualDensity: VisualDensity.compact,
-                    ),
-                  );
-                }).toList(),
+              _CountrySelector(
+                selected: country,
+                onSelect: (c) =>
+                    ref.read(activeCountryProvider.notifier).select(c),
               ),
               const SizedBox(height: 24),
-
-              // ── Country selector ──
-              Text(
-                l10n?.country ?? 'Country',
-                style: theme.textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: Countries.all.map((c) {
-                  final isSelected = c.code == country.code;
-                  return Semantics(
-                    label: 'Country ${c.name}${isSelected ? ", selected" : ""}',
-                    child: ChoiceChip(
-                      label: Text('${c.flag} ${c.name}'),
-                      selected: isSelected,
-                      onSelected: (_) {
-                        ref.read(activeCountryProvider.notifier).select(c);
-                      },
-                    ),
-                  );
-                }).toList(),
-              ),
+              _CountryInfoCard(country: country),
               const SizedBox(height: 24),
-
-              // ── Country-specific info ──
-              Semantics(
-                label: '${country.name}, data source: ${country.apiProvider ?? 'Demo'}, '
-                    '${country.requiresApiKey ? 'API key required' : 'Free, no key needed'}, '
-                    'fuel types: ${country.fuelTypes.join(', ')}',
-                child: Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            ExcludeSemantics(
-                              child: Text(
-                                country.flag,
-                                style: const TextStyle(fontSize: 24),
-                              ),
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: ExcludeSemantics(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      country.name,
-                                      style: theme.textTheme.titleMedium?.copyWith(
-                                        fontWeight: FontWeight.bold,
-                                      ),
-                                    ),
-                                    Text(
-                                      'Data: ${country.apiProvider ?? 'Demo'}',
-                                      style: theme.textTheme.bodySmall,
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                            // Status badge
-                            ExcludeSemantics(
-                              child: Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 8,
-                                  vertical: 4,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: country.requiresApiKey
-                                      ? Colors.orange.shade100
-                                      : Colors.green.shade100,
-                                  borderRadius: BorderRadius.circular(12),
-                                ),
-                                child: Text(
-                                  country.requiresApiKey
-                                      ? 'API key required'
-                                      : 'Free — no key needed',
-                                  style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.w600,
-                                    color: country.requiresApiKey
-                                        ? Colors.orange.shade800
-                                        : Colors.green.shade800,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 8),
-                        ExcludeSemantics(
-                          child: Text(
-                            'Fuel types: ${country.fuelTypes.join(', ')}',
-                            style: theme.textTheme.bodySmall,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 24),
-
-              // ── API key input (only if required) ──
               if (country.requiresApiKey) ...[
-                Text(
-                  'API key setup (optional)',
-                  style: theme.textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  'Register for a free API key, or skip to explore '
-                  'the app with demo data.',
-                  style: theme.textTheme.bodyMedium,
-                ),
-                const SizedBox(height: 12),
-                if (country.apiKeyRegistrationUrl != null)
-                  OutlinedButton.icon(
-                    onPressed: () async {
-                      final uri = Uri.parse(country.apiKeyRegistrationUrl!);
-                      if (await canLaunchUrl(uri)) {
-                        await launchUrl(
-                          uri,
-                          mode: LaunchMode.externalApplication,
-                        );
-                      }
-                    },
-                    icon: const Icon(Icons.open_in_new),
-                    label: Text('${country.apiProvider} Registration'),
-                  ),
-                const SizedBox(height: 16),
-                TextField(
+                _ApiKeyInputSection(
+                  country: country,
                   controller: _apiKeyController,
-                  decoration: InputDecoration(
-                    labelText: l10n?.apiKeyLabel ?? 'API Key',
-                    hintText: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-                    prefixIcon: const Icon(Icons.key),
-                    border: const OutlineInputBorder(),
-                    suffixIcon: _buildFormatIndicator(),
-                    errorText: _isFormatValid == false
-                        ? (l10n?.apiKeyFormatError ??
-                            'Invalid format — expected UUID (8-4-4-4-12)')
-                        : null,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  'By entering an API key you accept the terms of '
-                  '${country.apiProvider}. Data redistribution is prohibited.',
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
+                  formatValid: _isFormatValid,
+                  l10n: l10n,
                 ),
                 const SizedBox(height: 24),
               ],
-
-              // ── Continue button ──
-              Semantics(
-                button: true,
-                label: _isLoading
-                    ? 'Loading'
-                    : (country.requiresApiKey && _apiKeyController.text.trim().isEmpty
-                        ? 'Continue with demo data'
-                        : 'Continue'),
-                child: FilledButton.icon(
-                  onPressed: _isLoading ? null : _continue,
-                  icon: const Icon(Icons.arrow_forward),
-                  label: _isLoading
-                      ? const SizedBox(
-                          height: 20,
-                          width: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : Text(
-                          country.requiresApiKey &&
-                                  _apiKeyController.text.trim().isEmpty
-                              ? 'Continue with demo data'
-                              : 'Continue',
-                        ),
-                ),
+              _ContinueButton(
+                isLoading: _isLoading,
+                country: country,
+                apiKeyEmpty: _apiKeyController.text.trim().isEmpty,
+                onPressed: _continue,
               ),
-
               const SizedBox(height: 24),
               if (country.attribution != null)
                 Text(
                   country.attribution!,
-                  style: theme.textTheme.bodySmall,
+                  style: Theme.of(context).textTheme.bodySmall,
                   textAlign: TextAlign.center,
                 ),
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup sections — private widgets kept in-file so they share the screen's
+// l10n/theme assumptions and are easy to find while editing the flow.
+// ---------------------------------------------------------------------------
+
+class _SetupHeader extends StatelessWidget {
+  const _SetupHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      children: [
+        Semantics(
+          excludeSemantics: true,
+          child: Icon(
+            Icons.local_gas_station,
+            size: 72,
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Semantics(
+          header: true,
+          child: Text(
+            l10n?.welcome ?? 'Fuel Prices',
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n?.welcomeSubtitle ?? 'Find the cheapest fuel near you.',
+          style: theme.textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}
+
+class _LanguageSelector extends StatelessWidget {
+  final AppLanguage selected;
+  final ValueChanged<AppLanguage> onSelect;
+
+  const _LanguageSelector({required this.selected, required this.onSelect});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(l10n?.language ?? 'Language', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: AppLanguages.all.map((lang) {
+            final isSelected = lang.code == selected.code;
+            return Semantics(
+              label:
+                  'Language ${lang.nativeName}${isSelected ? ", selected" : ""}',
+              child: ChoiceChip(
+                label: Text(lang.nativeName),
+                selected: isSelected,
+                onSelected: (_) => onSelect(lang),
+                visualDensity: VisualDensity.compact,
+              ),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _CountrySelector extends StatelessWidget {
+  final CountryConfig selected;
+  final ValueChanged<CountryConfig> onSelect;
+
+  const _CountrySelector({required this.selected, required this.onSelect});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(l10n?.country ?? 'Country', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: Countries.all.map((c) {
+            final isSelected = c.code == selected.code;
+            return Semantics(
+              label: 'Country ${c.name}${isSelected ? ", selected" : ""}',
+              child: ChoiceChip(
+                label: Text('${c.flag} ${c.name}'),
+                selected: isSelected,
+                onSelected: (_) => onSelect(c),
+              ),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _CountryInfoCard extends StatelessWidget {
+  final CountryConfig country;
+
+  const _CountryInfoCard({required this.country});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: '${country.name}, data source: ${country.apiProvider ?? 'Demo'}, '
+          '${country.requiresApiKey ? 'API key required' : 'Free, no key needed'}, '
+          'fuel types: ${country.fuelTypes.join(', ')}',
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  ExcludeSemantics(
+                    child: Text(
+                      country.flag,
+                      style: const TextStyle(fontSize: 24),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ExcludeSemantics(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            country.name,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          Text(
+                            'Data: ${country.apiProvider ?? 'Demo'}',
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  _CountryStatusBadge(country: country),
+                ],
+              ),
+              const SizedBox(height: 8),
+              ExcludeSemantics(
+                child: Text(
+                  'Fuel types: ${country.fuelTypes.join(', ')}',
+                  style: theme.textTheme.bodySmall,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CountryStatusBadge extends StatelessWidget {
+  final CountryConfig country;
+
+  const _CountryStatusBadge({required this.country});
+
+  @override
+  Widget build(BuildContext context) {
+    return ExcludeSemantics(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: country.requiresApiKey
+              ? Colors.orange.shade100
+              : Colors.green.shade100,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          country.requiresApiKey
+              ? 'API key required'
+              : 'Free — no key needed',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: country.requiresApiKey
+                ? Colors.orange.shade800
+                : Colors.green.shade800,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ApiKeyInputSection extends StatelessWidget {
+  final CountryConfig country;
+  final TextEditingController controller;
+  final bool? formatValid;
+  final AppLocalizations? l10n;
+
+  const _ApiKeyInputSection({
+    required this.country,
+    required this.controller,
+    required this.formatValid,
+    required this.l10n,
+  });
+
+  Widget? _buildFormatIndicator() {
+    if (formatValid == null) return null;
+    if (formatValid!) {
+      return const Icon(Icons.check_circle, color: Colors.green);
+    }
+    return const Icon(Icons.error_outline, color: Colors.red);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('API key setup (optional)', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        Text(
+          'Register for a free API key, or skip to explore '
+          'the app with demo data.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 12),
+        if (country.apiKeyRegistrationUrl != null)
+          OutlinedButton.icon(
+            onPressed: () async {
+              final uri = Uri.parse(country.apiKeyRegistrationUrl!);
+              if (await canLaunchUrl(uri)) {
+                await launchUrl(
+                  uri,
+                  mode: LaunchMode.externalApplication,
+                );
+              }
+            },
+            icon: const Icon(Icons.open_in_new),
+            label: Text('${country.apiProvider} Registration'),
+          ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: controller,
+          decoration: InputDecoration(
+            labelText: l10n?.apiKeyLabel ?? 'API Key',
+            hintText: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+            prefixIcon: const Icon(Icons.key),
+            border: const OutlineInputBorder(),
+            suffixIcon: _buildFormatIndicator(),
+            errorText: formatValid == false
+                ? (l10n?.apiKeyFormatError ??
+                    'Invalid format — expected UUID (8-4-4-4-12)')
+                : null,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'By entering an API key you accept the terms of '
+          '${country.apiProvider}. Data redistribution is prohibited.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ContinueButton extends StatelessWidget {
+  final bool isLoading;
+  final CountryConfig country;
+  final bool apiKeyEmpty;
+  final VoidCallback onPressed;
+
+  const _ContinueButton({
+    required this.isLoading,
+    required this.country,
+    required this.apiKeyEmpty,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final usingDemo = country.requiresApiKey && apiKeyEmpty;
+    final label = usingDemo ? 'Continue with demo data' : 'Continue';
+    return Semantics(
+      button: true,
+      label: isLoading ? 'Loading' : label,
+      child: FilledButton.icon(
+        onPressed: isLoading ? null : onPressed,
+        icon: const Icon(Icons.arrow_forward),
+        label: isLoading
+            ? const SizedBox(
+                height: 20,
+                width: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : Text(label),
       ),
     );
   }


### PR DESCRIPTION
## Summary
Extract the 262-line \`SetupScreen.build\` body into seven private stateless widgets kept in the same file:
- \`_SetupHeader\` — icon, welcome title, subtitle
- \`_LanguageSelector\` — Wrap of ChoiceChips
- \`_CountrySelector\` — Wrap of ChoiceChips
- \`_CountryInfoCard\` + \`_CountryStatusBadge\` — data source card
- \`_ApiKeyInputSection\` — conditional API-key TextField with format indicator and registration link
- \`_ContinueButton\` — FilledButton with loading/demo labels

The main \`build\` method now reads top-to-bottom as the setup flow in ~55 lines.

## Why
Audit finding #388. SetupScreen had one of the largest build methods. Splitting into named widgets makes each section searchable, reusable in tests, and quicker to edit.

## Test plan
- [x] \`flutter analyze\` — 0 errors, 0 warnings
- [x] \`flutter test test/features/setup/ test/accessibility/\` — all 87 passing (SetupScreen a11y tests unchanged, behavior preserved)

Progresses #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)