### PR TITLE
feat(observability): wire Sentry DSN at build time + expose error trace export — closes #476

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -68,14 +68,17 @@ class AppInitializer {
 
     StartupTimer.instance.mark('pre_run_app');
 
-    final sentryDsn = storage.getSetting('sentry_dsn') as String?;
-    if (sentryDsn != null && sentryDsn.isNotEmpty) {
+    final dsn = resolveSentryDsn(storage);
+    final consentGiven = storage
+            .getSetting('consent_error_reporting') as bool? ??
+        false;
+    if (dsn.isNotEmpty && consentGiven) {
       final packageInfo = await PackageInfo.fromPlatform();
       final release =
           'tankstellen@${packageInfo.version}+${packageInfo.buildNumber}';
       await SentryFlutter.init(
         (options) {
-          options.dsn = sentryDsn;
+          options.dsn = dsn;
           options.tracesSampleRate = 0.2;
           options.environment = 'production';
           options.release = release;
@@ -85,6 +88,21 @@ class AppInitializer {
     } else {
       _launch(container, appBuilder);
     }
+  }
+
+  /// Resolves the active Sentry DSN at startup. The user-stored
+  /// `sentry_dsn` setting (entered manually via Settings > Diagnostics)
+  /// always wins, otherwise we fall back to the build-time `SENTRY_DSN`
+  /// dart-define. Returns the empty string when neither is configured —
+  /// callers must check `dsn.isNotEmpty` before passing it to
+  /// `SentryFlutter.init` (#476).
+  ///
+  /// Exposed for unit tests.
+  static String resolveSentryDsn(HiveStorage storage) {
+    final stored = storage.getSetting('sentry_dsn') as String?;
+    if (stored != null && stored.isNotEmpty) return stored;
+    const buildDsn = String.fromEnvironment('SENTRY_DSN');
+    return buildDsn;
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/core/error_tracing/storage/trace_storage.dart
+++ b/lib/core/error_tracing/storage/trace_storage.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -53,6 +55,27 @@ class TraceStorage {
   Future<void> delete(String id) => _box.delete(id);
   Future<void> clearAll() => _box.clear();
   int get count => _box.length;
+
+  /// Serialises every persisted trace into a single JSON document the
+  /// user can email or attach to a GitHub issue. Used by the privacy
+  /// dashboard's "Export error log" action (#476).
+  ///
+  /// Format:
+  /// ```json
+  /// {
+  ///   "exportedAt": "<iso8601>",
+  ///   "traceCount": 12,
+  ///   "traces": [ <ErrorTrace.toJson()>, ... ]
+  /// }
+  /// ```
+  String exportAsJson() {
+    final traces = getAll();
+    return const JsonEncoder.withIndent('  ').convert({
+      'exportedAt': DateTime.now().toUtc().toIso8601String(),
+      'traceCount': traces.length,
+      'traces': traces.map((t) => t.toJson()).toList(),
+    });
+  }
 
   Future<void> _prune() async {
     final cutoff = DateTime.now().subtract(maxAge);

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
+import '../../../../core/error_tracing/storage/trace_storage.dart';
 import '../../../../core/export/data_exporter.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -52,6 +53,20 @@ class _PrivacyDashboardScreenState
           const SizedBox(height: 12),
           PrivacyExportCsvButton(onPressed: _exportDataCsv),
           const SizedBox(height: 12),
+          // #476 — give users a way to share the locally-recorded error
+          // traces with the maintainer (or with their own bug report)
+          // even when Sentry is not configured. Uses Clipboard so we
+          // don't need a share_plus dependency.
+          OutlinedButton.icon(
+            key: const ValueKey('privacy-export-error-log-button'),
+            onPressed: _exportErrorLog,
+            icon: const Icon(Icons.bug_report_outlined),
+            label: Text(
+              'Copy error log to clipboard '
+              '(${ref.watch(traceStorageProvider).count})',
+            ),
+          ),
+          const SizedBox(height: 12),
           PrivacyDeleteAllButton(onPressed: _deleteAllData),
           SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
         ],
@@ -67,6 +82,17 @@ class _PrivacyDashboardScreenState
     SnackBarHelper.showSuccess(
       context,
       l?.privacyExportSuccess ?? 'Data exported to clipboard',
+    );
+  }
+
+  Future<void> _exportErrorLog() async {
+    final traces = ref.read(traceStorageProvider);
+    final json = traces.exportAsJson();
+    await Clipboard.setData(ClipboardData(text: json));
+    if (!mounted) return;
+    SnackBarHelper.showSuccess(
+      context,
+      'Error log copied to clipboard (${traces.count} entries)',
     );
   }
 

--- a/test/app/app_initializer_test.dart
+++ b/test/app/app_initializer_test.dart
@@ -126,6 +126,56 @@ void main() {
       expect(body, contains('runApp'));
     });
   });
+
+  group('Sentry observability wiring (#476)', () {
+    test(
+        'resolveSentryDsn prefers the user-stored sentry_dsn setting over '
+        'the build-time SENTRY_DSN dart-define', () {
+      // Source-level invariants: the resolver must read the storage
+      // setting first, then fall back to String.fromEnvironment.
+      final body =
+          _extractMethodBody(initSource, 'static String resolveSentryDsn');
+      expect(body, isNotNull, reason: 'resolveSentryDsn helper must exist');
+      // Storage read happens first.
+      final storedIdx = body!.indexOf("getSetting('sentry_dsn')");
+      final envIdx = body.indexOf('String.fromEnvironment');
+      expect(storedIdx, isNonNegative);
+      expect(envIdx, isNonNegative);
+      expect(storedIdx, lessThan(envIdx),
+          reason: 'storage setting must be checked before the dart-define '
+              'fallback so a power user can override the maintainer DSN');
+      // The dart-define key is exactly SENTRY_DSN (not e.g. SentryDSN or
+      // sentry_dsn — that would silently misalign with the build flag).
+      expect(body, contains("String.fromEnvironment('SENTRY_DSN')"),
+          reason: 'dart-define key must be exactly SENTRY_DSN to match the '
+              'build flag in the release workflow');
+    });
+
+    test(
+        'SentryFlutter.init is gated on (a) DSN non-empty AND '
+        '(b) consent_error_reporting setting being true', () {
+      final body =
+          _extractMethodBody(initSource, 'static Future<void> run');
+      expect(body, isNotNull);
+      // The init must check consent.
+      expect(body, contains('consent_error_reporting'),
+          reason: 'AppInitializer.run must check the user has opted in to '
+              'error reporting before initialising Sentry');
+      // And it must check the DSN is non-empty.
+      expect(body, contains('isNotEmpty'),
+          reason: 'init must guard on DSN.isNotEmpty so an empty SENTRY_DSN '
+              'in the build env never triggers Sentry');
+    });
+
+    test(
+        'main.dart still does NOT reference SentryFlutter — that is owned '
+        'by AppInitializer', () {
+      // Belt and braces: keep the forbidden-symbols list in sync if the
+      // Sentry rollout ever leaks back into main.dart.
+      expect(mainSource, isNot(contains('SentryFlutter')));
+      expect(mainSource, isNot(contains('SENTRY_DSN')));
+    });
+  });
 }
 
 /// Extracts the body of the first method that starts with [signature].

--- a/test/core/error_tracing/storage/trace_storage_test.dart
+++ b/test/core/error_tracing/storage/trace_storage_test.dart
@@ -146,5 +146,58 @@ void main() {
       expect(traces.first.deviceInfo.os, 'test');
       expect(traces.first.networkState.isOnline, isTrue);
     });
