### PR TITLE
fix(errors): drop ?template= so GitHub honors body= prefill

### DIFF
--- a/lib/core/error_reporting/error_report_formatter.dart
+++ b/lib/core/error_reporting/error_report_formatter.dart
@@ -10,7 +10,6 @@ class ErrorReportFormatter {
   const ErrorReportFormatter._();
 
   static const String _labels = 'type/bug,needs-triage';
-  static const String _template = 'bug_report.yml';
 
   /// Short, single-line title suitable for a GitHub issue.
   ///
@@ -89,15 +88,18 @@ class ErrorReportFormatter {
   }
 
   /// Builds the fully-qualified GitHub issue-new URL with title, body,
-  /// labels, and template parameters pre-filled.
+  /// and labels pre-filled.
   ///
-  /// GitHub's `?template=bug_report.yml` form only accepts query params
-  /// for specific fields defined in the template. We additionally pass
-  /// `title` and `body` for platforms that fall back to the plain form.
+  /// We intentionally do **not** pass `template=bug_report.yml` —
+  /// GitHub's issue-new page silently ignores `body=` whenever a
+  /// template is specified, because template mode prefills from
+  /// per-field query params whose keys match the template's `id:`s
+  /// (`description`, `steps`, `expected`, etc.). Since our `buildBody`
+  /// already produces a self-contained Markdown body, dropping the
+  /// template lets the full payload reach the form verbatim.
   static Uri buildIssueUrl(ErrorReportPayload p) {
     final base = Uri.parse('${AppConstants.githubRepoUrl}/issues/new');
     return base.replace(queryParameters: <String, String>{
-      'template': _template,
       'labels': _labels,
       'title': buildTitle(p),
       'body': buildBody(p),

--- a/test/core/error_reporting/error_report_formatter_test.dart
+++ b/test/core/error_reporting/error_report_formatter_test.dart
@@ -143,7 +143,7 @@ void main() {
       expect(url.path, endsWith('/issues/new'));
     });
 
-    test('passes title, body, labels, and template as query params', () {
+    test('passes title, body, and labels as query params', () {
       final url = ErrorReportFormatter.buildIssueUrl(
         _payload(
           sourceLabel: 'CMA Fuel Finder',
@@ -151,13 +151,50 @@ void main() {
           errorType: 'ApiException',
         ),
       );
-      expect(url.queryParameters['template'], 'bug_report.yml');
       expect(url.queryParameters['labels'], 'type/bug,needs-triage');
       expect(
         url.queryParameters['title'],
         'bug: CMA Fuel Finder — ApiException (HTTP 404)',
       );
       expect(url.queryParameters['body'], contains('## What happened'));
+    });
+
+    test('does NOT set a template query param (#506)', () {
+      // GitHub ignores ?body= whenever ?template= is present, so the
+      // reporter must never pass a template — otherwise the rich body
+      // built by buildBody silently never reaches the issue form.
+      final url = ErrorReportFormatter.buildIssueUrl(_payload());
+      expect(url.queryParameters.containsKey('template'), isFalse);
+    });
+
+    test('body query param matches buildBody output verbatim (#506)', () {
+      final payload = _payload(
+        sourceLabel: 'CMA Fuel Finder',
+        statusCode: 404,
+        errorType: 'ApiException',
+      );
+      final url = ErrorReportFormatter.buildIssueUrl(payload);
+      expect(
+        url.queryParameters['body'],
+        ErrorReportFormatter.buildBody(payload),
+      );
+    });
+
+    test('body query param is non-trivially populated (#506)', () {
+      // Regression guard: if a future refactor drops body again, this
+      // test will fire before the bug reaches users.
+      final url = ErrorReportFormatter.buildIssueUrl(
+        _payload(
+          sourceLabel: 'CMA Fuel Finder',
+          statusCode: 404,
+          errorMessage: 'Upstream 404',
+        ),
+      );
+      final body = url.queryParameters['body']!;
+      expect(body.length, greaterThan(200));
+      expect(body, contains('## What happened'));
+      expect(body, contains('## Environment'));
+      expect(body, contains('App version'));
     });
 
     test('url-encodes the title and body safely', () {


### PR DESCRIPTION
## Summary
- Dropping `?template=bug_report.yml` from the issue-new URL so GitHub honors the `body=` query param we were already building. In template mode, GitHub silently ignores the generic body and only prefills fields whose query keys match the template's `id:`s (`description`, `steps`, `expected`), which is why every filed report was showing up blank in the form.
- `labels=type/bug,needs-triage` still flows through, so triage is unaffected.
- Three new regression tests in `error_report_formatter_test.dart`: no `template` param is set, `body` matches `buildBody` output verbatim, and `body` is non-trivially populated (>200 chars).

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero warnings/errors
- [x] `flutter test` — all tests pass (3612 passed, 1 skipped)
- [ ] Manual: trigger an error on device, tap Report, verify the GitHub form arrives with the What happened? body pre-filled

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)