### PR TITLE
refactor(favorites): extract FavoritesFuelTab from favorites_screen (#388)

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -1,22 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import '../../../../core/services/service_result.dart';
-import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/sync/sync_provider.dart';
-import '../../../../core/widgets/empty_state.dart';
-import '../../../../core/widgets/snackbar_helper.dart';
-import '../../../search/domain/entities/station.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../providers/ev_favorites_provider.dart';
 import '../../providers/favorites_provider.dart';
 import '../widgets/alerts_tab.dart';
-import '../widgets/ev_favorite_card.dart';
-import '../widgets/ev_favorites_list_view.dart';
-import '../widgets/favorite_station_dismissible.dart';
-import '../widgets/favorites_loading_view.dart';
-import '../widgets/favorites_section_header.dart';
-import '../widgets/swipe_tutorial_banner.dart';
+import '../widgets/favorites_fuel_tab.dart';
 
 class FavoritesScreen extends ConsumerStatefulWidget {
   const FavoritesScreen({super.key});
@@ -38,7 +26,6 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final favoriteIds = ref.watch(favoritesProvider);
-    final stationsState = ref.watch(favoriteStationsProvider);
 
     // Reload favorites when the auth identity changes
     // (anonymous -> email, reconnect, disconnect, etc.)
@@ -76,124 +63,13 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
             ],
           ),
         ),
-        body: TabBarView(
+        body: const TabBarView(
           children: [
-            _buildFavoritesTab(context, l10n, favoriteIds, stationsState),
-            const AlertsTab(),
+            FavoritesFuelTab(),
+            AlertsTab(),
           ],
         ),
       ),
     );
   }
