### PR TITLE
feat(report): gate price/status reports to DE, route name/address to GitHub

### DIFF
--- a/lib/features/report/presentation/screens/report_screen.dart
+++ b/lib/features/report/presentation/screens/report_screen.dart
@@ -3,6 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/error/exceptions.dart';
+import '../../../../core/error_reporting/error_report_payload.dart';
+import '../../../../core/error_reporting/error_reporter.dart';
+import '../../../../core/error_reporting/error_reporter_context.dart';
 import '../../../../core/services/report_service.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/supabase_client.dart';
@@ -48,9 +51,20 @@ enum ReportType {
 
   /// True when this report type is a free-text metadata correction
   /// (new station name, new address). Takes a text input instead of
-  /// a price input, and submits to TankSync only (Tankerkoenig has
-  /// no endpoint for metadata corrections).
+  /// a price input.
+  ///
+  /// Since #508 these also route to GitHub instead of TankSync —
+  /// wrong metadata is almost always an implementation bug (the API
+  /// returned the wrong field, or our parser mapped it wrong), not
+  /// something a user correction can fix downstream.
   bool get needsText => this == wrongName || this == wrongAddress;
+
+  /// True when this report type files a GitHub issue instead of hitting
+  /// a community-report backend. Station name and address corrections
+  /// are always implementation bugs — shipping them as community edits
+  /// just hides the upstream issue, so we route the user to the
+  /// pre-filled GitHub issue flow built in #500 instead.
+  bool get routesToGitHub => this == wrongName || this == wrongAddress;
 
   /// True when this report type can be submitted to the Tankerkoenig
   /// complaint endpoint. The endpoint supports the original 5 types
@@ -92,6 +106,21 @@ enum ReportType {
     }
   }
 
