### PR TITLE
fix(ev): trigger EV search from criteria + watch EV favorites for rebuild

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../providers/ev_favorites_provider.dart';
 import '../../providers/favorites_provider.dart';
 import '../widgets/alerts_tab.dart';
 import '../widgets/favorites_fuel_tab.dart';
@@ -25,7 +26,13 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    // #538 — watch both fuel and EV favorites so the screen rebuilds
+    // when either set changes. The previous code only watched
+    // favoritesProvider (fuel), which meant adding an EV favorite
+    // never triggered a rebuild — the list stayed stale until the
+    // user switched tabs or restarted the app.
     final favoriteIds = ref.watch(favoritesProvider);
+    final evFavoriteIds = ref.watch(evFavoritesProvider);
 
     // Reload favorites when the auth identity changes
     // (anonymous -> email, reconnect, disconnect, etc.)
@@ -47,7 +54,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
             child: Text(l10n?.favorites ?? 'Favorites'),
           ),
           actions: [
-            if (favoriteIds.isNotEmpty)
+            if (favoriteIds.isNotEmpty || evFavoriteIds.isNotEmpty)
               IconButton(
                 icon: const Icon(Icons.refresh),
                 onPressed: () {

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/location/location_consent.dart';
+import '../../../../core/location/location_service.dart';
 import '../../../../core/services/location_search_service.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/storage/storage_providers.dart';
@@ -59,13 +60,34 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
       await LocationConsentDialog.recordConsent(settings);
     }
 
+    // #536 — the Electric path must call the EV search notifier, not
+    // the fuel search notifier. The previous code was a no-op read
+    // (`ref.read(eVSearchStateProvider)`) that never invoked
+    // `searchNearby()`. Mirrors the pattern in search_screen.dart:100-115.
     if (fuelType == FuelType.electric) {
-      ref.read(eVSearchStateProvider);
+      try {
+        final locationService = ref.read(locationServiceProvider);
+        final position = await locationService.getCurrentPosition();
+        unawaited(ref.read(eVSearchStateProvider.notifier).searchNearby(
+              lat: position.latitude,
+              lng: position.longitude,
+              radiusKm: radius,
+            ));
+      } catch (e) {
+        if (mounted) {
+          SnackBarHelper.show(
+            context,
+            '${AppLocalizations.of(context)?.gpsError ?? "GPS error"}: $e',
+          );
+        }
+        return;
+      }
+    } else {
+      unawaited(ref.read(searchStateProvider.notifier).searchByGps(
+            fuelType: fuelType,
+            radiusKm: radius,
+          ));
     }
-    unawaited(ref.read(searchStateProvider.notifier).searchByGps(
-          fuelType: fuelType,
-          radiusKm: radius,
-        ));
     if (mounted) Navigator.of(context).pop();
   }
 


### PR DESCRIPTION
## Summary
Two EV-related fixes bundled (same branch, same device testing session):

### #536 — EV search not triggered from Search Criteria screen
- `_performGpsSearch()` had a no-op `ref.read(eVSearchStateProvider)` that never called `searchNearby()`. The Rechercher button with Electric selected sent the user back to the empty "Recherchez des bornes de recharge" prompt.
- Now mirrors the working pattern from `search_screen.dart:100-115`: when `FuelType.electric` is selected, calls `eVSearchStateProvider.notifier.searchNearby()` with GPS + radius.

### #538 — EV favorites not triggering rebuild on FavoritesScreen
- `FavoritesScreen` only watched `favoritesProvider` (fuel). Adding an EV station to favorites never triggered a rebuild — the list stayed stale.
- Now watches both `favoritesProvider` and `evFavoritesProvider`, and combines them for the refresh button visibility check.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero warnings/errors.
- [x] `flutter test` — 3676 passing, 1 skipped (Argentina flaky network tests in parallel runs, pass in isolation, pre-existing).
- [ ] Manual: select Electric → tap Rechercher → verify results appear directly without a second tap.
- [ ] Manual: add an EV station as favorite → switch to Favoris → verify it appears.

Closes #536
Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)
