### PR TITLE
refactor(favorites): extract section header widget from favorites_screen build

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -19,6 +19,7 @@ import '../../providers/favorites_provider.dart';
 import '../widgets/alerts_tab.dart';
 import '../widgets/ev_favorite_card.dart';
 import '../widgets/favorites_loading_view.dart';
+import '../widgets/favorites_section_header.dart';
 import '../widgets/swipe_tutorial_banner.dart';
 
 class FavoritesScreen extends ConsumerStatefulWidget {
@@ -142,7 +143,11 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
                   children: [
                     // EV favorites section
                     if (hasEvFavorites) ...[
-                      _buildEvSectionHeader(context),
+                      FavoritesSectionHeader(
+                        icon: Icons.ev_station,
+                        label: l10n?.evChargingSection ?? 'EV Charging',
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+                      ),
                       ...evStations.map((ev) => EvFavoriteCard(
                             key: ValueKey('ev-${ev.id}'),
                             station: ev,
@@ -156,7 +161,10 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
                             },
                           )),
                       if (result.data.isNotEmpty)
-                        _buildFuelSectionHeader(context),
+                        FavoritesSectionHeader(
+                          icon: Icons.local_gas_station,
+                          label: l10n?.fuelStationsSection ?? 'Fuel Stations',
+                        ),
                     ],
                     // Fuel favorites
                     ...result.data.map((station) {
@@ -272,38 +280,6 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
     );
   }
 
-  Widget _buildEvSectionHeader(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-      child: Row(
-        children: [
-          Icon(Icons.ev_station, size: 16,
-              color: Theme.of(context).colorScheme.primary),
-          const SizedBox(width: 8),
-          Text(l10n?.evChargingSection ?? 'EV Charging',
-              style: Theme.of(context).textTheme.titleSmall),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildFuelSectionHeader(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-      child: Row(
-        children: [
-          Icon(Icons.local_gas_station, size: 16,
-              color: Theme.of(context).colorScheme.primary),
-          const SizedBox(width: 8),
-          Text(l10n?.fuelStationsSection ?? 'Fuel Stations',
-              style: Theme.of(context).textTheme.titleSmall),
-        ],
-      ),
-    );
-  }
-
   Widget _buildEvFavoritesSection(
     BuildContext context,
     AppLocalizations? l10n,
@@ -311,7 +287,11 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
   ) {
     return ListView(
       children: [
-        _buildEvSectionHeader(context),
+        FavoritesSectionHeader(
+          icon: Icons.ev_station,
+          label: l10n?.evChargingSection ?? 'EV Charging',
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+        ),
         ...evStations.map((ev) => EvFavoriteCard(
               key: ValueKey('ev-${ev.id}'),
               station: ev,

--- a/lib/features/favorites/presentation/widgets/favorites_section_header.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_section_header.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Section header used inside the Favorites screen to label the EV and
+/// fuel groups. Tiny widget but pulled out so the screen's `build` method
+/// stops carrying two near-identical 14-line `_buildXxxSectionHeader`
+/// helpers — and so the spacing/colour rules are pinned in one place.
+class FavoritesSectionHeader extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final EdgeInsets padding;
+
+  const FavoritesSectionHeader({
+    super.key,
+    required this.icon,
+    required this.label,
+    this.padding = const EdgeInsets.fromLTRB(16, 12, 16, 4),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: padding,
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: theme.colorScheme.primary),
+          const SizedBox(width: 8),
+          Text(label, style: theme.textTheme.titleSmall),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/favorites/presentation/widgets/favorites_section_header_test.dart
+++ b/test/features/favorites/presentation/widgets/favorites_section_header_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/favorites/presentation/widgets/favorites_section_header.dart';
+
+void main() {
+  group('FavoritesSectionHeader', () {
+    Future<void> pumpHeader(
+      WidgetTester tester, {
+      required IconData icon,
+      required String label,
+      EdgeInsets? padding,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FavoritesSectionHeader(
+              icon: icon,
+              label: label,
+              padding: padding ??
+                  const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the supplied label and icon', (tester) async {
+      await pumpHeader(
+        tester,
+        icon: Icons.ev_station,
+        label: 'EV Charging',
+      );
+      expect(find.text('EV Charging'), findsOneWidget);
+      expect(find.byIcon(Icons.ev_station), findsOneWidget);
+    });
+
+    testWidgets('uses the theme primary color for the icon', (tester) async {
+      const primary = Color(0xFF112233);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: const ColorScheme.light(primary: primary),
+          ),
+          home: const Scaffold(
+            body: FavoritesSectionHeader(
+              icon: Icons.local_gas_station,
+              label: 'Fuel Stations',
+            ),
+          ),
+        ),
+      );
+      final icon = tester.widget<Icon>(find.byType(Icon));
+      expect(icon.color, primary);
+    });
+
+    testWidgets('honours a custom padding override', (tester) async {
+      const padding = EdgeInsets.fromLTRB(20, 4, 8, 0);
+      await pumpHeader(
+        tester,
+        icon: Icons.local_gas_station,
+        label: 'Fuel Stations',
+        padding: padding,
+      );
+      final paddingWidget = tester.widget<Padding>(find.byType(Padding).first);
+      expect(paddingWidget.padding, padding);
+    });
+
+    testWidgets('default padding matches the original screen layout',
+        (tester) async {
+      await pumpHeader(
+        tester,
+        icon: Icons.local_gas_station,
+        label: 'Fuel Stations',
+      );
+      final paddingWidget = tester.widget<Padding>(find.byType(Padding).first);
+      expect(paddingWidget.padding,
+          const EdgeInsets.fromLTRB(16, 12, 16, 4));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Two near-identical 14-line \`_buildEvSectionHeader\` and \`_buildFuelSectionHeader\` helpers lived inline on the screen state. Pulls them into a single reusable \`FavoritesSectionHeader\` widget parameterised by icon, label, and padding so:

- The screen's build method no longer carries 28 lines of header markup
- Spacing/colour rules live in one place
- The header is testable without a Riverpod container

\`favorites_screen.dart\`: **330 → 310 lines (-20)**.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] **4 new tests** in \`favorites_section_header_test.dart\`:
  1. Renders the supplied label and icon
  2. Uses the theme primary color for the icon
  3. Honours a custom padding override
  4. Default padding matches the original screen layout
- [x] All 58 existing favorites tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)