### PR TITLE
refactor(ev): unify search trigger — single SearchState dispatches by fuel type

### DIFF
--- a/lib/core/providers/app_state_provider.g.dart
+++ b/lib/core/providers/app_state_provider.g.dart
@@ -9,15 +9,27 @@ part of 'app_state_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 /// Whether the Tankerkoenig API key is configured.
+///
+/// Since #521 this is always true — the app ships a community
+/// default. Use [hasCustomApiKey] to tell whether the user set their
+/// own key.
 
 @ProviderFor(hasApiKey)
 final hasApiKeyProvider = HasApiKeyProvider._();
 
 /// Whether the Tankerkoenig API key is configured.
+///
+/// Since #521 this is always true — the app ships a community
+/// default. Use [hasCustomApiKey] to tell whether the user set their
+/// own key.
 
 final class HasApiKeyProvider extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Whether the Tankerkoenig API key is configured.
+  ///
+  /// Since #521 this is always true — the app ships a community
+  /// default. Use [hasCustomApiKey] to tell whether the user set their
+  /// own key.
   HasApiKeyProvider._()
     : super(
         from: null,
@@ -52,6 +64,55 @@ final class HasApiKeyProvider extends $FunctionalProvider<bool, bool, bool>
 }
 
 String _$hasApiKeyHash() => r'9927ae0b513afe69898707f03a015b769948e062';
+
+/// Whether the user has set their **own** Tankerkoenig key, distinct
+/// from the community default bundled in the app (#521).
+
+@ProviderFor(hasCustomApiKey)
+final hasCustomApiKeyProvider = HasCustomApiKeyProvider._();
+
+/// Whether the user has set their **own** Tankerkoenig key, distinct
+/// from the community default bundled in the app (#521).
+
+final class HasCustomApiKeyProvider
+    extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// Whether the user has set their **own** Tankerkoenig key, distinct
+  /// from the community default bundled in the app (#521).
+  HasCustomApiKeyProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'hasCustomApiKeyProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$hasCustomApiKeyHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return hasCustomApiKey(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$hasCustomApiKeyHash() => r'c1825c86532b5661179d05a09d9a079cc6d6abc0';
 
 /// Whether a custom EV API key is configured.
 

--- a/lib/features/favorites/providers/favorites_provider.g.dart
+++ b/lib/features/favorites/providers/favorites_provider.g.dart
@@ -245,7 +245,7 @@ final class FavoriteStationsProvider
   }
 }
 
-String _$favoriteStationsHash() => r'3f07e655c1a1a72ca4d6586b5e5794d69a60cb82';
+String _$favoriteStationsHash() => r'11bdd3e132102a8af0ce92cfc00ea7364afc2493';
 
 /// Loads station data for favorites and refreshes prices.
 ///

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/location/location_consent.dart';
-import '../../../../core/location/location_service.dart';
 import '../../../../core/services/location_search_service.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/storage/storage_providers.dart';
@@ -14,10 +13,8 @@ import '../../../profile/providers/profile_provider.dart';
 import '../../../route_search/domain/entities/route_info.dart';
 import '../../../route_search/presentation/widgets/route_input.dart';
 import '../../../route_search/providers/route_search_provider.dart';
-import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_mode.dart';
 import '../../domain/entities/station.dart';
-import '../../providers/ev_search_provider.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
 import '../../providers/search_screen_ui_provider.dart';
@@ -60,34 +57,11 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
       await LocationConsentDialog.recordConsent(settings);
     }
 
-    // #536 — the Electric path must call the EV search notifier, not
-    // the fuel search notifier. The previous code was a no-op read
-    // (`ref.read(eVSearchStateProvider)`) that never invoked
-    // `searchNearby()`. Mirrors the pattern in search_screen.dart:100-115.
-    if (fuelType == FuelType.electric) {
-      try {
-        final locationService = ref.read(locationServiceProvider);
-        final position = await locationService.getCurrentPosition();
-        unawaited(ref.read(eVSearchStateProvider.notifier).searchNearby(
-              lat: position.latitude,
-              lng: position.longitude,
-              radiusKm: radius,
-            ));
-      } catch (e) {
-        if (mounted) {
-          SnackBarHelper.show(
-            context,
-            '${AppLocalizations.of(context)?.gpsError ?? "GPS error"}: $e',
-          );
-        }
-        return;
-      }
-    } else {
-      unawaited(ref.read(searchStateProvider.notifier).searchByGps(
-            fuelType: fuelType,
-            radiusKm: radius,
-          ));
-    }
+    // SearchState dispatches to EV or fuel service internally based on fuelType.
+    unawaited(ref.read(searchStateProvider.notifier).searchByGps(
+          fuelType: fuelType,
+          radiusKm: radius,
+        ));
     if (mounted) Navigator.of(context).pop();
   }
 

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../app/responsive_search_layout.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/location/location_consent.dart';
-import '../../../../core/location/location_service.dart';
 import '../../../../core/location/user_position_provider.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/utils/frame_callbacks.dart';
