### PR TITLE
refactor(search): promote AmenityFilterWrap to standalone widget

### DIFF
--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -16,11 +16,11 @@ import '../../../route_search/providers/route_search_provider.dart';
 import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_mode.dart';
 import '../../domain/entities/station.dart';
-import '../../domain/entities/station_amenity.dart';
 import '../../providers/ev_search_provider.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
 import '../../providers/search_screen_ui_provider.dart';
+import '../widgets/amenity_filter_wrap.dart';
 import '../widgets/brand_filter_chips.dart';
 import '../widgets/fuel_type_selector.dart';
 import '../widgets/location_input.dart';
@@ -219,7 +219,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
                 style: theme.textTheme.titleSmall,
               ),
               const SizedBox(height: 8),
-              _AmenityFilterWrap(
+              AmenityFilterWrap(
                 selected: amenities,
                 onToggle: (a) => ref
                     .read(selectedAmenitiesProvider.notifier)
@@ -269,45 +269,3 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
   }
 }
 
-/// Wrap of FilterChips, one per [StationAmenity].
-class _AmenityFilterWrap extends StatelessWidget {
-  final Set<StationAmenity> selected;
-  final ValueChanged<StationAmenity> onToggle;
-
-  const _AmenityFilterWrap({
-    required this.selected,
-    required this.onToggle,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    return Wrap(
-      spacing: 8,
-      runSpacing: 4,
-      children: [
-        for (final amenity in StationAmenity.values)
-          FilterChip(
-            key: ValueKey('criteria-amenity-${amenity.name}'),
-            avatar: Icon(amenityIcon(amenity), size: 18),
-            label: Text(_label(amenity, l10n)),
-            selected: selected.contains(amenity),
-            onSelected: (_) => onToggle(amenity),
-          ),
-      ],
-    );
-  }
-
-  String _label(StationAmenity a, AppLocalizations? l10n) {
-    return switch (a) {
-      StationAmenity.shop => l10n?.amenityShop ?? 'Shop',
-      StationAmenity.carWash => l10n?.amenityCarWash ?? 'Car Wash',
-      StationAmenity.airPump => l10n?.amenityAirPump ?? 'Air',
-      StationAmenity.toilet => l10n?.amenityToilet ?? 'WC',
-      StationAmenity.restaurant => l10n?.amenityRestaurant ?? 'Food',
-      StationAmenity.atm => l10n?.amenityAtm ?? 'ATM',
-      StationAmenity.wifi => l10n?.amenityWifi ?? 'WiFi',
-      StationAmenity.ev => l10n?.amenityEv ?? 'EV',
-    };
-  }
-}

--- a/lib/features/search/presentation/widgets/amenity_filter_wrap.dart
+++ b/lib/features/search/presentation/widgets/amenity_filter_wrap.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/station_amenity.dart';
+
+/// Wrap of FilterChips, one per [StationAmenity], used by the Search
+/// criteria screen to let the user filter results by station equipment
+/// (shop, car wash, toilet, EV, …).
+///
+/// Stateless: the parent owns the selection set and forwards toggles
+/// via [onToggle]. Pulled out of `search_criteria_screen.dart` so the
+/// screen drops the inline private widget and so the chip wrap can be
+/// exercised by widget tests in isolation.
+class AmenityFilterWrap extends StatelessWidget {
+  final Set<StationAmenity> selected;
+  final ValueChanged<StationAmenity> onToggle;
+
+  const AmenityFilterWrap({
+    super.key,
+    required this.selected,
+    required this.onToggle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Wrap(
+      spacing: 8,
+      runSpacing: 4,
+      children: [
+        for (final amenity in StationAmenity.values)
+          FilterChip(
+            key: ValueKey('criteria-amenity-${amenity.name}'),
+            avatar: Icon(amenityIcon(amenity), size: 18),
+            label: Text(_label(amenity, l10n)),
+            selected: selected.contains(amenity),
+            onSelected: (_) => onToggle(amenity),
+          ),
+      ],
+    );
+  }
+
+  String _label(StationAmenity a, AppLocalizations? l10n) {
+    return switch (a) {
+      StationAmenity.shop => l10n?.amenityShop ?? 'Shop',
+      StationAmenity.carWash => l10n?.amenityCarWash ?? 'Car Wash',
+      StationAmenity.airPump => l10n?.amenityAirPump ?? 'Air',
+      StationAmenity.toilet => l10n?.amenityToilet ?? 'WC',
+      StationAmenity.restaurant => l10n?.amenityRestaurant ?? 'Food',
+      StationAmenity.atm => l10n?.amenityAtm ?? 'ATM',
+      StationAmenity.wifi => l10n?.amenityWifi ?? 'WiFi',
+      StationAmenity.ev => l10n?.amenityEv ?? 'EV',
+    };
+  }
+}

--- a/test/features/search/presentation/widgets/amenity_filter_wrap_test.dart
+++ b/test/features/search/presentation/widgets/amenity_filter_wrap_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/domain/entities/station_amenity.dart';
+import 'package:tankstellen/features/search/presentation/widgets/amenity_filter_wrap.dart';
+
+void main() {
+  group('AmenityFilterWrap', () {
+    Future<void> pumpWrap(
+      WidgetTester tester, {
+      required Set<StationAmenity> selected,
+      required ValueChanged<StationAmenity> onToggle,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AmenityFilterWrap(
+              selected: selected,
+              onToggle: onToggle,
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders one FilterChip per amenity value', (tester) async {
+      await pumpWrap(tester, selected: const {}, onToggle: (_) {});
+      expect(
+        find.byType(FilterChip),
+        findsNWidgets(StationAmenity.values.length),
+      );
+    });
+
+    testWidgets('selected chips render in selected state', (tester) async {
+      await pumpWrap(
+        tester,
+        selected: {StationAmenity.shop, StationAmenity.toilet},
+        onToggle: (_) {},
+      );
+      final chips = tester.widgetList<FilterChip>(find.byType(FilterChip));
+      final selectedCount = chips.where((c) => c.selected).length;
+      expect(selectedCount, 2);
+    });
+
+    testWidgets('tapping a chip invokes onToggle with that amenity',
+        (tester) async {
+      StationAmenity? captured;
+      await pumpWrap(
+        tester,
+        selected: const {},
+        onToggle: (a) => captured = a,
+      );
+      await tester.tap(find.text('Shop'));
+      await tester.pump();
+      expect(captured, StationAmenity.shop);
+    });
+
+    testWidgets('every chip carries a stable ValueKey', (tester) async {
+      await pumpWrap(tester, selected: const {}, onToggle: (_) {});
+      for (final amenity in StationAmenity.values) {
+        expect(
+          find.byKey(ValueKey('criteria-amenity-${amenity.name}')),
+          findsOneWidget,
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The Search criteria screen still carried \`_AmenityFilterWrap\` as a private widget at the bottom of the file (~42 lines). Promotes it to \`presentation/widgets/amenity_filter_wrap.dart\` so:

- The screen file shrinks **313 → 271 lines (-42)**
- The \`station_amenity.dart\` import the screen no longer needs is dropped (analyzer flagged it as unused)
- The chip wrap can be exercised by widget tests in isolation

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] **4 new tests** in \`amenity_filter_wrap_test.dart\`:
  1. Renders one FilterChip per \`StationAmenity\` value
  2. Selected chips render in selected state
  3. Tapping a chip invokes \`onToggle\` with that amenity
  4. Every chip carries a stable \`criteria-amenity-{name}\` ValueKey
- [x] All 457 existing search tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)