### PR TITLE
fix(i18n): localize UI action labels and about section (~15 strings)

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -190,14 +190,14 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
                             alignment: Alignment.centerLeft,
                             padding: const EdgeInsets.only(left: 24),
                             color: Theme.of(context).colorScheme.primary,
-                            child: const Row(
+                            child: Row(
                               mainAxisSize: MainAxisSize.min,
                               children: [
-                                Icon(Icons.navigation,
+                                const Icon(Icons.navigation,
                                     color: Colors.white, size: 20),
-                                SizedBox(width: 8),
-                                Text('Navigate',
-                                    style: TextStyle(
+                                const SizedBox(width: 8),
+                                Text(l10n?.navigate ?? 'Navigate',
+                                    style: const TextStyle(
                                         color: Colors.white,
                                         fontWeight: FontWeight.bold)),
                               ],
@@ -210,15 +210,15 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
                             alignment: Alignment.centerRight,
                             padding: const EdgeInsets.only(right: 24),
                             color: Colors.red,
-                            child: const Row(
+                            child: Row(
                               mainAxisSize: MainAxisSize.min,
                               children: [
-                                Text('Remove',
-                                    style: TextStyle(
+                                Text(l10n?.remove ?? 'Remove',
+                                    style: const TextStyle(
                                         color: Colors.white,
                                         fontWeight: FontWeight.bold)),
-                                SizedBox(width: 8),
-                                Icon(Icons.delete, color: Colors.white, size: 20),
+                                const SizedBox(width: 8),
+                                const Icon(Icons.delete, color: Colors.white, size: 20),
                               ],
                             ),
                           ),
@@ -272,6 +272,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
   }
 
   Widget _buildEvSectionHeader(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
       child: Row(
@@ -279,13 +280,15 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
           Icon(Icons.ev_station, size: 16,
               color: Theme.of(context).colorScheme.primary),
           const SizedBox(width: 8),
-          Text('EV Charging', style: Theme.of(context).textTheme.titleSmall),
+          Text(l10n?.evChargingSection ?? 'EV Charging',
+              style: Theme.of(context).textTheme.titleSmall),
         ],
       ),
     );
   }
 
   Widget _buildFuelSectionHeader(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
       child: Row(
@@ -293,7 +296,8 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
           Icon(Icons.local_gas_station, size: 16,
               color: Theme.of(context).colorScheme.primary),
           const SizedBox(width: 8),
-          Text('Fuel Stations', style: Theme.of(context).textTheme.titleSmall),
+          Text(l10n?.fuelStationsSection ?? 'Fuel Stations',
+              style: Theme.of(context).textTheme.titleSmall),
         ],
       ),
     );

--- a/lib/features/favorites/presentation/widgets/alerts_tab.dart
+++ b/lib/features/favorites/presentation/widgets/alerts_tab.dart
@@ -50,14 +50,14 @@ class AlertsTab extends StatelessWidget {
               alignment: Alignment.centerRight,
               padding: const EdgeInsets.only(right: 24),
               color: Colors.red,
-              child: const Row(
+              child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text('Delete',
-                      style: TextStyle(
+                  Text(l10n?.delete ?? 'Delete',
+                      style: const TextStyle(
                           color: Colors.white, fontWeight: FontWeight.bold)),
-                  SizedBox(width: 8),
-                  Icon(Icons.delete, color: Colors.white, size: 20),
+                  const SizedBox(width: 8),
+                  const Icon(Icons.delete, color: Colors.white, size: 20),
                 ],
               ),
             ),

--- a/lib/features/profile/presentation/widgets/about_section.dart
+++ b/lib/features/profile/presentation/widgets/about_section.dart
@@ -66,7 +66,8 @@ class AboutSection extends StatelessWidget {
           ),
           ListTile(
             leading: const Icon(Icons.bug_report),
-            title: const Text('Report a bug / Suggest a feature'),
+            title: Text(AppLocalizations.of(context)?.aboutReportBug ??
+                'Report a bug / Suggest a feature'),
             onTap: () => launchUrl(
               Uri.parse(AppConstants.githubIssuesUrl),
               mode: LaunchMode.externalApplication,
@@ -77,7 +78,8 @@ class AboutSection extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
             child: Text(
-              'Support this project',
+              AppLocalizations.of(context)?.aboutSupportProject ??
+                  'Support this project',
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -86,8 +88,9 @@ class AboutSection extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Text(
-              'This app is free, open source, and has no ads. '
-              'If you find it useful, consider supporting the developer.',
+              AppLocalizations.of(context)?.aboutSupportDescription ??
+                  'This app is free, open source, and has no ads. '
+                      'If you find it useful, consider supporting the developer.',
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),

--- a/lib/features/profile/presentation/widgets/storage_bar.dart
+++ b/lib/features/profile/presentation/widgets/storage_bar.dart
@@ -34,14 +34,16 @@ class StorageBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (totalBytes == 0) {
+      final l10n = AppLocalizations.of(context);
       return Container(
         height: 24,
         decoration: BoxDecoration(
           color: theme.colorScheme.surfaceContainerHighest,
           borderRadius: BorderRadius.circular(12),
         ),
-        child: const Center(
-          child: Text('No storage used', style: TextStyle(fontSize: 11)),
+        child: Center(
+          child: Text(l10n?.noStorageUsed ?? 'No storage used',
+              style: const TextStyle(fontSize: 11)),
         ),
       );
     }

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -142,7 +142,8 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Your rating', style: theme.textTheme.titleMedium),
+                  Text(l10n?.yourRating ?? 'Your rating',
+                      style: theme.textTheme.titleMedium),
                   const SizedBox(height: 8),
                   Consumer(builder: (context, ref, _) {
                     final rating = ref.watch(stationRatingProvider(station.id));

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -212,13 +212,13 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: 24),
         color: Colors.orange.shade700,
-        child: const Row(
+        child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text('Hide',
-                style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
-            SizedBox(width: 8),
-            Icon(Icons.visibility_off, color: Colors.white, size: 20),
+            Text(l10n?.swipeHide ?? 'Hide',
+                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+            const SizedBox(width: 8),
+            const Icon(Icons.visibility_off, color: Colors.white, size: 20),
           ],
         ),
       ),

--- a/lib/features/search/presentation/widgets/swipeable_station_card.dart
+++ b/lib/features/search/presentation/widgets/swipeable_station_card.dart
@@ -72,13 +72,13 @@ class SwipeableStationCard extends ConsumerWidget {
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: 24),
         color: Colors.orange.shade700,
-        child: const Row(
+        child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text('Hide',
-                style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
-            SizedBox(width: 8),
-            Icon(Icons.visibility_off, color: Colors.white, size: 20),
+            Text(l10n?.swipeHide ?? 'Hide',
+                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+            const SizedBox(width: 8),
+            const Icon(Icons.visibility_off, color: Colors.white, size: 20),
           ],
         ),
       ),

--- a/lib/features/station_detail/presentation/widgets/station_rating_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_rating_section.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/widgets/star_rating.dart';
+import '../../../../l10n/app_localizations.dart';
 import '../../../search/providers/station_rating_provider.dart';
 
 /// User rating section showing interactive star rating for a station.
@@ -13,10 +14,12 @@ class StationRatingSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('Your rating', style: theme.textTheme.titleMedium),
+        Text(l10n?.yourRating ?? 'Your rating',
+            style: theme.textTheme.titleMedium),
         const SizedBox(height: 8),
         Consumer(builder: (context, ref, _) {
           final rating = ref.watch(stationRatingProvider(stationId));

--- a/lib/features/vehicle/presentation/widgets/vehicle_card.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/vehicle_profile.dart';
 
 /// Compact summary card for one [VehicleProfile].
@@ -62,6 +63,7 @@ class VehicleCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final subtitle = _subtitle();
 
     return Card(
@@ -115,12 +117,14 @@ class VehicleCard extends StatelessWidget {
           },
           itemBuilder: (context) => [
             if (!isActive)
-              const PopupMenuItem(
+              PopupMenuItem(
                 value: 'activate',
-                child: Text('Set active'),
+                child: Text(l10n?.vehicleSetActive ?? 'Set active'),
               ),
-            const PopupMenuItem(value: 'edit', child: Text('Edit')),
-            const PopupMenuItem(value: 'delete', child: Text('Delete')),
+            PopupMenuItem(
+                value: 'edit', child: Text(l10n?.edit ?? 'Edit')),
+            PopupMenuItem(
+                value: 'delete', child: Text(l10n?.delete ?? 'Delete')),
           ],
         ),
         onTap: onTap,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -952,5 +952,14 @@
   "linkDeviceCodeFieldHint": "UUID vom anderen Gerät einfügen",
   "linkDeviceImportButton": "Daten importieren",
   "linkDeviceHowItWorksTitle": "So funktioniert es",
-  "linkDeviceHowItWorksBody": "1. Auf Gerät A: Gerätecode oben kopieren\n2. Auf Gerät B: in das Feld \"Gerätecode\" einfügen\n3. \"Daten importieren\" tippen, um Favoriten und Alarme zusammenzuführen\n4. Beide Geräte haben dann alle kombinierten Daten\n\nJedes Gerät behält seine eigene anonyme Identität. Daten werden zusammengeführt, nicht verschoben."
+  "linkDeviceHowItWorksBody": "1. Auf Gerät A: Gerätecode oben kopieren\n2. Auf Gerät B: in das Feld \"Gerätecode\" einfügen\n3. \"Daten importieren\" tippen, um Favoriten und Alarme zusammenzuführen\n4. Beide Geräte haben dann alle kombinierten Daten\n\nJedes Gerät behält seine eigene anonyme Identität. Daten werden zusammengeführt, nicht verschoben.",
+  "vehicleSetActive": "Aktivieren",
+  "swipeHide": "Ausblenden",
+  "evChargingSection": "Elektro-Laden",
+  "fuelStationsSection": "Tankstellen",
+  "yourRating": "Ihre Bewertung",
+  "noStorageUsed": "Kein Speicher verwendet",
+  "aboutReportBug": "Fehler melden / Funktion vorschlagen",
+  "aboutSupportProject": "Dieses Projekt unterstützen",
+  "aboutSupportDescription": "Diese App ist kostenlos, Open Source und werbefrei. Wenn sie Ihnen gefällt, unterstützen Sie bitte den Entwickler."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -963,5 +963,14 @@
   "linkDeviceCodeFieldHint": "Paste the UUID from other device",
   "linkDeviceImportButton": "Import data",
   "linkDeviceHowItWorksTitle": "How it works",
-  "linkDeviceHowItWorksBody": "1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved."
+  "linkDeviceHowItWorksBody": "1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.",
+  "vehicleSetActive": "Set active",
+  "swipeHide": "Hide",
+  "evChargingSection": "EV Charging",
+  "fuelStationsSection": "Fuel Stations",
+  "yourRating": "Your rating",
+  "noStorageUsed": "No storage used",
+  "aboutReportBug": "Report a bug / Suggest a feature",
+  "aboutSupportProject": "Support this project",
+  "aboutSupportDescription": "This app is free, open source, and has no ads. If you find it useful, consider supporting the developer."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -617,5 +617,14 @@
   "linkDeviceCodeFieldHint": "Collez l'UUID de l'autre appareil",
   "linkDeviceImportButton": "Importer les données",
   "linkDeviceHowItWorksTitle": "Comment ça marche",
-  "linkDeviceHowItWorksBody": "1. Sur l'appareil A : copiez le code ci-dessus\n2. Sur l'appareil B : collez-le dans le champ « Code de l'appareil »\n3. Appuyez sur « Importer les données » pour fusionner favoris et alertes\n4. Les deux appareils auront toutes les données combinées\n\nChaque appareil garde sa propre identité anonyme. Les données sont fusionnées, pas déplacées."
+  "linkDeviceHowItWorksBody": "1. Sur l'appareil A : copiez le code ci-dessus\n2. Sur l'appareil B : collez-le dans le champ « Code de l'appareil »\n3. Appuyez sur « Importer les données » pour fusionner favoris et alertes\n4. Les deux appareils auront toutes les données combinées\n\nChaque appareil garde sa propre identité anonyme. Les données sont fusionnées, pas déplacées.",
+  "vehicleSetActive": "Activer",
+  "swipeHide": "Masquer",
+  "evChargingSection": "Recharge EV",
+  "fuelStationsSection": "Stations-service",
+  "yourRating": "Votre note",
+  "noStorageUsed": "Aucun stockage utilisé",
+  "aboutReportBug": "Signaler un bug / Suggérer une fonctionnalité",
+  "aboutSupportProject": "Soutenir ce projet",
+  "aboutSupportDescription": "Cette application est gratuite, open source et sans publicité. Si vous la trouvez utile, soutenez le développeur."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4356,6 +4356,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.'**
   String get linkDeviceHowItWorksBody;
+
+  /// No description provided for @vehicleSetActive.
+  ///
+  /// In en, this message translates to:
+  /// **'Set active'**
+  String get vehicleSetActive;
+
+  /// No description provided for @swipeHide.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide'**
+  String get swipeHide;
+
+  /// No description provided for @evChargingSection.
+  ///
+  /// In en, this message translates to:
+  /// **'EV Charging'**
+  String get evChargingSection;
+
+  /// No description provided for @fuelStationsSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Fuel Stations'**
+  String get fuelStationsSection;
+
+  /// No description provided for @yourRating.
+  ///
+  /// In en, this message translates to:
+  /// **'Your rating'**
+  String get yourRating;
+
+  /// No description provided for @noStorageUsed.
+  ///
+  /// In en, this message translates to:
+  /// **'No storage used'**
+  String get noStorageUsed;
+
+  /// No description provided for @aboutReportBug.
+  ///
+  /// In en, this message translates to:
+  /// **'Report a bug / Suggest a feature'**
+  String get aboutReportBug;
+
+  /// No description provided for @aboutSupportProject.
+  ///
+  /// In en, this message translates to:
+  /// **'Support this project'**
+  String get aboutSupportProject;
+
+  /// No description provided for @aboutSupportDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.'**
+  String get aboutSupportDescription;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2289,4 +2289,32 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2289,4 +2289,32 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2287,4 +2287,32 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2305,4 +2305,32 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. Auf Gerät A: Gerätecode oben kopieren\n2. Auf Gerät B: in das Feld \"Gerätecode\" einfügen\n3. \"Daten importieren\" tippen, um Favoriten und Alarme zusammenzuführen\n4. Beide Geräte haben dann alle kombinierten Daten\n\nJedes Gerät behält seine eigene anonyme Identität. Daten werden zusammengeführt, nicht verschoben.';
+
+  @override
+  String get vehicleSetActive => 'Aktivieren';
+
+  @override
+  String get swipeHide => 'Ausblenden';
+
+  @override
+  String get evChargingSection => 'Elektro-Laden';
+
+  @override
+  String get fuelStationsSection => 'Tankstellen';
+
+  @override
+  String get yourRating => 'Ihre Bewertung';
+
+  @override
+  String get noStorageUsed => 'Kein Speicher verwendet';
+
+  @override
+  String get aboutReportBug => 'Fehler melden / Funktion vorschlagen';
+
+  @override
+  String get aboutSupportProject => 'Dieses Projekt unterstützen';
+
+  @override
+  String get aboutSupportDescription =>
+      'Diese App ist kostenlos, Open Source und werbefrei. Wenn sie Ihnen gefällt, unterstützen Sie bitte den Entwickler.';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2291,4 +2291,32 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2282,4 +2282,32 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2290,4 +2290,32 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2284,4 +2284,32 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2287,4 +2287,32 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2305,4 +2305,32 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. Sur l\'appareil A : copiez le code ci-dessus\n2. Sur l\'appareil B : collez-le dans le champ « Code de l\'appareil »\n3. Appuyez sur « Importer les données » pour fusionner favoris et alertes\n4. Les deux appareils auront toutes les données combinées\n\nChaque appareil garde sa propre identité anonyme. Les données sont fusionnées, pas déplacées.';
+
+  @override
+  String get vehicleSetActive => 'Activer';
+
+  @override
+  String get swipeHide => 'Masquer';
+
+  @override
+  String get evChargingSection => 'Recharge EV';
+
+  @override
+  String get fuelStationsSection => 'Stations-service';
+
+  @override
+  String get yourRating => 'Votre note';
+
+  @override
+  String get noStorageUsed => 'Aucun stockage utilisé';
+
+  @override
+  String get aboutReportBug => 'Signaler un bug / Suggérer une fonctionnalité';
+
+  @override
+  String get aboutSupportProject => 'Soutenir ce projet';
+
+  @override
+  String get aboutSupportDescription =>
+      'Cette application est gratuite, open source et sans publicité. Si vous la trouvez utile, soutenez le développeur.';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2286,4 +2286,32 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2291,4 +2291,32 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2290,4 +2290,32 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2288,4 +2288,32 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2290,4 +2290,32 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2286,4 +2286,32 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2291,4 +2291,32 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2289,4 +2289,32 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2290,4 +2290,32 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2289,4 +2289,32 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2290,4 +2290,32 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2284,4 +2284,32 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2288,4 +2288,32 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get linkDeviceHowItWorksBody =>
       '1. On Device A: copy the device code above\n2. On Device B: paste it in the \"Device code\" field\n3. Tap \"Import data\" to merge favorites and alerts\n4. Both devices will have all combined data\n\nEach device keeps its own anonymous identity. Data is merged, not moved.';
+
+  @override
+  String get vehicleSetActive => 'Set active';
+
+  @override
+  String get swipeHide => 'Hide';
+
+  @override
+  String get evChargingSection => 'EV Charging';
+
+  @override
+  String get fuelStationsSection => 'Fuel Stations';
+
+  @override
+  String get yourRating => 'Your rating';
+
+  @override
+  String get noStorageUsed => 'No storage used';
+
+  @override
+  String get aboutReportBug => 'Report a bug / Suggest a feature';
+
+  @override
+  String get aboutSupportProject => 'Support this project';
+
+  @override
+  String get aboutSupportDescription =>
+      'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
 }


### PR DESCRIPTION
## Summary
Batch 4 (final) of the sync wizard i18n sweep. Covers the remaining hardcoded strings in the UI action layer and misc widgets:

- **vehicle_card.dart** — Set active / Edit / Delete popup items
- **alerts_tab.dart** — Delete swipe background
- **favorites_screen.dart** — Navigate / Remove swipe labels, EV Charging / Fuel Stations section headers
- **route_results_view.dart** — Hide swipe label
- **swipeable_station_card.dart** — Hide swipe label
- **station_rating_section.dart** — \"Your rating\" header
- **ev_station_detail_screen.dart** — \"Your rating\" header
- **storage_bar.dart** — \"No storage used\" empty label
- **about_section.dart** — \"Report a bug\", \"Support this project\", donation description

## New keys
9 new keys: `vehicleSetActive`, `swipeHide`, `evChargingSection`, `fuelStationsSection`, `yourRating`, `noStorageUsed`, `aboutReportBug`, `aboutSupportProject`, `aboutSupportDescription`.

Reused existing keys where they already fit: `edit`, `delete`, `navigate`, `remove`.

All 3 translated locales (en/de/fr) have full translations; the other 20 locales fall back to English via the standard mechanism.

## Not translated (intentional)
- \"Uniform\" / \"Balanced\" — internal strategy identifiers used as map keys
- \"GitHub\" / \"PayPal\" / \"Revolut\" — proper nouns / brand names

## Test plan
- [x] `flutter gen-l10n` clean
- [x] `flutter analyze --no-fatal-infos` — 0 errors, 0 warnings
- [x] `flutter test` — only pre-existing flaky network test (`api_connectivity_test.dart: Argentina — Energía CSV`) fails, confirmed identical failure on master branch
- [x] Existing widget tests still pass — they render without AppLocalizations delegate and hit the English fallback strings

Closes #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)