+
+    group('exportAsJson (#476)', () {
+      test('returns an empty traces array when no traces are stored', () {
+        final raw = storage.exportAsJson();
+        final decoded = jsonDecode(raw) as Map<String, dynamic>;
+        expect(decoded['traceCount'], 0);
+        expect(decoded['traces'], isEmpty);
+        expect(decoded['exportedAt'], isA<String>());
+      });
+
+      test('serialises every persisted trace into the traces array',
+          () async {
+        await Hive.box('error_traces')
+            .put('e1', _makePlainJson(id: 'e1'));
+        await Hive.box('error_traces')
+            .put('e2', _makePlainJson(id: 'e2'));
+        await Hive.box('error_traces')
+            .put('e3', _makePlainJson(id: 'e3'));
+
+        final raw = storage.exportAsJson();
+        final decoded = jsonDecode(raw) as Map<String, dynamic>;
+        expect(decoded['traceCount'], 3);
+        final traces = decoded['traces'] as List;
+        expect(traces, hasLength(3));
+        // Every item has the canonical ErrorTrace shape.
+        for (final t in traces) {
+          final m = t as Map<String, dynamic>;
+          expect(m, contains('id'));
+          expect(m, contains('timestamp'));
+          expect(m, contains('errorMessage'));
+        }
+      });
+
+      test('includes an ISO-8601 exportedAt timestamp in UTC', () {
+        final raw = storage.exportAsJson();
+        final decoded = jsonDecode(raw) as Map<String, dynamic>;
+        final ts = decoded['exportedAt'] as String;
+        expect(ts, endsWith('Z'),
+            reason: 'exportedAt should be ISO-8601 UTC for portability');
+        // Round-trip parses cleanly.
+        expect(() => DateTime.parse(ts), returnsNormally);
+      });
+
+      test('output is pretty-printed (uses indentation) for human review',
+          () {
+        final raw = storage.exportAsJson();
+        // JsonEncoder.withIndent uses 2-space indent — the second line
+        // should start with two spaces.
+        final lines = raw.split('\n');
+        expect(lines.length, greaterThan(1));
+        expect(lines[1], startsWith('  '));
+      });
+    });
   });
 }

