### PR TITLE
refactor(background): extract Tankerkoenig batch price fetcher

### DIFF
--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -8,6 +8,7 @@ import '../../features/search/domain/entities/fuel_type.dart';
 import '../../features/widget/data/home_widget_service.dart';
 import '../constants/field_names.dart';
 import '../notifications/local_notification_service.dart';
+import '../services/impl/tankerkoenig_batch_price_fetcher.dart';
 import '../storage/hive_storage.dart';
 import '../utils/json_extensions.dart';
 import 'background_price_fetcher_provider.dart';
@@ -142,49 +143,27 @@ Future<void> _refreshPricesAndCheckAlerts() async {
 
     if (allStationIds.isEmpty) return;
 
-    // 2. Fetch prices for all stations via Tankerkoenig batch endpoint
+    // 2. Fetch prices for all stations via the shared Tankerkoenig batch
+    //    fetcher. The fetcher handles chunking + parsing + retry — see
+    //    TankerkoenigBatchPriceFetcher.
     final now = DateTime.now();
-    final prices = <String, Map<String, dynamic>>{};
-    if (apiKey != null && apiKey.isNotEmpty) {
-      final dio = Dio(BaseOptions(
-        connectTimeout: BackgroundService.bgConnectTimeout,
-        receiveTimeout: BackgroundService.bgReceiveTimeout,
-      ));
-
-      // Tankerkoenig prices endpoint (batch) with retry
-      const batchSize = BackgroundService.tankerkoenigBatchSize;
-      for (var i = 0; i < allStationIds.length; i += batchSize) {
-        final batch = allStationIds.sublist(
-          i,
-          i + batchSize > allStationIds.length ? allStationIds.length : i + batchSize,
-        );
-        final ids = batch.join(',');
-
-        final data = await fetchWithRetry(
-          dio: dio,
-          url: 'https://creativecommons.tankerkoenig.de/json/prices.php',
-          queryParameters: {'ids': ids, 'apikey': apiKey},
-          config: const BackgroundRetryConfig(
-            maxAttempts: BackgroundService.maxRetryAttempts,
-            baseDelay: BackgroundService.retryBaseDelay,
-          ),
-        );
-        if (data != null && data[TankerkoenigFields.ok] == true && data[TankerkoenigFields.prices] != null) {
-          final rawPrices = data.getMap(TankerkoenigFields.prices);
-          if (rawPrices != null) {
-            for (final entry in rawPrices.entries) {
-              final value = entry.value;
-              if (value is Map<String, dynamic>) {
-                prices[entry.key] = value;
-              } else if (value is Map) {
-                prices[entry.key] = Map<String, dynamic>.from(value);
-              }
-            }
-          }
-        }
-      }
-      debugPrint('BackgroundService: fetched prices for ${prices.length} stations');
-    }
+    final dio = Dio(BaseOptions(
+      connectTimeout: BackgroundService.bgConnectTimeout,
+      receiveTimeout: BackgroundService.bgReceiveTimeout,
+    ));
+    final fetcher = TankerkoenigBatchPriceFetcher(
+      dio: dio,
+      batchSize: BackgroundService.tankerkoenigBatchSize,
+      retryConfig: const BackgroundRetryConfig(
+        maxAttempts: BackgroundService.maxRetryAttempts,
+        baseDelay: BackgroundService.retryBaseDelay,
+      ),
+    );
+    final prices = await fetcher.fetchBatch(
+      ids: allStationIds,
+      apiKey: apiKey,
+    );
+    debugPrint('BackgroundService: fetched prices for ${prices.length} stations');
 
     // 3. Record price history for each station
     if (prices.isNotEmpty) {

--- a/lib/core/services/impl/tankerkoenig_batch_price_fetcher.dart
+++ b/lib/core/services/impl/tankerkoenig_batch_price_fetcher.dart
@@ -1,0 +1,95 @@
+import 'package:dio/dio.dart';
+
+import '../../background/background_retry.dart';
+import '../../constants/field_names.dart';
+import '../../utils/json_extensions.dart';
+
+/// Fetches Tankerkoenig prices for an arbitrary number of station IDs by
+/// chunking the request into batches that respect the API's per-call ID
+/// limit, and returns a flat `id → priceMap` lookup for the caller to do
+/// whatever it wants with (price-history recording, alert evaluation,
+/// cache update — see [BackgroundService]).
+///
+/// Pulled out of `background_service.dart` for issue #426 so the batching
+/// + parsing + retry logic lives in exactly one place. The class is pure
+/// Dart with no Riverpod dependency, so it works the same way in the
+/// main isolate (with a Ref-provided Dio) and in the WorkManager
+/// background isolate (with a freshly-constructed Dio).
+class TankerkoenigBatchPriceFetcher {
+  TankerkoenigBatchPriceFetcher({
+    required Dio dio,
+    this.batchSize = 10,
+    this.url = 'https://creativecommons.tankerkoenig.de/json/prices.php',
+    this.retryConfig = const BackgroundRetryConfig(
+      maxAttempts: 3,
+      baseDelay: Duration(seconds: 2),
+    ),
+  }) : _dio = dio;
+
+  final Dio _dio;
+
+  /// Maximum number of station IDs sent in a single request. Tankerkoenig's
+  /// docs cap this at 10.
+  final int batchSize;
+
+  /// API endpoint. Constructor-overridable so tests can point at a fake.
+  final String url;
+
+  /// Backoff policy passed to [fetchWithRetry] for transient errors.
+  final BackgroundRetryConfig retryConfig;
+
+  /// Fetches prices for [ids] in batches of [batchSize] and merges the
+  /// results into a single map keyed by station ID. Returns an empty map
+  /// when [ids] is empty or when [apiKey] is null/empty.
+  ///
+  /// Failed batches are silently dropped so a partial result is still
+  /// useful (e.g. one batch of 10 fails but the other 20 stations still
+  /// get fresh prices). Per-batch errors are retried via
+  /// [BackgroundRetryConfig] before being given up on.
+  Future<Map<String, Map<String, dynamic>>> fetchBatch({
+    required List<String> ids,
+    required String? apiKey,
+  }) async {
+    if (ids.isEmpty || apiKey == null || apiKey.isEmpty) {
+      return const <String, Map<String, dynamic>>{};
+    }
+
+    final result = <String, Map<String, dynamic>>{};
+
+    for (var i = 0; i < ids.length; i += batchSize) {
+      final batch = ids.sublist(
+        i,
+        i + batchSize > ids.length ? ids.length : i + batchSize,
+      );
+      final joined = batch.join(',');
+
+      final data = await fetchWithRetry(
+        dio: _dio,
+        url: url,
+        queryParameters: {'ids': joined, 'apikey': apiKey},
+        config: retryConfig,
+      );
+      _mergeBatch(data, into: result);
+    }
+    return result;
+  }
+
+  void _mergeBatch(
+    Map<String, dynamic>? data, {
+    required Map<String, Map<String, dynamic>> into,
+  }) {
+    if (data == null) return;
+    if (data[TankerkoenigFields.ok] != true) return;
+    if (data[TankerkoenigFields.prices] == null) return;
+    final raw = data.getMap(TankerkoenigFields.prices);
+    if (raw == null) return;
+    for (final entry in raw.entries) {
+      final value = entry.value;
+      if (value is Map<String, dynamic>) {
+        into[entry.key] = value;
+      } else if (value is Map) {
+        into[entry.key] = Map<String, dynamic>.from(value);
+      }
+    }
+  }
+}

--- a/test/core/services/impl/tankerkoenig_batch_price_fetcher_test.dart
+++ b/test/core/services/impl/tankerkoenig_batch_price_fetcher_test.dart
@@ -1,0 +1,185 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/background_retry.dart';
+import 'package:tankstellen/core/services/impl/tankerkoenig_batch_price_fetcher.dart';
+
+/// Records each request the adapter receives and replies with the next
+/// queued response. Lets the test drive batch-handling without going to
+/// the real Tankerkoenig API.
+class _RecordingAdapter implements HttpClientAdapter {
+  final List<RequestOptions> requests = [];
+  final List<ResponseBody> responses;
+
+  _RecordingAdapter(this.responses);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    if (responses.isEmpty) {
+      throw StateError('no more queued responses');
+    }
+    return responses.removeAt(0);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _jsonResponse(String body) {
+  return ResponseBody.fromString(
+    body,
+    200,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+Dio _dioWith(List<ResponseBody> responses) {
+  final dio = Dio();
+  dio.httpClientAdapter = _RecordingAdapter(responses);
+  return dio;
+}
+
+void main() {
+  group('TankerkoenigBatchPriceFetcher.fetchBatch', () {
+    test('returns empty map when ids list is empty', () async {
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: _dioWith([]));
+      final result =
+          await fetcher.fetchBatch(ids: const [], apiKey: 'key');
+      expect(result, isEmpty);
+    });
+
+    test('returns empty map when apiKey is null', () async {
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: _dioWith([]));
+      final result =
+          await fetcher.fetchBatch(ids: const ['a'], apiKey: null);
+      expect(result, isEmpty);
+    });
+
+    test('returns empty map when apiKey is empty string', () async {
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: _dioWith([]));
+      final result = await fetcher.fetchBatch(ids: const ['a'], apiKey: '');
+      expect(result, isEmpty);
+    });
+
+    test('parses a single batch into the id → price map', () async {
+      final dio = _dioWith([
+        _jsonResponse('{"ok":true,"prices":{'
+            '"abc":{"e5":1.799,"e10":1.749,"diesel":1.659,"status":"open"},'
+            '"def":{"e5":1.819,"e10":1.769,"diesel":1.679,"status":"open"}'
+            '}}'),
+      ]);
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: dio);
+
+      final result = await fetcher.fetchBatch(
+        ids: const ['abc', 'def'],
+        apiKey: 'key',
+      );
+
+      expect(result.keys, unorderedEquals(['abc', 'def']));
+      expect(result['abc']!['e5'], 1.799);
+      expect(result['def']!['diesel'], 1.679);
+    });
+
+    test('chunks 25 ids into 3 requests at the default batchSize of 10',
+        () async {
+      // 3 success responses, one per batch.
+      final dio = _dioWith([
+        _jsonResponse('{"ok":true,"prices":{}}'),
+        _jsonResponse('{"ok":true,"prices":{}}'),
+        _jsonResponse('{"ok":true,"prices":{}}'),
+      ]);
+      final adapter = dio.httpClientAdapter as _RecordingAdapter;
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: dio);
+
+      final ids = List.generate(25, (i) => 'station-$i');
+      await fetcher.fetchBatch(ids: ids, apiKey: 'key');
+
+      expect(adapter.requests, hasLength(3));
+      // 10, 10, 5
+      expect(
+        adapter.requests[0].queryParameters['ids'].toString().split(',').length,
+        10,
+      );
+      expect(
+        adapter.requests[1].queryParameters['ids'].toString().split(',').length,
+        10,
+      );
+      expect(
+        adapter.requests[2].queryParameters['ids'].toString().split(',').length,
+        5,
+      );
+    });
+
+    test('honours a custom batchSize', () async {
+      final dio = _dioWith([
+        _jsonResponse('{"ok":true,"prices":{}}'),
+        _jsonResponse('{"ok":true,"prices":{}}'),
+        _jsonResponse('{"ok":true,"prices":{}}'),
+        _jsonResponse('{"ok":true,"prices":{}}'),
+      ]);
+      final adapter = dio.httpClientAdapter as _RecordingAdapter;
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: dio, batchSize: 2);
+
+      final ids = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+      await fetcher.fetchBatch(ids: ids, apiKey: 'key');
+
+      // 7 ids with batchSize 2 → 4 requests (2,2,2,1)
+      expect(adapter.requests, hasLength(4));
+    });
+
+    test('drops a batch whose response has ok:false', () async {
+      final dio = _dioWith([
+        _jsonResponse('{"ok":false,"message":"rate limited"}'),
+        _jsonResponse('{"ok":true,"prices":{"x":{"e5":1.5,"status":"open"}}}'),
+      ]);
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: dio, batchSize: 1);
+
+      final result =
+          await fetcher.fetchBatch(ids: const ['bad', 'x'], apiKey: 'key');
+
+      expect(result.keys, ['x']);
+      expect(result['x']!['e5'], 1.5);
+    });
+
+    test('passes the api key as a query parameter', () async {
+      final dio = _dioWith([_jsonResponse('{"ok":true,"prices":{}}')]);
+      final adapter = dio.httpClientAdapter as _RecordingAdapter;
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: dio);
+
+      await fetcher.fetchBatch(ids: const ['a'], apiKey: 'super-secret');
+
+      expect(adapter.requests.single.queryParameters['apikey'], 'super-secret');
+    });
+
+    test('a partial-failure result still merges good batches', () async {
+      // First batch succeeds, second fails after the configured retry budget.
+      final dio = _dioWith([
+        _jsonResponse('{"ok":true,"prices":{"a":{"e5":1.5,"status":"open"}}}'),
+        _jsonResponse('{"ok":false,"message":"oops"}'),
+        _jsonResponse('{"ok":false,"message":"oops"}'),
+        _jsonResponse('{"ok":false,"message":"oops"}'),
+      ]);
+      final fetcher = TankerkoenigBatchPriceFetcher(
+        dio: dio,
+        batchSize: 1,
+        retryConfig: const BackgroundRetryConfig(
+          maxAttempts: 1,
+          baseDelay: Duration.zero,
+        ),
+      );
+
+      final result = await fetcher.fetchBatch(
+        ids: const ['a', 'b'],
+        apiKey: 'key',
+      );
+
+      expect(result.keys, ['a']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The background isolate had inline batching + parsing + retry logic for the Tankerkoenig prices endpoint with no unit coverage. Pulls it into a standalone \`TankerkoenigBatchPriceFetcher\` that takes a Dio in its constructor — the BG isolate constructs its own Dio (no Riverpod in the isolate) while the main isolate could later use the same class via a Ref-provided Dio.

The fetcher handles:
- Chunking N station IDs into batches of \`batchSize\` (default 10, matching Tankerkoenig's per-call cap)
- Per-batch retry via the existing \`BackgroundRetryConfig\` backoff
- Parsing the \`ok\`/\`prices\` envelope and merging successful batches
- Silently dropping failed batches so partial results still land

\`background_service.dart\` goes from **314 → 293 lines**; the inline 42-line batch loop becomes a single \`fetcher.fetchBatch()\` call.

Refs #426

## Test plan
- [x] \`flutter analyze\` clean
- [x] **9 new regression tests** in \`tankerkoenig_batch_price_fetcher_test.dart\` using a recording \`HttpClientAdapter\` (no real HTTP):
  1. Empty ids list → empty result
  2. Null apiKey → empty result
  3. Empty apiKey → empty result
  4. Single batch parses the id → priceMap lookup
  5. 25 ids with default batchSize 10 → exactly 3 requests (10/10/5)
  6. Custom batchSize 2 → 4 requests for 7 ids (2/2/2/1)
  7. Batch with \`ok:false\` is dropped, other batches still merged
  8. apiKey forwarded as a query parameter
  9. Partial failure: first batch succeeds, second fails after retries → first batch still in result
- [x] All 81 existing background tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)