### PR TITLE
refactor(profile): extract ProfileFuelTypeDropdown (#388)

### DIFF
--- a/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
@@ -4,9 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/country/country_config.dart';
 import '../../../../core/language/language_provider.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/user_profile.dart';
 import '../../providers/profile_edit_provider.dart';
+import 'profile_fuel_type_dropdown.dart';
 import 'profile_landing_screen_dropdown.dart';
 import 'profile_radius_slider.dart';
 
@@ -119,23 +119,9 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
                 ),
               ),
               const SizedBox(height: 16),
-              DropdownButtonFormField<FuelType>(
-                initialValue: editState.fuelType,
-                decoration: InputDecoration(
-                  labelText:
-                      AppLocalizations.of(context)?.preferredFuel ?? 'Preferred fuel',
-                  border: const OutlineInputBorder(),
-                ),
-                items: FuelType.values
-                    .where((t) => t != FuelType.all)
-                    .map((t) => DropdownMenuItem(
-                          value: t,
-                          child: Text(t.displayName),
-                        ))
-                    .toList(),
-                onChanged: (v) {
-                  if (v != null) editCtrl.setFuelType(v);
-                },
+              ProfileFuelTypeDropdown(
+                value: editState.fuelType,
+                onChanged: editCtrl.setFuelType,
               ),
               const SizedBox(height: 16),
               ProfileRadiusSlider(

--- a/lib/features/profile/presentation/widgets/profile_fuel_type_dropdown.dart
+++ b/lib/features/profile/presentation/widgets/profile_fuel_type_dropdown.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../../../../features/search/domain/entities/fuel_type.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Dropdown for picking the user's preferred [FuelType] in the profile
+/// edit sheet. Filters out [FuelType.all] (a search-time wildcard, not a
+/// real preference) and labels options via [FuelType.displayName].
+///
+/// Pulled out of `profile_edit_sheet.dart` so the sheet's `build` method
+/// drops the inline dropdown block and so the filter + display labels
+/// can be exercised by widget tests in isolation.
+class ProfileFuelTypeDropdown extends StatelessWidget {
+  final FuelType value;
+  final ValueChanged<FuelType> onChanged;
+
+  const ProfileFuelTypeDropdown({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return DropdownButtonFormField<FuelType>(
+      initialValue: value,
+      decoration: InputDecoration(
+        labelText: l10n?.preferredFuel ?? 'Preferred fuel',
+        border: const OutlineInputBorder(),
+      ),
+      items: FuelType.values
+          .where((t) => t != FuelType.all)
+          .map((t) => DropdownMenuItem(
+                value: t,
+                child: Text(t.displayName),
+              ))
+          .toList(),
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+    );
+  }
+}

--- a/test/features/profile/presentation/widgets/profile_fuel_type_dropdown_test.dart
+++ b/test/features/profile/presentation/widgets/profile_fuel_type_dropdown_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/profile/presentation/widgets/profile_fuel_type_dropdown.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  group('ProfileFuelTypeDropdown', () {
+    Future<void> pumpDropdown(
+      WidgetTester tester, {
+      required FuelType value,
+      ValueChanged<FuelType>? onChanged,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ProfileFuelTypeDropdown(
+              value: value,
+              onChanged: onChanged ?? (_) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the displayName of the selected fuel type',
+        (tester) async {
+      await pumpDropdown(tester, value: FuelType.e10);
+      expect(find.text(FuelType.e10.displayName), findsOneWidget);
+    });
+
+    testWidgets('opening the menu lists every FuelType except `all`',
+        (tester) async {
+      await pumpDropdown(tester, value: FuelType.e10);
+      await tester.tap(find.byType(DropdownButtonFormField<FuelType>));
+      await tester.pumpAndSettle();
+
+      // The "all" wildcard must not appear as a profile preference.
+      expect(find.text(FuelType.all.displayName), findsNothing);
+      // A few real fuel types should appear in the open menu.
+      expect(find.text(FuelType.e5.displayName), findsAtLeast(1));
+      expect(find.text(FuelType.diesel.displayName), findsAtLeast(1));
+    });
+
+    testWidgets('forwards selection to onChanged when user picks a new fuel',
+        (tester) async {
+      FuelType? captured;
+      await pumpDropdown(
+        tester,
+        value: FuelType.e10,
+        onChanged: (v) => captured = v,
+      );
+      await tester.tap(find.byType(DropdownButtonFormField<FuelType>));
+      await tester.pumpAndSettle();
+      // .last is the menu entry (the field label is .first).
+      await tester.tap(find.text(FuelType.diesel.displayName).last);
+      await tester.pumpAndSettle();
+      expect(captured, FuelType.diesel);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Pulls the inline preferred-fuel `DropdownButtonFormField` out of `profile_edit_sheet.dart` into its own widget under `lib/features/profile/presentation/widgets/`
- The dropdown filters out `FuelType.all` (a search-time wildcard, not a real preference) and labels options via `FuelType.displayName`
- `profile_edit_sheet.dart` 466 -> 452 lines; drops the now-unused `fuel_type` import
- 3 new widget tests cover the selected-fuel display, the filtered option list (no `all`), and tap forwarding

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean
- [x] `flutter test test/features/profile/` — 108 tests pass
- [x] CI build-android

Closes part of #388.