### PR TITLE
ci(test): exclude network-tagged api_connectivity tests from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,11 @@ jobs:
           restore-keys: ${{ runner.os }}-pub-
       - run: flutter pub get
       - run: dart run build_runner build --delete-conflicting-outputs
-      - run: flutter test --coverage
+      # Excludes the `network` tag — those tests hit real third-party
+      # APIs (Argentina, Italy MIMIT, etc.) that intermittently time out
+      # and cannot block PRs. Run them on demand with
+      # `flutter test --tags=network` from a workstation.
+      - run: flutter test --coverage --exclude-tags=network
       - name: Check coverage threshold
         run: bash scripts/check_coverage.sh
       - name: Check startup time budget

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,11 @@
+# Test runner configuration.
+#
+# Declares the tags that test files use so flutter_test doesn't warn
+# about unknown tags. Tag-based exclusions live in the test command
+# itself (see .github/workflows/ci.yml `--exclude-tags=network`).
+tags:
+  network:
+    description: >
+      Tests that hit real third-party APIs over the network. Intermittent
+      upstream timeouts mean these cannot block PRs. Run on demand with
+      `flutter test --tags=network`.

--- a/test/core/services/api_connectivity_test.dart
+++ b/test/core/services/api_connectivity_test.dart
@@ -1,10 +1,19 @@
+@Tags(['network'])
+library;
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Integration tests that verify each country's fuel price API is reachable
 /// and returns valid data. These tests hit real endpoints.
 ///
-/// Run with: flutter test test/core/services/api_connectivity_test.dart
+/// Tagged `network` so the main CI run excludes them — the upstream APIs
+/// (Argentina, Italy MIMIT, Spain MITECO) intermittently time out and
+/// must not block PRs. Run on demand with:
+///
+///   flutter test test/core/services/api_connectivity_test.dart --tags=network
+///
+/// or from a workstation via `flutter test --tags=network`.
 void main() {
   late Dio dio;
 


### PR DESCRIPTION
## Summary
The integration tests in \`api_connectivity_test.dart\` hit real upstream APIs (Tankerkoenig, Prix Carburants, MIMIT, MITECO, E-Control, Argentina Energía, Denmark) that intermittently time out or 5xx. This has been breaking **~1 in 3 PRs** over the past day with unrelated CI failures, forcing manual reruns and slowing every loop.

This PR tags the test library with \`@Tags(['network'])\` and excludes that tag from the main \`flutter test\` run via \`--exclude-tags=network\`. Adds a \`dart_test.yaml\` declaring the tag so the runner doesn't warn about it.

Tests still run on demand with:
\`\`\`
flutter test test/core/services/api_connectivity_test.dart --tags=network
flutter test --tags=network
\`\`\`

The full CI run goes from 3315 + flake to **3371 + 1 skipped + zero failures**.

## Test plan
- [x] \`flutter test --exclude-tags=network test/core/services/api_connectivity_test.dart\` — "No tests ran" (proves exclusion)
- [x] \`flutter test --exclude-tags=network\` (full suite) — **3371 pass, 1 skipped, 0 failures**
- [x] \`dart_test.yaml\` declares the tag so runner doesn't warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)