### PR TITLE
fix(mx): swap datos.gob.mx for CRE azure feeds

### DIFF
--- a/lib/core/services/impl/mexico_station_service.dart
+++ b/lib/core/services/impl/mexico_station_service.dart
@@ -1,4 +1,6 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:xml/xml.dart';
 
 import '../../../features/search/data/models/search_params.dart';
 import '../../../features/search/domain/entities/station.dart';
@@ -8,26 +10,46 @@ import '../dio_factory.dart';
 import '../service_result.dart';
 import '../station_service.dart';
 import '../mixins/station_service_helpers.dart';
-import '../mixins/cached_dataset_mixin.dart';
 
 /// CRE (Comisión Reguladora de Energía) Mexican fuel price service.
 ///
-/// Uses Mexico's open data portal (datos.gob.mx) for fuel station prices.
-/// Free, no API key required. Data updated ~6 times daily.
+/// The previous implementation queried `api.datos.gob.mx/v2/...`
+/// which has been retired — requests simply time out in the TLS
+/// handshake (see #505). Switched to the CRE public publication
+/// hosted on Azure, which is the canonical upstream for the official
+/// Mexican fuel price dataset:
 ///
-/// API: https://datos.gob.mx/busca/dataset/ubicacion-de-gasolineras-y-precios-comerciales-de-gasolina-y-diesel
-class MexicoStationService with StationServiceHelpers, CachedDatasetMixin implements StationService {
-  final Dio _dio = DioFactory.create(
-    connectTimeout: const Duration(seconds: 15),
-    receiveTimeout: const Duration(seconds: 60), // Large dataset
-  );
+/// - `https://publicacionexterna.azurewebsites.net/publicaciones/places`
+///   returns one `<place>` per station with `<name>`, `<cre_id>`, and
+///   `<location><x/><y/></location>` (x = longitude, y = latitude).
+/// - `https://publicacionexterna.azurewebsites.net/publicaciones/prices`
+///   returns one `<place>` per station with one or more
+///   `<gas_price type="regular|premium|diesel">` children. Prices
+///   are Mexican pesos per litre.
+///
+/// Both feeds are joined client-side by `place_id` to produce
+/// fully-populated [Station] records. The merged list is cached for
+/// 4 hours — the CRE dataset updates several times daily but rarely
+/// faster than that.
+class MexicoStationService
+    with StationServiceHelpers
+    implements StationService {
+  final Dio _dio;
+  final String _baseUrl;
 
-  /// datos.gob.mx public fuel prices endpoint — no API key required.
-  /// Returns station names, municipalities, states, and prices for
-  /// Regular, Premium, and Diesel. Updated 6 times daily by CRE.
-  static const _pricesUrl = 'https://api.datos.gob.mx/v2/precio.gasolina.publico';
+  MexicoStationService({
+    Dio? dio,
+    String baseUrl = 'https://publicacionexterna.azurewebsites.net/publicaciones',
+  })  : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 15),
+              receiveTimeout: const Duration(seconds: 45),
+            ),
+        _baseUrl = baseUrl;
 
-  List<Map<String, dynamic>>? _cachedResults;
+  static const Duration _cacheTtl = Duration(hours: 4);
+
+  List<_CreStation>? _cachedStations;
   DateTime? _lastFetch;
 
   @override