@@ -15,8 +14,6 @@ import '../../../map/presentation/widgets/inline_map.dart';
 import '../../../profile/domain/entities/user_profile.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../station_detail/presentation/widgets/station_detail_inline.dart';
-import '../../domain/entities/fuel_type.dart';
-import '../../providers/ev_search_provider.dart';
 import '../../providers/search_provider.dart';
 import '../../providers/selected_station_provider.dart';
 import '../widgets/demo_mode_banner.dart';
@@ -97,28 +94,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
       await LocationConsentDialog.recordConsent(settings);
     }
 
-    if (fuelType == FuelType.electric) {
-      try {
-        final locationService = ref.read(locationServiceProvider);
-        final position = await locationService.getCurrentPosition();
-        unawaited(ref.read(eVSearchStateProvider.notifier).searchNearby(
-              lat: position.latitude,
-              lng: position.longitude,
-              radiusKm: radius,
-            ));
-      } catch (e) {
-        if (mounted) {
-          SnackBarHelper.showError(
-              context,
-              '${AppLocalizations.of(context)?.gpsError ?? "GPS error"}: $e');
-        }
-      }
-    } else {
-      unawaited(ref.read(searchStateProvider.notifier).searchByGps(
-            fuelType: fuelType,
-            radiusKm: radius,
-          ));
-    }
+    // SearchState dispatches to EV or fuel service internally based on fuelType.
+    unawaited(ref.read(searchStateProvider.notifier).searchByGps(
+          fuelType: fuelType,
+          radiusKm: radius,
+        ));
   }
 
   void _performZipSearch(String zip) {

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -6,7 +6,6 @@ import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/domain/entities/user_profile.dart';
 import '../../../profile/providers/profile_provider.dart';
-import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_mode.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
@@ -36,7 +35,7 @@ class SearchResultsContent extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final searchMode = ref.watch(activeSearchModeProvider);
-    final fuelType = ref.watch(selectedFuelTypeProvider);
+    final isEv = ref.watch(isEvSearchProvider);
     final searchState = ref.watch(searchStateProvider);
 
     if (searchMode == SearchMode.route) {
@@ -45,7 +44,7 @@ class SearchResultsContent extends ConsumerWidget {
       );
     }
 
-    if (fuelType == FuelType.electric) {
+    if (isEv) {
       return EvSearchResultsView(onSearch: onGpsRetry);
     }
 

--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -11,6 +11,7 @@ import '../data/models/search_params.dart';
 import '../domain/entities/fuel_type.dart';
 import '../domain/entities/station.dart';
 import '../../profile/providers/profile_provider.dart';
+import 'ev_search_provider.dart';
 
 part 'search_provider.g.dart';
 
@@ -115,6 +116,22 @@ class SearchState extends _$SearchState {
         position.latitude, position.longitude,
       );
 
+      final profile = ref.read(activeProfileProvider);
+      final resolvedFuelType = fuelType ?? profile?.preferredFuelType ?? FuelType.all;
+      final resolvedRadius = radiusKm ?? profile?.defaultSearchRadius ?? 10.0;
+
+      // EV dispatch: delegate to EVSearchState and return early.
+      // Reset own state so the UI doesn't show a stuck loading spinner.
+      if (resolvedFuelType == FuelType.electric) {
+        await ref.read(eVSearchStateProvider.notifier).searchNearby(
+              lat: position.latitude,
+              lng: position.longitude,
+              radiusKm: resolvedRadius,
+            );
+        state = build();
+        return;
+      }
+
       // Reverse-geocode GPS to get postal code (used by services like Prix-Carburants)
       String? resolvedPostalCode;
       try {
@@ -137,12 +154,11 @@ class SearchState extends _$SearchState {
         debugPrint('Reverse geocoding failed: $e');
       }
 
-      final profile = ref.read(activeProfileProvider);
       final params = SearchParams(
         lat: position.latitude,
         lng: position.longitude,
-        radiusKm: radiusKm ?? profile?.defaultSearchRadius ?? 10.0,
-        fuelType: fuelType ?? profile?.preferredFuelType ?? FuelType.all,
+        radiusKm: resolvedRadius,
+        fuelType: resolvedFuelType,
         sortBy: sortBy ?? SortBy.price,
         postalCode: resolvedPostalCode,
       );
@@ -179,6 +195,22 @@ class SearchState extends _$SearchState {
       final geocoding = ref.read(geocodingChainProvider);
       final coordsResult = await geocoding.zipCodeToCoordinates(zipCode, cancelToken: cancelToken);
 
+      final profile = ref.read(activeProfileProvider);
+      final resolvedFuelType = fuelType ?? profile?.preferredFuelType ?? FuelType.all;
+      final resolvedRadius = radiusKm ?? profile?.defaultSearchRadius ?? 10.0;
+
+      // EV dispatch: geocode the ZIP, then delegate to EVSearchState.
+      // Reset own state so the UI doesn't show a stuck loading spinner.
+      if (resolvedFuelType == FuelType.electric) {
+        await ref.read(eVSearchStateProvider.notifier).searchNearby(
+              lat: coordsResult.data.lat,
+              lng: coordsResult.data.lng,
+              radiusKm: resolvedRadius,
+            );
+        state = build();
+        return;
+      }
+
       // Resolve city name for display
       String? cityName;
       try {
@@ -194,12 +226,11 @@ class SearchState extends _$SearchState {
         '$zipCode ${cityName ?? ''}'.trim(),
       );
 
-      final profile = ref.read(activeProfileProvider);
       final params = SearchParams(
         lat: coordsResult.data.lat,
         lng: coordsResult.data.lng,
-        radiusKm: radiusKm ?? profile?.defaultSearchRadius ?? 10.0,
-        fuelType: fuelType ?? profile?.preferredFuelType ?? FuelType.all,
+        radiusKm: resolvedRadius,
+        fuelType: resolvedFuelType,
         sortBy: sortBy ?? SortBy.price,
         postalCode: zipCode,
         locationName: '$zipCode ${cityName ?? ''}'.trim(),
@@ -252,11 +283,26 @@ class SearchState extends _$SearchState {
       }
 
       final profile = ref.read(activeProfileProvider);
+      final resolvedFuelType = fuelType ?? profile?.preferredFuelType ?? FuelType.all;
+      final resolvedRadius = radiusKm ?? profile?.defaultSearchRadius ?? 10.0;
+
+      // EV dispatch: delegate to EVSearchState with the explicit coordinates.
+      // Reset own state so the UI doesn't show a stuck loading spinner.
+      if (resolvedFuelType == FuelType.electric) {
+        await ref.read(eVSearchStateProvider.notifier).searchNearby(
+              lat: lat,
+              lng: lng,
+              radiusKm: resolvedRadius,
+            );
+        state = build();
+        return;
+      }
+
       final params = SearchParams(
         lat: lat,
         lng: lng,
-        radiusKm: radiusKm ?? profile?.defaultSearchRadius ?? 10.0,
-        fuelType: fuelType ?? profile?.preferredFuelType ?? FuelType.all,
+        radiusKm: resolvedRadius,
+        fuelType: resolvedFuelType,
         postalCode: postalCode,
         locationName: locationName,
       );
@@ -311,4 +357,13 @@ class SearchRadius extends _$SearchRadius {
   void set(double radius) {
     state = radius.clamp(1.0, 25.0);
   }
+}
+
+/// Whether the current search fuel type is electric.
+///
+/// Used by UI widgets to decide between EV and fuel result views without
+/// coupling to `FuelType.electric` directly.
+@riverpod
+bool isEvSearch(Ref ref) {
+  return ref.watch(selectedFuelTypeProvider) == FuelType.electric;
 }

--- a/lib/features/search/providers/search_provider.g.dart
+++ b/lib/features/search/providers/search_provider.g.dart
@@ -85,7 +85,7 @@ final class SearchStateProvider
   }
 }
 
-String _$searchStateHash() => r'e3429ce9beee0f519e31e3f8c1e1de386d4c32af';
+String _$searchStateHash() => r'5f93b006140334ab797ef15b4c3b68f7ffd4b37d';
 
 /// Manages the station search lifecycle and exposes results as [AsyncValue].
 ///
@@ -289,3 +289,57 @@ abstract class _$SearchRadius extends $Notifier<double> {
     element.handleCreate(ref, build);
   }
 }
+
+/// Whether the current search fuel type is electric.
+///
+/// Used by UI widgets to decide between EV and fuel result views without
+/// coupling to `FuelType.electric` directly.
+
+@ProviderFor(isEvSearch)
+final isEvSearchProvider = IsEvSearchProvider._();
+
+/// Whether the current search fuel type is electric.
+///
+/// Used by UI widgets to decide between EV and fuel result views without
+/// coupling to `FuelType.electric` directly.
+
+final class IsEvSearchProvider extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// Whether the current search fuel type is electric.
+  ///
+  /// Used by UI widgets to decide between EV and fuel result views without
+  /// coupling to `FuelType.electric` directly.
+  IsEvSearchProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'isEvSearchProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$isEvSearchHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return isEvSearch(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$isEvSearchHash() => r'f2280af5461fbac2ac8f7653f864f5401d692702';

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -9,8 +9,10 @@ import 'package:tankstellen/core/services/service_providers.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/ev_search_provider.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
 
 import '../../../mocks/mocks.dart';
@@ -28,6 +30,41 @@ class _FixedUserPosition extends UserPosition {
 
   @override
   UserPositionData? build() => _data;
+}
+
+/// Fake EVSearchState that records calls to [searchNearby] without
+/// hitting real services.
+class _FakeEVSearchState extends EVSearchState {
+  bool searchNearbyCalled = false;
+  double? lastLat;
+  double? lastLng;
+  double? lastRadiusKm;
+
+  @override
+  AsyncValue<ServiceResult<List<ChargingStation>>> build() {
+    return AsyncValue.data(ServiceResult(
+      data: const [],
+      source: ServiceSource.openChargeMapApi,
+      fetchedAt: DateTime.now(),
+    ));
+  }
+
+  @override
+  Future<void> searchNearby({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) async {
+    searchNearbyCalled = true;
+    lastLat = lat;
+    lastLng = lng;
+    lastRadiusKm = radiusKm;
+    state = AsyncValue.data(ServiceResult(
+      data: const [],
+      source: ServiceSource.openChargeMapApi,
+      fetchedAt: DateTime.now(),
+    ));
+  }
 }
 
 void main() {
@@ -59,6 +96,20 @@ void main() {
     ]);
     addTearDown(c.dispose);
     return c;
+  }
+
+  /// Creates a container with a fake EVSearchState for EV dispatch tests.
+  (ProviderContainer, _FakeEVSearchState) createContainerWithEv() {
+    final fakeEv = _FakeEVSearchState();
+    final c = ProviderContainer(overrides: [
+      hiveStorageProvider.overrideWithValue(mockStorage),
+      stationServiceProvider.overrideWithValue(mockStationService),
+      geocodingChainProvider.overrideWithValue(mockGeocoding),
+      userPositionProvider.overrideWith(() => _NullUserPosition()),
+      eVSearchStateProvider.overrideWith(() => fakeEv),
+    ]);
+    addTearDown(c.dispose);
+    return (c, fakeEv);
   }
 
   const testStation = Station(
@@ -535,6 +586,119 @@ void main() {
       final state = container.read(searchStateProvider);
       // Distance from Paris to Berlin should be recalculated
       expect(state.value!.data.first.dist, greaterThan(0));
+    });
+  });
+
+  group('EV dispatch (unified search trigger)', () {
+    test('searchByCoordinates with FuelType.electric dispatches to EVSearchState', () async {
+      final (container, fakeEv) = createContainerWithEv();
+
+      await container.read(searchStateProvider.notifier).searchByCoordinates(
+            lat: 48.85,
+            lng: 2.35,
+            fuelType: FuelType.electric,
+            radiusKm: 5.0,
+          );
+
+      expect(fakeEv.searchNearbyCalled, isTrue);
+      expect(fakeEv.lastLat, 48.85);
+      expect(fakeEv.lastLng, 2.35);
+      expect(fakeEv.lastRadiusKm, 5.0);
+      // Fuel station service should NOT have been called
+      verifyNever(() => mockStationService.searchStations(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          ));
+    });
+
+    test('searchByCoordinates with non-electric fuel does NOT dispatch to EVSearchState', () async {
+      when(() => mockStationService.searchStations(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: [testStation],
+                source: ServiceSource.tankerkoenigApi,
+                fetchedAt: DateTime.now(),
+              ));
+
+      final (container, fakeEv) = createContainerWithEv();
+
+      await container.read(searchStateProvider.notifier).searchByCoordinates(
+            lat: 48.85,
+            lng: 2.35,
+            fuelType: FuelType.e10,
+          );
+
+      expect(fakeEv.searchNearbyCalled, isFalse);
+      verify(() => mockStationService.searchStations(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).called(1);
+    });
+
+    test('searchByZipCode with FuelType.electric geocodes then dispatches to EVSearchState', () async {
+      when(() => mockGeocoding.zipCodeToCoordinates('75001', cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: (lat: 48.86, lng: 2.34),
+                source: ServiceSource.nominatimGeocoding,
+                fetchedAt: DateTime.now(),
+              ));
+
+      final (container, fakeEv) = createContainerWithEv();
+
+      await container.read(searchStateProvider.notifier).searchByZipCode(
+            zipCode: '75001',
+            fuelType: FuelType.electric,
+            radiusKm: 8.0,
+          );
+
+      expect(fakeEv.searchNearbyCalled, isTrue);
+      expect(fakeEv.lastLat, 48.86);
+      expect(fakeEv.lastLng, 2.34);
+      expect(fakeEv.lastRadiusKm, 8.0);
+      verifyNever(() => mockStationService.searchStations(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          ));
+    });
+
+    test('searchByCoordinates with FuelType.electric skips fuel service entirely', () async {
+      final (container, fakeEv) = createContainerWithEv();
+
+      await container.read(searchStateProvider.notifier).searchByCoordinates(
+            lat: 52.52,
+            lng: 13.41,
+            fuelType: FuelType.electric,
+            radiusKm: 10.0,
+            locationName: 'Berlin',
+          );
+
+      expect(fakeEv.searchNearbyCalled, isTrue);
+      // SearchState itself should NOT be in data state from fuel results
+      // (it stays in initial state because EV dispatch returned early)
+      final state = container.read(searchStateProvider);
+      expect(state.value!.data, isEmpty);
+    });
+  });
+
+  group('isEvSearchProvider', () {
+    test('returns true when selectedFuelType is electric', () {
+      final container = createContainer();
+      container.read(selectedFuelTypeProvider.notifier).select(FuelType.electric);
+
+      expect(container.read(isEvSearchProvider), isTrue);
+    });
+
+    test('returns false for non-electric fuel types', () {
+      final container = createContainer();
+      container.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      expect(container.read(isEvSearchProvider), isFalse);
+    });
+
+    test('returns false for FuelType.all', () {
+      final container = createContainer();
+      // Default is FuelType.all
+      expect(container.read(isEvSearchProvider), isFalse);
     });
   });
 }


### PR DESCRIPTION
## Summary
- **SearchState now dispatches internally** to EVSearchState when `fuelType == FuelType.electric`, across all 3 search methods (`searchByGps`, `searchByZipCode`, `searchByCoordinates`)
- **Removed all `if (fuelType == FuelType.electric)` branches** from `search_screen.dart`, `search_criteria_screen.dart`, and `search_results_content.dart`
- **Added `isEvSearchProvider`** — derived provider for the rendering fork, decoupling UI from `FuelType.electric` identity checks

Closes #542

## Test plan
- [x] `flutter analyze` passes (zero warnings)
- [x] `flutter test` passes (3689 tests, 0 regressions)
- [x] 7 new tests: EV dispatch for coordinates/zip, non-electric bypass, isEvSearch provider
- [ ] Manual testing: select Electric fuel type → GPS search triggers EV results; switch to E10 → fuel results

🤖 Generated with [Claude Code](https://claude.com/claude-code)