### PR TITLE
refactor(services): integrate Tankerkoenig into CountryServiceRegistry — remove Germany special case

### DIFF
--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -3,6 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../cache/cache_manager.dart';
 import '../country/country_config.dart';
+import '../storage/storage_providers.dart';
 import 'impl/argentina_station_service.dart';
 import 'impl/australia_station_service.dart';
 import 'impl/demo_station_service.dart';
@@ -14,7 +15,9 @@ import 'impl/miteco_station_service.dart';
 import 'impl/osm_brand_enricher.dart';
 import 'impl/portugal_station_service.dart';
 import 'impl/prix_carburants_station_service.dart';
+import 'impl/tankerkoenig_station_service.dart';
 import 'impl/uk_station_service.dart';
+import 'service_providers.dart';
 import 'service_result.dart';
 import 'station_service.dart';
 import 'station_service_chain.dart';
@@ -198,12 +201,20 @@ class CountryServiceRegistry {
 // These are top-level functions (not closures) so they can be used in
 // const CountryServiceEntry constructors.
 
+/// Germany factory. Reads the API-key state from storage and either:
+///  - returns [DemoStationService] when no key is present (so the user sees
+///    realistic-looking data without configuring anything), or
+///  - constructs the real [TankerkoenigStationService] backed by the
+///    rate-limited Dio from [tankerkoenigDioProvider].
+///
+/// This used to live in `service_providers.dart` as a Germany special case;
+/// pulling it into the registry restores the "single source of truth"
+/// invariant the registry promises.
 StationService _createTankerkoenig(Ref ref) {
-  // Dio is injected via the tankerkoenigDioProvider in service_providers.dart.
-  // This factory is only called when an API key is present.
-  throw UnsupportedError(
-    'DE uses tankerkoenigDioProvider — use buildServiceForGermany() instead',
-  );
+  final storage = ref.read(storageRepositoryProvider);
+  if (!storage.hasApiKey()) return DemoStationService(countryCode: 'DE');
+  final dio = ref.read(tankerkoenigDioProvider);
+  return TankerkoenigStationService(dio);
 }
 
 StationService _createPrixCarburants(Ref ref) {

--- a/lib/core/services/service_providers.dart
+++ b/lib/core/services/service_providers.dart
@@ -7,14 +7,10 @@ import '../storage/storage_providers.dart';
 import 'country_service_registry.dart';
 import 'dio_factory.dart';
 import 'geocoding_chain.dart';
-import 'impl/demo_station_service.dart';
 import 'impl/native_geocoding_provider.dart';
 import 'impl/nominatim_geocoding_provider.dart';
-import 'impl/tankerkoenig_station_service.dart';
 import 'service_config.dart';
-import 'service_result.dart';
 import 'station_service.dart';
-import 'station_service_chain.dart';
 
 part 'service_providers.g.dart';
 
@@ -49,12 +45,12 @@ Dio tankerkoenigDio(Ref ref) {
 // Station service with full fallback chain
 // ---------------------------------------------------------------------------
 
-/// Returns the appropriate station service based on the active country
-/// and whether an API key is configured.
+/// Returns the appropriate station service based on the active country.
 ///
-/// Uses [CountryServiceRegistry] to look up the correct service factory.
-/// Countries that require an API key (e.g. DE) fall back to demo data
-/// when no key is configured.
+/// Delegates to [CountryServiceRegistry], which is the single source of
+/// truth for per-country service wiring — including Germany. Countries
+/// that require an API key fall back to [DemoStationService] from inside
+/// the registry's factory function when no key is configured.
 @riverpod
 StationService stationService(Ref ref) {
   final country = ref.watch(activeCountryProvider);
@@ -67,28 +63,8 @@ StationService stationService(Ref ref) {
 StationService stationServiceForCountry(Ref ref, String countryCode) =>
     _resolveServiceForCountry(ref, countryCode);
 
-/// Shared resolution logic used by both [stationService] and
-/// [stationServiceForCountry].
-///
-/// Germany is special-cased because its Dio instance requires the API key
-/// interceptor from [tankerkoenigDioProvider]. All other countries use
-/// [CountryServiceRegistry.buildService] directly.
 StationService _resolveServiceForCountry(Ref ref, String countryCode) {
   final cache = ref.read(cacheManagerProvider);
-
-  // Germany needs special handling: API key check + dedicated Dio instance
-  if (countryCode == 'DE') {
-    final storage = ref.read(storageRepositoryProvider);
-    if (!storage.hasApiKey()) return DemoStationService(countryCode: 'DE');
-    final dio = ref.read(tankerkoenigDioProvider);
-    return StationServiceChain(
-      TankerkoenigStationService(dio),
-      cache,
-      errorSource: ServiceSource.tankerkoenigApi,
-      countryCode: 'DE',
-    );
-  }
-
   return CountryServiceRegistry.buildService(countryCode, ref, cache);
 }
 

--- a/lib/core/services/service_providers.g.dart
+++ b/lib/core/services/service_providers.g.dart
@@ -47,34 +47,34 @@ final class TankerkoenigDioProvider extends $FunctionalProvider<Dio, Dio, Dio>
   }
 }
 
-String _$tankerkoenigDioHash() => r'5ade6219b0e5455fcda1bd7d05904c5eb75a770a';
+String _$tankerkoenigDioHash() => r'bf30524d1ff9225e6dd29e0a4b92c6cac725a4e3';
 
-/// Returns the appropriate station service based on the active country
-/// and whether an API key is configured.
+/// Returns the appropriate station service based on the active country.
 ///
-/// Uses [CountryServiceRegistry] to look up the correct service factory.
-/// Countries that require an API key (e.g. DE) fall back to demo data
-/// when no key is configured.
+/// Delegates to [CountryServiceRegistry], which is the single source of
+/// truth for per-country service wiring — including Germany. Countries
+/// that require an API key fall back to [DemoStationService] from inside
+/// the registry's factory function when no key is configured.
 
 @ProviderFor(stationService)
 final stationServiceProvider = StationServiceProvider._();
 
-/// Returns the appropriate station service based on the active country
-/// and whether an API key is configured.
+/// Returns the appropriate station service based on the active country.
 ///
-/// Uses [CountryServiceRegistry] to look up the correct service factory.
-/// Countries that require an API key (e.g. DE) fall back to demo data
-/// when no key is configured.
+/// Delegates to [CountryServiceRegistry], which is the single source of
+/// truth for per-country service wiring — including Germany. Countries
+/// that require an API key fall back to [DemoStationService] from inside
+/// the registry's factory function when no key is configured.
 
 final class StationServiceProvider
     extends $FunctionalProvider<StationService, StationService, StationService>
     with $Provider<StationService> {
-  /// Returns the appropriate station service based on the active country
-  /// and whether an API key is configured.
+  /// Returns the appropriate station service based on the active country.
   ///
-  /// Uses [CountryServiceRegistry] to look up the correct service factory.
-  /// Countries that require an API key (e.g. DE) fall back to demo data
-  /// when no key is configured.
+  /// Delegates to [CountryServiceRegistry], which is the single source of
+  /// truth for per-country service wiring — including Germany. Countries
+  /// that require an API key fall back to [DemoStationService] from inside
+  /// the registry's factory function when no key is configured.
   StationServiceProvider._()
     : super(
         from: null,

--- a/lib/features/favorites/providers/favorites_provider.g.dart
+++ b/lib/features/favorites/providers/favorites_provider.g.dart
@@ -68,7 +68,7 @@ final class FavoritesProvider
   }
 }
 
-String _$favoritesHash() => r'6a2dd0d2a07ddc58f4c91e23a406722861c833e8';
+String _$favoritesHash() => r'1472d9efc6c5f230389b5f23f77f05d1fcef51d2';
 
 /// Manages the user's list of favorite station IDs.
 ///

--- a/test/core/services/germany_no_special_case_test.dart
+++ b/test/core/services/germany_no_special_case_test.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression tests for issue #425 — Germany used to be special-cased in
+/// `service_providers.dart` (`if (countryCode == 'DE') ...`). The fix moved
+/// that branch into the `CountryServiceRegistry` factory function so the
+/// registry stays the single source of truth.
+///
+/// These are source-level tests (no Riverpod container) because the real
+/// providers touch storage and Dio singletons that aren't available under
+/// flutter_test without a device binding.
+void main() {
+  late String providersSource;
+  late String registrySource;
+
+  setUpAll(() {
+    providersSource =
+        File('lib/core/services/service_providers.dart').readAsStringSync();
+    registrySource =
+        File('lib/core/services/country_service_registry.dart')
+            .readAsStringSync();
+  });
+
+  group('service_providers.dart no longer special-cases any country', () {
+    test('no `countryCode == "DE"` branch in service_providers.dart', () {
+      // Picks up both single- and double-quoted forms.
+      expect(providersSource, isNot(matches(RegExp("countryCode\\s*==\\s*['\"]DE['\"]"))));
+    });
+
+    test('no other country code literal lurks in the resolver', () {
+      // `_resolveServiceForCountry` should now be a one-liner that delegates
+      // to the registry. Any country code string literal here would mean
+      // we've reintroduced a special case.
+      const codes = ['DE', 'FR', 'IT', 'ES', 'AT', 'BE', 'LU', 'GB', 'AR', 'PT', 'AU', 'MX', 'DK'];
+      for (final code in codes) {
+        expect(
+          providersSource,
+          isNot(matches(RegExp("countryCode\\s*==\\s*['\"]$code['\"]"))),
+          reason: 'No special-case branch should reference $code',
+        );
+      }
+    });
+
+    test('_resolveServiceForCountry delegates to CountryServiceRegistry', () {
+      expect(providersSource, contains('CountryServiceRegistry.buildService'));
+    });
+
+    test('service_providers.dart no longer imports DemoStationService or '
+        'TankerkoenigStationService directly', () {
+      // After the refactor those types live exclusively inside the registry.
+      expect(providersSource,
+          isNot(contains("import 'impl/demo_station_service.dart'")));
+      expect(
+          providersSource,
+          isNot(contains(
+              "import 'impl/tankerkoenig_station_service.dart'")));
+    });
+  });
+
+  group('CountryServiceRegistry now owns the Germany factory', () {
+    test('_createTankerkoenig is no longer an UnsupportedError stub', () {
+      // The stub used to throw UnsupportedError because the registry had no
+      // way to wire the API-key check. After #425 it returns Demo or the
+      // real Tankerkoenig service depending on the storage state.
+      expect(
+        registrySource,
+        isNot(contains('UnsupportedError')),
+        reason: '_createTankerkoenig should be implemented, not a stub',
+      );
+    });
+
+    test('Germany factory falls back to DemoStationService when no API key',
+        () {
+      expect(registrySource, contains('hasApiKey()'));
+      expect(registrySource, contains("DemoStationService(countryCode: 'DE')"));
+    });
+
+    test('Germany factory uses tankerkoenigDioProvider when key present', () {
+      expect(registrySource, contains('tankerkoenigDioProvider'));
+      expect(registrySource, contains('TankerkoenigStationService(dio)'));
+    });
+
+    test('every supported country still has a registry entry', () {
+      // Sanity check that the const list still holds the full set after
+      // the refactor, since assertAllCountriesRegistered runs only at
+      // app startup (in debug mode).
+      const expected = [
+        'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR',
+        'PT', 'GB', 'AU', 'MX',
+      ];
+      for (final code in expected) {
+        expect(
+          registrySource,
+          contains("countryCode: '$code'"),
+          reason: '$code entry missing from CountryServiceRegistry',
+        );
+      }
+    });
+  });
+}

--- a/test/core/services/service_providers_test.dart
+++ b/test/core/services/service_providers_test.dart
@@ -42,13 +42,18 @@ void main() {
   }
 
   group('stationServiceProvider', () {
-    test('returns DemoStationService when DE and no API key', () {
+    test('returns DemoStationService chain when DE and no API key', () {
+      // After #425 the Germany factory lives in CountryServiceRegistry
+      // and the registry wraps every service (including the demo
+      // fallback) in a StationServiceChain. The behaviour is preserved:
+      // demo data still backs the chain, the chain is just the consistent
+      // outer type so callers don't have to special-case Germany either.
       when(() => mockStorage.hasApiKey()).thenReturn(false);
 
       final container = createContainer(country: Countries.germany);
       final service = container.read(stationServiceProvider);
 
-      expect(service, isA<DemoStationService>());
+      expect(service, isA<StationServiceChain>());
     });
 
     test('returns StationServiceChain when DE and API key present', () {


### PR DESCRIPTION
## Summary
\`service_providers.dart\` had an \`if (countryCode == 'DE') ...\` branch that bypassed \`CountryServiceRegistry\`, even though the registry was documented as the "single source of truth" for per-country wiring. This PR moves the API-key check + dedicated Dio wiring into the registry's \`_createTankerkoenig\` factory function (which used to be a stubbed \`UnsupportedError\`), so \`_resolveServiceForCountry\` is now a one-liner that delegates to the registry for *every* country.

## Behaviour change
The Demo fallback for Germany (no API key) is now wrapped in \`StationServiceChain\`, same as every other country. The underlying data is unchanged; only the outer type differs. Updated the corresponding test to assert \`StationServiceChain\` instead of unwrapped \`DemoStationService\`.

Closes #425

## Test plan
- [x] \`flutter analyze\` clean
- [x] **8 new regression tests** in \`germany_no_special_case_test.dart\`:
  1. service_providers.dart contains no \`countryCode == 'DE'\` (or any other country code) branch
  2. _resolveServiceForCountry delegates to CountryServiceRegistry
  3. service_providers.dart no longer imports DemoStationService/TankerkoenigStationService directly
  4. \`_createTankerkoenig\` is no longer an \`UnsupportedError\` stub
  5. Germany factory falls back to DemoStationService when no API key
  6. Germany factory uses \`tankerkoenigDioProvider\` when key present
  7. Every supported country still has a registry entry
- [x] Updated \`service_providers_test.dart\` — DE-without-key now asserts the wrapped \`StationServiceChain\`
- [x] All other country wiring (FR, AT, ES, IT, DK, AR, PT, GB, AU, MX, unknown) tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)