### PR TITLE
fix(search): actually apply amenity, open-only, and brand filters to results

### DIFF
--- a/lib/features/search/presentation/widgets/brand_filter_chips.dart
+++ b/lib/features/search/presentation/widgets/brand_filter_chips.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/brand_registry.dart';
 import '../../domain/entities/station.dart';
+import '../../domain/entities/station_amenity.dart';
 import '../../providers/brand_filter_provider.dart';
 
 /// Horizontally scrollable brand filter chips with major brands grouped.
@@ -139,6 +140,37 @@ List<Station> applyBrandFilter(
 
   if (excludeHighway) {
     result = result.where((s) => s.stationType != 'A').toList();
+  }
+
+  return result;
+}
+
+/// Filters stations by required amenities and open-status (#491).
+///
+/// A station passes the amenity filter only if it provides **every**
+/// amenity the user selected (AND semantics, not OR). An empty
+/// [requiredAmenities] set is a no-op. When [openOnly] is true, closed
+/// stations are excluded regardless of amenities.
+///
+/// Previously this logic did not exist: the criteria screen wrote to
+/// `selectedAmenitiesProvider` and `openOnlyFilterProvider` but the
+/// results list never read those providers, so toggling WiFi / Boutique
+/// / "Ouvertes uniquement" had zero effect on the displayed stations.
+List<Station> applyAmenityAndStatusFilters(
+  List<Station> stations, {
+  required Set<StationAmenity> requiredAmenities,
+  required bool openOnly,
+}) {
+  var result = stations;
+
+  if (requiredAmenities.isNotEmpty) {
+    result = result
+        .where((s) => requiredAmenities.every(s.amenities.contains))
+        .toList();
+  }
+
+  if (openOnly) {
+    result = result.where((s) => s.isOpen).toList();
   }
 
   return result;

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -187,10 +187,22 @@ class SearchResultsList extends ConsumerWidget {
               // Apply brand and highway filters
               final selectedBrands = ref.watch(selectedBrandsProvider);
               final excludeHighway = ref.watch(excludeHighwayStationsProvider);
-              final filtered = applyBrandFilter(
+              final brandFiltered = applyBrandFilter(
                 afterIgnored,
                 selectedBrands: selectedBrands,
                 excludeHighway: excludeHighway,
+              );
+              // #491 — apply amenity + open-only filters. These providers
+              // are written by the criteria screen but were previously
+              // read nowhere, so toggling WiFi / "Ouvertes uniquement" /
+              // any other amenity chip had zero visible effect.
+              final requiredAmenities =
+                  ref.watch(selectedAmenitiesProvider);
+              final openOnly = ref.watch(openOnlyFilterProvider);
+              final filtered = applyAmenityAndStatusFilters(
+                brandFiltered,
+                requiredAmenities: requiredAmenities,
+                openOnly: openOnly,
               );
               final sorted = _sortStations(filtered, sortMode, ref);
               final allPrices = ref.watch(allPricesViewEnabledProvider);

--- a/lib/features/search/providers/brand_filter_provider.dart
+++ b/lib/features/search/providers/brand_filter_provider.dart
@@ -4,9 +4,11 @@ part 'brand_filter_provider.g.dart';
 
 /// Manages the set of selected brand names for filtering search results.
 ///
-/// Screen-scoped (not keepAlive) — resets when the user navigates away.
-/// Empty set means "show all brands" (no filter active).
-@riverpod
+/// App-lifetime state (keepAlive) so the filter selection survives the
+/// criteria screen ⇄ results screen navigation. Previously screen-scoped,
+/// which auto-disposed the state between navigation frames and silently
+/// reset the filter to empty (#491). Empty set means "show all brands".
+@Riverpod(keepAlive: true)
 class SelectedBrands extends _$SelectedBrands {
   @override
   Set<String> build() => const {};
@@ -30,7 +32,9 @@ class SelectedBrands extends _$SelectedBrands {
 
 /// Whether the motorway/highway station filter is active.
 /// When true, stations with stationType == "A" (autoroute) are excluded.
-@riverpod
+///
+/// keepAlive so the toggle survives navigation, matching [SelectedBrands] (#491).
+@Riverpod(keepAlive: true)
 class ExcludeHighwayStations extends _$ExcludeHighwayStations {
   @override
   bool build() => false;

--- a/lib/features/search/providers/brand_filter_provider.g.dart
+++ b/lib/features/search/providers/brand_filter_provider.g.dart
@@ -10,29 +10,35 @@ part of 'brand_filter_provider.dart';
 // ignore_for_file: type=lint, type=warning
 /// Manages the set of selected brand names for filtering search results.
 ///
-/// Screen-scoped (not keepAlive) — resets when the user navigates away.
-/// Empty set means "show all brands" (no filter active).
+/// App-lifetime state (keepAlive) so the filter selection survives the
+/// criteria screen ⇄ results screen navigation. Previously screen-scoped,
+/// which auto-disposed the state between navigation frames and silently
+/// reset the filter to empty (#491). Empty set means "show all brands".
 
 @ProviderFor(SelectedBrands)
 final selectedBrandsProvider = SelectedBrandsProvider._();
 
 /// Manages the set of selected brand names for filtering search results.
 ///
-/// Screen-scoped (not keepAlive) — resets when the user navigates away.
-/// Empty set means "show all brands" (no filter active).
+/// App-lifetime state (keepAlive) so the filter selection survives the
+/// criteria screen ⇄ results screen navigation. Previously screen-scoped,
+/// which auto-disposed the state between navigation frames and silently
+/// reset the filter to empty (#491). Empty set means "show all brands".
 final class SelectedBrandsProvider
     extends $NotifierProvider<SelectedBrands, Set<String>> {
   /// Manages the set of selected brand names for filtering search results.
   ///
-  /// Screen-scoped (not keepAlive) — resets when the user navigates away.
-  /// Empty set means "show all brands" (no filter active).
+  /// App-lifetime state (keepAlive) so the filter selection survives the
+  /// criteria screen ⇄ results screen navigation. Previously screen-scoped,
+  /// which auto-disposed the state between navigation frames and silently
+  /// reset the filter to empty (#491). Empty set means "show all brands".
   SelectedBrandsProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
         name: r'selectedBrandsProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -53,12 +59,14 @@ final class SelectedBrandsProvider
   }
 }
 
-String _$selectedBrandsHash() => r'1b406f31ffd0f3d2d9e85cb714fc260df69384de';
+String _$selectedBrandsHash() => r'80ae4d8d00fd95b4aa9b7d86167a257f240488b6';
 
 /// Manages the set of selected brand names for filtering search results.
 ///
-/// Screen-scoped (not keepAlive) — resets when the user navigates away.
-/// Empty set means "show all brands" (no filter active).
+/// App-lifetime state (keepAlive) so the filter selection survives the
+/// criteria screen ⇄ results screen navigation. Previously screen-scoped,
+/// which auto-disposed the state between navigation frames and silently
+/// reset the filter to empty (#491). Empty set means "show all brands".
 
 abstract class _$SelectedBrands extends $Notifier<Set<String>> {
   Set<String> build();
@@ -80,23 +88,29 @@ abstract class _$SelectedBrands extends $Notifier<Set<String>> {
 
 /// Whether the motorway/highway station filter is active.
 /// When true, stations with stationType == "A" (autoroute) are excluded.
+///
+/// keepAlive so the toggle survives navigation, matching [SelectedBrands] (#491).
 
 @ProviderFor(ExcludeHighwayStations)
 final excludeHighwayStationsProvider = ExcludeHighwayStationsProvider._();
 
 /// Whether the motorway/highway station filter is active.
 /// When true, stations with stationType == "A" (autoroute) are excluded.
+///
+/// keepAlive so the toggle survives navigation, matching [SelectedBrands] (#491).
 final class ExcludeHighwayStationsProvider
     extends $NotifierProvider<ExcludeHighwayStations, bool> {
   /// Whether the motorway/highway station filter is active.
   /// When true, stations with stationType == "A" (autoroute) are excluded.
+  ///
+  /// keepAlive so the toggle survives navigation, matching [SelectedBrands] (#491).
   ExcludeHighwayStationsProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
         name: r'excludeHighwayStationsProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -118,10 +132,12 @@ final class ExcludeHighwayStationsProvider
 }
 
 String _$excludeHighwayStationsHash() =>
-    r'11cf69d65c49220d2904629b9fb8fb5f92df333f';
+    r'c07895ef69caf31407c10ad9dd0d12171116d781';
 
 /// Whether the motorway/highway station filter is active.
 /// When true, stations with stationType == "A" (autoroute) are excluded.
+///
+/// keepAlive so the toggle survives navigation, matching [SelectedBrands] (#491).
 
 abstract class _$ExcludeHighwayStations extends $Notifier<bool> {
   bool build();

--- a/test/features/search/presentation/widgets/brand_filter_test.dart
+++ b/test/features/search/presentation/widgets/brand_filter_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/domain/entities/station_amenity.dart';
 import 'package:tankstellen/features/search/presentation/widgets/brand_filter_chips.dart';
 
 import '../../../../helpers/pump_app.dart';
@@ -102,6 +103,118 @@ void main() {
         [stationWithSpaces], selectedBrands: const {'Shell'}, excludeHighway: false,
       );
       expect(result.length, 1);
+    });
+  });
+
+  group('applyAmenityAndStatusFilters (#491)', () {
+    const wifiShopOpen = Station(
+      id: 'a',
+      name: 'A',
+      brand: 'SHELL',
+      street: 'Str',
+      postCode: '10000',
+      place: 'Berlin',
+      lat: 0,
+      lng: 0,
+      isOpen: true,
+      amenities: {StationAmenity.wifi, StationAmenity.shop},
+    );
+    const wifiOnlyClosed = Station(
+      id: 'b',
+      name: 'B',
+      brand: 'ARAL',
+      street: 'Str',
+      postCode: '10000',
+      place: 'Berlin',
+      lat: 0,
+      lng: 0,
+      isOpen: false,
+      amenities: {StationAmenity.wifi},
+    );
+    const shopOnlyOpen = Station(
+      id: 'c',
+      name: 'C',
+      brand: 'JET',
+      street: 'Str',
+      postCode: '10000',
+      place: 'Berlin',
+      lat: 0,
+      lng: 0,
+      isOpen: true,
+      amenities: {StationAmenity.shop},
+    );
+    const noneOpen = Station(
+      id: 'd',
+      name: 'D',
+      brand: 'TOTAL',
+      street: 'Str',
+      postCode: '10000',
+      place: 'Berlin',
+      lat: 0,
+      lng: 0,
+      isOpen: true,
+    );
+
+    final all = [wifiShopOpen, wifiOnlyClosed, shopOnlyOpen, noneOpen];
+
+    test('empty amenity set + openOnly false → no filtering', () {
+      final result = applyAmenityAndStatusFilters(
+        all,
+        requiredAmenities: const {},
+        openOnly: false,
+      );
+      expect(result.length, 4);
+    });
+
+    test('single amenity (wifi) → only stations with wifi pass', () {
+      final result = applyAmenityAndStatusFilters(
+        all,
+        requiredAmenities: const {StationAmenity.wifi},
+        openOnly: false,
+      );
+      expect(result.map((s) => s.id), containsAll(['a', 'b']));
+      expect(result.length, 2);
+    });
+
+    test('multiple amenities use AND semantics, not OR', () {
+      // Require wifi AND shop → only station A has both.
+      final result = applyAmenityAndStatusFilters(
+        all,
+        requiredAmenities: const {StationAmenity.wifi, StationAmenity.shop},
+        openOnly: false,
+      );
+      expect(result.length, 1);
+      expect(result.first.id, 'a');
+    });
+
+    test('openOnly excludes closed stations', () {
+      final result = applyAmenityAndStatusFilters(
+        all,
+        requiredAmenities: const {},
+        openOnly: true,
+      );
+      expect(result.map((s) => s.id), containsAll(['a', 'c', 'd']));
+      expect(result.any((s) => s.id == 'b'), isFalse);
+    });
+
+    test('amenity + openOnly combine — wifi AND open', () {
+      final result = applyAmenityAndStatusFilters(
+        all,
+        requiredAmenities: const {StationAmenity.wifi},
+        openOnly: true,
+      );
+      // B has wifi but is closed → excluded.
+      expect(result.length, 1);
+      expect(result.first.id, 'a');
+    });
+
+    test('station with no amenities fails every non-empty amenity filter', () {
+      final result = applyAmenityAndStatusFilters(
+        [noneOpen],
+        requiredAmenities: const {StationAmenity.shop},
+        openOnly: false,
+      );
+      expect(result, isEmpty);
     });
   });
 

--- a/test/features/search/presentation/widgets/search_results_list_filter_test.dart
+++ b/test/features/search/presentation/widgets/search_results_list_filter_test.dart
@@ -1,0 +1,198 @@
+// Regression tests for #491 — verify that amenity, open-only, and brand
+// filter providers actually narrow the visible station list in
+// [SearchResultsList]. Before the fix, only the brand filter was applied;
+// the amenity and open-only providers were written from the criteria
+// screen but never read by the results list, so toggling WiFi / Boutique
+// / "Ouvertes uniquement" had zero effect on what the user saw.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/domain/entities/station_amenity.dart';
+import 'package:tankstellen/features/search/presentation/widgets/search_results_list.dart';
+import 'package:tankstellen/features/search/providers/brand_filter_provider.dart';
+import 'package:tankstellen/features/search/providers/search_screen_ui_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+const _totalWifiOpen = Station(
+  id: 's1',
+  name: 'Total WiFi',
+  brand: 'TOTAL',
+  street: '1 rue A',
+  postCode: '34120',
+  place: 'Pézenas',
+  lat: 43.45,
+  lng: 3.42,
+  isOpen: true,
+  amenities: {StationAmenity.wifi, StationAmenity.shop},
+);
+const _essoShopClosed = Station(
+  id: 's2',
+  name: 'Esso Closed',
+  brand: 'ESSO',
+  street: '2 rue B',
+  postCode: '34120',
+  place: 'Pézenas',
+  lat: 43.46,
+  lng: 3.43,
+  isOpen: false,
+  amenities: {StationAmenity.shop},
+);
+const _essoWifiOpen = Station(
+  id: 's3',
+  name: 'Esso WiFi',
+  brand: 'ESSO',
+  street: '3 rue C',
+  postCode: '34120',
+  place: 'Pézenas',
+  lat: 43.47,
+  lng: 3.44,
+  isOpen: true,
+  amenities: {StationAmenity.wifi},
+);
+const _independentOpen = Station(
+  id: 's4',
+  name: 'Independent',
+  brand: '',
+  street: '4 rue D',
+  postCode: '34120',
+  place: 'Pézenas',
+  lat: 43.48,
+  lng: 3.45,
+  isOpen: true,
+);
+
+Finder _cardById(String id) => find.byKey(ValueKey('station-$id'));
+
+Future<void> _pumpList(
+  WidgetTester tester, {
+  List<Object> extraOverrides = const [],
+}) async {
+  final test = standardTestOverrides();
+  when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+  when(() => test.mockStorage.getApiKey()).thenReturn(null);
+  when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+  when(() => test.mockStorage.getRatings()).thenReturn(<String, int>{});
+
+  await pumpApp(
+    tester,
+    SearchResultsList(
+      result: ServiceResult<List<Station>>(
+        data: const [
+          _totalWifiOpen,
+          _essoShopClosed,
+          _essoWifiOpen,
+          _independentOpen,
+        ],
+        source: ServiceSource.cache,
+        fetchedAt: DateTime(2026, 4, 14),
+      ),
+      onRefresh: () {},
+    ),
+    overrides: [...test.overrides, ...extraOverrides],
+  );
+}
+
+void main() {
+  group('SearchResultsList filter application (#491)', () {
+    testWidgets('no filters → all 4 stations visible', (tester) async {
+      await _pumpList(tester);
+      expect(_cardById('s1'), findsOneWidget);
+      expect(_cardById('s2'), findsOneWidget);
+      expect(_cardById('s3'), findsOneWidget);
+      expect(_cardById('s4'), findsOneWidget);
+    });
+
+    testWidgets(
+        'amenity filter WiFi → closes-over the two non-wifi stations',
+        (tester) async {
+      await _pumpList(tester, extraOverrides: [
+        selectedAmenitiesProvider
+            .overrideWith(() => _FakeAmenities({StationAmenity.wifi})),
+      ]);
+      expect(_cardById('s1'), findsOneWidget);
+      expect(_cardById('s3'), findsOneWidget);
+      expect(_cardById('s2'), findsNothing,
+          reason: 'Esso Closed has shop but no wifi — must be hidden');
+      expect(_cardById('s4'), findsNothing,
+          reason: 'Independent has no amenities — must be hidden');
+    });
+
+    testWidgets(
+        'amenity filter Shop+WiFi (AND) → only Total WiFi passes',
+        (tester) async {
+      await _pumpList(tester, extraOverrides: [
+        selectedAmenitiesProvider.overrideWith(
+          () => _FakeAmenities({StationAmenity.wifi, StationAmenity.shop}),
+        ),
+      ]);
+      expect(_cardById('s1'), findsOneWidget);
+      expect(_cardById('s2'), findsNothing);
+      expect(_cardById('s3'), findsNothing);
+      expect(_cardById('s4'), findsNothing);
+    });
+
+    testWidgets('openOnly → closed Esso disappears', (tester) async {
+      await _pumpList(tester, extraOverrides: [
+        openOnlyFilterProvider.overrideWith(() => _FakeOpenOnly(true)),
+      ]);
+      expect(_cardById('s1'), findsOneWidget);
+      expect(_cardById('s3'), findsOneWidget);
+      expect(_cardById('s4'), findsOneWidget);
+      expect(_cardById('s2'), findsNothing);
+    });
+
+    testWidgets('brand filter TotalEnergies → only Total station',
+        (tester) async {
+      await _pumpList(tester, extraOverrides: [
+        selectedBrandsProvider
+            .overrideWith(() => _FakeBrands({'TotalEnergies'})),
+      ]);
+      expect(_cardById('s1'), findsOneWidget);
+      expect(_cardById('s2'), findsNothing);
+      expect(_cardById('s3'), findsNothing);
+      expect(_cardById('s4'), findsNothing);
+    });
+
+    testWidgets(
+        'brand + amenity + openOnly combine — WiFi + TotalEnergies + open',
+        (tester) async {
+      await _pumpList(tester, extraOverrides: [
+        selectedBrandsProvider
+            .overrideWith(() => _FakeBrands({'TotalEnergies'})),
+        selectedAmenitiesProvider
+            .overrideWith(() => _FakeAmenities({StationAmenity.wifi})),
+        openOnlyFilterProvider.overrideWith(() => _FakeOpenOnly(true)),
+      ]);
+      expect(_cardById('s1'), findsOneWidget);
+      expect(_cardById('s2'), findsNothing);
+      expect(_cardById('s3'), findsNothing);
+      expect(_cardById('s4'), findsNothing);
+    });
+  });
+}
+
+class _FakeAmenities extends SelectedAmenities {
+  _FakeAmenities(this._initial);
+  final Set<StationAmenity> _initial;
+  @override
+  Set<StationAmenity> build() => _initial;
+}
+
+class _FakeOpenOnly extends OpenOnlyFilter {
+  _FakeOpenOnly(this._initial);
+  final bool _initial;
+  @override
+  bool build() => _initial;
+}
+
+class _FakeBrands extends SelectedBrands {
+  _FakeBrands(this._initial);
+  final Set<String> _initial;
+  @override
+  Set<String> build() => _initial;
+}


### PR DESCRIPTION
## Summary

Two independent bugs made the Search criteria filters cosmetic. Fixes #491.

1. **Amenity + open-only filters were never applied.** `selectedAmenitiesProvider` and `openOnlyFilterProvider` were written from the criteria screen but never read anywhere on the results path. Toggling WiFi / Boutique / "Ouvertes uniquement" had zero effect on the displayed stations.
2. **Brand filter state was auto-disposed across navigation.** `selectedBrandsProvider` was `@riverpod` without `keepAlive: true`. The criteria screen is a top-level GoRoute, not a modal on top of the results screen — when the criteria screen popped, the provider had no listeners for a brief moment and auto-disposed, resetting the selection to empty. The brand filter appeared set on the criteria screen and arrived blank on the results screen.

## Fix

- `SelectedBrands` and `ExcludeHighwayStations` → `keepAlive: true` (matching the pre-existing `SelectedAmenities` / `OpenOnlyFilter` pattern)
- New `applyAmenityAndStatusFilters` helper in `brand_filter_chips.dart` — multi-select amenities use **AND** semantics (a station must provide all selected amenities), matching the chip UI affordance
- `SearchResultsList` now chains `applyBrandFilter → applyAmenityAndStatusFilters → sort`, reading both new providers

## Why this wasn't caught

The existing tests covered `applyBrandFilter` as a pure function and the amenity chip toggle as a UI unit, but nothing exercised the full chain (provider write → results list rebuild → filter applied). The new widget tests close that gap by pumping `SearchResultsList` directly and asserting the visible card list narrows when each provider is overridden.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — zero warnings
- [x] `flutter test` — 3581 pass (12 new tests)
- [x] 6 unit cases for `applyAmenityAndStatusFilters`: empty set, single amenity, AND semantics (multi-select), openOnly alone, openOnly + amenity, station-with-no-amenities edge case
- [x] 6 widget cases for `SearchResultsList` filter application: no filters (baseline), WiFi only, WiFi+Shop (AND), openOnly, TotalEnergies brand filter, all three combined
- [ ] Manual on device — rebuild APK, perform a search in Pézenas, tap Critères → WiFi + TotalEnergies → Rechercher → confirm only Total stations with WiFi are shown

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)