### PR TITLE
fix(map): force tile refetch via onMapReady so Carte tab isn't blank after search

### DIFF
--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -69,6 +69,23 @@ class StationMapLayers extends StatelessWidget {
             interactionOptions: const InteractionOptions(
               flags: InteractiveFlag.all,
             ),
+            // #496 — force the TileLayer to refetch tiles once the map
+            // has actually laid out. When the map screen sits inside
+            // StatefulShellRoute.indexedStack, the widget is pre-built
+            // offstage with degenerate constraints and the TileLayer's
+            // viewport is empty. The initState-based nudge in
+            // MapScreen fires before FlutterMap attaches the controller,
+            // so it gets swallowed. onMapReady fires exactly when the
+            // controller is attached AND the map has real constraints,
+            // which is the only reliable moment to nudge.
+            onMapReady: () {
+              try {
+                mapController.move(center, zoom);
+              } catch (_) {
+                // Controller in an unexpected state — skip silently, the
+                // user can still pan to trigger tile loading.
+              }
+            },
           ),
           children: [
             TileLayer(

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -1,6 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+import '../../../../helpers/pump_app.dart';
 
 void main() {
   group('StationMapLayers.zoomForRadius', () {
@@ -68,6 +73,42 @@ void main() {
       expect(bounds.west.isFinite, isTrue);
       expect(bounds.north.isFinite, isTrue);
       expect(bounds.south.isFinite, isTrue);
+    });
+  });
+
+  group('StationMapLayers onMapReady nudge (#496)', () {
+    testWidgets(
+        'FlutterMap is configured with an onMapReady callback so the '
+        'tile layer gets re-triggered once the controller is attached',
+        (tester) async {
+      final controller = MapController();
+      await pumpApp(
+        tester,
+        SizedBox(
+          width: 400,
+          height: 400,
+          child: StationMapLayers(
+            mapController: controller,
+            stations: const [],
+            center: const LatLng(48.8566, 2.3522),
+            zoom: 12,
+            searchRadiusKm: 10,
+            selectedFuel: FuelType.e10,
+          ),
+        ),
+      );
+
+      // The regression from #496 is that MapOptions.onMapReady was null
+      // and the initState-based nudge in MapScreen fires before the
+      // controller attaches. Asserting onMapReady != null locks in the
+      // fix — if someone removes it, this test fails and the tiles go
+      // blank again on cold visits to the Carte tab.
+      final flutterMap = tester.widget<FlutterMap>(find.byType(FlutterMap));
+      expect(flutterMap.options.onMapReady, isNotNull,
+          reason: 'MapOptions.onMapReady must be set so the TileLayer '
+              'retriggers its viewport fetch once the controller '
+              'attaches — otherwise the map renders blank white tiles '
+              'until the user pans (#496)');
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #496 — the map tab showed blank white tiles after running a search until the user manually panned.

### Root cause

The existing #473 fix in `MapScreen.initState` (lines 41-53) tries to nudge the `MapController` with a delayed `postFrameCallback`:

```dart
WidgetsBinding.instance.addPostFrameCallback((_) {
  Future.delayed(const Duration(milliseconds: 100), () {
    if (!mounted) return;
    try {
      final camera = _mapController.camera;
      _mapController.move(camera.center, camera.zoom);
    } catch (_) { /* swallowed */ }
  });
});
```

This runs once, in `initState`, **before** `flutter_map` has attached the `MapController` to the `FlutterMap` instance inside `StationMapLayers`. The `move()` call hits the controller's "not yet attached" `StateError`, lands in the silent `catch`, and is swallowed. Since `MapScreen` is kept alive by `StatefulShellRoute.indexedStack`, `initState` never runs again and the tile layer's viewport stays empty until the user pans or pinches.

### Fix

Wire up `MapOptions.onMapReady` inside `StationMapLayers` and do the `move(center, zoom)` nudge there. `onMapReady` fires exactly when the controller is attached to a real, sized `FlutterMap`, which is the only reliable moment to trigger a `TileLayer` refetch.

```dart
MapOptions(
  initialCenter: center,
  initialZoom: zoom,
  onMapReady: () {
    try {
      mapController.move(center, zoom);
    } catch (_) { /* safe fallback — user pan still works */ }
  },
),
```

### Regression test

`station_map_layers_test.dart` now pumps a `StationMapLayers` widget and asserts `MapOptions.onMapReady` is non-null. If someone strips the callback during a refactor, CI fails with a clear message instead of the tiles silently going blank on cold visits to the Carte tab.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — zero warnings
- [x] `flutter test` — 3584 passing (previously 3583)
- [x] New widget test: `MapOptions.onMapReady` is non-null
- [ ] Manual on device: rebuild APK, Recherche → run search → tap Carte → confirm tiles load immediately without panning
- [ ] Manual on device: Carte → back to Recherche → new search → back to Carte → confirm tiles still load immediately

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)