### PR TITLE
refactor(profile): extract ProfileLandingScreenDropdown (#388)

### DIFF
--- a/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
@@ -7,6 +7,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/user_profile.dart';
 import '../../providers/profile_edit_provider.dart';
+import 'profile_landing_screen_dropdown.dart';
 
 /// Profile edit bottom sheet. Form state (fuel, radius, rating mode, etc.)
 /// lives in [profileEditControllerProvider] so changes trigger selective
@@ -159,26 +160,9 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
               const SizedBox(height: 16),
               _RatingModeSection(state: editState, ctrl: editCtrl),
               const SizedBox(height: 16),
-              DropdownButtonFormField<LandingScreen>(
-                initialValue: editState.landingScreen,
-                decoration: InputDecoration(
-                  labelText:
-                      AppLocalizations.of(context)?.landingScreen ?? 'Start screen',
-                  border: const OutlineInputBorder(),
-                ),
-                // Exclude 'map' from landing options — map is not a landing screen
-                items: LandingScreen.values
-                    .where((s) => s != LandingScreen.map)
-                    .map((s) => DropdownMenuItem(
-                          value: s,
-                          child: Text(s.localizedName(
-                            Localizations.localeOf(context).languageCode,
-                          )),
-                        ))
-                    .toList(),
-                onChanged: (v) {
-                  if (v != null) editCtrl.setLandingScreen(v);
-                },
+              ProfileLandingScreenDropdown(
+                value: editState.landingScreen,
+                onChanged: editCtrl.setLandingScreen,
               ),
               const SizedBox(height: 16),
               _CountrySection(state: editState, ctrl: editCtrl),

--- a/lib/features/profile/presentation/widgets/profile_landing_screen_dropdown.dart
+++ b/lib/features/profile/presentation/widgets/profile_landing_screen_dropdown.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/user_profile.dart';
+
+/// Dropdown for picking the user's preferred [LandingScreen] (the screen
+/// that opens when the app is launched). Filters out [LandingScreen.map]
+/// because the map is not a valid landing destination, and labels every
+/// option using [LandingScreen.localizedName] in the active locale.
+///
+/// Pulled out of `profile_edit_sheet.dart` so the sheet's `build` method
+/// drops 20 lines and so the filter + localization can be exercised by
+/// widget tests in isolation.
+class ProfileLandingScreenDropdown extends StatelessWidget {
+  final LandingScreen value;
+  final ValueChanged<LandingScreen> onChanged;
+
+  const ProfileLandingScreenDropdown({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final languageCode = Localizations.localeOf(context).languageCode;
+    return DropdownButtonFormField<LandingScreen>(
+      initialValue: value,
+      decoration: InputDecoration(
+        labelText: l10n?.landingScreen ?? 'Start screen',
+        border: const OutlineInputBorder(),
+      ),
+      items: LandingScreen.values
+          .where((s) => s != LandingScreen.map)
+          .map((s) => DropdownMenuItem(
+                value: s,
+                child: Text(s.localizedName(languageCode)),
+              ))
+          .toList(),
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+    );
+  }
+}

--- a/test/features/profile/presentation/widgets/profile_landing_screen_dropdown_test.dart
+++ b/test/features/profile/presentation/widgets/profile_landing_screen_dropdown_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/profile/domain/entities/user_profile.dart';
+import 'package:tankstellen/features/profile/presentation/widgets/profile_landing_screen_dropdown.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  group('ProfileLandingScreenDropdown', () {
+    Future<void> pumpDropdown(
+      WidgetTester tester, {
+      required LandingScreen value,
+      ValueChanged<LandingScreen>? onChanged,
+      Locale locale = const Locale('en'),
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          locale: locale,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ProfileLandingScreenDropdown(
+              value: value,
+              onChanged: onChanged ?? (_) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the localized English label for the selected option',
+        (tester) async {
+      await pumpDropdown(tester, value: LandingScreen.nearest);
+      expect(find.text('Nearest stations'), findsOneWidget);
+    });
+
+    testWidgets('renders the localized German label when locale is de',
+        (tester) async {
+      await pumpDropdown(
+        tester,
+        value: LandingScreen.cheapest,
+        locale: const Locale('de'),
+      );
+      expect(find.text('Günstigste'), findsOneWidget);
+    });
+
+    testWidgets(
+        'opening the menu shows every LandingScreen option except `map`',
+        (tester) async {
+      await pumpDropdown(tester, value: LandingScreen.nearest);
+      await tester.tap(find.byType(DropdownButtonFormField<LandingScreen>));
+      await tester.pumpAndSettle();
+
+      // 4 enum values - 1 (map filtered out) = 3 items in the menu, plus 1
+      // for the field display => 4 occurrences of "Nearest stations" once
+      // selected. We just check map's English label is absent.
+      expect(find.text('Map'), findsNothing);
+      expect(find.text('Favorites'), findsAtLeast(1));
+      expect(find.text('Cheapest nearby'), findsAtLeast(1));
+      expect(find.text('Nearest stations'), findsAtLeast(1));
+    });
+
+    testWidgets('forwards selection to onChanged when user picks a new option',
+        (tester) async {
+      LandingScreen? captured;
+      await pumpDropdown(
+        tester,
+        value: LandingScreen.nearest,
+        onChanged: (v) => captured = v,
+      );
+      await tester.tap(find.byType(DropdownButtonFormField<LandingScreen>));
+      await tester.pumpAndSettle();
+      // Tap the menu entry for "Cheapest nearby" — there are two entries
+      // showing this label inside the open menu (the one in the field and
+      // the menu item); .last is the menu item.
+      await tester.tap(find.text('Cheapest nearby').last);
+      await tester.pumpAndSettle();
+      expect(captured, LandingScreen.cheapest);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Pulls the inline `LandingScreen` dropdown out of `profile_edit_sheet.dart` into its own widget under `lib/features/profile/presentation/widgets/`
- The dropdown filters out `LandingScreen.map` (invalid as a landing destination) and labels options via `LandingScreen.localizedName` in the active locale
- `profile_edit_sheet.dart` 494 -> 478 lines
- 4 new widget tests cover English/German labels, the filtered option set, and tap forwarding

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean
- [x] `flutter test test/features/profile/` — 101 tests pass
- [x] CI build-android

Closes part of #388.