### PR TITLE
docs: refresh README feature list for current state — closes #397

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,17 @@ Tankstellen helps drivers find the cheapest fuel nearby, along a route, or in a 
 - **Real-time prices** from official government data sources
 - **11 countries** — Germany, France, Austria, Spain, Italy, Denmark, Portugal, UK, Argentina, Australia, Mexico
 - **23 languages** — from Bulgarian to Swedish
-- **Route search** — find the cheapest station along your planned route
+- **Route search** — find the cheapest station along your planned route, with saved itineraries
+- **EV charging** — OpenChargeMap integration with connector type, max power, and pricing
+- **Driving mode** — full-screen, in-car friendly map with large markers and voice announcements
+- **Vehicle profiles** — combustion, hybrid, or EV; battery, connectors, tank capacity
+- **Fuel consumption tracking** — log fill-ups manually, by **receipt scan** (OCR), or via **OBD-II** (ELM327)
+- **Calculator** — tank fill cost, cross-station savings, fuel budget projections
+- **Carbon dashboard** — CO₂ emissions per vehicle with 30-day rolling chart
 - **Price alerts** — get notified when prices drop below your threshold
 - **Price history & predictions** — 30-day charts and "best time to fill" analysis
+- **Brand registry & filter** — country-specific brand recognition, filter by Total / Esso / Shell / etc.
+- **Landing screen selection** — open the app to nearest, cheapest, favorites, or map
 - **Favorites** — quick access to your regular stations with swipe actions
 - **Home screen widget** — see prices without opening the app
 - **Offline-capable** — local-first architecture with smart caching


### PR DESCRIPTION
## Summary
Wraps up the audit's "wiki + README + CLAUDE.md drift" item (#397) by bringing the README Features list in line with the actual feature surface.

## What changed in this PR
README.md gains the modules that landed in recent work but never made it into the bullet list:

- **EV charging** (OpenChargeMap integration)
- **Driving mode** (full-screen, in-car friendly map)
- **Vehicle profiles** (combustion / hybrid / EV)
- **Fuel consumption tracking** (manual entry, receipt scan, OBD-II)
- **Calculator** (tank fill cost, cross-station savings)
- **Carbon dashboard** (CO₂ emissions per vehicle)
- **Brand registry & filter**
- **Landing screen selection**

Also notes "saved itineraries" on the existing Route search bullet.

## What was already done outside this PR
The wiki side of #397 was pushed directly to `tankstellen.wiki.git` (GitHub wikis live in their own git repo). That commit added/updated:
- **Features.md** — 10 new feature sections (Driving Mode, Vehicle Profiles, Fuel Consumption Tracking, Calculator, Carbon Dashboard, Saved Itineraries, Brand Registry & Filter, Landing Screen Selection, Onboarding & Setup, Help Banners)
- **User-Guide.md** — fixed outdated country list (dropped Belgium/Luxembourg, added the actual 11) and added a Vehicle Profiles & Fill-up Tracking sub-section
- **FAQ.md** — new page covering general questions, API keys, privacy, features, building from source, contributing
- **_Sidebar.md** / **Home.md** — link the new FAQ page

CLAUDE.md is gitignored (local-only) and was updated in my working copy so the loop's mental model matches reality (version 4.1.0 → 4.3.0, "7 countries live" → "11 countries live, 23 languages"). It's not part of the PR diff because git ignores it.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — only pre-existing infos, no new warnings from doc changes
- [x] Wiki commit pushed and visible at https://github.com/fdittgen-png/tankstellen/wiki

Closes #397.