### PR TITLE
refactor(favorites): extract FavoriteStationDismissible from favorites_screen build

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -2,22 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/services/service_result.dart';
-import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/sync/sync_provider.dart';
-import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../search/domain/entities/fuel_type.dart';
-import '../../../search/presentation/widgets/station_card.dart';
-import '../../../profile/providers/profile_provider.dart';
 import '../../providers/ev_favorites_provider.dart';
 import '../../providers/favorites_provider.dart';
 import '../widgets/alerts_tab.dart';
 import '../widgets/ev_favorite_card.dart';
 import '../widgets/ev_favorites_list_view.dart';
+import '../widgets/favorite_station_dismissible.dart';
 import '../widgets/favorites_loading_view.dart';
 import '../widgets/favorites_section_header.dart';
 import '../widgets/swipe_tutorial_banner.dart';
@@ -36,10 +32,6 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
     Future.microtask(() {
       ref.read(favoriteStationsProvider.notifier).loadAndRefresh();
     });
-  }
-
-  void _openStationInMaps(double lat, double lng, String label) {
-    NavigationUtils.openInMaps(lat, lng, label: label);
   }
 
   @override
@@ -167,86 +159,10 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
                         ),
                     ],
                     // Fuel favorites
-                    ...result.data.map((station) {
-                      final label = station.displayName;
-                      return Dismissible(
-                        key: ValueKey('fav-${station.id}'),
-                        confirmDismiss: (direction) async {
-                          if (direction == DismissDirection.startToEnd) {
-                            _openStationInMaps(station.lat, station.lng, label);
-                            return false;
-                          } else {
-                            await ref
-                                .read(favoritesProvider.notifier)
-                                .remove(station.id);
-                            if (!context.mounted) return true;
-                            final l10nSnack = AppLocalizations.of(context);
-                            SnackBarHelper.showWithUndo(
-                              context,
-                              l10nSnack?.removedFromFavoritesName(label) ??
-                                  '$label removed from favorites',
-                              undoLabel: l10nSnack?.undo ?? 'Undo',
-                              onUndo: () => ref
-                                  .read(favoritesProvider.notifier)
-                                  .add(station.id, stationData: station),
-                            );
-                            return true;
-                          }
-                        },
-                        background: Semantics(
-                          label: 'Navigate to $label',
-                          child: Container(
-                            alignment: Alignment.centerLeft,
-                            padding: const EdgeInsets.only(left: 24),
-                            color: Theme.of(context).colorScheme.primary,
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const Icon(Icons.navigation,
-                                    color: Colors.white, size: 20),
-                                const SizedBox(width: 8),
-                                Text(l10n?.navigate ?? 'Navigate',
-                                    style: const TextStyle(
-                                        color: Colors.white,
-                                        fontWeight: FontWeight.bold)),
-                              ],
-                            ),
-                          ),
-                        ),
-                        secondaryBackground: Semantics(
-                          label: 'Remove $label from favorites',
-                          child: Container(
-                            alignment: Alignment.centerRight,
-                            padding: const EdgeInsets.only(right: 24),
-                            color: Colors.red,
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text(l10n?.remove ?? 'Remove',
-                                    style: const TextStyle(
-                                        color: Colors.white,
-                                        fontWeight: FontWeight.bold)),
-                                const SizedBox(width: 8),
-                                const Icon(Icons.delete, color: Colors.white, size: 20),
-                              ],
-                            ),
-                          ),
-                        ),
-                        child: StationCard(
-                          key: ValueKey(station.id),
-                          station: station,
-                          selectedFuelType: FuelType.all,
-                          isFavorite: true,
-                          profileFuelType: ref.watch(activeProfileProvider)?.preferredFuelType,
-                          onTap: () => context.push('/station/${station.id}'),
-                          onFavoriteTap: () {
-                            ref
-                                .read(favoritesProvider.notifier)
-                                .remove(station.id);
-                          },
-                        ),
-                      );
-                    }),
+                    ...result.data.map(
+                      (station) =>
+                          FavoriteStationDismissible(station: station),
+                    ),
                   ],
                 ),
               ),

