### PR TITLE
fix(profile): landing screen sort + routing bugs

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../core/data/storage_repository.dart';
 import '../core/error_tracing/integrations/navigation_trace_observer.dart';
 import '../core/storage/storage_keys.dart';
 import '../core/storage/storage_providers.dart';
@@ -34,6 +35,30 @@ import 'shell_screen.dart';
 import 'station_id_validator.dart';
 
 part 'router.g.dart';
+
+/// Resolves the route to land on based on the active profile's
+/// `landingScreen` preference. `cheapest` and `nearest` both open the Search
+/// screen ('/') — the sort order is derived separately by `SelectedSortMode`.
+/// Exposed for unit tests.
+String resolveLandingLocation(StorageRepository storage) {
+  final profileId = storage.getActiveProfileId();
+  if (profileId == null) return '/';
+  final landing = storage.getProfile(profileId)?['landingScreen']?.toString();
+  switch (landing) {
+    case 'favorites':
+    case 'LandingScreen.favorites':
+      return '/favorites';
+    case 'map':
+    case 'LandingScreen.map':
+      return '/map';
+    case 'cheapest':
+    case 'LandingScreen.cheapest':
+    case 'nearest':
+    case 'LandingScreen.nearest':
+    default:
+      return '/';
+  }
+}
 
 Widget _invalidIdScreen(BuildContext context, String path) {
   return Scaffold(
@@ -96,27 +121,16 @@ GoRouter router(Ref ref) {
 
       // Step 1: GDPR consent must be given before anything else
       if (!hasConsent && !isConsent) return '/consent';
-      if (hasConsent && isConsent) return isReady ? '/' : '/setup';
+      if (hasConsent && isConsent) {
+        return isReady ? resolveLandingLocation(storage) : '/setup';
+      }
 
       // Step 2: Setup (onboarding) must be complete before main app
       if (!isReady && !isSetup && !isConsent) return '/setup';
-      if (isReady && (isSetup || state.matchedLocation == '/')) {
-        // Route to profile landing screen preference
-        final profileId = storage.getActiveProfileId();
-        if (profileId != null) {
-          final profile = storage.getProfile(profileId);
-          final landing = profile?['landingScreen']?.toString();
-          switch (landing) {
-            case 'favorites':
-            case 'LandingScreen.favorites':
-              if (state.matchedLocation != '/favorites') return '/favorites';
-            case 'map':
-            case 'LandingScreen.map':
-              if (state.matchedLocation != '/map') return '/map';
-          }
-        }
-        if (isSetup) return '/';
-      }
+      // Landing preference is only applied when leaving the setup flow — not
+      // on every subsequent navigation back to '/', which would trap the
+      // user on their landing tab.
+      if (isReady && isSetup) return resolveLandingLocation(storage);
       return null;
     },
     routes: [

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'a1636eccf2b8821e709cdb346f70cf2049979142';
+String _$routerHash() => r'261d0b69af14af2a0ad9f8b182b68a44ea378feb';

--- a/lib/core/country/country_provider.g.dart
+++ b/lib/core/country/country_provider.g.dart
@@ -41,7 +41,7 @@ final class ActiveCountryProvider
   }
 }
 
-String _$activeCountryHash() => r'722e09262531a5e38eefc889071f0c8eb2329e44';
+String _$activeCountryHash() => r'f892c75e5c0adf31c923f5de143f33e9192fb99d';
 
 abstract class _$ActiveCountry extends $Notifier<CountryConfig> {
   CountryConfig build();

--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'7887e8d3af8e2b0402b00cb5f9e270b4ce8c2edc';
+String _$syncStateHash() => r'2edb4d01fc0d3db00d9e21ef9720c01d9058635f';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/features/favorites/providers/favorites_provider.g.dart
+++ b/lib/features/favorites/providers/favorites_provider.g.dart
@@ -245,7 +245,7 @@ final class FavoriteStationsProvider
   }
 }
 
