### PR TITLE
refactor(setup): extract CountryInfoCard from setup_screen (#388)

### DIFF
--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -13,7 +13,7 @@ import '../../../profile/providers/profile_provider.dart';
 import '../../data/api_key_validator.dart';
 import '../../providers/api_key_validator_provider.dart';
 import '../widgets/api_key_input_section.dart';
-import '../widgets/country_status_badge.dart';
+import '../widgets/country_info_card.dart';
 
 class SetupScreen extends ConsumerStatefulWidget {
   const SetupScreen({super.key});
@@ -151,7 +151,7 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
                     ref.read(activeCountryProvider.notifier).select(c),
               ),
               const SizedBox(height: 24),
-              _CountryInfoCard(country: country),
+              CountryInfoCard(country: country),
               const SizedBox(height: 24),
               if (country.requiresApiKey) ...[
                 ApiKeyInputSection(
@@ -298,71 +298,6 @@ class _CountrySelector extends StatelessWidget {
     );
   }
 }
-
-class _CountryInfoCard extends StatelessWidget {
-  final CountryConfig country;
-
-  const _CountryInfoCard({required this.country});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Semantics(
-      label: '${country.name}, data source: ${country.apiProvider ?? 'Demo'}, '
-          '${country.requiresApiKey ? 'API key required' : 'Free, no key needed'}, '
-          'fuel types: ${country.fuelTypes.join(', ')}',
-      child: Card(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  ExcludeSemantics(
-                    child: Text(
-                      country.flag,
-                      style: const TextStyle(fontSize: 24),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: ExcludeSemantics(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            country.name,
-                            style: theme.textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                          Text(
-                            'Data: ${country.apiProvider ?? 'Demo'}',
-                            style: theme.textTheme.bodySmall,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  CountryStatusBadge(country: country),
-                ],
-              ),
-              const SizedBox(height: 8),
-              ExcludeSemantics(
-                child: Text(
-                  'Fuel types: ${country.fuelTypes.join(', ')}',
-                  style: theme.textTheme.bodySmall,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 
 class _ContinueButton extends StatelessWidget {
   final bool isLoading;

--- a/lib/features/setup/presentation/widgets/country_info_card.dart
+++ b/lib/features/setup/presentation/widgets/country_info_card.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/country/country_config.dart';
+import 'country_status_badge.dart';
+
+/// Setup screen card summarising a [CountryConfig]: flag, name, API data
+/// source, the API-key requirement badge, and the supported fuel types.
+/// Pulled out of `setup_screen.dart` so the screen no longer carries this
+/// 60-line widget block and so the semantics envelope (which announces
+/// the entire card as a single sentence to screen readers, instead of
+/// reading each detail) can be exercised by widget tests in isolation.
+class CountryInfoCard extends StatelessWidget {
+  final CountryConfig country;
+
+  const CountryInfoCard({super.key, required this.country});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: '${country.name}, data source: ${country.apiProvider ?? 'Demo'}, '
+          '${country.requiresApiKey ? 'API key required' : 'Free, no key needed'}, '
+          'fuel types: ${country.fuelTypes.join(', ')}',
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  ExcludeSemantics(
+                    child: Text(
+                      country.flag,
+                      style: const TextStyle(fontSize: 24),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ExcludeSemantics(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            country.name,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          Text(
+                            'Data: ${country.apiProvider ?? 'Demo'}',
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  CountryStatusBadge(country: country),
+                ],
+              ),
+              const SizedBox(height: 8),
+              ExcludeSemantics(
+                child: Text(
+                  'Fuel types: ${country.fuelTypes.join(', ')}',
+                  style: theme.textTheme.bodySmall,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/setup/presentation/widgets/country_info_card_test.dart
+++ b/test/features/setup/presentation/widgets/country_info_card_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/country_info_card.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/country_status_badge.dart';
+
+const _germany = CountryConfig(
+  code: 'DE',
+  name: 'Deutschland',
+  flag: '🇩🇪',
+  locale: 'de_DE',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'PLZ',
+  requiresApiKey: true,
+  apiProvider: 'Tankerkoenig',
+  fuelTypes: ['e5', 'e10', 'diesel'],
+);
+
+const _demoCountry = CountryConfig(
+  code: 'XX',
+  name: 'Demoland',
+  flag: '🏳',
+  locale: 'en_US',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'ZIP',
+  requiresApiKey: false,
+  fuelTypes: ['e5', 'diesel'],
+);
+
+void main() {
+  group('CountryInfoCard', () {
+    Future<void> pumpCard(WidgetTester tester, CountryConfig country) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CountryInfoCard(country: country),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the country name and the data-source line',
+        (tester) async {
+      await pumpCard(tester, _germany);
+      expect(find.text('Deutschland'), findsOneWidget);
+      expect(find.text('Data: Tankerkoenig'), findsOneWidget);
+    });
+
+    testWidgets('renders "Data: Demo" when no apiProvider is configured',
+        (tester) async {
+      await pumpCard(tester, _demoCountry);
+      expect(find.text('Data: Demo'), findsOneWidget);
+    });
+
+    testWidgets('renders the comma-joined fuel types line', (tester) async {
+      await pumpCard(tester, _germany);
+      expect(find.text('Fuel types: e5, e10, diesel'), findsOneWidget);
+    });
+
+    testWidgets('embeds a CountryStatusBadge for the API-key requirement',
+        (tester) async {
+      await pumpCard(tester, _germany);
+      expect(find.byType(CountryStatusBadge), findsOneWidget);
+    });
+
+    testWidgets(
+        'wraps the whole card in a Semantics envelope so screen readers '
+        'announce one sentence instead of every detail twice',
+        (tester) async {
+      await pumpCard(tester, _germany);
+      // The combined semantics label includes the API-key requirement and
+      // the fuel-types list — match a substring so this stays robust to
+      // tweaks elsewhere in the sentence.
+      final sem = find.bySemanticsLabel(
+        RegExp(r'Deutschland.*API key required.*e5, e10, diesel'),
+      );
+      expect(sem, findsAtLeast(1));
+    });
+
+    testWidgets(
+        'wraps the visual flag/title/fuels in ExcludeSemantics so they '
+        "don't double up with the parent Semantics label", (tester) async {
+      await pumpCard(tester, _germany);
+      expect(find.byType(ExcludeSemantics), findsAtLeast(3));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Pulls the 60-line `_CountryInfoCard` out of `setup_screen.dart` into its own widget under `lib/features/setup/presentation/widgets/`
- `setup_screen.dart` 400 -> 335 lines; drops the now-unused `country_status_badge` import (the badge is embedded inside the extracted card)
- 6 new widget tests cover name/data-source line, demo fallback (no `apiProvider`), fuel-types row, embedded `CountryStatusBadge`, the parent `Semantics` envelope, and the `ExcludeSemantics` wrapping that prevents double-reads

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean
- [x] `flutter test test/features/setup/` — 87 tests pass
- [x] CI build-android

Closes part of #388.