### PR TITLE
refactor(profile): extract ProfileRadiusSlider (#388)

### DIFF
--- a/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
@@ -8,6 +8,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/user_profile.dart';
 import '../../providers/profile_edit_provider.dart';
 import 'profile_landing_screen_dropdown.dart';
+import 'profile_radius_slider.dart';
 
 /// Profile edit bottom sheet. Form state (fuel, radius, rating mode, etc.)
 /// lives in [profileEditControllerProvider] so changes trigger selective
@@ -137,22 +138,9 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
                 },
               ),
               const SizedBox(height: 16),
-              Row(
-                children: [
-                  Text(
-                      '${AppLocalizations.of(context)?.defaultRadius ?? "Radius"}:'),
-                  Expanded(
-                    child: Slider(
-                      value: editState.radius,
-                      min: 1,
-                      max: 25,
-                      divisions: 24,
-                      label: '${editState.radius.round()} km',
-                      onChanged: editCtrl.setRadius,
-                    ),
-                  ),
-                  Text('${editState.radius.round()} km'),
-                ],
+              ProfileRadiusSlider(
+                value: editState.radius,
+                onChanged: editCtrl.setRadius,
               ),
               const SizedBox(height: 16),
               _RouteSegmentSection(state: editState, ctrl: editCtrl),

--- a/lib/features/profile/presentation/widgets/profile_radius_slider.dart
+++ b/lib/features/profile/presentation/widgets/profile_radius_slider.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Profile-edit slider for the user's preferred default search radius
+/// (1–25 km). Renders a "Radius:" label, the [Slider] itself, and a
+/// trailing "X km" readout that mirrors the current value.
+///
+/// Pulled out of `profile_edit_sheet.dart` so the sheet's `build` method
+/// drops the inline `Row` block and so the slider's range, division
+/// count, and value mirroring can be exercised by widget tests in
+/// isolation.
+class ProfileRadiusSlider extends StatelessWidget {
+  final double value;
+  final ValueChanged<double> onChanged;
+
+  const ProfileRadiusSlider({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Row(
+      children: [
+        Text('${l10n?.defaultRadius ?? "Radius"}:'),
+        Expanded(
+          child: Slider(
+            value: value,
+            min: 1,
+            max: 25,
+            divisions: 24,
+            label: '${value.round()} km',
+            onChanged: onChanged,
+          ),
+        ),
+        Text('${value.round()} km'),
+      ],
+    );
+  }
+}

--- a/test/features/profile/presentation/widgets/profile_radius_slider_test.dart
+++ b/test/features/profile/presentation/widgets/profile_radius_slider_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/profile/presentation/widgets/profile_radius_slider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  group('ProfileRadiusSlider', () {
+    Future<void> pumpSlider(
+      WidgetTester tester, {
+      required double value,
+      ValueChanged<double>? onChanged,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ProfileRadiusSlider(
+              value: value,
+              onChanged: onChanged ?? (_) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the trailing readout matching the value rounded to '
+        'the nearest km', (tester) async {
+      await pumpSlider(tester, value: 12.4);
+      expect(find.text('12 km'), findsOneWidget);
+    });
+
+    testWidgets('exposes the slider with the correct min/max/divisions',
+        (tester) async {
+      await pumpSlider(tester, value: 5);
+      final slider = tester.widget<Slider>(find.byType(Slider));
+      expect(slider.min, 1);
+      expect(slider.max, 25);
+      expect(slider.divisions, 24);
+      expect(slider.value, 5);
+    });
+
+    testWidgets('forwards drag changes to onChanged', (tester) async {
+      double? captured;
+      await pumpSlider(
+        tester,
+        value: 5,
+        onChanged: (v) => captured = v,
+      );
+      // Drag the thumb to the far right end of the slider.
+      await tester.drag(find.byType(Slider), const Offset(500, 0));
+      await tester.pump();
+      expect(captured, isNotNull);
+      expect(captured, greaterThan(5));
+    });
+
+    testWidgets('renders the leading localized "Default radius:" label',
+        (tester) async {
+      await pumpSlider(tester, value: 1);
+      // The English ARB resolves `defaultRadius` to "Default radius".
+      expect(find.text('Default radius:'), findsOneWidget);
+      expect(find.text('1 km'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Pulls the inline radius `Slider` `Row` out of `profile_edit_sheet.dart` into its own widget under `lib/features/profile/presentation/widgets/`
- The slider has a fixed **1–25 km range with 24 divisions** and a trailing "X km" readout that mirrors the current value
- `profile_edit_sheet.dart` 478 -> 466 lines
- 4 new widget tests cover the readout rounding, min/max/divisions exposure, drag forwarding, and the localized "Default radius:" label

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean
- [x] `flutter test test/features/profile/` — 105 tests pass
- [x] CI build-android

Closes part of #388.