### PR TITLE
fix(favorites): render each row in its origin-country currency

### DIFF
--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -248,4 +248,53 @@ class Countries {
         : localeStr.toUpperCase();
     return byCode(code) ?? germany; // Default fallback
   }
+
+  /// Maps a station id prefix to the country code it came from.
+  ///
+  /// Used by the Favorites list to render each row in its origin
+  /// country's currency (see #514) — otherwise a UK station in a
+  /// French profile would display \`£1.559\` as \`1,559 €\`.
+  ///
+  /// Only country-specific prefixes produce a hit. Services that use
+  /// raw upstream ids (Tankerkoenig UUIDs for DE, Prix-Carburants
+  /// numeric ids for FR, E-Control ids for AT, MITECO \`IDEESS\` for
+  /// ES, MISE registry ids for IT) return \`null\` — the caller falls
+  /// back to the active profile country.
+  ///
+  /// Known prefixes:
+  /// - \`pt-\` → PT (Portugal DGEG, #503)
+  /// - \`uk-\` → GB (UK CMA Fuel Finder, #499)
+  /// - \`au-\` → AU (Australia FuelCheck)
+  /// - \`mx-\` → MX (Mexico CRE)
+  /// - \`ar-\` → AR (Argentina)
+  /// - \`ok-\` / \`shell-\` → DK (Denmark — two retailer-specific feeds)
+  /// - \`demo-\` → null (demo service, no real country)
+  static const Map<String, String> _stationIdPrefixToCountry = {
+    'pt-': 'PT',
+    'uk-': 'GB',
+    'au-': 'AU',
+    'mx-': 'MX',
+    'ar-': 'AR',
+    'ok-': 'DK',
+    'shell-': 'DK',
+  };
+
+  /// Returns the ISO country code inferred from a station id's prefix,
+  /// or \`null\` when the id has no recognised country prefix.
+  static String? countryCodeForStationId(String? stationId) {
+    if (stationId == null || stationId.isEmpty) return null;
+    for (final entry in _stationIdPrefixToCountry.entries) {
+      if (stationId.startsWith(entry.key)) return entry.value;
+    }
+    return null;
+  }
+
+  /// Returns the [CountryConfig] inferred from a station id's prefix,
+  /// or \`null\` when no match is found or the prefix's country is not
+  /// part of [all] (e.g. \`BE\` / \`LU\` — no full config yet).
+  static CountryConfig? countryForStationId(String? stationId) {
+    final code = countryCodeForStationId(stationId);
+    if (code == null) return null;
+    return byCode(code);
+  }
 }