-
-  Widget _buildFavoritesTab(
-    BuildContext context,
-    AppLocalizations? l10n,
-    List<String> favoriteIds,
-    AsyncValue<ServiceResult<List<Station>>> stationsState,
-  ) {
-    final evStations = ref.watch(evFavoriteStationsProvider);
-    final hasEvFavorites = evStations.isNotEmpty;
-
-    if (favoriteIds.isEmpty && !hasEvFavorites) {
-      return Semantics(
-        label:
-            'No favorites yet. Tap the star on a station to save it as a favorite.',
-        child: EmptyState(
-          icon: Icons.star_outline,
-          iconSize: 80,
-          title: l10n?.noFavorites ?? 'No favorites yet',
-          subtitle: l10n?.noFavoritesHint ??
-              'Tap the star on a station to save it here',
-          actionLabel: l10n?.search ?? 'Search Stations',
-          onAction: () => context.go('/'),
-        ),
-      );
-    }
-
-    // If only EV favorites (no fuel), show them directly
-    if (favoriteIds.isEmpty && hasEvFavorites) {
-      return EvFavoritesListView(evStations: evStations);
-    }
-
-    return stationsState.when(
-      data: (result) {
-        if (result.data.isEmpty && !hasEvFavorites) {
-          return const FavoritesLoadingView();
-        }
-        return RefreshIndicator(
-          onRefresh: () async {
-            await ref.read(favoriteStationsProvider.notifier).loadAndRefresh();
-          },
-          child: Column(
-            children: [
-              if (result.data.isNotEmpty)
-                ServiceStatusBanner(result: result),
-              const SwipeTutorialBanner(),
-              Expanded(
-                child: ListView(
-                  children: [
-                    // EV favorites section
-                    if (hasEvFavorites) ...[
-                      FavoritesSectionHeader(
-                        icon: Icons.ev_station,
-                        label: l10n?.evChargingSection ?? 'EV Charging',
-                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-                      ),
-                      ...evStations.map((ev) => EvFavoriteCard(
-                            key: ValueKey('ev-${ev.id}'),
-                            station: ev,
-                            onTap: () => context.push('/ev-station', extra: ev),
-                            onFavoriteTap: () {
-                              ref.read(evFavoritesProvider.notifier).remove(ev.id);
-                              SnackBarHelper.show(
-                                context,
-                                l10n?.removedFromFavorites ?? 'Removed from favorites',
-                              );
-                            },
-                          )),
-                      if (result.data.isNotEmpty)
-                        FavoritesSectionHeader(
-                          icon: Icons.local_gas_station,
-                          label: l10n?.fuelStationsSection ?? 'Fuel Stations',
-                        ),
-                    ],
-                    // Fuel favorites
-                    ...result.data.map(
-                      (station) =>
-                          FavoriteStationDismissible(station: station),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        );
-      },
-      loading: () => hasEvFavorites
-          ? EvFavoritesListView(evStations: evStations)
-          : const FavoritesLoadingView(),
-      error: (error, _) => Semantics(
-        label: 'Error loading favorites: ${error.toString()}',
-        child: Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(Icons.error_outline, size: 48),
-              const SizedBox(height: 16),
-              Text(error.toString(), textAlign: TextAlign.center),
-              const SizedBox(height: 16),
-              FilledButton(
-                onPressed: () {
-                  ref.read(favoriteStationsProvider.notifier).loadAndRefresh();
-                },
-                child: Text(l10n?.retry ?? 'Retry'),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
 }

--- a/lib/features/favorites/presentation/widgets/favorites_fuel_tab.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_fuel_tab.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/services/widgets/service_status_banner.dart';
+import '../../../../core/widgets/empty_state.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../providers/ev_favorites_provider.dart';
+import '../../providers/favorites_provider.dart';
+import 'ev_favorite_card.dart';
+import 'ev_favorites_list_view.dart';
+import 'favorite_station_dismissible.dart';
+import 'favorites_loading_view.dart';
+import 'favorites_section_header.dart';
+import 'swipe_tutorial_banner.dart';
+
+/// Body of the "Favorites" tab inside `FavoritesScreen`. Owns the four
+/// rendering branches (empty / EV-only / loaded / error) and the EV+fuel
+/// section composition. Pulled out of `favorites_screen.dart` so the
+/// screen's `build` method becomes a thin Scaffold + TabBar shell and so
+/// each branch can be exercised by widget tests in isolation without
+/// constructing a full `DefaultTabController`.
+class FavoritesFuelTab extends ConsumerWidget {
+  const FavoritesFuelTab({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final favoriteIds = ref.watch(favoritesProvider);
+    final stationsState = ref.watch(favoriteStationsProvider);
+    final evStations = ref.watch(evFavoriteStationsProvider);
+    final hasEvFavorites = evStations.isNotEmpty;
+
+    if (favoriteIds.isEmpty && !hasEvFavorites) {
+      return Semantics(
+        label:
+            'No favorites yet. Tap the star on a station to save it as a favorite.',
+        child: EmptyState(
+          icon: Icons.star_outline,
+          iconSize: 80,
+          title: l10n?.noFavorites ?? 'No favorites yet',
+          subtitle: l10n?.noFavoritesHint ??
+              'Tap the star on a station to save it here',
+          actionLabel: l10n?.search ?? 'Search Stations',
+          onAction: () => context.go('/'),
+        ),
+      );
+    }
+
+    if (favoriteIds.isEmpty && hasEvFavorites) {
+      return EvFavoritesListView(evStations: evStations);
+    }
+
+    return stationsState.when(
+      data: (result) {
+        if (result.data.isEmpty && !hasEvFavorites) {
+          return const FavoritesLoadingView();
+        }
+        return RefreshIndicator(
+          onRefresh: () async {
+            await ref.read(favoriteStationsProvider.notifier).loadAndRefresh();
+          },
+          child: Column(
+            children: [
+              if (result.data.isNotEmpty)
+                ServiceStatusBanner(result: result),
+              const SwipeTutorialBanner(),
+              Expanded(
+                child: ListView(
+                  children: [
+                    if (hasEvFavorites) ...[
+                      FavoritesSectionHeader(
+                        icon: Icons.ev_station,
+                        label: l10n?.evChargingSection ?? 'EV Charging',
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+                      ),
+                      ...evStations.map((ev) => EvFavoriteCard(
+                            key: ValueKey('ev-${ev.id}'),
+                            station: ev,
+                            onTap: () =>
+                                context.push('/ev-station', extra: ev),
+                            onFavoriteTap: () {
+                              ref
+                                  .read(evFavoritesProvider.notifier)
+                                  .remove(ev.id);
+                              SnackBarHelper.show(
+                                context,
+                                l10n?.removedFromFavorites ??
+                                    'Removed from favorites',
+                              );
+                            },
+                          )),
+                      if (result.data.isNotEmpty)
+                        FavoritesSectionHeader(
+                          icon: Icons.local_gas_station,
+                          label: l10n?.fuelStationsSection ?? 'Fuel Stations',
+                        ),
+                    ],
+                    ...result.data.map(
+                      (station) =>
+                          FavoriteStationDismissible(station: station),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+      loading: () => hasEvFavorites
+          ? EvFavoritesListView(evStations: evStations)
+          : const FavoritesLoadingView(),
+      error: (error, _) => Semantics(
+        label: 'Error loading favorites: ${error.toString()}',
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.error_outline, size: 48),
+              const SizedBox(height: 16),
+              Text(error.toString(), textAlign: TextAlign.center),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () {
+                  ref
+                      .read(favoriteStationsProvider.notifier)
+                      .loadAndRefresh();
+                },
+                child: Text(l10n?.retry ?? 'Retry'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/favorites/presentation/widgets/favorites_fuel_tab_test.dart
+++ b/test/features/favorites/presentation/widgets/favorites_fuel_tab_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/favorites/presentation/widgets/favorites_fuel_tab.dart';
+import 'package:tankstellen/features/favorites/providers/ev_favorites_provider.dart';
+import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+ChargingStation _evStation({String id = 'ev-1', String name = 'Test Charger'}) {
+  return ChargingStation(
+    id: id,
+    name: name,
+    latitude: 48.8,
+    longitude: 2.3,
+    address: '1 Rue de Test',
+  );
+}
+
+void main() {
+  group('FavoritesFuelTab', () {
+    testWidgets('renders empty state when no favorites of any kind',
+        (tester) async {
+      final test = standardTestOverrides(favoriteIds: []);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const Material(child: FavoritesFuelTab()),
+        overrides: test.overrides,
+      );
+
+      expect(find.text('No favorites yet'), findsOneWidget);
+      expect(find.byIcon(Icons.star_outline), findsOneWidget);
+    });
+
+    testWidgets(
+        'renders EV-only list when there are no fuel favorites '
+        'but EV favorites exist', (tester) async {
+      final test = standardTestOverrides(favoriteIds: []);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const Material(child: FavoritesFuelTab()),
+        overrides: [
+          ...test.overrides,
+          evFavoriteStationsProvider
+              .overrideWith(() => _FixedEvFavorites([_evStation()])),
+        ].cast(),
+      );
+
+      // EV-only branch flips us into the EV-only path; the fuel empty-state
+      // copy must NOT appear.
+      expect(find.text('No favorites yet'), findsNothing);
+    });
+
+    testWidgets('renders error UI with retry button when stream errors',
+        (tester) async {
+      final test = standardTestOverrides(favoriteIds: ['stub-id']);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const Material(child: FavoritesFuelTab()),
+        overrides: [
+          ...test.overrides,
+          favoriteStationsProvider
+              .overrideWith(() => _ErroringFavoriteStations()),
+        ].cast(),
+      );
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.text('Try again'), findsOneWidget);
+    });
+  });
+}
+
+class _FixedEvFavorites extends EvFavoriteStations {
+  _FixedEvFavorites(this._stations);
+  final List<ChargingStation> _stations;
+
+  @override
+  List<ChargingStation> build() => _stations;
+}
+
+class _ErroringFavoriteStations extends FavoriteStations {
+  @override
+  AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.error(
+        Exception('boom'),
+        StackTrace.current,
+      );
+
+  @override
+  Future<void> loadAndRefresh() async {}
+}


### PR DESCRIPTION
## Summary
- Pulls the 110-line `_buildFavoritesTab` helper out of `favorites_screen.dart` into a standalone `FavoritesFuelTab` ConsumerWidget under `lib/features/favorites/presentation/widgets/`
- `favorites_screen.dart` 199 -> 75 lines; the screen's build method becomes a thin `Scaffold` + `TabBar` shell
- 3 new widget tests cover the **empty**, **EV-only fallback**, and **error-with-retry** branches — paths the existing screen tests didn't reach

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean (only pre-existing infos)
- [x] `flutter test test/features/favorites/` — 61 tests pass
- [x] CI build-android

Closes part of #388.