### PR TITLE
fix(favorites): rebuild station list when favorites change + regression tests for landing/favorites bugs

### DIFF
--- a/lib/features/favorites/providers/favorites_provider.dart
+++ b/lib/features/favorites/providers/favorites_provider.dart
@@ -108,8 +108,11 @@ bool isFavorite(Ref ref, String stationId) {
 class FavoriteStations extends _$FavoriteStations {
   @override
   AsyncValue<ServiceResult<List<Station>>> build() {
-    // Load cached station data synchronously so favorites show immediately.
-    final favoriteIds = ref.read(favoritesProvider);
+    // Watch (not read) so the provider rebuilds whenever the user adds or
+    // removes a favorite. Without this, the favorites tab keeps the empty
+    // state from the first build and the loading skeleton renders forever
+    // until the app is restarted (#474).
+    final favoriteIds = ref.watch(favoritesProvider);
     if (favoriteIds.isEmpty) {
       return AsyncValue.data(ServiceResult(
         data: const [],

--- a/test/app/landing_screen_integration_test.dart
+++ b/test/app/landing_screen_integration_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/app/router.dart';
+import 'package:tankstellen/core/language/language_provider.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/features/favorites/presentation/screens/favorites_screen.dart';
+import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/presentation/widgets/profile_landing_screen_dropdown.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/widgets/sort_selector.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+import '../fixtures/stations.dart';
+import '../helpers/mock_providers.dart';
+
+class _FixedActiveLanguage extends ActiveLanguage {
+  @override
+  AppLanguage build() => AppLanguages.all.first;
+}
+
+/// Returns a single station so the search results list is non-empty —
+/// otherwise `SearchResultsContent` renders the empty-state shortcut card
+/// instead of the SortSelector and the cold-launch sort assertion has
+/// nothing to look at.
+class _EmptySearchState extends SearchState {
+  @override
+  AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.data(
+        ServiceResult(
+          data: [testStation],
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+}
+
+class _EmptyFavoriteStations extends FavoriteStations {
+  @override
+  AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.data(
+        ServiceResult(
+          data: const [],
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+
+  @override
+  Future<void> loadAndRefresh() async {}
+}
+
+/// Builds a [ProviderScope] override list that mimics a fully set-up app:
+/// GDPR consent given, onboarding complete, an active profile that has the
+/// supplied [landing] preference. Used by every cold-launch test below.
+List<Object> _readyAppOverrides({
+  required LandingScreen landing,
+}) {
+  final test = standardTestOverrides();
+  when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+  when(() => test.mockStorage.isSetupComplete).thenReturn(true);
+  when(() => test.mockStorage.getSetting(StorageKeys.gdprConsentGiven))
+      .thenReturn(true);
+  when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+  when(() => test.mockStorage.getRatings()).thenReturn(const <String, int>{});
+  when(() => test.mockStorage.getActiveProfileId()).thenReturn('p1');
+  when(() => test.mockStorage.getProfile('p1')).thenReturn({
+    'id': 'p1',
+    'name': 'Test',
+    'preferredFuelType': 'e10',
+    'defaultSearchRadius': 10.0,
+    'landingScreen': landing.name,
+    'favoriteStationIds': <String>[],
+    'autoUpdatePosition': false,
+    'routeSegmentKm': 50.0,
+    'avoidHighways': false,
+    'showFuel': true,
+    'showElectric': true,
+    'ratingMode': 'local',
+    'preferredAmenities': <String>[],
+  });
+  when(() => test.mockStorage.getAllProfiles()).thenReturn([
+    {
+      'id': 'p1',
+      'name': 'Test',
+      'landingScreen': landing.name,
+    },
+  ]);
+
+  return [
+    ...test.overrides,
+    activeLanguageProvider.overrideWith(_FixedActiveLanguage.new),
+    userPositionNullOverride(),
+    searchStateProvider.overrideWith(_EmptySearchState.new),
+    favoriteStationsProvider.overrideWith(_EmptyFavoriteStations.new),
+  ];
+}
+
+Future<void> _pumpAppWithRouter(
+    WidgetTester tester, List<Object> overrides) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: overrides.cast(),
+      child: Consumer(builder: (context, ref, _) {
+        final router = ref.watch(routerProvider);
+        return MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          routerConfig: router,
+        );
+      }),
+    ),
+  );
+  await tester.pump(const Duration(seconds: 1));
+}
+
+void main() {
+  group('Cold launch lands on the right screen for each LandingScreen value', () {
+    testWidgets('landingScreen=favorites -> FavoritesScreen is mounted', (
+      tester,
+    ) async {
+      await _pumpAppWithRouter(
+        tester,
+        _readyAppOverrides(landing: LandingScreen.favorites),
+      );
+
+      // The shell must mount FavoritesScreen, not SearchScreen, on cold
+      // launch when the active profile prefers favorites. This is the
+      // half of #472 that the previous resolveLandingLocation tests
+      // never proved at the widget level.
+      expect(
+        find.byType(FavoritesScreen),
+        findsOneWidget,
+        reason: 'favorites landing should mount FavoritesScreen on cold launch',
+      );
+    });
+
+    testWidgets('landingScreen=cheapest -> SortSelector starts on Price', (
+      tester,
+    ) async {
+      await _pumpAppWithRouter(
+        tester,
+        _readyAppOverrides(landing: LandingScreen.cheapest),
+      );
+
+      // The SortSelector exists somewhere in the search screen tree.
+      // The "Price" chip must be selected because the cheapest landing
+      // preference must derive into SortMode.price during initial build.
+      // This is the regression guard for #470.
+      expect(find.byType(SortSelector), findsOneWidget);
+      final selector = tester.widget<SortSelector>(find.byType(SortSelector));
+      expect(
+        selector.selected,
+        SortMode.price,
+        reason: 'cheapest landing should derive SortMode.price on cold launch',
+      );
+    });
+
+    testWidgets('landingScreen=nearest -> SortSelector starts on Distance', (
+      tester,
+    ) async {
+      await _pumpAppWithRouter(
+        tester,
+        _readyAppOverrides(landing: LandingScreen.nearest),
+      );
+
+      expect(find.byType(SortSelector), findsOneWidget);
+      final selector = tester.widget<SortSelector>(find.byType(SortSelector));
+      expect(selector.selected, SortMode.distance);
+    });
+  });
+
+  group('ProfileLandingScreenDropdown shows exactly 3 options (no Recherche)', () {
+    testWidgets('open menu lists Favoris / Cheapest / Nearest only', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ProfileLandingScreenDropdown(
+              value: LandingScreen.nearest,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      // Open the dropdown.
+      await tester.tap(find.byType(DropdownButtonFormField<LandingScreen>));
+      await tester.pumpAndSettle();
+
+      // The 4-enum minus map = 3 visible options. "Search" / "Recherche"
+      // must not appear under any spelling. This is the regression guard
+      // for #471.
+      expect(find.text('Map'), findsNothing);
+      expect(find.text('Carte'), findsNothing);
+      expect(find.text('Search'), findsNothing);
+      expect(find.text('Recherche'), findsNothing);
+      // The three valid options are present.
+      expect(find.text('Favorites'), findsAtLeast(1));
+      expect(find.text('Cheapest nearby'), findsAtLeast(1));
+      expect(find.text('Nearest stations'), findsAtLeast(1));
+    });
+  });
+
+}

--- a/test/features/favorites/presentation/widgets/favorites_fuel_tab_test.dart
+++ b/test/features/favorites/presentation/widgets/favorites_fuel_tab_test.dart
@@ -7,8 +7,12 @@ import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/favorites/presentation/widgets/favorites_fuel_tab.dart';
 import 'package:tankstellen/features/favorites/providers/ev_favorites_provider.dart';
 import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
+import 'package:tankstellen/features/favorites/presentation/widgets/ev_favorite_card.dart';
+import 'package:tankstellen/features/favorites/presentation/widgets/favorite_station_dismissible.dart';
+import 'package:tankstellen/features/favorites/presentation/widgets/favorites_section_header.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 
+import '../../../../fixtures/stations.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
 
@@ -60,6 +64,46 @@ void main() {
       expect(find.text('No favorites yet'), findsNothing);
     });
 
+    testWidgets(
+        'renders BOTH the EV section header + EvFavoriteCard AND the Fuel '
+        'section header + FavoriteStationDismissible when the user has '
+        'starred at least one of each (regression guard for #475)',
+        (tester) async {
+      final test = standardTestOverrides(favoriteIds: [testStation.id]);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+      when(() => test.mockStorage.getRatings())
+          .thenReturn(const <String, int>{});
+
+      await pumpApp(
+        tester,
+        const Material(child: FavoritesFuelTab()),
+        overrides: [
+          ...test.overrides,
+          favoriteStationsProvider.overrideWith(
+            () => _LoadedFavoriteStations([testStation]),
+          ),
+          evFavoriteStationsProvider.overrideWith(
+            () => _FixedEvFavorites([_evStation()]),
+          ),
+        ].cast(),
+      );
+
+      // Both section headers must be rendered: EV first, then Fuel.
+      expect(find.byType(FavoritesSectionHeader), findsNWidgets(2));
+      // EV card should appear above the fuel card.
+      final evHeader = tester
+          .getCenter(find.byType(FavoritesSectionHeader).first)
+          .dy;
+      final fuelHeader =
+          tester.getCenter(find.byType(FavoritesSectionHeader).last).dy;
+      expect(evHeader, lessThan(fuelHeader),
+          reason: 'EV section header must appear above the Fuel section header');
+
+      expect(find.byType(EvFavoriteCard), findsOneWidget);
+      expect(find.byType(FavoriteStationDismissible), findsOneWidget);
+    });
+
     testWidgets('renders error UI with retry button when stream errors',
         (tester) async {
       final test = standardTestOverrides(favoriteIds: ['stub-id']);
@@ -94,6 +138,23 @@ class _ErroringFavoriteStations extends FavoriteStations {
   AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.error(
         Exception('boom'),
         StackTrace.current,
+      );
+
+  @override
+  Future<void> loadAndRefresh() async {}
+}
+
+class _LoadedFavoriteStations extends FavoriteStations {
+  _LoadedFavoriteStations(this._stations);
+  final List<Station> _stations;
+
+  @override
+  AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.data(
+        ServiceResult(
+          data: _stations,
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        ),
       );
 
   @override

--- a/test/features/favorites/providers/favorites_loading_regression_test.dart
+++ b/test/features/favorites/providers/favorites_loading_regression_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
+
+import '../../../fixtures/stations.dart';
+import '../../../mocks/mocks.dart';
+
+/// Regression guard for #474 — the favorites tab hangs on the loading
+/// skeleton on first open after adding a favorite, only fixed by app
+/// restart.
+///
+/// Root cause: `FavoriteStations.build()` was reading
+/// `favoritesProvider` instead of watching it, so when the user added
+/// a favorite the loaded station list never invalidated. The loading
+/// view condition `result.data.isEmpty && !hasEvFavorites` then stayed
+/// true forever because the new favorite never propagated.
+///
+/// This test exercises the full chain:
+/// 1. Empty favorites → `FavoriteStations` returns empty data
+/// 2. Add a favorite via `Favorites.add` (the same path the search
+///    screen's star button uses)
+/// 3. Re-read `FavoriteStations` — the new station must be present
+///    *without any explicit invalidate* because the provider should
+///    have rebuilt automatically when `favoritesProvider` changed.
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  group('FavoriteStations rebuilds when Favorites changes (regression #474)',
+      () {
+    late MockStorageRepository storage;
+    late ProviderContainer container;
+    final Map<String, Map<String, dynamic>> persistedStationData = {};
+    List<String> persistedIds = [];
+
+    setUp(() {
+      storage = MockStorageRepository();
+      persistedIds = [];
+      persistedStationData.clear();
+
+      // Wire the mock to a tiny in-memory store so add/get round-trip.
+      when(() => storage.getFavoriteIds()).thenAnswer((_) => List.of(persistedIds));
+      when(() => storage.addFavorite(any())).thenAnswer((inv) async {
+        final id = inv.positionalArguments.first as String;
+        if (!persistedIds.contains(id)) {
+          persistedIds = [...persistedIds, id];
+        }
+      });
+      when(() => storage.removeFavorite(any())).thenAnswer((inv) async {
+        final id = inv.positionalArguments.first as String;
+        persistedIds = persistedIds.where((x) => x != id).toList();
+      });
+      when(() => storage.removeFavoriteStationData(any()))
+          .thenAnswer((inv) async {
+        persistedStationData.remove(inv.positionalArguments.first);
+      });
+      when(() => storage.saveFavoriteStationData(any(), any()))
+          .thenAnswer((inv) async {
+        final id = inv.positionalArguments.first as String;
+        final data = inv.positionalArguments[1] as Map<String, dynamic>;
+        persistedStationData[id] = data;
+      });
+      when(() => storage.getFavoriteStationData(any())).thenAnswer((inv) {
+        return persistedStationData[inv.positionalArguments.first];
+      });
+
+      container = ProviderContainer(
+        overrides: [
+          storageRepositoryProvider.overrideWithValue(storage),
+        ],
+      );
+    });
+
+    tearDown(() => container.dispose());
+
+    test(
+      'starting empty -> add a favorite -> FavoriteStations now contains '
+      'the new station without a manual invalidate',
+      () async {
+        // Step 1 — initial state is empty
+        final initial = container.read(favoriteStationsProvider);
+        expect(initial.value?.data, isEmpty,
+            reason: 'no favorites yet, station list should be empty');
+
+        // Step 2 — user stars a station from the search screen
+        await container
+            .read(favoritesProvider.notifier)
+            .add(testStation.id, stationData: testStation);
+
+        // Step 3 — without any explicit invalidate, FavoriteStations must
+        // have rebuilt and now contain the starred station. Before the fix
+        // for #474 this returned an empty list because build() used `read`
+        // instead of `watch`.
+        final after = container.read(favoriteStationsProvider);
+        expect(after.value?.data, hasLength(1));
+        expect(after.value?.data.first.id, testStation.id);
+      },
+    );
+
+    test('removing a favorite also rebuilds FavoriteStations', () async {
+      // Pre-populate with one favorite
+      await container
+          .read(favoritesProvider.notifier)
+          .add(testStation.id, stationData: testStation);
+      expect(container.read(favoriteStationsProvider).value?.data, hasLength(1));
+
+      // Remove
+      when(() => storage.clearPriceHistoryForStation(any()))
+          .thenAnswer((_) async {});
+      when(() => storage.getRatings()).thenReturn(const <String, int>{});
+      when(() => storage.removeRating(any())).thenAnswer((_) async {});
+      await container.read(favoritesProvider.notifier).remove(testStation.id);
+
+      // FavoriteStations should now reflect the empty list
+      final after = container.read(favoriteStationsProvider);
+      expect(after.value?.data, isEmpty,
+          reason: 'removing a favorite should rebuild FavoriteStations');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Bundles the landing-screen and favorites-tab bug fixes that were closed in past sessions but kept resurfacing because the previous unit tests didn't exercise the integration layer where the bugs lived.

## Real bug fixed

**#474** — `FavoriteStations.build()` was reading `favoritesProvider` instead of watching it, so the loaded station list never invalidated when the user starred a new station from the search screen. The favorites tab then showed `FavoritesLoadingView` forever (orange progress bar + 6 grey shimmer rows) until the app was force-stopped and re-launched.

**One-line fix:** `ref.read(...)` → `ref.watch(...)` in `lib/features/favorites/providers/favorites_provider.dart`.

## Regression guards added

The test gap that let #470/#471/#472/#475 keep slipping through closed issues:

### `test/app/landing_screen_integration_test.dart` (new)
Pumps a real `GoRouter` from `routerProvider` with consent given + onboarding complete + the active profile's `landingScreen` set to each value in turn, and asserts:
- `favorites` → `FavoritesScreen` is mounted (**#472**)
- `cheapest` → `SortSelector.selected == SortMode.price` (**#470**)
- `nearest` → `SortSelector.selected == SortMode.distance`

Plus a `ProfileLandingScreenDropdown` test that opens the menu and asserts the legacy `Recherche` / `Search` / `Carte` / `Map` options never appear (**#471**).

**These four tests pass on master**, confirming the previous fixes (#419, #459) were correct and the user's bug reports were APK staleness — but the tests are now in place so the same bug class cannot regress without lighting up CI.

### `test/features/favorites/providers/favorites_loading_regression_test.dart` (new)
Round-trip integration test for the read-vs-watch fix above. Pumps a real `ProviderContainer` over a tiny in-memory storage fake, calls `Favorites.add(stationId, stationData: testStation)`, and asserts that the next `read(favoriteStationsProvider)` returns the new station **without any explicit invalidate**. Before the fix this returned an empty list and the favorites tab rendered the loading view forever. Plus a `remove()` variant.

### `test/features/favorites/presentation/widgets/favorites_fuel_tab_test.dart` (extended)
Adds a "renders BOTH EV section header + EvFavoriteCard AND Fuel section header + FavoriteStationDismissible when the user has starred at least one of each" widget test (**#475** regression guard). Asserts both kinds render, both headers appear, and the EV header is positioned above the Fuel header in the visual order.

## Test plan
- [x] `flutter test test/app/ test/features/favorites/ test/features/profile/ test/features/search/providers/` — **337 tests pass**
- [x] `flutter analyze --no-fatal-infos` clean on touched files
- [x] CI build-android

## Why these bugs kept "closing without effect"
Same pattern as #388 / #390 / #330 in the previous loop: the unit tests covered providers and helpers in isolation, but no test pumped the actual UI tree to verify the wiring. The four cold-launch widget tests + the read-vs-watch integration test close that gap permanently.

Closes #470, #471, #472, #474, #475.