--- a/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
+++ b/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/error_tracing/storage/trace_storage.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 import 'package:tankstellen/core/sync/sync_config.dart';
 import 'package:tankstellen/core/sync/sync_provider.dart';
@@ -7,6 +9,18 @@ import 'package:tankstellen/features/profile/presentation/screens/privacy_dashbo
 
 import '../../../../helpers/pump_app.dart';
 import '../../../../mocks/mocks.dart';
+
+/// Stub TraceStorage that doesn't touch Hive — the privacy dashboard
+/// reads `count` from the provider during build, and the production
+/// implementation calls `Hive.box('error_traces')` which fails in
+/// widget tests where Hive isn't initialised.
+class _StubTraceStorage extends TraceStorage {
+  @override
+  int get count => 0;
+
+  @override
+  String exportAsJson() => '{"traceCount":0,"traces":[]}';
+}
 
 void main() {
   group('PrivacyDashboardScreen', () {
@@ -39,6 +53,7 @@ void main() {
     List<Object> _overrides() => [
           storageRepositoryProvider.overrideWithValue(mockStorage),
           syncStateProvider.overrideWith(() => _DisabledSyncState()),
+          traceStorageProvider.overrideWithValue(_StubTraceStorage()),
         ];
 
     testWidgets('shows local data counts', (tester) async {
@@ -87,12 +102,41 @@ void main() {
         overrides: [
           storageRepositoryProvider.overrideWithValue(mockStorage),
           syncStateProvider.overrideWith(() => _EnabledSyncState()),
+          traceStorageProvider.overrideWithValue(_StubTraceStorage()),
         ],
       );
 
       expect(find.text('Tankstellen Community'), findsOneWidget);
       expect(find.textContaining('user-abc'), findsOneWidget);
       expect(find.text('View server data'), findsOneWidget);
+    });
+
+    testWidgets(
+        'shows the "Copy error log to clipboard" button labelled with the '
+        'current trace count (#476)', (tester) async {
+      await pumpApp(
+        tester,
+        const PrivacyDashboardScreen(),
+        overrides: _overrides(),
+      );
+
+      // The button lives in the ListView below the fold — scroll it
+      // into view first.
+      await tester.scrollUntilVisible(
+        find.byKey(const ValueKey('privacy-export-error-log-button')),
+        50.0,
+      );
+
+      // The new button is keyed for stable lookup; the label includes the
+      // count from the (stubbed) TraceStorage which returns 0.
+      expect(
+        find.byKey(const ValueKey('privacy-export-error-log-button')),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Copy error log to clipboard (0)'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows export button', (tester) async {


### PR DESCRIPTION
## Background
The consent screen promised *"Anonymous crash reports help improve the app... Reports are sent via Sentry only when configured"*, but the maintainer received nothing because the Sentry DSN was read from a Hive setting (`sentry_dsn`) that **no UI ever wrote**. Every "Error Reporting: ON" install was silently sending nothing.

## Changes

### 1. Build-time Sentry DSN
`AppInitializer.run` now resolves the DSN via a new `resolveSentryDsn(storage)` helper that reads the user-stored `sentry_dsn` setting first, then falls back to a `--dart-define=SENTRY_DSN`. The official release build can plumb in `--dart-define=SENTRY_DSN=$SENTRY_DSN` from a GitHub secret; self-hosters and privacy-conscious users can override via the storage setting (UI for that is a follow-up).

### 2. Consent gate
`SentryFlutter.init` is now gated on the `consent_error_reporting` storage flag being `true`. The consent screen toggle finally has an effect: turning it off prevents Sentry from initialising even if a DSN is baked in.

### 3. Local trace export
`TraceStorage.exportAsJson()` serialises every persisted local trace into a pretty-printed JSON document (with `exportedAt`, `traceCount`, and an array of traces). The privacy dashboard gains a **"Copy error log to clipboard (N)"** button that shows the current trace count and writes the JSON to the clipboard via `Clipboard.setData`. Users can paste this into a GitHub issue, an email, or any text editor — **no `share_plus` dependency added**.

## Rollout plan after merge
1. Create a Sentry project at `sentry.io/.../tankstellen` (free tier covers ~5k events/month)
2. Get the DSN, store as a GitHub repo secret `SENTRY_DSN`
3. Plumb into `flutter build apk --dart-define=SENTRY_DSN=$SENTRY_DSN` in the release workflow
4. Set up alerts for `level:error` events
5. Sentry release tracking will use the existing `tankstellen@<version>+<build>` tag

## Tests added (8 new)
- **`app_initializer_test.dart`** — 3 source-level invariants:
  - `resolveSentryDsn` checks storage first then `String.fromEnvironment('SENTRY_DSN')`
  - `SentryFlutter.init` call site checks both `consent_error_reporting` and `isNotEmpty` on the DSN
  - `main.dart` still does not reference `SentryFlutter` or `SENTRY_DSN`
- **`trace_storage_test.dart`** — 4 behavioural tests:
  - empty array on no traces
  - full serialisation of all stored traces
  - ISO-8601 UTC `exportedAt` timestamp
  - indented (pretty-printed) output for human review
- **`privacy_dashboard_screen_test.dart`** — widget test that:
  - scrolls the new button into view
  - asserts the key and the `(0)` count label
  - plus a `_StubTraceStorage` override so the existing dashboard tests stop crashing when the screen reads `traceStorageProvider` during build

## Test plan
- [x] `flutter test test/app/ test/core/error_tracing/ test/features/profile/` — 250 tests pass
- [x] `flutter analyze --no-fatal-infos` clean on all 6 touched files
- [x] CI build-android

Closes #476.