+  /// Returns the report types that should be visible on the report
+  /// screen for a given country.
+  ///
+  /// - Germany: all 10 types (Tankerkoenig community report covers
+  ///   prices and open/closed status; name/address still route to
+  ///   GitHub because they're implementation bugs).
+  /// - Everywhere else: only the 2 GitHub-routed types. The first 8
+  ///   (price + status) have no meaningful backend outside DE —
+  ///   Tankerkoenig is DE-only, and community price corrections don't
+  ///   feed back into the source-of-truth country APIs.
+  static List<ReportType> visibleForCountry(String countryCode) {
+    if (countryCode == 'DE') return ReportType.values;
+    return const [ReportType.wrongName, ReportType.wrongAddress];
+  }
+
   /// Localized display name for this report type.
   String displayName(AppLocalizations? l10n) {
     switch (this) {
@@ -126,7 +155,17 @@ enum ReportType {
 /// the price text controller is owned locally for lifecycle reasons.
 class ReportScreen extends ConsumerStatefulWidget {
   final String stationId;
-  const ReportScreen({super.key, required this.stationId});
+
+  /// Reporter used for GitHub-routed report types (see #508). Defaults
+  /// to a real [ErrorReporter] that launches the browser after the
+  /// user confirms the consent dialog. Tests inject a fake.
+  final ErrorReporter? reporter;
+
+  const ReportScreen({
+    super.key,
+    required this.stationId,
+    this.reporter,
+  });
 
   @override
   ConsumerState<ReportScreen> createState() => _ReportScreenState();
@@ -191,6 +230,40 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
 
     notifier.setSubmitting(true);
     try {
+      // #508 — name / address errors are implementation bugs, not
+      // community data corrections. Route them to a pre-filled GitHub
+      // issue instead of the Tankerkoenig / TankSync backends.
+      if (selectedType.routesToGitHub) {
+        final country = ref.read(activeCountryProvider);
+        final correction = _textController.text.trim();
+        final payload = ErrorReportPayload(
+          errorType: 'WrongMetadataReport',
+          errorMessage:
+              '${selectedType.fuelTypeColumnValue} reported wrong for '
+                  'station ${widget.stationId}: "$correction"',
+          sourceLabel: country.apiProvider ?? country.name,
+          countryCode: country.code,
+          appVersion: ErrorReporterContext.currentAppVersion(),
+          platform: ErrorReporterContext.currentPlatform(),
+          locale: ErrorReporterContext.currentLocale(context),
+          capturedAt: DateTime.now(),
+        );
+        final launched = await (widget.reporter ?? const ErrorReporter())
+            .reportError(context, payload);
+        if (mounted && launched) {
+          SnackBarHelper.showSuccess(
+            context,
+            l10n?.reportSent ?? 'Report sent. Thank you!',
+          );
+          // Use Navigator.maybePop so the path works both under the
+          // real GoRouter shell and under the plain MaterialApp that
+          // widget tests use — context.pop() would throw
+          // \`No GoRouter found in context\` in tests.
+          await Navigator.of(context).maybePop();
+        }
+        return;
+      }
+
       final apiKeys = ref.read(apiKeyStorageProvider);
       final apiKey = apiKeys.getApiKey();
       final price = selectedType.needsPrice
@@ -310,6 +383,17 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
         TankSyncClient.isConnected && syncConfig.userId != null;
     final hasAnyBackend = canSubmitTankerkoenig || canSubmitTankSync;
 
+    // #508 — GitHub-routed types (wrongName / wrongAddress) need no
+    // backend at all — the reporter opens the consent dialog and hands
+    // off to the browser. So the radio row and submit button are
+    // always usable when such a type is selected, regardless of
+    // Tankerkoenig / TankSync availability.
+    final visibleTypes = ReportType.visibleForCountry(country.code);
+    final allVisibleRouteToGitHub =
+        visibleTypes.every((t) => t.routesToGitHub);
+    final selectedIsGitHubRouted =
+        selectedType != null && selectedType.routesToGitHub;
+
     return Scaffold(
       appBar: AppBar(
         // #484 — was "Signaler un prix" but two of the existing options
@@ -330,7 +414,11 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
           // #484 — banner telling the user that no reporting backend is
           // available for their country/config. Previously the form
           // accepted their input and silently failed on submit.
-          if (!hasAnyBackend) ...[
+          //
+          // #508 — hide the banner when the user only sees GitHub-routed
+          // types (non-DE case), because there's nothing to configure
+          // and the form still works.
+          if (!hasAnyBackend && !allVisibleRouteToGitHub) ...[
             Container(
               key: const ValueKey('report-no-backend-banner'),
               padding: const EdgeInsets.all(12),
@@ -366,12 +454,15 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
             style: theme.textTheme.titleMedium,
           ),
           const SizedBox(height: 12),
-          ...ReportType.values.map(
+          ...visibleTypes.map(
             (type) => RadioListTile<ReportType>(
               value: type,
               groupValue: selectedType,
               title: Text(type.displayName(l10n)),
-              onChanged: hasAnyBackend
+              // #508 — GitHub-routed types are always selectable. The
+              // legacy price/status types remain gated on an available
+              // Tankerkoenig/TankSync backend.
+              onChanged: (type.routesToGitHub || hasAnyBackend)
                   ? (v) => ref
                       .read(reportFormControllerProvider.notifier)
                       .selectType(v)
@@ -408,10 +499,10 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
           ],
           const SizedBox(height: 24),
           FilledButton(
-            onPressed: hasAnyBackend &&
-                    selectedType != null &&
+            onPressed: selectedType != null &&
                     !form.isSubmitting &&
-                    _hasRequiredInput(selectedType)
+                    _hasRequiredInput(selectedType) &&
+                    (selectedIsGitHubRouted || hasAnyBackend)
                 ? _submit
                 : null,
             child: form.isSubmitting

--- a/test/features/report/presentation/screens/report_screen_test.dart
+++ b/test/features/report/presentation/screens/report_screen_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/error_reporting/error_report_payload.dart';
+import 'package:tankstellen/core/error_reporting/error_reporter.dart';
 import 'package:tankstellen/features/report/presentation/screens/report_screen.dart';
 
 import '../../../../helpers/mock_providers.dart';
@@ -92,7 +94,8 @@ void main() {
   group('ReportScreen country gating (regression #484)', () {
     testWidgets(
         'DE without Tankerkoenig key and without TankSync → no-backend '
-        'banner shown, submit button disabled, radios disabled',
+        'banner shown; price/status radios disabled but name/address '
+        '(GitHub-routed, #508) stay enabled',
         (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -104,35 +107,61 @@ void main() {
         overrides: test.overrides,
       );
 
-      // Banner is present.
+      // Banner is present — price/status reports still need a backend
+      // in DE, so when neither Tankerkoenig nor TankSync is configured
+      // we surface the banner so the user knows to configure one.
       expect(
         find.byKey(const ValueKey('report-no-backend-banner')),
         findsOneWidget,
       );
 
-      // Scroll the button into view (#484 — 10 radios push it below fold).
-      await tester.scrollUntilVisible(
-        find.byType(FilledButton),
-        120,
-        scrollable: find.byType(Scrollable).first,
-      );
-      // Submit button is disabled.
+      // Walk every radio we can find as we scroll: GitHub-routed types
+      // (wrongName, wrongAddress) must be enabled even without a
+      // backend; everything else must be disabled.
+      //
+      // `true`  → enabled (onChanged != null)
+      // `false` → disabled (onChanged == null)
+      //
+      // Start at the top of the list, then drag DOWN so lazy items
+      // below the fold get built into the tree.
+      final seen = <ReportType, bool>{};
+      final scrollable = find.byType(Scrollable).first;
+      for (var i = 0;
+          i < 20 && seen.length < ReportType.values.length;
+          i++) {
+        for (final radio in tester.widgetList<RadioListTile<ReportType>>(
+            find.byType(RadioListTile<ReportType>))) {
+          seen.putIfAbsent(radio.value, () => radio.onChanged != null);
+        }
+        if (seen.length == ReportType.values.length) break;
+        await tester.drag(scrollable, const Offset(0, -200));
+        await tester.pump();
+      }
+
+      // Now the list is scrolled to (or past) the bottom — the submit
+      // button should be in view. It must be disabled because no
+      // report type is selected yet.
       final button = tester.widget<FilledButton>(find.byType(FilledButton));
       expect(button.onPressed, isNull);
 
-      // Every radio option has a null onChanged (disabled).
-      for (final radio in tester
-          .widgetList<RadioListTile<ReportType>>(
-              find.byType(RadioListTile<ReportType>))) {
-        expect(radio.onChanged, isNull,
-            reason:
-                'radios must be disabled when no backend is available');
+      for (final type in ReportType.values) {
+        expect(seen.containsKey(type), isTrue,
+            reason: '$type must be rendered in DE even without a backend');
+        if (type.routesToGitHub) {
+          expect(seen[type], isTrue,
+              reason:
+                  '$type is GitHub-routed and must stay enabled (#508)');
+        } else {
+          expect(seen[type], isFalse,
+              reason:
+                  '$type needs a backend and must be disabled here');
+        }
       }
     });
 
     testWidgets(
-        'FR without TankSync → no-backend banner shown (Tankerkoenig '
-        'path is DE-only, so non-DE users MUST have TankSync)',
+        'FR without TankSync → no banner, only wrongName + wrongAddress '
+        'visible, both enabled (#508)',
         (tester) async {
       final test = standardTestOverrides(country: Countries.france);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -143,17 +172,35 @@ void main() {
         const ReportScreen(stationId: 'test-station-1'),
         overrides: test.overrides,
       );
+      await tester.pumpAndSettle();
 
+      // Outside DE, only GitHub-routed types are visible — nothing
+      // needs configuring, so the banner must NOT appear.
       expect(
         find.byKey(const ValueKey('report-no-backend-banner')),
-        findsOneWidget,
+        findsNothing,
       );
+
+      // Exactly two radios, both GitHub-routed, both enabled.
+      final radios = tester
+          .widgetList<RadioListTile<ReportType>>(
+              find.byType(RadioListTile<ReportType>))
+          .toList();
+      expect(radios, hasLength(2));
+      expect(
+        radios.map((r) => r.value).toList(),
+        equals([ReportType.wrongName, ReportType.wrongAddress]),
+      );
+      for (final r in radios) {
+        expect(r.onChanged, isNotNull,
+            reason: 'GitHub-routed radios must be enabled regardless of '
+                'backend availability');
+      }
     });
 
     testWidgets(
-        'FR with TankSync key but no Tankerkoenig key still falls into the '
-        'no-backend case when the sync provider reports as disconnected '
-        '(standardTestOverrides uses _DisabledSyncState by default)',
+        'FR with no sync — submit button enables when wrongAddress is '
+        'selected and text is entered, even without any backend (#508)',
         (tester) async {
       final test = standardTestOverrides(country: Countries.france);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -164,15 +211,25 @@ void main() {
         const ReportScreen(stationId: 'test-station-1'),
         overrides: test.overrides,
       );
+      await tester.pumpAndSettle();
 
-      // The default sync state in the test helper is _DisabledSyncState
-      // (userId is null), so TankSync is effectively not connected.
-      // This mirrors the real-world scenario where French users without
-      // TankSync configured previously got a silent failure.
-      expect(
-        find.byKey(const ValueKey('report-no-backend-banner')),
-        findsOneWidget,
+      // Select wrongAddress
+      await tester.tap(find.text('Adresse incorrecte'));
+      await tester.pumpAndSettle();
+
+      // Button still disabled without text.
+      var button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNull);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('report-correction-text-field')),
+        '42 rue de la République, 34310 Montagnac',
       );
+      await tester.pumpAndSettle();
+
+      button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNotNull,
+          reason: 'GitHub-routed reports must work without a backend');
     });
 
     testWidgets(
@@ -340,6 +397,182 @@ void main() {
     });
   });
 
+  group('ReportScreen country-gated visibility (#508)', () {
+    testWidgets(
+        'DE — all 10 report types are rendered', (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(true);
+      when(() => test.mockStorage.getApiKey())
+          .thenReturn('11111111-2222-3333-4444-555555555555');
+
+      await pumpApp(
+        tester,
+        const ReportScreen(stationId: 'test-station-1'),
+        overrides: test.overrides,
+      );
+      await tester.pumpAndSettle();
+
+      final seen = <ReportType>{};
+      final scrollable = find.byType(Scrollable).first;
+      for (var i = 0;
+          i < 20 && seen.length < ReportType.values.length;
+          i++) {
+        for (final radio in tester.widgetList<RadioListTile<ReportType>>(
+            find.byType(RadioListTile<ReportType>))) {
+          seen.add(radio.value);
+        }
+        await tester.drag(scrollable, const Offset(0, -200));
+        await tester.pump();
+      }
+      expect(seen, equals(ReportType.values.toSet()));
+    });
+
+    testWidgets('FR — only wrongName + wrongAddress are rendered',
+        (tester) async {
+      final test = standardTestOverrides(country: Countries.france);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getApiKey()).thenReturn(null);
+
+      await pumpApp(
+        tester,
+        const ReportScreen(stationId: 'test-station-1'),
+        overrides: test.overrides,
+      );
+      await tester.pumpAndSettle();
+
+      final values = tester
+          .widgetList<RadioListTile<ReportType>>(
+              find.byType(RadioListTile<ReportType>))
+          .map((r) => r.value)
+          .toList();
+      expect(
+        values,
+        equals(const [ReportType.wrongName, ReportType.wrongAddress]),
+      );
+    });
+
+    test('visibleForCountry returns all types for DE, last 2 for FR/GB', () {
+      expect(
+        ReportType.visibleForCountry('DE'),
+        equals(ReportType.values),
+      );
+      expect(
+        ReportType.visibleForCountry('FR'),
+        equals(const [ReportType.wrongName, ReportType.wrongAddress]),
+      );
+      expect(
+        ReportType.visibleForCountry('GB'),
+        equals(const [ReportType.wrongName, ReportType.wrongAddress]),
+      );
+    });
+
+    test('routesToGitHub covers exactly wrongName + wrongAddress', () {
+      for (final t in ReportType.values) {
+        expect(t.routesToGitHub, t == ReportType.wrongName || t == ReportType.wrongAddress,
+            reason: '$t routesToGitHub is wrong');
+      }
+    });
+  });
+
+  group('ReportScreen GitHub routing (#508)', () {
+    testWidgets(
+        'wrongAddress on FR hands off to ErrorReporter with populated payload',
+        (tester) async {
+      ErrorReportPayload? captured;
+      final reporter = ErrorReporter(launcher: (uri) async => true);
+
+      final test = standardTestOverrides(country: Countries.france);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getApiKey()).thenReturn(null);
+
+      // A wrapped reporter that records the payload on reportError and
+      // then delegates (with consent skipped) to the real one.
+      final recording = _RecordingReporter((p) => captured = p);
+
+      await pumpApp(
+        tester,
+        ReportScreen(
+          stationId: 'station-42',
+          reporter: recording,
+        ),
+        overrides: test.overrides,
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Adresse incorrecte'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('report-correction-text-field')),
+        '42 rue de la République',
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(FilledButton));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull, reason: 'reporter must be invoked');
+      expect(captured!.countryCode, 'FR');
+      expect(captured!.errorType, 'WrongMetadataReport');
+      expect(captured!.errorMessage, contains('station-42'));
+      expect(captured!.errorMessage, contains('42 rue de la République'));
+      expect(captured!.sourceLabel, isNotNull);
+
+      // Silence the unused-field lint on `reporter`.
+      expect(reporter, isA<ErrorReporter>());
+    });
+
+    testWidgets(
+        'wrongName on DE still routes to GitHub (not to Tankerkoenig)',
+        (tester) async {
+      ErrorReportPayload? captured;
+      final recording = _RecordingReporter((p) => captured = p);
+
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(true);
+      when(() => test.mockStorage.getApiKey())
+          .thenReturn('11111111-2222-3333-4444-555555555555');
+
+      await pumpApp(
+        tester,
+        ReportScreen(
+          stationId: 'station-99',
+          reporter: recording,
+        ),
+        overrides: test.overrides,
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text('Nom de la station incorrect'),
+        120,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.tap(find.text('Nom de la station incorrect'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('report-correction-text-field')),
+        'Shell Castelnau',
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.byType(FilledButton),
+        120,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.tap(find.byType(FilledButton));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.countryCode, 'DE');
+      expect(captured!.errorType, 'WrongMetadataReport');
+      expect(captured!.errorMessage, contains('station-99'));
+      expect(captured!.errorMessage, contains('Shell Castelnau'));
+    });
+  });
+
   group('ReportType enum (#484)', () {
     test('fuelTypeColumnValue returns the DB-facing identifier', () {
       expect(ReportType.wrongE5.fuelTypeColumnValue, 'e5');
@@ -383,4 +616,26 @@ void main() {
       }
     });
   });
+}
+
+/// Test double that extends [ErrorReporter] and short-circuits
+/// `reportError` to record the payload — skipping both the consent
+/// dialog and the real browser launcher.
+class _RecordingReporter extends ErrorReporter {
+  _RecordingReporter(this.onReport)
+      : super(launcher: _noopLauncher);
+
+  final void Function(ErrorReportPayload) onReport;
+
+  static Future<bool> _noopLauncher(Uri _) async => true;
+
+  @override
+  Future<bool> reportError(
+    BuildContext context,
+    ErrorReportPayload payload, {
+    bool requireConsent = true,
+  }) async {
+    onReport(payload);
+    return true;
+  }
 }


### PR DESCRIPTION
## Summary
- Non-DE users now see only the **last 2** report types (\`wrongName\`, \`wrongAddress\`). The first 8 (prices, open/closed status) were meaningless outside Germany because Tankerkoenig is DE-only and community price corrections don't flow back into the source-of-truth country APIs.
- \`wrongName\` and \`wrongAddress\` **always** route to a GitHub issue via the \`#500\` \`ErrorReporter\`, regardless of country (including DE). Wrong station metadata is almost always an implementation bug in how we read the upstream response.
- The \"no reporting backend configured\" banner is hidden for non-DE users because there's nothing to configure.
- New \`ReportType.visibleForCountry\` + \`ReportType.routesToGitHub\` as the single source of truth.
- \`ReportScreen\` now takes an optional \`ErrorReporter\` for test injection (mirrors the pattern from \`#500\` \`ServiceChainErrorWidget\`).

## Test plan
- [x] DE renders all 10 radios (regression of existing test).
- [x] FR renders exactly 2 radios and they're \`wrongName\` + \`wrongAddress\` in the right order.
- [x] DE without any backend keeps \`wrongName\`/\`wrongAddress\` enabled while disabling price/status radios (new assertion).
- [x] FR can submit \`wrongAddress\` without any backend configured.
- [x] Tapping \"Envoyer\" hands the reporter a payload carrying \`countryCode\`, \`errorType\`, station id, and correction text (verified via a \`_RecordingReporter\` subclass).
- [x] Two pre-existing #484 tests updated to reflect the new non-DE behaviour.
- [x] \`flutter analyze --no-fatal-infos\` — zero warnings/errors
- [x] \`flutter test\` — 3618 passing, 1 skipped

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)