### PR TITLE
refactor(consumption): extract scan/OBD button row from add_fill_up_screen build

### DIFF
--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -11,6 +11,7 @@ import '../../data/obd2/obd2_transport.dart';
 import '../../data/receipt_scan_service.dart';
 import '../../domain/entities/fill_up.dart';
 import '../../providers/consumption_providers.dart';
+import '../widgets/fill_up_input_buttons.dart';
 
 /// Form to add a new [FillUp] entry.
 class AddFillUpScreen extends ConsumerStatefulWidget {
@@ -143,36 +144,11 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
           padding: const EdgeInsets.all(16),
           children: [
             // Scan receipt + OBD buttons
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _scanning ? null : _scanReceipt,
-                    icon: _scanning
-                        ? const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.document_scanner),
-                    label: Text(l?.scanReceipt ?? 'Scan receipt'),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _obdReading ? null : _readObd,
-                    icon: _obdReading
-                        ? const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.bluetooth),
-                    label: Text(l?.obdConnect ?? 'OBD-II'),
-                  ),
-                ),
-              ],
+            FillUpInputButtons(
+              scanning: _scanning,
+              obdReading: _obdReading,
+              onScanReceipt: _scanReceipt,
+              onReadObd: _readObd,
             ),
             const SizedBox(height: 12),
             if (widget.stationName != null) ...[

--- a/lib/features/consumption/presentation/widgets/fill_up_input_buttons.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_input_buttons.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Row of the two side-by-side input shortcut buttons on the Add Fill-up
+/// screen — *Scan receipt* (ML Kit text recognition) and *OBD-II* (Bluetooth
+/// odometer reading). Each button shows a spinner while the corresponding
+/// background task is running.
+///
+/// Stateless: the parent screen owns the loading flags and delivers them
+/// + the action callbacks via the constructor. Pulled out of
+/// `add_fill_up_screen.dart` so the screen's build method drops the
+/// 31-line inline button-row markup.
+class FillUpInputButtons extends StatelessWidget {
+  final bool scanning;
+  final bool obdReading;
+  final VoidCallback onScanReceipt;
+  final VoidCallback onReadObd;
+
+  const FillUpInputButtons({
+    super.key,
+    required this.scanning,
+    required this.obdReading,
+    required this.onScanReceipt,
+    required this.onReadObd,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: scanning ? null : onScanReceipt,
+            icon: scanning
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.document_scanner),
+            label: Text(l?.scanReceipt ?? 'Scan receipt'),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: obdReading ? null : onReadObd,
+            icon: obdReading
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.bluetooth),
+            label: Text(l?.obdConnect ?? 'OBD-II'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/consumption/presentation/widgets/fill_up_input_buttons_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_input_buttons_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_input_buttons.dart';
+
+void main() {
+  group('FillUpInputButtons', () {
+    Future<void> pumpButtons(
+      WidgetTester tester, {
+      required bool scanning,
+      required bool obdReading,
+      VoidCallback? onScanReceipt,
+      VoidCallback? onReadObd,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FillUpInputButtons(
+              scanning: scanning,
+              obdReading: obdReading,
+              onScanReceipt: onScanReceipt ?? () {},
+              onReadObd: onReadObd ?? () {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders both buttons in their idle state', (tester) async {
+      await pumpButtons(tester, scanning: false, obdReading: false);
+      expect(find.text('Scan receipt'), findsOneWidget);
+      expect(find.text('OBD-II'), findsOneWidget);
+      expect(find.byIcon(Icons.document_scanner), findsOneWidget);
+      expect(find.byIcon(Icons.bluetooth), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('shows a spinner on the scan button while scanning',
+        (tester) async {
+      await pumpButtons(tester, scanning: true, obdReading: false);
+      expect(find.byIcon(Icons.document_scanner), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows a spinner on the OBD button while reading',
+        (tester) async {
+      await pumpButtons(tester, scanning: false, obdReading: true);
+      expect(find.byIcon(Icons.bluetooth), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('disables the scan button while scanning', (tester) async {
+      var pressed = false;
+      await pumpButtons(
+        tester,
+        scanning: true,
+        obdReading: false,
+        onScanReceipt: () => pressed = true,
+      );
+      // Disabled buttons don't fire onPressed.
+      await tester.tap(find.text('Scan receipt'));
+      await tester.pump();
+      expect(pressed, isFalse);
+    });
+
+    testWidgets('disables the OBD button while reading', (tester) async {
+      var pressed = false;
+      await pumpButtons(
+        tester,
+        scanning: false,
+        obdReading: true,
+        onReadObd: () => pressed = true,
+      );
+      await tester.tap(find.text('OBD-II'));
+      await tester.pump();
+      expect(pressed, isFalse);
+    });
+
+    testWidgets('forwards onScanReceipt when idle', (tester) async {
+      var pressed = false;
+      await pumpButtons(
+        tester,
+        scanning: false,
+        obdReading: false,
+        onScanReceipt: () => pressed = true,
+      );
+      await tester.tap(find.text('Scan receipt'));
+      await tester.pump();
+      expect(pressed, isTrue);
+    });
+
+    testWidgets('forwards onReadObd when idle', (tester) async {
+      var pressed = false;
+      await pumpButtons(
+        tester,
+        scanning: false,
+        obdReading: false,
+        onReadObd: () => pressed = true,
+      );
+      await tester.tap(find.text('OBD-II'));
+      await tester.pump();
+      expect(pressed, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The 147-line build method on \`AddFillUpScreen\` had a 31-line inline \`Row\` of two \`OutlinedButton\`s at the top with two near-identical loading-state branches. Pulls it into a stateless \`FillUpInputButtons\` widget that takes the \`scanning\`/\`obdReading\` flags + action callbacks as constructor params.

Both buttons keep their "spinner replaces icon while pending + button disabled while pending" semantics; the screen state stays the source of truth for the loading flags.

\`add_fill_up_screen.dart\`: **322 → 298 lines (-24)**.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] **7 new tests** in \`fill_up_input_buttons_test.dart\`:
  1. Renders both buttons in their idle state
  2. Shows a spinner on the scan button while scanning
  3. Shows a spinner on the OBD button while reading
  4. Disables the scan button while scanning
  5. Disables the OBD button while reading
  6. Forwards \`onScanReceipt\` when idle
  7. Forwards \`onReadObd\` when idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)