### PR TITLE
fix(lint): elevate use_build_context_synchronously and unawaited_futures from info to error

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,19 +18,26 @@ analyzer:
     prefer_const_constructors: error
     prefer_const_declarations: info
     prefer_const_literals_to_create_immutables: info
+    # Safety lints elevated to error (issue #422). Each catches a real
+    # class of bug:
+    #   - use_build_context_synchronously → StateError on widget unmount
+    #   - unawaited_futures → fire-and-forget data persistence races
+    #   - cancel_subscriptions → leaked StreamSubscription on dispose
+    #   - close_sinks → leaked StreamController/IOSink on dispose
+    use_build_context_synchronously: error
+    unawaited_futures: error
+    cancel_subscriptions: error
+    close_sinks: error
     # Phase in at info so existing code isn't a wall of red; tighten once clean.
     avoid_print: info
     avoid_slow_async_io: info
     avoid_type_to_string: info
-    cancel_subscriptions: info
-    close_sinks: info
     no_logic_in_create_state: info
     prefer_void_to_null: info
     test_types_in_equals: info
     throw_in_finally: info
     unnecessary_statements: info
     unrelated_type_equality_checks: info
-    use_build_context_synchronously: info
     valid_regexps: info
 
 linter:

--- a/test/core/storage/hive_storage_test.dart
+++ b/test/core/storage/hive_storage_test.dart
@@ -201,7 +201,7 @@ void main() {
     test('getCachedData returns null when maxAge is exceeded', () async {
       // Manually insert an entry with old timestamp
       final box = Hive.box('cache');
-      box.put('old-key', {
+      await box.put('old-key', {
         'data': {'hello': 'world'},
         'timestamp': DateTime.now()
             .subtract(const Duration(hours: 2))
@@ -226,7 +226,7 @@ void main() {
 
     test('getCachedData without maxAge ignores age', () async {
       final box = Hive.box('cache');
-      box.put('ancient-key', {
+      await box.put('ancient-key', {
         'data': {'old': true},
         'timestamp': 0, // epoch start
       });
@@ -239,7 +239,7 @@ void main() {
       // cacheData wraps in {data: ..., timestamp: ...}
       // If someone stored a non-map as 'data', getCachedData should return null
       final box = Hive.box('cache');
-      box.put('string-data', {
+      await box.put('string-data', {
         'data': 'just a string',
         'timestamp': DateTime.now().millisecondsSinceEpoch,
       });

--- a/test/lint/analysis_options_severity_test.dart
+++ b/test/lint/analysis_options_severity_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yaml/yaml.dart';
+
+/// Pins the severity of the safety lints elevated in issue #422.
+///
+/// If anyone downgrades these back to `info` (or removes them) the test
+/// fails before the change can land. This is the "wall of info messages"
+/// guard called for in the audit.
+void main() {
+  late YamlMap analysisOptions;
+
+  setUpAll(() {
+    final file = File('analysis_options.yaml');
+    expect(file.existsSync(), isTrue,
+        reason: 'analysis_options.yaml must exist at project root');
+    analysisOptions = loadYaml(file.readAsStringSync()) as YamlMap;
+  });
+
+  group('safety lints are enforced at error severity', () {
+    /// Lints that must be `error` so the analyzer hard-fails on them.
+    const requiredErrorSeverity = {
+      'use_build_context_synchronously',
+      'unawaited_futures',
+      'cancel_subscriptions',
+      'close_sinks',
+      'prefer_const_constructors',
+    };
+
+    for (final lint in requiredErrorSeverity) {
+      test('$lint is set to error', () {
+        final analyzer = analysisOptions['analyzer'] as YamlMap;
+        final errors = analyzer['errors'] as YamlMap;
+        expect(
+          errors[lint],
+          equals('error'),
+          reason:
+              '$lint must stay at error severity (issue #422). Downgrading '
+              'this lint reintroduces an entire class of bugs the audit '
+              'flagged: data races, unmount crashes, leaked subscriptions.',
+        );
+      });
+    }
+
+    test('linter section still lists every safety lint', () {
+      final linter = analysisOptions['linter'] as YamlMap;
+      final rules = linter['rules'] as YamlList;
+      const expected = {
+        'use_build_context_synchronously',
+        'unawaited_futures',
+        'cancel_subscriptions',
+        'close_sinks',
+      };
+      for (final lint in expected) {
+        expect(
+          rules,
+          contains(lint),
+          reason: '$lint must be enabled in the linter rules list',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Following the resolution of #423 (lib/) and three trailing test fixes here, promotes four safety lints to \`error\` severity:

- \`use_build_context_synchronously\`
- \`unawaited_futures\`
- \`cancel_subscriptions\`
- \`close_sinks\`

Each catches a real class of bug: data races, unmount crashes, leaked StreamSubscription/Sink on dispose. Keeping them at info hid new violations in the wall of 159 messages from the audit.

Also fixes 3 trailing \`unawaited_futures\` violations in \`test/core/storage/hive_storage_test.dart\` — each \`box.put(...)\` that should have been awaited.

Closes #422

## Test plan
- [x] \`flutter analyze --no-fatal-infos\` — zero errors and zero \`unawaited_futures\`/\`use_build_context_synchronously\` reports anywhere
- [x] **New regression test** in \`test/lint/analysis_options_severity_test.dart\` — parses \`analysis_options.yaml\` and asserts every safety lint is present in \`analyzer.errors\` with severity \`error\`. Any future downgrade fails the test.
- [x] CI's existing \`flutter analyze\` step will hard-fail on any new violation now that the lints are elevated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)