### PR TITLE
fix(uk): aggregate CMA-compliant retailer feeds instead of dead wrapper

### DIFF
--- a/lib/core/services/impl/uk_station_service.dart
+++ b/lib/core/services/impl/uk_station_service.dart
@@ -12,103 +12,222 @@ import '../mixins/station_service_helpers.dart';
 
 /// UK Competition and Markets Authority (CMA) fuel price service.
 ///
-/// Uses the CMA's open fuel prices API launched in 2024.
-/// Free, no API key required for basic access.
+/// Under the CMA Fuel Finder scheme, major UK fuel retailers publish
+/// their station list and prices as a standardized JSON feed hosted on
+/// their own domain. There is no single aggregated endpoint — each
+/// retailer serves its own file. This service fans out across the known
+/// retailer feeds in parallel, tolerates per-retailer failures (a 404
+/// or timeout on one retailer does not kill the whole search), and
+/// aggregates the results client-side.
 ///
-/// Primary: https://www.fuel-finder.service.gov.uk/api/v1/pfs
-/// Alternative (no auth): CSV from gov.uk or checkfuelprices.co.uk
+/// Feed format (standardized by the CMA):
+/// ```json
+/// {
+///   "last_updated": "2025-01-01 08:00:00",
+///   "stations": [
+///     {
+///       "site_id": "...",
+///       "brand": "...",
+///       "address": "...",
+///       "postcode": "...",
+///       "location": {"latitude": 51.5, "longitude": -0.12},
+///       "prices": {"E5": 145.9, "E10": 142.9, "B7": 151.9, "SDV": 160.9}
+///     }
+///   ]
+/// }
+/// ```
 ///
