### PR TITLE
refactor(setup): extract LanguageSelector and CountrySelector (#388)

### DIFF
--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -14,6 +14,8 @@ import '../../data/api_key_validator.dart';
 import '../../providers/api_key_validator_provider.dart';
 import '../widgets/api_key_input_section.dart';
 import '../widgets/country_info_card.dart';
+import '../widgets/country_selector.dart';
+import '../widgets/language_selector.dart';
 
 class SetupScreen extends ConsumerStatefulWidget {
   const SetupScreen({super.key});
@@ -139,13 +141,13 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
               const SizedBox(height: 16),
               const _SetupHeader(),
               const SizedBox(height: 24),
-              _LanguageSelector(
+              LanguageSelector(
                 selected: language,
                 onSelect: (lang) =>
                     ref.read(activeLanguageProvider.notifier).select(lang),
               ),
               const SizedBox(height: 24),
-              _CountrySelector(
+              CountrySelector(
                 selected: country,
                 onSelect: (c) =>
                     ref.read(activeCountryProvider.notifier).select(c),
@@ -221,78 +223,6 @@ class _SetupHeader extends StatelessWidget {
           l10n?.welcomeSubtitle ?? 'Find the cheapest fuel near you.',
           style: theme.textTheme.bodyLarge,
           textAlign: TextAlign.center,
-        ),
-      ],
-    );
-  }
-}
-
-class _LanguageSelector extends StatelessWidget {
-  final AppLanguage selected;
-  final ValueChanged<AppLanguage> onSelect;
-
-  const _LanguageSelector({required this.selected, required this.onSelect});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text(l10n?.language ?? 'Language', style: theme.textTheme.titleMedium),
-        const SizedBox(height: 8),
-        Wrap(
-          spacing: 6,
-          runSpacing: 6,
-          children: AppLanguages.all.map((lang) {
-            final isSelected = lang.code == selected.code;
-            return Semantics(
-              label:
-                  'Language ${lang.nativeName}${isSelected ? ", selected" : ""}',
-              child: ChoiceChip(
-                label: Text(lang.nativeName),
-                selected: isSelected,
-                onSelected: (_) => onSelect(lang),
-                visualDensity: VisualDensity.compact,
-              ),
-            );
-          }).toList(),
-        ),
-      ],
-    );
-  }
-}
-
-class _CountrySelector extends StatelessWidget {
-  final CountryConfig selected;
-  final ValueChanged<CountryConfig> onSelect;
-
-  const _CountrySelector({required this.selected, required this.onSelect});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text(l10n?.country ?? 'Country', style: theme.textTheme.titleMedium),
-        const SizedBox(height: 8),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: Countries.all.map((c) {
-            final isSelected = c.code == selected.code;
-            return Semantics(
-              label: 'Country ${c.name}${isSelected ? ", selected" : ""}',
-              child: ChoiceChip(
-                label: Text('${c.flag} ${c.name}'),
-                selected: isSelected,
-                onSelected: (_) => onSelect(c),
-              ),
-            );
-          }).toList(),
         ),
       ],
     );

