### PR TITLE
fix(favorites): bbox fallback for per-station currency

### DIFF
--- a/lib/core/country/country_bounding_box.dart
+++ b/lib/core/country/country_bounding_box.dart
@@ -67,3 +67,55 @@ const countryBoundingBoxes = <String, CountryBoundingBox>{
   // Mexico: lat 14.39–32.72, lng -118.37–-86.71 (with margin)
   'MX': CountryBoundingBox(minLat: 14.0, maxLat: 33.0, minLng: -119.0, maxLng: -86.0),
 };
+
+/// Deterministic order used by [countryCodeFromLatLng] to walk
+/// [countryBoundingBoxes]. Small / island / coastal countries come
+/// first so their tight boxes are not shadowed by larger neighbours
+/// whose boxes incidentally overlap them (e.g. `PT`'s Iberian area
+/// is entirely inside `ES`'s box, so we must test `PT` first).
+///
+/// Cross-currency border cases (#516) were the primary motivation —
+/// getting a station misattributed between two euro-zone countries
+/// is invisible at the currency-symbol layer, but a UK/FR or DE/DK
+/// mix-up would flip the rendered symbol.
+///
+/// Ordering rationale:
+/// - `PT` first → its tight box is entirely inside `ES`'s generous
+///   one; Lisbon / Porto must not fall through to ES.
+/// - `GB` / island next → no continental overlap.
+/// - `DK` before `DE` → Copenhagen's lat sits inside DE's box.
+/// - `FR` before `DE` → Alsace (Strasbourg) sits inside both.
+/// - Continental EU countries last (DE) so stations outside every
+///   tighter box still get attributed to something European.
+/// - Non-EU countries last — they don't overlap anyone.
+const List<String> _bboxLookupOrder = [
+  'PT',
+  'GB',
+  'DK',
+  'AT',
+  'FR',
+  'IT',
+  'ES',
+  'DE',
+  'MX',
+  'AR',
+  'AU',
+];
+
+/// Returns the ISO country code whose bounding box contains the
+/// given point, or `null` when no box matches.
+///
+/// Used by `Countries.countryForStation` (#516) as a fallback when a
+/// station id has no country-specific prefix — every supported
+/// service still emits `lat` / `lng`, so the station can still be
+/// attributed to a country via its coordinates even if the id is a
+/// bare upstream identifier (FR Prix-Carburants, DE Tankerkoenig,
+/// AT E-Control, ES MITECO, IT MISE all fall into this case).
+String? countryCodeFromLatLng(double lat, double lng) {
+  for (final code in _bboxLookupOrder) {
+    final box = countryBoundingBoxes[code];
+    if (box == null) continue;
+    if (box.contains(lat, lng)) return code;
+  }
+  return null;
+}

--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -1,3 +1,5 @@
+import 'country_bounding_box.dart';
+
 /// Configuration for each supported country.
 /// Determines which services, fuel types, postal code formats,
 /// and API key requirements apply.
@@ -296,5 +298,37 @@ class Countries {
     final code = countryCodeForStationId(stationId);
     if (code == null) return null;
     return byCode(code);
+  }
+
+  /// Resolves the origin country of a station using:
+  ///
+  /// 1. The id prefix ([countryForStationId]) — fast, canonical,
+  ///    works for new search results from services that prefix their
+  ///    ids (PT, GB, MX, AR, DK retailer-specific, AU, demo).
+  /// 2. A bounding-box match on `lat` / `lng` when the prefix misses
+  ///    — fixes #516 for services that emit raw upstream ids (DE
+  ///    Tankerkoenig UUID, FR Prix-Carburants numeric id, AT
+  ///    E-Control, ES MITECO, IT MISE) and repairs legacy favorites
+  ///    saved before the prefix scheme existed.
+  ///
+  /// Returns \`null\` only when neither path resolves — the caller is
+  /// expected to fall back to the globally-set active profile
+  /// currency in that case.
+  ///
+  /// The prefix always wins over the bounding box. This is
+  /// deliberate: a service that explicitly tags its ids with a
+  /// country code is a stronger signal than a geometric hit test,
+  /// and it keeps existing (#514) behaviour unchanged for the cases
+  /// we already covered.
+  static CountryConfig? countryForStation({
+    required String? id,
+    required double lat,
+    required double lng,
+  }) {
+    final byPrefix = countryForStationId(id);
+    if (byPrefix != null) return byPrefix;
+    final bboxCode = countryCodeFromLatLng(lat, lng);
+    if (bboxCode == null) return null;
+    return byCode(bboxCode);
   }
 }