@@ -37,46 +59,25 @@ class MexicoStationService with StationServiceHelpers, CachedDatasetMixin implem
   }) async {
     try {
       await _ensureDataLoaded(cancelToken);
+      final cached = _cachedStations ?? const <_CreStation>[];
 
       final stations = <Station>[];
-
-      for (final item in _cachedResults ?? []) {
-        // datos.gob.mx doesn't always include lat/lng — use Nominatim geocoding
-        // as fallback when coordinates aren't available.
-        // For now, filter by state/municipality matching if no coordinates.
-        final regular = (item['precioRegular'] as num?)?.toDouble();
-        final premium = (item['precioPremium'] as num?)?.toDouble();
-        final diesel = (item['precioDiesel'] as num?)?.toDouble();
-
-        // Try to get coordinates (may not be in this dataset)
-        final lat = (item['latitud'] as num?)?.toDouble();
-        final lng = (item['longitud'] as num?)?.toDouble();
-
-        // If no coordinates, skip distance-based filtering
-        double dist = 0;
-        if (lat != null && lng != null) {
-          dist = distanceKm(params.lat, params.lng, lat, lng);
-          if (dist > params.radiusKm) continue;
-        } else {
-          // Without coordinates, include all results (user filters by municipality)
-          continue; // Skip stations without coordinates
-        }
-
-        final permiso = item['permiso']?.toString() ?? '${stations.length}';
-
+      for (final c in cached) {
+        final dist = distanceKm(params.lat, params.lng, c.lat, c.lng);
+        if (dist > params.radiusKm) continue;
         stations.add(Station(
-          id: 'mx-$permiso',
-          name: item['nombre']?.toString() ?? '',
-          brand: item['nombre']?.toString().split(' ').first ?? '',
+          id: 'mx-${c.id}',
+          name: c.name,
+          brand: c.name.split(' ').first,
           street: '',
           postCode: '',
-          place: '${item['municipio'] ?? ''}, ${item['estado'] ?? ''}',
-          lat: lat,
-          lng: lng,
+          place: '',
+          lat: c.lat,
+          lng: c.lng,
           dist: dist,
-          e5: regular,
-          e10: premium,
-          diesel: diesel,
+          e5: c.regular,
+          e10: c.premium,
+          diesel: c.diesel,
           isOpen: true,
         ));
       }
@@ -94,50 +95,201 @@ class MexicoStationService with StationServiceHelpers, CachedDatasetMixin implem
   }
 
   Future<void> _ensureDataLoaded(CancelToken? cancelToken) async {
-    // Cache for 4 hours (data updates 6x daily)
-    if (_cachedResults != null &&
+    if (_cachedStations != null &&
         _lastFetch != null &&
-        DateTime.now().difference(_lastFetch!).inHours < 4) {
+        DateTime.now().difference(_lastFetch!) < _cacheTtl) {
       return;
     }
 
-    // Fetch from datos.gob.mx — paginated, up to 1000 per page
-    final allResults = <Map<String, dynamic>>[];
-    int page = 1;
-    bool hasMore = true;
-
-    while (hasMore && page <= 20) { // Safety cap at 20 pages
-      final response = await _dio.get(
-        _pricesUrl,
-        queryParameters: {'page': page, 'pageSize': 1000},
+    final responses = await Future.wait([
+      _dio.get<String>(
+        '$_baseUrl/places',
+        options: Options(responseType: ResponseType.plain),
         cancelToken: cancelToken,
-      );
+      ),
+      _dio.get<String>(
+        '$_baseUrl/prices',
+        options: Options(responseType: ResponseType.plain),
+        cancelToken: cancelToken,
+      ),
+    ]);
 
-      final data = response.data;
-      if (data is Map<String, dynamic>) {
-        final results = data['results'] as List<dynamic>? ?? [];
-        if (results.isEmpty) {
-          hasMore = false;
-        } else {
-          allResults.addAll(results.cast<Map<String, dynamic>>());
-          page++;
-        }
-      } else {
-        hasMore = false;
-      }
+    final placesXml = responses[0].data;
+    final pricesXml = responses[1].data;
+    if (placesXml == null || placesXml.isEmpty) {
+      throw const ApiException(
+        message: 'CRE /places feed returned an empty body',
+      );
+    }
+    if (pricesXml == null || pricesXml.isEmpty) {
+      throw const ApiException(
+        message: 'CRE /prices feed returned an empty body',
+      );
     }
 
-    _cachedResults = allResults;
+    _cachedStations = _mergeFeeds(placesXml: placesXml, pricesXml: pricesXml);
     _lastFetch = DateTime.now();
+
+    if (_cachedStations!.isEmpty) {
+      throw const ApiException(
+        message: 'CRE feeds parsed to zero stations (schema change?)',
+      );
+    }
+  }
+
+  /// Parses the `/places` and `/prices` XML feeds and joins them by
+  /// `place_id`. The merged list drives [searchStations] via the
+  /// in-memory cache.
+  static List<_CreStation> _mergeFeeds({
+    required String placesXml,
+    required String pricesXml,
+  }) {
+    final places = _parsePlaces(placesXml);
+    final prices = _parsePrices(pricesXml);
+
+    final merged = <_CreStation>[];
+    for (final entry in places.entries) {
+      final meta = entry.value;
+      final p = prices[entry.key] ?? const _CrePrices();
+      merged.add(_CreStation(
+        id: entry.key,
+        name: meta.name,
+        lat: meta.lat,
+        lng: meta.lng,
+        regular: p.regular,
+        premium: p.premium,
+        diesel: p.diesel,
+      ));
+    }
+    return merged;
+  }
+
+  static Map<String, _CrePlace> _parsePlaces(String xmlString) {
+    final doc = XmlDocument.parse(xmlString);
+    final out = <String, _CrePlace>{};
+    for (final node in doc.findAllElements('place')) {
+      try {
+        final id = node.getAttribute('place_id');
+        if (id == null) continue;
+        final name =
+            node.findElements('name').firstOrNull?.innerText.trim() ?? '';
+        final location = node.findElements('location').firstOrNull;
+        if (location == null) continue;
+        final x = double.tryParse(
+          location.findElements('x').firstOrNull?.innerText.trim() ?? '',
+        );
+        final y = double.tryParse(
+          location.findElements('y').firstOrNull?.innerText.trim() ?? '',
+        );
+        if (x == null || y == null) continue;
+        out[id] = _CrePlace(name: name, lat: y, lng: x);
+      } catch (e) {
+        debugPrint('CRE place parse failed: $e');
+        continue;
+      }
+    }
+    return out;
+  }
+
+  static Map<String, _CrePrices> _parsePrices(String xmlString) {
+    final doc = XmlDocument.parse(xmlString);
+    final out = <String, _CrePrices>{};
+    for (final node in doc.findAllElements('place')) {
+      try {
+        final id = node.getAttribute('place_id');
+        if (id == null) continue;
+        double? regular, premium, diesel;
+        for (final gp in node.findElements('gas_price')) {
+          final type = gp.getAttribute('type');
+          final value = double.tryParse(gp.innerText.trim());
+          if (value == null) continue;
+          switch (type) {
+            case 'regular':
+              regular = value;
+              break;
+            case 'premium':
+              premium = value;
+              break;
+            case 'diesel':
+              diesel = value;
+              break;
+          }
+        }
+        out[id] = _CrePrices(
+          regular: regular,
+          premium: premium,
+          diesel: diesel,
+        );
+      } catch (e) {
+        debugPrint('CRE price parse failed: $e');
+        continue;
+      }
+    }
+    return out;
+  }
+
+  /// Clears the merged-station cache so the next search re-fetches
+  /// both feeds. Intended for tests.
+  @visibleForTesting
+  void clearCacheForTest() {
+    _cachedStations = null;
+    _lastFetch = null;
   }
 
   @override
-  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) async {
-    throw const ApiException(message: 'Station detail not supported for Mexico');
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String stationId,
+  ) async {
+    throw const ApiException(
+      message: 'Station detail not supported for Mexico',
+    );
   }
 
   @override
-  Future<ServiceResult<Map<String, StationPrices>>> getPrices(List<String> ids) async {
-    return ServiceResult(data: {}, source: ServiceSource.mexicoApi, fetchedAt: DateTime.now());
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    return ServiceResult(
+      data: const {},
+      source: ServiceSource.mexicoApi,
+      fetchedAt: DateTime.now(),
+    );
   }
+}
+
+/// Merged place+price record used for in-memory caching. The public
+/// [Station] is built from this when [MexicoStationService.searchStations]
+/// runs, so the cached shape is whatever is cheapest to build.
+class _CreStation {
+  final String id;
+  final String name;
+  final double lat;
+  final double lng;
+  final double? regular;
+  final double? premium;
+  final double? diesel;
+
+  const _CreStation({
+    required this.id,
+    required this.name,
+    required this.lat,
+    required this.lng,
+    required this.regular,
+    required this.premium,
+    required this.diesel,
+  });
+}
+
+class _CrePlace {
+  final String name;
+  final double lat;
+  final double lng;
+  const _CrePlace({required this.name, required this.lat, required this.lng});
+}
+
+class _CrePrices {
+  final double? regular;
+  final double? premium;
+  final double? diesel;
+  const _CrePrices({this.regular, this.premium, this.diesel});
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1834,7 +1834,7 @@ packages:
     source: hosted
     version: "1.1.0"
   xml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: xml
       sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   # Utilities
   collection: ^1.19.0
   meta: ^1.17.0
+  xml: ^6.6.1
   path_provider: ^2.1.5
   uuid: ^4.5.1
   connectivity_plus: ^7.1.1

--- a/test/core/services/impl/mexico_station_service_test.dart
+++ b/test/core/services/impl/mexico_station_service_test.dart
@@ -1,282 +1,370 @@
-import 'dart:math';
-
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/services/impl/mexico_station_service.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
-import 'package:tankstellen/features/search/domain/entities/station.dart';
 
-void main() {
-  late MexicoStationService service;
+/// Fake HTTP adapter that maps request URLs to canned XML responses.
+class _FakeCreAdapter implements HttpClientAdapter {
+  _FakeCreAdapter({required this.responses});
 
-  setUp(() {
-    service = MexicoStationService();
-  });
+  final Map<String, _CannedResponse> responses;
+  final List<String> requestedUrls = [];
 
-  group('MexicoStationService', () {
-    test('implements StationService interface', () {
-      expect(service, isA<StationService>());
-    });
-
-    group('getStationDetail', () {
-      test('throws ApiException (not supported)', () {
-        expect(
-          () => service.getStationDetail('mx-123'),
-          throwsA(isA<ApiException>()),
-        );
-      });
-
-      test('error message indicates lack of support', () async {
-        try {
-          await service.getStationDetail('mx-PERM001');
-          fail('Should have thrown');
-        } on ApiException catch (e) {
-          expect(e.message, contains('not supported'));
-        }
-      });
-    });
-
-    group('getPrices', () {
-      test('returns empty map (batch prices not supported)', () async {
-        final result = await service.getPrices(['mx-1', 'mx-2']);
-        expect(result.data, isEmpty);
-        expect(result.source, ServiceSource.mexicoApi);
-      });
-
-      test('returns valid ServiceResult for empty id list', () async {
-        final result = await service.getPrices([]);
-        expect(result.data, isA<Map<String, StationPrices>>());
-        expect(result.source, ServiceSource.mexicoApi);
-      });
-    });
-
-    group('searchStations integration', () {
-      test('returns ServiceResult with correct source', () async {
-        // Mexico City coordinates
-        const params = SearchParams(lat: 19.43, lng: -99.13, radiusKm: 5.0);
-        try {
-          final result = await service.searchStations(params);
-          expect(result.source, ServiceSource.mexicoApi);
-          expect(result.data, isA<List<Station>>());
-          expect(result.fetchedAt, isA<DateTime>());
-        } on ApiException {
-          // Network may not be available in CI.
-        }
-      });
-    });
-  });
-
-  group('MexicoStationService parsing (via _TestableMexicoService)', () {
-    late _TestableMexicoService testableService;
-
-    setUp(() {
-      testableService = _TestableMexicoService();
-    });
-
-    test('parseStation creates Station with full coordinates', () {
-      final item = {
-        'permiso': 'PL/1234/EXP/2020',
-        'nombre': 'Gasolinera PEMEX Norte',
-        'municipio': 'Benito Juárez',
-        'estado': 'Ciudad de México',
-        'precioRegular': 22.99,
-        'precioPremium': 24.89,
-        'precioDiesel': 23.45,
-        'latitud': 19.43,
-        'longitud': -99.13,
-      };
-
-      final station = testableService.testParseStation(
-        item,
-        searchLat: 19.43,
-        searchLng: -99.13,
-      );
-      expect(station, isNotNull);
-      expect(station!.id, 'mx-PL/1234/EXP/2020');
-      expect(station.name, 'Gasolinera PEMEX Norte');
-      expect(station.brand, 'Gasolinera');
-      expect(station.place, 'Benito Juárez, Ciudad de México');
-      expect(station.lat, 19.43);
-      expect(station.lng, -99.13);
-      expect(station.e5, 22.99);
-      expect(station.e10, 24.89);
-      expect(station.diesel, 23.45);
-      expect(station.isOpen, isTrue);
-    });
-
-    test('parseStation skips station without coordinates', () {
-      final item = {
-        'permiso': 'PL/0001',
-        'nombre': 'No Coords',
-        'precioRegular': 22.0,
-      };
-
-      final station = testableService.testParseStation(
-        item,
-        searchLat: 19.43,
-        searchLng: -99.13,
-      );
-      expect(station, isNull);
-    });
-
-    test('parseStation skips station outside radius', () {
-      final item = {
-        'permiso': 'PL/0002',
-        'nombre': 'Far Station',
-        'latitud': 25.67,
-        'longitud': -100.31,
-        'precioRegular': 22.0,
-      };
-
-      final station = testableService.testParseStation(
-        item,
-        searchLat: 19.43,
-        searchLng: -99.13,
-        radiusKm: 5.0,
-      );
-      expect(station, isNull);
-    });
-
-    test('parseStation handles null prices', () {
-      final item = {
-        'permiso': 'PL/0003',
-        'nombre': 'No Prices',
-        'latitud': 19.43,
-        'longitud': -99.13,
-        'precioRegular': null,
-        'precioPremium': null,
-        'precioDiesel': null,
-      };
-
-      final station = testableService.testParseStation(
-        item,
-        searchLat: 19.43,
-        searchLng: -99.13,
-      );
-      expect(station, isNotNull);
-      expect(station!.e5, isNull);
-      expect(station.e10, isNull);
-      expect(station.diesel, isNull);
-    });
-
-    test('parseStation extracts brand from first word of nombre', () {
-      final item = {
-        'permiso': 'PL/0004',
-        'nombre': 'PEMEX La Reforma',
-        'latitud': 19.43,
-        'longitud': -99.13,
-      };
-
-      final station = testableService.testParseStation(
-        item,
-        searchLat: 19.43,
-        searchLng: -99.13,
-      );
-      expect(station, isNotNull);
-      expect(station!.brand, 'PEMEX');
-    });
-
-    test('parseStation uses index fallback when permiso is null', () {
-      final item = {
-        'nombre': 'Station Without Permiso',
-        'latitud': 19.43,
-        'longitud': -99.13,
-      };
-
-      final station = testableService.testParseStation(
-        item,
-        searchLat: 19.43,
-        searchLng: -99.13,
-        index: 7,
-      );
-      expect(station, isNotNull);
-      expect(station!.id, 'mx-7');
-    });
-
-    test('extractResults handles paginated response format', () {
-      final data = <String, dynamic>{
-        'results': [
-          {'permiso': '1', 'nombre': 'S1'},
-          {'permiso': '2', 'nombre': 'S2'},
-          {'permiso': '3', 'nombre': 'S3'},
-        ],
-      };
-      final results = testableService.testExtractResults(data);
-      expect(results, hasLength(3));
-    });
-
-    test('extractResults returns empty for missing results key', () {
-      final data = <String, dynamic>{'total_count': 0};
-      expect(testableService.testExtractResults(data), isEmpty);
-    });
-
-    test('extractResults returns empty for non-map data', () {
-      expect(testableService.testExtractResults('string'), isEmpty);
-      expect(testableService.testExtractResults(null), isEmpty);
-    });
-  });
-}
-
-/// Testable wrapper that replicates MexicoStationService parsing.
-class _TestableMexicoService {
-  Station? testParseStation(
-    Map<String, dynamic> item, {
-    required double searchLat,
-    required double searchLng,
-    double radiusKm = 50.0,
-    int index = 0,
-  }) {
-    final regular = (item['precioRegular'] as num?)?.toDouble();
-    final premium = (item['precioPremium'] as num?)?.toDouble();
-    final diesel = (item['precioDiesel'] as num?)?.toDouble();
-
-    final lat = (item['latitud'] as num?)?.toDouble();
-    final lng = (item['longitud'] as num?)?.toDouble();
-
-    if (lat == null || lng == null) return null;
-
-    final dist = _distanceKm(searchLat, searchLng, lat, lng);
-    if (dist > radiusKm) return null;
-
-    final permiso = item['permiso']?.toString() ?? '$index';
-    final nombre = item['nombre']?.toString() ?? '';
-
-    return Station(
-      id: 'mx-$permiso',
-      name: nombre,
-      brand: nombre.split(' ').first,
-      street: '',
-      postCode: '',
-      place: '${item['municipio'] ?? ''}, ${item['estado'] ?? ''}',
-      lat: lat,
-      lng: lng,
-      dist: dist,
-      e5: regular,
-      e10: premium,
-      diesel: diesel,
-      isOpen: true,
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final url = options.uri.toString();
+    requestedUrls.add(url);
+    final canned = responses[url];
+    if (canned == null) {
+      return ResponseBody.fromString('not mapped', 404);
+    }
+    return ResponseBody.fromString(
+      canned.body,
+      canned.statusCode,
+      headers: {
+        Headers.contentTypeHeader: ['application/xml; charset=utf-8'],
+      },
     );
   }
 
-  List<Map<String, dynamic>> testExtractResults(dynamic data) {
-    if (data is Map<String, dynamic>) {
-      final results = data['results'] as List<dynamic>? ?? [];
-      return results.cast<Map<String, dynamic>>();
-    }
-    return [];
-  }
+  @override
+  void close({bool force = false}) {}
+}
 
-  double _distanceKm(double lat1, double lng1, double lat2, double lng2) {
-    const r = 6371.0;
-    final dLat = (lat2 - lat1) * pi / 180;
-    final dLng = (lng2 - lng1) * pi / 180;
-    final a = sin(dLat / 2) * sin(dLat / 2) +
-        cos(lat1 * pi / 180) *
-            cos(lat2 * pi / 180) *
-            sin(dLng / 2) *
-            sin(dLng / 2);
-    return r * 2 * atan2(sqrt(a), sqrt(1 - a));
+class _CannedResponse {
+  final String body;
+  final int statusCode;
+  const _CannedResponse(this.body, {this.statusCode = 200});
+}
+
+const _placesUrl =
+    'https://fake.cre/publicaciones/places';
+const _pricesUrl =
+    'https://fake.cre/publicaciones/prices';
+
+MexicoStationService _serviceWith({
+  required String placesXml,
+  required String pricesXml,
+  int placesStatus = 200,
+  int pricesStatus = 200,
+}) =>
+    _serviceAndAdapter(
+      placesXml: placesXml,
+      pricesXml: pricesXml,
+      placesStatus: placesStatus,
+      pricesStatus: pricesStatus,
+    ).service;
+
+({MexicoStationService service, _FakeCreAdapter adapter}) _serviceAndAdapter({
+  required String placesXml,
+  required String pricesXml,
+  int placesStatus = 200,
+  int pricesStatus = 200,
+}) {
+  final adapter = _FakeCreAdapter(responses: {
+    _placesUrl: _CannedResponse(placesXml, statusCode: placesStatus),
+    _pricesUrl: _CannedResponse(pricesXml, statusCode: pricesStatus),
+  });
+  final dio = Dio();
+  dio.httpClientAdapter = adapter;
+  return (
+    service: MexicoStationService(
+      dio: dio,
+      baseUrl: 'https://fake.cre/publicaciones',
+    ),
+    adapter: adapter,
+  );
+}
+
+const _cdmxParams = SearchParams(
+  lat: 19.43,
+  lng: -99.13,
+  radiusKm: 10,
+);
+
+String _placesXml(List<({String id, String name, double x, double y})> places) {
+  final buf = StringBuffer('<?xml version="1.0" encoding="utf-8"?>\n<places>');
+  for (final p in places) {
+    buf.write('''
+  <place place_id="${p.id}">
+    <name>${p.name}</name>
+    <cre_id>PL/${p.id}/EXP/ES/2015</cre_id>
+    <location>
+      <x>${p.x}</x>
+      <y>${p.y}</y>
+    </location>
+  </place>
+''');
   }
+  buf.write('</places>');
+  return buf.toString();
+}
+
+String _pricesXml(
+    List<({String id, double? regular, double? premium, double? diesel})>
+        prices) {
+  final buf = StringBuffer('<?xml version="1.0" encoding="utf-8"?>\n<places>');
+  for (final p in prices) {
+    buf.write('  <place place_id="${p.id}">');
+    if (p.regular != null) {
+      buf.write('<gas_price type="regular">${p.regular}</gas_price>');
+    }
+    if (p.premium != null) {
+      buf.write('<gas_price type="premium">${p.premium}</gas_price>');
+    }
+    if (p.diesel != null) {
+      buf.write('<gas_price type="diesel">${p.diesel}</gas_price>');
+    }
+    buf.write('</place>\n');
+  }
+  buf.write('</places>');
+  return buf.toString();
+}
+
+void main() {
+  group('MexicoStationService (public surface)', () {
+    test('implements StationService interface', () {
+      expect(MexicoStationService(), isA<StationService>());
+    });
+
+    test('getStationDetail throws ApiException', () {
+      expect(
+        () => MexicoStationService().getStationDetail('mx-123'),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('getPrices returns empty map with correct source', () async {
+      final result = await MexicoStationService().getPrices(['mx-1']);
+      expect(result.data, isEmpty);
+      expect(result.source, ServiceSource.mexicoApi);
+    });
+  });
+
+  group('searchStations (CRE azure feeds — #505 fix)', () {
+    test('fetches /places and /prices and joins by place_id', () async {
+      final service = _serviceWith(
+        placesXml: _placesXml([
+          (id: '11702', name: 'Gasolinera Centro', x: -99.13, y: 19.43),
+        ]),
+        pricesXml: _pricesXml([
+          (id: '11702', regular: 22.95, premium: 24.89, diesel: 23.45),
+        ]),
+      );
+
+      final result = await service.searchStations(_cdmxParams);
+      expect(result.source, ServiceSource.mexicoApi);
+      expect(result.data, hasLength(1));
+      final s = result.data.first;
+      expect(s.id, 'mx-11702');
+      expect(s.name, 'Gasolinera Centro');
+      expect(s.brand, 'Gasolinera');
+      expect(s.lat, 19.43);
+      expect(s.lng, closeTo(-99.13, 0.0001));
+      expect(s.e5, 22.95);
+      expect(s.e10, 24.89);
+      expect(s.diesel, 23.45);
+      expect(s.isOpen, isTrue);
+    });
+
+    test('location.x is longitude and y is latitude (never swapped)',
+        () async {
+      // Regression guard: CRE's <location> is <x>LNG</x><y>LAT</y>, which
+      // is backwards from the usual (lat, lng) convention.
+      final service = _serviceWith(
+        placesXml: _placesXml([
+          (id: '1', name: 'LNG first', x: -99.13, y: 19.43),
+        ]),
+        pricesXml: _pricesXml([
+          (id: '1', regular: 20.0, premium: null, diesel: null),
+        ]),
+      );
+      final result = await service.searchStations(_cdmxParams);
+      expect(result.data.first.lat, 19.43);
+      expect(result.data.first.lng, closeTo(-99.13, 0.0001));
+    });
+
+    test('stations without a matching price row still render (no prices)',
+        () async {
+      final service = _serviceWith(
+        placesXml: _placesXml([
+          (id: '42', name: 'No prices here', x: -99.13, y: 19.43),
+        ]),
+        pricesXml: _pricesXml([
+          // 42 not listed
+          (id: '99', regular: 22.0, premium: null, diesel: null),
+        ]),
+      );
+      final result = await service.searchStations(_cdmxParams);
+      expect(result.data, hasLength(1));
+      final s = result.data.first;
+      expect(s.e5, isNull);
+      expect(s.e10, isNull);
+      expect(s.diesel, isNull);
+    });
+
+    test('filters stations outside the search radius', () async {
+      final service = _serviceWith(
+        placesXml: _placesXml([
+          (id: '1', name: 'Cerca', x: -99.13, y: 19.43),
+          (id: '2', name: 'Lejos Monterrey', x: -100.31, y: 25.67),
+        ]),
+        pricesXml: _pricesXml([
+          (id: '1', regular: 22.0, premium: null, diesel: null),
+          (id: '2', regular: 22.0, premium: null, diesel: null),
+        ]),
+      );
+
+      final result = await service.searchStations(_cdmxParams);
+      expect(result.data, hasLength(1));
+      expect(result.data.first.name, 'Cerca');
+    });
+
+    test('sorts stations by distance ascending', () async {
+      final service = _serviceWith(
+        placesXml: _placesXml([
+          (id: '1', name: 'Far', x: -99.13, y: 19.49),
+          (id: '2', name: 'Near', x: -99.13, y: 19.431),
+        ]),
+        pricesXml: _pricesXml([
+          (id: '1', regular: 22.0, premium: null, diesel: null),
+          (id: '2', regular: 22.0, premium: null, diesel: null),
+        ]),
+      );
+
+      final result = await service.searchStations(_cdmxParams);
+      expect(result.data, hasLength(2));
+      expect(result.data.first.name, 'Near');
+      expect(result.data.last.name, 'Far');
+    });
+
+    test('caps results at 50', () async {
+      final places = List.generate(
+        80,
+        (i) => (
+          id: '$i',
+          name: 'S$i',
+          x: -99.13,
+          y: 19.43 + i * 0.0001,
+        ),
+      );
+      final prices = List.generate(
+        80,
+        (i) => (
+          id: '$i',
+          regular: 22.0 as double?,
+          premium: null as double?,
+          diesel: null as double?,
+        ),
+      );
+      final service = _serviceWith(
+        placesXml: _placesXml(places),
+        pricesXml: _pricesXml(prices),
+      );
+      final result = await service.searchStations(
+        const SearchParams(lat: 19.43, lng: -99.13, radiusKm: 500),
+      );
+      expect(result.data, hasLength(50));
+    });
+
+    test('throws ApiException on /places HTTP error (never silent)',
+        () async {
+      final service = _serviceWith(
+        placesXml: '<error/>',
+        pricesXml: _pricesXml([]),
+        placesStatus: 500,
+      );
+      expect(
+        () => service.searchStations(_cdmxParams),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('throws ApiException on /prices HTTP error', () async {
+      final service = _serviceWith(
+        placesXml: _placesXml(
+          [(id: '1', name: 'X', x: -99.13, y: 19.43)],
+        ),
+        pricesXml: '<error/>',
+        pricesStatus: 503,
+      );
+      expect(
+        () => service.searchStations(_cdmxParams),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('throws when the merged dataset is empty (schema change guard)',
+        () async {
+      final service = _serviceWith(
+        placesXml: '<?xml version="1.0"?><places></places>',
+        pricesXml: '<?xml version="1.0"?><places></places>',
+      );
+      expect(
+        () => service.searchStations(_cdmxParams),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('skips <place> entries without a valid location (x/y)', () async {
+      const xml = '''
+<?xml version="1.0" encoding="utf-8"?>
+<places>
+  <place place_id="1">
+    <name>No location</name>
+    <cre_id>PL/1/EXP/ES/2015</cre_id>
+  </place>
+  <place place_id="2">
+    <name>Good</name>
+    <cre_id>PL/2/EXP/ES/2015</cre_id>
+    <location>
+      <x>-99.13</x>
+      <y>19.43</y>
+    </location>
+  </place>
+</places>
+''';
+      final service = _serviceWith(
+        placesXml: xml,
+        pricesXml: _pricesXml([
+          (id: '1', regular: 22.0, premium: null, diesel: null),
+          (id: '2', regular: 22.0, premium: null, diesel: null),
+        ]),
+      );
+      final result = await service.searchStations(_cdmxParams);
+      expect(result.data, hasLength(1));
+      expect(result.data.first.name, 'Good');
+    });
+
+    test('second searchStations call within TTL reuses cached feeds',
+        () async {
+      final bundle = _serviceAndAdapter(
+        placesXml: _placesXml([
+          (id: '1', name: 'Cached', x: -99.13, y: 19.43),
+        ]),
+        pricesXml: _pricesXml([
+          (id: '1', regular: 22.0, premium: null, diesel: null),
+        ]),
+      );
+
+      await bundle.service.searchStations(_cdmxParams);
+      final firstCount = bundle.adapter.requestedUrls.length;
+      expect(firstCount, 2,
+          reason: 'first search fetches /places + /prices');
+
+      await bundle.service.searchStations(_cdmxParams);
+      expect(
+        bundle.adapter.requestedUrls.length,
+        firstCount,
+        reason: 'second search within TTL must NOT hit the network',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- \`api.datos.gob.mx/v2/precio.gasolina.publico\` is effectively dead — TLS handshake times out at 15 s on every search (verified live: 0 bytes after 21 s). \"Raise connectTimeout\" is a trap — the server is gone, not slow.
- Switched to the CRE public publication on Azure — \`https://publicacionexterna.azurewebsites.net/publicaciones/places\` + \`/prices\`. Both are XML, both ~2.5 MB, both respond in ~3 s. Joined by \`place_id\` client-side and cached for 4 hours.
- Dio and base URL now constructor-injectable; service driven by a fake \`HttpClientAdapter\` end-to-end (the previous mirror-parser helper is gone).
- Added \`xml: ^6.6.1\` as a direct dep (was already transitive).

## Regression guard: x is longitude, y is latitude
CRE's \`<location>\` puts longitude in \`<x>\` and latitude in \`<y>\`, backwards from the usual (lat, lng) convention. There's a dedicated test pinning this so a future refactor can't quietly swap them.

## Test plan
- [x] 14 tests in \`mexico_station_service_test.dart\`: feed fetch + join, x-is-lng regression, stations without a price row, radius filter, distance sort, cap at 50, HTTP 5xx on either feed → \`ApiException\`, empty parsed dataset → \`ApiException\` (schema-change guard), skipped \`<place>\` without \`<location>\`, TTL cache short-circuits second call.
- [x] \`flutter analyze --no-fatal-infos\` — zero warnings/errors
- [x] \`flutter test\` — 3624 passing, 1 skipped

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)