### PR TITLE
docs: add dartdoc to EV, vehicle and consumption public APIs

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -12,6 +12,8 @@ class Obd2Service {
 
   Obd2Service(this._transport);
 
+  /// `true` when the underlying [Obd2Transport] currently has an open
+  /// connection to the vehicle's ELM327 adapter.
   bool get isConnected => _transport.isConnected;
 
   /// Connect and initialize the ELM327 adapter.
@@ -88,6 +90,7 @@ class Obd2Service {
     }
   }
 
+  /// Close the transport connection. Safe to call multiple times.
   Future<void> disconnect() async {
     await _transport.disconnect();
   }

--- a/lib/features/consumption/data/receipt_parser.dart
+++ b/lib/features/consumption/data/receipt_parser.dart
@@ -1,15 +1,22 @@
-/// Parses fuel station receipt text (from OCR) to extract fill-up data.
+/// Structured fields extracted from a fuel receipt by [ReceiptParser].
 ///
-/// Supports common French and German receipt formats. Extracts:
-/// - Liters (volume)
-/// - Total cost (EUR)
-/// - Price per liter
-/// - Date (if found)
+/// All fields are nullable because OCR is best-effort: any combination
+/// may be missing depending on the receipt layout. Use [hasData] to check
+/// whether the parser found anything actionable.
 class ReceiptParseResult {
+  /// Volume dispensed in litres, or `null` if no volume could be parsed.
   final double? liters;
+
+  /// Total amount charged (currency is implicit — typically EUR).
   final double? totalCost;
+
+  /// Unit price per litre as printed on the receipt.
   final double? pricePerLiter;
+
+  /// Receipt date if a recognised format was found.
   final DateTime? date;
+
+  /// Detected station brand (matched against a small built-in list).
   final String? stationName;
 
   const ReceiptParseResult({
@@ -20,13 +27,23 @@ class ReceiptParseResult {
     this.stationName,
   });
 
+  /// `true` when the parser extracted at least volume or total cost.
   bool get hasData => liters != null || totalCost != null;
 }
 
+/// Parses raw OCR text from a fuel station receipt into a
+/// [ReceiptParseResult].
+///
+/// Supports common French and German receipt layouts. The matchers
+/// tolerate decimal commas/dots and the most frequent label variants
+/// (`TOTAL`, `MONTANT`, `BETRAG`, `Volume`, `Prix/L`, etc.).
 class ReceiptParser {
   const ReceiptParser();
 
-  /// Parse OCR text from a fuel receipt.
+  /// Parse OCR [text] from a fuel receipt and return the extracted fields.
+  ///
+  /// The result is always non-null; check [ReceiptParseResult.hasData] to
+  /// know whether the parser recognised anything useful.
   ReceiptParseResult parse(String text) {
     final lines = text.split('\n').map((l) => l.trim()).toList();
     final fullText = lines.join(' ');

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -23,24 +23,28 @@ class FillUpList extends _$FillUpList {
     return repo.getAll();
   }
 
+  /// Insert a new fill-up entry and refresh the list.
   Future<void> add(FillUp fillUp) async {
     final repo = ref.read(fillUpRepositoryProvider);
     await repo.save(fillUp);
     state = repo.getAll();
   }
 
+  /// Persist edits to an existing fill-up (matched by id) and refresh.
   Future<void> update(FillUp fillUp) async {
     final repo = ref.read(fillUpRepositoryProvider);
     await repo.save(fillUp);
     state = repo.getAll();
   }
 
+  /// Delete the fill-up with the given [id] and refresh the list.
   Future<void> remove(String id) async {
     final repo = ref.read(fillUpRepositoryProvider);
     await repo.delete(id);
     state = repo.getAll();
   }
 
+  /// Wipe the entire fill-up history. Used by the privacy dashboard.
   Future<void> clearAll() async {
     final repo = ref.read(fillUpRepositoryProvider);
     await repo.clear();

--- a/lib/features/ev/providers/ev_providers.dart
+++ b/lib/features/ev/providers/ev_providers.dart
@@ -60,8 +60,13 @@ class EvShowOnMap extends _$EvShowOnMap {
 /// Filter criteria applied to [evStationsProvider] results before they
 /// are rendered on the map or station list.
 class EvFilter {
+  /// Connector types the user wants to see (empty = no restriction).
   final Set<ConnectorType> connectorTypes;
+
+  /// Minimum charging power in kW (0 = any).
   final double minPowerKw;
+
+  /// When `true`, hide stations whose connectors are all in use/offline.
   final bool availableOnly;
 
   const EvFilter({
@@ -70,6 +75,7 @@ class EvFilter {
     this.availableOnly = false,
   });
 
+  /// Returns a new [EvFilter] with the supplied fields replaced.
   EvFilter copyWith({
     Set<ConnectorType>? connectorTypes,
     double? minPowerKw,
@@ -124,10 +130,12 @@ class EvFilterController extends _$EvFilterController {
     return EvFilter(connectorTypes: Set<ConnectorType>.from(connectors));
   }
 
+  /// Replace the selected connector set wholesale.
   void setConnectorTypes(Set<ConnectorType> types) {
     state = state.copyWith(connectorTypes: Set<ConnectorType>.from(types));
   }
 
+  /// Toggle a single connector type in the selected set.
   void toggleConnector(ConnectorType type) {
     final next = Set<ConnectorType>.from(state.connectorTypes);
     if (next.contains(type)) {
@@ -138,23 +146,34 @@ class EvFilterController extends _$EvFilterController {
     state = state.copyWith(connectorTypes: next);
   }
 
+  /// Update the minimum-power threshold (0 disables the filter).
   void setMinPowerKw(double value) {
     state = state.copyWith(minPowerKw: value);
   }
 
+  /// Toggle the "available connectors only" switch.
   void setAvailableOnly(bool value) {
     state = state.copyWith(availableOnly: value);
   }
 
+  /// Clear every filter back to the default (show everything).
   void reset() {
     state = const EvFilter();
   }
 }
 
 /// Parameters describing the map viewport for which to fetch EV stations.
+///
+/// Used as the family argument for [evStationsProvider]; equality determines
+/// whether a refetch is needed when the user pans the map.
 class EvViewport {
+  /// Centre latitude of the viewport.
   final double latitude;
+
+  /// Centre longitude of the viewport.
   final double longitude;
+
+  /// Search radius in kilometres around the centre point.
   final double radiusKm;
 
   const EvViewport({

--- a/lib/features/vehicle/providers/vehicle_providers.dart
+++ b/lib/features/vehicle/providers/vehicle_providers.dart
@@ -22,14 +22,19 @@ class VehicleProfileList extends _$VehicleProfileList {
     return repo.getAll();
   }
 
+  /// Persist [profile] (insert or update by id) and refresh the list.
+  ///
+  /// Also invalidates [activeVehicleProfileProvider] so callers that depend
+  /// on the active vehicle re-read it — saving the first profile auto-sets
+  /// it as active.
   Future<void> save(VehicleProfile profile) async {
     final repo = ref.read(vehicleProfileRepositoryProvider);
     await repo.save(profile);
     state = repo.getAll();
-    // Nudge the active-profile provider in case it just got auto-set.
     ref.invalidate(activeVehicleProfileProvider);
   }
 
+  /// Delete the profile with the given [id] and refresh the list.
   Future<void> remove(String id) async {
     final repo = ref.read(vehicleProfileRepositoryProvider);
     await repo.delete(id);
@@ -37,6 +42,7 @@ class VehicleProfileList extends _$VehicleProfileList {
     ref.invalidate(activeVehicleProfileProvider);
   }
 
+  /// Wipe all stored vehicle profiles. Used when the user resets the app.
   Future<void> clearAll() async {
     final repo = ref.read(vehicleProfileRepositoryProvider);
     await repo.clear();
@@ -55,6 +61,8 @@ class ActiveVehicleProfile extends _$ActiveVehicleProfile {
     return repo.getActive();
   }
 
+  /// Mark the profile with [id] as active and rebuild this provider so
+  /// dependent UI (EV filters, route calculator) picks up the new vehicle.
   Future<void> setActive(String id) async {
     final repo = ref.read(vehicleProfileRepositoryProvider);
     await repo.setActive(id);


### PR DESCRIPTION
## Summary
Add \`///\` dartdoc to the public methods and fields on the providers and helpers introduced in the recent EV/vehicle/consumption work:

- \`ReceiptParser\` & \`ReceiptParseResult\`: split misplaced class doc, document every field
- \`Obd2Service.isConnected\` and \`disconnect()\`
- \`VehicleProfileList.save / remove / clearAll\`, \`ActiveVehicleProfile.setActive\`
- \`EvFilter\` fields + mutator methods, \`EvViewport\` fields
- \`FillUpList.add / update / remove / clearAll\`

## Why
Audit finding #395. The newer feature modules had useful class-level dartdocs but the public mutators were undocumented.

## Test plan
- [x] \`flutter analyze\` — 0 errors, 0 warnings
- No new tests: pure documentation, no behavior change.

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)