### PR TITLE
refactor(setup): extract bottom navigation buttons from onboarding_wizard_screen build

### DIFF
--- a/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
+++ b/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/api_key_step.dart';
 import '../widgets/completion_step.dart';
 import '../widgets/country_language_step.dart';
 import '../widgets/landing_screen_step.dart';
+import '../widgets/onboarding_navigation_buttons.dart';
 import '../widgets/onboarding_progress_indicator.dart';
 import '../widgets/preferences_step.dart';
 import '../widgets/welcome_step.dart';
@@ -181,7 +182,6 @@ class _OnboardingWizardScreenState
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
     // Watch country to rebuild when it changes (affects step count).
     ref.watch(activeCountryProvider);
     final wizardState = ref.watch(onboardingWizardControllerProvider);
@@ -222,58 +222,14 @@ class _OnboardingWizardScreenState
               ),
             ),
             // Navigation buttons
-            Padding(
-              padding: EdgeInsets.fromLTRB(
-                32,
-                16,
-                32,
-                16 + MediaQuery.of(context).viewPadding.bottom,
-              ),
-              child: Row(
-                children: [
-                  // Back button
-                  if (currentStep > 0)
-                    TextButton.icon(
-                      onPressed: isLoading ? null : () => _back(currentStep),
-                      icon: const Icon(Icons.arrow_back),
-                      label: Text(l10n?.onboardingBack ?? 'Back'),
-                    )
-                  else
-                    const SizedBox(width: 80),
-                  const Spacer(),
-                  // Skip button (optional steps)
-                  if (_isCurrentStepSkippable(currentStep))
-                    Padding(
-                      padding: const EdgeInsets.only(right: 8),
-                      child: TextButton(
-                        onPressed:
-                            isLoading ? null : () => _skip(currentStep),
-                        child: Text(l10n?.onboardingSkip ?? 'Skip'),
-                      ),
-                    ),
-                  // Next / Finish button
-                  FilledButton.icon(
-                    onPressed: isLoading ? null : () => _next(currentStep),
-                    icon: isLoading
-                        ? const SizedBox(
-                            height: 18,
-                            width: 18,
-                            child:
-                                CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Icon(
-                            _isLastStep(currentStep)
-                                ? Icons.check
-                                : Icons.arrow_forward,
-                          ),
-                    label: Text(
-                      _isLastStep(currentStep)
-                          ? (l10n?.onboardingFinish ?? 'Get started')
-                          : (l10n?.onboardingNext ?? 'Next'),
-                    ),
-                  ),
-                ],
-              ),
+            OnboardingNavigationButtons(
+              currentStep: currentStep,
+              isLoading: isLoading,
+              isLastStep: _isLastStep(currentStep),
+              isSkippable: _isCurrentStepSkippable(currentStep),
+              onBack: () => _back(currentStep),
+              onNext: () => _next(currentStep),
+              onSkip: () => _skip(currentStep),
             ),
           ],
         ),

