### PR TITLE
refactor(search): extract SearchResultsContent from search_screen (#388)

### DIFF
--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -5,33 +5,24 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../app/responsive_search_layout.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/location/location_consent.dart';
+import '../../../../core/location/location_service.dart';
 import '../../../../core/location/user_position_provider.dart';
-import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/utils/frame_callbacks.dart';
-import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../map/presentation/widgets/inline_map.dart';
-import '../../providers/ev_search_provider.dart';
-import '../../providers/search_provider.dart';
-import '../widgets/demo_mode_banner.dart';
-import '../widgets/ev_search_results_view.dart';
-import '../widgets/search_results_list.dart';
-import '../widgets/search_summary_bar.dart';
-import '../widgets/user_position_bar.dart';
-import '../../providers/search_mode_provider.dart';
-import '../../../../core/location/location_service.dart';
-import '../../../../core/services/service_result.dart';
-import '../../domain/entities/fuel_type.dart';
-import '../../domain/entities/search_mode.dart';
-import '../../domain/entities/station.dart';
-import '../../providers/selected_station_provider.dart';
-import '../../../station_detail/presentation/widgets/station_detail_inline.dart';
 import '../../../profile/domain/entities/user_profile.dart';
 import '../../../profile/providers/profile_provider.dart';
-import '../widgets/nearest_shortcut_card.dart';
-import '../widgets/route_results_view.dart';
+import '../../../station_detail/presentation/widgets/station_detail_inline.dart';
+import '../../domain/entities/fuel_type.dart';
+import '../../providers/ev_search_provider.dart';
+import '../../providers/search_provider.dart';
+import '../../providers/selected_station_provider.dart';
+import '../widgets/demo_mode_banner.dart';
+import '../widgets/search_results_content.dart';
+import '../widgets/search_summary_bar.dart';
+import '../widgets/user_position_bar.dart';
 
 /// Main search screen — results-first layout.
 ///
@@ -186,8 +177,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
 
   Widget _buildSearchContent(BuildContext context) {
     final country = ref.watch(activeCountryProvider);
-    final searchState = ref.watch(searchStateProvider);
-    final l10n = AppLocalizations.of(context);
 
     return Column(
       children: [
@@ -219,61 +208,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         Expanded(
           child: Semantics(
             label: 'Search results',
-            child: _buildResults(context, l10n, searchState),
+            child: SearchResultsContent(onGpsRetry: _performGpsSearch),
           ),
         ),
       ],
-    );
-  }
-
-  Widget _buildResults(
-    BuildContext context,
-    AppLocalizations? l10n,
-    AsyncValue<ServiceResult<List<Station>>> searchState,
-  ) {
-    final searchMode = ref.watch(activeSearchModeProvider);
-    final fuelType = ref.watch(selectedFuelTypeProvider);
-
-    // Route mode — RouteResultsView returns slivers, wrap in CustomScrollView
-    if (searchMode == SearchMode.route) {
-      return const CustomScrollView(
-        slivers: [RouteResultsView()],
-      );
-    }
-
-    // EV mode (when Electric fuel type is selected)
-    if (fuelType == FuelType.electric) {
-      return EvSearchResultsView(onSearch: _performGpsSearch);
-    }
-
-    // Default: fuel station results
-    return searchState.when(
-      data: (result) {
-        if (result.data.isEmpty) {
-          return Center(
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  NearestShortcutCard(onTap: _performGpsSearch),
-                  const SizedBox(height: 16),
-                  Text(
-                    l10n?.startSearch ?? 'Search to find fuel stations.',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          );
-        }
-        return SearchResultsList(result: result, onRefresh: _performGpsSearch);
-      },
-      loading: () => const ShimmerStationList(),
-      error: (error, _) =>
-          ServiceChainErrorWidget(error: error, onRetry: _performGpsSearch),
     );
   }
 }

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/services/widgets/service_status_banner.dart';
+import '../../../../core/widgets/shimmer_placeholder.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/fuel_type.dart';
+import '../../domain/entities/search_mode.dart';
+import '../../providers/search_mode_provider.dart';
+import '../../providers/search_provider.dart';
+import 'ev_search_results_view.dart';
+import 'nearest_shortcut_card.dart';
+import 'route_results_view.dart';
+import 'search_results_list.dart';
+
+/// Renders the result panel of `SearchScreen` based on the current
+/// [SearchMode] and [FuelType]:
+///
+///  * Route mode -> [RouteResultsView] inside a `CustomScrollView`
+///  * Electric fuel -> [EvSearchResultsView]
+///  * Otherwise -> the standard `searchStateProvider` `AsyncValue` with
+///    shimmer/empty/loaded/error branches
+///
+/// Pulled out of `search_screen.dart` so the screen's `_buildResults`
+/// helper drops 50 lines and so the empty/loading/error branches can be
+/// exercised by widget tests in isolation. The screen still owns
+/// `_performGpsSearch`, so it is passed in as [onGpsRetry].
+class SearchResultsContent extends ConsumerWidget {
+  final Future<void> Function() onGpsRetry;
+
+  const SearchResultsContent({super.key, required this.onGpsRetry});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final searchMode = ref.watch(activeSearchModeProvider);
+    final fuelType = ref.watch(selectedFuelTypeProvider);
+    final searchState = ref.watch(searchStateProvider);
+
+    if (searchMode == SearchMode.route) {
+      return const CustomScrollView(
+        slivers: [RouteResultsView()],
+      );
+    }
+
+    if (fuelType == FuelType.electric) {
+      return EvSearchResultsView(onSearch: onGpsRetry);
+    }
+
+    return searchState.when(
+      data: (result) {
+        if (result.data.isEmpty) {
+          return Center(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  NearestShortcutCard(onTap: onGpsRetry),
+                  const SizedBox(height: 16),
+                  Text(
+                    l10n?.startSearch ?? 'Search to find fuel stations.',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+        return SearchResultsList(result: result, onRefresh: onGpsRetry);
+      },
+      loading: () => const ShimmerStationList(),
+      error: (error, _) =>
+          ServiceChainErrorWidget(error: error, onRetry: onGpsRetry),
+    );
+  }
+}

--- a/test/features/search/presentation/widgets/search_results_content_test.dart
+++ b/test/features/search/presentation/widgets/search_results_content_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/widgets/shimmer_placeholder.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/widgets/nearest_shortcut_card.dart';
+import 'package:tankstellen/features/search/presentation/widgets/search_results_content.dart';
+import 'package:tankstellen/features/search/presentation/widgets/search_results_list.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+import '../../../../fixtures/stations.dart';
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('SearchResultsContent', () {
+    Future<void> noopRetry() async {}
+
+    testWidgets('shows shimmer while the search state is loading',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      // Bypass pumpApp here — the shimmer animation never settles.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...test.overrides,
+            searchStateProvider.overrideWith(() => _LoadingSearchState()),
+          ].cast(),
+          child: MaterialApp(
+            localizationsDelegates:
+                AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SearchResultsContent(onGpsRetry: noopRetry),
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.byType(ShimmerStationList), findsOneWidget);
+    });
+
+    testWidgets(
+        'shows the nearest-shortcut card and start-search hint when the '
+        'data branch is empty', (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        SearchResultsContent(onGpsRetry: noopRetry),
+        overrides: [
+          ...test.overrides,
+          searchStateProvider.overrideWith(() => _EmptySearchState()),
+        ].cast(),
+      );
+
+      expect(find.byType(NearestShortcutCard), findsOneWidget);
+      expect(find.text('Search to find fuel stations.'), findsOneWidget);
+    });
+
+    testWidgets('shows the SearchResultsList when stations are loaded',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+      when(() => test.mockStorage.getRatings())
+          .thenReturn(const <String, int>{});
+
+      await pumpApp(
+        tester,
+        SearchResultsContent(onGpsRetry: noopRetry),
+        overrides: [
+          ...test.overrides,
+          searchStateProvider.overrideWith(
+            () => _LoadedSearchState([testStation]),
+          ),
+        ].cast(),
+      );
+
+      expect(find.byType(SearchResultsList), findsOneWidget);
+    });
+  });
+}
+
+class _LoadingSearchState extends SearchState {
+  @override
+  AsyncValue<ServiceResult<List<Station>>> build() => const AsyncValue.loading();
+}
+
+class _EmptySearchState extends SearchState {
+  @override
+  AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.data(
+        ServiceResult(
+          data: const [],
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+}
+
+class _LoadedSearchState extends SearchState {
+  _LoadedSearchState(this._stations);
+  final List<Station> _stations;
+
+  @override
+  AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.data(
+        ServiceResult(
+          data: _stations,
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+}


### PR DESCRIPTION
## Summary
- Pulls the 50-line `_buildResults` helper out of `search_screen.dart` into its own `SearchResultsContent` ConsumerWidget under `lib/features/search/presentation/widgets/`
- `search_screen.dart` 279 -> 217 lines; drops 5 imports that were only used by the extracted code path
- The screen still owns `_performGpsSearch`, passed in as `onGpsRetry` (powers refresh, retry, and the nearest-shortcut card)
- 3 new widget tests cover the **loading shimmer**, **empty-state shortcut card**, and **loaded results path**

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean (only pre-existing info)
- [x] `flutter test test/features/search/presentation/` — 197 tests pass
- [x] CI build-android

Closes part of #388.