### PR TITLE
refactor(vehicle): extract EV + combustion sections from edit_vehicle_screen build

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -5,6 +5,8 @@ import 'package:uuid/uuid.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/vehicle_profile.dart';
 import '../../providers/vehicle_providers.dart';
+import '../widgets/vehicle_combustion_section.dart';
+import '../widgets/vehicle_ev_section.dart';
 
 /// Form for adding or editing a [VehicleProfile].
 ///
@@ -79,6 +81,17 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     final trimmed = text.trim().replaceAll(',', '.');
     if (trimmed.isEmpty) return null;
     return double.tryParse(trimmed);
+  }
+
+  /// Shared validator for the optional numeric inputs on the form. Empty
+  /// values are accepted (they map to `null` in the saved profile); only
+  /// non-empty values that fail to parse get an error message.
+  String? _validateOptionalNumber(String? v) {
+    final l = AppLocalizations.of(context);
+    if (v == null || v.trim().isEmpty) return null;
+    return _parseDouble(v) == null
+        ? (l?.fieldInvalidNumber ?? 'Invalid number')
+        : null;
   }
 
   int _parseIntOr(String text, int fallback) {
@@ -160,122 +173,29 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
             ),
             const SizedBox(height: 24),
             if (showEv) ...[
-              Text(
-                l?.vehicleEvSectionTitle ?? 'Electric',
-                style: Theme.of(context).textTheme.titleSmall,
-              ),
-              const SizedBox(height: 8),
-              TextFormField(
-                controller: _batteryCtrl,
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
-                decoration: InputDecoration(
-                  labelText: l?.vehicleBatteryLabel ?? 'Battery capacity (kWh)',
-                ),
-                validator: (v) {
-                  if (v == null || v.trim().isEmpty) return null;
-                  return _parseDouble(v) == null
-                      ? (l?.fieldInvalidNumber ?? 'Invalid number')
-                      : null;
-                },
-              ),
-              const SizedBox(height: 8),
-              TextFormField(
-                controller: _maxKwCtrl,
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
-                decoration: InputDecoration(
-                  labelText:
-                      l?.vehicleMaxChargeLabel ?? 'Max charging power (kW)',
-                ),
-                validator: (v) {
-                  if (v == null || v.trim().isEmpty) return null;
-                  return _parseDouble(v) == null
-                      ? (l?.fieldInvalidNumber ?? 'Invalid number')
-                      : null;
-                },
-              ),
-              const SizedBox(height: 16),
-              Text(
-                l?.vehicleConnectorsLabel ?? 'Supported connectors',
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              const SizedBox(height: 8),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: ConnectorType.values.map((c) {
-                  final selected = _connectors.contains(c);
-                  return FilterChip(
-                    label: Text(c.label),
-                    selected: selected,
-                    onSelected: (value) {
-                      setState(() {
-                        if (value) {
-                          _connectors.add(c);
-                        } else {
-                          _connectors.remove(c);
-                        }
-                      });
-                    },
-                  );
-                }).toList(),
-              ),
-              const SizedBox(height: 16),
-              Row(
-                children: [
-                  Expanded(
-                    child: TextFormField(
-                      controller: _minSocCtrl,
-                      keyboardType: TextInputType.number,
-                      decoration: InputDecoration(
-                        labelText: l?.vehicleMinSocLabel ?? 'Min SoC %',
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: TextFormField(
-                      controller: _maxSocCtrl,
-                      keyboardType: TextInputType.number,
-                      decoration: InputDecoration(
-                        labelText: l?.vehicleMaxSocLabel ?? 'Max SoC %',
-                      ),
-                    ),
-                  ),
-                ],
+              VehicleEvSection(
+                batteryController: _batteryCtrl,
+                maxChargingKwController: _maxKwCtrl,
+                minSocController: _minSocCtrl,
+                maxSocController: _maxSocCtrl,
+                connectors: _connectors,
+                onToggleConnector: (c) => setState(() {
+                  if (_connectors.contains(c)) {
+                    _connectors.remove(c);
+                  } else {
+                    _connectors.add(c);
+                  }
+                }),
+                numberValidator: _validateOptionalNumber,
               ),
               const SizedBox(height: 24),
             ],
-            if (showCombustion) ...[
-              Text(
-                l?.vehicleCombustionSectionTitle ?? 'Combustion',
-                style: Theme.of(context).textTheme.titleSmall,
+            if (showCombustion)
+              VehicleCombustionSection(
+                tankController: _tankCtrl,
+                fuelTypeController: _fuelTypeCtrl,
+                numberValidator: _validateOptionalNumber,
               ),
-              const SizedBox(height: 8),
-              TextFormField(
-                controller: _tankCtrl,
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
-                decoration: InputDecoration(
-                  labelText: l?.vehicleTankLabel ?? 'Tank capacity (L)',
-                ),
-                validator: (v) {
-                  if (v == null || v.trim().isEmpty) return null;
-                  return _parseDouble(v) == null
-                      ? (l?.fieldInvalidNumber ?? 'Invalid number')
-                      : null;
-                },
-              ),
-              const SizedBox(height: 8),
-              TextFormField(
-                controller: _fuelTypeCtrl,
-                decoration: InputDecoration(
-                  labelText: l?.vehiclePreferredFuelLabel ?? 'Preferred fuel',
-                  hintText: 'e.g. Diesel, E10',
-                ),
-              ),
-            ],
             const SizedBox(height: 32),
             FilledButton.icon(
               onPressed: _save,

--- a/lib/features/vehicle/presentation/widgets/vehicle_combustion_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_combustion_section.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Combustion-engine portion of the [EditVehicleScreen] form. Owns the tank
+/// capacity and preferred fuel inputs.
+class VehicleCombustionSection extends StatelessWidget {
+  final TextEditingController tankController;
+  final TextEditingController fuelTypeController;
+  final String? Function(String?) numberValidator;
+
+  const VehicleCombustionSection({
+    super.key,
+    required this.tankController,
+    required this.fuelTypeController,
+    required this.numberValidator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          l?.vehicleCombustionSectionTitle ?? 'Combustion',
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        const SizedBox(height: 8),
+        TextFormField(
+          controller: tankController,
+          keyboardType:
+              const TextInputType.numberWithOptions(decimal: true),
+          decoration: InputDecoration(
+            labelText: l?.vehicleTankLabel ?? 'Tank capacity (L)',
+          ),
+          validator: numberValidator,
+        ),
+        const SizedBox(height: 8),
+        TextFormField(
+          controller: fuelTypeController,
+          decoration: InputDecoration(
+            labelText: l?.vehiclePreferredFuelLabel ?? 'Preferred fuel',
+            hintText: 'e.g. Diesel, E10',
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_ev_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_ev_section.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/vehicle_profile.dart';
+
+/// EV-specific portion of the [EditVehicleScreen] form. Owns the battery,
+/// max-charge-power, supported connectors, and SoC range fields. Statelessly
+/// surfaces every input through callbacks so the parent screen keeps a
+/// single source of truth for form state.
+class VehicleEvSection extends StatelessWidget {
+  final TextEditingController batteryController;
+  final TextEditingController maxChargingKwController;
+  final TextEditingController minSocController;
+  final TextEditingController maxSocController;
+  final Set<ConnectorType> connectors;
+  final ValueChanged<ConnectorType> onToggleConnector;
+  final String? Function(String?) numberValidator;
+
+  const VehicleEvSection({
+    super.key,
+    required this.batteryController,
+    required this.maxChargingKwController,
+    required this.minSocController,
+    required this.maxSocController,
+    required this.connectors,
+    required this.onToggleConnector,
+    required this.numberValidator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          l?.vehicleEvSectionTitle ?? 'Electric',
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        const SizedBox(height: 8),
+        TextFormField(
+          controller: batteryController,
+          keyboardType:
+              const TextInputType.numberWithOptions(decimal: true),
+          decoration: InputDecoration(
+            labelText: l?.vehicleBatteryLabel ?? 'Battery capacity (kWh)',
+          ),
+          validator: numberValidator,
+        ),
+        const SizedBox(height: 8),
+        TextFormField(
+          controller: maxChargingKwController,
+          keyboardType:
+              const TextInputType.numberWithOptions(decimal: true),
+          decoration: InputDecoration(
+            labelText:
+                l?.vehicleMaxChargeLabel ?? 'Max charging power (kW)',
+          ),
+          validator: numberValidator,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l?.vehicleConnectorsLabel ?? 'Supported connectors',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: ConnectorType.values.map((c) {
+            final selected = connectors.contains(c);
+            return FilterChip(
+              label: Text(c.label),
+              selected: selected,
+              onSelected: (_) => onToggleConnector(c),
+            );
+          }).toList(),
+        ),
+        const SizedBox(height: 16),
+        Row(
+          children: [
+            Expanded(
+              child: TextFormField(
+                controller: minSocController,
+                keyboardType: TextInputType.number,
+                decoration: InputDecoration(
+                  labelText: l?.vehicleMinSocLabel ?? 'Min SoC %',
+                ),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: TextFormField(
+                controller: maxSocController,
+                keyboardType: TextInputType.number,
+                decoration: InputDecoration(
+                  labelText: l?.vehicleMaxSocLabel ?? 'Max SoC %',
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_ev_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_ev_section_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_ev_section.dart';
+
+void main() {
+  group('VehicleEvSection', () {
+    late TextEditingController batteryCtrl;
+    late TextEditingController maxKwCtrl;
+    late TextEditingController minSocCtrl;
+    late TextEditingController maxSocCtrl;
+    late Set<ConnectorType> connectors;
+
+    setUp(() {
+      batteryCtrl = TextEditingController(text: '75');
+      maxKwCtrl = TextEditingController(text: '250');
+      minSocCtrl = TextEditingController(text: '20');
+      maxSocCtrl = TextEditingController(text: '80');
+      connectors = {ConnectorType.values.first};
+    });
+
+    tearDown(() {
+      batteryCtrl.dispose();
+      maxKwCtrl.dispose();
+      minSocCtrl.dispose();
+      maxSocCtrl.dispose();
+    });
+
+    Future<void> pumpSection(
+      WidgetTester tester, {
+      ValueChanged<ConnectorType>? onToggle,
+      String? Function(String?)? validator,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: VehicleEvSection(
+                batteryController: batteryCtrl,
+                maxChargingKwController: maxKwCtrl,
+                minSocController: minSocCtrl,
+                maxSocController: maxSocCtrl,
+                connectors: connectors,
+                onToggleConnector: onToggle ?? (_) {},
+                numberValidator: validator ?? (_) => null,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders all four numeric inputs + connector chips',
+        (tester) async {
+      await pumpSection(tester);
+      // 4 numeric fields: battery, max kw, min soc, max soc
+      expect(find.byType(TextFormField), findsNWidgets(4));
+      // One FilterChip per connector type
+      expect(
+        find.byType(FilterChip),
+        findsNWidgets(ConnectorType.values.length),
+      );
+    });
+
+    testWidgets('initial controller values populate the fields',
+        (tester) async {
+      await pumpSection(tester);
+      expect(find.text('75'), findsOneWidget);
+      expect(find.text('250'), findsOneWidget);
+      expect(find.text('20'), findsOneWidget);
+      expect(find.text('80'), findsOneWidget);
+    });
+
+    testWidgets('tapping an unselected connector chip invokes onToggleConnector',
+        (tester) async {
+      ConnectorType? captured;
+      // Pick a connector that is NOT preselected.
+      final unselected = ConnectorType.values
+          .firstWhere((c) => !connectors.contains(c));
+
+      await pumpSection(tester, onToggle: (c) => captured = c);
+
+      await tester.tap(find.text(unselected.label));
+      await tester.pump();
+
+      expect(captured, unselected);
+    });
+
+    testWidgets('selected connectors render in selected state', (tester) async {
+      await pumpSection(tester);
+      final selected = ConnectorType.values.first;
+      final chip = tester.widget<FilterChip>(
+        find.ancestor(
+          of: find.text(selected.label),
+          matching: find.byType(FilterChip),
+        ),
+      );
+      expect(chip.selected, isTrue);
+    });
+
+    testWidgets('numberValidator is wired to the battery + max kw fields',
+        (tester) async {
+      var calls = 0;
+      await pumpSection(
+        tester,
+        validator: (_) {
+          calls++;
+          return null;
+        },
+      );
+      // Find both number-bearing TextFormFields (the soc fields use a
+      // bare TextInputType.number with no validator).
+      final fields = tester
+          .widgetList<TextFormField>(find.byType(TextFormField))
+          .where((f) => f.validator != null)
+          .toList();
+      expect(fields, hasLength(2),
+          reason: 'battery + max charging power should both be validated');
+      for (final f in fields) {
+        f.validator!('1.5');
+      }
+      expect(calls, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The 167-line build method on \`EditVehicleScreen\` interleaved an 88-line EV section (battery, max charging power, connector chips, SoC range) with a 28-line combustion section (tank, preferred fuel) inside the same Form widget.

Pulls both sections into stateless widgets that take their controllers through the constructor and surface side-effects via callbacks:
- \`VehicleEvSection\`
- \`VehicleCombustionSection\`

Adds a shared \`_validateOptionalNumber\` helper on the screen so both sections can use the same validator without duplication.

\`edit_vehicle_screen.dart\`: **323 → 243 lines (-80)**.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] **5 new widget tests** in \`vehicle_ev_section_test.dart\`:
  1. Renders all four numeric inputs + connector chips
  2. Initial controller values populate the fields
  3. Tapping an unselected connector chip invokes \`onToggleConnector\`
  4. Selected connectors render in selected state
  5. \`numberValidator\` is wired to the battery + max kw fields
- [x] All 33 existing vehicle tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)