--- a/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/utils/navigation_utils.dart';
+import '../../../../core/utils/station_extensions.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../profile/providers/profile_provider.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+import '../../../search/domain/entities/station.dart';
+import '../../../search/presentation/widgets/station_card.dart';
+import '../../providers/favorites_provider.dart';
+
+/// Wraps a [StationCard] in a swipe-to-act gesture for the Favorites
+/// list. Swiping right launches turn-by-turn navigation in the system
+/// maps app; swiping left removes the favorite (with an undo snackbar).
+///
+/// Stateless apart from watching `activeProfileProvider` for the
+/// preferred fuel type and `favoritesProvider` for the remove/undo
+/// actions. Pulled out of `favorites_screen.dart` so the screen's
+/// `_buildFavoritesTab` helper drops the 80-line inline `Dismissible`
+/// block and so the swipe gestures can be exercised by widget tests.
+class FavoriteStationDismissible extends ConsumerWidget {
+  final Station station;
+
+  const FavoriteStationDismissible({super.key, required this.station});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final label = station.displayName;
+
+    return Dismissible(
+      key: ValueKey('fav-${station.id}'),
+      confirmDismiss: (direction) async {
+        if (direction == DismissDirection.startToEnd) {
+          await NavigationUtils.openInMaps(
+            station.lat,
+            station.lng,
+            label: label,
+          );
+          return false;
+        }
+        await ref.read(favoritesProvider.notifier).remove(station.id);
+        if (!context.mounted) return true;
+        final l10nSnack = AppLocalizations.of(context);
+        SnackBarHelper.showWithUndo(
+          context,
+          l10nSnack?.removedFromFavoritesName(label) ??
+              '$label removed from favorites',
+          undoLabel: l10nSnack?.undo ?? 'Undo',
+          onUndo: () => ref
+              .read(favoritesProvider.notifier)
+              .add(station.id, stationData: station),
+        );
+        return true;
+      },
+      background: Semantics(
+        label: 'Navigate to $label',
+        child: Container(
+          alignment: Alignment.centerLeft,
+          padding: const EdgeInsets.only(left: 24),
+          color: Theme.of(context).colorScheme.primary,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.navigation,
+                  color: Colors.white, size: 20),
+              const SizedBox(width: 8),
+              Text(
+                l10n?.navigate ?? 'Navigate',
+                style: const TextStyle(
+                    color: Colors.white, fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
+        ),
+      ),
+      secondaryBackground: Semantics(
+        label: 'Remove $label from favorites',
+        child: Container(
+          alignment: Alignment.centerRight,
+          padding: const EdgeInsets.only(right: 24),
+          color: Colors.red,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                l10n?.remove ?? 'Remove',
+                style: const TextStyle(
+                    color: Colors.white, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(width: 8),
+              const Icon(Icons.delete, color: Colors.white, size: 20),
+            ],
+          ),
+        ),
+      ),
+      child: StationCard(
+        key: ValueKey(station.id),
+        station: station,
+        selectedFuelType: FuelType.all,
+        isFavorite: true,
+        profileFuelType: ref.watch(activeProfileProvider)?.preferredFuelType,
+        onTap: () => context.push('/station/${station.id}'),
+        onFavoriteTap: () {
+          ref.read(favoritesProvider.notifier).remove(station.id);
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
The 80-line inline \`Dismissible\` block inside \`_buildFavoritesTab\` carried a swipe-right-to-navigate + swipe-left-to-remove gesture around every \`StationCard\`, plus all the Semantics labels and the undo-snackbar wiring. Pulls it into a standalone \`FavoriteStationDismissible\` ConsumerWidget so:

- The \`.map((station) {...})\` collapses to a 3-line lambda
- The dismissible interaction can be exercised by widget tests
- 4 unused imports + the unused \`_openStationInMaps\` helper drop out after the extraction

\`favorites_screen.dart\`: **283 → 199 lines (-84)**.

The widget reads the preferred fuel type from \`activeProfileProvider\` and the remove/undo actions from \`favoritesProvider\`, same as the inline version.

Refs #388

## Test plan
- [x] \`flutter analyze\` clean
- [x] All 58 existing favorites tests still pass
- [x] Behaviour preserved: \`FavoriteStationDismissible\` reproduces the exact same swipe-left (remove + undo snackbar) and swipe-right (open maps) semantics, including the Semantics labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)