### PR TITLE
fix(pt): switch DGEG to PesquisarPostos

### DIFF
--- a/lib/core/services/impl/portugal_station_service.dart
+++ b/lib/core/services/impl/portugal_station_service.dart
@@ -12,19 +12,79 @@ import '../mixins/station_service_helpers.dart';
 
 /// DGEG (Direção-Geral de Energia e Geologia) Portuguese fuel price service.
 ///
-/// Uses Portugal's open data portal for fuel station prices.
-/// Free, no API key required. Data updated daily by DGEG.
+/// Uses DGEG's `PesquisarPostos` endpoint, which returns one row per
+/// (station, fuel type) combination with the station's coordinates,
+/// address and fuel price already populated. The sibling
+/// `ListarDadosPostos` endpoint used by the previous implementation
+/// returned a station *index* with almost every meaningful field set
+/// to `null` (no coordinates, no prices, no address) — that's why
+/// Portugal search silently produced zero stations on 4.3.0 (see #503).
 ///
 /// API: https://precoscombustiveis.dgeg.gov.pt/api/PrecoComb/PesquisarPostos
-/// Station detail: https://precoscombustiveis.dgeg.gov.pt/api/PrecoComb/GetDadosPosto?id={id}
-/// No API key required. Reverse-engineered from the DGEG portal.
-class PortugalStationService with StationServiceHelpers implements StationService {
-  final Dio _dio = DioFactory.create(
-    connectTimeout: const Duration(seconds: 15),
-    receiveTimeout: const Duration(seconds: 30),
-  );
+/// No API key, no auth. Reverse-engineered from the DGEG portal.
+///
+/// Response shape (one row per station-fuel):
+/// ```json
+/// {
+///   "status": true,
+///   "mensagem": "sucesso",
+///   "resultado": [
+///     {
+///       "Id": 67360,
+///       "Nome": "INTERMARCHE VILAR FORMOSO",
+///       "Marca": "INTERMARCHÉ",
+///       "Morada": "Sitio da Represa",
+///       "CodPostal": "6355-289",
+///       "Localidade": "Vilar Formoso",
+///       "Municipio": "Almeida",
+///       "Distrito": "Guarda",
+///       "Latitude": 40.61817,
+///       "Longitude": -6.84339,
+///       "Combustivel": "Gasolina simples 95",
+///       "Preco": "1,719 €",
+///       "DataAtualizacao": "2026-04-14 08:00",
+///       "Quantidade": 3111
+///     },
+///     ...
+///   ]
+/// }
+/// ```
+///
+/// Prices are Portuguese-formatted decimals (`"1,719 €"`). The parser
+/// strips the euro sign and swaps the comma decimal separator for a
+/// dot before parsing. Stations are merged across fuel-type rows by
+/// `Id` so a single [Station] carries all known prices.
+class PortugalStationService
+    with StationServiceHelpers
+    implements StationService {
+  final Dio _dio;
+  final String _baseUrl;
+  final String _fuelTypeIds;
 
-  static const _baseUrl = 'https://precoscombustiveis.dgeg.gov.pt/api/PrecoComb';
+  PortugalStationService({
+    Dio? dio,
+    String baseUrl = 'https://precoscombustiveis.dgeg.gov.pt/api/PrecoComb',
+    String fuelTypeIds = defaultFuelTypeIds,
+  })  : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 15),
+              receiveTimeout: const Duration(seconds: 30),
+            ),
+        _baseUrl = baseUrl,
+        _fuelTypeIds = fuelTypeIds;
+
+  /// DGEG fuel type IDs we query — 95-octane petrol simples + gasóleo
+  /// (diesel) simples. Covers the two dominant fuels used by the app's
+  /// search UI.
+  ///
+  /// - `3201` → Gasolina simples 95
+  /// - `2101` → Gasóleo simples
+  ///
+  /// Other IDs exist (e.g. 3205 = Gasolina especial 95, 2105 = Gasóleo
+  /// especial, and various LPG/98/E85 variants) and can be added later
+  /// without changing the service's public shape — [_mergeInto] already
+  /// dispatches on the `Combustivel` label, not on the ID.
+  static const String defaultFuelTypeIds = '3201,2101';
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(
@@ -32,16 +92,15 @@ class PortugalStationService with StationServiceHelpers implements StationServic
     CancelToken? cancelToken,
   }) async {
     try {
-      // DGEG provides a bulk dataset — fetch all stations and filter by distance
-      final response = await _dio.get(
-        '$_baseUrl/ListarDadosPostos',
+      final response = await _dio.get<dynamic>(
+        '$_baseUrl/PesquisarPostos',
         queryParameters: {
-          'idsTiposComb': '', // All fuel types
+          'idsTiposComb': _fuelTypeIds,
           'idMarca': '',
           'idTipoPosto': '',
           'idDistrito': '',
           'idsMunicipios': '',
-          'qtdPorPagina': 5000,
+          'qtdPorPagina': 10000,
           'pagina': 1,
         },
         cancelToken: cancelToken,
@@ -49,61 +108,26 @@ class PortugalStationService with StationServiceHelpers implements StationServic
 
       final data = response.data;
       if (data is! Map<String, dynamic>) {
-        throw const ApiException(message: 'Invalid DGEG response');
+        throw const ApiException(
+          message: 'Invalid DGEG response (not an object)',
+        );
+      }
+      final resultado = data['resultado'];
+      if (resultado is! List) {
+        throw const ApiException(
+          message: 'Invalid DGEG response (resultado is not a list)',
+        );
       }
 
-      final resultado = data['resultado'] as List<dynamic>? ?? [];
-      final stations = <Station>[];
-
-      for (final item in resultado) {
-        try {
-          final lat = double.tryParse(item['Latitude']?.toString() ?? '');
-          final lng = double.tryParse(item['Longitude']?.toString() ?? '');
-          if (lat == null || lng == null) continue;
-
-          final dist = distanceKm(params.lat, params.lng, lat, lng);
-          if (dist > params.radiusKm) continue;
-
-          // Parse prices from combustiveis array
-          final combustiveis = item['Combustiveis'] as List<dynamic>? ?? [];
-          double? gasolina95, gasolina98, gasoleo, gpl;
-          for (final c in combustiveis) {
-            final tipo = c['DescritivoCombustivel']?.toString() ?? '';
-            final preco = double.tryParse(c['Preco']?.toString() ?? '');
-            if (tipo.contains('95')) gasolina95 = preco;
-            if (tipo.contains('98')) gasolina98 = preco;
-            if (tipo.contains('asóleo') || tipo.contains('Diesel')) gasoleo = preco;
-            if (tipo.contains('GPL')) gpl = preco;
-          }
-
-          stations.add(Station(
-            id: 'pt-${item['Id'] ?? item['CodPosto'] ?? stations.length}',
-            name: item['Nome']?.toString() ?? '',
-            brand: item['Marca']?.toString() ?? '',
-            street: item['Morada']?.toString() ?? '',
-            postCode: item['CodPostal']?.toString() ?? '',
-            place: item['Localidade']?.toString() ?? '',
-            lat: lat,
-            lng: lng,
-            dist: dist,
-            e5: gasolina95,
-            e10: gasolina95, // Portugal uses 95 as standard
-            e98: gasolina98,
-            diesel: gasoleo,
-            lpg: gpl,
-            isOpen: true,
-          ));
-        } catch (e) {
-          debugPrint('PT station parse failed: $e');
-          continue;
-        }
-      }
-
-      // Sort by distance
-      stations.sort((a, b) => a.dist.compareTo(b.dist));
+      final stations = parseAndFilter(
+        resultado,
+        lat: params.lat,
+        lng: params.lng,
+        radiusKm: params.radiusKm,
+      );
 
       return ServiceResult(
-        data: stations.take(50).toList(),
+        data: stations,
         source: ServiceSource.portugalApi,
         fetchedAt: DateTime.now(),
       );
@@ -112,13 +136,165 @@ class PortugalStationService with StationServiceHelpers implements StationServic
     }
   }
 
-  @override
-  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) async {
-    throw const ApiException(message: 'Station detail not supported for Portugal');
+  /// Groups [resultado] rows by station `Id`, attaches fuel prices,
+  /// filters by [radiusKm] from ([lat], [lng]), sorts by distance and
+  /// returns the nearest 50 stations.
+  ///
+  /// Exposed for unit tests — the HTTP layer is fake-adapter-driven
+  /// in the tests, but the parser is the interesting surface to pin
+  /// behaviour on (comma-decimal prices, missing coordinates, fuel
+  /// merging, radius filter, empty-never-silent).
+  @visibleForTesting
+  static List<Station> parseAndFilter(
+    List<dynamic> resultado, {
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) {
+    final byId = <int, _MergedRow>{};
+
+    for (final item in resultado) {
+      if (item is! Map) continue;
+      try {
+        final id = (item['Id'] as num?)?.toInt();
+        final itemLat = (item['Latitude'] as num?)?.toDouble();
+        final itemLng = (item['Longitude'] as num?)?.toDouble();
+        if (id == null || itemLat == null || itemLng == null) continue;
+
+        final existing = byId[id];
+        final merged = existing ??
+            _MergedRow(
+              id: id,
+              name: item['Nome']?.toString() ?? '',
+              brand: item['Marca']?.toString() ?? '',
+              street: item['Morada']?.toString() ?? '',
+              postCode: item['CodPostal']?.toString() ?? '',
+              place: item['Localidade']?.toString() ??
+                  item['Municipio']?.toString() ??
+                  '',
+              lat: itemLat,
+              lng: itemLng,
+            );
+
+        final price = _parsePriceEur(item['Preco']);
+        final fuel = item['Combustivel']?.toString() ?? '';
+        merged.assignPrice(fuel, price);
+
+        byId[id] = merged;
+      } catch (e) {
+        debugPrint('PT station row parse failed: $e');
+        continue;
+      }
+    }
+
+    final stations = <Station>[];
+    for (final row in byId.values) {
+      final dist = distanceKm(lat, lng, row.lat, row.lng);
+      if (dist > radiusKm) continue;
+      stations.add(Station(
+        id: 'pt-${row.id}',
+        name: row.name,
+        brand: row.brand,
+        street: row.street,
+        postCode: row.postCode,
+        place: row.place,
+        lat: row.lat,
+        lng: row.lng,
+        dist: dist,
+        e5: row.gasolina95,
+        // Portugal reports 95 simples as the single "petrol" — mirror it
+        // into e10 so the UI shows something for E10-preferred users.
+        e10: row.gasolina95,
+        e98: row.gasolina98,
+        diesel: row.gasoleo,
+        lpg: row.gpl,
+        isOpen: true,
+      ));
+    }
+
+    stations.sort((a, b) => a.dist.compareTo(b.dist));
+    return stations.take(50).toList();
+  }
+
+  /// Parses a DGEG price string like `"1,719 €"` into a double.
+  /// Returns `null` when the value is missing or unparseable.
+  @visibleForTesting
+  static double? parsePriceForTest(dynamic value) => _parsePriceEur(value);
+
+  static double? _parsePriceEur(dynamic value) {
+    if (value == null) return null;
+    final raw = value.toString().trim();
+    if (raw.isEmpty) return null;
+    final cleaned = raw
+        .replaceAll('€', '')
+        .replaceAll(RegExp(r'\s+'), '')
+        .replaceAll(',', '.');
+    return double.tryParse(cleaned);
   }
 
   @override
-  Future<ServiceResult<Map<String, StationPrices>>> getPrices(List<String> ids) async {
-    return ServiceResult(data: {}, source: ServiceSource.portugalApi, fetchedAt: DateTime.now());
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String stationId,
+  ) async {
+    throw const ApiException(
+      message: 'Station detail not supported for Portugal',
+    );
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    return ServiceResult(
+      data: const {},
+      source: ServiceSource.portugalApi,
+      fetchedAt: DateTime.now(),
+    );
+  }
+}
+
+/// Mutable accumulator used while merging DGEG rows for the same
+/// station Id across fuel types.
+class _MergedRow {
+  final int id;
+  final String name;
+  final String brand;
+  final String street;
+  final String postCode;
+  final String place;
+  final double lat;
+  final double lng;
+
+  double? gasolina95;
+  double? gasolina98;
+  double? gasoleo;
+  double? gpl;
+
+  _MergedRow({
+    required this.id,
+    required this.name,
+    required this.brand,
+    required this.street,
+    required this.postCode,
+    required this.place,
+    required this.lat,
+    required this.lng,
+  });
+
+  void assignPrice(String fuelLabel, double? price) {
+    if (price == null) return;
+    final label = fuelLabel.toLowerCase();
+    // Order matters: check "98" before the generic "95" contains check.
+    if (label.contains('98')) {
+      gasolina98 = price;
+    } else if (label.contains('95')) {
+      gasolina95 = price;
+    } else if (label.contains('gasóleo') ||
+        label.contains('gasoleo') ||
+        label.contains('diesel')) {
+      gasoleo = price;
+    } else if (label.contains('gpl')) {
+      gpl = price;
+    }
   }
 }

--- a/test/core/services/impl/portugal_station_service_test.dart
+++ b/test/core/services/impl/portugal_station_service_test.dart
@@ -1,396 +1,429 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/services/impl/portugal_station_service.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
-import 'package:tankstellen/core/utils/geo_utils.dart';
-import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
 
-/// Tests for [PortugalStationService] and its DGEG JSON parsing logic.
-///
-/// The service instantiates Dio internally via `DioFactory.create()`, so we
-/// can't inject a mock HTTP client directly. Instead, we mirror the parsing
-/// logic in a testable helper (`_TestablePortugalParser`) that reproduces the
-/// exact transformation from DGEG JSON payload -> [Station], and cover the
-/// public surface (interface compliance, unsupported endpoints) on the real
-/// service.
+/// Fake HTTP adapter returning a canned DGEG payload.
+class _FakeDgegAdapter implements HttpClientAdapter {
+  _FakeDgegAdapter({required this.reply, this.statusCode = 200});
+
+  final Object reply;
+  final int statusCode;
+  final List<RequestOptions> calls = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    calls.add(options);
+    final body = reply is String ? reply as String : jsonEncode(reply);
+    return ResponseBody.fromString(
+      body,
+      statusCode,
+      headers: {
+        Headers.contentTypeHeader: ['application/json; charset=utf-8'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Dio _dioWith(_FakeDgegAdapter adapter) {
+  final dio = Dio();
+  dio.httpClientAdapter = adapter;
+  return dio;
+}
+
+PortugalStationService _serviceWith(_FakeDgegAdapter adapter) {
+  return PortugalStationService(
+    dio: _dioWith(adapter),
+    baseUrl: 'https://fake.dgeg/api/PrecoComb',
+  );
+}
+
+/// Shorthand for a DGEG row.
+Map<String, dynamic> _row({
+  required int id,
+  required String name,
+  required double lat,
+  required double lng,
+  required String fuel,
+  required String preco,
+  String brand = 'GALP',
+  String morada = 'Avenida da Liberdade 100',
+  String codPostal = '1250-146',
+  String localidade = 'Lisboa',
+}) {
+  return {
+    'Id': id,
+    'Nome': name,
+    'Marca': brand,
+    'Morada': morada,
+    'CodPostal': codPostal,
+    'Localidade': localidade,
+    'Municipio': 'Lisboa',
+    'Distrito': 'Lisboa',
+    'Latitude': lat,
+    'Longitude': lng,
+    'Combustivel': fuel,
+    'Preco': preco,
+    'DataAtualizacao': '2026-04-14 08:00',
+    'Quantidade': 6051,
+  };
+}
+
+const _lisboaParams = SearchParams(
+  lat: 38.7223,
+  lng: -9.1393,
+  radiusKm: 10,
+);
+
 void main() {
-  late PortugalStationService service;
-
-  setUp(() {
-    service = PortugalStationService();
-  });
-
   group('PortugalStationService (public surface)', () {
     test('implements StationService interface', () {
-      expect(service, isA<StationService>());
+      expect(PortugalStationService(), isA<StationService>());
     });
 
     test('getStationDetail throws ApiException', () {
       expect(
-        () => service.getStationDetail('pt-123'),
+        () => PortugalStationService().getStationDetail('pt-123'),
         throwsA(isA<Exception>()),
       );
     });
 
     test('getPrices returns empty map with correct source', () async {
-      final result = await service.getPrices(['pt-1', 'pt-2']);
+      final result = await PortugalStationService().getPrices(['pt-1']);
       expect(result.data, isEmpty);
       expect(result.source, ServiceSource.portugalApi);
-      expect(result.isStale, isFalse);
     });
 
-    test('getPrices returns empty map for empty id list', () async {
-      final result = await service.getPrices([]);
-      expect(result.data, isEmpty);
-      expect(result.source, ServiceSource.portugalApi);
+    test('defaultFuelTypeIds covers 95 simples + gasoleo simples', () {
+      expect(PortugalStationService.defaultFuelTypeIds, '3201,2101');
     });
   });
 
-  group('DGEG response parsing', () {
-    late _TestablePortugalParser parser;
-
-    setUp(() {
-      parser = _TestablePortugalParser();
-    });
-
-    test('parses a well-formed DGEG response with all fuel types', () {
-      final data = {
+  group('searchStations (PesquisarPostos — #503 fix)', () {
+    test('hits PesquisarPostos with the default fuel ids', () async {
+      final adapter = _FakeDgegAdapter(reply: {
+        'status': true,
+        'mensagem': 'sucesso',
         'resultado': [
-          {
-            'Id': 12345,
-            'CodPosto': 'P12345',
-            'Nome': 'GALP Lisboa Centro',
-            'Marca': 'GALP',
-            'Morada': 'Avenida da Liberdade 100',
-            'CodPostal': '1250-146',
-            'Localidade': 'Lisboa',
-            'Latitude': '38.7223',
-            'Longitude': '-9.1393',
-            'Combustiveis': [
-              {'DescritivoCombustivel': 'Gasolina 95', 'Preco': '1.789'},
-              {'DescritivoCombustivel': 'Gasolina 98', 'Preco': '1.899'},
-              {'DescritivoCombustivel': 'Gasóleo', 'Preco': '1.659'},
-              {'DescritivoCombustivel': 'GPL Auto', 'Preco': '0.899'},
-            ],
-          },
+          _row(
+            id: 1,
+            name: 'GALP Lisboa',
+            lat: 38.7223,
+            lng: -9.1393,
+            fuel: 'Gasolina simples 95',
+            preco: '1,719 €',
+          ),
         ],
-      };
+      });
+      final service = _serviceWith(adapter);
 
-      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 5);
+      await service.searchStations(_lisboaParams);
 
-      expect(stations, hasLength(1));
-      final s = stations.first;
-      expect(s.id, 'pt-12345');
-      expect(s.name, 'GALP Lisboa Centro');
-      expect(s.brand, 'GALP');
-      expect(s.street, 'Avenida da Liberdade 100');
-      expect(s.postCode, '1250-146');
-      expect(s.place, 'Lisboa');
-      expect(s.lat, closeTo(38.7223, 0.0001));
-      expect(s.lng, closeTo(-9.1393, 0.0001));
-      expect(s.e5, 1.789);
-      expect(s.e10, 1.789); // Portugal uses 95 as e10 as well
-      expect(s.e98, 1.899);
-      expect(s.diesel, 1.659);
-      expect(s.lpg, 0.899);
-      expect(s.isOpen, isTrue);
+      expect(adapter.calls, hasLength(1));
+      final call = adapter.calls.single;
+      expect(call.uri.path, endsWith('/PesquisarPostos'));
+      expect(call.uri.queryParameters['idsTiposComb'], '3201,2101');
+      expect(call.uri.queryParameters['pagina'], '1');
     });
 
-    test('skips stations outside the search radius', () {
-      final data = {
+    test('merges fuel prices across multiple rows for the same station',
+        () async {
+      final adapter = _FakeDgegAdapter(reply: {
+        'status': true,
+        'mensagem': 'sucesso',
         'resultado': [
+          _row(
+            id: 42,
+            name: 'GALP Lisboa',
+            lat: 38.7223,
+            lng: -9.1393,
+            fuel: 'Gasolina simples 95',
+            preco: '1,719 €',
+          ),
+          _row(
+            id: 42,
+            name: 'GALP Lisboa',
+            lat: 38.7223,
+            lng: -9.1393,
+            fuel: 'Gasóleo simples',
+            preco: '1,599 €',
+          ),
+        ],
+      });
+      final service = _serviceWith(adapter);
+
+      final result = await service.searchStations(_lisboaParams);
+      expect(result.data, hasLength(1));
+      final s = result.data.first;
+      expect(s.id, 'pt-42');
+      expect(s.e5, closeTo(1.719, 0.0001));
+      expect(s.e10, closeTo(1.719, 0.0001),
+          reason: 'PT 95 simples is mirrored into e10 for the UI');
+      expect(s.diesel, closeTo(1.599, 0.0001));
+    });
+
+    test('parses comma-decimal Portuguese prices (1,719 € -> 1.719)',
+        () async {
+      final adapter = _FakeDgegAdapter(reply: {
+        'resultado': [
+          _row(
+            id: 1,
+            name: 'X',
+            lat: 38.7223,
+            lng: -9.1393,
+            fuel: 'Gasolina simples 95',
+            preco: '1,899 €',
+          ),
+        ],
+      });
+      final result = await _serviceWith(adapter).searchStations(_lisboaParams);
+      expect(result.data.first.e5, closeTo(1.899, 0.0001));
+    });
+
+    test('filters stations outside the search radius', () async {
+      final adapter = _FakeDgegAdapter(reply: {
+        'resultado': [
+          _row(
+            id: 1,
+            name: 'Near',
+            lat: 38.7223,
+            lng: -9.1393,
+            fuel: 'Gasolina simples 95',
+            preco: '1,7 €',
+          ),
+          _row(
+            id: 2,
+            name: 'Porto',
+            lat: 41.1579, // ~280km from Lisbon
+            lng: -8.6291,
+            fuel: 'Gasolina simples 95',
+            preco: '1,8 €',
+          ),
+        ],
+      });
+      final result = await _serviceWith(adapter).searchStations(_lisboaParams);
+      expect(result.data, hasLength(1));
+      expect(result.data.first.name, 'Near');
+    });
+
+    test('returns an empty list (not an error) when the API reply '
+        'contains no stations inside the radius', () async {
+      final adapter = _FakeDgegAdapter(reply: {
+        'resultado': [
+          _row(
+            id: 1,
+            name: 'Far away',
+            lat: 41.1579,
+            lng: -8.6291,
+            fuel: 'Gasolina simples 95',
+            preco: '1,8 €',
+          ),
+        ],
+      });
+      final result = await _serviceWith(adapter).searchStations(_lisboaParams);
+      expect(result.data, isEmpty);
+      expect(result.source, ServiceSource.portugalApi);
+    });
+
+    test('throws ApiException on HTTP error (never silent)', () async {
+      final adapter = _FakeDgegAdapter(
+        reply: '<html>500</html>',
+        statusCode: 500,
+      );
+      expect(
+        () => _serviceWith(adapter).searchStations(_lisboaParams),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('throws when the response is not a JSON object', () async {
+      final adapter = _FakeDgegAdapter(reply: '[]');
+      expect(
+        () => _serviceWith(adapter).searchStations(_lisboaParams),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('throws when resultado is missing or not a list', () async {
+      final adapter = _FakeDgegAdapter(reply: {
+        'status': true,
+        'mensagem': 'sucesso',
+        // resultado absent
+      });
+      expect(
+        () => _serviceWith(adapter).searchStations(_lisboaParams),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+
+  group('parseAndFilter (exposed parser)', () {
+    test('skips rows missing Latitude / Longitude', () {
+      final stations = PortugalStationService.parseAndFilter(
+        [
           {
             'Id': 1,
+            'Nome': 'No coords',
+            'Combustivel': 'Gasolina simples 95',
+            'Preco': '1,7 €',
+          },
+          {
+            'Id': 2,
+            'Nome': 'Good',
+            'Latitude': 38.7223,
+            'Longitude': -9.1393,
+            'Combustivel': 'Gasolina simples 95',
+            'Preco': '1,7 €',
+          },
+        ],
+        lat: 38.7223,
+        lng: -9.1393,
+        radiusKm: 5,
+      );
+      expect(stations, hasLength(1));
+      expect(stations.first.name, 'Good');
+    });
+
+    test('sorts by distance ascending', () {
+      final stations = PortugalStationService.parseAndFilter(
+        [
+          {
+            'Id': 1,
+            'Nome': 'Far',
+            'Latitude': 38.7500,
+            'Longitude': -9.1393,
+            'Combustivel': 'Gasolina simples 95',
+            'Preco': '1,7 €',
+          },
+          {
+            'Id': 2,
             'Nome': 'Near',
-            'Marca': 'BP',
-            'Morada': '',
-            'CodPostal': '',
-            'Localidade': '',
-            'Latitude': '38.7223',
-            'Longitude': '-9.1393',
-            'Combustiveis': <dynamic>[],
-          },
-          {
-            'Id': 2,
-            'Nome': 'Far (Porto)',
-            'Marca': 'BP',
-            'Morada': '',
-            'CodPostal': '',
-            'Localidade': '',
-            'Latitude': '41.1579',
-            'Longitude': '-8.6291',
-            'Combustiveis': <dynamic>[],
+            'Latitude': 38.7230,
+            'Longitude': -9.1393,
+            'Combustivel': 'Gasolina simples 95',
+            'Preco': '1,7 €',
           },
         ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 50);
-
-      expect(stations, hasLength(1));
-      expect(stations.first.name, 'Near');
-    });
-
-    test('skips stations with unparseable coordinates', () {
-      final data = {
-        'resultado': [
-          {
-            'Id': 1,
-            'Nome': 'Bad coords',
-            'Marca': 'REPSOL',
-            'Morada': '',
-            'CodPostal': '',
-            'Localidade': '',
-            'Latitude': 'not-a-number',
-            'Longitude': 'nope',
-            'Combustiveis': <dynamic>[],
-          },
-          {
-            'Id': 2,
-            'Nome': 'Good coords',
-            'Marca': 'REPSOL',
-            'Morada': '',
-            'CodPostal': '',
-            'Localidade': '',
-            'Latitude': '38.7223',
-            'Longitude': '-9.1393',
-            'Combustiveis': <dynamic>[],
-          },
-        ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 5);
-
-      expect(stations, hasLength(1));
-      expect(stations.first.name, 'Good coords');
-    });
-
-    test('handles missing Combustiveis array gracefully', () {
-      final data = {
-        'resultado': [
-          {
-            'Id': 99,
-            'Nome': 'No prices',
-            'Marca': 'BP',
-            'Morada': 'Rua X',
-            'CodPostal': '1000-001',
-            'Localidade': 'Lisboa',
-            'Latitude': '38.7223',
-            'Longitude': '-9.1393',
-          },
-        ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 10);
-
-      expect(stations, hasLength(1));
-      final s = stations.first;
-      expect(s.e5, isNull);
-      expect(s.e10, isNull);
-      expect(s.e98, isNull);
-      expect(s.diesel, isNull);
-      expect(s.lpg, isNull);
-    });
-
-    test('falls back through Id -> CodPosto -> index for station id', () {
-      final data = {
-        'resultado': [
-          {
-            // No Id, no CodPosto — should fall back to index (0)
-            'Nome': 'Unnamed',
-            'Marca': '',
-            'Morada': '',
-            'CodPostal': '',
-            'Localidade': '',
-            'Latitude': '38.7223',
-            'Longitude': '-9.1393',
-            'Combustiveis': <dynamic>[],
-          },
-          {
-            'CodPosto': 'POST-42',
-            'Nome': 'With CodPosto',
-            'Marca': '',
-            'Morada': '',
-            'CodPostal': '',
-            'Localidade': '',
-            'Latitude': '38.7223',
-            'Longitude': '-9.1393',
-            'Combustiveis': <dynamic>[],
-          },
-        ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 10);
-
-      expect(stations, hasLength(2));
-      // Stations are sorted by distance; both share coords, so order is insertion
-      final ids = stations.map((s) => s.id).toSet();
-      expect(ids, contains('pt-0'));
-      expect(ids, contains('pt-POST-42'));
-    });
-
-    test('returns empty list for empty resultado', () {
-      final stations = parser.parseResponse(
-        {'resultado': <dynamic>[]},
-        lat: 38.7223,
-        lng: -9.1393,
-        radiusKm: 10,
-      );
-      expect(stations, isEmpty);
-    });
-
-    test('returns empty list when resultado key is missing', () {
-      final stations = parser.parseResponse(
-        <String, dynamic>{},
-        lat: 38.7223,
-        lng: -9.1393,
-        radiusKm: 10,
-      );
-      expect(stations, isEmpty);
-    });
-
-    test('caps result list at 50 stations', () {
-      final resultado = <Map<String, dynamic>>[];
-      for (var i = 0; i < 120; i++) {
-        resultado.add({
-          'Id': i,
-          'Nome': 'Station $i',
-          'Marca': 'BP',
-          'Morada': '',
-          'CodPostal': '',
-          'Localidade': '',
-          // Tiny offset to keep all within radius
-          'Latitude': (38.7223 + i * 0.0001).toString(),
-          'Longitude': '-9.1393',
-          'Combustiveis': <dynamic>[],
-        });
-      }
-
-      final stations = parser.parseResponse(
-        {'resultado': resultado},
         lat: 38.7223,
         lng: -9.1393,
         radiusKm: 50,
       );
-
-      expect(stations.length, lessThanOrEqualTo(50));
-    });
-
-    test('sorts stations by distance ascending', () {
-      final data = {
-        'resultado': [
-          {
-            'Id': 1,
-            'Nome': 'Far',
-            'Marca': '',
-            'Morada': '',
-            'CodPostal': '',
-            'Localidade': '',
-            'Latitude': '38.7500',
-            'Longitude': '-9.1393',
-            'Combustiveis': <dynamic>[],
-          },
-          {
-            'Id': 2,
-            'Nome': 'Near',
-            'Marca': '',
-            'Morada': '',
-            'CodPostal': '',
-            'Localidade': '',
-            'Latitude': '38.7230',
-            'Longitude': '-9.1393',
-            'Combustiveis': <dynamic>[],
-          },
-        ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 50);
-
-      expect(stations, hasLength(2));
       expect(stations.first.name, 'Near');
       expect(stations.last.name, 'Far');
     });
 
-    test('matches Diesel variant spelled "Diesel" as well as "Gasóleo"', () {
-      final data = {
-        'resultado': [
+    test('caps results at 50', () {
+      final rows = List.generate(
+        120,
+        (i) => {
+          'Id': i,
+          'Nome': 'S$i',
+          'Latitude': 38.7223 + i * 0.0001,
+          'Longitude': -9.1393,
+          'Combustivel': 'Gasolina simples 95',
+          'Preco': '1,7 €',
+        },
+      );
+      final stations = PortugalStationService.parseAndFilter(
+        rows,
+        lat: 38.7223,
+        lng: -9.1393,
+        radiusKm: 500,
+      );
+      expect(stations, hasLength(50));
+    });
+
+    test('fuel label dispatch: 98 before 95, gasóleo variants, GPL', () {
+      final stations = PortugalStationService.parseAndFilter(
+        [
           {
             'Id': 1,
-            'Nome': 'Diesel spelling',
-            'Marca': '',
-            'Morada': '',
-            'CodPostal': '',
-            'Localidade': '',
-            'Latitude': '38.7223',
-            'Longitude': '-9.1393',
-            'Combustiveis': [
-              {'DescritivoCombustivel': 'Diesel Premium', 'Preco': '1.712'},
-            ],
+            'Nome': 'All fuels',
+            'Latitude': 38.7223,
+            'Longitude': -9.1393,
+            'Combustivel': 'Gasolina simples 98',
+            'Preco': '1,899 €',
+          },
+          {
+            'Id': 1,
+            'Latitude': 38.7223,
+            'Longitude': -9.1393,
+            'Combustivel': 'Gasolina simples 95',
+            'Preco': '1,799 €',
+          },
+          {
+            'Id': 1,
+            'Latitude': 38.7223,
+            'Longitude': -9.1393,
+            'Combustivel': 'Gasóleo simples',
+            'Preco': '1,599 €',
+          },
+          {
+            'Id': 1,
+            'Latitude': 38.7223,
+            'Longitude': -9.1393,
+            'Combustivel': 'GPL Auto',
+            'Preco': '0,899 €',
           },
         ],
-      };
-
-      final stations = parser.parseResponse(data, lat: 38.7223, lng: -9.1393, radiusKm: 5);
-
-      expect(stations.first.diesel, 1.712);
+        lat: 38.7223,
+        lng: -9.1393,
+        radiusKm: 5,
+      );
+      expect(stations, hasLength(1));
+      final s = stations.first;
+      expect(s.e98, closeTo(1.899, 0.0001));
+      expect(s.e5, closeTo(1.799, 0.0001));
+      expect(s.diesel, closeTo(1.599, 0.0001));
+      expect(s.lpg, closeTo(0.899, 0.0001));
     });
   });
-}
 
-/// Mirror of [PortugalStationService]'s DGEG parsing logic so we can unit
-/// test the JSON -> Station mapping without HTTP.
-class _TestablePortugalParser {
-  List<Station> parseResponse(
-    Map<String, dynamic> data, {
-    required double lat,
-    required double lng,
-    required double radiusKm,
-  }) {
-    final resultado = data['resultado'] as List<dynamic>? ?? [];
-    final stations = <Station>[];
+  group('parsePriceForTest (comma-decimal)', () {
+    test('1,719 € -> 1.719', () {
+      expect(
+        PortugalStationService.parsePriceForTest('1,719 €'),
+        closeTo(1.719, 0.0001),
+      );
+    });
 
-    for (final item in resultado) {
-      try {
-        final itemLat = double.tryParse(item['Latitude']?.toString() ?? '');
-        final itemLng = double.tryParse(item['Longitude']?.toString() ?? '');
-        if (itemLat == null || itemLng == null) continue;
+    test('1.719 (already dot) -> 1.719', () {
+      expect(
+        PortugalStationService.parsePriceForTest('1.719'),
+        closeTo(1.719, 0.0001),
+      );
+    });
 
-        final dist = distanceKm(lat, lng, itemLat, itemLng);
-        if (dist > radiusKm) continue;
+    test('empty / whitespace / null -> null', () {
+      expect(PortugalStationService.parsePriceForTest(null), isNull);
+      expect(PortugalStationService.parsePriceForTest(''), isNull);
+      expect(PortugalStationService.parsePriceForTest('   '), isNull);
+    });
 
-        final combustiveis = item['Combustiveis'] as List<dynamic>? ?? [];
-        double? gasolina95, gasolina98, gasoleo, gpl;
-        for (final c in combustiveis) {
-          final tipo = c['DescritivoCombustivel']?.toString() ?? '';
-          final preco = double.tryParse(c['Preco']?.toString() ?? '');
-          if (tipo.contains('95')) gasolina95 = preco;
-          if (tipo.contains('98')) gasolina98 = preco;
-          if (tipo.contains('asóleo') || tipo.contains('Diesel')) gasoleo = preco;
-          if (tipo.contains('GPL')) gpl = preco;
-        }
+    test('non-numeric -> null', () {
+      expect(
+        PortugalStationService.parsePriceForTest('n.d.'),
+        isNull,
+      );
+    });
 
-        stations.add(Station(
-          id: 'pt-${item['Id'] ?? item['CodPosto'] ?? stations.length}',
-          name: item['Nome']?.toString() ?? '',
-          brand: item['Marca']?.toString() ?? '',
-          street: item['Morada']?.toString() ?? '',
-          postCode: item['CodPostal']?.toString() ?? '',
-          place: item['Localidade']?.toString() ?? '',
-          lat: itemLat,
-          lng: itemLng,
-          dist: dist,
-          e5: gasolina95,
-          e10: gasolina95,
-          e98: gasolina98,
-          diesel: gasoleo,
-          lpg: gpl,
-          isOpen: true,
-        ));
-      } catch (_) {
-        continue;
-      }
-    }
-
-    stations.sort((a, b) => a.dist.compareTo(b.dist));
-    return stations.take(50).toList();
-  }
+    test('strips embedded whitespace and euro symbol', () {
+      expect(
+        PortugalStationService.parsePriceForTest(' 1 , 5 9 9 € '),
+        closeTo(1.599, 0.0001),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- The previous Portugal implementation hit \`/ListarDadosPostos\`, which returns a station *index* with \`Latitude\`, \`Longitude\`, \`Morada\`, and \`Combustiveis\` all set to \`null\`. Every row was discarded for missing coords, the service returned an empty list without an error, and the UI silently bounced back to the initial search prompt (#503).
- Switch to \`/PesquisarPostos\`, which returns one row per (station, fuel type) with all the location + price fields populated. Rows are merged by station \`Id\`.
- Prices are Portuguese-formatted (\`\"1,719 €\"\`, comma decimal) — new \`_parsePriceEur\` helper strips the euro symbol and swaps the comma.
- Dio and the base URL are now constructor-injectable so the service can be driven by a fake \`HttpClientAdapter\` in tests (same pattern as #499 UK).

## Probe evidence
Verified live against the DGEG API:
- \`ListarDadosPostos\` returns 2 MB JSON of stations where \`Latitude\`/\`Longitude\`/\`Combustiveis\` are all \`null\`.
- \`PesquisarPostos?idsTiposComb=3201,2101&qtdPorPagina=10000\` returns the full 6051-row dataset in one request (~2.2 MB) with populated coordinates and prices.

## Test plan
- [x] 21 new/updated tests in \`portugal_station_service_test.dart\` covering endpoint + query params, fuel merging, comma-decimal price parsing, radius filter, HTTP 500 → \`ApiException\`, malformed response → \`ApiException\`, and \`parseAndFilter\` edge cases.
- [x] \`flutter analyze --no-fatal-infos\` — zero warnings/errors
- [x] \`flutter test\` — 3625 passing, 1 skipped

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)