### PR TITLE
refactor(calculator): extract sections from oversized build method

### DIFF
--- a/lib/features/calculator/presentation/screens/calculator_screen.dart
+++ b/lib/features/calculator/presentation/screens/calculator_screen.dart
@@ -3,6 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/calculator_provider.dart';
+import '../widgets/calculator_empty_hint.dart';
+import '../widgets/calculator_input_field.dart';
+import '../widgets/calculator_result_card.dart';
 
 class CalculatorScreen extends ConsumerStatefulWidget {
   final double? initialPrice;
@@ -53,7 +56,7 @@ class _CalculatorScreenState extends ConsumerState<CalculatorScreen> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(calculatorProvider);
-    final theme = Theme.of(context);
+    final notifier = ref.read(calculatorProvider.notifier);
     final l10n = AppLocalizations.of(context);
 
     return Scaffold(
@@ -68,156 +71,36 @@ class _CalculatorScreenState extends ConsumerState<CalculatorScreen> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          // Distance input
-          TextField(
+          CalculatorInputField(
             controller: _distanceController,
-            decoration: InputDecoration(
-              labelText: l10n?.distanceKm ?? 'Distance (km)',
-              hintText: 'e.g. 150',
-              prefixIcon: const Icon(Icons.straighten),
-              border: const OutlineInputBorder(),
-            ),
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            onChanged: (value) {
-              final parsed = double.tryParse(value) ?? 0;
-              ref.read(calculatorProvider.notifier).setDistance(parsed);
-            },
+            labelText: l10n?.distanceKm ?? 'Distance (km)',
+            hintText: 'e.g. 150',
+            icon: Icons.straighten,
+            onParsed: notifier.setDistance,
           ),
           const SizedBox(height: 16),
-
-          // Consumption input
-          TextField(
+          CalculatorInputField(
             controller: _consumptionController,
-            decoration: InputDecoration(
-              labelText: l10n?.consumptionL100km ?? 'Consumption (L/100km)',
-              hintText: 'e.g. 7.0',
-              prefixIcon: const Icon(Icons.local_gas_station),
-              border: const OutlineInputBorder(),
-            ),
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            onChanged: (value) {
-              final parsed = double.tryParse(value) ?? 0;
-              ref.read(calculatorProvider.notifier).setConsumption(parsed);
-            },
+            labelText: l10n?.consumptionL100km ?? 'Consumption (L/100km)',
+            hintText: 'e.g. 7.0',
+            icon: Icons.local_gas_station,
+            onParsed: notifier.setConsumption,
           ),
           const SizedBox(height: 16),
-
-          // Price input
-          TextField(
+          CalculatorInputField(
             controller: _priceController,
-            decoration: InputDecoration(
-              labelText: l10n?.fuelPriceEurL ?? 'Fuel price (\u20ac/L)',
-              hintText: 'e.g. 1.899',
-              prefixIcon: const Icon(Icons.euro),
-              border: const OutlineInputBorder(),
-            ),
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            onChanged: (value) {
-              final parsed = double.tryParse(value) ?? 0;
-              ref.read(calculatorProvider.notifier).setPrice(parsed);
-            },
+            labelText: l10n?.fuelPriceEurL ?? 'Fuel price (\u20ac/L)',
+            hintText: 'e.g. 1.899',
+            icon: Icons.euro,
+            onParsed: notifier.setPrice,
           ),
           const SizedBox(height: 32),
-
-          // Result card
           if (state.hasInput)
-            Card(
-              elevation: 2,
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  children: [
-                    Icon(
-                      Icons.calculate_outlined,
-                      size: 40,
-                      color: theme.colorScheme.primary,
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      l10n?.tripCost ?? 'Trip Cost',
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        _ResultItem(
-                          label: l10n?.fuelNeeded ?? 'Fuel needed',
-                          value: '${state.calculation.totalLiters.toStringAsFixed(1)} L',
-                        ),
-                        _ResultItem(
-                          label: l10n?.totalCost ?? 'Total cost',
-                          value: '${state.calculation.totalCost.toStringAsFixed(2)} \u20ac',
-                          highlight: true,
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            )
+            CalculatorResultCard(state: state)
           else
-            Center(
-              child: Padding(
-                padding: const EdgeInsets.all(32),
-                child: Column(
-                  children: [
-                    Icon(
-                      Icons.calculate_outlined,
-                      size: 64,
-                      color: theme.colorScheme.outline,
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      l10n?.enterCalcValues ?? 'Enter distance, consumption, and price to calculate trip cost',
-                      textAlign: TextAlign.center,
-                      style: theme.textTheme.bodyLarge?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
+            const CalculatorEmptyHint(),
         ],
       ),
-    );
-  }
-}
-
-class _ResultItem extends StatelessWidget {
-  final String label;
-  final String value;
-  final bool highlight;
-
-  const _ResultItem({
-    required this.label,
-    required this.value,
-    this.highlight = false,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Column(
-      children: [
-        Text(
-          label,
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-        ),
-        const SizedBox(height: 4),
-        Text(
-          value,
-          style: highlight
-              ? theme.textTheme.headlineSmall?.copyWith(
-                  color: theme.colorScheme.primary,
-                  fontWeight: FontWeight.bold,
-                )
-              : theme.textTheme.titleLarge,
-        ),
-      ],
     );
   }
 }

--- a/lib/features/calculator/presentation/widgets/calculator_empty_hint.dart
+++ b/lib/features/calculator/presentation/widgets/calculator_empty_hint.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Placeholder shown when the calculator has no input yet.
+class CalculatorEmptyHint extends StatelessWidget {
+  const CalculatorEmptyHint({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          children: [
+            Icon(
+              Icons.calculate_outlined,
+              size: 64,
+              color: theme.colorScheme.outline,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              l10n?.enterCalcValues ??
+                  'Enter distance, consumption, and price to calculate trip cost',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/calculator/presentation/widgets/calculator_input_field.dart
+++ b/lib/features/calculator/presentation/widgets/calculator_input_field.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+/// Numeric text field used by the fuel cost calculator.
+///
+/// Wraps a [TextField] with decimal keyboard, outlined border, and a parse
+/// callback that forwards the parsed value (0 on invalid input) to the
+/// caller — the calculator's three inputs are structurally identical except
+/// for label, hint, icon, and the notifier method they forward to.
+class CalculatorInputField extends StatelessWidget {
+  final TextEditingController controller;
+  final String labelText;
+  final String hintText;
+  final IconData icon;
+  final ValueChanged<double> onParsed;
+
+  const CalculatorInputField({
+    super.key,
+    required this.controller,
+    required this.labelText,
+    required this.hintText,
+    required this.icon,
+    required this.onParsed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: labelText,
+        hintText: hintText,
+        prefixIcon: Icon(icon),
+        border: const OutlineInputBorder(),
+      ),
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      onChanged: (value) => onParsed(double.tryParse(value) ?? 0),
+    );
+  }
+}

--- a/lib/features/calculator/presentation/widgets/calculator_result_card.dart
+++ b/lib/features/calculator/presentation/widgets/calculator_result_card.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../providers/calculator_provider.dart';
+
+/// Card showing the trip cost result for the calculator.
+///
+/// Reads from [CalculatorState] directly so the parent screen doesn't need to
+/// pipe individual numbers through the widget tree.
+class CalculatorResultCard extends StatelessWidget {
+  final CalculatorState state;
+
+  const CalculatorResultCard({super.key, required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Icon(
+              Icons.calculate_outlined,
+              size: 40,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              l10n?.tripCost ?? 'Trip Cost',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                _ResultItem(
+                  label: l10n?.fuelNeeded ?? 'Fuel needed',
+                  value:
+                      '${state.calculation.totalLiters.toStringAsFixed(1)} L',
+                ),
+                _ResultItem(
+                  label: l10n?.totalCost ?? 'Total cost',
+                  value:
+                      '${state.calculation.totalCost.toStringAsFixed(2)} \u20ac',
+                  highlight: true,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ResultItem extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool highlight;
+
+  const _ResultItem({
+    required this.label,
+    required this.value,
+    this.highlight = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: highlight
+              ? theme.textTheme.headlineSmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.bold,
+                )
+              : theme.textTheme.titleLarge,
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/calculator/presentation/widgets/calculator_input_field_test.dart
+++ b/test/features/calculator/presentation/widgets/calculator_input_field_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/calculator/presentation/widgets/calculator_input_field.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('CalculatorInputField', () {
+    testWidgets('renders label, hint and icon', (tester) async {
+      await pumpApp(
+        tester,
+        CalculatorInputField(
+          controller: TextEditingController(),
+          labelText: 'Distance (km)',
+          hintText: 'e.g. 150',
+          icon: Icons.straighten,
+          onParsed: (_) {},
+        ),
+      );
+
+      expect(find.text('Distance (km)'), findsOneWidget);
+      expect(find.text('e.g. 150'), findsOneWidget);
+      expect(find.byIcon(Icons.straighten), findsOneWidget);
+    });
+
+    testWidgets('forwards parsed value on change', (tester) async {
+      double? parsed;
+      await pumpApp(
+        tester,
+        CalculatorInputField(
+          controller: TextEditingController(),
+          labelText: 'Distance (km)',
+          hintText: 'e.g. 150',
+          icon: Icons.straighten,
+          onParsed: (v) => parsed = v,
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), '42.5');
+      expect(parsed, 42.5);
+    });
+
+    testWidgets('forwards 0 for unparseable input', (tester) async {
+      double? parsed;
+      await pumpApp(
+        tester,
+        CalculatorInputField(
+          controller: TextEditingController(),
+          labelText: 'Distance (km)',
+          hintText: 'e.g. 150',
+          icon: Icons.straighten,
+          onParsed: (v) => parsed = v,
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'abc');
+      expect(parsed, 0);
+    });
+  });
+}

--- a/test/features/calculator/presentation/widgets/calculator_result_card_test.dart
+++ b/test/features/calculator/presentation/widgets/calculator_result_card_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/calculator/presentation/widgets/calculator_result_card.dart';
+import 'package:tankstellen/features/calculator/providers/calculator_provider.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('CalculatorResultCard', () {
+    testWidgets('renders trip cost header, fuel needed and total cost',
+        (tester) async {
+      const state = CalculatorState(
+        distanceKm: 100,
+        consumptionPer100Km: 7,
+        pricePerLiter: 2,
+      );
+
+      await pumpApp(tester, const CalculatorResultCard(state: state));
+
+      expect(find.text('Trip Cost'), findsOneWidget);
+      expect(find.text('Fuel needed'), findsOneWidget);
+      expect(find.text('Total cost'), findsOneWidget);
+      // 100 km * 7 L/100km = 7 L
+      expect(find.text('7.0 L'), findsOneWidget);
+      // 7 L * 2 €/L = 14.00 €
+      expect(find.text('14.00 \u20ac'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/calculator/presentation/widgets/calculator_result_card_test.dart
+++ b/test/features/calculator/presentation/widgets/calculator_result_card_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/calculator/presentation/widgets/calculator_result_card.dart';
 import 'package:tankstellen/features/calculator/providers/calculator_provider.dart';


### PR DESCRIPTION
## Summary
First slice of #388. Reduces `CalculatorScreen.build()` from **131 to 46 lines** and the whole screen file from **224 to 106 lines** by extracting three dedicated section widgets into a new `widgets/` folder:

- **CalculatorInputField** — unifies the three duplicated TextField blocks (distance / consumption / price) behind a single parameterised widget. Saves 3× the boilerplate going forward.
- **CalculatorResultCard** — the trip-cost result card with Fuel needed / Total cost items (the private `_ResultItem` helper moves with it).
- **CalculatorEmptyHint** — the placeholder shown before the user enters any values.

## Why
Audit finding #388: 15 build methods exceed 50 lines. This is 1 of 15. Behaviour is identical — pure structural split.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — 0 errors, 0 warnings
- [x] `flutter test test/features/calculator/` — 12 tests passing (8 existing + 4 new)
- [x] New widget tests: `calculator_input_field_test.dart` (3 tests covering render, parsed value forwarding, unparseable input), `calculator_result_card_test.dart` (1 test covering trip-cost math)
- [x] Existing `calculator_screen_test.dart` still passes unchanged — confirms identical behaviour

Progresses #388 (1 of 15 oversized build methods extracted). Follow-ups will target the next-largest offenders: `consent_settings_section.dart` (261 lines), `profile_edit_sheet.dart` (255 lines), `api_key_section.dart` (173 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)