### PR TITLE
feat(api-key): bundle default Tankerkoenig community key

### DIFF
--- a/lib/core/data/storage_repository.dart
+++ b/lib/core/data/storage_repository.dart
@@ -63,10 +63,23 @@ abstract class SettingsStorage {
 
 /// API key secure storage.
 abstract class ApiKeyStorage {
+  /// Returns the Tankerkoenig API key — either the user's custom key
+  /// from secure storage, or the bundled community default (#521) when
+  /// the user has not set one. Never returns null in a supported
+  /// configuration.
   String? getApiKey();
   Future<void> setApiKey(String key);
   Future<void> deleteApiKey();
+
+  /// Whether *any* Tankerkoenig key is available — since #521 this is
+  /// always true, because the app ships a default community key.
   bool hasApiKey();
+
+  /// Whether the user has explicitly set their own Tankerkoenig key
+  /// (distinct from the default community key). Use this in the UI to
+  /// tell "Configurée" from "Clé communautaire par défaut".
+  bool hasCustomApiKey();
+
   String? getEvApiKey();
   bool hasEvApiKey();
   bool hasCustomEvApiKey();

--- a/lib/core/providers/app_state_provider.dart
+++ b/lib/core/providers/app_state_provider.dart
@@ -5,10 +5,22 @@ import '../storage/storage_providers.dart';
 part 'app_state_provider.g.dart';
 
 /// Whether the Tankerkoenig API key is configured.
+///
+/// Since #521 this is always true — the app ships a community
+/// default. Use [hasCustomApiKey] to tell whether the user set their
+/// own key.
 @riverpod
 bool hasApiKey(Ref ref) {
   final storage = ref.watch(storageRepositoryProvider);
   return storage.hasApiKey();
+}
+
+/// Whether the user has set their **own** Tankerkoenig key, distinct
+/// from the community default bundled in the app (#521).
+@riverpod
+bool hasCustomApiKey(Ref ref) {
+  final storage = ref.watch(storageRepositoryProvider);
+  return storage.hasCustomApiKey();
 }
 
 /// Whether a custom EV API key is configured.

--- a/lib/core/storage/hive_storage.dart
+++ b/lib/core/storage/hive_storage.dart
@@ -90,6 +90,8 @@ class HiveStorage implements StorageRepository {
   @override
   bool hasApiKey() => _settings.hasApiKey();
   @override
+  bool hasCustomApiKey() => _settings.hasCustomApiKey();
+  @override
   String? getEvApiKey() => _settings.getEvApiKey();
   @override
   bool hasEvApiKey() => _settings.hasEvApiKey();

--- a/lib/core/storage/stores/settings_hive_store.dart
+++ b/lib/core/storage/stores/settings_hive_store.dart
@@ -18,6 +18,20 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
   // In-memory cache to avoid async reads on every API call.
   static String? _apiKeyCache;
 
+  /// Default Tankerkoenig **community** API key shipped with the app
+  /// (#521). Every fresh install starts with this key so German search
+  /// returns real data out of the box — no user onboarding required.
+  /// Users who want their own key can still paste one in Settings →
+  /// API Keys → Tankerkoenig; the custom key then overrides this
+  /// default and `hasCustomApiKey()` flips to true.
+  ///
+  /// Rate limits apply to the community key because it is shared
+  /// across all public builds. That trade-off is deliberate — the
+  /// alternative was shipping "demo mode" on first launch, which
+  /// returned zero stations and made the app look broken.
+  static const defaultTankerkoenigKey =
+      'ff6250b2-a85d-41e5-b483-c052caff0ca9';
+
   /// Load API key from secure storage into memory. Call once at startup.
   static Future<void> loadApiKey() async {
     _apiKeyCache = await _secureStorage.read(key: StorageKeys.apiKey);
@@ -26,7 +40,11 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
   }
 
   @override
-  String? getApiKey() => _apiKeyCache;
+  String? getApiKey() {
+    final custom = _apiKeyCache;
+    if (custom != null && custom.isNotEmpty) return custom;
+    return defaultTankerkoenigKey;
+  }
 
   @override
   Future<void> setApiKey(String key) async {
@@ -42,7 +60,15 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
 
   @override
   bool hasApiKey() {
-    final key = getApiKey();
+    // #521 — a Tankerkoenig key is always available (custom or community
+    // default), so the app is never in a "demo mode" with respect to
+    // German search.
+    return true;
+  }
+
+  @override
+  bool hasCustomApiKey() {
+    final key = _apiKeyCache;
     return key != null && key.isNotEmpty;
   }
 

--- a/lib/features/profile/presentation/widgets/config_verification_widget.dart
+++ b/lib/features/profile/presentation/widgets/config_verification_widget.dart
@@ -20,7 +20,10 @@ class ConfigVerificationWidget extends ConsumerWidget {
     final apiKeys = ref.read(apiKeyStorageProvider);
     final syncConfig = ref.watch(syncStateProvider);
     final profile = ref.watch(activeProfileProvider);
-    final hasApiKey = apiKeys.hasApiKey();
+    // #521 — hasApiKey is always true now (community default always
+    // available). We render one of two states based on hasCustomApiKey
+    // instead: user-configured key vs shipped default.
+    final hasCustomApiKey = apiKeys.hasCustomApiKey();
     final isEmail = syncConfig.hasEmail;
 
     return Card(
@@ -62,10 +65,15 @@ class ConfigVerificationWidget extends ConsumerWidget {
             _ConfigRow(
               icon: Icons.key,
               label: l?.configTankerkoenigKey ?? 'Tankerkoenig API key',
-              value: hasApiKey
+              // #521 — never render "Not set (demo mode)": the bundled
+              // community key means the app always has a working key.
+              // The row now distinguishes user-set (Configurée / green)
+              // from the community default (same status — real data,
+              // just not the user's own key).
+              value: hasCustomApiKey
                   ? (l?.configApiKeyConfigured ?? 'Configured')
-                  : (l?.configApiKeyNotSet ?? 'Not set (demo mode)'),
-              status: hasApiKey ? _Status.ok : _Status.warning,
+                  : (l?.configApiKeyCommunity ?? 'Default (community key)'),
+              status: _Status.ok,
             ),
             _ConfigRow(
               icon: Icons.ev_station,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -160,6 +160,7 @@
   "configTankerkoenigKey": "Tankerkönig API-Schlüssel",
   "configApiKeyConfigured": "Konfiguriert",
   "configApiKeyNotSet": "Nicht gesetzt (Demo-Modus)",
+  "configApiKeyCommunity": "Standard-Community-Schlüssel",
   "configEvKey": "Ladesäulen API-Schlüssel",
   "configEvKeyCustom": "Eigener Schlüssel",
   "configEvKeyShared": "Standard (geteilt)",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -160,6 +160,7 @@
   "configTankerkoenigKey": "Tankerkoenig API key",
   "configApiKeyConfigured": "Configured",
   "configApiKeyNotSet": "Not set (demo mode)",
+  "configApiKeyCommunity": "Default (community key)",
   "configEvKey": "EV charging API key",
   "configEvKeyCustom": "Custom key",
   "configEvKeyShared": "Default (shared)",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -149,6 +149,7 @@
   "configTankerkoenigKey": "Clé API Tankerkoenig",
   "configApiKeyConfigured": "Configurée",
   "configApiKeyNotSet": "Non définie (mode démo)",
+  "configApiKeyCommunity": "Clé communautaire par défaut",
   "configEvKey": "Clé API recharge VE",
   "configEvKeyCustom": "Clé personnalisée",
   "configEvKeyShared": "Partagée par défaut",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -890,6 +890,12 @@ abstract class AppLocalizations {
   /// **'Not set (demo mode)'**
   String get configApiKeyNotSet;
 
+  /// No description provided for @configApiKeyCommunity.
+  ///
+  /// In en, this message translates to:
+  /// **'Default (community key)'**
+  String get configApiKeyCommunity;
+
   /// No description provided for @configEvKey.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -408,6 +408,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -408,6 +408,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -408,6 +408,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -408,6 +408,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get configApiKeyNotSet => 'Nicht gesetzt (Demo-Modus)';
 
   @override
+  String get configApiKeyCommunity => 'Standard-Community-Schlüssel';
+
+  @override
   String get configEvKey => 'Ladesäulen API-Schlüssel';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -407,6 +407,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -405,6 +405,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -409,6 +409,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -407,6 +407,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -408,6 +408,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -408,6 +408,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get configApiKeyNotSet => 'Non définie (mode démo)';
 
   @override
+  String get configApiKeyCommunity => 'Clé communautaire par défaut';
+
+  @override
   String get configEvKey => 'Clé API recharge VE';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -407,6 +407,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -409,6 +409,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -409,6 +409,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -408,6 +408,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -408,6 +408,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -408,6 +408,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -409,6 +409,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -408,6 +408,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -409,6 +409,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -408,6 +408,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -408,6 +408,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -408,6 +408,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -408,6 +408,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get configApiKeyNotSet => 'Not set (demo mode)';
 
   @override
+  String get configApiKeyCommunity => 'Default (community key)';
+
+  @override
   String get configEvKey => 'EV charging API key';
 
   @override

--- a/test/core/data/storage_repository_test.dart
+++ b/test/core/data/storage_repository_test.dart
@@ -18,7 +18,14 @@ void main() {
       expect(mock.getFavoriteIds(), isEmpty);
       expect(mock.getRatings(), isEmpty);
       expect(mock.getIgnoredIds(), isEmpty);
-      expect(mock.hasApiKey(), isFalse);
+      // #521 — hasApiKey is always true (bundled community default);
+      // the custom-key flag is what the UI actually branches on now.
+      expect(mock.hasApiKey(), isTrue);
+      expect(mock.hasCustomApiKey(), isFalse);
+      // The mock's isSetupComplete still returns false because the
+      // mock hasn't been wired to track skipped/custom state — this
+      // test only verifies the interface, not the SettingsHiveStore
+      // implementation, so the old assertion stands.
       expect(mock.isSetupComplete, isFalse);
       expect(mock.alertCount, 0);
       expect(mock.favoriteCount, 0);
@@ -111,7 +118,8 @@ class _MockStorageRepository implements StorageRepository {
   @override String? getApiKey() => null;
   @override Future<void> setApiKey(String key) async {}
   @override Future<void> deleteApiKey() async {}
-  @override bool hasApiKey() => false;
+  @override bool hasApiKey() => true;
+  @override bool hasCustomApiKey() => false;
   @override String? getEvApiKey() => null;
   @override bool hasEvApiKey() => false;
   @override bool hasCustomEvApiKey() => false;

--- a/test/core/storage/hive_storage_test.dart
+++ b/test/core/storage/hive_storage_test.dart
@@ -319,9 +319,15 @@ void main() {
       expect(storage.isSetupComplete, isTrue);
     });
 
-    test('isSetupComplete returns false with no api key and no skip', () {
-      // API key cache is null by default and setup not skipped
-      expect(storage.isSetupComplete, isFalse);
+    test(
+        '#521: isSetupComplete is true on a fresh install because the '
+        'community default key is always available', () {
+      // Before #521 this returned false until the user either set a
+      // custom key or explicitly skipped setup. Since the community
+      // key is bundled, there is no "unconfigured" starting state any
+      // more — the onboarding flow can jump straight to the landing
+      // screen.
+      expect(storage.isSetupComplete, isTrue);
     });
   });
 
@@ -597,12 +603,25 @@ void main() {
   // API Key (in-memory cache only — cannot test secure storage in unit tests)
   // ---------------------------------------------------------------------------
   group('API Key (in-memory)', () {
-    test('getApiKey returns null by default', () {
-      expect(storage.getApiKey(), isNull);
+    test(
+        '#521: getApiKey returns the bundled community key when no '
+        'custom key is set', () {
+      final key = storage.getApiKey();
+      expect(key, isNotNull);
+      expect(key, isNotEmpty);
+      // Pin the exact community key — the value is part of the
+      // shipped behaviour and must not drift without review.
+      expect(key, 'ff6250b2-a85d-41e5-b483-c052caff0ca9');
     });
 
-    test('hasApiKey returns false when no key set', () {
-      expect(storage.hasApiKey(), isFalse);
+    test('#521: hasApiKey is always true (community default present)', () {
+      expect(storage.hasApiKey(), isTrue);
+    });
+
+    test(
+        '#521: hasCustomApiKey is false when only the community '
+        'default is available', () {
+      expect(storage.hasCustomApiKey(), isFalse);
     });
 
     test('hasEvApiKey returns true (default key always available)', () {

--- a/test/core/storage/storage_repository_provider_test.dart
+++ b/test/core/storage/storage_repository_provider_test.dart
@@ -286,7 +286,8 @@ class _InMemoryStorageRepository implements StorageRepository {
   @override String? getApiKey() => null;
   @override Future<void> setApiKey(String key) async {}
   @override Future<void> deleteApiKey() async {}
-  @override bool hasApiKey() => false;
+  @override bool hasApiKey() => true;
+  @override bool hasCustomApiKey() => false;
   @override String? getEvApiKey() => null;
   @override bool hasEvApiKey() => false;
   @override bool hasCustomEvApiKey() => false;

--- a/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
+++ b/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
@@ -50,6 +50,7 @@ void main() {
       when(() => mockStorage.cacheEntryCount).thenReturn(15);
       when(() => mockStorage.getItineraries()).thenReturn([{'id': 'r1'}]);
       when(() => mockStorage.hasApiKey()).thenReturn(true);
+      when(() => mockStorage.hasCustomApiKey()).thenReturn(true);
       when(() => mockStorage.getApiKey()).thenReturn('key');
       when(() => mockStorage.hasEvApiKey()).thenReturn(false);
       when(() => mockStorage.hasCustomEvApiKey()).thenReturn(false);

--- a/test/features/profile/presentation/widgets/config_verification_widget_test.dart
+++ b/test/features/profile/presentation/widgets/config_verification_widget_test.dart
@@ -43,8 +43,13 @@ List<Object> _buildOverrides({
   bool syncEnabled = false,
 }) {
   final mockStorage = MockStorageRepository();
-  when(() => mockStorage.hasApiKey()).thenReturn(hasApiKey);
-  when(() => mockStorage.getApiKey()).thenReturn(hasApiKey ? 'some-key' : null);
+  // #521 — hasApiKey is always true in production (community default
+  // always available). The `hasApiKey` parameter here actually controls
+  // whether the user has set their OWN key on top of the default.
+  when(() => mockStorage.hasApiKey()).thenReturn(true);
+  when(() => mockStorage.hasCustomApiKey()).thenReturn(hasApiKey);
+  when(() => mockStorage.getApiKey())
+      .thenReturn(hasApiKey ? 'custom-key' : 'ff6250b2-a85d-41e5-b483-c052caff0ca9');
   when(() => mockStorage.hasEvApiKey()).thenReturn(false);
   when(() => mockStorage.hasCustomEvApiKey()).thenReturn(false);
 
@@ -116,20 +121,23 @@ void main() {
     });
 
     testWidgets(
-        'Tankerkoenig row shows "Non définie (mode démo)" under FR when '
-        'no key is set', (tester) async {
+        '#521: Tankerkoenig row shows "Clé communautaire par défaut" '
+        'when no custom key is set (FR)', (tester) async {
       await pumpApp(
         tester,
         const ConfigVerificationWidget(),
         overrides: _buildOverrides(profile: _sampleProfile()),
         locale: const Locale('fr'),
       );
-      expect(find.text('Non définie (mode démo)'), findsOneWidget);
+      // The community key is bundled — we never render "demo mode".
+      expect(find.text('Clé communautaire par défaut'), findsOneWidget);
+      expect(find.text('Non définie (mode démo)'), findsNothing);
       expect(find.text('Not set (demo mode)'), findsNothing);
     });
 
-    testWidgets('Tankerkoenig row shows "Configurée" under FR when a key is set',
-        (tester) async {
+    testWidgets(
+        '#521: Tankerkoenig row shows "Configurée" under FR when the '
+        'user has set their own key', (tester) async {
       await pumpApp(
         tester,
         const ConfigVerificationWidget(),
@@ -138,6 +146,7 @@ void main() {
         locale: const Locale('fr'),
       );
       expect(find.text('Configurée'), findsOneWidget);
+      expect(find.text('Clé communautaire par défaut'), findsNothing);
     });
 
     testWidgets('TankSync row shows "Désactivée" under FR when disconnected',

--- a/test/security/no_hardcoded_secrets_test.dart
+++ b/test/security/no_hardcoded_secrets_test.dart
@@ -58,6 +58,9 @@ void main() {
             if (line.trimLeft().startsWith('//')) continue;
             // Exclude default EV API key (intentionally public, shared key)
             if (line.contains('defaultEvApiKey')) continue;
+            // #521 — bundled Tankerkoenig community key (intentionally
+            // public, rate-limited, shared across public builds).
+            if (line.contains('defaultTankerkoenigKey')) continue;
             violations.add('${file.path}:${i + 1}: $line');
           }
         }


### PR DESCRIPTION
## Summary
- Ships a default Tankerkoenig **community** API key (`ff6250b2-a85d-41e5-b483-c052caff0ca9`). Fresh installs return real German station data on the very first search without any onboarding.
- Users can still paste their own key in Settings → API Keys → Tankerkoenig. A custom key overrides the default; `hasCustomApiKey()` is the new flag.
- `hasApiKey()` is always true now (key is always available), so the "demo mode" state is gone for Tankerkoenig.
- `isSetupComplete` returns true on fresh install, so the onboarding flow jumps straight to the landing screen after GDPR consent.

## UI
- `ConfigVerificationWidget` row for the Tankerkoenig key branches on `hasCustomApiKey`:
  - user-set → **Configurée** / Configured / Konfiguriert
  - default → new l10n key `configApiKeyCommunity` → **Clé communautaire par défaut** / Default (community key) / Standard-Community-Schlüssel
- The old "Not set (demo mode)" state is unreachable from the UI.

## Security lint
- `no_hardcoded_secrets_test` allowlists the community UUID by symbol name (`defaultTankerkoenigKey`), same way `defaultEvApiKey` is allowlisted. Any other hardcoded UUID anywhere in `lib/` still trips the lint.

## Test plan
- [x] `hive_storage_test`: getApiKey returns the pinned community UUID by default; hasApiKey true; hasCustomApiKey false; isSetupComplete true on fresh install.
- [x] `config_verification_widget_test`: FR row shows "Clé communautaire par défaut" with no custom key, "Configurée" with a custom key, regression guard that "Not set (demo mode)" never renders.
- [x] Mock chain in `privacy_dashboard_screen_test` and `storage_repository_test` updated for the new `hasCustomApiKey` interface method.
- [x] `flutter analyze --no-fatal-infos` — zero warnings/errors.
- [x] `flutter test` — 3670 passing, 1 skipped.

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)
