### PR TITLE
refactor(settings): tighten vertical spacing on Paramètres

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -28,19 +28,23 @@ class ProfileScreen extends ConsumerWidget {
       ),
       body: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        padding: const EdgeInsets.all(16),
+        // #530 — compact vertical spacing. Was `EdgeInsets.all(16)` plus
+        // `SizedBox(height: 32)` between every major section, which ate
+        // ~180 dp of whitespace on a single screen. Tightened to 8 dp
+        // top / 16 dp sides + 16 dp section gaps + 4 dp header-to-body.
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
         children: [
           // Profiles
           _SectionHeader(icon: Icons.person, title: l?.sectionProfile ?? 'Profile'),
-          const SizedBox(height: 8),
+          const SizedBox(height: 4),
           const ProfileListSection(),
-          const SizedBox(height: 32),
+          const SizedBox(height: 16),
 
           // Location
           _SectionHeader(icon: Icons.my_location, title: l?.sectionLocation ?? 'Location'),
-          const SizedBox(height: 8),
+          const SizedBox(height: 4),
           const LocationSectionWidget(),
-          const SizedBox(height: 32),
+          const SizedBox(height: 16),
 
           // TankSync
           const _FoldableSection(
@@ -85,14 +89,14 @@ class ProfileScreen extends ConsumerWidget {
             title: l?.storageAndCache ?? 'Storage & cache',
             child: const StorageSection(),
           ),
-          const SizedBox(height: 32),
+          const SizedBox(height: 16),
 
           // About
           _SectionHeader(
               icon: Icons.info_outline, title: l?.about ?? 'About'),
-          const SizedBox(height: 8),
+          const SizedBox(height: 4),
           const AboutSection(),
-          const SizedBox(height: 32),
+          const SizedBox(height: 16),
 
           // Privacy & Consent
           _FoldableSection(

--- a/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -98,6 +98,36 @@ void main() {
       expect(find.text('Configuration & Privacy'), findsNothing);
     });
 
+    testWidgets(
+        '#530: no vertical SizedBox spacer taller than 16 dp on the '
+        'Settings screen body', (tester) async {
+      // Regression guard for #530 — the previous layout had four
+      // `SizedBox(height: 32)` spacers between major sections,
+      // eating ~100 dp of whitespace. A *vertical spacer* is a
+      // `SizedBox` whose width is null / infinite and whose height
+      // exceeds 16 dp. Square boxes (icons) and fixed-width sized
+      // boxes (avatar wrappers) are excluded by the width-is-null
+      // filter.
+      await pumpApp(
+        tester,
+        const ProfileScreen(),
+        overrides: overrides,
+      );
+
+      final verticalSpacers = tester
+          .widgetList<SizedBox>(find.byType(SizedBox))
+          .where((s) => s.width == null)
+          .where((s) => (s.height ?? 0) > 16)
+          .toList();
+
+      expect(
+        verticalSpacers,
+        isEmpty,
+        reason: '#530: no vertical spacer should exceed 16 dp — found '
+            '${verticalSpacers.map((s) => s.height).toList()}',
+      );
+    });
+
     testWidgets('does not render the ConfigVerificationWidget (#519)',
         (tester) async {
       await pumpApp(


### PR DESCRIPTION
## Summary
- After #519 moved `ConfigVerificationWidget` off the Settings screen, the body still carried four 32 dp section gaps plus the original 16 dp `ListView` padding — ~100 dp of whitespace that served no visible purpose.
- Tightened: list padding `EdgeInsets.all(16)` → `EdgeInsets.fromLTRB(16, 8, 16, 16)`; major section gaps 32 → 16; header-to-body gaps 8 → 4.
- `_FoldableSection` cards are untouched; the 16 dp gap between Profile / Location / About / Privacy Dashboard is still well above Material's 8 dp grid minimum.

## Test plan
- [x] New regression guard in `profile_screen_test.dart`: asserts no *vertical* `SizedBox` (width=null, height > 16) exists on the Settings screen body. Square boxes (icon placeholders) are filtered out by the width-is-null predicate.
- [x] `flutter analyze --no-fatal-infos` clean.
- [x] `flutter test` — green (3676 passing; Argentina network tests are flaky in parallel runs, pass in isolation, unrelated).

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)
