### PR TITLE
fix(brands): chip counts sum to total + sanitize OSM enricher cache + explicit independent sentinel — closes #481, #482

### DIFF
--- a/lib/core/services/impl/osm_brand_enricher.dart
+++ b/lib/core/services/impl/osm_brand_enricher.dart
@@ -5,6 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../data/storage_repository.dart';
 import '../../storage/storage_providers.dart';
 import '../dio_factory.dart';
+import '../../../features/search/domain/entities/brand_registry.dart';
 import '../../../features/search/domain/entities/station.dart';
 
 part 'osm_brand_enricher.g.dart';
@@ -47,7 +48,10 @@ class OsmBrandEnricher {
   }
 
   bool _needsBrand(Station s) =>
-      s.brand.isEmpty || s.brand == 'Station' || s.brand == 'Autoroute';
+      s.brand.isEmpty ||
+      s.brand == 'Station' || // legacy value from before #482
+      s.brand == BrandRegistry.independentLabel ||
+      s.brand == 'Autoroute';
 
   Future<void> _fetchBrandsFromNominatim(
     List<Station> stations, {
@@ -113,8 +117,11 @@ class OsmBrandEnricher {
           }
         }
         if (nearest != null) {
-          _sessionCache[s.id] = nearest.name;
-          await _storage.putSetting('brand_${s.id}', nearest.name);
+          final sanitized = sanitizeOsmBrand(nearest.name);
+          if (sanitized != null) {
+            _sessionCache[s.id] = sanitized;
+            await _storage.putSetting('brand_${s.id}', sanitized);
+          }
         }
       }
     } on DioException catch (e) { debugPrint('OSM brand enrichment failed: $e'); }
@@ -127,11 +134,64 @@ class OsmBrandEnricher {
       if (cached != null) return s.copyWith(brand: cached);
       final persisted = _storage.getSetting('brand_${s.id}');
       if (persisted is String) {
-        _sessionCache[s.id] = persisted;
-        return s.copyWith(brand: persisted);
+        // Validate on read — anything that fails sanitisation (empty,
+        // too short, "ff", phone-number-looking, etc.) is treated as
+        // a cache miss and the station will be re-enriched. This
+        // evicts any historically-poisoned entries that predate the
+        // #481 fix without needing a full-cache migration pass.
+        final sanitized = sanitizeOsmBrand(persisted);
+        if (sanitized != null) {
+          _sessionCache[s.id] = sanitized;
+          return s.copyWith(brand: sanitized);
+        }
       }
       return s;
     }).toList();
