### PR TITLE
fix(i18n): localize service banner and chain error widgets

### DIFF
--- a/lib/core/error/error_localizer.dart
+++ b/lib/core/error/error_localizer.dart
@@ -30,6 +30,11 @@ class ErrorLocalizer {
       return l10n?.errorNoApiKey ?? 'No API key configured. Go to Settings to add one.';
     }
 
+    if (error is NoEvApiKeyException) {
+      return l10n?.errorNoEvApiKey ??
+          'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+    }
+
     if (error is ServiceChainExhaustedException) {
       return l10n?.errorAllServicesFailed ?? 'Could not load data. Check your connection and try again.';
     }

--- a/lib/core/error/exceptions.dart
+++ b/lib/core/error/exceptions.dart
@@ -46,6 +46,20 @@ class NoApiKeyException extends AppException {
   String toString() => message;
 }
 
+/// Thrown when the user tries to perform an EV charging-station lookup
+/// without an OpenChargeMap key configured. Routed through ErrorLocalizer
+/// so the UI message is translated.
+class NoEvApiKeyException extends AppException {
+  const NoEvApiKeyException();
+
+  @override
+  String get message =>
+      'OpenChargeMap API key not configured. Set it up in Settings to search for EV charging stations.';
+
+  @override
+  String toString() => message;
+}
+
 /// Thrown when every service in a fallback chain has failed,
 /// including the cache. Carries accumulated errors from each step
 /// so the UI can report exactly what went wrong.

--- a/lib/core/services/widgets/service_status_banner.dart
+++ b/lib/core/services/widgets/service_status_banner.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../error/error_localizer.dart';
 import '../../error/exceptions.dart';
 import '../service_result.dart';
 
@@ -16,6 +17,7 @@ class ServiceStatusBanner extends StatelessWidget {
     }
 
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final Color backgroundColor;
     final IconData icon;
     final String message;
@@ -23,11 +25,12 @@ class ServiceStatusBanner extends StatelessWidget {
     if (result.isStale) {
       backgroundColor = theme.colorScheme.errorContainer;
       icon = Icons.cloud_off;
-      message = 'Offline — ${result.freshnessLabel}';
+      message =
+          '${l10n?.offlineLabel ?? 'Offline'} — ${result.freshnessLabel}';
     } else if (result.hadFallbacks) {
       backgroundColor = theme.colorScheme.tertiaryContainer;
       icon = Icons.info_outline;
-      message = result.fallbackSummary;
+      message = _localizedFallbackSummary(result, l10n);
     } else {
       return const SizedBox.shrink();
     }
@@ -47,6 +50,16 @@ class ServiceStatusBanner extends StatelessWidget {
   }
 }
 
+/// Builds the "X unavailable. Using Y." banner message using the active
+/// localization, falling back to the untranslated [ServiceResult.fallbackSummary].
+String _localizedFallbackSummary(ServiceResult result, AppLocalizations? l10n) {
+  if (result.errors.isEmpty) return '';
+  final failedNames = result.errors.map((e) => e.source.displayName).join(', ');
+  final current = result.source.displayName;
+  return l10n?.fallbackSummary(failedNames, current) ??
+      result.fallbackSummary;
+}
+
 /// Shows error when the entire service chain failed.
 /// Formats errors for humans — never shows raw Dart objects.
 class ServiceChainErrorWidget extends StatelessWidget {
@@ -61,49 +74,60 @@ class ServiceChainErrorWidget extends StatelessWidget {
 
   /// Extract a short, user-friendly title from the error.
   String _title(AppLocalizations? l10n) {
-    if (error is NoApiKeyException) {
-      return l10n?.noResults ?? 'API key required';
+    if (error is NoApiKeyException || error is NoEvApiKeyException) {
+      return l10n?.errorTitleApiKey ?? 'API key required';
     }
     if (error is LocationException) {
-      return l10n?.noResults ?? 'Location unavailable';
+      return l10n?.errorTitleLocation ?? 'Location unavailable';
     }
     return l10n?.noResults ?? 'No stations found.';
   }
 
   /// Extract actionable hint text from the error chain.
   String _hint(AppLocalizations? l10n) {
-    // Check for common patterns in error messages
     final msg = error.toString().toLowerCase();
-    if (msg.contains('no stations found') || msg.contains('keine tankstellen')) {
-      return 'Try increasing the search radius or search a different location.';
+    if (msg.contains('no stations found') ||
+        msg.contains('keine tankstellen')) {
+      return l10n?.errorHintNoStations ??
+          'Try increasing the search radius or search a different location.';
     }
-    if (msg.contains('api key') || error is NoApiKeyException) {
-      return 'Configure your API key in Settings.';
+    if (msg.contains('api key') ||
+        error is NoApiKeyException ||
+        error is NoEvApiKeyException) {
+      return l10n?.errorHintApiKey ?? 'Configure your API key in Settings.';
     }
-    if (msg.contains('location') || msg.contains('gps') || error is LocationException) {
-      return l10n?.locationDenied ?? 'Location unavailable. Try searching by postal code or city name.';
+    if (msg.contains('location') ||
+        msg.contains('gps') ||
+        error is LocationException) {
+      return l10n?.locationDenied ??
+          'Location unavailable. Try searching by postal code or city name.';
     }
     if (msg.contains('timeout') || msg.contains('connection')) {
-      return 'Check your internet connection and try again.';
+      return l10n?.errorHintConnection ??
+          'Check your internet connection and try again.';
     }
-    if (msg.contains('route') || msg.contains('osrm') || msg.contains('routing')) {
-      return 'Route calculation failed. Check your internet connection and try again.';
+    if (msg.contains('route') ||
+        msg.contains('osrm') ||
+        msg.contains('routing')) {
+      return l10n?.errorHintRouting ??
+          'Route calculation failed. Check your internet connection and try again.';
     }
-    return 'Try again or search by postal code / city name.';
+    return l10n?.errorHintFallback ??
+        'Try again or search by postal code / city name.';
   }
 
   /// Extract technical details for the expandable section.
-  List<String> _technicalDetails() {
+  List<String> _technicalDetails(AppLocalizations? l10n) {
     if (error is ServiceChainExhaustedException) {
       final chain = error as ServiceChainExhaustedException;
       return chain.errors.map((e) {
         if (e is ServiceError) {
           return '${e.source.displayName}: ${e.message}';
         }
-        return e.toString();
+        return ErrorLocalizer.localize(e, l10n);
       }).toList();
     }
-    return [error.toString()];
+    return [ErrorLocalizer.localize(error, l10n)];
   }
 
   @override
@@ -145,12 +169,12 @@ class ServiceChainErrorWidget extends StatelessWidget {
               data: theme.copyWith(dividerColor: Colors.transparent),
               child: ExpansionTile(
                 title: Text(
-                  'Details',
+                  l10n?.detailsLabel ?? 'Details',
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
                 ),
-                children: _technicalDetails()
+                children: _technicalDetails(l10n)
                     .map((d) => Padding(
                           padding: const EdgeInsets.symmetric(
                               horizontal: 16, vertical: 2),

--- a/lib/core/services/widgets/service_status_banner.dart
+++ b/lib/core/services/widgets/service_status_banner.dart
@@ -117,17 +117,24 @@ class ServiceChainErrorWidget extends StatelessWidget {
   }
 
   /// Extract technical details for the expandable section.
+  ///
+  /// Domain exceptions go through [ErrorLocalizer] so the user sees the
+  /// translated message; unknown errors stay as their raw [toString] so the
+  /// expandable section still carries useful debug info.
   List<String> _technicalDetails(AppLocalizations? l10n) {
+    String render(Object e) =>
+        e is AppException ? ErrorLocalizer.localize(e, l10n) : e.toString();
+
     if (error is ServiceChainExhaustedException) {
       final chain = error as ServiceChainExhaustedException;
       return chain.errors.map((e) {
         if (e is ServiceError) {
           return '${e.source.displayName}: ${e.message}';
         }
-        return ErrorLocalizer.localize(e, l10n);
+        return render(e);
       }).toList();
     }
-    return [ErrorLocalizer.localize(error, l10n)];
+    return [render(error)];
   }
 
   @override

--- a/lib/features/search/providers/ev_search_provider.dart
+++ b/lib/features/search/providers/ev_search_provider.dart
@@ -32,10 +32,7 @@ class EVSearchState extends _$EVSearchState {
       final storage = ref.read(storageRepositoryProvider);
       final apiKey = storage.getEvApiKey();
       if (apiKey == null || apiKey.isEmpty) {
-        throw const ApiException(
-          message: 'OpenChargeMap API key not configured. '
-              'Set it up in Settings to search for EV charging stations.',
-        );
+        throw const NoEvApiKeyException();
       }
 
       final country = ref.read(activeCountryProvider);

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -822,5 +822,16 @@
   "ratingModeShared": "Geteilt",
   "ratingDescLocal": "Bewertungen nur auf diesem Gerät gespeichert",
   "ratingDescPrivate": "Mit Ihrer Datenbank synchronisiert (nicht für andere sichtbar)",
-  "ratingDescShared": "Für alle Nutzer Ihrer Datenbank sichtbar"
+  "ratingDescShared": "Für alle Nutzer Ihrer Datenbank sichtbar",
+  "errorNoEvApiKey": "OpenChargeMap-API-Schlüssel nicht konfiguriert. Fügen Sie einen in den Einstellungen hinzu, um Ladestationen zu suchen.",
+  "offlineLabel": "Offline",
+  "fallbackSummary": "{failed} nicht verfügbar. Verwende {current}.",
+  "errorTitleApiKey": "API-Schlüssel erforderlich",
+  "errorTitleLocation": "Standort nicht verfügbar",
+  "errorHintNoStations": "Erhöhen Sie den Suchradius oder suchen Sie an einem anderen Ort.",
+  "errorHintApiKey": "Konfigurieren Sie Ihren API-Schlüssel in den Einstellungen.",
+  "errorHintConnection": "Prüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.",
+  "errorHintRouting": "Routenberechnung fehlgeschlagen. Prüfen Sie Ihre Internetverbindung.",
+  "errorHintFallback": "Versuchen Sie es erneut oder suchen Sie nach Postleitzahl / Stadt.",
+  "detailsLabel": "Details"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -822,5 +822,22 @@
   "ratingModeShared": "Shared",
   "ratingDescLocal": "Ratings saved on this device only",
   "ratingDescPrivate": "Synced with your database (not visible to others)",
-  "ratingDescShared": "Visible to all users of your database"
+  "ratingDescShared": "Visible to all users of your database",
+  "errorNoEvApiKey": "OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.",
+  "offlineLabel": "Offline",
+  "fallbackSummary": "{failed} unavailable. Using {current}.",
+  "@fallbackSummary": {
+    "placeholders": {
+      "failed": { "type": "String" },
+      "current": { "type": "String" }
+    }
+  },
+  "errorTitleApiKey": "API key required",
+  "errorTitleLocation": "Location unavailable",
+  "errorHintNoStations": "Try increasing the search radius or search a different location.",
+  "errorHintApiKey": "Configure your API key in Settings.",
+  "errorHintConnection": "Check your internet connection and try again.",
+  "errorHintRouting": "Route calculation failed. Check your internet connection and try again.",
+  "errorHintFallback": "Try again or search by postal code / city name.",
+  "detailsLabel": "Details"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -487,5 +487,16 @@
   "ratingModeShared": "Partagé",
   "ratingDescLocal": "Notes enregistrées uniquement sur cet appareil",
   "ratingDescPrivate": "Synchronisé avec votre base de données (non visible par les autres)",
-  "ratingDescShared": "Visible par tous les utilisateurs de votre base de données"
+  "ratingDescShared": "Visible par tous les utilisateurs de votre base de données",
+  "errorNoEvApiKey": "Clé API OpenChargeMap non configurée. Ajoutez-en une dans Paramètres pour rechercher des bornes de recharge.",
+  "offlineLabel": "Hors ligne",
+  "fallbackSummary": "{failed} indisponible. Utilisation de {current}.",
+  "errorTitleApiKey": "Clé API requise",
+  "errorTitleLocation": "Position indisponible",
+  "errorHintNoStations": "Augmentez le rayon de recherche ou cherchez à un autre endroit.",
+  "errorHintApiKey": "Configurez votre clé API dans Paramètres.",
+  "errorHintConnection": "Vérifiez votre connexion internet et réessayez.",
+  "errorHintRouting": "Calcul d'itinéraire échoué. Vérifiez votre connexion internet.",
+  "errorHintFallback": "Réessayez ou cherchez par code postal / ville.",
+  "detailsLabel": "Détails"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3612,6 +3612,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Visible to all users of your database'**
   String get ratingDescShared;
+
+  /// No description provided for @errorNoEvApiKey.
+  ///
+  /// In en, this message translates to:
+  /// **'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.'**
+  String get errorNoEvApiKey;
+
+  /// No description provided for @offlineLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Offline'**
+  String get offlineLabel;
+
+  /// No description provided for @fallbackSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'{failed} unavailable. Using {current}.'**
+  String fallbackSummary(String failed, String current);
+
+  /// No description provided for @errorTitleApiKey.
+  ///
+  /// In en, this message translates to:
+  /// **'API key required'**
+  String get errorTitleApiKey;
+
+  /// No description provided for @errorTitleLocation.
+  ///
+  /// In en, this message translates to:
+  /// **'Location unavailable'**
+  String get errorTitleLocation;
+
+  /// No description provided for @errorHintNoStations.
+  ///
+  /// In en, this message translates to:
+  /// **'Try increasing the search radius or search a different location.'**
+  String get errorHintNoStations;
+
+  /// No description provided for @errorHintApiKey.
+  ///
+  /// In en, this message translates to:
+  /// **'Configure your API key in Settings.'**
+  String get errorHintApiKey;
+
+  /// No description provided for @errorHintConnection.
+  ///
+  /// In en, this message translates to:
+  /// **'Check your internet connection and try again.'**
+  String get errorHintConnection;
+
+  /// No description provided for @errorHintRouting.
+  ///
+  /// In en, this message translates to:
+  /// **'Route calculation failed. Check your internet connection and try again.'**
+  String get errorHintRouting;
+
+  /// No description provided for @errorHintFallback.
+  ///
+  /// In en, this message translates to:
+  /// **'Try again or search by postal code / city name.'**
+  String get errorHintFallback;
+
+  /// No description provided for @detailsLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Details'**
+  String get detailsLabel;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1881,4 +1881,44 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1881,4 +1881,44 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1879,4 +1879,44 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1894,4 +1894,45 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Für alle Nutzer Ihrer Datenbank sichtbar';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap-API-Schlüssel nicht konfiguriert. Fügen Sie einen in den Einstellungen hinzu, um Ladestationen zu suchen.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed nicht verfügbar. Verwende $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API-Schlüssel erforderlich';
+
+  @override
+  String get errorTitleLocation => 'Standort nicht verfügbar';
+
+  @override
+  String get errorHintNoStations =>
+      'Erhöhen Sie den Suchradius oder suchen Sie an einem anderen Ort.';
+
+  @override
+  String get errorHintApiKey =>
+      'Konfigurieren Sie Ihren API-Schlüssel in den Einstellungen.';
+
+  @override
+  String get errorHintConnection =>
+      'Prüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
+
+  @override
+  String get errorHintRouting =>
+      'Routenberechnung fehlgeschlagen. Prüfen Sie Ihre Internetverbindung.';
+
+  @override
+  String get errorHintFallback =>
+      'Versuchen Sie es erneut oder suchen Sie nach Postleitzahl / Stadt.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1883,4 +1883,44 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1874,4 +1874,44 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1882,4 +1882,44 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1876,4 +1876,44 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1879,4 +1879,44 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1891,4 +1891,44 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get ratingDescShared =>
       'Visible par tous les utilisateurs de votre base de données';
+
+  @override
+  String get errorNoEvApiKey =>
+      'Clé API OpenChargeMap non configurée. Ajoutez-en une dans Paramètres pour rechercher des bornes de recharge.';
+
+  @override
+  String get offlineLabel => 'Hors ligne';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed indisponible. Utilisation de $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'Clé API requise';
+
+  @override
+  String get errorTitleLocation => 'Position indisponible';
+
+  @override
+  String get errorHintNoStations =>
+      'Augmentez le rayon de recherche ou cherchez à un autre endroit.';
+
+  @override
+  String get errorHintApiKey => 'Configurez votre clé API dans Paramètres.';
+
+  @override
+  String get errorHintConnection =>
+      'Vérifiez votre connexion internet et réessayez.';
+
+  @override
+  String get errorHintRouting =>
+      'Calcul d\'itinéraire échoué. Vérifiez votre connexion internet.';
+
+  @override
+  String get errorHintFallback =>
+      'Réessayez ou cherchez par code postal / ville.';
+
+  @override
+  String get detailsLabel => 'Détails';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1878,4 +1878,44 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1883,4 +1883,44 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1882,4 +1882,44 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1880,4 +1880,44 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1882,4 +1882,44 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1878,4 +1878,44 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1883,4 +1883,44 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1881,4 +1881,44 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1882,4 +1882,44 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1881,4 +1881,44 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1882,4 +1882,44 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1876,4 +1876,44 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1880,4 +1880,44 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get ratingDescShared => 'Visible to all users of your database';
+
+  @override
+  String get errorNoEvApiKey =>
+      'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+
+  @override
+  String get offlineLabel => 'Offline';
+
+  @override
+  String fallbackSummary(String failed, String current) {
+    return '$failed unavailable. Using $current.';
+  }
+
+  @override
+  String get errorTitleApiKey => 'API key required';
+
+  @override
+  String get errorTitleLocation => 'Location unavailable';
+
+  @override
+  String get errorHintNoStations =>
+      'Try increasing the search radius or search a different location.';
+
+  @override
+  String get errorHintApiKey => 'Configure your API key in Settings.';
+
+  @override
+  String get errorHintConnection =>
+      'Check your internet connection and try again.';
+
+  @override
+  String get errorHintRouting =>
+      'Route calculation failed. Check your internet connection and try again.';
+
+  @override
+  String get errorHintFallback =>
+      'Try again or search by postal code / city name.';
+
+  @override
+  String get detailsLabel => 'Details';
 }

--- a/test/core/error/error_localizer_test.dart
+++ b/test/core/error/error_localizer_test.dart
@@ -55,6 +55,15 @@ void main() {
       expect(msg, contains('Settings'));
     });
 
+    test('NoEvApiKeyException returns OpenChargeMap setup message', () {
+      final msg = ErrorLocalizer.localize(
+        const NoEvApiKeyException(),
+        null,
+      );
+      expect(msg, contains('OpenChargeMap'));
+      expect(msg, contains('Settings'));
+    });
+
     test('ServiceChainExhaustedException returns data load error', () {
       final msg = ErrorLocalizer.localize(
         const ServiceChainExhaustedException(errors: []),

--- a/test/core/error/exceptions_test.dart
+++ b/test/core/error/exceptions_test.dart
@@ -165,6 +165,7 @@ void main() {
         const CacheException(message: 'b'),
         const LocationException(message: 'c'),
         const NoApiKeyException(),
+        const NoEvApiKeyException(),
         const ServiceChainExhaustedException(errors: []),
       ];
       for (final e in exceptions) {
@@ -174,6 +175,7 @@ void main() {
           CacheException() => 'cache',
           LocationException() => 'location',
           NoApiKeyException() => 'nokey',
+          NoEvApiKeyException() => 'noevkey',
           ServiceChainExhaustedException() => 'chain',
         };
         expect(result, isNotEmpty);


### PR DESCRIPTION
## Summary
- Add \`NoEvApiKeyException\` so the \"OpenChargeMap API key not configured\" message can be translated via \`ErrorLocalizer\` instead of being thrown as an \`ApiException\` with a hardcoded English string.
- Replace 8 hardcoded English strings in \`service_status_banner.dart\` (Offline label, fallback summary, error titles/hints, Details label) with l10n keys.
- Route \`ServiceChainErrorWidget._technicalDetails\` through \`ErrorLocalizer\` so individual chain errors are translated when expanded.
- Add EN/DE/FR translations for the new keys. The 20 other locales fall back to English via Flutter's standard mechanism, then \`flutter gen-l10n\` regenerates the AppLocalizations bindings.

## Why
Audit finding #393. EV-search and service-chain errors leaked English text into otherwise-translated UIs.

## Test plan
- [x] \`flutter analyze\` — 0 errors, 0 warnings (sealed-class switch test updated for \`NoEvApiKeyException\`).
- [x] \`flutter test test/core/error/ test/features/search/\` — 476 tests passing including new \`NoEvApiKeyException\` cases.

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)