--- a/lib/core/services/impl/argentina_station_service.dart
+++ b/lib/core/services/impl/argentina_station_service.dart
@@ -91,8 +91,15 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
 
       for (final entry in stationMap.values) {
         final raw = entry.raw;
+        // #516 — preserve the `ar-` prefix so Countries.countryForStationId
+        // can dispatch AR stations off the id alone. The previous form
+        // built `'ar-…'.hashCode.toString()` which discarded the prefix
+        // into an opaque integer, leaving the `ar-` dispatch path in
+        // country_config.dart as dead code for real Argentine stations.
+        final signatureHash =
+            '${raw.empresa}-${raw.direccion}'.hashCode.abs();
         stations.add(Station(
-          id: 'ar-${raw.empresa}-${raw.direccion}'.hashCode.toString(),
+          id: 'ar-$signatureHash',
           name: raw.empresa,
           brand: raw.bandera,
           street: raw.direccion,

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -54,11 +54,23 @@ class StationCard extends StatelessWidget {
 
   double? get _displayPrice => station.priceFor(selectedFuelType);
 
-  /// Per-station currency symbol derived from the station id's country
-  /// prefix (#514). Returns `null` for ids without a recognised
-  /// prefix — callers fall back to the active profile currency.
-  String? get _stationCurrency =>
-      Countries.countryForStationId(station.id)?.currencySymbol;
+  /// Per-station currency symbol derived from the station's origin
+  /// country (#514 / #516). The resolution order is:
+  ///
+  /// 1. Id prefix (`uk-`, `pt-`, `mx-`, …) for services that tag
+  ///    their ids with a country code.
+  /// 2. Bounding-box match on `lat` / `lng` — catches raw upstream
+  ///    ids (DE Tankerkoenig UUIDs, FR Prix-Carburants numeric ids,
+  ///    AT E-Control, ES MITECO, IT MISE) and repairs legacy
+  ///    favorites saved before the prefix scheme existed.
+  ///
+  /// Returns `null` when neither path resolves — the caller falls
+  /// back to the globally-set active profile currency.
+  String? get _stationCurrency => Countries.countryForStation(
+        id: station.id,
+        lat: station.lat,
+        lng: station.lng,
+      )?.currencySymbol;
 
   @override
   Widget build(BuildContext context) {

--- a/test/core/country/country_bounding_box_test.dart
+++ b/test/core/country/country_bounding_box_test.dart
@@ -149,4 +149,101 @@ void main() {
       expect(countryBoundingBoxes['FR']!.contains(-34.60, -58.38), isFalse);
     });
   });
+
+  group('countryCodeFromLatLng (#516 bbox lookup)', () {
+    // Cross-currency boundaries — these MUST resolve correctly or the
+    // user sees the wrong symbol.
+    test('Paris → FR (EUR, not GB)', () {
+      expect(countryCodeFromLatLng(48.85, 2.35), 'FR');
+    });
+
+    test('Lyon → FR', () {
+      expect(countryCodeFromLatLng(45.75, 4.85), 'FR');
+    });
+
+    test('London → GB (GBP, not FR)', () {
+      expect(countryCodeFromLatLng(51.51, -0.13), 'GB');
+    });
+
+    test('Manchester → GB', () {
+      expect(countryCodeFromLatLng(53.48, -2.24), 'GB');
+    });
+
+    test('Berlin → DE (lng outside FR box)', () {
+      expect(countryCodeFromLatLng(52.52, 13.41), 'DE');
+    });
+
+    test('Copenhagen → DK (DKK, not DE EUR)', () {
+      expect(countryCodeFromLatLng(55.68, 12.57), 'DK');
+    });
+
+    test('Lisbon → PT (PT tested before the generous ES box)', () {
+      expect(countryCodeFromLatLng(38.72, -9.14), 'PT');
+    });
+
+    test('Porto → PT', () {
+      expect(countryCodeFromLatLng(41.16, -8.63), 'PT');
+    });
+
+    test('Madrid → ES', () {
+      expect(countryCodeFromLatLng(40.42, -3.70), 'ES');
+    });
+
+    test('Rome → IT (lng outside FR)', () {
+      expect(countryCodeFromLatLng(41.90, 12.50), 'IT');
+    });
+
+    test('Vienna → AT (lng outside DE and FR)', () {
+      expect(countryCodeFromLatLng(48.21, 16.37), 'AT');
+    });
+
+    test('Sydney → AU', () {
+      expect(countryCodeFromLatLng(-33.87, 151.21), 'AU');
+    });
+
+    test('CDMX → MX', () {
+      expect(countryCodeFromLatLng(19.43, -99.13), 'MX');
+    });
+
+    test('Buenos Aires → AR', () {
+      expect(countryCodeFromLatLng(-34.60, -58.38), 'AR');
+    });
+
+    test('returns null for mid-Atlantic coordinates', () {
+      expect(countryCodeFromLatLng(0.0, -30.0), isNull);
+    });
+
+    test('returns null for mid-Pacific coordinates', () {
+      expect(countryCodeFromLatLng(0.0, -150.0), isNull);
+    });
+
+    test('returns null for Antarctica', () {
+      expect(countryCodeFromLatLng(-80.0, 0.0), isNull);
+    });
+
+    // EU-zone ambiguous points — all that matters is they resolve
+    // to SOME EUR country. For currency dispatch the precise country
+    // code is irrelevant when both candidates share the currency.
+    group('EU-zone ambiguous points resolve to a EUR country', () {
+      final eurCountries = {'FR', 'DE', 'AT', 'IT', 'ES', 'PT', 'BE', 'LU', 'NL'};
+
+      test('Munich lands somewhere in the EUR zone', () {
+        final code = countryCodeFromLatLng(48.14, 11.58);
+        expect(code, isNotNull);
+        expect(eurCountries, contains(code));
+      });
+
+      test('Nice lands somewhere in the EUR zone', () {
+        final code = countryCodeFromLatLng(43.70, 7.27);
+        expect(code, isNotNull);
+        expect(eurCountries, contains(code));
+      });
+
+      test('Salzburg lands somewhere in the EUR zone', () {
+        final code = countryCodeFromLatLng(47.80, 13.05);
+        expect(code, isNotNull);
+        expect(eurCountries, contains(code));
+      });
+    });
+  });
 }

--- a/test/core/services/impl/argentina_station_service_test.dart
+++ b/test/core/services/impl/argentina_station_service_test.dart
@@ -469,9 +469,11 @@ col0,col1,col2,YPF,AV. RIVADAVIA 5000,CABALLITO,Buenos Aires,col7,col8,Nafta pre
       final rawStations = parser.testParseCsv(csv);
       final raw = rawStations.first;
 
-      // Build station like the service does
+      // Build station like the service does (#516 — id keeps the
+      // `ar-` prefix so Countries.countryForStationId can dispatch
+      // off it).
       final station = Station(
-        id: 'ar-${raw.empresa}-${raw.direccion}'.hashCode.toString(),
+        id: 'ar-${'${raw.empresa}-${raw.direccion}'.hashCode.abs()}',
         name: raw.empresa,
         brand: raw.bandera,
         street: raw.direccion,
@@ -499,6 +501,25 @@ col0,col1,col2,YPF,AV. RIVADAVIA 5000,CABALLITO,Buenos Aires,col7,col8,Nafta pre
       expect(station.isOpen, isTrue);
       expect(station.region, 'Buenos Aires');
       expect(station.updatedAt, '2026-03-20');
+    });
+
+    test('#516: station id keeps the ar- prefix and is stable + unique', () {
+      // The previous form `'ar-\${empresa}-\${direccion}'.hashCode.toString()`
+      // destroyed the prefix into an opaque integer, leaving the
+      // `ar-` dispatch path dead for real Argentine stations.
+      String buildId(String empresa, String direccion) =>
+          'ar-${'$empresa-$direccion'.hashCode.abs()}';
+
+      final a1 = buildId('YPF', 'AV. RIVADAVIA 5000');
+      final a2 = buildId('YPF', 'AV. RIVADAVIA 5000');
+      final b = buildId('SHELL', 'AV. CORRIENTES 1234');
+
+      expect(a1, startsWith('ar-'),
+          reason: '#516: the ar- prefix must survive the hash');
+      expect(a1, equals(a2),
+          reason: 'same (empresa, direccion) → same id (determinism)');
+      expect(a1, isNot(equals(b)),
+          reason: 'different stations must get different ids');
     });
 
     test('stations with zero lat/lng are filtered out during merge', () {

--- a/test/core/utils/price_formatter_test.dart
+++ b/test/core/utils/price_formatter_test.dart
@@ -215,4 +215,85 @@ void main() {
       expect(Countries.countryForStationId(null), isNull);
     });
   });
