### PR TITLE
security(ci): read Android signing config from env vars, fail release builds without a keystore — closes #48

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,36 @@ jobs:
           restore-keys: ${{ runner.os }}-pub-
       - run: flutter pub get
       - run: dart run build_runner build --delete-conflicting-outputs
+      # #48 — Decode the release keystore from a GitHub secret into a temp
+      # file, then export the three env vars gradle's resolveReleaseSigning()
+      # helper reads. The keystore file is written to a runner-local path
+      # outside the checkout so it never ends up in an artifact.
+      - name: Decode signing keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ] || [ -z "$ANDROID_KEYSTORE_PASSWORD" ] || [ -z "$ANDROID_KEY_ALIAS" ]; then
+            echo "::error::Missing one of ANDROID_KEYSTORE_BASE64 / ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_ALIAS secrets. Release builds require all three — see #48." >&2
+            exit 1
+          fi
+          KEYSTORE_PATH="$RUNNER_TEMP/tankstellen-release.jks"
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_PATH"
+          if ! [ -s "$KEYSTORE_PATH" ]; then
+            echo "::error::Decoded keystore is empty or invalid base64" >&2
+            exit 1
+          fi
+          echo "ANDROID_KEYSTORE_PATH=$KEYSTORE_PATH" >> "$GITHUB_ENV"
+          echo "ANDROID_KEYSTORE_PASSWORD=$ANDROID_KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
+          echo "ANDROID_KEY_ALIAS=$ANDROID_KEY_ALIAS" >> "$GITHUB_ENV"
       - name: Build APK (split per ABI)
         run: flutter build apk --release --split-per-abi --flavor play
       - name: Build App Bundle
         run: flutter build appbundle --release --flavor play
+      - name: Clean up decoded keystore
+        if: always()
+        run: rm -f "$RUNNER_TEMP/tankstellen-release.jks"
       - uses: actions/upload-artifact@v7
         with:
           name: android-apk

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,12 +7,67 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
-// Load signing key properties
+// -----------------------------------------------------------------------------
+// Signing config resolution (#48)
+//
+// Secrets are resolved in this order so env vars (CI, secure local dev via
+// direnv) always win over the legacy plaintext file:
+//
+//   1. Environment variables:
+//        ANDROID_KEYSTORE_PATH      — absolute path to the .jks file
+//        ANDROID_KEYSTORE_PASSWORD  — store password
+//        ANDROID_KEY_ALIAS          — key alias inside the store
+//        ANDROID_KEY_PASSWORD       — key password (falls back to store password)
+//   2. Legacy `key.properties` file at the project root (still supported for
+//      developer convenience; slated for removal once every dev has switched
+//      to env vars).
+//
+// If neither is present AND a release build is requested, the build FAILS
+// instead of silently falling back to the debug signing key. That failure is
+// the fix for the second half of #48's acceptance criteria: "CI explicitly
+// fails without key.properties instead of falling back to debug signing".
+// -----------------------------------------------------------------------------
 val keystorePropertiesFile = rootProject.file("key.properties")
-val keystoreProperties = Properties()
+val legacyKeystoreProperties = Properties()
 if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+    legacyKeystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