--- a/lib/core/utils/price_formatter.dart
+++ b/lib/core/utils/price_formatter.dart
@@ -67,9 +67,14 @@ class PriceFormatter {
       _cachedDistanceFormat ??= NumberFormat('0.0', _locale);
 
   /// Format price as plain string (e.g., "1,459 €" or "1.459 £").
-  static String formatPrice(double? price) {
+  ///
+  /// Pass [currencyOverride] to force a specific symbol — used by the
+  /// Favorites list (see #514) to render each row in the origin
+  /// country's currency rather than the globally-set profile currency.
+  static String formatPrice(double? price, {String? currencyOverride}) {
     if (price == null || price <= 0) return '--';
-    return '${_fullFormat.format(price)} $currency';
+    final cur = currencyOverride ?? currency;
+    return '${_fullFormat.format(price)} $cur';
   }
 
   /// Format price without currency symbol for compact display.

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../../../core/country/country_config.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
@@ -53,10 +54,20 @@ class StationCard extends StatelessWidget {
 
   double? get _displayPrice => station.priceFor(selectedFuelType);
 
+  /// Per-station currency symbol derived from the station id's country
+  /// prefix (#514). Returns `null` for ids without a recognised
+  /// prefix — callers fall back to the active profile currency.
+  String? get _stationCurrency =>
+      Countries.countryForStationId(station.id)?.currencySymbol;
+
   @override
   Widget build(BuildContext context) {
     final price = _displayPrice;
-    final formattedPrice = PriceFormatter.formatPrice(price);
+    final currencyOverride = _stationCurrency;
+    final formattedPrice = PriceFormatter.formatPrice(
+      price,
+      currencyOverride: currencyOverride,
+    );
     final semanticStatus = station.isOpen ? 'Open' : 'Closed';
     final semanticLabel =
         '${_hasBrand ? station.brand : station.name}, ${station.street}, '
@@ -101,6 +112,7 @@ class StationCard extends StatelessWidget {
                   station: station,
                   selectedFuelType: selectedFuelType,
                   price: price,
+                  currencyOverride: currencyOverride,
                   fuelColor: fuelColor,
                   isFavorite: isFavorite,
                   isCheapest: isCheapest,
@@ -239,6 +251,7 @@ class _StationPriceColumn extends StatelessWidget {
   final Station station;
   final FuelType selectedFuelType;
   final double? price;
+  final String? currencyOverride;
   final Color fuelColor;
   final bool isFavorite;
   final bool isCheapest;
@@ -251,6 +264,7 @@ class _StationPriceColumn extends StatelessWidget {
     required this.station,
     required this.selectedFuelType,
     required this.price,
+    required this.currencyOverride,
     required this.fuelColor,
     required this.isFavorite,
     required this.isCheapest,
@@ -290,6 +304,7 @@ class _StationPriceColumn extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
               text: PriceFormatter.priceTextSpan(
                 price,
+                currencyOverride: currencyOverride,
                 baseStyle: theme.textTheme.titleLarge!.copyWith(
                   fontWeight: FontWeight.bold,
                   color: station.isOpen

--- a/test/core/utils/price_formatter_test.dart
+++ b/test/core/utils/price_formatter_test.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
 import 'package:tankstellen/core/utils/price_formatter.dart';
 
 void main() {
@@ -102,6 +104,115 @@ void main() {
         PriceFormatter.setCountry('ZZ');
         expect(PriceFormatter.currency, '€'); // default
       });
+    });
+  });
+
+  group('currencyOverride (#514 favorites per-station currency)', () {
+    test('formatPrice honours currencyOverride over the global country',
+        () {
+      PriceFormatter.setCountry('FR');
+      expect(
+        PriceFormatter.formatPrice(1.559, currencyOverride: '£'),
+        contains('£'),
+      );
+      expect(
+        PriceFormatter.formatPrice(1.559, currencyOverride: '£'),
+        isNot(contains('€')),
+      );
+    });
+
+    test('formatPrice without override keeps the global currency', () {
+      PriceFormatter.setCountry('FR');
+      expect(PriceFormatter.formatPrice(1.559), contains('€'));
+    });
+
+    test('priceTextSpan honours currencyOverride', () {
+      PriceFormatter.setCountry('FR');
+      final span = PriceFormatter.priceTextSpan(
+        1.559,
+        baseStyle: const TextStyle(fontSize: 14),
+        currencyOverride: '£',
+      );
+      final rendered = span.toPlainText();
+      expect(rendered, contains('£'));
+      expect(rendered, isNot(contains('€')));
+    });
+
+    test('priceTextSpan without override falls back to global currency',
+        () {
+      PriceFormatter.setCountry('FR');
+      final span = PriceFormatter.priceTextSpan(
+        1.559,
+        baseStyle: const TextStyle(fontSize: 14),
+      );
+      expect(span.toPlainText(), contains('€'));
+    });
+  });
+
+  group('Countries.countryCodeForStationId (#514)', () {
+    test('dispatches every known country-specific prefix', () {
+      expect(Countries.countryCodeForStationId('pt-12345'), 'PT');
+      expect(Countries.countryCodeForStationId('uk-BP1'), 'GB');
+      expect(Countries.countryCodeForStationId('au-NSW001'), 'AU');
+      expect(Countries.countryCodeForStationId('mx-abc'), 'MX');
+      expect(Countries.countryCodeForStationId('ar-xyz'), 'AR');
+      expect(Countries.countryCodeForStationId('ok-42'), 'DK');
+      expect(Countries.countryCodeForStationId('shell-42'), 'DK');
+    });
+
+    test('returns null for raw numeric ids (FR / ES / IT / DE / AT)', () {
+      // These services use unprefixed upstream ids — Tankerkoenig
+      // UUIDs, Prix-Carburants numeric ids, MISE registry ids, etc.
+      expect(Countries.countryCodeForStationId('12345'), isNull);
+      expect(
+        Countries.countryCodeForStationId(
+            '550e8400-e29b-41d4-a716-446655440000'),
+        isNull,
+      );
+    });
+
+    test('returns null for unknown prefixes and empty / null input', () {
+      expect(Countries.countryCodeForStationId('zz-123'), isNull);
+      expect(Countries.countryCodeForStationId(''), isNull);
+      expect(Countries.countryCodeForStationId(null), isNull);
+    });
+
+    test('demo ids are not mapped to a country', () {
+      expect(Countries.countryCodeForStationId('demo-48.1-2.0-5'), isNull);
+    });
+  });
+
+  group('Countries.countryForStationId (#514)', () {
+    test('returns the CountryConfig with the origin currency symbol', () {
+      expect(
+        Countries.countryForStationId('uk-BP1')?.currencySymbol,
+        '£',
+      );
+      expect(
+        Countries.countryForStationId('pt-42')?.currencySymbol,
+        '€',
+      );
+      expect(
+        Countries.countryForStationId('mx-foo')?.currencySymbol,
+        '\$',
+      );
+      expect(
+        Countries.countryForStationId('au-NSW001')?.currencySymbol,
+        '\$',
+      );
+      expect(
+        Countries.countryForStationId('ar-xyz')?.currencySymbol,
+        '\$',
+      );
+      expect(
+        Countries.countryForStationId('ok-10')?.currencySymbol,
+        'kr',
+      );
+    });
+
+    test('returns null when no prefix matches', () {
+      expect(Countries.countryForStationId('12345'), isNull);
+      expect(Countries.countryForStationId(null), isNull);
     });
   });
 }

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/core/theme/fuel_colors.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/core/utils/price_tier.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
@@ -490,6 +491,146 @@ void main() {
         expect(find.text('E5: '), findsNothing);
         expect(find.text('E10: '), findsNothing);
         expect(find.text('Diesel: '), findsNothing);
+      });
+    });
+
+    group('per-station currency (#514)', () {
+      String _priceRichText(WidgetTester tester) {
+        // Concatenate all RichText.toPlainText() so the fuel price
+        // RichText (which embeds the superscript 9/10ths digit as a
+        // WidgetSpan) is captured alongside plain fragments.
+        return tester
+            .widgetList<RichText>(find.byType(RichText))
+            .map((r) => r.text.toPlainText())
+            .join('\n');
+      }
+
+      tearDown(() {
+        // Leave the formatter in a stable default so later tests
+        // don't see whatever we set here.
+        PriceFormatter.setCountry('DE');
+      });
+
+      testWidgets(
+          'uk- prefix renders £ even when the active profile is France',
+          (tester) async {
+        PriceFormatter.setCountry('FR');
+
+        const ukStation = Station(
+          id: 'uk-BP1',
+          name: 'BP Victoria',
+          brand: 'BP',
+          street: '1 Victoria St',
+          postCode: 'SW1E 6DE',
+          place: 'London',
+          lat: 51.4975,
+          lng: -0.1357,
+          dist: 1.5,
+          e5: 1.559,
+          e10: 1.459,
+          diesel: 1.529,
+          isOpen: true,
+        );
+
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: ukStation,
+            selectedFuelType: FuelType.e5,
+          ),
+        );
+
+        final rendered = _priceRichText(tester);
+        expect(rendered, contains('£'),
+            reason: 'UK station must render its price in pounds');
+        expect(rendered, isNot(contains('€')),
+            reason: 'UK station must not use the profile € symbol');
+      });
+
+      testWidgets(
+          'pt- prefix keeps € and matches the active FR profile', (tester) async {
+        PriceFormatter.setCountry('FR');
+
+        const ptStation = Station(
+          id: 'pt-42',
+          name: 'GALP Lisboa',
+          brand: 'GALP',
+          street: 'Avenida',
+          postCode: '1250',
+          place: 'Lisboa',
+          lat: 38.7223,
+          lng: -9.1393,
+          dist: 2.5,
+          e5: 1.789,
+          diesel: 1.659,
+          isOpen: true,
+        );
+
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: ptStation,
+            selectedFuelType: FuelType.e5,
+          ),
+        );
+
+        expect(_priceRichText(tester), contains('€'));
+      });
+
+      testWidgets(
+          'unprefixed id (Tankerkoenig) falls back to the active profile '
+          'currency', (tester) async {
+        PriceFormatter.setCountry('GB');
+
+        // testStation has a UUID id (no country prefix), so it must
+        // follow the global PriceFormatter.setCountry.
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: testStation,
+            selectedFuelType: FuelType.e5,
+          ),
+        );
+
+        final rendered = _priceRichText(tester);
+        expect(rendered, contains('£'),
+            reason: 'unprefixed station must follow the active profile '
+                '(here GB → £)');
+      });
+
+      testWidgets(
+          'mx- prefix renders the peso symbol under a FR profile',
+          (tester) async {
+        PriceFormatter.setCountry('FR');
+
+        const mxStation = Station(
+          id: 'mx-11702',
+          name: 'PEMEX Centro',
+          brand: 'PEMEX',
+          street: '',
+          postCode: '',
+          place: 'Ciudad de México',
+          lat: 19.43,
+          lng: -99.13,
+          dist: 1.2,
+          e5: 22.95,
+          e10: 24.89,
+          diesel: 23.45,
+          isOpen: true,
+        );
+
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: mxStation,
+            selectedFuelType: FuelType.e5,
+          ),
+        );
+
+        final rendered = _priceRichText(tester);
+        expect(rendered, contains('\$'),
+            reason: 'MX station must render the peso \$ symbol');
+        expect(rendered, isNot(contains('€')));
       });
     });
   });


