### PR TITLE
fix(privacy): add root index.html for GitHub Pages + URL reachability test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ copilot/
 # Development documentation (kept in docs/ for reference)
 docs/*
 # Except: privacy policy (deployed to GitHub Pages), Play Store docs, contributor guides, README screenshots
+!docs/index.html
 !docs/privacy-policy/
 !docs/play-store/
 !docs/decisions/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — Fuel Prices App</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --fg: #1a1a1a;
+      --accent: #0066cc;
+      --muted: #666666;
+      --border: #e0e0e0;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #1a1a1a;
+        --fg: #e0e0e0;
+        --accent: #66aaff;
+        --muted: #999999;
+        --border: #333333;
+      }
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      line-height: 1.6;
+      padding: 2rem 1rem;
+      max-width: 720px;
+      margin: 0 auto;
+    }
+    h1 { font-size: 1.8rem; margin-bottom: 0.5rem; }
+    h2 { font-size: 1.3rem; margin-top: 2rem; margin-bottom: 0.5rem; border-bottom: 1px solid var(--border); padding-bottom: 0.3rem; }
+    p, ul { margin-bottom: 1rem; }
+    ul { padding-left: 1.5rem; }
+    li { margin-bottom: 0.3rem; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .meta { color: var(--muted); font-size: 0.9rem; margin-bottom: 2rem; }
+    .contact { background: var(--border); padding: 1rem; border-radius: 8px; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+
+<h1>Privacy Policy</h1>
+<p class="meta">Fuel Prices App (de.tankstellen.app) &mdash; Last updated: 7 April 2026</p>
+
+<h2>1. Overview</h2>
+<p>
+  Fuel Prices ("the app") is a free, open-source fuel and EV charging price comparison app.
+  It is designed with a <strong>local-first, privacy-respecting</strong> architecture.
+  There are no ads, no analytics, and no tracking.
+</p>
+
+<h2>2. Data collected</h2>
+
+<h3>2.1 Location data (approximate)</h3>
+<p>
+  When you grant location permission, the app reads your approximate position to find
+  nearby fuel stations. Your coordinates are sent to third-party price APIs (see Section 4)
+  as part of the search query. Location data is <strong>not stored on any server we operate</strong>
+  and is never used for tracking or profiling.
+</p>
+
+<h3>2.2 API key</h3>
+<p>
+  You provide your own API key (e.g. Tankerkoenig). The key is stored locally in
+  encrypted secure storage (Android Keystore / iOS Keychain). It is sent only to the
+  corresponding API provider and is never transmitted to us or any other party.
+</p>
+
+<h3>2.3 Favorites, profiles, and settings</h3>
+<p>
+  Your favorites, search profiles, fuel preferences, and app settings are stored
+  locally on your device using Hive (an encrypted local database).
+</p>
+
+<h3>2.4 TankSync (optional cloud sync)</h3>
+<p>
+  If you opt in to TankSync, an anonymous account is created via Supabase.
+  The following data is synced to the server:
+</p>
+<ul>
+  <li>Anonymous user ID (UUID, no email or name)</li>
+  <li>Favorite station IDs</li>
+  <li>Price alert configurations</li>
+  <li>Community price reports (station ID, fuel type, price, timestamp)</li>
+</ul>
+<p>
+  TankSync is entirely optional and disabled by default. You can view, export, and
+  delete all server-side data from the "Data Transparency" screen in the app.
+</p>
+
+<h2>3. Data NOT collected</h2>
+<p>The app does <strong>not</strong> collect:</p>
+<ul>
+  <li>Name, email address, or phone number</li>
+  <li>Financial or payment information</li>
+  <li>Health or fitness data</li>
+  <li>Contacts, messages, or call logs</li>
+  <li>Photos, videos, or files</li>
+  <li>Browsing history</li>
+  <li>Device advertising identifiers</li>
+  <li>Analytics or crash reports (unless Sentry is opted into — not currently active)</li>
+</ul>
+
+<h2>4. Third-party services</h2>
+<p>The app communicates with the following third-party APIs:</p>
+<ul>
+  <li><strong>Tankerkoenig</strong> (creativecommons.tankerkoenig.de) — German fuel prices. Receives: search coordinates, API key.</li>
+  <li><strong>Prix Carburants</strong> (data.economie.gouv.fr) — French fuel prices. Receives: search coordinates.</li>
+  <li><strong>Italian fuel price API</strong> (osservaprezzi.mise.gov.it) — Italian fuel prices. Receives: search coordinates.</li>
+  <li><strong>Spanish fuel price API</strong> (sedeaplicaciones.minetur.gob.es) — Spanish fuel prices. Receives: search coordinates.</li>
+  <li><strong>Austrian fuel price API</strong> (spritpreisrechner.at) — Austrian fuel prices. Receives: search coordinates.</li>
+  <li><strong>Belgian fuel price API</strong> (fuelwatch.be) — Belgian fuel prices. Receives: search coordinates.</li>
+  <li><strong>Luxembourg fuel price API</strong> (data.public.lu) — Luxembourg fuel prices. Receives: search coordinates.</li>
+  <li><strong>OpenChargeMap</strong> (api.openchargemap.io) — EV charging station data. Receives: search coordinates.</li>
+  <li><strong>Nominatim / OpenStreetMap</strong> (nominatim.openstreetmap.org) — Geocoding. Receives: search text or coordinates.</li>
+  <li><strong>OpenStreetMap tile servers</strong> (tile.openstreetmap.org) — Map tiles. Receives: tile coordinates.</li>
+  <li><strong>Supabase</strong> (only if TankSync is enabled) — Cloud sync backend. Receives: anonymous user data (see Section 2.4).</li>
+</ul>
+<p>
+  Each provider has its own privacy policy. We encourage you to review them.
+  The app does not share data between these providers.
+</p>
+
+<h2>5. Data security</h2>
+<ul>
+  <li>All network communication uses HTTPS (TLS encryption in transit).</li>
+  <li>API keys are stored in platform-native encrypted storage (Android Keystore).</li>
+  <li>Local data is stored in Hive (local database on device storage).</li>
+  <li>No data is sent to any server unless you initiate a search or enable TankSync.</li>
+</ul>
+
+<h2>6. Your rights</h2>
+<p>You have the right to:</p>
+<ul>
+  <li><strong>Access</strong> — View all locally stored data in the app's Storage section.</li>
+  <li><strong>Export</strong> — Export your TankSync data as JSON from the Data Transparency screen.</li>
+  <li><strong>Delete</strong> — Delete all local data via Settings > Delete all data. Delete all server data via TankSync > Data Transparency > Delete everything.</li>
+  <li><strong>Withdraw consent</strong> — Revoke location permission in your device settings at any time. Disable TankSync at any time.</li>
+</ul>
+
+<h2>7. Children's privacy</h2>
+<p>
+  The app is not directed at children under 13. We do not knowingly collect
+  personal information from children.
+</p>
+
+<h2>8. Changes to this policy</h2>
+<p>
+  We may update this policy from time to time. Changes will be published at this URL
+  and noted with an updated date. Continued use of the app constitutes acceptance
+  of the updated policy.
+</p>
+
+<h2>9. Contact</h2>
+<div class="contact">
+  <p><strong>Developer:</strong> Florian DITTGEN</p>
+  <p><strong>Email:</strong> <a href="mailto:fdittgen@gmail.com">fdittgen@gmail.com</a></p>
+  <p><strong>Source code:</strong> <a href="https://github.com/fdittgen-png/tankstellen">github.com/fdittgen-png/tankstellen</a></p>
+</div>
+
+</body>
+</html>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -792,7 +792,7 @@ packages:
     source: hosted
     version: "1.0.2"
   http:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,6 +77,9 @@ dev_dependencies:
   json_serializable: ^6.13.0
   riverpod_generator: ^4.0.3
 
+  # URL reachability test (#539)
+  http: ^1.3.0
+
   # Testing
   mocktail: ^1.0.5
   yaml: ^3.1.3

--- a/test/security/external_urls_reachable_test.dart
+++ b/test/security/external_urls_reachable_test.dart
@@ -1,0 +1,47 @@
+@Tags(['network'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:tankstellen/core/constants/app_constants.dart';
+
+/// Verifies that every user-facing URL constant in [AppConstants] is
+/// reachable (returns HTTP 2xx or 3xx). Tagged `network` so it only
+/// runs in CI jobs / manual invocations with network access:
+///
+///   flutter test --tags=network
+///
+/// The default CI step runs `--exclude-tags=network`, so this test
+/// does NOT block offline PR checks.
+void main() {
+  group('External URLs reachable (#539)', () {
+    /// URLs the app opens in the user's browser. A 404 on any of
+    /// these is a visible broken link the user sees after tapping a
+    /// Settings tile or About entry.
+    final urlsToCheck = <String, String>{
+      'privacyPolicyUrl': AppConstants.privacyPolicyUrl,
+      'githubRepoUrl': AppConstants.githubRepoUrl,
+      'githubIssuesUrl': AppConstants.githubIssuesUrl,
+      'tankerkoenigRegistrationUrl': AppConstants.tankerkoenigRegistrationUrl,
+      'paypalUrl': AppConstants.paypalUrl,
+      'revolutUrl': AppConstants.revolutUrl,
+    };
+
+    for (final entry in urlsToCheck.entries) {
+      test('${entry.key} responds with 2xx or 3xx', () async {
+        final response = await http.head(
+          Uri.parse(entry.value),
+        ).timeout(
+          const Duration(seconds: 15),
+          onTimeout: () => http.Response('timeout', 408),
+        );
+        expect(
+          response.statusCode,
+          lessThan(400),
+          reason: '${entry.key} (${entry.value}) returned '
+              'HTTP ${response.statusCode} — broken link',
+        );
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- The privacy policy URL (`https://fdittgen-png.github.io/tankstellen/`) returned 404. The page existed at `docs/privacy-policy/index.html` but there was no `docs/index.html` for GitHub Pages to serve at the root path.
- Copied the privacy page to `docs/index.html` and whitelisted it in `.gitignore`.
- Added a `@Tags(['network'])` test that HEAD-requests every user-facing URL in `AppConstants` and asserts all return HTTP < 400. CI excludes this tag by default (`--exclude-tags=network`), so it only runs manually or in a dedicated network-enabled CI step.

## Action required after merge
Enable GitHub Pages in the repo: **Settings → Pages → Deploy from branch → master → /docs → Save**. The URL will start resolving within minutes.

## Test plan
- [x] `flutter test --exclude-tags=network` — all existing tests pass (network test excluded).
- [x] `flutter analyze --no-fatal-infos` — clean.
- [x] New `test/security/external_urls_reachable_test.dart` — 6 URL checks, tagged `network`.
- [ ] After enabling Pages: `flutter test --tags=network` — all 6 URLs respond < 400.

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)