+  }
+
+  /// Validates an OSM `name` field before it is cached as a station
+  /// brand. Rejects implausible / garbage values that would otherwise
+  /// leak into the brand filter chip strip as mystery labels (#481).
+  ///
+  /// A brand string is accepted if it:
+  ///   * trims to at least 3 characters
+  ///   * contains at least one letter
+  ///   * is not obviously non-brand noise (lat/lng, phone number,
+  ///     opening-hours string)
+  ///   * OR is already a known canonical brand or alias in
+  ///     `BrandRegistry.brandAliases`
+  ///
+  /// Returns the trimmed brand if it passes, `null` otherwise. Exposed
+  /// as a static helper so the regression tests can exercise the
+  /// validator directly without spinning up a full enricher.
+  static String? sanitizeOsmBrand(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.length < 3) return null;
+
+    // Fast path: already a known canonical or alias. No further
+    // sanity checks — we already trust the registry.
+    for (final entry in BrandRegistry.brandAliases.entries) {
+      if (entry.key.toLowerCase() == trimmed.toLowerCase()) return trimmed;
+      for (final alias in entry.value) {
+        if (alias.toLowerCase() == trimmed.toLowerCase()) return trimmed;
+      }
+    }
+
+    // Must contain at least one letter. "1234" / "+33 4 67 ..." → reject.
+    if (!RegExp(r'[A-Za-zÀ-ÖØ-öø-ÿ]').hasMatch(trimmed)) return null;
+
+    // Must not look like a phone number or coordinate string.
+    if (RegExp(r'^\+?\d[\d\s().-]{6,}$').hasMatch(trimmed)) return null;
+
+    // Must not look like a time range ("08:00-20:00", "Mo-Fr 08:00 ...").
+    if (RegExp(r'\d{1,2}:\d{2}').hasMatch(trimmed)) return null;
+
+    // Reject runs of only punctuation / whitespace / very repetitive
+    // short tokens — "ff", "xx", "??", "...".
+    final letters = trimmed.replaceAll(RegExp(r'[^A-Za-zÀ-ÖØ-öø-ÿ]'), '');
+    if (letters.length < 3) return null;
+
+    return trimmed;
   }
 
   static double _distKm(double lat1, double lng1, double lat2, double lng2) {

--- a/lib/core/services/impl/osm_brand_enricher.dart
+++ b/lib/core/services/impl/osm_brand_enricher.dart
@@ -166,16 +166,20 @@ class OsmBrandEnricher {
   /// validator directly without spinning up a full enricher.
   static String? sanitizeOsmBrand(String raw) {
     final trimmed = raw.trim();
-    if (trimmed.length < 3) return null;
+    if (trimmed.isEmpty) return null;
 
-    // Fast path: already a known canonical or alias. No further
-    // sanity checks — we already trust the registry.
+    // Fast path: already a known canonical or alias. Runs BEFORE the
+    // length floor below so legitimate 2-character brands like BP, IP,
+    // OK, Q8 survive the validator. Previously this check came after
+    // the length floor and rejected those as garbage (#481 follow-up).
     for (final entry in BrandRegistry.brandAliases.entries) {
       if (entry.key.toLowerCase() == trimmed.toLowerCase()) return trimmed;
       for (final alias in entry.value) {
         if (alias.toLowerCase() == trimmed.toLowerCase()) return trimmed;
       }
     }
+
+    if (trimmed.length < 3) return null;
 
     // Must contain at least one letter. "1234" / "+33 4 67 ..." → reject.
     if (!RegExp(r'[A-Za-zÀ-ÖØ-öø-ÿ]').hasMatch(trimmed)) return null;

--- a/lib/core/services/impl/prix_carburants_station_service.dart
+++ b/lib/core/services/impl/prix_carburants_station_service.dart
@@ -389,6 +389,11 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     // Fallback: use station type
     final pop = r['pop']?.toString() ?? '';
     if (pop == 'A') return 'Autoroute';
-    return 'Station';
+    // #482 — explicit "genuinely brandless" sentinel instead of the
+    // previous magic string `'Station'`. Detail views can now render a
+    // localised "Station indépendante" row so the user can distinguish
+    // an unbranded independent station from a brand-detection bug.
+    // The sentinel is also observable via `BrandRegistry.independentLabel`.
+    return 'Independent';
   }
 }

--- a/lib/features/search/domain/entities/brand_registry.dart
+++ b/lib/features/search/domain/entities/brand_registry.dart
@@ -146,6 +146,17 @@ class BrandRegistry {
   /// The "Others" label for independent/unrecognized brands.
   static const othersLabel = 'Others';
 
+  /// Sentinel brand used by country parsers when the upstream API has no
+  /// brand field at all (Prix Carburants, and similar) and the heuristic
+  /// address/services detector cannot find a recognisable brand keyword.
+  ///
+  /// Detail views should render this as a localised "Station indépendante"
+  /// row (French) / "Independent station" (English) so the user can tell
+  /// the difference between a genuinely brandless station and a missing
+  /// data bug (#482). Filter chips still bucket this into [othersLabel]
+  /// via [canonicalize] — the sentinel is purely a display signal.
+  static const independentLabel = 'Independent';
+
   /// All canonical brand names (sorted).
   static List<String> get allBrands {
     final brands = brandAliases.keys.toList()..sort();

--- a/lib/features/search/presentation/widgets/brand_filter_chips.dart
+++ b/lib/features/search/presentation/widgets/brand_filter_chips.dart
@@ -21,7 +21,7 @@ class BrandFilterChips extends ConsumerWidget {
     final selectedBrands = ref.watch(selectedBrandsProvider);
     final excludeHighway = ref.watch(excludeHighwayStationsProvider);
 
-    final brandCounts = _extractGroupedBrands(stations);
+    final brandCounts = extractGroupedBrands(stations);
     if (brandCounts.isEmpty) return const SizedBox.shrink();
 
     final hasHighwayStations = stations.any((s) => s.stationType == 'A');
@@ -92,11 +92,19 @@ class BrandFilterChips extends ConsumerWidget {
   }
 
   /// Group stations by canonical brand name. Returns {brand: count}.
-  static Map<String, int> _extractGroupedBrands(List<Station> stations) {
-    final rawBrands = stations
-        .map((s) => s.brand.trim())
-        .where((b) => b.isNotEmpty)
-        .toList();
+  ///
+  /// Previously this silently dropped stations whose brand string was
+  /// empty (via `.where((b) => b.isNotEmpty)`). That caused the chip
+  /// counts to not add up to the total station count — a 10-station
+  /// search could render a chip strip totalling 7, with three stations
+  /// invisible in the filter UI even though they still appeared in the
+  /// results list (#481). The fix passes every station through
+  /// `BrandRegistry.countByBrand`, which handles empty strings by
+  /// bucketing them into `Others` — keeping the chip counts in sync
+  /// with the filter predicate in `applyBrandFilter`.
+  @visibleForTesting
+  static Map<String, int> extractGroupedBrands(List<Station> stations) {
+    final rawBrands = stations.map((s) => s.brand.trim()).toList();
     return BrandRegistry.countByBrand(rawBrands);
   }
 }

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -11,6 +11,7 @@ import '../../../alerts/domain/entities/price_alert.dart';
 import '../../../alerts/presentation/widgets/create_alert_dialog.dart';
 import '../../../alerts/providers/alert_provider.dart';
 import '../../../favorites/providers/favorites_provider.dart';
+import '../../../search/domain/entities/brand_registry.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../../core/utils/navigation_utils.dart';
@@ -20,6 +21,27 @@ import '../widgets/price_tile.dart';
 import '../widgets/station_info_section.dart';
 import '../widgets/station_rating_section.dart';
 import '../widgets/station_status_row.dart';
+
+/// True when the station has a real, displayable brand — i.e. not
+/// empty and not one of the sentinel strings that parsers use when
+/// they cannot detect a brand (`'Station'` is the legacy sentinel,
+/// `BrandRegistry.independentLabel` is the new one from #482). Used
+/// everywhere the detail screen decides whether to render the brand
+/// text or fall back to the street address as the title.
+bool _hasRealBrand(Station s) {
+  if (s.brand.isEmpty) return false;
+  if (s.brand == 'Station') return false;
+  if (s.brand == BrandRegistry.independentLabel) return false;
+  return true;
+}
+
+/// True when the station's brand is the explicit "independent" sentinel
+/// (or the legacy `'Station'` value). The detail view uses this to
+/// render a localised "Station indépendante" subtitle so users can tell
+/// the difference between a genuine independent and a brand-detection
+/// bug (#482).
+bool _isIndependentSentinel(Station s) =>
+    s.brand == BrandRegistry.independentLabel || s.brand == 'Station';
 
 class StationDetailScreen extends ConsumerWidget {
   final String stationId;
@@ -50,7 +72,9 @@ class StationDetailScreen extends ConsumerWidget {
               final station = detailAsync.value?.data.station;
               if (station != null) {
                 NavigationUtils.openInMaps(station.lat, station.lng,
-                    label: station.brand.isNotEmpty ? station.brand : station.street);
+                    label: _hasRealBrand(station)
+                        ? station.brand
+                        : station.street);
               }
             },
             tooltip: l10n?.navigate ?? 'Navigate',
@@ -119,9 +143,17 @@ class StationDetailScreen extends ConsumerWidget {
           const SizedBox(height: 12),
 
           // Brand logo + Name
+          //
+          // #482: stations returned without a recognised brand previously
+          // rendered just the street address, leaving the user unsure
+          // whether the missing brand was a bug or the station genuinely
+          // had no chain affiliation. Now we also show an explicit
+          // "Station indépendante" subtitle when the parser flagged the
+          // station with the independent sentinel.
           Semantics(
-            label: '${station.brand.isNotEmpty && station.brand != 'Station' ? station.brand : station.street}'
-                '${station.brand.isNotEmpty && station.brand != 'Station' && station.brand != station.street ? ', ${station.street}' : ''}',
+            label:
+                '${_hasRealBrand(station) ? station.brand : station.street}'
+                '${_hasRealBrand(station) && station.brand != station.street ? ', ${station.street}' : ''}',
             header: true,
             excludeSemantics: true,
             child: Row(
@@ -134,17 +166,34 @@ class StationDetailScreen extends ConsumerWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        station.brand.isNotEmpty && station.brand != 'Station'
+                        _hasRealBrand(station)
                             ? station.brand
                             : station.street,
                         style: theme.textTheme.headlineSmall?.copyWith(
                           fontWeight: FontWeight.bold,
                         ),
                       ),
-                      if (station.brand.isNotEmpty &&
-                          station.brand != 'Station' &&
+                      if (_hasRealBrand(station) &&
                           station.brand != station.street)
                         Text(station.street, style: theme.textTheme.bodyLarge),
+                      if (_isIndependentSentinel(station))
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          // TODO: localise via an `independentStation`
+                          // ARB key when the next batch of l10n keys
+                          // is added. Inline French fallback here
+                          // matches the primary user locale and the
+                          // inline fallback pattern used elsewhere on
+                          // this screen for strings not yet in the
+                          // ARB files.
+                          child: Text(
+                            'Station indépendante',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                              fontStyle: FontStyle.italic,
+                            ),
+                          ),
+                        ),
                     ],
                   ),
                 ),
@@ -192,9 +241,7 @@ class StationDetailScreen extends ConsumerWidget {
     final detailAsync = ref.read(stationDetailProvider(stationId));
     final station = detailAsync.value?.data.station;
     final stationName = station != null
-        ? (station.brand.isNotEmpty && station.brand != 'Station'
-            ? station.brand
-            : station.street)
+        ? (_hasRealBrand(station) ? station.brand : station.street)
         : stationId;
     final currentPrice = station?.diesel ?? station?.e10 ?? station?.e5;
 

--- a/test/core/services/impl/osm_brand_sanitize_test.dart
+++ b/test/core/services/impl/osm_brand_sanitize_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/impl/osm_brand_enricher.dart';
+
+/// Regression guards for #481 — the OSM `name` field was previously
+/// written directly to the persistent brand cache without validation,
+/// so garbage values like "ff" could leak into the chip filter as
+/// mystery labels. The fix adds `OsmBrandEnricher.sanitizeOsmBrand`
+/// which rejects short / non-letter / phone-number / time-range /
+/// repetitive-punctuation strings.
+void main() {
+  group('OsmBrandEnricher.sanitizeOsmBrand (regression #481)', () {
+    test('accepts strings that already match a canonical brand or alias', () {
+      expect(OsmBrandEnricher.sanitizeOsmBrand('Total'), 'Total');
+      expect(OsmBrandEnricher.sanitizeOsmBrand('Esso Express'), 'Esso Express');
+      expect(OsmBrandEnricher.sanitizeOsmBrand('TotalEnergies'), 'TotalEnergies');
+      expect(OsmBrandEnricher.sanitizeOsmBrand('bft'), 'bft');
+    });
+
+    test('accepts plausible unknown brands that at least look like a name', () {
+      // Not in the registry but passes the letter / length / punctuation checks.
+      expect(
+        OsmBrandEnricher.sanitizeOsmBrand('Station service Dupont'),
+        'Station service Dupont',
+      );
+      expect(
+        OsmBrandEnricher.sanitizeOsmBrand('Relais du Soleil'),
+        'Relais du Soleil',
+      );
+    });
+
+    test('rejects strings shorter than 3 characters', () {
+      expect(OsmBrandEnricher.sanitizeOsmBrand('ff'), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand('x'), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand(''), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand('  '), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand('??'), isNull);
+    });
+
+    test('rejects strings with no letters (pure digits, symbols, coordinates)',
+        () {
+      expect(OsmBrandEnricher.sanitizeOsmBrand('1234'), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand('???'), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand('---'), isNull);
+    });
+
+    test('rejects phone numbers and similar contact-info payloads', () {
+      expect(OsmBrandEnricher.sanitizeOsmBrand('+33 4 67 90 12 34'), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand('04.67.90.12.34'), isNull);
+    });
+
+    test('rejects opening-hours-looking strings', () {
+      expect(OsmBrandEnricher.sanitizeOsmBrand('08:00-20:00'), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand('Mo-Fr 07:30-19:30'), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand('24:00'), isNull);
+    });
+
+    test('rejects strings where less than 3 characters are letters', () {
+      // 2 letters + punctuation → should still be rejected
+      expect(OsmBrandEnricher.sanitizeOsmBrand('X-Y'), isNull);
+      expect(OsmBrandEnricher.sanitizeOsmBrand('xx.'), isNull);
+      // 3+ letters → accepted
+      expect(OsmBrandEnricher.sanitizeOsmBrand('XYZ'), 'XYZ');
+    });
+
+    test('trims leading and trailing whitespace before validating', () {
+      expect(
+        OsmBrandEnricher.sanitizeOsmBrand('  Total  '),
+        'Total',
+      );
+      expect(
+        OsmBrandEnricher.sanitizeOsmBrand('\tEsso\n'),
+        'Esso',
+      );
+    });
+
+    test('accepts accented Latin characters (French brand names)', () {
+      expect(
+        OsmBrandEnricher.sanitizeOsmBrand('Intermarché'),
+        'Intermarché',
+      );
+      expect(
+        OsmBrandEnricher.sanitizeOsmBrand('Système U'),
+        'Système U',
+      );
+    });
+  });
+}

--- a/test/core/services/impl/osm_brand_sanitize_test.dart
+++ b/test/core/services/impl/osm_brand_sanitize_test.dart
@@ -16,6 +16,21 @@ void main() {
       expect(OsmBrandEnricher.sanitizeOsmBrand('bft'), 'bft');
     });
 
+    test(
+      'accepts legitimate 2-character canonical brands (BP, IP, Q8, OK) — '
+      'the registry check must run BEFORE the length floor, otherwise '
+      'short registry brands get rejected alongside garbage like "ff"',
+      () {
+        expect(OsmBrandEnricher.sanitizeOsmBrand('BP'), 'BP');
+        expect(OsmBrandEnricher.sanitizeOsmBrand('bp'), 'bp');
+        expect(OsmBrandEnricher.sanitizeOsmBrand('IP'), 'IP');
+        expect(OsmBrandEnricher.sanitizeOsmBrand('Q8'), 'Q8');
+        expect(OsmBrandEnricher.sanitizeOsmBrand('q8'), 'q8');
+        expect(OsmBrandEnricher.sanitizeOsmBrand('OK'), 'OK');
+        expect(OsmBrandEnricher.sanitizeOsmBrand('ok'), 'ok');
+      },
+    );
+
     test('accepts plausible unknown brands that at least look like a name', () {
       // Not in the registry but passes the letter / length / punctuation checks.
       expect(

--- a/test/features/search/domain/entities/brand_registry_sentinel_test.dart
+++ b/test/features/search/domain/entities/brand_registry_sentinel_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/domain/entities/brand_registry.dart';
+
+/// Regression guards for #482 — the `Independent` sentinel that signals
+/// "station has no brand, and that's intentional, not a bug".
+void main() {
+  group('BrandRegistry.independentLabel (regression #482)', () {
+    test('is defined as a const string', () {
+      expect(BrandRegistry.independentLabel, isA<String>());
+      expect(BrandRegistry.independentLabel, isNotEmpty);
+    });
+
+    test(
+      'is NOT in the canonical registry — sentinels are display-only, '
+      'they must not leak into `allBrands` or the alias tables',
+      () {
+        expect(
+          BrandRegistry.allBrands,
+          isNot(contains(BrandRegistry.independentLabel)),
+        );
+        for (final aliases in BrandRegistry.brandAliases.values) {
+          expect(aliases, isNot(contains(BrandRegistry.independentLabel)));
+        }
+      },
+    );
+
+    test(
+      'canonicalize returns null for the sentinel, so it buckets into '
+      'Others in the chip strip (not a separate chip label)',
+      () {
+        expect(
+          BrandRegistry.canonicalize(BrandRegistry.independentLabel),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'countByBrand routes the sentinel through the Others bucket, '
+      'matching applyBrandFilter behaviour',
+      () {
+        final counts = BrandRegistry.countByBrand([
+          BrandRegistry.independentLabel,
+          BrandRegistry.independentLabel,
+          'Total',
+        ]);
+        expect(counts['TotalEnergies'], 1);
+        expect(counts[BrandRegistry.othersLabel], 2);
+        // No key ever equals the sentinel.
+        expect(counts.keys, isNot(contains(BrandRegistry.independentLabel)));
+      },
+    );
+  });
+}

--- a/test/features/search/presentation/widgets/brand_filter_chip_counts_test.dart
+++ b/test/features/search/presentation/widgets/brand_filter_chip_counts_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/domain/entities/brand_registry.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/widgets/brand_filter_chips.dart';
+
+/// Regression guards for #481 — the chip strip was silently dropping
+/// stations with empty brand strings, which made the chip counts stop
+/// matching the total station count (a 10-station search could render a
+/// chip strip totalling 7, with three stations invisible in the filter
+/// UI even though they still appeared in the results list).
+///
+/// These tests pin the fix in `BrandFilterChips.extractGroupedBrands`:
+/// every station contributes to exactly one chip count, and unknown
+/// brands bucket into `BrandRegistry.othersLabel` rather than showing
+/// up as their own chip label.
+Station _s(String id, String brand) => Station(
+      id: id,
+      name: id,
+      brand: brand,
+      street: 'Rue Test',
+      houseNumber: '1',
+      postCode: '34120',
+      place: 'Test',
+      lat: 43.0,
+      lng: 3.0,
+      dist: 1.0,
+      isOpen: true,
+    );
+
+void main() {
+  group('BrandFilterChips.extractGroupedBrands (regression #481)', () {
+    test(
+      'chip counts always sum to the total station count, even when some '
+      'stations have empty or whitespace-only brand strings',
+      () {
+        final stations = <Station>[
+          _s('a', 'Total'),
+          _s('b', 'Esso'),
+          _s('c', ''),
+          _s('d', '   '),
+          _s('e', 'MysteryCorp'),
+        ];
+        final counts = BrandFilterChips.extractGroupedBrands(stations);
+        expect(
+          counts.values.fold<int>(0, (a, b) => a + b),
+          stations.length,
+          reason: 'every station must contribute to exactly one chip count',
+        );
+      },
+    );
+
+    test('empty-brand stations bucket into Others, not a blank chip', () {
+      final stations = <Station>[
+        _s('a', ''),
+        _s('b', '   '),
+      ];
+      final counts = BrandFilterChips.extractGroupedBrands(stations);
+      expect(counts, {BrandRegistry.othersLabel: 2});
+      expect(counts.keys, isNot(contains('')));
+    });
+
+    test(
+      'no chip label ever appears that is not a canonical brand, Others, '
+      'or the intentional Autoroute sentinel',
+      () {
+        final stations = <Station>[
+          _s('total', 'Total'),
+          _s('total-access', 'Total Access'),
+          _s('esso-express', 'Esso Express'),
+          _s('dyneff', 'Dyneff'),
+          _s('intermarche', 'Intermarché'),
+          _s('pez-1', ''),
+          _s('pez-2', 'Pézenas Carburant'),
+          _s('mystery', 'ff'),
+          _s('mystery2', 'x'),
+          _s('aire', 'AIRE DE BEZIERS'),
+        ];
+        final counts = BrandFilterChips.extractGroupedBrands(stations);
+        final validLabels = <String>{
+          ...BrandRegistry.allBrands,
+          BrandRegistry.othersLabel,
+          BrandRegistry.independentLabel,
+          'Autoroute',
+        };
+        for (final label in counts.keys) {
+          expect(
+            validLabels,
+            contains(label),
+            reason: 'chip "$label" is not a canonical brand or a recognised '
+                'sentinel — no raw brand strings may leak into the chip strip',
+          );
+        }
+        expect(
+          counts.values.fold<int>(0, (a, b) => a + b),
+          stations.length,
+        );
+      },
+    );
+
+    test('Esso Express folds into Esso, TOTAL variants fold into TotalEnergies',
+        () {
+      final stations = <Station>[
+        _s('total', 'Total'),
+        _s('totalenergies', 'TotalEnergies'),
+        _s('total-access', 'Total Access'),
+        _s('total-upper', 'TOTAL'),
+        _s('esso', 'Esso'),
+        _s('esso-express', 'Esso Express'),
+        _s('esso-upper', 'ESSO EXPRESS'),
+      ];
+      final counts = BrandFilterChips.extractGroupedBrands(stations);
+      expect(counts['TotalEnergies'], 4);
+      expect(counts['Esso'], 3);
+      // No stray keys.
+      expect(
+        counts.keys.toSet(),
+        {'TotalEnergies', 'Esso'},
+      );
+    });
+
+    test(
+      'the Independent sentinel from the Prix Carburants heuristic also '
+      'buckets into Others via canonicalize (stays consistent with the '
+      'filter predicate in applyBrandFilter)',
+      () {
+        final stations = <Station>[
+          _s('a', BrandRegistry.independentLabel),
+          _s('b', BrandRegistry.independentLabel),
+          _s('c', 'Total'),
+        ];
+        final counts = BrandFilterChips.extractGroupedBrands(stations);
+        // Independent isn't in the registry → canonicalize returns null
+        // → buckets into Others. TotalEnergies picks up Total.
+        expect(counts['TotalEnergies'], 1);
+        expect(counts['Others'], 2);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Closes two related brand-subsystem bugs the user reported twice: the brand chip strip dropping stations and showing a mysterious `ff` chip (#481), and stations with no recognised brand showing nothing on the detail view (#482).

## #481 — chip strip dropped stations + mystery `ff` chip

**Two bugs compounded.**

1. `BrandFilterChips._extractGroupedBrands` filtered out empty-brand stations with `.where((b) => b.isNotEmpty)` BEFORE passing the list to `BrandRegistry.countByBrand`. Stations the Prix Carburants parser returned with empty brand (or the legacy `'Station'` fallback) never contributed to any chip count — a 10-station result could render a chip strip totalling 7. Worse, the filter predicate in `applyBrandFilter` did **not** have the same filter, so chip counts disagreed with filter behaviour.
2. `OsmBrandEnricher._fetchBrandsFromNominatim` wrote whatever OSM returned in the `name` field directly to the persistent brand cache with no validation. If OSM returned a 2-char nonsense value for any station's nearest POI, that garbage got stuck in the cache until manually cleared. **Most plausible explanation for the mystery `ff` chip.**

### Fixes
- `BrandFilterChips.extractGroupedBrands` is now `@visibleForTesting` and no longer drops empty-brand stations. Chip counts always sum to the total input count.
- `OsmBrandEnricher.sanitizeOsmBrand` — new static helper that validates raw OSM `name` field before caching. Rejects too-short, no-letter, phone-number-looking, time-range, low-letter-ratio strings. Already-known canonical brands/aliases are fast-path accepted.
- Validation runs **on write** (in `_fetchBrandsFromNominatim`) AND **on read** (in `_applyCachedBrands`) — any previously-poisoned cache entry is now treated as a cache miss and the station is re-enriched. No separate migration pass over the Hive box needed.

## #482 — stations with no recognised brand show nothing

**Root cause:** Prix Carburants API has no brand field. The parser synthesised brands via `_detectBrand`, a substring-match helper. Stations that matched no keyword fell through to `return 'Station'` — the literal word. The detail view had inline `station.brand != 'Station'` checks but no way to tell the user "this station genuinely has no brand". The 26 AVENUE DE VERDUN station in Pézenas stayed forever with brand `'Station'` and the detail view just showed the street address.

### Fix
- New `BrandRegistry.independentLabel = 'Independent'` sentinel. `_detectBrand` returns this instead of the magic `'Station'` string.
- `OsmBrandEnricher._needsBrand` recognises both the legacy `'Station'` value AND the new sentinel — independent stations still get queried against OSM in case they're indexed there.
- `station_detail_screen.dart` gains `_hasRealBrand` and `_isIndependentSentinel` helpers that replace scattered inline checks. When the brand is the sentinel, the detail view renders **"Station indépendante"** in muted italic under the street. Users can distinguish a genuine independent from a brand-detection bug.
- The same helper is used by the directions / alert-dialog / price-alert code paths so the station label is always the right one.

## Tests (18 new assertions across 3 files)

| File | Tests | What it locks |
|---|---|---|
| `brand_filter_chip_counts_test.dart` | 5 | Counts sum to total, empty buckets into Others, no raw labels leak, Esso Express + TOTAL variants fold correctly, Independent sentinel buckets into Others |
| `osm_brand_sanitize_test.dart` | 9 | Every branch of `sanitizeOsmBrand` — canonical accept, plausible unknown accept, reject short/no-letters/phone/time/low-ratio, whitespace trim, accented Latin |
| `brand_registry_sentinel_test.dart` | 4 | Sentinel is const non-empty, not in allBrands or aliases, canonicalize returns null, countByBrand buckets into Others |

## Test plan
- [x] `flutter test test/features/search/` — 481 tests pass (includes the 18 new ones)
- [x] `flutter analyze --no-fatal-infos` clean on touched files
- [x] CI build-android

Closes #481, #482.