--- a/lib/features/setup/presentation/widgets/country_selector.dart
+++ b/lib/features/setup/presentation/widgets/country_selector.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/country/country_config.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Setup screen section: a wrap of [ChoiceChip]s for picking the active
+/// [CountryConfig] (one chip per supported country). Pulled out of
+/// `setup_screen.dart` so the screen no longer carries this widget block
+/// inline and so the Semantics labels (which announce "selected" state to
+/// screen readers) can be exercised by widget tests in isolation.
+class CountrySelector extends StatelessWidget {
+  final CountryConfig selected;
+  final ValueChanged<CountryConfig> onSelect;
+
+  const CountrySelector({
+    super.key,
+    required this.selected,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(l10n?.country ?? 'Country', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: Countries.all.map((c) {
+            final isSelected = c.code == selected.code;
+            return Semantics(
+              label: 'Country ${c.name}${isSelected ? ", selected" : ""}',
+              child: ChoiceChip(
+                label: Text('${c.flag} ${c.name}'),
+                selected: isSelected,
+                onSelected: (_) => onSelect(c),
+              ),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/setup/presentation/widgets/language_selector.dart
+++ b/lib/features/setup/presentation/widgets/language_selector.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/language/language_provider.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Setup screen section: a wrap of [ChoiceChip]s for picking the active
+/// [AppLanguage]. Pulled out of `setup_screen.dart` so the screen no
+/// longer carries this widget block inline and so the Semantics labels
+/// (which announce "selected" state to screen readers) can be exercised
+/// by widget tests in isolation.
+class LanguageSelector extends StatelessWidget {
+  final AppLanguage selected;
+  final ValueChanged<AppLanguage> onSelect;
+
+  const LanguageSelector({
+    super.key,
+    required this.selected,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(l10n?.language ?? 'Language', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: AppLanguages.all.map((lang) {
+            final isSelected = lang.code == selected.code;
+            return Semantics(
+              label:
+                  'Language ${lang.nativeName}${isSelected ? ", selected" : ""}',
+              child: ChoiceChip(
+                label: Text(lang.nativeName),
+                selected: isSelected,
+                onSelected: (_) => onSelect(lang),
+                visualDensity: VisualDensity.compact,
+              ),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/setup/presentation/widgets/country_selector_test.dart
+++ b/test/features/setup/presentation/widgets/country_selector_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/country_selector.dart';
+
+void main() {
+  group('CountrySelector', () {
+    Future<void> pumpSelector(
+      WidgetTester tester, {
+      required CountryConfig selected,
+      required ValueChanged<CountryConfig> onSelect,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: CountrySelector(
+                selected: selected,
+                onSelect: onSelect,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders one ChoiceChip per supported country',
+        (tester) async {
+      await pumpSelector(
+        tester,
+        selected: Countries.all.first,
+        onSelect: (_) {},
+      );
+      expect(
+        find.byType(ChoiceChip),
+        findsNWidgets(Countries.all.length),
+      );
+    });
+
+    testWidgets('marks the chip matching `selected` as selected',
+        (tester) async {
+      final germany = Countries.germany;
+      await pumpSelector(
+        tester,
+        selected: germany,
+        onSelect: (_) {},
+      );
+      final selectedChip = tester.widget<ChoiceChip>(
+        find.ancestor(
+          of: find.text('${germany.flag} ${germany.name}'),
+          matching: find.byType(ChoiceChip),
+        ),
+      );
+      expect(selectedChip.selected, isTrue);
+    });
+
+    testWidgets('forwards taps to onSelect with the chosen country',
+        (tester) async {
+      CountryConfig? captured;
+      // Pick a country that is NOT Countries.all.first so we know the tap
+      // changed the selection.
+      final target = Countries.all.firstWhere(
+        (c) => c.code != Countries.all.first.code,
+      );
+      await pumpSelector(
+        tester,
+        selected: Countries.all.first,
+        onSelect: (c) => captured = c,
+      );
+      await tester.ensureVisible(find.text('${target.flag} ${target.name}'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('${target.flag} ${target.name}'));
+      expect(captured?.code, target.code);
+    });
+
+    testWidgets(
+        'announces selected state via the Semantics label so screen '
+        'readers know which country is active', (tester) async {
+      await pumpSelector(
+        tester,
+        selected: Countries.germany,
+        onSelect: (_) {},
+      );
+      expect(
+        find.bySemanticsLabel(
+          RegExp('Country ${Countries.germany.name}, selected'),
+        ),
+        findsAtLeast(1),
+      );
+    });
+  });
+}

--- a/test/features/setup/presentation/widgets/language_selector_test.dart
+++ b/test/features/setup/presentation/widgets/language_selector_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/language/language_provider.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/language_selector.dart';
+
+void main() {
+  group('LanguageSelector', () {
+    Future<void> pumpSelector(
+      WidgetTester tester, {
+      required AppLanguage selected,
+      required ValueChanged<AppLanguage> onSelect,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: LanguageSelector(
+                selected: selected,
+                onSelect: onSelect,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders one ChoiceChip per supported language',
+        (tester) async {
+      await pumpSelector(
+        tester,
+        selected: AppLanguages.all.first,
+        onSelect: (_) {},
+      );
+      expect(
+        find.byType(ChoiceChip),
+        findsNWidgets(AppLanguages.all.length),
+      );
+    });
+
+    testWidgets('marks the chip matching `selected` as selected',
+        (tester) async {
+      final german =
+          AppLanguages.all.firstWhere((l) => l.code == 'de');
+      await pumpSelector(
+        tester,
+        selected: german,
+        onSelect: (_) {},
+      );
+      final selectedChip = tester.widget<ChoiceChip>(
+        find.ancestor(
+          of: find.text(german.nativeName),
+          matching: find.byType(ChoiceChip),
+        ),
+      );
+      expect(selectedChip.selected, isTrue);
+    });
+
+    testWidgets('forwards taps to onSelect with the chosen language',
+        (tester) async {
+      AppLanguage? captured;
+      final french =
+          AppLanguages.all.firstWhere((l) => l.code == 'fr');
+      await pumpSelector(
+        tester,
+        selected: AppLanguages.all.first,
+        onSelect: (lang) => captured = lang,
+      );
+      // Scroll the French chip into view in case the wrap row pushes it down.
+      await tester.ensureVisible(find.text(french.nativeName));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(french.nativeName));
+      expect(captured?.code, 'fr');
+    });
+
+    testWidgets(
+        'announces selected state via the Semantics label so screen '
+        'readers know which language is active', (tester) async {
+      final english =
+          AppLanguages.all.firstWhere((l) => l.code == 'en');
+      await pumpSelector(
+        tester,
+        selected: english,
+        onSelect: (_) {},
+      );
+      expect(
+        find.bySemanticsLabel(
+          RegExp('Language ${english.nativeName}, selected'),
+        ),
+        findsAtLeast(1),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Pulls the two parallel `ChoiceChip` selector widgets out of `setup_screen.dart` into their own files under `lib/features/setup/presentation/widgets/`
- Both selectors share the same shape (`Wrap` of `Semantics`-wrapped `ChoiceChip`s with a "selected" hint for screen readers)
- `setup_screen.dart` 335 -> 265 lines
- 8 new widget tests (4 per selector): chip count, selected state, tap forwarding, Semantics envelope

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean
- [x] `flutter test test/features/setup/` — 95 tests pass
- [x] CI build-android

Closes part of #388.