### PR TITLE
refactor(setup): promote CountryStatusBadge to standalone widget

### DIFF
--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -13,6 +13,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../data/api_key_validator.dart';
 import '../../providers/api_key_validator_provider.dart';
+import '../widgets/country_status_badge.dart';
 
 class SetupScreen extends ConsumerStatefulWidget {
   const SetupScreen({super.key});
@@ -344,7 +345,7 @@ class _CountryInfoCard extends StatelessWidget {
                       ),
                     ),
                   ),
-                  _CountryStatusBadge(country: country),
+                  CountryStatusBadge(country: country),
                 ],
               ),
               const SizedBox(height: 8),
@@ -362,38 +363,6 @@ class _CountryInfoCard extends StatelessWidget {
   }
 }
 
-class _CountryStatusBadge extends StatelessWidget {
-  final CountryConfig country;
-
-  const _CountryStatusBadge({required this.country});
-
-  @override
-  Widget build(BuildContext context) {
-    return ExcludeSemantics(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        decoration: BoxDecoration(
-          color: country.requiresApiKey
-              ? Colors.orange.shade100
-              : Colors.green.shade100,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: Text(
-          country.requiresApiKey
-              ? 'API key required'
-              : 'Free — no key needed',
-          style: TextStyle(
-            fontSize: 11,
-            fontWeight: FontWeight.w600,
-            color: country.requiresApiKey
-                ? Colors.orange.shade800
-                : Colors.green.shade800,
-          ),
-        ),
-      ),
-    );
-  }
-}
 
 class _ApiKeyInputSection extends StatelessWidget {
   final CountryConfig country;

--- a/lib/features/setup/presentation/widgets/country_status_badge.dart
+++ b/lib/features/setup/presentation/widgets/country_status_badge.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/country/country_config.dart';
+
+/// Small pill that labels a country with either "API key required" (orange)
+/// or "Free — no key needed" (green). Used inside the country picker on
+/// the Setup screen.
+///
+/// Pulled out of `setup_screen.dart` so the screen stops carrying the
+/// inline private widget and so the badge can be exercised by widget
+/// tests in isolation. The styling rule (orange vs green based on
+/// `country.requiresApiKey`) now lives in exactly one place.
+class CountryStatusBadge extends StatelessWidget {
+  final CountryConfig country;
+
+  const CountryStatusBadge({super.key, required this.country});
+
+  @override
+  Widget build(BuildContext context) {
+    final requiresKey = country.requiresApiKey;
+    return ExcludeSemantics(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color:
+              requiresKey ? Colors.orange.shade100 : Colors.green.shade100,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          requiresKey ? 'API key required' : 'Free — no key needed',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color:
+                requiresKey ? Colors.orange.shade800 : Colors.green.shade800,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/setup/presentation/widgets/country_status_badge_test.dart
+++ b/test/features/setup/presentation/widgets/country_status_badge_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/country_status_badge.dart';
+
+const _withKey = CountryConfig(
+  code: 'DE',
+  name: 'Deutschland',
+  flag: '🇩🇪',
+  locale: 'de_DE',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'PLZ',
+  requiresApiKey: true,
+);
+
+const _withoutKey = CountryConfig(
+  code: 'FR',
+  name: 'France',
+  flag: '🇫🇷',
+  locale: 'fr_FR',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'Code postal',
+  requiresApiKey: false,
+);
+
+void main() {
+  group('CountryStatusBadge', () {
+    Future<void> pumpBadge(WidgetTester tester, CountryConfig country) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CountryStatusBadge(country: country),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders "API key required" when requiresApiKey is true',
+        (tester) async {
+      await pumpBadge(tester, _withKey);
+      expect(find.text('API key required'), findsOneWidget);
+      expect(find.text('Free — no key needed'), findsNothing);
+    });
+
+    testWidgets('renders "Free — no key needed" when requiresApiKey is false',
+        (tester) async {
+      await pumpBadge(tester, _withoutKey);
+      expect(find.text('Free — no key needed'), findsOneWidget);
+      expect(find.text('API key required'), findsNothing);
+    });
+
+    testWidgets('uses the orange palette when an API key is required',
+        (tester) async {
+      await pumpBadge(tester, _withKey);
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, Colors.orange.shade100);
+    });
+
+    testWidgets('uses the green palette when no API key is required',
+        (tester) async {
+      await pumpBadge(tester, _withoutKey);
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, Colors.green.shade100);
+    });
+
+    testWidgets('is wrapped in ExcludeSemantics so the pill never reads to '
+        'screen readers (the country tile already announces it)',
+        (tester) async {
+      await pumpBadge(tester, _withKey);
+      // findsAtLeastNWidgets(1) — the badge tree introduces one
+      // ExcludeSemantics; the test scaffold may add another one (e.g.
+      // around the body), so we only assert *at least* one is present.
+      expect(find.byType(ExcludeSemantics), findsAtLeast(1));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The 508-line \`setup_screen.dart\` carried 7 private widgets in the same file. Promotes the simplest one — \`_CountryStatusBadge\`, a 33-line "API key required / Free — no key needed" pill — to a standalone widget under \`presentation/widgets/\`.

The styling rule (orange when \`country.requiresApiKey\`, green otherwise) now lives in exactly one place and is exercisable by widget tests in isolation.

\`setup_screen.dart\`: **508 → 477 lines (-31)**.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] **5 new tests** in \`country_status_badge_test.dart\`:
  1. Renders "API key required" when \`requiresApiKey\` is true
  2. Renders "Free — no key needed" when \`requiresApiKey\` is false
  3. Uses the orange palette when an API key is required
  4. Uses the green palette when no API key is required
  5. Is wrapped in \`ExcludeSemantics\` (the country tile already announces it to screen readers)
- [x] All 74 existing setup tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)