### PR DESCRIPTION
## Summary
- \`StationCard\` was formatting prices with \`PriceFormatter\`'s globally-set currency symbol (driven by the active profile), even when the favorites list contained stations from multiple countries. A UK station saved while the profile was on France rendered \`1.559\` GBP as \`\"1,559 €\"\` — the number was right, the symbol was wrong.
- New \`Countries.countryCodeForStationId\` / \`countryForStationId\` helpers map the country-specific station id prefixes the service layer already emits (\`pt-\`, \`uk-\`, \`au-\`, \`mx-\`, \`ar-\`, \`ok-\`, \`shell-\`) back to a \`CountryConfig\`. Services that use raw upstream ids (Tankerkoenig UUIDs for DE, Prix-Carburants numeric ids for FR, E-Control / MITECO / MISE ids) return \`null\` so the caller falls back to today's behaviour — no visible change for same-country-only favorites.
- \`PriceFormatter.formatPrice\` now accepts the same \`currencyOverride\` parameter that \`priceTextSpan\` already had.
- \`StationCard\` computes the override once per build from the station id prefix and threads it through \`_StationPriceColumn\` to both the semantic label path (\`formatPrice\`) and the visible \`RichText\` path (\`priceTextSpan\`).

## Test plan
- [x] \`PriceFormatter.formatPrice\` / \`priceTextSpan\`: \`currencyOverride\` wins over the global, missing override falls back to the global.
- [x] \`Countries.countryCodeForStationId\`: every known prefix dispatches, raw numeric / UUID / unknown / empty / null all return \`null\`, \`demo-\` is excluded.
- [x] \`StationCard\` (4 new widget tests): \`uk-\` under FR profile → £, \`pt-\` under FR → €, unprefixed under GB → £ (global fall-through preserved), \`mx-\` under FR → \$.
- [x] \`flutter analyze --no-fatal-infos\` — zero warnings/errors
- [x] \`flutter test\` — 3629 passing, 1 skipped

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)