### PR TITLE
refactor(sync): extract 2 sections from sync_setup_screen build

### DIFF
--- a/lib/features/sync/presentation/screens/sync_setup_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_setup_screen.dart
@@ -11,7 +11,8 @@ import '../widgets/qr_scanner_screen.dart';
 import '../widgets/sync_credentials_step.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../widgets/sync_mode_card.dart';
+import '../widgets/sync_done_step.dart';
+import '../widgets/sync_mode_step.dart';
 
 /// Clean 3-step sync setup: Mode -> Credentials (if needed) -> Auth -> Done.
 ///
@@ -156,7 +157,12 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
       key: ValueKey(setup.step),
       padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPad),
       children: switch (setup.step) {
-        SyncSetupStep.mode => _buildModeStep(),
+        SyncSetupStep.mode => [
+            SyncModeStep(
+              onSelectMode: ctrl.selectMode,
+              onStayOffline: () => Navigator.pop(context),
+            ),
+          ],
         SyncSetupStep.credentials => [
             ListenableBuilder(
               listenable: Listenable.merge([_urlController, _keyController]),
@@ -186,117 +192,8 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
               error: setup.error,
             ),
           ],
-        SyncSetupStep.done => _buildDoneStep(),
+        SyncSetupStep.done => const [SyncDoneStep()],
       },
     );
