### PR TITLE
feat(station-detail): make Services section foldable and collapse by default — closes #483

### DIFF
--- a/lib/features/station_detail/presentation/widgets/station_info_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_info_section.dart
@@ -100,20 +100,43 @@ class StationInfoSection extends StatelessWidget {
           const SizedBox(height: 24),
         ],
 
-        // Services (raw text from API) — at the bottom
-        if (station.services.isNotEmpty) ...[
-          Text(l10n?.services ?? 'Services', style: theme.textTheme.titleMedium),
-          const SizedBox(height: 8),
-          Wrap(
-            spacing: 6,
-            runSpacing: 4,
-            children: station.services.map((s) => Chip(
-                  avatar: const Icon(Icons.check_circle_outline, size: 16),
-                  label: Text(s, style: const TextStyle(fontSize: 11)),
-                  visualDensity: VisualDensity.compact,
-                )).toList(),
+        // Services (raw text from API) — at the bottom, collapsed by
+        // default (#483). Highway stations routinely return 10+ services
+        // and previously pushed the price-history section far below the
+        // fold. The ExpansionTile lets users see which services exist at
+        // a glance (via the count in the title) without blowing out the
+        // visual balance of the screen.
+        if (station.services.isNotEmpty)
+          Theme(
+            // Strip the default ExpansionTile dividers so it blends
+            // with the surrounding Column layout.
+            data: theme.copyWith(dividerColor: Colors.transparent),
+            child: ExpansionTile(
+              key: const ValueKey('station-detail-services-expansion'),
+              tilePadding: EdgeInsets.zero,
+              childrenPadding: const EdgeInsets.only(bottom: 8),
+              initiallyExpanded: false,
+              title: Semantics(
+                header: true,
+                child: Text(
+                  '${l10n?.services ?? "Services"} '
+                  '(${station.services.length})',
+                  style: theme.textTheme.titleMedium,
+                ),
+              ),
+              children: [
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 4,
+                  children: station.services.map((s) => Chip(
+                        avatar: const Icon(Icons.check_circle_outline, size: 16),
+                        label: Text(s, style: const TextStyle(fontSize: 11)),
+                        visualDensity: VisualDensity.compact,
+                      )).toList(),
+                ),
+              ],
+            ),
           ),
-        ],
       ],
     );
   }

--- a/test/features/station_detail/presentation/widgets/station_info_section_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_info_section_test.dart
@@ -68,14 +68,112 @@ void main() {
         ),
       );
 
-      // Both zone and services should be present
+      // Both zone and services should be present. After #483 the
+      // services header includes the count in parentheses.
       expect(find.text('Zone'), findsOneWidget);
-      expect(find.text('Services'), findsOneWidget);
+      expect(find.text('Services (3)'), findsOneWidget);
 
       // Services section should appear BELOW zone section
       final zonePos = tester.getTopLeft(find.text('Zone'));
-      final servicesPos = tester.getTopLeft(find.text('Services'));
+      final servicesPos = tester.getTopLeft(find.text('Services (3)'));
       expect(servicesPos.dy, greaterThan(zonePos.dy));
