### PR TITLE
refactor(setup): extract ApiKeyInputSection from setup_screen (#388)

### DIFF
--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '../../../../core/country/country_config.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/language/language_provider.dart';
@@ -13,6 +12,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../data/api_key_validator.dart';
 import '../../providers/api_key_validator_provider.dart';
+import '../widgets/api_key_input_section.dart';
 import '../widgets/country_status_badge.dart';
 
 class SetupScreen extends ConsumerStatefulWidget {
@@ -154,7 +154,7 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
               _CountryInfoCard(country: country),
               const SizedBox(height: 24),
               if (country.requiresApiKey) ...[
-                _ApiKeyInputSection(
+                ApiKeyInputSection(
                   country: country,
                   controller: _apiKeyController,
                   formatValid: _isFormatValid,
@@ -363,83 +363,6 @@ class _CountryInfoCard extends StatelessWidget {
   }
 }
 
-
-class _ApiKeyInputSection extends StatelessWidget {
-  final CountryConfig country;
-  final TextEditingController controller;
-  final bool? formatValid;
-  final AppLocalizations? l10n;
-
-  const _ApiKeyInputSection({
-    required this.country,
-    required this.controller,
-    required this.formatValid,
-    required this.l10n,
-  });
-
-  Widget? _buildFormatIndicator() {
-    if (formatValid == null) return null;
-    if (formatValid!) {
-      return const Icon(Icons.check_circle, color: Colors.green);
-    }
-    return const Icon(Icons.error_outline, color: Colors.red);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text('API key setup (optional)', style: theme.textTheme.titleMedium),
-        const SizedBox(height: 8),
-        Text(
-          'Register for a free API key, or skip to explore '
-          'the app with demo data.',
-          style: theme.textTheme.bodyMedium,
-        ),
-        const SizedBox(height: 12),
-        if (country.apiKeyRegistrationUrl != null)
-          OutlinedButton.icon(
-            onPressed: () async {
-              final uri = Uri.parse(country.apiKeyRegistrationUrl!);
-              if (await canLaunchUrl(uri)) {
-                await launchUrl(
-                  uri,
-                  mode: LaunchMode.externalApplication,
-                );
-              }
-            },
-            icon: const Icon(Icons.open_in_new),
-            label: Text('${country.apiProvider} Registration'),
-          ),
-        const SizedBox(height: 16),
-        TextField(
-          controller: controller,
-          decoration: InputDecoration(
-            labelText: l10n?.apiKeyLabel ?? 'API Key',
-            hintText: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-            prefixIcon: const Icon(Icons.key),
-            border: const OutlineInputBorder(),
-            suffixIcon: _buildFormatIndicator(),
-            errorText: formatValid == false
-                ? (l10n?.apiKeyFormatError ??
-                    'Invalid format — expected UUID (8-4-4-4-12)')
-                : null,
-          ),
-        ),
-        const SizedBox(height: 8),
-        Text(
-          'By entering an API key you accept the terms of '
-          '${country.apiProvider}. Data redistribution is prohibited.',
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-        ),
-      ],
-    );
-  }
-}
 
 class _ContinueButton extends StatelessWidget {
   final bool isLoading;

--- a/lib/features/setup/presentation/widgets/api_key_input_section.dart
+++ b/lib/features/setup/presentation/widgets/api_key_input_section.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../../core/country/country_config.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Setup screen section: optional API key input with format validation and a
+/// link to the provider's registration page. Used only when
+/// [CountryConfig.requiresApiKey] is true. Pulled out of `setup_screen.dart`
+/// so the screen no longer carries an 80-line widget block and so the
+/// validation indicator + registration launch can be exercised by widget
+/// tests in isolation.
+class ApiKeyInputSection extends StatelessWidget {
+  final CountryConfig country;
+  final TextEditingController controller;
+  final bool? formatValid;
+  final AppLocalizations? l10n;
+
+  const ApiKeyInputSection({
+    super.key,
+    required this.country,
+    required this.controller,
+    required this.formatValid,
+    required this.l10n,
+  });
+
+  Widget? _buildFormatIndicator() {
+    if (formatValid == null) return null;
+    if (formatValid!) {
+      return const Icon(Icons.check_circle, color: Colors.green);
+    }
+    return const Icon(Icons.error_outline, color: Colors.red);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('API key setup (optional)', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        Text(
+          'Register for a free API key, or skip to explore '
+          'the app with demo data.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 12),
+        if (country.apiKeyRegistrationUrl != null)
+          OutlinedButton.icon(
+            onPressed: () async {
+              final uri = Uri.parse(country.apiKeyRegistrationUrl!);
+              if (await canLaunchUrl(uri)) {
+                await launchUrl(
+                  uri,
+                  mode: LaunchMode.externalApplication,
+                );
+              }
+            },
+            icon: const Icon(Icons.open_in_new),
+            label: Text('${country.apiProvider} Registration'),
+          ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: controller,
+          decoration: InputDecoration(
+            labelText: l10n?.apiKeyLabel ?? 'API Key',
+            hintText: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+            prefixIcon: const Icon(Icons.key),
+            border: const OutlineInputBorder(),
+            suffixIcon: _buildFormatIndicator(),
+            errorText: formatValid == false
+                ? (l10n?.apiKeyFormatError ??
+                    'Invalid format — expected UUID (8-4-4-4-12)')
+                : null,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'By entering an API key you accept the terms of '
+          '${country.apiProvider}. Data redistribution is prohibited.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/setup/presentation/widgets/api_key_input_section_test.dart
+++ b/test/features/setup/presentation/widgets/api_key_input_section_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/api_key_input_section.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+const _germany = CountryConfig(
+  code: 'DE',
+  name: 'Deutschland',
+  flag: '🇩🇪',
+  locale: 'de_DE',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'PLZ',
+  requiresApiKey: true,
+  apiProvider: 'Tankerkoenig',
+  apiKeyRegistrationUrl: 'https://creativecommons.tankerkoenig.de/',
+);
+
+const _germanyNoUrl = CountryConfig(
+  code: 'DE',
+  name: 'Deutschland',
+  flag: '🇩🇪',
+  locale: 'de_DE',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'PLZ',
+  requiresApiKey: true,
+  apiProvider: 'Tankerkoenig',
+);
+
+void main() {
+  group('ApiKeyInputSection', () {
+    Future<void> pumpSection(
+      WidgetTester tester, {
+      required bool? formatValid,
+      CountryConfig country = _germany,
+      TextEditingController? controller,
+    }) async {
+      final ctrl = controller ?? TextEditingController();
+      addTearDown(ctrl.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: ApiKeyInputSection(
+                country: country,
+                controller: ctrl,
+                formatValid: formatValid,
+                l10n: null,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('shows no validation indicator when format state is null',
+        (tester) async {
+      await pumpSection(tester, formatValid: null);
+      expect(find.byIcon(Icons.check_circle), findsNothing);
+      expect(find.byIcon(Icons.error_outline), findsNothing);
+    });
+
+    testWidgets('shows green check when the format is valid', (tester) async {
+      await pumpSection(tester, formatValid: true);
+      final icon = tester.widget<Icon>(find.byIcon(Icons.check_circle));
+      expect(icon.color, Colors.green);
+    });
+
+    testWidgets('shows red error icon and error text when format is invalid',
+        (tester) async {
+      await pumpSection(tester, formatValid: false);
+      final icon = tester.widget<Icon>(find.byIcon(Icons.error_outline));
+      expect(icon.color, Colors.red);
+      expect(
+        find.text('Invalid format — expected UUID (8-4-4-4-12)'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders the registration button when a URL is configured',
+        (tester) async {
+      await pumpSection(tester, formatValid: null);
+      expect(find.text('Tankerkoenig Registration'), findsOneWidget);
+      expect(find.byIcon(Icons.open_in_new), findsOneWidget);
+    });
+
+    testWidgets('omits the registration button when no URL is configured',
+        (tester) async {
+      await pumpSection(tester, formatValid: null, country: _germanyNoUrl);
+      expect(find.text('Tankerkoenig Registration'), findsNothing);
+      expect(find.byIcon(Icons.open_in_new), findsNothing);
+    });
+
+    testWidgets('routes typed text into the supplied controller',
+        (tester) async {
+      final controller = TextEditingController();
+      await pumpSection(tester, formatValid: null, controller: controller);
+      await tester.enterText(find.byType(TextField), 'abc-123');
+      expect(controller.text, 'abc-123');
+    });
+
+    testWidgets('renders the terms-of-use disclaimer with provider name',
+        (tester) async {
+      await pumpSection(tester, formatValid: null);
+      expect(
+        find.textContaining('Tankerkoenig'),
+        findsAtLeast(1),
+      );
+      expect(
+        find.textContaining('Data redistribution is prohibited.'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Pulls the 75-line `_ApiKeyInputSection` out of `setup_screen.dart` into its own widget under `lib/features/setup/presentation/widgets/`
- `setup_screen.dart` 477 -> 400 lines; drops the now-unused `package:url_launcher/url_launcher.dart` import
- 7 new widget tests cover the three format states (null/valid/invalid), conditional registration button, controller wiring, and terms-of-use footer

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean
- [x] `flutter test test/features/setup/` — 81 tests pass
- [x] CI build-android

Closes part of #388.