+
+data class ReleaseSigningConfig(
+    val storeFile: String,
+    val storePassword: String,
+    val keyAlias: String,
+    val keyPassword: String,
+)
+
+fun resolveReleaseSigning(): ReleaseSigningConfig? {
+    val envPath = System.getenv("ANDROID_KEYSTORE_PATH")
+    val envPass = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+    val envAlias = System.getenv("ANDROID_KEY_ALIAS")
+    val envKeyPass = System.getenv("ANDROID_KEY_PASSWORD") ?: envPass
+
+    if (!envPath.isNullOrEmpty() && !envPass.isNullOrEmpty() && !envAlias.isNullOrEmpty()) {
+        return ReleaseSigningConfig(
+            storeFile = envPath,
+            storePassword = envPass,
+            keyAlias = envAlias,
+            keyPassword = envKeyPass ?: envPass,
+        )
+    }
+
+    if (keystorePropertiesFile.exists()) {
+        return ReleaseSigningConfig(
+            storeFile = legacyKeystoreProperties["storeFile"] as String,
+            storePassword = legacyKeystoreProperties["storePassword"] as String,
+            keyAlias = legacyKeystoreProperties["keyAlias"] as String,
+            keyPassword = legacyKeystoreProperties["keyPassword"] as String,
+        )
+    }
+
+    return null
+}
+
+val releaseSigning: ReleaseSigningConfig? = resolveReleaseSigning()
 
 android {
     namespace = "de.tankstellen.tankstellen"
@@ -42,12 +97,12 @@ android {
     }
 
     signingConfigs {
-        if (keystorePropertiesFile.exists()) {
+        if (releaseSigning != null) {
             create("release") {
-                keyAlias = keystoreProperties["keyAlias"] as String
-                keyPassword = keystoreProperties["keyPassword"] as String
-                storeFile = file(keystoreProperties["storeFile"] as String)
-                storePassword = keystoreProperties["storePassword"] as String
+                keyAlias = releaseSigning.keyAlias
+                keyPassword = releaseSigning.keyPassword
+                storeFile = file(releaseSigning.storeFile)
+                storePassword = releaseSigning.storePassword
             }
         }
     }
@@ -60,10 +115,21 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = if (keystorePropertiesFile.exists()) {
+            // #48 — if a release build is requested but no release signing
+            // config is resolvable, FAIL THE BUILD. We never silently fall
+            // back to the debug signing key: that produced artefacts that
+            // looked valid in CI but would not upgrade an existing install
+            // on user devices.
+            signingConfig = if (releaseSigning != null) {
                 signingConfigs.getByName("release")
             } else {
-                signingConfigs.getByName("debug")
+                throw GradleException(
+                    "No release signing configuration available. " +
+                        "Set ANDROID_KEYSTORE_PATH / ANDROID_KEYSTORE_PASSWORD / " +
+                        "ANDROID_KEY_ALIAS environment variables (CI: use GitHub " +
+                        "Secrets), or create android/key.properties locally. " +
+                        "Release builds never fall back to the debug key — see #48."
+                )
             }
         }
     }

--- a/test/app/signing_config_test.dart
+++ b/test/app/signing_config_test.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression guards for #48 — the Android signing config must:
+///
+/// 1. Resolve release signing from environment variables first (CI path)
+/// 2. Fall back to `android/key.properties` if env vars are missing
+///    (legacy local-dev path)
+/// 3. **Fail the build** if neither is present, instead of silently
+///    dropping to the debug signing key. That silent fallback was the
+///    bug that made every master CI release artifact debug-signed
+///    without anyone noticing.
+///
+/// These are source-level invariants (not runtime gradle execution)
+/// because spinning up gradle inside the Flutter test harness is
+/// impractical. The tests read `android/app/build.gradle.kts` and assert
+/// the right structural patterns are present.
+void main() {
+  late String gradleSource;
+  late String ciSource;
+
+  setUpAll(() {
+    gradleSource = File('android/app/build.gradle.kts').readAsStringSync();
+    ciSource = File('.github/workflows/ci.yml').readAsStringSync();
+  });
+
+  group('Android release signing — no silent debug fallback (#48)', () {
+    test(
+      'build.gradle.kts throws a GradleException when no signing config '
+      'can be resolved, instead of falling back to the debug key',
+      () {
+        // The old bug was an `else` branch that assigned the debug signing
+        // config. The fix throws GradleException with a message that names
+        // every env var the user needs to set.
+        expect(
+          gradleSource,
+          contains('GradleException'),
+          reason: 'release signingConfig must throw GradleException on miss',
+        );
+        expect(
+          gradleSource,
+          isNot(contains('signingConfigs.getByName("debug")')),
+          reason:
+              'build must never route release output through the debug '
+              'signing config — that was the original #48 bug',
+        );
+      },
+    );
+
+    test(
+      'signing config resolution checks env vars BEFORE the legacy '
+      'key.properties file, so CI secrets always win over a stale local file',
+      () {
+        // The resolveReleaseSigning() helper must read the env var names
+        // expected by the CI workflow.
+        expect(gradleSource, contains('ANDROID_KEYSTORE_PATH'));
+        expect(gradleSource, contains('ANDROID_KEYSTORE_PASSWORD'));
+        expect(gradleSource, contains('ANDROID_KEY_ALIAS'));
+        // And the env-var branch must appear before the legacy-file branch
+        // in source order so the environment wins.
+        final envIdx = gradleSource.indexOf('ANDROID_KEYSTORE_PATH');
+        final legacyIdx = gradleSource.indexOf('legacyKeystoreProperties');
+        expect(envIdx, isNonNegative);
+        expect(legacyIdx, isNonNegative);
+        expect(
+          envIdx,
+          lessThan(legacyIdx),
+          reason: 'env-var resolution path must precede the legacy file path',
+        );
+      },
+    );
+
+    test(
+      'the error message names every env var the user must set so failed '
+      'builds self-document the fix',
+      () {
+        final errorBlock = gradleSource
+            .split('GradleException')
+            .elementAt(1); // text after the throw keyword
+        expect(errorBlock, contains('ANDROID_KEYSTORE_PATH'));
+        expect(errorBlock, contains('ANDROID_KEYSTORE_PASSWORD'));
+        expect(errorBlock, contains('ANDROID_KEY_ALIAS'));
+        expect(errorBlock, contains('key.properties'));
+        expect(errorBlock, contains('#48'));
+      },
+    );
+  });
+
+  group('CI workflow writes the decoded keystore + env vars (#48)', () {
+    test(
+      'ci.yml has a "Decode signing keystore" step that reads three '
+      'GitHub Secrets and exports env vars before the APK/AAB build',
+      () {
+        // The step name is the contract — don't rename it without
+        // updating this test.
+        expect(ciSource, contains('Decode signing keystore'));
+        // The three secrets the CI workflow must consume.
+        expect(ciSource, contains('secrets.ANDROID_KEYSTORE_BASE64'));
+        expect(ciSource, contains('secrets.ANDROID_KEYSTORE_PASSWORD'));
+        expect(ciSource, contains('secrets.ANDROID_KEY_ALIAS'));
+        // The three env vars gradle reads, written to GITHUB_ENV.
+        expect(ciSource, contains('ANDROID_KEYSTORE_PATH='));
+        expect(ciSource, contains('ANDROID_KEYSTORE_PASSWORD='));
+        expect(ciSource, contains('ANDROID_KEY_ALIAS='));
+      },
+    );
+
+    test(
+      'ci.yml decode step fails FAST with a descriptive error if any of '
+      'the three secrets are empty — we do not want silent debug signing',
+      () {
+        final decodeStep = ciSource
+            .split('Decode signing keystore')
+            .elementAt(1)
+            .split('- name: Build APK')
+            .first;
+        expect(decodeStep, contains('exit 1'),
+            reason: 'missing secret must fail the step');
+        expect(decodeStep, contains('#48'),
+            reason: 'error message should reference the issue for grep');
+      },
+    );
+
+    test(
+      'ci.yml has a cleanup step that unconditionally removes the decoded '
+      'keystore from the runner so it never ends up in an artifact or log',
+      () {
+        expect(ciSource, contains('Clean up decoded keystore'));
+        expect(ciSource, contains('if: always()'));
+        expect(ciSource, contains('rm -f "\$RUNNER_TEMP/tankstellen-release.jks"'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Closes the second half of #48 — *"CI explicitly fails without key.properties instead of falling back to debug signing"*. The first half (rotate the compromised key, store the new one outside plaintext) was done manually via the rotation walkthrough on April 14; this PR lands the code changes.

## The bug that was shipping silently

`android/app/build.gradle.kts` used to have:

```kotlin
signingConfig = if (keystorePropertiesFile.exists()) {
    signingConfigs.getByName("release")
} else {
    signingConfigs.getByName("debug")
}
```

`key.properties` is gitignored, so on CI (where it never existed) every release build silently dropped to the debug signing key. The APKs + AAB uploaded to GitHub Releases on tag push looked fine but wouldn't upgrade a real user install because the cert didn't match anything. Nobody noticed because nobody was actually sideloading the CI artefacts.

## Fix

### `android/app/build.gradle.kts`
New `resolveReleaseSigning()` helper that resolves the keystore + credentials in order:

1. **Environment variables** — `ANDROID_KEYSTORE_PATH`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS` (plus optional `ANDROID_KEY_PASSWORD`, falling back to the store password). This is the CI path and also supports secure local dev via `direnv` / shell rc files.
2. **Legacy `key.properties`** — kept for local developer convenience. Slated for removal once every dev switches to env vars.
3. **Neither** → the `signingConfig` assignment throws `GradleException` with a message naming every env var the user must set, plus a pointer to #48. No more silent debug fallback.

### `.github/workflows/ci.yml`
New **"Decode signing keystore"** step in the `build-android` job, reading three GitHub Secrets:

- `ANDROID_KEYSTORE_BASE64` — `base64` of the `.jks`
- `ANDROID_KEYSTORE_PASSWORD`
- `ANDROID_KEY_ALIAS`

Writes the decoded keystore to `$RUNNER_TEMP/tankstellen-release.jks` (outside the checkout, so it can never end up in an artifact or log), exports the three env vars the new gradle helper reads, then runs the APK + AAB builds. A final **"Clean up decoded keystore"** step runs unconditionally (`if: always()`) to delete the file even if the build fails.

If any of the three secrets is missing, the decode step fails fast with a clear `::error::` message referencing #48.

### `test/app/signing_config_test.dart` (new — 6 regression guards)

Source-level structural tests (gradle is hard to execute inside the Flutter test harness, so we assert the right patterns are present in the file):

1. `build.gradle.kts` throws `GradleException` instead of assigning `signingConfigs.getByName("debug")` in the release branch
2. env-var resolution path appears in source **before** the legacy `key.properties` branch (CI secrets always win over a stale local file)
3. the error message names every env var + `key.properties` + `#48` so failed builds self-document the fix
4. `ci.yml` has a "Decode signing keystore" step reading the three secrets and writing the three env vars
5. `ci.yml` fails fast when any secret is empty
6. `ci.yml` has an unconditional cleanup step removing the decoded keystore after the build

## Local verification

On this machine before pushing:

```
flutter build apk --release --flavor play --target-platform android-arm64
→ succeeds (via legacy key.properties path, no env vars set)
apksigner verify build/app/outputs/flutter-apk/app-play-release.apk
→ Signer #1 certificate SHA-256 digest: f7b4a81838e23b21420d5a6bb2ebce7a42f96bbc28f5b249c38d9c1c6e0ef4c2
```

That's the rotated key from Step 3 of the keystore walkthrough — the same cert the user's current installed APK is signed with, so they'll upgrade cleanly.

## GitHub Secrets prerequisite

Three repo secrets were created **before this PR was pushed**, so CI can consume them on the first run:

- `ANDROID_KEYSTORE_BASE64`
- `ANDROID_KEYSTORE_PASSWORD`
- `ANDROID_KEY_ALIAS`

Verified via `gh secret list` before pushing.

## Test plan
- [x] `flutter test test/app/signing_config_test.dart` — 6 tests pass
- [x] `flutter analyze --no-fatal-infos` clean on touched files
- [x] Local `flutter build apk --release --flavor play` succeeds via the legacy `key.properties` path
- [x] Fresh APK cert matches the rotated key fingerprint
- [ ] CI build-android with the new secrets — this PR run is the first time the secret path is exercised; if anything is misconfigured it fails loudly here instead of sneaking into production

## Follow-up (Step 7 — not in this PR)

After this merges, the working directory will still have:
- `android/app/fuel-prices-release.jks` — the **old compromised** 2770-byte keystore (legacy)
- `android/fuel-prices-release.jks` — the **new rotated** 4418-byte keystore (current)
- `android/key.properties` — still plaintext locally (used only for local dev; CI no longer reads it)

Step 7 will secure-delete the old compromised file and (optionally) migrate local dev from `key.properties` to env vars via direnv. I'll do that as a separate, smaller follow-up once this PR lands and CI confirms the env-var path works.

Closes #48.