-  }
-
-  List<Widget> _buildModeStep() {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-    final ctrl = ref.read(syncSetupControllerProvider.notifier);
-    return [
-      Semantics(
-        header: true,
-        child: Text(
-          l10n?.syncHowToSyncQuestion ?? 'How would you like to sync?',
-          style: theme.textTheme.titleMedium,
-        ),
-      ),
-      const SizedBox(height: 4),
-      Text(
-        l10n?.syncOfflineDescription ??
-            'Your app works fully offline. Cloud sync is optional.',
-        style: theme.textTheme.bodySmall
-            ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-      ),
-      const SizedBox(height: 20),
-
-      Semantics(
-        label: 'Tankstellen Community, shared. Share favorites and ratings with all users.',
-        button: true,
-        child: SyncModeCard(
-          icon: Icons.public,
-          title: l10n?.syncModeCommunityTitle ?? 'Tankstellen Community',
-          subtitle: l10n?.syncModeCommunitySubtitle ??
-              'Share favorites & ratings with all users',
-          privacyLabel: l10n?.syncPrivacyShared ?? 'Shared',
-          privacyColor: Colors.green,
-          onTap: () => ctrl.selectMode(SyncMode.community),
-        ),
-      ),
-      const SizedBox(height: 10),
-
-      Semantics(
-        label: 'Private Database, private. Your own Supabase, full data control.',
-        button: true,
-        child: SyncModeCard(
-          icon: Icons.lock_outline,
-          title: l10n?.syncModePrivateTitle ?? 'Private Database',
-          subtitle: l10n?.syncModePrivateSubtitle ??
-              'Your own Supabase — full data control',
-          privacyLabel: l10n?.syncPrivacyPrivate ?? 'Private',
-          privacyColor: Colors.blue,
-          onTap: () => ctrl.selectMode(SyncMode.private),
-        ),
-      ),
-      const SizedBox(height: 10),
-
-      Semantics(
-        label: 'Join a Group, group access. Family or friends shared database.',
-        button: true,
-        child: SyncModeCard(
-          icon: Icons.group_outlined,
-          title: l10n?.syncModeGroupTitle ?? 'Join a Group',
-          subtitle:
-              l10n?.syncModeGroupSubtitle ?? 'Family or friends shared database',
-          privacyLabel: l10n?.syncPrivacyGroup ?? 'Group',
-          privacyColor: Colors.orange,
-          onTap: () => ctrl.selectMode(SyncMode.joinExisting),
-        ),
-      ),
-
-      const SizedBox(height: 24),
-      Center(
-        child: TextButton.icon(
-          onPressed: () => Navigator.pop(context),
-          icon: const Icon(Icons.signal_wifi_off, size: 16),
-          label: Text(l10n?.syncStayOfflineButton ?? 'Stay offline'),
-        ),
-      ),
-    ];
-  }
-
-  List<Widget> _buildDoneStep() {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-    return [
-      const SizedBox(height: 40),
-      Semantics(
-        label: 'Successfully connected. Your data will now sync automatically.',
-        liveRegion: true,
-        child: Column(
-          children: [
-            const ExcludeSemantics(
-              child: Icon(Icons.check_circle, size: 64, color: Colors.green),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              l10n?.syncSuccessTitle ?? 'Successfully connected!',
-              style: theme.textTheme.titleLarge,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              l10n?.syncSuccessDescription ??
-                  'Your data will now sync automatically.',
-              style: theme.textTheme.bodyMedium
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
-      ),
-    ];
   }
 }

--- a/lib/features/sync/presentation/widgets/sync_done_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_done_step.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Final step of the TankSync setup wizard — confirms a successful
+/// connection. The parent screen pops the route after a short delay.
+class SyncDoneStep extends StatelessWidget {
+  const SyncDoneStep({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      children: [
+        const SizedBox(height: 40),
+        Semantics(
+          label:
+              'Successfully connected. Your data will now sync automatically.',
+          liveRegion: true,
+          child: Column(
+            children: [
+              const ExcludeSemantics(
+                child: Icon(Icons.check_circle, size: 64, color: Colors.green),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                l10n?.syncSuccessTitle ?? 'Successfully connected!',
+                style: theme.textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                l10n?.syncSuccessDescription ??
+                    'Your data will now sync automatically.',
+                style: theme.textTheme.bodyMedium
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/sync/presentation/widgets/sync_mode_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_mode_step.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/sync/sync_config.dart';
+import '../../../../l10n/app_localizations.dart';
+import 'sync_mode_card.dart';
+
+/// First step of the TankSync setup wizard — lets the user pick between the
+/// public Tankstellen Community database, a private Supabase instance, or
+/// joining an existing group/family database.
+///
+/// Behaviour-only widget: stateless, all decisions delegated to callbacks.
+class SyncModeStep extends StatelessWidget {
+  final ValueChanged<SyncMode> onSelectMode;
+  final VoidCallback onStayOffline;
+
+  const SyncModeStep({
+    super.key,
+    required this.onSelectMode,
+    required this.onStayOffline,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Semantics(
+          header: true,
+          child: Text(
+            l10n?.syncHowToSyncQuestion ?? 'How would you like to sync?',
+            style: theme.textTheme.titleMedium,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          l10n?.syncOfflineDescription ??
+              'Your app works fully offline. Cloud sync is optional.',
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        ),
+        const SizedBox(height: 20),
+        Semantics(
+          label:
+              'Tankstellen Community, shared. Share favorites and ratings with all users.',
+          button: true,
+          child: SyncModeCard(
+            icon: Icons.public,
+            title: l10n?.syncModeCommunityTitle ?? 'Tankstellen Community',
+            subtitle: l10n?.syncModeCommunitySubtitle ??
+                'Share favorites & ratings with all users',
+            privacyLabel: l10n?.syncPrivacyShared ?? 'Shared',
+            privacyColor: Colors.green,
+            onTap: () => onSelectMode(SyncMode.community),
+          ),
+        ),
+        const SizedBox(height: 10),
+        Semantics(
+          label:
+              'Private Database, private. Your own Supabase, full data control.',
+          button: true,
+          child: SyncModeCard(
+            icon: Icons.lock_outline,
+            title: l10n?.syncModePrivateTitle ?? 'Private Database',
+            subtitle: l10n?.syncModePrivateSubtitle ??
+                'Your own Supabase — full data control',
+            privacyLabel: l10n?.syncPrivacyPrivate ?? 'Private',
+            privacyColor: Colors.blue,
+            onTap: () => onSelectMode(SyncMode.private),
+          ),
+        ),
+        const SizedBox(height: 10),
+        Semantics(
+          label:
+              'Join a Group, group access. Family or friends shared database.',
+          button: true,
+          child: SyncModeCard(
+            icon: Icons.group_outlined,
+            title: l10n?.syncModeGroupTitle ?? 'Join a Group',
+            subtitle: l10n?.syncModeGroupSubtitle ??
+                'Family or friends shared database',
+            privacyLabel: l10n?.syncPrivacyGroup ?? 'Group',
+            privacyColor: Colors.orange,
+            onTap: () => onSelectMode(SyncMode.joinExisting),
+          ),
+        ),
+        const SizedBox(height: 24),
+        Center(
+          child: TextButton.icon(
+            onPressed: onStayOffline,
+            icon: const Icon(Icons.signal_wifi_off, size: 16),
+            label: Text(l10n?.syncStayOfflineButton ?? 'Stay offline'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/sync/presentation/widgets/sync_mode_step_test.dart
+++ b/test/features/sync/presentation/widgets/sync_mode_step_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/sync_config.dart';
+import 'package:tankstellen/features/sync/presentation/widgets/sync_mode_step.dart';
+
+void main() {
+  group('SyncModeStep', () {
+    Future<void> pumpStep(
+      WidgetTester tester, {
+      required ValueChanged<SyncMode> onSelectMode,
+      required VoidCallback onStayOffline,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SyncModeStep(
+              onSelectMode: onSelectMode,
+              onStayOffline: onStayOffline,
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders three sync mode cards + stay-offline button',
+        (tester) async {
+      await pumpStep(
+        tester,
+        onSelectMode: (_) {},
+        onStayOffline: () {},
+      );
+
+      expect(find.text('Tankstellen Community'), findsOneWidget);
+      expect(find.text('Private Database'), findsOneWidget);
+      expect(find.text('Join a Group'), findsOneWidget);
+      expect(find.text('Stay offline'), findsOneWidget);
+    });
+
+    testWidgets('tapping community card invokes onSelectMode(community)',
+        (tester) async {
+      SyncMode? captured;
+      await pumpStep(
+        tester,
+        onSelectMode: (mode) => captured = mode,
+        onStayOffline: () {},
+      );
+
+      await tester.tap(find.text('Tankstellen Community'));
+      await tester.pump();
+
+      expect(captured, SyncMode.community);
+    });
+
+    testWidgets('tapping private card invokes onSelectMode(private)',
+        (tester) async {
+      SyncMode? captured;
+      await pumpStep(
+        tester,
+        onSelectMode: (mode) => captured = mode,
+        onStayOffline: () {},
+      );
+
+      await tester.tap(find.text('Private Database'));
+      await tester.pump();
+
+      expect(captured, SyncMode.private);
+    });
+
+    testWidgets('tapping join card invokes onSelectMode(joinExisting)',
+        (tester) async {
+      SyncMode? captured;
+      await pumpStep(
+        tester,
+        onSelectMode: (mode) => captured = mode,
+        onStayOffline: () {},
+      );
+
+      await tester.tap(find.text('Join a Group'));
+      await tester.pump();
+
+      expect(captured, SyncMode.joinExisting);
+    });
+
+    testWidgets('tapping stay-offline invokes onStayOffline', (tester) async {
+      var called = false;
+      await pumpStep(
+        tester,
+        onSelectMode: (_) {},
+        onStayOffline: () => called = true,
+      );
+
+      await tester.tap(find.text('Stay offline'));
+      await tester.pump();
+
+      expect(called, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The 302-line \`SyncSetupScreen\` had two inline \`_buildModeStep\` and \`_buildDoneStep\` methods that returned dozens of widgets. Pulls them out into stateless \`SyncModeStep\` and \`SyncDoneStep\` widgets following the pattern from #414 → #420.

The screen now renders the Mode step as \`SyncModeStep(onSelectMode: ctrl.selectMode, onStayOffline: () => Navigator.pop(context))\` — much easier to follow and unit-test in isolation.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] Existing \`sync_setup_screen_test.dart\` and \`sync_mode_test.dart\` still pass (behaviour preserved)
- [x] **New widget test** \`sync_mode_step_test.dart\` covers all 4 callbacks: community/private/joinExisting select + stay-offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)