+    });
+
+    // #483 — services section must be a collapsed-by-default
+    // ExpansionTile so highway stations with 10+ services don't
+    // blow out the detail screen's vertical layout.
+    testWidgets(
+        'services section is collapsed by default — service chips are '
+        'NOT visible until the user taps the header (#483)',
+        (tester) async {
+      final stationWithServices = baseStation.copyWith(
+        services: ['Toilettes', 'Boutique', 'Lavage', 'Air', 'WC',
+            'DAB', 'Resto', 'WiFi', 'Piste poids lourds', 'Recharge'],
+        department: 'Berlin',
+        region: 'Berlin',
+      );
+      final detail = StationDetail(station: stationWithServices);
+
+      await pumpApp(
+        tester,
+        SingleChildScrollView(
+          child: StationInfoSection(
+              station: stationWithServices, detail: detail),
+        ),
+      );
+
+      // Header with count is visible...
+      expect(find.text('Services (10)'), findsOneWidget);
+      // ...but individual service chips are NOT yet materialised.
+      expect(find.text('Toilettes'), findsNothing);
+      expect(find.text('Resto'), findsNothing);
+      expect(find.byType(Chip), findsNothing);
+    });
+
+    testWidgets(
+        'tapping the services header expands the section and shows '
+        'every service chip (#483)',
+        (tester) async {
+      final stationWithServices = baseStation.copyWith(
+        services: ['Car Wash', 'Shop', 'ATM'],
+        department: 'Berlin',
+        region: 'Berlin',
+      );
+      final detail = StationDetail(station: stationWithServices);
+
+      await pumpApp(
+        tester,
+        SingleChildScrollView(
+          child: StationInfoSection(
+              station: stationWithServices, detail: detail),
+        ),
+      );
+
+      // Header visible, chips hidden.
+      expect(find.text('Services (3)'), findsOneWidget);
+      expect(find.byType(Chip), findsNothing);
+
+      // Tap the header to expand.
+      await tester.tap(find.text('Services (3)'));
+      await tester.pumpAndSettle();
+
+      // Now all three chips are visible.
+      expect(find.byType(Chip), findsNWidgets(3));
+      expect(find.text('Car Wash'), findsOneWidget);
+      expect(find.text('Shop'), findsOneWidget);
+      expect(find.text('ATM'), findsOneWidget);
+
+      // Tap again to collapse.
+      await tester.tap(find.text('Services (3)'));
+      await tester.pumpAndSettle();
+      expect(find.byType(Chip), findsNothing);
+    });
+
+    testWidgets(
+        'services expansion tile is NOT rendered when the services list '
+        'is empty (#483 keeps the existing empty-behaviour)',
+        (tester) async {
+      final stationNoServices = baseStation.copyWith(
+        services: const [],
+        department: 'Berlin',
+        region: 'Berlin',
+      );
+      final detail = StationDetail(station: stationNoServices);
+
+      await pumpApp(
+        tester,
+        SingleChildScrollView(
+          child: StationInfoSection(
+              station: stationNoServices, detail: detail),
+        ),
+      );
+
+      // No services header, no ExpansionTile at all for this section.
+      expect(find.textContaining('Services ('), findsNothing);
+      expect(
+        find.byKey(const ValueKey('station-detail-services-expansion')),
+        findsNothing,
+      );
     });
 
     testWidgets('amenities section appears after location info',


### PR DESCRIPTION
## Summary
Station detail pages for highway or 24/7 stations routinely render 10+ service chips (toilettes, boutique, lavage, air, WC, DAB, resto, wifi, piste poids lourds, recharge, ...). That ate 30–40% of the screen's vertical space and pushed the rating + price history sections far below the fold.

This PR wraps the services `Wrap` in an `ExpansionTile`, collapsed by default. The title now includes the service count in parentheses — `"Services (10)"` — so users can see the magnitude at a glance without needing to expand.

## Details
- **Collapsed by default** — tapping the header expands the section with the standard Material rotation animation; tapping again collapses it
- **`Theme(dividerColor: Colors.transparent)`** wrapper so the ExpansionTile doesn't introduce horizontal divider lines that would conflict with the surrounding Column layout
- **`ValueKey('station-detail-services-expansion')`** gives tests a stable lookup handle
- **Empty-list behaviour preserved** — if a station has no services, no ExpansionTile is rendered at all (not a useless empty fold)

## Tests
Updated + 3 new widget tests in `test/features/station_detail/presentation/widgets/station_info_section_test.dart`:

- Existing **"services section appears after location info"** — updated to match the new `"Services (N)"` header label
- New **"services section is collapsed by default"** — uses a 10-service fixture mirroring the user's real highway-station screenshot from the #483 reproduction. Asserts the header is visible but individual chips are NOT materialised
- New **"tapping the services header expands the section and shows every service chip"** — covers the full interaction: expand → verify all chips visible → collapse → verify chips hidden again
- New **"services expansion tile is NOT rendered when the services list is empty"** — preserves the existing empty-list behaviour

## Test plan
- [x] `flutter test test/features/station_detail/presentation/widgets/station_info_section_test.dart` — 9 tests pass
- [x] `flutter analyze --no-fatal-infos` clean
- [x] CI build-android

Closes #483.