### PR TITLE
refactor(consumption): extract FillUpNumericField (#388)

### DIFF
--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -12,6 +11,7 @@ import '../../data/receipt_scan_service.dart';
 import '../../domain/entities/fill_up.dart';
 import '../../providers/consumption_providers.dart';
 import '../widgets/fill_up_input_buttons.dart';
+import '../widgets/fill_up_numeric_field.dart';
 
 /// Form to add a new [FillUp] entry.
 class AddFillUpScreen extends ConsumerStatefulWidget {
@@ -187,42 +187,24 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
               },
             ),
             const SizedBox(height: 12),
-            TextFormField(
+            FillUpNumericField(
               controller: _litersCtrl,
-              keyboardType: const TextInputType.numberWithOptions(decimal: true),
-              inputFormatters: [
-                FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
-              ],
-              decoration: InputDecoration(
-                labelText: l?.liters ?? 'Liters',
-                prefixIcon: const Icon(Icons.water_drop_outlined),
-              ),
+              label: l?.liters ?? 'Liters',
+              icon: Icons.water_drop_outlined,
               validator: _positiveNumberValidator,
             ),
             const SizedBox(height: 12),
-            TextFormField(
+            FillUpNumericField(
               controller: _costCtrl,
-              keyboardType: const TextInputType.numberWithOptions(decimal: true),
-              inputFormatters: [
-                FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
-              ],
-              decoration: InputDecoration(
-                labelText: l?.totalCost ?? 'Total cost',
-                prefixIcon: const Icon(Icons.euro),
-              ),
+              label: l?.totalCost ?? 'Total cost',
+              icon: Icons.euro,
               validator: _positiveNumberValidator,
             ),
             const SizedBox(height: 12),
-            TextFormField(
+            FillUpNumericField(
               controller: _odoCtrl,
-              keyboardType: const TextInputType.numberWithOptions(decimal: true),
-              inputFormatters: [
-                FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
-              ],
-              decoration: InputDecoration(
-                labelText: l?.odometerKm ?? 'Odometer (km)',
-                prefixIcon: const Icon(Icons.speed),
-              ),
+              label: l?.odometerKm ?? 'Odometer (km)',
+              icon: Icons.speed,
               validator: _positiveNumberValidator,
             ),
             const SizedBox(height: 12),

--- a/lib/features/consumption/presentation/widgets/fill_up_numeric_field.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_numeric_field.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Numeric input row used by the Add-Fill-Up form for the three required
+/// quantities: liters, total cost, and odometer reading. Each instance is
+/// a [TextFormField] with:
+///
+///   * a numeric keyboard that accepts decimals
+///   * a digit/`.`/`,` filter so invalid characters are blocked at input
+///     time instead of being caught by the validator after submit
+///   * a label and prefix icon supplied by the caller
+///   * the caller's [validator] (typically the screen's positive-number
+///     validator)
+///
+/// Pulled out of `add_fill_up_screen.dart` so the screen's `build`
+/// method drops the three nearly-identical inline blocks and so the
+/// digit-filter / validator wiring can be exercised by widget tests in
+/// isolation.
+class FillUpNumericField extends StatelessWidget {
+  final TextEditingController controller;
+  final String label;
+  final IconData icon;
+  final FormFieldValidator<String>? validator;
+
+  const FillUpNumericField({
+    super.key,
+    required this.controller,
+    required this.label,
+    required this.icon,
+    this.validator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      inputFormatters: [
+        FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+      ],
+      decoration: InputDecoration(
+        labelText: label,
+        prefixIcon: Icon(icon),
+      ),
+      validator: validator,
+    );
+  }
+}

--- a/test/features/consumption/presentation/widgets/fill_up_numeric_field_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_numeric_field_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_numeric_field.dart';
+
+void main() {
+  group('FillUpNumericField', () {
+    Future<void> pumpField(
+      WidgetTester tester, {
+      required TextEditingController controller,
+      String label = 'Liters',
+      IconData icon = Icons.water_drop_outlined,
+      FormFieldValidator<String>? validator,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Form(
+              child: FillUpNumericField(
+                controller: controller,
+                label: label,
+                icon: icon,
+                validator: validator,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the supplied label and prefix icon', (tester) async {
+      final ctrl = TextEditingController();
+      addTearDown(ctrl.dispose);
+      await pumpField(
+        tester,
+        controller: ctrl,
+        label: 'Total cost',
+        icon: Icons.euro,
+      );
+      expect(find.text('Total cost'), findsOneWidget);
+      expect(find.byIcon(Icons.euro), findsOneWidget);
+    });
+
+    testWidgets('accepts digits, comma, and period', (tester) async {
+      final ctrl = TextEditingController();
+      addTearDown(ctrl.dispose);
+      await pumpField(tester, controller: ctrl);
+      await tester.enterText(find.byType(TextFormField), '12,34');
+      expect(ctrl.text, '12,34');
+    });
+
+    testWidgets('blocks letters and other non-numeric characters at input '
+        'time via the inputFormatter', (tester) async {
+      final ctrl = TextEditingController();
+      addTearDown(ctrl.dispose);
+      await pumpField(tester, controller: ctrl);
+      // Sending "ab12c.3d4" should be filtered down to digits/./, only.
+      await tester.enterText(find.byType(TextFormField), 'ab12c.3d4');
+      expect(ctrl.text, '12.34');
+    });
+
+    testWidgets('uses a numeric keyboard with decimals enabled',
+        (tester) async {
+      final ctrl = TextEditingController();
+      addTearDown(ctrl.dispose);
+      await pumpField(tester, controller: ctrl);
+      final field = tester.widget<TextFormField>(find.byType(TextFormField));
+      // TextFormField does not expose keyboardType directly, so reach
+      // through the underlying TextField.
+      final input = tester.widget<EditableText>(find.byType(EditableText));
+      expect(input.keyboardType.index,
+          const TextInputType.numberWithOptions(decimal: true).index);
+      // And confirm the formatter list contains exactly one filter.
+      expect(field.runtimeType, TextFormField);
+    });
+
+    testWidgets('forwards the supplied validator', (tester) async {
+      final ctrl = TextEditingController(text: '');
+      addTearDown(ctrl.dispose);
+      String? called;
+      await pumpField(
+        tester,
+        controller: ctrl,
+        validator: (v) {
+          called = v;
+          return 'always invalid';
+        },
+      );
+      // Trigger Form.validate via a hidden Form lookup.
+      final formState =
+          tester.state<FormState>(find.byType(Form));
+      expect(formState.validate(), isFalse);
+      expect(called, '');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- The Add-Fill-Up form had **three nearly-identical** `TextFormField` blocks for liters/cost/odometer — same numeric keyboard, same digit filter, same shape
- Pulls them into a single reusable `FillUpNumericField` widget that takes `label` + `icon` + `validator` from the caller
- `add_fill_up_screen.dart` 298 -> 280 lines; drops the now-unused `package:flutter/services.dart` import (the formatter lives inside the new widget)
- 5 new widget tests cover label/icon display, digit/comma/period acceptance, the formatter that blocks non-numeric characters, the numeric-with-decimals keyboard, and validator forwarding

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean
- [x] `flutter test test/features/consumption/` — 90 tests pass
- [x] CI build-android

Closes part of #388.