### PR TITLE
refactor(setup): extract SetupHeader and SetupContinueButton (#388)

### DIFF
--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import '../../../../core/country/country_config.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/language/language_provider.dart';
 import '../../../../core/storage/storage_providers.dart';
@@ -16,6 +15,8 @@ import '../widgets/api_key_input_section.dart';
 import '../widgets/country_info_card.dart';
 import '../widgets/country_selector.dart';
 import '../widgets/language_selector.dart';
+import '../widgets/setup_continue_button.dart';
+import '../widgets/setup_header.dart';
 
 class SetupScreen extends ConsumerStatefulWidget {
   const SetupScreen({super.key});
@@ -139,7 +140,7 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: 16),
-              const _SetupHeader(),
+              const SetupHeader(),
               const SizedBox(height: 24),
               LanguageSelector(
                 selected: language,
@@ -164,7 +165,7 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
                 ),
                 const SizedBox(height: 24),
               ],
-              _ContinueButton(
+              SetupContinueButton(
                 isLoading: _isLoading,
                 country: country,
                 apiKeyEmpty: _apiKeyController.text.trim().isEmpty,
@@ -180,85 +181,6 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Setup sections — private widgets kept in-file so they share the screen's
-// l10n/theme assumptions and are easy to find while editing the flow.
-// ---------------------------------------------------------------------------
-
-class _SetupHeader extends StatelessWidget {
-  const _SetupHeader();
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-    return Column(
-      children: [
-        Semantics(
-          excludeSemantics: true,
-          child: Icon(
-            Icons.local_gas_station,
-            size: 72,
-            color: theme.colorScheme.primary,
-          ),
-        ),
-        const SizedBox(height: 16),
-        Semantics(
-          header: true,
-          child: Text(
-            l10n?.welcome ?? 'Fuel Prices',
-            style: theme.textTheme.headlineMedium?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ),
-        const SizedBox(height: 8),
-        Text(
-          l10n?.welcomeSubtitle ?? 'Find the cheapest fuel near you.',
-          style: theme.textTheme.bodyLarge,
-          textAlign: TextAlign.center,
-        ),
-      ],
-    );
-  }
-}
-
-class _ContinueButton extends StatelessWidget {
-  final bool isLoading;
-  final CountryConfig country;
-  final bool apiKeyEmpty;
-  final VoidCallback onPressed;
-
-  const _ContinueButton({
-    required this.isLoading,
-    required this.country,
-    required this.apiKeyEmpty,
-    required this.onPressed,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final usingDemo = country.requiresApiKey && apiKeyEmpty;
-    final label = usingDemo ? 'Continue with demo data' : 'Continue';
-    return Semantics(
-      button: true,
-      label: isLoading ? 'Loading' : label,
-      child: FilledButton.icon(
-        onPressed: isLoading ? null : onPressed,
-        icon: const Icon(Icons.arrow_forward),
-        label: isLoading
-            ? const SizedBox(
-                height: 20,
-                width: 20,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              )
-            : Text(label),
       ),
     );
   }

--- a/lib/features/setup/presentation/widgets/setup_continue_button.dart
+++ b/lib/features/setup/presentation/widgets/setup_continue_button.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/country/country_config.dart';
+
+/// "Continue" CTA at the bottom of the setup screen. Switches its label
+/// between "Continue with demo data" and "Continue" depending on whether
+/// the active [CountryConfig] requires an API key and whether the user
+/// has actually entered one. Renders a spinner while [isLoading] is true
+/// and disables the button. Pulled out of `setup_screen.dart` so the
+/// screen no longer carries this widget block inline and so the
+/// label-switching + loading state can be exercised by widget tests.
+class SetupContinueButton extends StatelessWidget {
+  final bool isLoading;
+  final CountryConfig country;
+  final bool apiKeyEmpty;
+  final VoidCallback onPressed;
+
+  const SetupContinueButton({
+    super.key,
+    required this.isLoading,
+    required this.country,
+    required this.apiKeyEmpty,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final usingDemo = country.requiresApiKey && apiKeyEmpty;
+    final label = usingDemo ? 'Continue with demo data' : 'Continue';
+    return Semantics(
+      button: true,
+      label: isLoading ? 'Loading' : label,
+      child: FilledButton.icon(
+        onPressed: isLoading ? null : onPressed,
+        icon: const Icon(Icons.arrow_forward),
+        label: isLoading
+            ? const SizedBox(
+                height: 20,
+                width: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : Text(label),
+      ),
+    );
+  }
+}

--- a/lib/features/setup/presentation/widgets/setup_header.dart
+++ b/lib/features/setup/presentation/widgets/setup_header.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Hero header for the setup screen: gas-pump icon, app title (announced
+/// as a heading), and a one-line subtitle. Pulled out of
+/// `setup_screen.dart` so the screen no longer carries this widget block
+/// inline.
+class SetupHeader extends StatelessWidget {
+  const SetupHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      children: [
+        Semantics(
+          excludeSemantics: true,
+          child: Icon(
+            Icons.local_gas_station,
+            size: 72,
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Semantics(
+          header: true,
+          child: Text(
+            l10n?.welcome ?? 'Fuel Prices',
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n?.welcomeSubtitle ?? 'Find the cheapest fuel near you.',
+          style: theme.textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/setup/presentation/widgets/setup_continue_button_test.dart
+++ b/test/features/setup/presentation/widgets/setup_continue_button_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/setup_continue_button.dart';
+
+const _germany = CountryConfig(
+  code: 'DE',
+  name: 'Deutschland',
+  flag: '🇩🇪',
+  locale: 'de_DE',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'PLZ',
+  requiresApiKey: true,
+);
+
+const _france = CountryConfig(
+  code: 'FR',
+  name: 'France',
+  flag: '🇫🇷',
+  locale: 'fr_FR',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'Code postal',
+  requiresApiKey: false,
+);
+
+void main() {
+  group('SetupContinueButton', () {
+    Future<void> pumpButton(
+      WidgetTester tester, {
+      required CountryConfig country,
+      required bool apiKeyEmpty,
+      bool isLoading = false,
+      VoidCallback? onPressed,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SetupContinueButton(
+              isLoading: isLoading,
+              country: country,
+              apiKeyEmpty: apiKeyEmpty,
+              onPressed: onPressed ?? () {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+        'reads "Continue with demo data" when the country requires a key '
+        'but the user has not entered one', (tester) async {
+      await pumpButton(tester, country: _germany, apiKeyEmpty: true);
+      expect(find.text('Continue with demo data'), findsOneWidget);
+    });
+
+    testWidgets(
+        'reads plain "Continue" when the country requires a key and the '
+        'user has supplied one', (tester) async {
+      await pumpButton(tester, country: _germany, apiKeyEmpty: false);
+      expect(find.text('Continue'), findsOneWidget);
+      expect(find.text('Continue with demo data'), findsNothing);
+    });
+
+    testWidgets(
+        'reads plain "Continue" when the country does not require a key',
+        (tester) async {
+      await pumpButton(tester, country: _france, apiKeyEmpty: true);
+      expect(find.text('Continue'), findsOneWidget);
+    });
+
+    testWidgets('replaces the label with a spinner while isLoading is true',
+        (tester) async {
+      await pumpButton(
+        tester,
+        country: _germany,
+        apiKeyEmpty: false,
+        isLoading: true,
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Continue'), findsNothing);
+    });
+
+    testWidgets('disables the button while isLoading is true', (tester) async {
+      var taps = 0;
+      await pumpButton(
+        tester,
+        country: _germany,
+        apiKeyEmpty: false,
+        isLoading: true,
+        onPressed: () => taps++,
+      );
+      await tester.tap(find.byType(FilledButton));
+      expect(taps, 0);
+    });
+
+    testWidgets('forwards taps to onPressed when not loading',
+        (tester) async {
+      var taps = 0;
+      await pumpButton(
+        tester,
+        country: _germany,
+        apiKeyEmpty: false,
+        onPressed: () => taps++,
+      );
+      await tester.tap(find.byType(FilledButton));
+      expect(taps, 1);
+    });
+
+    testWidgets('announces "Loading" via Semantics when loading',
+        (tester) async {
+      await pumpButton(
+        tester,
+        country: _germany,
+        apiKeyEmpty: false,
+        isLoading: true,
+      );
+      expect(find.bySemanticsLabel('Loading'), findsAtLeast(1));
+    });
+  });
+}

--- a/test/features/setup/presentation/widgets/setup_header_test.dart
+++ b/test/features/setup/presentation/widgets/setup_header_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/setup_header.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  group('SetupHeader', () {
+    Future<void> pumpHeader(WidgetTester tester,
+        {Locale locale = const Locale('en')}) {
+      return tester.pumpWidget(
+        MaterialApp(
+          locale: locale,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: SetupHeader()),
+        ),
+      );
+    }
+
+    testWidgets('renders the gas-pump hero icon', (tester) async {
+      await pumpHeader(tester);
+      expect(find.byIcon(Icons.local_gas_station), findsOneWidget);
+    });
+
+    testWidgets('renders the welcome title and subtitle in English',
+        (tester) async {
+      await pumpHeader(tester);
+      // The welcome key resolves to "Fuel Prices" in English; subtitle to
+      // "Find the cheapest fuel near you." Both must render.
+      expect(find.text('Fuel Prices'), findsOneWidget);
+      expect(find.text('Find the cheapest fuel near you.'), findsOneWidget);
+    });
+
+    testWidgets('marks the title with header semantics for screen readers',
+        (tester) async {
+      await pumpHeader(tester);
+      // Look for a Semantics node with header: true wrapping the title.
+      final headerSemantics = find.byWidgetPredicate(
+        (w) =>
+            w is Semantics &&
+            w.properties.header == true &&
+            w.child is Text &&
+            (w.child as Text).data == 'Fuel Prices',
+      );
+      expect(headerSemantics, findsOneWidget);
+    });
+
+    testWidgets('hides the icon from semantics so screen readers do not '
+        'announce a meaningless graphic', (tester) async {
+      await pumpHeader(tester);
+      // The icon is wrapped in `Semantics(excludeSemantics: true, ...)`,
+      // so it produces no semantics label.
+      expect(
+        find.bySemanticsLabel(RegExp('local_gas_station|gas')),
+        findsNothing,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Pulls the last two private widgets out of `setup_screen.dart`:
  - `SetupHeader` — hero icon + title + subtitle, with header semantics
  - `SetupContinueButton` — CTA that switches between "Continue" and "Continue with demo data" based on `country.requiresApiKey` + `apiKeyEmpty`, and renders a spinner + Loading semantics while disabled
- `setup_screen.dart` 265 -> 187 lines and is now **free of in-file widget classes** — a pure screen composing widgets from `presentation/widgets/`
- Drops the now-unused `country_config` import
- 11 new widget tests across both extracted widgets

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean
- [x] `flutter test test/features/setup/` — 106 tests pass
- [x] CI build-android

Closes part of #388.