### PR TITLE
fix(prices): use batch fetcher in main isolate and stop truncating to 10 IDs

### DIFF
--- a/lib/core/services/impl/tankerkoenig_batch_price_fetcher.dart
+++ b/lib/core/services/impl/tankerkoenig_batch_price_fetcher.dart
@@ -40,7 +40,12 @@ class TankerkoenigBatchPriceFetcher {
 
   /// Fetches prices for [ids] in batches of [batchSize] and merges the
   /// results into a single map keyed by station ID. Returns an empty map
-  /// when [ids] is empty or when [apiKey] is null/empty.
+  /// when [ids] is empty.
+  ///
+  /// Pass [apiKey] to send the key as a query parameter directly — used by
+  /// the background isolate where there's no Dio interceptor. In the main
+  /// isolate the key is injected by the Dio interceptor in
+  /// `service_providers.dart` so callers can omit it.
   ///
   /// Failed batches are silently dropped so a partial result is still
   /// useful (e.g. one batch of 10 fails but the other 20 stations still
@@ -48,9 +53,9 @@ class TankerkoenigBatchPriceFetcher {
   /// [BackgroundRetryConfig] before being given up on.
   Future<Map<String, Map<String, dynamic>>> fetchBatch({
     required List<String> ids,
-    required String? apiKey,
+    String? apiKey,
   }) async {
-    if (ids.isEmpty || apiKey == null || apiKey.isEmpty) {
+    if (ids.isEmpty) {
       return const <String, Map<String, dynamic>>{};
     }
 
@@ -66,7 +71,10 @@ class TankerkoenigBatchPriceFetcher {
       final data = await fetchWithRetry(
         dio: _dio,
         url: url,
-        queryParameters: {'ids': joined, 'apikey': apiKey},
+        queryParameters: {
+          'ids': joined,
+          if (apiKey != null && apiKey.isNotEmpty) 'apikey': apiKey,
+        },
         config: retryConfig,
       );
       _mergeBatch(data, into: result);

--- a/lib/core/services/impl/tankerkoenig_station_service.dart
+++ b/lib/core/services/impl/tankerkoenig_station_service.dart
@@ -6,6 +6,7 @@ import '../../error/exceptions.dart';
 import '../mixins/station_service_helpers.dart';
 import '../service_result.dart';
 import '../station_service.dart';
+import 'tankerkoenig_batch_price_fetcher.dart';
 
 /// Concrete StationService implementation for the Tankerkoenig API.
 ///
@@ -16,8 +17,13 @@ import '../station_service.dart';
 /// - Wraps all results in ServiceResult with source metadata
 class TankerkoenigStationService with StationServiceHelpers implements StationService {
   final Dio _dio;
+  final TankerkoenigBatchPriceFetcher _priceFetcher;
 
-  TankerkoenigStationService(this._dio);
+  TankerkoenigStationService(this._dio)
+      : _priceFetcher = TankerkoenigBatchPriceFetcher(
+          dio: _dio,
+          batchSize: ApiConstants.maxPriceQueryIds,
+        );
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(
@@ -119,22 +125,16 @@ class TankerkoenigStationService with StationServiceHelpers implements StationSe
       );
     }
 
-    final queryIds = ids.length > ApiConstants.maxPriceQueryIds
-        ? ids.take(ApiConstants.maxPriceQueryIds).toList()
-        : ids;
-
+    // The batch fetcher chunks `ids` into Tankerkoenig's per-call cap and
+    // merges the responses, so callers (e.g. favorites refresh with >10
+    // stations) get prices for *every* requested station instead of just
+    // the first 10. The API key is added by the Dio interceptor in
+    // service_providers.dart, so we don't pass it here.
     try {
-      final response = await _dio.get(
-        ApiConstants.pricesEndpoint,
-        queryParameters: {'ids': queryIds.join(',')},
+      final raw = await _priceFetcher.fetchBatch(ids: ids);
+      final prices = raw.map(
+        (id, data) => MapEntry(id, StationPrices.fromJson(data)),
       );
-      _checkOk(response.data);
-
-      final pricesJson = response.data['prices'] as Map<String, dynamic>? ?? {};
-      final prices = pricesJson.map((id, data) {
-        final p = data as Map<String, dynamic>;
-        return MapEntry(id, StationPrices.fromJson(p));
-      });
 
       return ServiceResult(
         data: prices,

--- a/test/core/services/impl/tankerkoenig_batch_price_fetcher_test.dart
+++ b/test/core/services/impl/tankerkoenig_batch_price_fetcher_test.dart
@@ -54,17 +54,48 @@ void main() {
       expect(result, isEmpty);
     });
 
-    test('returns empty map when apiKey is null', () async {
-      final fetcher = TankerkoenigBatchPriceFetcher(dio: _dioWith([]));
-      final result =
-          await fetcher.fetchBatch(ids: const ['a'], apiKey: null);
-      expect(result, isEmpty);
+    test('omits apikey query parameter when apiKey is null', () async {
+      // Main isolate uses a Dio interceptor to inject the key, so the
+      // fetcher should not send `apikey` itself.
+      final dio = _dioWith([_jsonResponse('{"ok":true,"prices":{}}')]);
+      final adapter = dio.httpClientAdapter as _RecordingAdapter;
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: dio);
+
+      await fetcher.fetchBatch(ids: const ['a']);
+
+      expect(adapter.requests.single.queryParameters.containsKey('apikey'),
+          isFalse);
+      expect(adapter.requests.single.queryParameters['ids'], 'a');
     });
 
-    test('returns empty map when apiKey is empty string', () async {
-      final fetcher = TankerkoenigBatchPriceFetcher(dio: _dioWith([]));
-      final result = await fetcher.fetchBatch(ids: const ['a'], apiKey: '');
-      expect(result, isEmpty);
+    test('omits apikey query parameter when apiKey is empty string', () async {
+      final dio = _dioWith([_jsonResponse('{"ok":true,"prices":{}}')]);
+      final adapter = dio.httpClientAdapter as _RecordingAdapter;
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: dio);
+
+      await fetcher.fetchBatch(ids: const ['a'], apiKey: '');
+
+      expect(adapter.requests.single.queryParameters.containsKey('apikey'),
+          isFalse);
+    });
+
+    test('main-isolate path: 25 ids still chunk into 3 batches', () async {
+      // Regression for #426 — main isolate getPrices used to truncate
+      // `ids.take(10)`; now it must batch the full list.
+      final dio = _dioWith([
+        _jsonResponse('{"ok":true,"prices":{}}'),
+        _jsonResponse('{"ok":true,"prices":{}}'),
+        _jsonResponse('{"ok":true,"prices":{}}'),
+      ]);
+      final adapter = dio.httpClientAdapter as _RecordingAdapter;
+      final fetcher = TankerkoenigBatchPriceFetcher(dio: dio);
+
+      final ids = List.generate(25, (i) => 'station-$i');
+      // No apiKey: simulating the main-isolate path
+      await fetcher.fetchBatch(ids: ids);
+
+      expect(adapter.requests, hasLength(3),
+          reason: '25 ids must produce 3 requests, not be truncated to 10');
     });
 
     test('parses a single batch into the id → price map', () async {


### PR DESCRIPTION
## Summary
\`TankerkoenigStationService.getPrices()\` used to call \`ids.take(ApiConstants.maxPriceQueryIds)\` which silently dropped any station beyond the first 10. Users with 15 favorites only saw fresh prices for the first 10 — a real bug visible to anyone with a long favorites list.

Wires the service through \`TankerkoenigBatchPriceFetcher\` (extracted in #436) so the main isolate gets the same chunking + retry + partial-failure-merge logic as the background isolate. The fetcher's \`apiKey\` parameter is now optional so the main isolate can rely on the existing Dio interceptor in \`service_providers.dart\` to inject the key, while the background isolate (no interceptor) keeps passing the key explicitly.

This finishes the dual-surface goal of #426.

Closes #426

## Test plan
- [x] \`flutter analyze\` clean
- [x] **New regression test**: \`main-isolate path: 25 ids still chunk into 3 batches\` — exercises the no-\`apiKey\` branch with >10 IDs and asserts 3 requests are fired (vs the old single truncated request)
- [x] **Updated tests**: replace the two "returns empty when apiKey null/empty" cases (wrong invariant after this change) with two new ones that assert \`apikey\` is omitted from the query when not passed — proving the main-isolate path doesn't double-set the key
- [x] All 475 service + background tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)