### PR TITLE
refactor(sync): promote LinkDeviceHowItWorksCard to standalone widget

### DIFF
--- a/lib/features/sync/presentation/screens/link_device_screen.dart
+++ b/lib/features/sync/presentation/screens/link_device_screen.dart
@@ -6,6 +6,7 @@ import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/link_device_provider.dart';
+import '../widgets/link_device_how_it_works_card.dart';
 
 class LinkDeviceScreen extends ConsumerStatefulWidget {
   const LinkDeviceScreen({super.key});
@@ -42,7 +43,7 @@ class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
           const SizedBox(height: 16),
           _ImportFromDeviceCard(codeController: _codeController),
           const SizedBox(height: 16),
-          const _HowItWorksCard(),
+          const LinkDeviceHowItWorksCard(),
         ],
       ),
     );
@@ -229,48 +230,3 @@ class _ImportFromDeviceCard extends ConsumerWidget {
   }
 }
 
-/// Explanation card describing how the merge works step-by-step.
-class _HowItWorksCard extends StatelessWidget {
-  const _HowItWorksCard();
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.info_outline, size: 20),
-                const SizedBox(width: 8),
-                Text(
-                  l10n?.linkDeviceHowItWorksTitle ?? 'How it works',
-                  style: theme.textTheme.titleSmall
-                      ?.copyWith(fontWeight: FontWeight.bold),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Text(
-              l10n?.linkDeviceHowItWorksBody ??
-                  '1. On Device A: copy the device code above\n'
-                      '2. On Device B: paste it in the "Device code" field\n'
-                      '3. Tap "Import data" to merge favorites and alerts\n'
-                      '4. Both devices will have all combined data\n\n'
-                      'Each device keeps its own anonymous identity. '
-                      'Data is merged, not moved.',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/lib/features/sync/presentation/widgets/link_device_how_it_works_card.dart
+++ b/lib/features/sync/presentation/widgets/link_device_how_it_works_card.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Explanation card describing how the device-link / merge flow works,
+/// rendered at the bottom of the Link Device screen.
+///
+/// Pulled out of `link_device_screen.dart` so the screen stops carrying
+/// the inline 44-line `Card(...)` block, the help text lives in a single
+/// place, and the card is exercisable by widget tests in isolation.
+class LinkDeviceHowItWorksCard extends StatelessWidget {
+  const LinkDeviceHowItWorksCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.info_outline, size: 20),
+                const SizedBox(width: 8),
+                Text(
+                  l10n?.linkDeviceHowItWorksTitle ?? 'How it works',
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n?.linkDeviceHowItWorksBody ??
+                  '1. On Device A: copy the device code above\n'
+                      '2. On Device B: paste it in the "Device code" field\n'
+                      '3. Tap "Import data" to merge favorites and alerts\n'
+                      '4. Both devices will have all combined data\n\n'
+                      'Each device keeps its own anonymous identity. '
+                      'Data is merged, not moved.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/sync/presentation/widgets/link_device_how_it_works_card_test.dart
+++ b/test/features/sync/presentation/widgets/link_device_how_it_works_card_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/sync/presentation/widgets/link_device_how_it_works_card.dart';
+
+void main() {
+  group('LinkDeviceHowItWorksCard', () {
+    Future<void> pumpCard(WidgetTester tester) {
+      return tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LinkDeviceHowItWorksCard(),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the title and the info icon', (tester) async {
+      await pumpCard(tester);
+      expect(find.text('How it works'), findsOneWidget);
+      expect(find.byIcon(Icons.info_outline), findsOneWidget);
+    });
+
+    testWidgets('renders the step-by-step body text', (tester) async {
+      await pumpCard(tester);
+      expect(
+        find.textContaining('On Device A'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('On Device B'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Import data'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders inside a Card', (tester) async {
+      await pumpCard(tester);
+      expect(find.byType(Card), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The Link Device screen still carried three private classes inline (\`_ThisDeviceCard\`, \`_ImportFromDeviceCard\`, \`_HowItWorksCard\`) after #417 first split them out. Promotes the simplest one — \`_HowItWorksCard\` — to a standalone widget under \`presentation/widgets/\`, since it has zero state dependencies and the screen file can shrink immediately.

\`link_device_screen.dart\`: **276 → 232 lines (-44)**.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] **3 new tests** in \`link_device_how_it_works_card_test.dart\`:
  1. Renders the title and the info icon
  2. Renders the step-by-step body text (Device A / Device B / Import)
  3. Renders inside a Card
- [x] All 105 existing sync tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)