-String _$favoriteStationsHash() => r'28057deab1398e89c8423e5dd03ca4737205a0df';
+String _$favoriteStationsHash() => r'3f07e655c1a1a72ca4d6586b5e5794d69a60cb82';
 
 /// Loads station data for favorites and refreshes prices.
 ///

--- a/lib/features/profile/data/models/user_profile.dart
+++ b/lib/features/profile/data/models/user_profile.dart
@@ -6,7 +6,6 @@ part 'user_profile.freezed.dart';
 part 'user_profile.g.dart';
 
 enum LandingScreen {
-  search('search'),
   favorites('favorites'),
   map('map'),
   cheapest('cheapest'),
@@ -18,7 +17,6 @@ enum LandingScreen {
   /// Localized display name. Falls back to English.
   String localizedName(String languageCode) {
     const names = {
-      'search': {'en': 'Search', 'de': 'Suche', 'fr': 'Recherche', 'es': 'Buscar', 'it': 'Cerca', 'nl': 'Zoeken', 'da': 'Søg', 'sv': 'Sök', 'fi': 'Haku', 'pl': 'Szukaj'},
       'favorites': {'en': 'Favorites', 'de': 'Favoriten', 'fr': 'Favoris', 'es': 'Favoritos', 'it': 'Preferiti', 'nl': 'Favorieten', 'da': 'Favoritter', 'sv': 'Favoriter', 'fi': 'Suosikit', 'pl': 'Ulubione'},
       'map': {'en': 'Map', 'de': 'Karte', 'fr': 'Carte', 'es': 'Mapa', 'it': 'Mappa', 'nl': 'Kaart', 'da': 'Kort', 'sv': 'Karta', 'fi': 'Kartta', 'pl': 'Mapa'},
       'cheapest': {'en': 'Cheapest nearby', 'de': 'Günstigste', 'fr': 'Moins cher', 'es': 'Más barato', 'it': 'Più economico', 'nl': 'Goedkoopste', 'da': 'Billigste', 'sv': 'Billigast', 'fi': 'Halvin', 'pl': 'Najtańsze'},
@@ -38,7 +36,7 @@ abstract class UserProfile with _$UserProfile {
     required String name,
     @FuelTypeJsonConverter() @Default(FuelType.e10) FuelType preferredFuelType,
     @Default(10.0) double defaultSearchRadius,
-    @Default(LandingScreen.search) LandingScreen landingScreen,
+    @Default(LandingScreen.nearest) LandingScreen landingScreen,
     @Default([]) List<String> favoriteStationIds,
     String? homeZipCode,
     @Default(false) bool autoUpdatePosition,

--- a/lib/features/profile/data/models/user_profile.freezed.dart
+++ b/lib/features/profile/data/models/user_profile.freezed.dart
@@ -230,7 +230,7 @@ return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchR
 @JsonSerializable()
 
 class _UserProfile implements UserProfile {
-  const _UserProfile({required this.id, required this.name, @FuelTypeJsonConverter() this.preferredFuelType = FuelType.e10, this.defaultSearchRadius = 10.0, this.landingScreen = LandingScreen.search, final  List<String> favoriteStationIds = const [], this.homeZipCode, this.autoUpdatePosition = false, this.countryCode, this.languageCode, this.routeSegmentKm = 50.0, this.avoidHighways = false, this.showFuel = true, this.showElectric = true, this.ratingMode = 'local', final  List<StationAmenity> preferredAmenities = const []}): _favoriteStationIds = favoriteStationIds,_preferredAmenities = preferredAmenities;
+  const _UserProfile({required this.id, required this.name, @FuelTypeJsonConverter() this.preferredFuelType = FuelType.e10, this.defaultSearchRadius = 10.0, this.landingScreen = LandingScreen.nearest, final  List<String> favoriteStationIds = const [], this.homeZipCode, this.autoUpdatePosition = false, this.countryCode, this.languageCode, this.routeSegmentKm = 50.0, this.avoidHighways = false, this.showFuel = true, this.showElectric = true, this.ratingMode = 'local', final  List<StationAmenity> preferredAmenities = const []}): _favoriteStationIds = favoriteStationIds,_preferredAmenities = preferredAmenities;
   factory _UserProfile.fromJson(Map<String, dynamic> json) => _$UserProfileFromJson(json);
 
 @override final  String id;

--- a/lib/features/profile/data/models/user_profile.g.dart
+++ b/lib/features/profile/data/models/user_profile.g.dart
@@ -18,7 +18,7 @@ _UserProfile _$UserProfileFromJson(Map<String, dynamic> json) => _UserProfile(
       (json['defaultSearchRadius'] as num?)?.toDouble() ?? 10.0,
   landingScreen:
       $enumDecodeNullable(_$LandingScreenEnumMap, json['landingScreen']) ??
-      LandingScreen.search,
+      LandingScreen.nearest,
   favoriteStationIds:
       (json['favoriteStationIds'] as List<dynamic>?)
           ?.map((e) => e as String)
@@ -65,7 +65,6 @@ Map<String, dynamic> _$UserProfileToJson(_UserProfile instance) =>
     };
 
 const _$LandingScreenEnumMap = {
-  LandingScreen.search: 'search',
   LandingScreen.favorites: 'favorites',
   LandingScreen.map: 'map',
   LandingScreen.cheapest: 'cheapest',

--- a/lib/features/profile/data/repositories/profile_repository.dart
+++ b/lib/features/profile/data/repositories/profile_repository.dart
@@ -23,21 +23,33 @@ class ProfileRepository {
     if (id == null) return null;
     final data = _storage.getProfile(id);
     if (data == null) return null;
-    return UserProfile.fromJson(data);
+    return UserProfile.fromJson(_migrateLegacyLandingScreen(data));
   }
 
   List<UserProfile> getAllProfiles() {
     return _storage
         .getAllProfiles()
-        .map((data) => UserProfile.fromJson(data))
+        .map((data) => UserProfile.fromJson(_migrateLegacyLandingScreen(data)))
         .toList();
+  }
+
+  /// Rewrites the legacy `LandingScreen.search` value (removed in 4.2.0) to
+  /// `nearest` so `fromJson` does not throw on profiles saved before the enum
+  /// was trimmed. `search` was always equivalent to the default distance sort,
+  /// which `nearest` now represents explicitly.
+  Map<String, dynamic> _migrateLegacyLandingScreen(Map<String, dynamic> data) {
+    final landing = data['landingScreen'];
+    if (landing == 'search' || landing == 'LandingScreen.search') {
+      return {...data, 'landingScreen': 'nearest'};
+    }
+    return data;
   }
 
   Future<UserProfile> createProfile({
     required String name,
     FuelType preferredFuelType = FuelType.e10,
     double defaultSearchRadius = 10.0,
-    LandingScreen landingScreen = LandingScreen.search,
+    LandingScreen landingScreen = LandingScreen.nearest,
     String? homeZipCode,
     String? countryCode,
     String? languageCode,

--- a/lib/features/search/providers/ev_search_provider.g.dart
+++ b/lib/features/search/providers/ev_search_provider.g.dart
@@ -53,7 +53,7 @@ final class EVSearchStateProvider
   }
 }
 
-String _$eVSearchStateHash() => r'e9bdc4fe2b271863aaa7e258337af59b538588e6';
+String _$eVSearchStateHash() => r'0bb1242b016c492e7a4afa40718a8e014fbe7615';
 
 /// Manages EV charging station search, parallel to [SearchState] for fuel.
 

--- a/lib/features/search/providers/search_screen_ui_provider.dart
+++ b/lib/features/search/providers/search_screen_ui_provider.dart
@@ -1,4 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../../profile/data/models/user_profile.dart';
+import '../../profile/providers/profile_provider.dart';
 import '../../route_search/domain/route_search_strategy.dart';
 import '../domain/entities/station_amenity.dart';
 import '../presentation/widgets/sort_selector.dart';
@@ -6,10 +8,20 @@ import '../presentation/widgets/sort_selector.dart';
 part 'search_screen_ui_provider.g.dart';
 
 /// The currently selected sort mode for the search results list.
+///
+/// The initial value derives from the active profile's [LandingScreen]
+/// preference: `cheapest` → price sort, everything else → distance.
+/// Users can still override via [set] from the sort chips.
 @riverpod
 class SelectedSortMode extends _$SelectedSortMode {
   @override
-  SortMode build() => SortMode.distance;
+  SortMode build() {
+    final profile = ref.watch(activeProfileProvider);
+    return switch (profile?.landingScreen) {
+      LandingScreen.cheapest => SortMode.price,
+      _ => SortMode.distance,
+    };
+  }
 
   void set(SortMode value) => state = value;
 }

--- a/lib/features/search/providers/search_screen_ui_provider.g.dart
+++ b/lib/features/search/providers/search_screen_ui_provider.g.dart
@@ -9,14 +9,26 @@ part of 'search_screen_ui_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 /// The currently selected sort mode for the search results list.
+///
+/// The initial value derives from the active profile's [LandingScreen]
+/// preference: `cheapest` → price sort, everything else → distance.
+/// Users can still override via [set] from the sort chips.
 
 @ProviderFor(SelectedSortMode)
 final selectedSortModeProvider = SelectedSortModeProvider._();
 
 /// The currently selected sort mode for the search results list.
+///
+/// The initial value derives from the active profile's [LandingScreen]
+/// preference: `cheapest` → price sort, everything else → distance.
+/// Users can still override via [set] from the sort chips.
 final class SelectedSortModeProvider
     extends $NotifierProvider<SelectedSortMode, SortMode> {
   /// The currently selected sort mode for the search results list.
+  ///
+  /// The initial value derives from the active profile's [LandingScreen]
+  /// preference: `cheapest` → price sort, everything else → distance.
+  /// Users can still override via [set] from the sort chips.
   SelectedSortModeProvider._()
     : super(
         from: null,
@@ -44,9 +56,13 @@ final class SelectedSortModeProvider
   }
 }
 
-String _$selectedSortModeHash() => r'bee5aedaae37772d7269ada2fc72fa69f071a22d';
+String _$selectedSortModeHash() => r'a6e2bb0baad440211f4c41c657f5e88fe64d4012';
 
 /// The currently selected sort mode for the search results list.
+///
+/// The initial value derives from the active profile's [LandingScreen]
+/// preference: `cheapest` → price sort, everything else → distance.
+/// Users can still override via [set] from the sort chips.
 
 abstract class _$SelectedSortMode extends $Notifier<SortMode> {
   SortMode build();

--- a/lib/features/setup/presentation/widgets/landing_screen_step.dart
+++ b/lib/features/setup/presentation/widgets/landing_screen_step.dart
@@ -76,7 +76,6 @@ class LandingScreenStep extends ConsumerWidget {
 
   static IconData _iconFor(LandingScreen screen) {
     return switch (screen) {
-      LandingScreen.search => Icons.search,
       LandingScreen.favorites => Icons.star,
       LandingScreen.map => Icons.map,
       LandingScreen.cheapest => Icons.trending_down,

--- a/lib/features/setup/providers/onboarding_wizard_provider.dart
+++ b/lib/features/setup/providers/onboarding_wizard_provider.dart
@@ -20,7 +20,7 @@ class OnboardingWizardState {
     this.homeZipCode,
     this.defaultSearchRadius = 10.0,
     FuelType? preferredFuelType,
-    this.landingScreen = LandingScreen.search,
+    this.landingScreen = LandingScreen.nearest,
   }) : preferredFuelType = preferredFuelType ?? FuelType.e10;
 
   OnboardingWizardState copyWith({

--- a/test/app/landing_screen_routing_test.dart
+++ b/test/app/landing_screen_routing_test.dart
@@ -1,66 +1,91 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/app/router.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/features/profile/data/models/user_profile.dart';
 
-void main() {
-  group('LandingScreen routing', () {
-    test('search landing maps to / route', () {
-      const screen = LandingScreen.search;
-      final route = _routeForLanding(screen);
-      expect(route, '/');
-    });
+class _FakeStorage extends Mock implements StorageRepository {
+  final Map<String, Map<String, dynamic>> _profiles = {};
+  String? _activeId;
 
-    test('favorites landing maps to /favorites route', () {
-      const screen = LandingScreen.favorites;
-      final route = _routeForLanding(screen);
-      expect(route, '/favorites');
-    });
+  void setActiveProfile(String id, Map<String, dynamic> profile) {
+    _profiles[id] = profile;
+    _activeId = id;
+  }
 
-    test('map landing maps to /map route', () {
-      const screen = LandingScreen.map;
-      final route = _routeForLanding(screen);
-      expect(route, '/map');
-    });
+  @override
+  String? getActiveProfileId() => _activeId;
 
-    test('cheapest landing maps to / route (auto-search triggers)', () {
-      const screen = LandingScreen.cheapest;
-      final route = _routeForLanding(screen);
-      expect(route, '/');
-    });
-
-    test('nearest landing maps to / route (auto-search triggers)', () {
-      const screen = LandingScreen.nearest;
-      final route = _routeForLanding(screen);
-      expect(route, '/');
-    });
-
-    test('all LandingScreen values produce valid routes', () {
-      for (final screen in LandingScreen.values) {
-        final route = _routeForLanding(screen);
-        expect(route, anyOf('/', '/favorites', '/map'),
-            reason: '$screen should map to a valid route');
-      }
-    });
-
-    test('LandingScreen enum serialization matches router switch', () {
-      // The router reads landing as a string from JSON storage.
-      // Verify all enum names are handled.
-      expect(LandingScreen.search.name, 'search');
-      expect(LandingScreen.favorites.name, 'favorites');
-      expect(LandingScreen.map.name, 'map');
-      expect(LandingScreen.cheapest.name, 'cheapest');
-      expect(LandingScreen.nearest.name, 'nearest');
-    });
-  });
+  @override
+  Map<String, dynamic>? getProfile(String id) => _profiles[id];
 }
 
-/// Mirrors the routing logic in router.dart redirect.
-String _routeForLanding(LandingScreen screen) {
-  switch (screen.name) {
-    case 'favorites':
-      return '/favorites';
-    case 'map':
-      return '/map';
-    default:
-      return '/';
-  }
+void main() {
+  group('resolveLandingLocation', () {
+    test('no active profile → /', () {
+      final storage = _FakeStorage();
+      expect(resolveLandingLocation(storage), '/');
+    });
+
+    test('favorites landing → /favorites', () {
+      final storage = _FakeStorage()
+        ..setActiveProfile('p', {'landingScreen': 'favorites'});
+      expect(resolveLandingLocation(storage), '/favorites');
+    });
+
+    test('legacy "LandingScreen.favorites" prefixed form → /favorites', () {
+      final storage = _FakeStorage()
+        ..setActiveProfile('p', {'landingScreen': 'LandingScreen.favorites'});
+      expect(resolveLandingLocation(storage), '/favorites');
+    });
+
+    test('map landing → /map', () {
+      final storage = _FakeStorage()
+        ..setActiveProfile('p', {'landingScreen': 'map'});
+      expect(resolveLandingLocation(storage), '/map');
+    });
+
+    test('cheapest landing → / (sort is handled separately)', () {
+      final storage = _FakeStorage()
+        ..setActiveProfile('p', {'landingScreen': 'cheapest'});
+      expect(resolveLandingLocation(storage), '/');
+    });
+
+    test('nearest landing → /', () {
+      final storage = _FakeStorage()
+        ..setActiveProfile('p', {'landingScreen': 'nearest'});
+      expect(resolveLandingLocation(storage), '/');
+    });
+
+    test('unknown landing value falls through to /', () {
+      final storage = _FakeStorage()
+        ..setActiveProfile('p', {'landingScreen': 'somethingElse'});
+      expect(resolveLandingLocation(storage), '/');
+    });
+
+    test('missing landingScreen field → /', () {
+      final storage = _FakeStorage()..setActiveProfile('p', {'name': 'X'});
+      expect(resolveLandingLocation(storage), '/');
+    });
+  });
+
+  group('LandingScreen enum', () {
+    test('no longer contains search', () {
+      final names = LandingScreen.values.map((v) => v.name).toList();
+      expect(names, unorderedEquals(['favorites', 'map', 'cheapest', 'nearest']));
+    });
+
+    test('every remaining value resolves to a valid route', () {
+      final storage = _FakeStorage();
+      for (final screen in LandingScreen.values) {
+        storage.setActiveProfile('p', {'landingScreen': screen.name});
+        final route = resolveLandingLocation(storage);
+        expect(
+          route,
+          anyOf('/', '/favorites', '/map'),
+          reason: '$screen should map to a valid route',
+        );
+      }
+    });
+  });
 }

--- a/test/features/profile/presentation/widgets/profile_card_test.dart
+++ b/test/features/profile/presentation/widgets/profile_card_test.dart
@@ -16,7 +16,7 @@ final _testProfile = const UserProfile(
   name: 'Home',
   preferredFuelType: FuelType.e10,
   defaultSearchRadius: 10.0,
-  landingScreen: LandingScreen.search,
+  landingScreen: LandingScreen.nearest,
   countryCode: 'DE',
 );
 

--- a/test/features/profile/providers/profile_provider_test.dart
+++ b/test/features/profile/providers/profile_provider_test.dart
@@ -50,7 +50,7 @@ void main() {
         expect(profile.name, 'Default');
         expect(profile.preferredFuelType, FuelType.e10);
         expect(profile.defaultSearchRadius, 10.0);
-        expect(profile.landingScreen, LandingScreen.search);
+        expect(profile.landingScreen, LandingScreen.nearest);
       });
 
       test('creates profile with custom values', () async {
@@ -218,7 +218,7 @@ void main() {
       const profile = UserProfile(id: 'abc', name: 'Test');
       expect(profile.preferredFuelType, FuelType.e10);
       expect(profile.defaultSearchRadius, 10.0);
-      expect(profile.landingScreen, LandingScreen.search);
+      expect(profile.landingScreen, LandingScreen.nearest);
       expect(profile.favoriteStationIds, isEmpty);
       expect(profile.autoUpdatePosition, isFalse);
       expect(profile.showFuel, isTrue);
@@ -255,24 +255,80 @@ void main() {
   // -------------------------------------------------------------------------
   group('LandingScreen', () {
     test('has correct English display names', () {
-      expect(LandingScreen.search.displayName, 'Search');
+      expect(LandingScreen.nearest.displayName, 'Nearest stations');
       expect(LandingScreen.favorites.displayName, 'Favorites');
       expect(LandingScreen.map.displayName, 'Map');
       expect(LandingScreen.cheapest.displayName, 'Cheapest nearby');
     });
 
     test('localizedName returns German for de', () {
-      expect(LandingScreen.search.localizedName('de'), 'Suche');
+      expect(LandingScreen.nearest.localizedName('de'), 'Nächste Tankstellen');
       expect(LandingScreen.favorites.localizedName('de'), 'Favoriten');
     });
 
     test('localizedName returns French for fr', () {
-      expect(LandingScreen.search.localizedName('fr'), 'Recherche');
+      expect(LandingScreen.nearest.localizedName('fr'), 'À proximité');
       expect(LandingScreen.favorites.localizedName('fr'), 'Favoris');
     });
 
     test('localizedName falls back to English for unknown language', () {
-      expect(LandingScreen.search.localizedName('xx'), 'Search');
+      expect(LandingScreen.nearest.localizedName('xx'), 'Nearest stations');
+    });
+
+    test('search is removed from the enum', () {
+      final names = LandingScreen.values.map((v) => v.name).toList();
+      expect(names, isNot(contains('search')));
+      expect(LandingScreen.values, hasLength(4));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Legacy `search` landing migration
+  // -------------------------------------------------------------------------
+  group('ProfileRepository legacy landingScreen migration', () {
+    late _InMemoryHiveStorage storage;
+    late ProfileRepository repo;
+
+    setUp(() {
+      storage = _InMemoryHiveStorage();
+      repo = ProfileRepository(storage);
+    });
+
+    test('getActiveProfile rewrites legacy "search" value to "nearest"',
+        () async {
+      // Simulate a profile saved before LandingScreen.search was removed.
+      const id = 'legacy-profile';
+      storage._profiles[id] = {
+        'id': id,
+        'name': 'Legacy',
+        'landingScreen': 'search',
+      };
+      storage._activeProfileId = id;
+
+      final profile = repo.getActiveProfile();
+      expect(profile, isNotNull);
+      expect(profile!.landingScreen, LandingScreen.nearest);
+    });
+
+    test('getAllProfiles rewrites legacy "LandingScreen.search" form',
+        () async {
+      storage._profiles['legacy'] = {
+        'id': 'legacy',
+        'name': 'Legacy',
+        'landingScreen': 'LandingScreen.search',
+      };
+      storage._profiles['fresh'] = {
+        'id': 'fresh',
+        'name': 'Fresh',
+        'landingScreen': 'favorites',
+      };
+
+      final all = repo.getAllProfiles();
+      expect(all, hasLength(2));
+      final legacy = all.firstWhere((p) => p.id == 'legacy');
+      final fresh = all.firstWhere((p) => p.id == 'fresh');
+      expect(legacy.landingScreen, LandingScreen.nearest);
+      expect(fresh.landingScreen, LandingScreen.favorites);
     });
   });
 }

--- a/test/features/search/presentation/widgets/location_input_test.dart
+++ b/test/features/search/presentation/widgets/location_input_test.dart
@@ -66,7 +66,7 @@ void main() {
       const profile = UserProfile(
         id: 'test',
         name: 'Test',
-        landingScreen: LandingScreen.search,
+        landingScreen: LandingScreen.favorites,
         homeZipCode: '34540',
       );
       expect(profile.landingScreen, isNot(LandingScreen.cheapest));
@@ -79,12 +79,16 @@ void main() {
       final selectable = LandingScreen.values
           .where((s) => s != LandingScreen.map)
           .toList();
-      expect(selectable.length, 4);
-      expect(selectable, contains(LandingScreen.search));
+      expect(selectable.length, 3);
       expect(selectable, contains(LandingScreen.favorites));
       expect(selectable, contains(LandingScreen.cheapest));
       expect(selectable, contains(LandingScreen.nearest));
       expect(selectable, isNot(contains(LandingScreen.map)));
+    });
+
+    test('search landing option is removed from the enum', () {
+      final names = LandingScreen.values.map((v) => v.name).toList();
+      expect(names, isNot(contains('search')));
     });
   });
 

--- a/test/features/search/providers/search_screen_ui_provider_test.dart
+++ b/test/features/search/providers/search_screen_ui_provider_test.dart
@@ -1,9 +1,71 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
 import 'package:tankstellen/features/route_search/domain/route_search_strategy.dart';
+import 'package:tankstellen/features/search/presentation/widgets/sort_selector.dart';
 import 'package:tankstellen/features/search/providers/search_screen_ui_provider.dart';
 
+ProviderContainer _containerWithLanding(LandingScreen? landing) {
+  final profile = landing == null
+      ? null
+      : UserProfile(id: 't', name: 'T', landingScreen: landing);
+  final container = ProviderContainer(
+    overrides: [
+      activeProfileProvider.overrideWith(() => _FakeActive(profile)),
+    ],
+  );
+  return container;
+}
+
+class _FakeActive extends ActiveProfile {
+  _FakeActive(this._profile);
+  final UserProfile? _profile;
+  @override
+  UserProfile? build() => _profile;
+}
+
 void main() {
+  group('SelectedSortMode default derived from landing preference', () {
+    test('no profile → distance', () {
+      final container = _containerWithLanding(null);
+      addTearDown(container.dispose);
+      expect(container.read(selectedSortModeProvider), SortMode.distance);
+    });
+
+    test('cheapest landing → price sort', () {
+      final container = _containerWithLanding(LandingScreen.cheapest);
+      addTearDown(container.dispose);
+      expect(container.read(selectedSortModeProvider), SortMode.price);
+    });
+
+    test('nearest landing → distance sort', () {
+      final container = _containerWithLanding(LandingScreen.nearest);
+      addTearDown(container.dispose);
+      expect(container.read(selectedSortModeProvider), SortMode.distance);
+    });
+
+    test('favorites landing → distance sort', () {
+      final container = _containerWithLanding(LandingScreen.favorites);
+      addTearDown(container.dispose);
+      expect(container.read(selectedSortModeProvider), SortMode.distance);
+    });
+
+    test('map landing → distance sort', () {
+      final container = _containerWithLanding(LandingScreen.map);
+      addTearDown(container.dispose);
+      expect(container.read(selectedSortModeProvider), SortMode.distance);
+    });
+
+    test('set() overrides the derived default', () {
+      final container = _containerWithLanding(LandingScreen.cheapest);
+      addTearDown(container.dispose);
+      expect(container.read(selectedSortModeProvider), SortMode.price);
+      container.read(selectedSortModeProvider.notifier).set(SortMode.rating);
+      expect(container.read(selectedSortModeProvider), SortMode.rating);
+    });
+  });
+
   group('FiltersExpanded', () {
     test('defaults to true', () {
       final container = ProviderContainer();


### PR DESCRIPTION
## Summary
Three related UX bugs in the landing screen / profile / bottom nav flow:

- **Sort mode ignored `landingScreen` preference** — `SelectedSortMode` now watches `activeProfileProvider` and derives the default sort (`cheapest` → price, everything else → distance). Manual sort-chip overrides still win.
- **Favoris landing dropped the user on empty Recherche** — the redirect re-fired on every navigation back to `/`, trapping users on their landing tab. It now only applies on the consent → / and setup → / transitions, so tab switching works normally.
- **`LandingScreen.search` was redundant with `nearest`/`cheapest`** — removed from the enum; legacy `search` values in stored profiles are migrated to `nearest` at read time in `ProfileRepository`.

Closes #418

## Test plan
- [x] `flutter analyze` — zero new warnings
- [x] `flutter test` — all impacted tests pass (3315 passed, 1 pre-existing Argentina API network flake)
- [x] New unit tests: `SelectedSortMode` derivation from each `LandingScreen` value; `set()` override
- [x] New unit tests: `resolveLandingLocation()` for every landing value incl. legacy `LandingScreen.*` prefix
- [x] New unit tests: `ProfileRepository` migration of legacy `search` → `nearest` (both `search` and `LandingScreen.search` forms)
- [x] Updated existing tests that relied on `LandingScreen.search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)