### PR TITLE
refactor(sync): promote LinkDeviceThisDeviceCard to standalone widget

### DIFF
--- a/lib/features/sync/presentation/screens/link_device_screen.dart
+++ b/lib/features/sync/presentation/screens/link_device_screen.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/sync/supabase_client.dart';
-import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/link_device_provider.dart';
 import '../widgets/link_device_how_it_works_card.dart';
+import '../widgets/link_device_this_device_card.dart';
 
 class LinkDeviceScreen extends ConsumerStatefulWidget {
   const LinkDeviceScreen({super.key});
@@ -39,7 +38,7 @@ class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          _ThisDeviceCard(myId: _myId),
+          LinkDeviceThisDeviceCard(myId: _myId),
           const SizedBox(height: 16),
           _ImportFromDeviceCard(codeController: _codeController),
           const SizedBox(height: 16),
@@ -50,85 +49,6 @@ class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
   }
 }
 
-/// Card showing the current device's anonymous user id with a copy button.
-class _ThisDeviceCard extends StatelessWidget {
-  final String? myId;
-
-  const _ThisDeviceCard({required this.myId});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.smartphone, size: 20),
-                const SizedBox(width: 8),
-                Text(
-                  l10n?.linkDeviceThisDeviceLabel ?? 'This device',
-                  style: theme.textTheme.titleMedium
-                      ?.copyWith(fontWeight: FontWeight.bold),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Text(
-              l10n?.linkDeviceShareCodeHint ??
-                  'Share this code with your other device:',
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-            ),
-            const SizedBox(height: 8),
-            Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: SelectableText(
-                      myId ??
-                          (l10n?.linkDeviceNotConnected ?? 'Not connected'),
-                      style: theme.textTheme.bodySmall
-                          ?.copyWith(fontFamily: 'monospace'),
-                    ),
-                  ),
-                  if (myId != null)
-                    IconButton(
-                      icon: const Icon(Icons.copy, size: 18),
-                      tooltip:
-                          l10n?.linkDeviceCopyCodeTooltip ?? 'Copy code',
-                      onPressed: () {
-                        Clipboard.setData(ClipboardData(text: myId!));
-                        SnackBarHelper.show(
-                          context,
-                          AppLocalizations.of(context)?.deviceCodeCopied ??
-                              'Device code copied',
-                        );
-                      },
-                      padding: EdgeInsets.zero,
-                      constraints: const BoxConstraints(
-                          minWidth: 32, minHeight: 32),
-                    ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
 
 /// Card with the code input field and the "Import data" button. Needs
 /// access to the parent's TextEditingController (kept local to the widget

--- a/lib/features/sync/presentation/widgets/link_device_this_device_card.dart
+++ b/lib/features/sync/presentation/widgets/link_device_this_device_card.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Card showing the current device's anonymous user id (the value the
+/// other device pastes into its "Device code" field). Includes a copy
+/// button when an id is available.
+///
+/// Pulled out of `link_device_screen.dart` so the screen drops the
+/// inline 78-line `_ThisDeviceCard` private widget and so this card can
+/// be exercised by widget tests in isolation.
+class LinkDeviceThisDeviceCard extends StatelessWidget {
+  final String? myId;
+
+  const LinkDeviceThisDeviceCard({super.key, required this.myId});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.smartphone, size: 20),
+                const SizedBox(width: 8),
+                Text(
+                  l10n?.linkDeviceThisDeviceLabel ?? 'This device',
+                  style: theme.textTheme.titleMedium
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              l10n?.linkDeviceShareCodeHint ??
+                  'Share this code with your other device:',
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+            const SizedBox(height: 8),
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: SelectableText(
+                      myId ??
+                          (l10n?.linkDeviceNotConnected ?? 'Not connected'),
+                      style: theme.textTheme.bodySmall
+                          ?.copyWith(fontFamily: 'monospace'),
+                    ),
+                  ),
+                  if (myId != null)
+                    IconButton(
+                      icon: const Icon(Icons.copy, size: 18),
+                      tooltip:
+                          l10n?.linkDeviceCopyCodeTooltip ?? 'Copy code',
+                      onPressed: () {
+                        Clipboard.setData(ClipboardData(text: myId!));
+                        SnackBarHelper.show(
+                          context,
+                          AppLocalizations.of(context)?.deviceCodeCopied ??
+                              'Device code copied',
+                        );
+                      },
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(
+                          minWidth: 32, minHeight: 32),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/sync/presentation/widgets/link_device_this_device_card_test.dart
+++ b/test/features/sync/presentation/widgets/link_device_this_device_card_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/sync/presentation/widgets/link_device_this_device_card.dart';
+
+void main() {
+  group('LinkDeviceThisDeviceCard', () {
+    Future<void> pumpCard(WidgetTester tester, {String? myId}) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: LinkDeviceThisDeviceCard(myId: myId),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the device id when one is provided', (tester) async {
+      await pumpCard(tester, myId: 'abc-123-def');
+      expect(find.text('abc-123-def'), findsOneWidget);
+      expect(find.text('Not connected'), findsNothing);
+    });
+
+    testWidgets('renders "Not connected" when myId is null', (tester) async {
+      await pumpCard(tester, myId: null);
+      expect(find.text('Not connected'), findsOneWidget);
+    });
+
+    testWidgets('shows the copy button when myId is non-null',
+        (tester) async {
+      await pumpCard(tester, myId: 'abc-123');
+      expect(find.byIcon(Icons.copy), findsOneWidget);
+    });
+
+    testWidgets('hides the copy button when myId is null', (tester) async {
+      await pumpCard(tester, myId: null);
+      expect(find.byIcon(Icons.copy), findsNothing);
+    });
+
+    testWidgets('tapping the copy button writes the id to the clipboard',
+        (tester) async {
+      // Mock the clipboard channel because flutter_test doesn't ship a
+      // platform implementation.
+      String? captured;
+      TestDefaultBinaryMessengerBinding
+          .instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          final args = call.arguments as Map;
+          captured = args['text'] as String?;
+        }
+        return null;
+      });
+
+      await pumpCard(tester, myId: 'copy-me-please');
+      await tester.tap(find.byIcon(Icons.copy));
+      await tester.pump();
+
+      expect(captured, 'copy-me-please');
+
+      TestDefaultBinaryMessengerBinding
+          .instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Promotes the second of the three private cards in \`link_device_screen.dart\` to a standalone widget under \`presentation/widgets/\`. Follows #447 (HowItWorksCard) and continues the cleanup started by #417.

The card displays the device's anonymous user id with a copy-to-clipboard button. Pulling it out:
- Drops 78 lines of inline private widget from the screen
- Eliminates 2 imports the analyzer flagged as unused once the widget left the file (\`services.dart\`, \`snackbar_helper.dart\`)
- Lets the copy interaction be exercised by widget tests

\`link_device_screen.dart\`: **232 → 152 lines (-80)**.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] **5 new tests** in \`link_device_this_device_card_test.dart\`:
  1. Renders the device id when one is provided
  2. Renders "Not connected" when \`myId\` is null
  3. Shows the copy button when \`myId\` is non-null
  4. Hides the copy button when \`myId\` is null
  5. Tapping the copy button writes the id to the clipboard (mocked \`SystemChannels.platform\` handler)
- [x] All 110 existing sync tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)