### PR TITLE
fix(deps): declare path_provider, meta, and yaml as direct dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1021,7 +1021,7 @@ packages:
     source: hosted
     version: "0.13.0"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
@@ -1141,7 +1141,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -1842,7 +1842,7 @@ packages:
     source: hosted
     version: "6.6.1"
   yaml:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
 
   # Utilities
   collection: ^1.19.0
+  meta: ^1.17.0
+  path_provider: ^2.1.5
   uuid: ^4.5.1
   connectivity_plus: ^7.1.1
   shared_preferences: ^2.5.5
@@ -76,6 +78,7 @@ dev_dependencies:
 
   # Testing
   mocktail: ^1.0.5
+  yaml: ^3.1.3
   flutter_launcher_icons: ^0.14.4
 
 flutter:

--- a/test/core/location/movement_detection_test.dart
+++ b/test/core/location/movement_detection_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:riverpod/riverpod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tankstellen/core/location/geolocator_wrapper.dart';
 import 'package:tankstellen/core/location/movement_detection_provider.dart';
 

--- a/test/features/calculator/providers/calculator_provider_test.dart
+++ b/test/features/calculator/providers/calculator_provider_test.dart
@@ -1,6 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-// ignore: depend_on_referenced_packages
-import 'package:riverpod/riverpod.dart';
 import 'package:tankstellen/features/calculator/data/models/trip_calculation.dart';
 import 'package:tankstellen/features/calculator/providers/calculator_provider.dart';
 

--- a/test/lint/declared_dependencies_test.dart
+++ b/test/lint/declared_dependencies_test.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yaml/yaml.dart';
+
+/// Guards against undeclared package imports.
+///
+/// Background: a transitive dependency can disappear at any \`flutter pub
+/// upgrade\` if the package that pulled it in stops depending on it. Code
+/// that imports such a package then breaks the build (or, worse for code
+/// running in the background isolate, breaks at runtime). This test walks
+/// every \`.dart\` source file under \`lib/\` and \`test/\` and asserts that
+/// every \`import 'package:NAME/...'\` resolves to a package that is
+/// explicitly declared in \`pubspec.yaml\`.
+///
+/// See issue #421 for the original incident (\`path_provider\` and \`meta\`
+/// imported but not declared).
+void main() {
+  /// Packages that ship with Flutter / Dart and don't need to appear in
+  /// pubspec.yaml.
+  const builtins = <String>{
+    'flutter',
+    'flutter_test',
+    'flutter_driver',
+    'flutter_localizations',
+    'flutter_web_plugins',
+    'integration_test',
+    // The current package itself — \`import 'package:tankstellen/...'\`.
+    'tankstellen',
+  };
+
+  late Set<String> declared;
+
+  setUpAll(() {
+    final pubspec =
+        loadYaml(File('pubspec.yaml').readAsStringSync()) as YamlMap;
+    declared = <String>{
+      ..._collectDependencyNames(pubspec['dependencies']),
+      ..._collectDependencyNames(pubspec['dev_dependencies']),
+    };
+  });
+
+  test('every package: import in lib/ is declared in pubspec.yaml', () {
+    final undeclared = _findUndeclaredImports(
+      Directory('lib'),
+      declared: declared,
+      builtins: builtins,
+    );
+    expect(
+      undeclared,
+      isEmpty,
+      reason:
+          'Undeclared imports found in lib/. Add them to pubspec.yaml '
+          '(see issue #421):\n${_formatViolations(undeclared)}',
+    );
+  });
+
+  test('every package: import in test/ is declared in pubspec.yaml', () {
+    final undeclared = _findUndeclaredImports(
+      Directory('test'),
+      declared: declared,
+      builtins: builtins,
+    );
+    expect(
+      undeclared,
+      isEmpty,
+      reason:
+          'Undeclared imports found in test/. Add them to dev_dependencies '
+          '(see issue #421):\n${_formatViolations(undeclared)}',
+    );
+  });
+}
+
+/// Reads dependency names out of a pubspec dependencies map. Skips entries
+/// whose value is a map containing \`sdk:\` (e.g. \`flutter: { sdk: flutter }\`
+/// is still represented by the key \`flutter\`).
+Set<String> _collectDependencyNames(Object? section) {
+  if (section is! YamlMap) return const <String>{};
+  return section.keys.cast<String>().toSet();
+}
+
+/// Returns a map of relative file path → set of undeclared package names.
+Map<String, Set<String>> _findUndeclaredImports(
+  Directory root, {
+  required Set<String> declared,
+  required Set<String> builtins,
+}) {
+  final allowed = <String>{...declared, ...builtins};
+  final violations = <String, Set<String>>{};
+
+  if (!root.existsSync()) return violations;
+
+  final importPattern = RegExp(
+    r'''^\s*import\s+['"]package:([a-zA-Z0-9_]+)/''',
+    multiLine: true,
+  );
+
+  for (final entity in root.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File) continue;
+    final path = entity.path.replaceAll('\\', '/');
+    if (!path.endsWith('.dart')) continue;
+    // Generated files mirror their owner's imports, no need to double-check.
+    if (path.endsWith('.g.dart') || path.endsWith('.freezed.dart')) continue;
+    if (path.endsWith('.config.dart') || path.endsWith('.gen.dart')) continue;
+
+    final source = entity.readAsStringSync();
+    for (final match in importPattern.allMatches(source)) {
+      final pkg = match.group(1)!;
+      if (!allowed.contains(pkg)) {
+        violations.putIfAbsent(path, () => <String>{}).add(pkg);
+      }
+    }
+  }
+
+  return violations;
+}
+
+String _formatViolations(Map<String, Set<String>> violations) {
+  final entries = violations.entries.toList()
+    ..sort((a, b) => a.key.compareTo(b.key));
+  return entries
+      .map((e) => '  ${e.key}: ${(e.value.toList()..sort()).join(", ")}')
+      .join('\n');
+}


### PR DESCRIPTION
## Summary
\`hive_isolate_lock.dart\` and \`nominatim_geocoding_provider.dart\` import \`path_provider\` and \`meta\` directly; \`yaml\` is used by lint tests. None were declared in \`pubspec.yaml\` — a future \`flutter pub upgrade\` could remove them and break the build (or, for \`path_provider\` in the background isolate, only break at runtime).

This PR:
- Declares \`path_provider ^2.1.5\`, \`meta ^1.17.0\`, \`yaml ^3.1.3\` in pubspec.yaml.
- Swaps two test files from the bare \`package:riverpod\` import to the already-declared \`flutter_riverpod\` to keep the dependency surface minimal.
- Adds **\`test/lint/declared_dependencies_test.dart\`**: walks every \`.dart\` file under \`lib/\` and \`test/\`, extracts every \`package:NAME/...\` import, and asserts the package is declared in \`pubspec.yaml\`. This is the regression guard requested in the issue.

Closes #421

## Test plan
- [x] \`flutter pub get\` resolves cleanly
- [x] \`flutter analyze --no-fatal-infos\` — zero new errors/warnings (the previous \`depend_on_referenced_packages\` info on the yaml import is also gone)
- [x] New \`declared_dependencies_test.dart\` passes (catches both the original \`path_provider\`/\`meta\` violations and 2 new \`riverpod\` imports it found)
- [x] Full \`flutter test\` — 3316 pass, 1 pre-existing Argentina API network flake (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)