### PR TITLE
fix(a11y): add tooltips to remaining unlabeled IconButtons

### DIFF
--- a/lib/features/profile/presentation/widgets/profile_list_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_list_section.dart
@@ -49,6 +49,8 @@ class ProfileListSection extends ConsumerWidget {
                     ),
                   IconButton(
                     icon: const Icon(Icons.edit),
+                    tooltip: AppLocalizations.of(context)?.editProfile ??
+                        'Edit profile',
                     onPressed: () => _editProfile(context, ref, profile),
                   ),
                 ],

--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -239,6 +239,7 @@ class _RouteInputState extends ConsumerState<RouteInput> {
               prefixIcon: Icons.more_vert,
               suffixWidget: IconButton(
                 icon: const Icon(Icons.close, size: 16),
+                tooltip: l10n?.remove ?? 'Remove',
                 onPressed: () => _removeStop(i),
               ),
               onCitySelected: (city) => _onStopCitySelected(i, city),

--- a/lib/features/sync/presentation/widgets/sync_credentials_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_credentials_step.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/sync/sync_config.dart';
+import '../../../../l10n/app_localizations.dart';
 
 /// Credentials input step for private/join-existing sync modes.
 ///
@@ -97,6 +98,9 @@ class SyncCredentialsStep extends StatelessWidget {
                   ),
                 IconButton(
                   icon: Icon(showKey ? Icons.visibility_off : Icons.visibility, size: 18),
+                  tooltip: showKey
+                      ? (AppLocalizations.of(context)?.hideKey ?? 'Hide key')
+                      : (AppLocalizations.of(context)?.showKey ?? 'Show key'),
                   onPressed: onToggleKeyVisibility,
                 ),
               ],

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -833,5 +833,8 @@
   "errorHintConnection": "Prüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.",
   "errorHintRouting": "Routenberechnung fehlgeschlagen. Prüfen Sie Ihre Internetverbindung.",
   "errorHintFallback": "Versuchen Sie es erneut oder suchen Sie nach Postleitzahl / Stadt.",
-  "detailsLabel": "Details"
+  "detailsLabel": "Details",
+  "remove": "Entfernen",
+  "showKey": "Schlüssel anzeigen",
+  "hideKey": "Schlüssel verbergen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -839,5 +839,8 @@
   "errorHintConnection": "Check your internet connection and try again.",
   "errorHintRouting": "Route calculation failed. Check your internet connection and try again.",
   "errorHintFallback": "Try again or search by postal code / city name.",
-  "detailsLabel": "Details"
+  "detailsLabel": "Details",
+  "remove": "Remove",
+  "showKey": "Show key",
+  "hideKey": "Hide key"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -498,5 +498,8 @@
   "errorHintConnection": "Vérifiez votre connexion internet et réessayez.",
   "errorHintRouting": "Calcul d'itinéraire échoué. Vérifiez votre connexion internet.",
   "errorHintFallback": "Réessayez ou cherchez par code postal / ville.",
-  "detailsLabel": "Détails"
+  "detailsLabel": "Détails",
+  "remove": "Retirer",
+  "showKey": "Afficher la clé",
+  "hideKey": "Masquer la clé"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3678,6 +3678,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Details'**
   String get detailsLabel;
+
+  /// No description provided for @remove.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove'**
+  String get remove;
+
+  /// No description provided for @showKey.
+  ///
+  /// In en, this message translates to:
+  /// **'Show key'**
+  String get showKey;
+
+  /// No description provided for @hideKey.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide key'**
+  String get hideKey;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1921,4 +1921,13 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1921,4 +1921,13 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1919,4 +1919,13 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1935,4 +1935,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Entfernen';
+
+  @override
+  String get showKey => 'Schlüssel anzeigen';
+
+  @override
+  String get hideKey => 'Schlüssel verbergen';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1923,4 +1923,13 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1914,4 +1914,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1922,4 +1922,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1916,4 +1916,13 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1919,4 +1919,13 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1931,4 +1931,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Détails';
+
+  @override
+  String get remove => 'Retirer';
+
+  @override
+  String get showKey => 'Afficher la clé';
+
+  @override
+  String get hideKey => 'Masquer la clé';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1918,4 +1918,13 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1923,4 +1923,13 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1922,4 +1922,13 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1920,4 +1920,13 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1922,4 +1922,13 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1918,4 +1918,13 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1923,4 +1923,13 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1921,4 +1921,13 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1922,4 +1922,13 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1921,4 +1921,13 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1922,4 +1922,13 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1916,4 +1916,13 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1920,4 +1920,13 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get detailsLabel => 'Details';
+
+  @override
+  String get remove => 'Remove';
+
+  @override
+  String get showKey => 'Show key';
+
+  @override
+  String get hideKey => 'Hide key';
 }


### PR DESCRIPTION
## Summary
- Add localized tooltips to the three remaining unlabeled IconButtons surfaced by the audit:
  - \`profile_list_section.dart\` — edit-profile pencil → \`editProfile\`
  - \`sync_credentials_step.dart\` — show/hide-key visibility toggle → \`showKey\` / \`hideKey\`
  - \`route_input.dart\` — remove-stop close button → \`remove\`
- Add \`remove\`, \`showKey\`, \`hideKey\` keys to EN/DE/FR ARB files; other locales fall back to English via the standard mechanism, regenerated via \`flutter gen-l10n\`.

## Why
Audit finding #394. After the back-button sweep merged in #399, these three were the last user-facing IconButtons reaching the screen reader without an accessible name.

## Test plan
- [x] \`flutter analyze\` — 0 errors, 0 warnings
- [x] \`flutter test test/features/sync/ test/features/profile/ test/features/route_search/ test/accessibility/\` — 254 tests passing

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)