+
+  group('Countries.countryForStation (#516 prefix + bbox fallback)', () {
+    test('id prefix wins over bounding-box match', () {
+      // A uk- prefixed id at Paris coordinates must still map to GB.
+      // The service-layer tag is the strongest signal — don't let
+      // geometry override it.
+      final c = Countries.countryForStation(
+        id: 'uk-BP1',
+        lat: 48.85,
+        lng: 2.35,
+      );
+      expect(c?.code, 'GB');
+      expect(c?.currencySymbol, '£');
+    });
+
+    test('bbox fallback catches a bare numeric id at French coords '
+        '(Prix-Carburants shape)', () {
+      final c = Countries.countryForStation(
+        id: '12345',
+        lat: 48.85,
+        lng: 2.35,
+      );
+      expect(c?.code, 'FR');
+      expect(c?.currencySymbol, '€');
+    });
+
+    test('bbox fallback catches a Tankerkoenig UUID at Berlin coords', () {
+      final c = Countries.countryForStation(
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        lat: 52.52,
+        lng: 13.40,
+      );
+      expect(c?.code, 'DE');
+      expect(c?.currencySymbol, '€');
+    });
+
+    test('MITECO IDEESS id at Madrid resolves to ES', () {
+      final c = Countries.countryForStation(
+        id: '42',
+        lat: 40.42,
+        lng: -3.70,
+      );
+      expect(c?.code, 'ES');
+    });
+
+    test('MISE registry id at Rome resolves to IT', () {
+      final c = Countries.countryForStation(
+        id: '99',
+        lat: 41.90,
+        lng: 12.50,
+      );
+      expect(c?.code, 'IT');
+    });
+
+    test('E-Control id at Vienna resolves to AT', () {
+      final c = Countries.countryForStation(
+        id: '123',
+        lat: 48.21,
+        lng: 16.37,
+      );
+      expect(c?.code, 'AT');
+    });
+
+    test('mid-ocean point with unknown id returns null', () {
+      final c = Countries.countryForStation(
+        id: 'raw-42',
+        lat: 0.0,
+        lng: -30.0,
+      );
+      expect(c, isNull);
+    });
+
+    test('null id + French coords still resolves via bbox', () {
+      final c = Countries.countryForStation(
+        id: null,
+        lat: 48.85,
+        lng: 2.35,
+      );
+      expect(c?.code, 'FR');
+    });
+  });
 }

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -578,12 +578,15 @@ void main() {
       });
 
       testWidgets(
-          'unprefixed id (Tankerkoenig) falls back to the active profile '
-          'currency', (tester) async {
+          'unprefixed Tankerkoenig UUID with German coordinates resolves '
+          'to € via bbox fallback (#516)', (tester) async {
+        // Under #516 the bounding-box fallback kicks in when the id
+        // carries no country prefix. testStation has a UUID + Berlin
+        // coords, so it must render with € regardless of the active
+        // profile — previously (#514) it would have fallen through
+        // to the profile currency.
         PriceFormatter.setCountry('GB');
 
-        // testStation has a UUID id (no country prefix), so it must
-        // follow the global PriceFormatter.setCountry.
         await pumpApp(
           tester,
           const StationCard(
@@ -593,9 +596,90 @@ void main() {
         );
 
         final rendered = _priceRichText(tester);
-        expect(rendered, contains('£'),
-            reason: 'unprefixed station must follow the active profile '
-                '(here GB → £)');
+        expect(rendered, contains('€'),
+            reason: 'Berlin coordinates must resolve to DE → € even '
+                'under a GB profile (bbox fallback)');
+        expect(rendered, isNot(contains('£')),
+            reason: 'a German station must not borrow the profile £');
+      });
+
+      testWidgets(
+          '#516: bare-numeric FR Prix-Carburants id at Paris coords '
+          'renders € under a GB profile', (tester) async {
+        // The exact scenario from the bug report screenshot: the
+        // active profile is UK, a favorite French station has a raw
+        // Prix-Carburants numeric id (no fr- prefix), and the old
+        // #514 dispatch fell through to the profile currency (£).
+        // With #516 the bounding-box lookup must pick up the French
+        // coords and render €.
+        PriceFormatter.setCountry('GB');
+
+        const frStation = Station(
+          id: '12345', // Prix-Carburants emits bare numeric ids
+          name: 'Pézenas Carburant',
+          brand: 'INTERMARCHÉ',
+          street: '18 Avenue de Verdun',
+          postCode: '34120',
+          place: 'Pézenas',
+          lat: 43.4612, // Pézenas, Hérault, France
+          lng: 3.4252,
+          dist: 2.5,
+          e5: 1.999,
+          e10: 1.999,
+          diesel: 2.269,
+          isOpen: true,
+        );
+
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: frStation,
+            selectedFuelType: FuelType.e10,
+          ),
+        );
+
+        final rendered = _priceRichText(tester);
+        expect(rendered, contains('€'),
+            reason: 'French coordinates must resolve to FR → € even '
+                'with a bare numeric id and a GB profile');
+        expect(rendered, isNot(contains('£')),
+            reason: 'French station must not inherit the profile £');
+      });
+
+      testWidgets(
+          '#516: uk- prefixed station under a FR profile still renders £',
+          (tester) async {
+        // Mirror of the scenario above — the other direction, to prove
+        // the prefix path still works after #516 changes the resolver.
+        PriceFormatter.setCountry('FR');
+
+        const ukStation = Station(
+          id: 'uk-MFG-Streatham',
+          name: 'MFG Streatham Leigham',
+          brand: 'ESSO',
+          street: '928.3 km',
+          postCode: 'SW16',
+          place: 'London',
+          lat: 51.42,
+          lng: -0.13,
+          dist: 928.3,
+          e5: 1.759,
+          e10: 1.579,
+          diesel: 1.939,
+          isOpen: true,
+        );
+
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: ukStation,
+            selectedFuelType: FuelType.e10,
+          ),
+        );
+
+        final rendered = _priceRichText(tester);
+        expect(rendered, contains('£'));
+        expect(rendered, isNot(contains('€')));
       });
 
       testWidgets(


### PR DESCRIPTION
## Summary
- **#514 didn't cover every service.** Its dispatch looked only at the station-id prefix — but FR Prix-Carburants, DE Tankerkoenig, AT E-Control, ES MITECO, and IT MISE all emit raw upstream ids with no country prefix, so `Countries.countryForStationId` silently returned `null` and every row in those countries fell back to the active profile currency. A French favorite under a UK profile showed `1,99 £` instead of `1,99 €`.
- **Argentina was broken in a different way.** `'ar-${empresa}-${direccion}'.hashCode.toString()` hashed the prefix into an opaque integer, so the `ar-` dispatch was dead code for every real Argentine station.

## Fix
- New `Countries.countryForStation(id, lat, lng)` composer: id-prefix lookup first, then a bounding-box lookup on lat/lng. Cross-currency borders (FR↔GB, DK↔DE, EU↔MX/AR/AU) are always correct; EU-zone misattributions inside the same currency are explicitly tolerated.
- Deterministic bbox walk order tuned so small/tight countries (PT, DK, AT) come before generous neighbours (ES, DE, IT) that incidentally overlap them.
- `StationCard._stationCurrency` now feeds lat/lng through the composer in addition to the id.
- Argentina id rewritten as `'ar-${'<empresa>-<direccion>'.hashCode.abs()}'` so the prefix survives into the persisted id. Same (empresa, direccion) is still deterministic.

## Why the #514 tests didn't catch this
The widget tests hand-built `Station(id: 'uk-BP1')` / `'mx-11702'` objects — they exercised the dispatch surface in isolation but never loaded a real station from any service, so the broken services never showed up. The new widget tests use **bare numeric ids + real French / Berlin / Vienna / Rome / Madrid coordinates**, matching the actual Station shape emitted by FR/DE/AT/IT/ES at runtime.

## Test plan
- [x] `countryCodeFromLatLng` unit tests pin every cross-currency border plus each supported country capital. Ambiguous EU-zone points (Munich / Nice / Salzburg) are asserted to land in *some* EUR country rather than a specific one.
- [x] `Countries.countryForStation` composer tests: id-prefix wins over bbox (`uk-BP1` at Paris → GB); bare numeric at Paris → FR; Tankerkoenig UUID at Berlin → DE; MITECO at Madrid → ES; MISE at Rome → IT; E-Control at Vienna → AT; null id + bbox match; mid-ocean → null.
- [x] `StationCard` widget tests reproduce the exact bug-report scenario: a French Prix-Carburants station with a bare numeric id at Pézenas coords renders `€` under a GB profile. And the reverse: `uk-` at London under a FR profile still renders `£`.
- [x] Argentina id regression: `ar-` prefix survives, determinism preserved, distinct stations don't collide.
- [x] `flutter analyze --no-fatal-infos` — zero warnings/errors
- [x] `flutter test` — 3660 passing, 1 skipped

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
