### PR TITLE
fix(i18n): localize sync wizard credential flow (~30 strings)

### DIFF
--- a/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
+++ b/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
+import '../../../../l10n/app_localizations.dart';
+
 /// Full-screen QR code scanner for scanning TankSync credentials.
 class QrScannerScreen extends StatefulWidget {
   const QrScannerScreen({super.key});
@@ -15,7 +17,10 @@ class _QrScannerScreenState extends State<QrScannerScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Scan QR Code')),
+      appBar: AppBar(
+          title: Text(
+              AppLocalizations.of(context)?.syncWizardScanQrCode ??
+                  'Scan QR Code')),
       body: MobileScanner(
         onDetect: (capture) {
           if (_scanned) return;

--- a/lib/features/sync/presentation/widgets/sync_credentials_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_credentials_step.dart
@@ -31,6 +31,7 @@ class SyncCredentialsStep extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final keyLen = keyController.text.length;
 
     return Column(
@@ -40,27 +41,32 @@ class SyncCredentialsStep extends StatelessWidget {
           FilledButton.icon(
             onPressed: onScanQr,
             icon: const Icon(Icons.qr_code_scanner),
-            label: const Text('Scan QR Code'),
+            label: Text(l10n?.syncWizardScanQrCode ?? 'Scan QR Code'),
             style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
           ),
           const SizedBox(height: 6),
           Text(
-            'Ask the database owner to show their QR code',
+            l10n?.syncWizardAskOwnerQrShort ??
+                'Ask the database owner to show their QR code',
             style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 16),
-          const Row(children: [
-            Expanded(child: Divider()),
-            Padding(padding: EdgeInsets.symmetric(horizontal: 16), child: Text('or enter manually')),
-            Expanded(child: Divider()),
+          Row(children: [
+            const Expanded(child: Divider()),
+            Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(l10n?.syncWizardOrEnterManually ??
+                    'or enter manually')),
+            const Expanded(child: Divider()),
           ]),
           const SizedBox(height: 16),
         ],
 
         if (selectedMode == SyncMode.private) ...[
           Text(
-            'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.',
+            l10n?.syncCredentialsPrivateHint ??
+                'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.',
             style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
           ),
           const SizedBox(height: 16),
@@ -68,11 +74,13 @@ class SyncCredentialsStep extends StatelessWidget {
 
         TextField(
           controller: urlController,
-          decoration: const InputDecoration(
-            labelText: 'Database URL',
-            hintText: 'https://your-project.supabase.co',
-            border: OutlineInputBorder(),
-            prefixIcon: Icon(Icons.link, size: 18),
+          decoration: InputDecoration(
+            labelText:
+                l10n?.syncCredentialsDatabaseUrlLabel ?? 'Database URL',
+            hintText: l10n?.syncWizardSupabaseUrlHint ??
+                'https://your-project.supabase.co',
+            border: const OutlineInputBorder(),
+            prefixIcon: const Icon(Icons.link, size: 18),
             isDense: true,
           ),
           maxLines: 1,
@@ -82,8 +90,10 @@ class SyncCredentialsStep extends StatelessWidget {
         TextField(
           controller: keyController,
           decoration: InputDecoration(
-            labelText: 'Access Key',
-            hintText: 'eyJhbGciOiJIUzI1NiIs...',
+            labelText:
+                l10n?.syncCredentialsAccessKeyLabel ?? 'Access Key',
+            hintText: l10n?.syncCredentialsAccessKeyHint ??
+                'eyJhbGciOiJIUzI1NiIs...',
             border: const OutlineInputBorder(),
             prefixIcon: const Icon(Icons.key, size: 18),
             isDense: true,
@@ -99,8 +109,8 @@ class SyncCredentialsStep extends StatelessWidget {
                 IconButton(
                   icon: Icon(showKey ? Icons.visibility_off : Icons.visibility, size: 18),
                   tooltip: showKey
-                      ? (AppLocalizations.of(context)?.hideKey ?? 'Hide key')
-                      : (AppLocalizations.of(context)?.showKey ?? 'Show key'),
+                      ? (l10n?.hideKey ?? 'Hide key')
+                      : (l10n?.showKey ?? 'Show key'),
                   onPressed: onToggleKeyVisibility,
                 ),
               ],
@@ -114,7 +124,7 @@ class SyncCredentialsStep extends StatelessWidget {
         const SizedBox(height: 20),
         FilledButton(
           onPressed: onContinue,
-          child: const Text('Continue'),
+          child: Text(l10n?.continueButton ?? 'Continue'),
         ),
       ],
     );

--- a/lib/features/sync/presentation/widgets/wizard_create_new.dart
+++ b/lib/features/sync/presentation/widgets/wizard_create_new.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../../../l10n/app_localizations.dart';
+
 /// Guided step-by-step flow for creating a new Supabase project.
 class WizardCreateNew extends StatelessWidget {
   final int currentStep;
@@ -25,7 +27,8 @@ class WizardCreateNew extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final steps = _guideSteps;
+    final l10n = AppLocalizations.of(context);
+    final steps = _guideSteps(l10n);
     final step = steps[currentStep.clamp(0, steps.length - 1)];
 
     return Column(
@@ -38,7 +41,9 @@ class WizardCreateNew extends StatelessWidget {
         ),
         const SizedBox(height: 16),
 
-        Text('Step ${currentStep + 1} of ${steps.length + 1}',
+        Text(
+            l10n?.syncWizardStepOfSteps(currentStep + 1, steps.length + 1) ??
+                'Step ${currentStep + 1} of ${steps.length + 1}',
             style: theme.textTheme.labelMedium?.copyWith(color: theme.colorScheme.primary)),
         const SizedBox(height: 8),
         Text(step.title, style: theme.textTheme.titleMedium),
@@ -64,11 +69,13 @@ class WizardCreateNew extends StatelessWidget {
           const SizedBox(height: 16),
           TextField(
             controller: urlController,
-            decoration: const InputDecoration(
-              labelText: 'Supabase URL',
-              hintText: 'https://your-project.supabase.co',
-              border: OutlineInputBorder(),
-              prefixIcon: Icon(Icons.link),
+            decoration: InputDecoration(
+              labelText:
+                  l10n?.syncWizardSupabaseUrlLabel ?? 'Supabase URL',
+              hintText: l10n?.syncWizardSupabaseUrlHint ??
+                  'https://your-project.supabase.co',
+              border: const OutlineInputBorder(),
+              prefixIcon: const Icon(Icons.link),
             ),
             maxLines: 1,
           ),
@@ -83,13 +90,15 @@ class WizardCreateNew extends StatelessWidget {
             if (currentStep > 0)
               TextButton(
                 onPressed: onBack,
-                child: const Text('Back'),
+                child: Text(l10n?.syncWizardBack ?? 'Back'),
               )
             else
               const SizedBox(),
             FilledButton(
               onPressed: currentStep < 2 ? onNext : onContinue,
-              child: Text(currentStep < 2 ? 'Next' : 'Continue'),
+              child: Text(currentStep < 2
+                  ? (l10n?.syncWizardNext ?? 'Next')
+                  : (l10n?.continueButton ?? 'Continue')),
             ),
           ],
         ),
@@ -97,34 +106,37 @@ class WizardCreateNew extends StatelessWidget {
     );
   }
 
-  static List<_GuideStep> get _guideSteps => const [
+  static List<_GuideStep> _guideSteps(AppLocalizations? l10n) => [
     _GuideStep(
-      title: 'Create a Supabase project',
-      instructions: '1. Tap "Open Supabase" below\n'
-          '2. Create a free account (if you don\'t have one)\n'
-          '3. Click "New Project"\n'
-          '4. Choose a name and region\n'
-          '5. Wait ~2 minutes for it to start',
-      actionLabel: 'Open Supabase',
+      title: l10n?.syncWizardCreateSupabaseTitle ?? 'Create a Supabase project',
+      instructions: l10n?.syncWizardCreateSupabaseInstructions ??
+          '1. Tap "Open Supabase" below\n'
+              '2. Create a free account (if you don\'t have one)\n'
+              '3. Click "New Project"\n'
+              '4. Choose a name and region\n'
+              '5. Wait ~2 minutes for it to start',
+      actionLabel: l10n?.syncWizardOpenSupabase ?? 'Open Supabase',
       actionUrl: 'https://supabase.com/dashboard/new',
     ),
     _GuideStep(
-      title: 'Enable Anonymous Sign-ins',
-      instructions: '1. In your Supabase dashboard:\n'
-          '   Authentication → Providers\n'
-          '2. Find "Anonymous Sign-ins"\n'
-          '3. Toggle it ON\n'
-          '4. Click "Save"',
-      actionLabel: 'Open Auth Settings',
+      title: l10n?.syncWizardEnableAnonTitle ?? 'Enable Anonymous Sign-ins',
+      instructions: l10n?.syncWizardEnableAnonInstructions ??
+          '1. In your Supabase dashboard:\n'
+              '   Authentication → Providers\n'
+              '2. Find "Anonymous Sign-ins"\n'
+              '3. Toggle it ON\n'
+              '4. Click "Save"',
+      actionLabel: l10n?.syncWizardOpenAuthSettings ?? 'Open Auth Settings',
       actionUrl: null,
     ),
     _GuideStep(
-      title: 'Copy your credentials',
-      instructions: '1. Go to Settings → API in your dashboard\n'
-          '2. Copy the "Project URL"\n'
-          '3. Copy the "anon public" key\n'
-          '4. Paste them below',
-      actionLabel: 'Open API Settings',
+      title: l10n?.syncWizardCopyCredentialsTitle ?? 'Copy your credentials',
+      instructions: l10n?.syncWizardCopyCredentialsInstructions ??
+          '1. Go to Settings → API in your dashboard\n'
+              '2. Copy the "Project URL"\n'
+              '3. Copy the "anon public" key\n'
+              '4. Paste them below',
+      actionLabel: l10n?.syncWizardOpenApiSettings ?? 'Open API Settings',
       actionUrl: null,
     ),
   ];

--- a/lib/features/sync/presentation/widgets/wizard_join_existing.dart
+++ b/lib/features/sync/presentation/widgets/wizard_join_existing.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../../../l10n/app_localizations.dart';
+
 /// Join existing database step: QR scan or manual URL+key entry.
 class WizardJoinExisting extends StatelessWidget {
   final TextEditingController urlController;
@@ -20,45 +22,54 @@ class WizardJoinExisting extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text('Join an existing database', style: theme.textTheme.titleMedium),
+        Text(
+            l10n?.syncWizardJoinExistingTitle ?? 'Join an existing database',
+            style: theme.textTheme.titleMedium),
         const SizedBox(height: 16),
 
         // QR Scanner
         FilledButton.icon(
           onPressed: onScanQr,
           icon: const Icon(Icons.qr_code_scanner),
-          label: const Text('Scan QR Code'),
+          label: Text(l10n?.syncWizardScanQrCode ?? 'Scan QR Code'),
           style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
         ),
         const SizedBox(height: 8),
         Text(
-          'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)',
+          l10n?.syncWizardAskOwnerQr ??
+              'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)',
           style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
           textAlign: TextAlign.center,
         ),
 
         const SizedBox(height: 24),
-        const Row(children: [
-          Expanded(child: Divider()),
-          Padding(padding: EdgeInsets.symmetric(horizontal: 16), child: Text('or')),
-          Expanded(child: Divider()),
+        Row(children: [
+          const Expanded(child: Divider()),
+          Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(l10n?.syncOrDivider ?? 'or')),
+          const Expanded(child: Divider()),
         ]),
         const SizedBox(height: 24),
 
         // Manual entry
-        Text('Enter manually', style: theme.textTheme.titleSmall),
+        Text(l10n?.syncWizardEnterManuallyTitle ?? 'Enter manually',
+            style: theme.textTheme.titleSmall),
         const SizedBox(height: 12),
         TextField(
           controller: urlController,
-          decoration: const InputDecoration(
-            labelText: 'Supabase URL',
-            hintText: 'https://your-project.supabase.co',
-            border: OutlineInputBorder(),
-            prefixIcon: Icon(Icons.link),
-            helperText: 'Whitespace and line breaks removed automatically',
+          decoration: InputDecoration(
+            labelText: l10n?.syncWizardSupabaseUrlLabel ?? 'Supabase URL',
+            hintText: l10n?.syncWizardSupabaseUrlHint ??
+                'https://your-project.supabase.co',
+            border: const OutlineInputBorder(),
+            prefixIcon: const Icon(Icons.link),
+            helperText: l10n?.syncWizardUrlHelperText ??
+                'Whitespace and line breaks removed automatically',
           ),
           maxLines: 1,
         ),
@@ -67,7 +78,7 @@ class WizardJoinExisting extends StatelessWidget {
         const SizedBox(height: 24),
         FilledButton(
           onPressed: onContinue,
-          child: const Text('Continue'),
+          child: Text(l10n?.continueButton ?? 'Continue'),
         ),
       ],
     );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -886,5 +886,36 @@
   "syncWizardTitleConnect": "TankSync verbinden",
   "syncSetupTitleYourDatabase": "Ihre Datenbank",
   "syncSetupTitleJoinGroup": "Gruppe beitreten",
-  "syncSetupTitleAccount": "Ihr Konto"
+  "syncSetupTitleAccount": "Ihr Konto",
+  "syncWizardBack": "Zurück",
+  "syncWizardNext": "Weiter",
+  "syncWizardStepOfSteps": "Schritt {current} von {total}",
+  "@syncWizardStepOfSteps": {
+    "placeholders": {
+      "current": { "type": "int" },
+      "total": { "type": "int" }
+    }
+  },
+  "syncWizardCreateSupabaseTitle": "Supabase-Projekt erstellen",
+  "syncWizardCreateSupabaseInstructions": "1. Unten auf \"Supabase öffnen\" tippen\n2. Kostenloses Konto erstellen (falls noch nicht vorhanden)\n3. Auf \"New Project\" klicken\n4. Namen und Region wählen\n5. Etwa 2 Minuten warten, bis es bereit ist",
+  "syncWizardOpenSupabase": "Supabase öffnen",
+  "syncWizardEnableAnonTitle": "Anonyme Anmeldungen aktivieren",
+  "syncWizardEnableAnonInstructions": "1. Im Supabase-Dashboard:\n   Authentication → Providers\n2. \"Anonymous Sign-ins\" suchen\n3. Aktivieren\n4. \"Save\" klicken",
+  "syncWizardOpenAuthSettings": "Auth-Einstellungen öffnen",
+  "syncWizardCopyCredentialsTitle": "Zugangsdaten kopieren",
+  "syncWizardCopyCredentialsInstructions": "1. Zu Settings → API im Dashboard gehen\n2. \"Project URL\" kopieren\n3. Den \"anon public\"-Schlüssel kopieren\n4. Beide unten einfügen",
+  "syncWizardOpenApiSettings": "API-Einstellungen öffnen",
+  "syncWizardSupabaseUrlLabel": "Supabase-URL",
+  "syncWizardSupabaseUrlHint": "https://ihr-projekt.supabase.co",
+  "syncWizardJoinExistingTitle": "Bestehender Datenbank beitreten",
+  "syncWizardScanQrCode": "QR-Code scannen",
+  "syncWizardAskOwnerQr": "Bitten Sie den Datenbank-Besitzer, den QR-Code zu zeigen\n(Einstellungen → TankSync → Teilen)",
+  "syncWizardAskOwnerQrShort": "Bitten Sie den Datenbank-Besitzer, den QR-Code zu zeigen",
+  "syncWizardEnterManuallyTitle": "Manuell eingeben",
+  "syncWizardOrEnterManually": "oder manuell eingeben",
+  "syncWizardUrlHelperText": "Leerzeichen und Zeilenumbrüche werden automatisch entfernt",
+  "syncCredentialsPrivateHint": "Geben Sie Ihre Supabase-Zugangsdaten ein. Sie finden diese im Dashboard unter Settings > API.",
+  "syncCredentialsDatabaseUrlLabel": "Datenbank-URL",
+  "syncCredentialsAccessKeyLabel": "Zugangsschlüssel",
+  "syncCredentialsAccessKeyHint": "eyJhbGciOiJIUzI1NiIs..."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -897,5 +897,36 @@
   "syncWizardTitleConnect": "Connect TankSync",
   "syncSetupTitleYourDatabase": "Your database",
   "syncSetupTitleJoinGroup": "Join a group",
-  "syncSetupTitleAccount": "Your account"
+  "syncSetupTitleAccount": "Your account",
+  "syncWizardBack": "Back",
+  "syncWizardNext": "Next",
+  "syncWizardStepOfSteps": "Step {current} of {total}",
+  "@syncWizardStepOfSteps": {
+    "placeholders": {
+      "current": { "type": "int" },
+      "total": { "type": "int" }
+    }
+  },
+  "syncWizardCreateSupabaseTitle": "Create a Supabase project",
+  "syncWizardCreateSupabaseInstructions": "1. Tap \"Open Supabase\" below\n2. Create a free account (if you don't have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start",
+  "syncWizardOpenSupabase": "Open Supabase",
+  "syncWizardEnableAnonTitle": "Enable Anonymous Sign-ins",
+  "syncWizardEnableAnonInstructions": "1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"",
+  "syncWizardOpenAuthSettings": "Open Auth Settings",
+  "syncWizardCopyCredentialsTitle": "Copy your credentials",
+  "syncWizardCopyCredentialsInstructions": "1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below",
+  "syncWizardOpenApiSettings": "Open API Settings",
+  "syncWizardSupabaseUrlLabel": "Supabase URL",
+  "syncWizardSupabaseUrlHint": "https://your-project.supabase.co",
+  "syncWizardJoinExistingTitle": "Join an existing database",
+  "syncWizardScanQrCode": "Scan QR Code",
+  "syncWizardAskOwnerQr": "Ask the database owner to show you their QR code\n(Settings → TankSync → Share)",
+  "syncWizardAskOwnerQrShort": "Ask the database owner to show their QR code",
+  "syncWizardEnterManuallyTitle": "Enter manually",
+  "syncWizardOrEnterManually": "or enter manually",
+  "syncWizardUrlHelperText": "Whitespace and line breaks removed automatically",
+  "syncCredentialsPrivateHint": "Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.",
+  "syncCredentialsDatabaseUrlLabel": "Database URL",
+  "syncCredentialsAccessKeyLabel": "Access Key",
+  "syncCredentialsAccessKeyHint": "eyJhbGciOiJIUzI1NiIs..."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -551,5 +551,36 @@
   "syncWizardTitleConnect": "Connecter TankSync",
   "syncSetupTitleYourDatabase": "Votre base de données",
   "syncSetupTitleJoinGroup": "Rejoindre un groupe",
-  "syncSetupTitleAccount": "Votre compte"
+  "syncSetupTitleAccount": "Votre compte",
+  "syncWizardBack": "Retour",
+  "syncWizardNext": "Suivant",
+  "syncWizardStepOfSteps": "Étape {current} sur {total}",
+  "@syncWizardStepOfSteps": {
+    "placeholders": {
+      "current": { "type": "int" },
+      "total": { "type": "int" }
+    }
+  },
+  "syncWizardCreateSupabaseTitle": "Créer un projet Supabase",
+  "syncWizardCreateSupabaseInstructions": "1. Appuyez sur « Ouvrir Supabase » ci-dessous\n2. Créez un compte gratuit (si vous n'en avez pas)\n3. Cliquez sur « New Project »\n4. Choisissez un nom et une région\n5. Attendez environ 2 minutes",
+  "syncWizardOpenSupabase": "Ouvrir Supabase",
+  "syncWizardEnableAnonTitle": "Activer les connexions anonymes",
+  "syncWizardEnableAnonInstructions": "1. Dans votre tableau de bord Supabase :\n   Authentication → Providers\n2. Trouvez « Anonymous Sign-ins »\n3. Activez-le\n4. Cliquez sur « Save »",
+  "syncWizardOpenAuthSettings": "Ouvrir les paramètres d'authentification",
+  "syncWizardCopyCredentialsTitle": "Copier vos identifiants",
+  "syncWizardCopyCredentialsInstructions": "1. Allez dans Settings → API dans votre tableau de bord\n2. Copiez la « Project URL »\n3. Copiez la clé « anon public »\n4. Collez-les ci-dessous",
+  "syncWizardOpenApiSettings": "Ouvrir les paramètres API",
+  "syncWizardSupabaseUrlLabel": "URL Supabase",
+  "syncWizardSupabaseUrlHint": "https://votre-projet.supabase.co",
+  "syncWizardJoinExistingTitle": "Rejoindre une base existante",
+  "syncWizardScanQrCode": "Scanner le QR Code",
+  "syncWizardAskOwnerQr": "Demandez au propriétaire de la base de vous montrer son QR code\n(Paramètres → TankSync → Partager)",
+  "syncWizardAskOwnerQrShort": "Demandez au propriétaire de la base de montrer son QR code",
+  "syncWizardEnterManuallyTitle": "Saisir manuellement",
+  "syncWizardOrEnterManually": "ou saisir manuellement",
+  "syncWizardUrlHelperText": "Les espaces et les sauts de ligne sont automatiquement supprimés",
+  "syncCredentialsPrivateHint": "Entrez les identifiants de votre projet Supabase. Vous les trouverez dans votre tableau de bord sous Settings > API.",
+  "syncCredentialsDatabaseUrlLabel": "URL de la base de données",
+  "syncCredentialsAccessKeyLabel": "Clé d'accès",
+  "syncCredentialsAccessKeyHint": "eyJhbGciOiJIUzI1NiIs..."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3996,6 +3996,156 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Your account'**
   String get syncSetupTitleAccount;
+
+  /// No description provided for @syncWizardBack.
+  ///
+  /// In en, this message translates to:
+  /// **'Back'**
+  String get syncWizardBack;
+
+  /// No description provided for @syncWizardNext.
+  ///
+  /// In en, this message translates to:
+  /// **'Next'**
+  String get syncWizardNext;
+
+  /// No description provided for @syncWizardStepOfSteps.
+  ///
+  /// In en, this message translates to:
+  /// **'Step {current} of {total}'**
+  String syncWizardStepOfSteps(int current, int total);
+
+  /// No description provided for @syncWizardCreateSupabaseTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Create a Supabase project'**
+  String get syncWizardCreateSupabaseTitle;
+
+  /// No description provided for @syncWizardCreateSupabaseInstructions.
+  ///
+  /// In en, this message translates to:
+  /// **'1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start'**
+  String get syncWizardCreateSupabaseInstructions;
+
+  /// No description provided for @syncWizardOpenSupabase.
+  ///
+  /// In en, this message translates to:
+  /// **'Open Supabase'**
+  String get syncWizardOpenSupabase;
+
+  /// No description provided for @syncWizardEnableAnonTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable Anonymous Sign-ins'**
+  String get syncWizardEnableAnonTitle;
+
+  /// No description provided for @syncWizardEnableAnonInstructions.
+  ///
+  /// In en, this message translates to:
+  /// **'1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"'**
+  String get syncWizardEnableAnonInstructions;
+
+  /// No description provided for @syncWizardOpenAuthSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Open Auth Settings'**
+  String get syncWizardOpenAuthSettings;
+
+  /// No description provided for @syncWizardCopyCredentialsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy your credentials'**
+  String get syncWizardCopyCredentialsTitle;
+
+  /// No description provided for @syncWizardCopyCredentialsInstructions.
+  ///
+  /// In en, this message translates to:
+  /// **'1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below'**
+  String get syncWizardCopyCredentialsInstructions;
+
+  /// No description provided for @syncWizardOpenApiSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Open API Settings'**
+  String get syncWizardOpenApiSettings;
+
+  /// No description provided for @syncWizardSupabaseUrlLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Supabase URL'**
+  String get syncWizardSupabaseUrlLabel;
+
+  /// No description provided for @syncWizardSupabaseUrlHint.
+  ///
+  /// In en, this message translates to:
+  /// **'https://your-project.supabase.co'**
+  String get syncWizardSupabaseUrlHint;
+
+  /// No description provided for @syncWizardJoinExistingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Join an existing database'**
+  String get syncWizardJoinExistingTitle;
+
+  /// No description provided for @syncWizardScanQrCode.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan QR Code'**
+  String get syncWizardScanQrCode;
+
+  /// No description provided for @syncWizardAskOwnerQr.
+  ///
+  /// In en, this message translates to:
+  /// **'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)'**
+  String get syncWizardAskOwnerQr;
+
+  /// No description provided for @syncWizardAskOwnerQrShort.
+  ///
+  /// In en, this message translates to:
+  /// **'Ask the database owner to show their QR code'**
+  String get syncWizardAskOwnerQrShort;
+
+  /// No description provided for @syncWizardEnterManuallyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter manually'**
+  String get syncWizardEnterManuallyTitle;
+
+  /// No description provided for @syncWizardOrEnterManually.
+  ///
+  /// In en, this message translates to:
+  /// **'or enter manually'**
+  String get syncWizardOrEnterManually;
+
+  /// No description provided for @syncWizardUrlHelperText.
+  ///
+  /// In en, this message translates to:
+  /// **'Whitespace and line breaks removed automatically'**
+  String get syncWizardUrlHelperText;
+
+  /// No description provided for @syncCredentialsPrivateHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.'**
+  String get syncCredentialsPrivateHint;
+
+  /// No description provided for @syncCredentialsDatabaseUrlLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Database URL'**
+  String get syncCredentialsDatabaseUrlLabel;
+
+  /// No description provided for @syncCredentialsAccessKeyLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Access Key'**
+  String get syncCredentialsAccessKeyLabel;
+
+  /// No description provided for @syncCredentialsAccessKeyHint.
+  ///
+  /// In en, this message translates to:
+  /// **'eyJhbGciOiJIUzI1NiIs...'**
+  String get syncCredentialsAccessKeyHint;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2092,4 +2092,88 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2092,4 +2092,88 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2090,4 +2090,88 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2108,4 +2108,88 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Ihr Konto';
+
+  @override
+  String get syncWizardBack => 'Zurück';
+
+  @override
+  String get syncWizardNext => 'Weiter';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Schritt $current von $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Supabase-Projekt erstellen';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Unten auf \"Supabase öffnen\" tippen\n2. Kostenloses Konto erstellen (falls noch nicht vorhanden)\n3. Auf \"New Project\" klicken\n4. Namen und Region wählen\n5. Etwa 2 Minuten warten, bis es bereit ist';
+
+  @override
+  String get syncWizardOpenSupabase => 'Supabase öffnen';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Anonyme Anmeldungen aktivieren';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. Im Supabase-Dashboard:\n   Authentication → Providers\n2. \"Anonymous Sign-ins\" suchen\n3. Aktivieren\n4. \"Save\" klicken';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Auth-Einstellungen öffnen';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Zugangsdaten kopieren';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Zu Settings → API im Dashboard gehen\n2. \"Project URL\" kopieren\n3. Den \"anon public\"-Schlüssel kopieren\n4. Beide unten einfügen';
+
+  @override
+  String get syncWizardOpenApiSettings => 'API-Einstellungen öffnen';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase-URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://ihr-projekt.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Bestehender Datenbank beitreten';
+
+  @override
+  String get syncWizardScanQrCode => 'QR-Code scannen';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Bitten Sie den Datenbank-Besitzer, den QR-Code zu zeigen\n(Einstellungen → TankSync → Teilen)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Bitten Sie den Datenbank-Besitzer, den QR-Code zu zeigen';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Manuell eingeben';
+
+  @override
+  String get syncWizardOrEnterManually => 'oder manuell eingeben';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Leerzeichen und Zeilenumbrüche werden automatisch entfernt';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Geben Sie Ihre Supabase-Zugangsdaten ein. Sie finden diese im Dashboard unter Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Datenbank-URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Zugangsschlüssel';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2094,4 +2094,88 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2085,4 +2085,88 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2093,4 +2093,88 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2087,4 +2087,88 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2090,4 +2090,88 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2105,4 +2105,89 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Votre compte';
+
+  @override
+  String get syncWizardBack => 'Retour';
+
+  @override
+  String get syncWizardNext => 'Suivant';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Étape $current sur $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Créer un projet Supabase';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Appuyez sur « Ouvrir Supabase » ci-dessous\n2. Créez un compte gratuit (si vous n\'en avez pas)\n3. Cliquez sur « New Project »\n4. Choisissez un nom et une région\n5. Attendez environ 2 minutes';
+
+  @override
+  String get syncWizardOpenSupabase => 'Ouvrir Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Activer les connexions anonymes';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. Dans votre tableau de bord Supabase :\n   Authentication → Providers\n2. Trouvez « Anonymous Sign-ins »\n3. Activez-le\n4. Cliquez sur « Save »';
+
+  @override
+  String get syncWizardOpenAuthSettings =>
+      'Ouvrir les paramètres d\'authentification';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copier vos identifiants';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Allez dans Settings → API dans votre tableau de bord\n2. Copiez la « Project URL »\n3. Copiez la clé « anon public »\n4. Collez-les ci-dessous';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Ouvrir les paramètres API';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'URL Supabase';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://votre-projet.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Rejoindre une base existante';
+
+  @override
+  String get syncWizardScanQrCode => 'Scanner le QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Demandez au propriétaire de la base de vous montrer son QR code\n(Paramètres → TankSync → Partager)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Demandez au propriétaire de la base de montrer son QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Saisir manuellement';
+
+  @override
+  String get syncWizardOrEnterManually => 'ou saisir manuellement';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Les espaces et les sauts de ligne sont automatiquement supprimés';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Entrez les identifiants de votre projet Supabase. Vous les trouverez dans votre tableau de bord sous Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'URL de la base de données';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Clé d\'accès';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2089,4 +2089,88 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2094,4 +2094,88 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2093,4 +2093,88 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2091,4 +2091,88 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2093,4 +2093,88 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2089,4 +2089,88 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2094,4 +2094,88 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2092,4 +2092,88 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2093,4 +2093,88 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2092,4 +2092,88 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2093,4 +2093,88 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2087,4 +2087,88 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2091,4 +2091,88 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get syncSetupTitleAccount => 'Your account';
+
+  @override
+  String get syncWizardBack => 'Back';
+
+  @override
+  String get syncWizardNext => 'Next';
+
+  @override
+  String syncWizardStepOfSteps(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
+  String get syncWizardCreateSupabaseTitle => 'Create a Supabase project';
+
+  @override
+  String get syncWizardCreateSupabaseInstructions =>
+      '1. Tap \"Open Supabase\" below\n2. Create a free account (if you don\'t have one)\n3. Click \"New Project\"\n4. Choose a name and region\n5. Wait ~2 minutes for it to start';
+
+  @override
+  String get syncWizardOpenSupabase => 'Open Supabase';
+
+  @override
+  String get syncWizardEnableAnonTitle => 'Enable Anonymous Sign-ins';
+
+  @override
+  String get syncWizardEnableAnonInstructions =>
+      '1. In your Supabase dashboard:\n   Authentication → Providers\n2. Find \"Anonymous Sign-ins\"\n3. Toggle it ON\n4. Click \"Save\"';
+
+  @override
+  String get syncWizardOpenAuthSettings => 'Open Auth Settings';
+
+  @override
+  String get syncWizardCopyCredentialsTitle => 'Copy your credentials';
+
+  @override
+  String get syncWizardCopyCredentialsInstructions =>
+      '1. Go to Settings → API in your dashboard\n2. Copy the \"Project URL\"\n3. Copy the \"anon public\" key\n4. Paste them below';
+
+  @override
+  String get syncWizardOpenApiSettings => 'Open API Settings';
+
+  @override
+  String get syncWizardSupabaseUrlLabel => 'Supabase URL';
+
+  @override
+  String get syncWizardSupabaseUrlHint => 'https://your-project.supabase.co';
+
+  @override
+  String get syncWizardJoinExistingTitle => 'Join an existing database';
+
+  @override
+  String get syncWizardScanQrCode => 'Scan QR Code';
+
+  @override
+  String get syncWizardAskOwnerQr =>
+      'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)';
+
+  @override
+  String get syncWizardAskOwnerQrShort =>
+      'Ask the database owner to show their QR code';
+
+  @override
+  String get syncWizardEnterManuallyTitle => 'Enter manually';
+
+  @override
+  String get syncWizardOrEnterManually => 'or enter manually';
+
+  @override
+  String get syncWizardUrlHelperText =>
+      'Whitespace and line breaks removed automatically';
+
+  @override
+  String get syncCredentialsPrivateHint =>
+      'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.';
+
+  @override
+  String get syncCredentialsDatabaseUrlLabel => 'Database URL';
+
+  @override
+  String get syncCredentialsAccessKeyLabel => 'Access Key';
+
+  @override
+  String get syncCredentialsAccessKeyHint => 'eyJhbGciOiJIUzI1NiIs...';
 }

--- a/test/features/sync/presentation/widgets/wizard_create_new_test.dart
+++ b/test/features/sync/presentation/widgets/wizard_create_new_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/sync/presentation/widgets/wizard_create_new.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('WizardCreateNew', () {
+    Widget buildWidget({
+      int currentStep = 0,
+      VoidCallback? onBack,
+      VoidCallback? onNext,
+      VoidCallback? onContinue,
+    }) {
+      return WizardCreateNew(
+        currentStep: currentStep,
+        urlController: TextEditingController(),
+        keyController: TextEditingController(),
+        keyField: const SizedBox.shrink(),
+        onBack: onBack ?? () {},
+        onNext: onNext ?? () {},
+        onContinue: onContinue,
+      );
+    }
+
+    testWidgets('step 1 shows Create Supabase title, Next button, no Back',
+        (tester) async {
+      await pumpApp(tester, buildWidget());
+
+      expect(find.text('Create a Supabase project'), findsOneWidget);
+      expect(find.text('Step 1 of 4'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Next'), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Back'), findsNothing);
+    });
+
+    testWidgets('step 2 shows Enable Anonymous title + Back button',
+        (tester) async {
+      await pumpApp(tester, buildWidget(currentStep: 1));
+
+      expect(find.text('Enable Anonymous Sign-ins'), findsOneWidget);
+      expect(find.text('Step 2 of 4'), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Back'), findsOneWidget);
+    });
+
+    testWidgets('final step shows Continue button and URL field',
+        (tester) async {
+      await pumpApp(
+        tester,
+        buildWidget(currentStep: 2, onContinue: () {}),
+      );
+
+      expect(find.text('Copy your credentials'), findsOneWidget);
+      expect(find.text('Step 3 of 4'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Continue'), findsOneWidget);
+      expect(find.text('Supabase URL'), findsOneWidget);
+    });
+
+    testWidgets('Next tap invokes onNext callback', (tester) async {
+      var nexted = false;
+      await pumpApp(tester, buildWidget(onNext: () => nexted = true));
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Next'));
+      await tester.pumpAndSettle();
+      expect(nexted, isTrue);
+    });
+  });
+}

--- a/test/features/sync/presentation/widgets/wizard_join_existing_test.dart
+++ b/test/features/sync/presentation/widgets/wizard_join_existing_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/sync/presentation/widgets/wizard_join_existing.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('WizardJoinExisting', () {
+    testWidgets('renders localized QR, manual-entry, and Continue strings',
+        (tester) async {
+      await pumpApp(
+        tester,
+        WizardJoinExisting(
+          urlController: TextEditingController(),
+          keyController: TextEditingController(),
+          keyField: const SizedBox.shrink(),
+          onScanQr: () {},
+          onContinue: null,
+        ),
+      );
+
+      expect(find.text('Join an existing database'), findsOneWidget);
+      expect(find.text('Scan QR Code'), findsOneWidget);
+      expect(find.text('Enter manually'), findsOneWidget);
+      expect(find.text('Continue'), findsOneWidget);
+    });
+
+    testWidgets('scan QR button invokes callback', (tester) async {
+      var scanned = false;
+      await pumpApp(
+        tester,
+        WizardJoinExisting(
+          urlController: TextEditingController(),
+          keyController: TextEditingController(),
+          keyField: const SizedBox.shrink(),
+          onScanQr: () => scanned = true,
+          onContinue: null,
+        ),
+      );
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Scan QR Code'));
+      await tester.pumpAndSettle();
+      expect(scanned, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Batch 2 of the sync wizard i18n sweep. Covers the credential-entry + QR scan flow every private/join-existing TankSync user sees after picking their sync mode:

- **wizard_create_new.dart** — 3-step Supabase setup guide (create project, enable anon sign-ins, copy credentials), step indicator, back/next/continue
- **wizard_join_existing.dart** — title, Scan QR button, ask-owner hint, or divider, manual entry, URL field + helper text
- **sync_credentials_step.dart** — private-mode hint, Database URL / Access Key labels + hints, QR short prompt, or-enter-manually divider
- **qr_scanner_screen.dart** — app bar title

Added 29 l10n keys to `app_en.arb`, `app_de.arb`, `app_fr.arb` with full translations. The other 20 locales fall back to English via the standard mechanism.

## Why
Audit finding #385. These are the remaining highest-impact hardcoded strings in the sync wizard — the onboarding flow every TankSync user walks through before reaching the schema-check step that batch 1 already covered.

## Test plan
- [x] `flutter gen-l10n` clean (only expected untranslated-messages info in other locales)
- [x] `flutter analyze --no-fatal-infos` — 0 errors, 0 warnings
- [x] `flutter test test/features/sync/` — 97 tests passing (up from 91; added 6 new)
- [x] New widget tests: `wizard_create_new_test.dart` (4), `wizard_join_existing_test.dart` (2)
- [x] Existing sync tests still pass — they render without an AppLocalizations delegate and hit the English fallback strings

Progresses #385. Remaining scope: auth_form_widget / email_auth_card, ntfy_setup, link_device_screen (batch 2c), then UI actions (batch 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)