-/// The CMA API requires OAuth 2.0 (client credentials). For MVP we use
-/// the free checkfuelprices.co.uk wrapper which provides the same data
-/// without authentication. Can be upgraded to official OAuth later.
+/// Prices are in pence per litre — [_parsePence] converts values above
+/// 10 back to pounds.
 class UkStationService with StationServiceHelpers implements StationService {
-  final Dio _dio = DioFactory.create(
-    connectTimeout: const Duration(seconds: 15),
-    receiveTimeout: const Duration(seconds: 30),
-  );
+  final Dio _dio;
+  final List<String> _feedUrls;
 
-  // Free wrapper API — same CMA data, no auth required
-  static const _baseUrl = 'https://checkfuelprices.co.uk/api';
+  UkStationService({Dio? dio, List<String>? feedUrls})
+      : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 8),
+              receiveTimeout: const Duration(seconds: 12),
+            ),
+        _feedUrls = feedUrls ?? defaultCmaFeedUrls;
+
+  /// Canonical list of CMA-compliant retailer feeds.
+  ///
+  /// Published at https://www.gov.uk/guidance/access-fuel-price-data. The
+  /// list is intentionally permissive — missing or broken URLs degrade
+  /// gracefully because each fetch is isolated in [_fetchFeed].
+  static const List<String> defaultCmaFeedUrls = [
+    'https://applegreenstores.com/fuel-prices/data.json',
+    'https://fuelprices.asconagroup.co.uk/newfuel.json',
+    'https://storelocator.asda.com/fuel_prices_data.json',
+    'https://www.bp.com/en_gb/united-kingdom/home/fuelprices/fuel_prices_data.json',
+    'https://fuelprices.esso.co.uk/latestdata.json',
+    'https://jetlocal.co.uk/fuel_prices_data.json',
+    'https://api2.krlmedia.com/integration/live_price/krl',
+    'https://www.morrisons.com/fuel-prices/fuel.json',
+    'https://moto-way.com/fuel-price/fuel_prices.json',
+    'https://fuel.motorfuelgroup.com/fuel_prices_data.json',
+    'https://www.rontec-servicestations.co.uk/fuel-prices/data/fuel_prices_data.json',
+    'https://api.sainsburys.co.uk/v1/exports/latest/fuel_prices_data.json',
+    'https://www.sgnretail.uk/files/data/SGN_daily_fuel_prices.json',
+    'https://www.tesco.com/fuel_prices/fuel_prices_data.json',
+  ];
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(
     SearchParams params, {
     CancelToken? cancelToken,
   }) async {
-    try {
-      final response = await _dio.get(
-        '$_baseUrl/stations',
-        queryParameters: {
-          'lat': params.lat,
-          'lng': params.lng,
-          'radius': params.radiusKm,
-        },
-        cancelToken: cancelToken,
+    final results = await Future.wait(
+      _feedUrls.map((url) => _fetchFeed(url, cancelToken)),
+    );
+
+    final merged = <dynamic>[];
+    var failureCount = 0;
+    for (final list in results) {
+      if (list == null) {
+        failureCount++;
+      } else {
+        merged.addAll(list);
+      }
+    }
+
+    if (merged.isEmpty && failureCount == _feedUrls.length) {
+      throw const ApiException(
+        message: 'All CMA retailer feeds unreachable',
       );
+    }
+
+    final stations = parseCmaStations(
+      merged,
+      lat: params.lat,
+      lng: params.lng,
+      radiusKm: params.radiusKm,
+    );
+
+    return ServiceResult(
+      data: stations,
+      source: ServiceSource.ukApi,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  Future<List<dynamic>?> _fetchFeed(
+    String url,
+    CancelToken? cancelToken,
+  ) async {
+    try {
+      final response = await _dio.get<dynamic>(
+        url,
+        cancelToken: cancelToken,
+        options: Options(
+          // Tolerate 404 / 410 — a dead retailer feed must not poison the
+          // whole search. Only network / 5xx failures bubble up.
+          validateStatus: (status) => status != null && status < 500,
+          responseType: ResponseType.json,
+        ),
+      );
+      if (response.statusCode == null || response.statusCode! >= 400) {
+        debugPrint('UK feed $url → HTTP ${response.statusCode}');
+        return null;
+      }
 
       final data = response.data;
-      List<dynamic> stationList;
       if (data is Map<String, dynamic>) {
-        stationList = data['stations'] as List<dynamic>? ?? data['data'] as List<dynamic>? ?? [];
-      } else if (data is List) {
-        stationList = data;
-      } else {
-        throw const ApiException(message: 'Invalid UK fuel price response');
+        final list = data['stations'] as List<dynamic>? ??
+            data['data'] as List<dynamic>? ??
+            const [];
+        return List<dynamic>.from(list);
       }
-
-      final stations = <Station>[];
-      for (final item in stationList) {
-        try {
-          final lat = (item['location']?['latitude'] ?? item['lat'] as num?)?.toDouble();
-          final lng = (item['location']?['longitude'] ?? item['lng'] as num?)?.toDouble();
-          if (lat == null || lng == null) continue;
-
-          final dist = distanceKm(params.lat, params.lng, lat, lng);
-          if (dist > params.radiusKm) continue;
-
-          final prices = item['prices'] as Map<String, dynamic>? ?? {};
-
-          stations.add(Station(
-            id: 'uk-${item['id'] ?? item['site_id'] ?? stations.length}',
-            name: item['name']?.toString() ?? item['site_name']?.toString() ?? '',
-            brand: item['brand']?.toString() ?? '',
-            street: item['address']?.toString() ?? '',
-            postCode: item['postcode']?.toString() ?? '',
-            place: item['town']?.toString() ?? item['locality']?.toString() ?? '',
-            lat: lat,
-            lng: lng,
-            dist: dist,
-            // UK prices in pence per litre — convert to pounds
-            e5: _parsePence(prices['E5'] ?? prices['unleaded']),
-            e10: _parsePence(prices['E10']),
-            e98: _parsePence(prices['super_unleaded'] ?? prices['E5_97']),
-            diesel: _parsePence(prices['B7'] ?? prices['diesel']),
-            isOpen: true,
-          ));
-        } catch (e) {
-          debugPrint('UK station parse failed: $e');
-          continue;
-        }
-      }
-
-      stations.sort((a, b) => a.dist.compareTo(b.dist));
-
-      return ServiceResult(
-        data: stations.take(50).toList(),
-        source: ServiceSource.ukApi,
-        fetchedAt: DateTime.now(),
-      );
+      if (data is List) return List<dynamic>.from(data);
+      return null;
     } on DioException catch (e) {
-      throwApiException(e, defaultMessage: 'UK fuel price API error');
+      debugPrint('UK feed $url failed: ${e.type.name}');
+      return null;
+    } catch (e) {
+      debugPrint('UK feed $url parse error: $e');
+      return null;
     }
   }
 
-  /// UK prices may be in pence — convert to pounds if > 10.
-  double? _parsePence(dynamic value) {
+  /// Parses a merged list of CMA station records into [Station] entities,
+  /// filters to the search radius, dedupes by `site_id`, sorts by
+  /// distance, and caps at 50 results.
+  ///
+  /// Exposed for tests.
+  @visibleForTesting
+  static List<Station> parseCmaStations(
+    List<dynamic> items, {
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) {
+    final seenIds = <String>{};
+    final stations = <Station>[];
+
+    for (final item in items) {
+      if (item is! Map) continue;
+      try {
+        final location = item['location'];
+        final locMap = location is Map ? location : null;
+        final itemLat = (locMap?['latitude'] as num?)?.toDouble() ??
+            (item['lat'] as num?)?.toDouble();
+        final itemLng = (locMap?['longitude'] as num?)?.toDouble() ??
+            (item['lng'] as num?)?.toDouble();
+        if (itemLat == null || itemLng == null) continue;
+
+        final dist = distanceKm(lat, lng, itemLat, itemLng);
+        if (dist > radiusKm) continue;
+
+        final rawId = item['site_id']?.toString() ??
+            item['id']?.toString() ??
+            '${itemLat.toStringAsFixed(5)}_${itemLng.toStringAsFixed(5)}';
+        final stationId = 'uk-$rawId';
+        if (!seenIds.add(stationId)) continue;
+
+        final prices = item['prices'] is Map
+            ? Map<String, dynamic>.from(item['prices'] as Map)
+            : <String, dynamic>{};
+
+        stations.add(Station(
+          id: stationId,
+          name: item['site_name']?.toString() ??
+              item['name']?.toString() ??
+              item['brand']?.toString() ??
+              '',
+          brand: item['brand']?.toString() ?? '',
+          street: item['address']?.toString() ?? '',
+          postCode: item['postcode']?.toString() ?? '',
+          place: item['town']?.toString() ?? item['locality']?.toString() ?? '',
+          lat: itemLat,
+          lng: itemLng,
+          dist: dist,
+          e5: _parsePence(prices['E5'] ?? prices['unleaded']),
+          e10: _parsePence(prices['E10']),
+          e98: _parsePence(prices['super_unleaded'] ?? prices['E5_97']),
+          diesel: _parsePence(prices['B7'] ?? prices['diesel']),
+          isOpen: true,
+        ));
+      } catch (e) {
+        debugPrint('UK station parse failed: $e');
+        continue;
+      }
+    }
+
+    stations.sort((a, b) => a.dist.compareTo(b.dist));
+    return stations.take(50).toList();
+  }
+
+  /// UK CMA prices are published in pence per litre. Anything above 10
+  /// is treated as pence and divided by 100; anything at or below 10 is
+  /// assumed to already be in pounds.
+  @visibleForTesting
+  static double? parsePenceForTest(dynamic value) => _parsePence(value);
+
+  static double? _parsePence(dynamic value) {
     if (value == null) return null;
     final price = double.tryParse(value.toString());
     if (price == null) return null;
-    // If price > 10, it's likely in pence — convert to pounds
     return price > 10 ? price / 100 : price;
   }
 
@@ -118,7 +237,13 @@ class UkStationService with StationServiceHelpers implements StationService {
   }
 
   @override
-  Future<ServiceResult<Map<String, StationPrices>>> getPrices(List<String> ids) async {
-    return ServiceResult(data: {}, source: ServiceSource.ukApi, fetchedAt: DateTime.now());
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    return ServiceResult(
+      data: const {},
+      source: ServiceSource.ukApi,
+      fetchedAt: DateTime.now(),
+    );
   }
 }

--- a/test/core/services/error_recovery_pattern_test.dart
+++ b/test/core/services/error_recovery_pattern_test.dart
@@ -14,7 +14,9 @@ void main() {
       'lib/core/services/impl/econtrol_station_service.dart',
       'lib/core/services/impl/miteco_station_service.dart',
       'lib/core/services/impl/denmark_station_service.dart',
-      'lib/core/services/impl/uk_station_service.dart',
+      // UK service intentionally omitted: it fans out to many retailer
+      // feeds and isolates DioException per-feed instead of bubbling
+      // through a single `throwApiException` at the top level.
       'lib/core/services/impl/australia_station_service.dart',
       'lib/core/services/impl/mexico_station_service.dart',
       'lib/core/services/impl/portugal_station_service.dart',

--- a/test/core/services/impl/uk_station_service_test.dart
+++ b/test/core/services/impl/uk_station_service_test.dart
@@ -1,79 +1,307 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/services/impl/uk_station_service.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
-import 'package:tankstellen/core/utils/geo_utils.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 
-/// Tests for [UkStationService] and its CMA / checkfuelprices.co.uk
-/// JSON parsing logic.
+/// Fake HTTP adapter that returns a canned response per URL.
 ///
-/// The production service instantiates Dio internally via `DioFactory.create()`,
-/// which means we can't inject a mock HTTP client. We therefore mirror the
-/// parsing logic in `_TestableUkParser` and exercise the real service only
-/// for its synchronous public surface.
-void main() {
-  late UkStationService service;
+/// `responses` maps each URL to either a full JSON string (served with
+/// status 200) or a status code (served with an empty body). Unmapped
+/// URLs behave as-if the retailer were offline (status 404).
+class _FakeAdapter implements HttpClientAdapter {
+  final Map<String, Object> responses;
+  final List<String> requestedUrls = [];
 
-  setUp(() {
-    service = UkStationService();
+  _FakeAdapter(this.responses);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestedUrls.add(options.uri.toString());
+    final reply = responses[options.uri.toString()];
+
+    if (reply is String) {
+      return ResponseBody.fromString(
+        reply,
+        200,
+        headers: {
+          Headers.contentTypeHeader: ['application/json'],
+        },
+      );
+    }
+    if (reply is int) {
+      return ResponseBody.fromString('', reply);
+    }
+    // Unmapped URLs simulate a dead retailer feed.
+    return ResponseBody.fromString('', 404);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Dio _dioWith(Map<String, Object> responses) {
+  final dio = Dio();
+  dio.httpClientAdapter = _FakeAdapter(responses);
+  return dio;
+}
+
+/// Standard CMA-format feed payload for the given site.
+String _cmaFeed({
+  required String siteId,
+  required String brand,
+  required String name,
+  required double lat,
+  required double lng,
+  double e5 = 155.9,
+  double e10 = 145.9,
+  double diesel = 152.9,
+  String postcode = 'SW1E 6DE',
+  String address = '1 Victoria St',
+}) {
+  return jsonEncode({
+    'last_updated': '2025-01-01 08:00:00',
+    'stations': [
+      {
+        'site_id': siteId,
+        'brand': brand,
+        'site_name': name,
+        'address': address,
+        'postcode': postcode,
+        'town': 'London',
+        'location': {'latitude': lat, 'longitude': lng},
+        'prices': {'E5': e5, 'E10': e10, 'B7': diesel},
+      },
+    ],
   });
+}
 
+const _searchParams = SearchParams(lat: 51.5, lng: -0.12, radiusKm: 50);
+
+void main() {
   group('UkStationService (public surface)', () {
     test('implements StationService interface', () {
-      expect(service, isA<StationService>());
+      expect(UkStationService(), isA<StationService>());
     });
 
     test('getStationDetail throws ApiException', () {
       expect(
-        () => service.getStationDetail('uk-123'),
+        () => UkStationService().getStationDetail('uk-123'),
         throwsA(isA<Exception>()),
       );
     });
 
     test('getPrices returns empty map with correct source', () async {
-      final result = await service.getPrices(['uk-1', 'uk-2']);
+      final result = await UkStationService().getPrices(['uk-1']);
       expect(result.data, isEmpty);
       expect(result.source, ServiceSource.ukApi);
       expect(result.isStale, isFalse);
     });
 
-    test('getPrices returns empty map for empty id list', () async {
-      final result = await service.getPrices([]);
-      expect(result.data, isEmpty);
-      expect(result.source, ServiceSource.ukApi);
+    test('default feed list is non-empty', () {
+      expect(UkStationService.defaultCmaFeedUrls, isNotEmpty);
     });
   });
 
-  group('CMA / checkfuelprices.co.uk response parsing', () {
-    late _TestableUkParser parser;
+  group('searchStations (aggregated CMA feeds)', () {
+    test('aggregates stations from multiple retailer feeds', () async {
+      const bpUrl = 'https://bp.example/feed.json';
+      const tescoUrl = 'https://tesco.example/feed.json';
 
-    setUp(() {
-      parser = _TestableUkParser();
+      final dio = _dioWith({
+        bpUrl: _cmaFeed(
+          siteId: 'BP1',
+          brand: 'BP',
+          name: 'BP Victoria',
+          lat: 51.4975,
+          lng: -0.1357,
+        ),
+        tescoUrl: _cmaFeed(
+          siteId: 'TES1',
+          brand: 'Tesco',
+          name: 'Tesco Extra',
+          lat: 51.5001,
+          lng: -0.12,
+          e5: 150.0,
+          e10: 140.0,
+          diesel: 148.0,
+        ),
+      });
+
+      final service = UkStationService(
+        dio: dio,
+        feedUrls: const [bpUrl, tescoUrl],
+      );
+
+      final result = await service.searchStations(_searchParams);
+      expect(result.source, ServiceSource.ukApi);
+      expect(result.data, hasLength(2));
+      final ids = result.data.map((s) => s.id).toSet();
+      expect(ids, containsAll(<String>['uk-BP1', 'uk-TES1']));
     });
 
-    test('parses a well-formed response with prices in pence', () {
-      // Realistic CMA-style payload: prices are in pence (e.g. 145.9 = £1.459)
-      final data = {
+    test('tolerates a 404 from one retailer while returning others', () async {
+      const bpUrl = 'https://bp.example/feed.json';
+      const deadUrl = 'https://dead.example/feed.json';
+
+      final dio = _dioWith({
+        bpUrl: _cmaFeed(
+          siteId: 'BP1',
+          brand: 'BP',
+          name: 'BP Victoria',
+          lat: 51.4975,
+          lng: -0.1357,
+        ),
+        deadUrl: 404,
+      });
+
+      final service = UkStationService(
+        dio: dio,
+        feedUrls: const [bpUrl, deadUrl],
+      );
+
+      final result = await service.searchStations(_searchParams);
+      expect(result.data, hasLength(1));
+      expect(result.data.first.brand, 'BP');
+    });
+
+    test('throws ApiException when ALL feeds fail', () async {
+      const a = 'https://a.example/feed.json';
+      const b = 'https://b.example/feed.json';
+
+      final dio = _dioWith({a: 404, b: 404});
+      final service = UkStationService(dio: dio, feedUrls: const [a, b]);
+
+      expect(
+        () => service.searchStations(_searchParams),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('tolerates retailer-level 5xx without killing the whole search',
+        () async {
+      const good = 'https://good.example/feed.json';
+      const brokenUrl = 'https://broken.example/feed.json';
+
+      // 5xx from one retailer bubbles up as a Dio exception which we
+      // catch per-feed. The good feed should still return data.
+      final dio = _dioWith({
+        good: _cmaFeed(
+          siteId: 'G1',
+          brand: 'Good',
+          name: 'Good Station',
+          lat: 51.5,
+          lng: -0.12,
+        ),
+        brokenUrl: 502,
+      });
+
+      final service = UkStationService(
+        dio: dio,
+        feedUrls: const [good, brokenUrl],
+      );
+
+      final result = await service.searchStations(_searchParams);
+      expect(result.data, hasLength(1));
+      expect(result.data.first.brand, 'Good');
+    });
+
+    test('dedupes stations that appear in multiple feeds by site_id',
+        () async {
+      const feedA = 'https://a.example/feed.json';
+      const feedB = 'https://b.example/feed.json';
+
+      // Same site_id served from two different feeds — only one wins.
+      final payload = _cmaFeed(
+        siteId: 'DUPLICATE',
+        brand: 'Shared',
+        name: 'Shared Station',
+        lat: 51.5,
+        lng: -0.12,
+      );
+
+      final dio = _dioWith({feedA: payload, feedB: payload});
+      final service = UkStationService(
+        dio: dio,
+        feedUrls: const [feedA, feedB],
+      );
+
+      final result = await service.searchStations(_searchParams);
+      expect(result.data, hasLength(1));
+      expect(result.data.first.id, 'uk-DUPLICATE');
+    });
+
+    test('filters stations outside the search radius', () async {
+      const feed = 'https://a.example/feed.json';
+
+      final payload = jsonEncode({
         'stations': [
           {
-            'id': 'ABC123',
-            'name': 'BP Victoria Street',
+            'site_id': 'LON',
             'brand': 'BP',
-            'address': '123 Victoria Street',
-            'postcode': 'SW1E 6DE',
-            'town': 'London',
-            'location': {'latitude': 51.4975, 'longitude': -0.1357},
-            'prices': {
-              'E10': 145.9,
-              'E5': 155.9,
-              'B7': 152.9,
-            },
+            'site_name': 'London',
+            'location': {'latitude': 51.5, 'longitude': -0.12},
+            'prices': <String, dynamic>{},
+          },
+          {
+            'site_id': 'EDI',
+            'brand': 'BP',
+            'site_name': 'Edinburgh',
+            'location': {'latitude': 55.9533, 'longitude': -3.1883},
+            'prices': <String, dynamic>{},
           },
         ],
-      };
+      });
 
-      final stations = parser.parseResponse(data, lat: 51.4975, lng: -0.1357, radiusKm: 10);
+      final dio = _dioWith({feed: payload});
+      final service =
+          UkStationService(dio: dio, feedUrls: const [feed]);
+
+      final result = await service.searchStations(
+        const SearchParams(lat: 51.5, lng: -0.12, radiusKm: 20),
+      );
+      expect(result.data, hasLength(1));
+      expect(result.data.first.name, 'London');
+    });
+  });
+
+  group('parseCmaStations (CMA payload parser)', () {
+    List<Station> parse(
+      dynamic items, {
+      double lat = 51.5,
+      double lng = -0.12,
+      double radiusKm = 50,
+    }) {
+      return UkStationService.parseCmaStations(
+        items is List ? items : [items],
+        lat: lat,
+        lng: lng,
+        radiusKm: radiusKm,
+      );
+    }
+
+    test('parses a well-formed station with prices in pence', () {
+      final stations = parse([
+        {
+          'site_id': 'ABC123',
+          'site_name': 'BP Victoria Street',
+          'brand': 'BP',
+          'address': '123 Victoria Street',
+          'postcode': 'SW1E 6DE',
+          'town': 'London',
+          'location': {'latitude': 51.4975, 'longitude': -0.1357},
+          'prices': {'E10': 145.9, 'E5': 155.9, 'B7': 152.9},
+        },
+      ]);
 
       expect(stations, hasLength(1));
       final s = stations.first;
@@ -83,7 +311,6 @@ void main() {
       expect(s.street, '123 Victoria Street');
       expect(s.postCode, 'SW1E 6DE');
       expect(s.place, 'London');
-      // Pence -> pounds conversion
       expect(s.e10, closeTo(1.459, 0.0001));
       expect(s.e5, closeTo(1.559, 0.0001));
       expect(s.diesel, closeTo(1.529, 0.0001));
@@ -91,30 +318,24 @@ void main() {
     });
 
     test('keeps prices under 10 as-is (already in pounds)', () {
-      final data = {
-        'stations': [
-          {
-            'id': 1,
-            'name': 'Already pounds',
-            'brand': 'Shell',
-            'location': {'latitude': 51.5, 'longitude': -0.12},
-            'prices': {
-              'E10': 1.459,
-              'B7': 1.529,
-            },
-          },
-        ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 10);
+      final stations = parse([
+        {
+          'site_id': 1,
+          'site_name': 'Already pounds',
+          'brand': 'Shell',
+          'location': {'latitude': 51.5, 'longitude': -0.12},
+          'prices': {'E10': 1.459, 'B7': 1.529},
+        },
+      ]);
 
       expect(stations.first.e10, 1.459);
       expect(stations.first.diesel, 1.529);
     });
 
-    test('supports alternate field names (site_id, site_name, lat/lng, unleaded)', () {
-      final data = {
-        'data': [
+    test('supports alternate field names (lat/lng, unleaded, super_unleaded)',
+        () {
+      final stations = parse(
+        [
           {
             'site_id': 'SITE42',
             'site_name': 'Tesco Extra',
@@ -132,249 +353,98 @@ void main() {
             },
           },
         ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 53.4808, lng: -2.2426, radiusKm: 20);
+        lat: 53.4808,
+        lng: -2.2426,
+      );
 
       expect(stations, hasLength(1));
       final s = stations.first;
       expect(s.id, 'uk-SITE42');
-      expect(s.name, 'Tesco Extra');
       expect(s.place, 'Manchester');
-      expect(s.lat, closeTo(53.4808, 0.0001));
-      expect(s.e5, closeTo(1.449, 0.0001)); // unleaded
+      expect(s.e5, closeTo(1.449, 0.0001));
       expect(s.e10, closeTo(1.429, 0.0001));
       expect(s.diesel, closeTo(1.519, 0.0001));
-      expect(s.e98, closeTo(1.589, 0.0001)); // super_unleaded
-    });
-
-    test('accepts a top-level list payload', () {
-      final data = [
-        {
-          'id': 1,
-          'name': 'Station A',
-          'lat': 51.5,
-          'lng': -0.12,
-          'prices': <String, dynamic>{},
-        },
-      ];
-
-      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 5);
-      expect(stations, hasLength(1));
-      expect(stations.first.name, 'Station A');
+      expect(s.e98, closeTo(1.589, 0.0001));
     });
 
     test('skips stations with missing coordinates', () {
-      final data = {
-        'stations': [
-          {
-            'id': 1,
-            'name': 'No coords',
-            'prices': <String, dynamic>{},
-          },
-          {
-            'id': 2,
-            'name': 'With coords',
-            'lat': 51.5,
-            'lng': -0.12,
-            'prices': <String, dynamic>{},
-          },
-        ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 5);
+      final stations = parse([
+        {'site_id': 1, 'site_name': 'No coords', 'prices': <String, dynamic>{}},
+        {
+          'site_id': 2,
+          'site_name': 'With coords',
+          'location': {'latitude': 51.5, 'longitude': -0.12},
+          'prices': <String, dynamic>{},
+        },
+      ]);
       expect(stations, hasLength(1));
       expect(stations.first.name, 'With coords');
     });
 
-    test('skips stations outside the search radius', () {
-      final data = {
-        'stations': [
-          {
-            'id': 1,
-            'name': 'London',
-            'lat': 51.5,
-            'lng': -0.12,
-            'prices': <String, dynamic>{},
-          },
-          {
-            'id': 2,
-            'name': 'Edinburgh',
-            'lat': 55.9533,
-            'lng': -3.1883,
-            'prices': <String, dynamic>{},
-          },
-        ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 50);
-      expect(stations, hasLength(1));
-      expect(stations.first.name, 'London');
-    });
-
-    test('returns empty list for empty stations list', () {
-      final stations = parser.parseResponse(
-        {'stations': <dynamic>[]},
-        lat: 51.5,
-        lng: -0.12,
-        radiusKm: 10,
-      );
-      expect(stations, isEmpty);
-    });
-
-    test('handles missing prices map without crashing', () {
-      final data = {
-        'stations': [
-          {
-            'id': 1,
-            'name': 'No prices key',
-            'lat': 51.5,
-            'lng': -0.12,
-          },
-        ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 5);
-
-      expect(stations, hasLength(1));
-      final s = stations.first;
-      expect(s.e5, isNull);
-      expect(s.e10, isNull);
-      expect(s.e98, isNull);
-      expect(s.diesel, isNull);
-    });
-
     test('sorts stations by distance ascending', () {
-      final data = {
-        'stations': [
-          {
-            'id': 1,
-            'name': 'Far',
-            'lat': 51.52,
-            'lng': -0.12,
-            'prices': <String, dynamic>{},
-          },
-          {
-            'id': 2,
-            'name': 'Near',
-            'lat': 51.5001,
-            'lng': -0.12,
-            'prices': <String, dynamic>{},
-          },
-        ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 51.5, lng: -0.12, radiusKm: 50);
+      final stations = parse([
+        {
+          'site_id': 'FAR',
+          'site_name': 'Far',
+          'location': {'latitude': 51.52, 'longitude': -0.12},
+          'prices': <String, dynamic>{},
+        },
+        {
+          'site_id': 'NEAR',
+          'site_name': 'Near',
+          'location': {'latitude': 51.5001, 'longitude': -0.12},
+          'prices': <String, dynamic>{},
+        },
+      ]);
       expect(stations, hasLength(2));
       expect(stations.first.name, 'Near');
       expect(stations.last.name, 'Far');
     });
 
     test('caps results at 50 stations', () {
-      final list = <Map<String, dynamic>>[];
-      for (var i = 0; i < 120; i++) {
-        list.add({
-          'id': i,
-          'name': 'S$i',
-          'lat': 51.5 + i * 0.0001,
-          'lng': -0.12,
+      final list = List<Map<String, dynamic>>.generate(
+        120,
+        (i) => {
+          'site_id': 'S$i',
+          'site_name': 'S$i',
+          'location': {'latitude': 51.5 + i * 0.0001, 'longitude': -0.12},
           'prices': <String, dynamic>{},
-        });
-      }
-
-      final stations = parser.parseResponse(
-        {'stations': list},
-        lat: 51.5,
-        lng: -0.12,
-        radiusKm: 50,
+        },
       );
 
-      expect(stations.length, lessThanOrEqualTo(50));
+      final stations = parse(list, radiusKm: 500);
+      expect(stations.length, 50);
     });
 
-    test('_parsePence returns null for null value', () {
-      expect(parser.parsePence(null), isNull);
+    test('dedupes by site_id within a single payload', () {
+      final stations = parse([
+        {
+          'site_id': 'DUP',
+          'site_name': 'First',
+          'location': {'latitude': 51.5, 'longitude': -0.12},
+          'prices': <String, dynamic>{},
+        },
+        {
+          'site_id': 'DUP',
+          'site_name': 'Second',
+          'location': {'latitude': 51.5, 'longitude': -0.12},
+          'prices': <String, dynamic>{},
+        },
+      ]);
+      expect(stations, hasLength(1));
+      expect(stations.first.name, 'First');
     });
 
-    test('_parsePence returns null for non-numeric value', () {
-      expect(parser.parsePence('abc'), isNull);
-    });
-
-    test('_parsePence converts pence (>10) to pounds', () {
-      expect(parser.parsePence(145.9), closeTo(1.459, 0.0001));
-      expect(parser.parsePence('155'), closeTo(1.55, 0.0001));
-    });
-
-    test('_parsePence keeps values <=10 unchanged (already in pounds)', () {
-      expect(parser.parsePence(1.459), 1.459);
-      expect(parser.parsePence('2.5'), 2.5);
+    test('parsePenceForTest — null, non-numeric, pence, and pounds', () {
+      expect(UkStationService.parsePenceForTest(null), isNull);
+      expect(UkStationService.parsePenceForTest('abc'), isNull);
+      expect(
+        UkStationService.parsePenceForTest(145.9),
+        closeTo(1.459, 0.0001),
+      );
+      expect(UkStationService.parsePenceForTest('155'), closeTo(1.55, 0.0001));
+      expect(UkStationService.parsePenceForTest(1.459), 1.459);
+      expect(UkStationService.parsePenceForTest('2.5'), 2.5);
     });
   });
-}
-
-/// Mirror of [UkStationService]'s parsing logic for unit-testing without HTTP.
-class _TestableUkParser {
-  List<Station> parseResponse(
-    dynamic data, {
-    required double lat,
-    required double lng,
-    required double radiusKm,
-  }) {
-    List<dynamic> stationList;
-    if (data is Map<String, dynamic>) {
-      stationList = data['stations'] as List<dynamic>? ??
-          data['data'] as List<dynamic>? ??
-          [];
-    } else if (data is List) {
-      stationList = data;
-    } else {
-      return [];
-    }
-
-    final stations = <Station>[];
-    for (final item in stationList) {
-      try {
-        final location = item['location'] as Map<String, dynamic>?;
-        final itemLat =
-            (location?['latitude'] as num?)?.toDouble() ?? (item['lat'] as num?)?.toDouble();
-        final itemLng =
-            (location?['longitude'] as num?)?.toDouble() ?? (item['lng'] as num?)?.toDouble();
-        if (itemLat == null || itemLng == null) continue;
-
-        final dist = distanceKm(lat, lng, itemLat, itemLng);
-        if (dist > radiusKm) continue;
-
-        final prices = item['prices'] as Map<String, dynamic>? ?? <String, dynamic>{};
-
-        stations.add(Station(
-          id: 'uk-${item['id'] ?? item['site_id'] ?? stations.length}',
-          name: item['name']?.toString() ?? item['site_name']?.toString() ?? '',
-          brand: item['brand']?.toString() ?? '',
-          street: item['address']?.toString() ?? '',
-          postCode: item['postcode']?.toString() ?? '',
-          place: item['town']?.toString() ?? item['locality']?.toString() ?? '',
-          lat: itemLat,
-          lng: itemLng,
-          dist: dist,
-          e5: parsePence(prices['E5'] ?? prices['unleaded']),
-          e10: parsePence(prices['E10']),
-          e98: parsePence(prices['super_unleaded'] ?? prices['E5_97']),
-          diesel: parsePence(prices['B7'] ?? prices['diesel']),
-          isOpen: true,
-        ));
-      } catch (_) {
-        continue;
-      }
-    }
-
-    stations.sort((a, b) => a.dist.compareTo(b.dist));
-    return stations.take(50).toList();
-  }
-
-  double? parsePence(dynamic value) {
-    if (value == null) return null;
-    final price = double.tryParse(value.toString());
-    if (price == null) return null;
-    return price > 10 ? price / 100 : price;
-  }
 }


### PR DESCRIPTION
## Summary
- Replaces the 404ing `checkfuelprices.co.uk/api/stations` wrapper with a fan-out over the per-retailer CMA Fuel Finder JSON feeds (gov.uk scheme).
- Each retailer fetch is isolated: 404/410/5xx/timeouts are caught per feed and logged; only an all-feeds-failed scenario throws so the service chain can fall back to stale cache.
- Extracts the station parser to a static `@visibleForTesting` helper and dedupes by `site_id` across feeds.
- Dio and the feed-URL list are now constructor-injectable, enabling tests that cover: multi-feed aggregation, per-feed 404 tolerance, per-feed 5xx tolerance, all-fail throws, and cross-feed dedupe.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero warnings/errors
- [x] `flutter test` — all 3583 tests pass
- [x] New test coverage for aggregated fan-out via fake `HttpClientAdapter`
- [ ] Manual UK search on device once CI is green

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)