--- a/lib/features/setup/presentation/widgets/onboarding_navigation_buttons.dart
+++ b/lib/features/setup/presentation/widgets/onboarding_navigation_buttons.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Bottom navigation row of the onboarding wizard — Back / Skip / Next.
+///
+/// Stateless: the parent screen owns the wizard step state and passes the
+/// flags + callbacks through. Pulled out of `onboarding_wizard_screen.dart`
+/// so the screen's build method drops the 45-line inline `Row(...)` block
+/// and the button-state logic can be exercised by widget tests.
+class OnboardingNavigationButtons extends StatelessWidget {
+  /// Zero-based index of the current page.
+  final int currentStep;
+
+  /// Whether the *Next* / *Finish* action is in flight (controls the
+  /// spinner and disables every button so the user can't fire two
+  /// actions at once).
+  final bool isLoading;
+
+  /// `true` when the current step is the last one — flips the *Next*
+  /// button to *Finish* with a check icon.
+  final bool isLastStep;
+
+  /// `true` when the current step is optional — surfaces the *Skip* button.
+  final bool isSkippable;
+
+  final VoidCallback onBack;
+  final VoidCallback onNext;
+  final VoidCallback onSkip;
+
+  const OnboardingNavigationButtons({
+    super.key,
+    required this.currentStep,
+    required this.isLoading,
+    required this.isLastStep,
+    required this.isSkippable,
+    required this.onBack,
+    required this.onNext,
+    required this.onSkip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        32,
+        16,
+        32,
+        16 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      child: Row(
+        children: [
+          // Back button — hidden on the first step but the empty SizedBox
+          // keeps the right-side button aligned.
+          if (currentStep > 0)
+            TextButton.icon(
+              onPressed: isLoading ? null : onBack,
+              icon: const Icon(Icons.arrow_back),
+              label: Text(l10n?.onboardingBack ?? 'Back'),
+            )
+          else
+            const SizedBox(width: 80),
+          const Spacer(),
+          if (isSkippable)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: TextButton(
+                onPressed: isLoading ? null : onSkip,
+                child: Text(l10n?.onboardingSkip ?? 'Skip'),
+              ),
+            ),
+          FilledButton.icon(
+            onPressed: isLoading ? null : onNext,
+            icon: isLoading
+                ? const SizedBox(
+                    height: 18,
+                    width: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Icon(isLastStep ? Icons.check : Icons.arrow_forward),
+            label: Text(
+              isLastStep
+                  ? (l10n?.onboardingFinish ?? 'Get started')
+                  : (l10n?.onboardingNext ?? 'Next'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/setup/presentation/widgets/onboarding_navigation_buttons_test.dart
+++ b/test/features/setup/presentation/widgets/onboarding_navigation_buttons_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/onboarding_navigation_buttons.dart';
+
+void main() {
+  group('OnboardingNavigationButtons', () {
+    Future<void> pumpButtons(
+      WidgetTester tester, {
+      required int currentStep,
+      bool isLoading = false,
+      bool isLastStep = false,
+      bool isSkippable = false,
+      VoidCallback? onBack,
+      VoidCallback? onNext,
+      VoidCallback? onSkip,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: OnboardingNavigationButtons(
+              currentStep: currentStep,
+              isLoading: isLoading,
+              isLastStep: isLastStep,
+              isSkippable: isSkippable,
+              onBack: onBack ?? () {},
+              onNext: onNext ?? () {},
+              onSkip: onSkip ?? () {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('hides Back button on first step', (tester) async {
+      await pumpButtons(tester, currentStep: 0);
+      expect(find.text('Back'), findsNothing);
+      expect(find.text('Next'), findsOneWidget);
+    });
+
+    testWidgets('shows Back button on later steps', (tester) async {
+      await pumpButtons(tester, currentStep: 2);
+      expect(find.text('Back'), findsOneWidget);
+    });
+
+    testWidgets('hides Skip button when step is not skippable',
+        (tester) async {
+      await pumpButtons(tester, currentStep: 1, isSkippable: false);
+      expect(find.text('Skip'), findsNothing);
+    });
+
+    testWidgets('shows Skip button when step is skippable', (tester) async {
+      await pumpButtons(tester, currentStep: 1, isSkippable: true);
+      expect(find.text('Skip'), findsOneWidget);
+    });
+
+    testWidgets('shows "Get started" + check icon on the last step',
+        (tester) async {
+      await pumpButtons(tester, currentStep: 3, isLastStep: true);
+      expect(find.text('Get started'), findsOneWidget);
+      expect(find.byIcon(Icons.check), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward), findsNothing);
+    });
+
+    testWidgets('shows "Next" + arrow icon on intermediate steps',
+        (tester) async {
+      await pumpButtons(tester, currentStep: 1, isLastStep: false);
+      expect(find.text('Next'), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+
+    testWidgets('shows spinner instead of icon while loading', (tester) async {
+      await pumpButtons(tester, currentStep: 1, isLoading: true);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward), findsNothing);
+    });
+
+    testWidgets('disables every button while loading', (tester) async {
+      var nextPressed = false;
+      var skipPressed = false;
+      var backPressed = false;
+      await pumpButtons(
+        tester,
+        currentStep: 2,
+        isLoading: true,
+        isSkippable: true,
+        onBack: () => backPressed = true,
+        onNext: () => nextPressed = true,
+        onSkip: () => skipPressed = true,
+      );
+      await tester.tap(find.text('Back'));
+      await tester.tap(find.text('Skip'));
+      await tester.tap(find.text('Next'));
+      await tester.pump();
+      expect(backPressed, isFalse);
+      expect(skipPressed, isFalse);
+      expect(nextPressed, isFalse);
+    });
+
+    testWidgets('forwards onBack/onNext/onSkip when idle', (tester) async {
+      var backPressed = false;
+      var nextPressed = false;
+      var skipPressed = false;
+      await pumpButtons(
+        tester,
+        currentStep: 2,
+        isSkippable: true,
+        onBack: () => backPressed = true,
+        onNext: () => nextPressed = true,
+        onSkip: () => skipPressed = true,
+      );
+      await tester.tap(find.text('Back'));
+      await tester.pump();
+      expect(backPressed, isTrue);
+
+      await tester.tap(find.text('Skip'));
+      await tester.pump();
+      expect(skipPressed, isTrue);
+
+      await tester.tap(find.text('Next'));
+      await tester.pump();
+      expect(nextPressed, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The 100-line build method on \`OnboardingWizardScreen\` carried a 45-line inline \`Row(Back / Skip / Next)\` block whose button-state logic was hard to follow at a glance. Pulls it into a stateless \`OnboardingNavigationButtons\` widget that takes the relevant flags (\`currentStep\`, \`isLoading\`, \`isLastStep\`, \`isSkippable\`) + three callbacks through the constructor.

The screen state stays the source of truth for loading flags and step-counting logic; the new widget only renders.

\`onboarding_wizard_screen.dart\`: **283 → 240 lines (-43)**.

Also drops a now-unused \`l10n\` local variable that the analyzer flagged once the inline button block was gone.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] **9 new tests** in \`onboarding_navigation_buttons_test.dart\`:
  1. Hides Back button on first step
  2. Shows Back button on later steps
  3. Hides Skip button when step is not skippable
  4. Shows Skip button when step is skippable
  5. Shows "Get started" + check icon on the last step
  6. Shows "Next" + arrow icon on intermediate steps
  7. Shows spinner instead of icon while loading
  8. Disables every button while loading
  9. Forwards \`onBack\`/\`onNext\`/\`onSkip\` when idle
- [x] All 69 existing setup tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)