### PR TITLE
docs(contributing): document signing-config env vars and release-build failure mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,33 @@ flutter pub get
 flutter run -d emulator-5554
 ```
 
+### Release builds
+
+Debug builds (`flutter run`, `flutter build apk --debug`) work out of the box.
+Release builds (`flutter build apk --release`, `flutter build appbundle --release`)
+require the Android signing keystore to be resolvable or the build will
+**fail with a `GradleException`** — there is no silent fallback to the debug
+key (see [#48](https://github.com/fdittgen-png/tankstellen/issues/48)).
+
+Signing config resolution order on every build:
+
+1. **Environment variables** (preferred) — set these in your shell rc or via
+   `direnv`:
+   ```bash
+   export ANDROID_KEYSTORE_PATH="$HOME/.android/fuel-prices-release.jks"
+   export ANDROID_KEYSTORE_PASSWORD="<your store password>"
+   export ANDROID_KEY_ALIAS="fuel-prices"
+   # optional: ANDROID_KEY_PASSWORD (falls back to store password)
+   ```
+2. **Legacy `android/key.properties`** — still supported for convenience.
+   Gitignored, plaintext, not recommended for multi-dev machines but fine
+   for a single-dev laptop.
+3. **Neither** — release build fails fast with an error naming every env var
+   you need to set.
+
+For CI and the secrets rotation process, see the **Android Release Signing**
+section in the [Security wiki page](https://github.com/fdittgen-png/tankstellen/wiki/Security).
+
 ## Branch and PR Workflow
 
 We follow **GitHub Flow** with conventional commits and squash merges.
@@ -244,6 +271,14 @@ never deletes — only explicit user actions trigger server deletes.
 - **Consent → setup → main app.** The router has redirects for both
   GDPR consent and onboarding completion. New screens reachable from
   outside the shell must respect these gates or you'll trap the user.
+- **Release builds fail without a signing keystore.** As of #48 the
+  build throws a `GradleException` when neither the env vars nor
+  `android/key.properties` are set. This is intentional — the old code
+  silently fell back to the debug signing key, which produced CI
+  release artefacts that couldn't upgrade a real user install. If you
+  hit this error, read the env var names in the error message and set
+  them in your shell rc. See the "Release builds" subsection of
+  "Development Setup" above.
 
 ### 9. Where to look when you're stuck
 


### PR DESCRIPTION
## Summary
Follow-up to #48 (the Android signing rotation that shipped yesterday). Documents the new developer workflow in the in-repo `CONTRIBUTING.md`:

1. **Development Setup** → new "Release builds" subsection covering:
   - The env-vars-first resolution order (`ANDROID_KEYSTORE_PATH` / `ANDROID_KEYSTORE_PASSWORD` / `ANDROID_KEY_ALIAS`)
   - The legacy `android/key.properties` fallback
   - The hard `GradleException` failure mode when neither is set
   - A direct link to the Security wiki page for CI secrets rotation

2. **For Junior Devs gotchas** → new entry explaining the "release build fails without a signing keystore" error message and how to recover from it. This is the single most likely surprise a new contributor will hit when first running `flutter build apk --release` on a fresh clone.

## Wiki pushed separately
The wiki side of today's docs refresh was pushed directly to `tankstellen.wiki.git` in a separate commit. That commit updated five pages:

- **Security.md** — new "Android Release Signing" section with the full resolution order, CI decode flow, required secrets, and the "never silently fall back to debug" invariant. Plus a new "Error Reporting & Observability" section covering the Sentry opt-in path and local trace export.
- **Features.md** — "Independent station label" subsection, "Foldable Services section" subsection, new top-level "Community Reports" section documenting the country-aware report routing, new top-level "Error Reporting & Observability" section.
- **FAQ.md** — 5 new Q&A entries covering the "Station indépendante" label, the greyed-out report button, where the error log ends up, the "Others" brand filter bug recovery, plus a note about the cache-clear step.
- **User-Guide.md** — Privacy dashboard now documents the "Copy error log to clipboard" button.
- **Contributing.md** (wiki) — new "Android Release Signing (CI Secrets)" section paired with the in-repo doc.

Total wiki diff: 5 files changed, 218 insertions, 1 deletion.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — only pre-existing infos, no new warnings from CONTRIBUTING.md changes
- [x] Links in CONTRIBUTING.md resolve (wiki page exists, #48 exists)
- [x] CI build-android