### PR TITLE
refactor(station-detail): extract status row from station_detail_screen build

### DIFF
--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
-import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/brand_logo.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -15,12 +14,12 @@ import '../../../favorites/providers/favorites_provider.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../../core/utils/navigation_utils.dart';
-import '../../../search/providers/station_rating_provider.dart';
 import '../../providers/station_detail_provider.dart';
 import '../widgets/price_history_section.dart';
 import '../widgets/price_tile.dart';
 import '../widgets/station_info_section.dart';
 import '../widgets/station_rating_section.dart';
+import '../widgets/station_status_row.dart';
 
 class StationDetailScreen extends ConsumerWidget {
   final String stationId;
@@ -112,54 +111,10 @@ class StationDetailScreen extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Open/closed status + freshness inline + rating stars (top-right)
-          Row(
-            children: [
-              Expanded(
-                child: Semantics(
-                  label: 'Station is ${station.isOpen ? 'open' : 'closed'}',
-                  child: Row(
-                    children: [
-                      ExcludeSemantics(
-                        child: Container(
-                          width: 12, height: 12,
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: station.isOpen
-                                ? DarkModeColors.success(context)
-                                : DarkModeColors.error(context),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 6),
-                      ExcludeSemantics(
-                        child: Text(
-                          _buildStatusText(station, serviceResult, l10n),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            color: station.isOpen
-                                ? DarkModeColors.success(context)
-                                : DarkModeColors.error(context),
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              // Compact rating stars (top-right)
-              Consumer(builder: (context, ref, _) {
-                final rating = ref.watch(stationRatingProvider(stationId));
-                if (rating == null) return const SizedBox.shrink();
-                return Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: List.generate(5, (i) => Icon(
-                    i < rating ? Icons.star : Icons.star_border,
-                    size: 16,
-                    color: i < rating ? Colors.amber : Colors.grey.shade400,
-                  )),
-                );
-              }),
-            ],
+          StationStatusRow(
+            station: station,
+            serviceResult: serviceResult,
+            stationId: stationId,
           ),
           const SizedBox(height: 12),
 
@@ -231,20 +186,6 @@ class StationDetailScreen extends ConsumerWidget {
         ],
       ),
     );
-  }
-
-  /// Builds status text combining open/closed with freshness, e.g. "Open — < 1 min ago".
-  String _buildStatusText(
-    Station station,
-    ServiceResult<StationDetail> result,
-    AppLocalizations? l10n,
-  ) {
-    final status = station.isOpen
-        ? (l10n?.open ?? 'Open')
-        : (l10n?.closed ?? 'Closed');
-    final agoSuffix = l10n?.freshnessAgo ?? 'ago';
-    final freshness = result.freshnessLabel;
-    return '$status — $freshness $agoSuffix';
   }
 
   Future<void> _showCreateAlertDialog(BuildContext context, WidgetRef ref) async {

--- a/lib/features/station_detail/presentation/widgets/station_status_row.dart
+++ b/lib/features/station_detail/presentation/widgets/station_status_row.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/services/service_result.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/station.dart';
+import '../../../search/providers/station_rating_provider.dart';
+
+/// Top row of the station detail screen — open/closed dot + freshness
+/// text on the left, compact 5-star rating on the right.
+///
+/// Stateless apart from watching `stationRatingProvider` (which the parent
+/// previously did inline via `Consumer`). Pulled out of
+/// `station_detail_screen.dart` so the screen's `_buildContent` helper
+/// drops the 49-line inline `Row(...)` block and so the row can be
+/// covered by widget tests in isolation.
+class StationStatusRow extends ConsumerWidget {
+  final Station station;
+  final ServiceResult<dynamic> serviceResult;
+
+  /// ID used to look up the rating from `stationRatingProvider`. Usually
+  /// the `stationId` field on the screen.
+  final String stationId;
+
+  const StationStatusRow({
+    super.key,
+    required this.station,
+    required this.serviceResult,
+    required this.stationId,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final rating = ref.watch(stationRatingProvider(stationId));
+
+    final color = station.isOpen
+        ? DarkModeColors.success(context)
+        : DarkModeColors.error(context);
+
+    return Row(
+      children: [
+        Expanded(
+          child: Semantics(
+            label: 'Station is ${station.isOpen ? 'open' : 'closed'}',
+            child: Row(
+              children: [
+                ExcludeSemantics(
+                  child: Container(
+                    width: 12,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: color,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 6),
+                ExcludeSemantics(
+                  child: Text(
+                    _buildStatusText(station, serviceResult, l10n),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: color,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (rating != null)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List.generate(
+              5,
+              (i) => Icon(
+                i < rating ? Icons.star : Icons.star_border,
+                size: 16,
+                color: i < rating ? Colors.amber : Colors.grey.shade400,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  /// Combines open/closed with freshness, e.g. "Open — < 1 min ago".
+  /// Visible-for-testing.
+  static String _buildStatusText(
+    Station station,
+    ServiceResult<dynamic> result,
+    AppLocalizations? l10n,
+  ) {
+    final status = station.isOpen
+        ? (l10n?.open ?? 'Open')
+        : (l10n?.closed ?? 'Closed');
+    final agoSuffix = l10n?.freshnessAgo ?? 'ago';
+    final freshness = result.freshnessLabel;
+    return '$status — $freshness $agoSuffix';
+  }
+}

--- a/test/features/station_detail/presentation/widgets/station_status_row_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_status_row_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/station_rating_provider.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/station_status_row.dart';
+
+ServiceResult<dynamic> _result({DateTime? fetchedAt}) {
+  return ServiceResult(
+    data: const Object(),
+    source: ServiceSource.tankerkoenigApi,
+    fetchedAt: fetchedAt ?? DateTime.now().subtract(const Duration(seconds: 10)),
+  );
+}
+
+Station _station({bool isOpen = true}) {
+  return Station(
+    id: 'st-1',
+    name: 'Test',
+    brand: 'JET',
+    street: 'Hauptstr.',
+    houseNumber: '12',
+    postCode: '10115',
+    place: 'Berlin',
+    lat: 52.5,
+    lng: 13.4,
+    dist: 1.0,
+    e5: 1.79,
+    e10: 1.74,
+    diesel: 1.65,
+    isOpen: isOpen,
+  );
+}
+
+/// Test stub for the keep-alive [StationRatings] notifier so we can seed
+/// the rating without touching real Hive storage.
+class _FakeStationRatings extends StationRatings {
+  _FakeStationRatings(this._initial);
+  final Map<String, int> _initial;
+  @override
+  Map<String, int> build() => _initial;
+}
+
+void main() {
+  group('StationStatusRow', () {
+    Future<void> pumpRow(
+      WidgetTester tester, {
+      required Station station,
+      required ServiceResult<dynamic> serviceResult,
+      int? rating,
+    }) {
+      final ratings = <String, int>{};
+      if (rating != null) ratings[station.id] = rating;
+      return tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            stationRatingsProvider
+                .overrideWith(() => _FakeStationRatings(ratings)),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: StationStatusRow(
+                station: station,
+                serviceResult: serviceResult,
+                stationId: station.id,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the open status text when station is open',
+        (tester) async {
+      await pumpRow(
+        tester,
+        station: _station(isOpen: true),
+        serviceResult: _result(),
+      );
+      expect(find.textContaining('Open —'), findsOneWidget);
+    });
+
+    testWidgets('renders the closed status text when station is closed',
+        (tester) async {
+      await pumpRow(
+        tester,
+        station: _station(isOpen: false),
+        serviceResult: _result(),
+      );
+      expect(find.textContaining('Closed —'), findsOneWidget);
+    });
+
+    testWidgets('shows 5 star icons when a rating is present', (tester) async {
+      await pumpRow(
+        tester,
+        station: _station(),
+        serviceResult: _result(),
+        rating: 4,
+      );
+      // Total icons = 1 status dot Container (not Icon) + 4 filled stars +
+      // 1 outline star = 5 Icons.
+      final filled = find.byIcon(Icons.star);
+      final empty = find.byIcon(Icons.star_border);
+      expect(filled, findsNWidgets(4));
+      expect(empty, findsNWidgets(1));
+    });
+
+    testWidgets('hides star row when no rating is present', (tester) async {
+      await pumpRow(
+        tester,
+        station: _station(),
+        serviceResult: _result(),
+        rating: null,
+      );
+      expect(find.byIcon(Icons.star), findsNothing);
+      expect(find.byIcon(Icons.star_border), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The 130-line \`_buildContent\` method on \`StationDetailScreen\` had a 49-line inline \`Row(...)\` block at the top that combined the open/closed dot, the freshness text, and a \`Consumer\`-watched compact star-rating display.

Pulls it into a stateless \`StationStatusRow\` \`ConsumerWidget\` that watches \`stationRatingProvider\` itself, and moves the \`_buildStatusText\` helper into a static method on the new widget so it stays co-located with its only caller.

The screen drops 2 unused imports (\`dark_mode_colors\` and \`station_rating_provider\`) the analyzer flagged after the extraction.

\`station_detail_screen.dart\`: **277 → 218 lines (-59)**.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] **4 new tests** in \`station_status_row_test.dart\`:
  1. Renders the open status text when station is open
  2. Renders the closed status text when station is closed
  3. Shows 5 star icons (4 filled + 1 outline) when \`rating = 4\`
  4. Hides star row when no rating is present
- [x] All 24 station_detail tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)