### PR TITLE
refactor(ev): unified SearchResultItem wrapper for mixed fuel + EV results

### DIFF
--- a/lib/features/driving/presentation/screens/driving_mode_screen.dart
+++ b/lib/features/driving/presentation/screens/driving_mode_screen.dart
@@ -81,9 +81,8 @@ class _DrivingModeScreenState extends ConsumerState<DrivingModeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final searchState = ref.watch(searchStateProvider);
     final selectedFuel = ref.watch(selectedFuelTypeProvider);
-    final stations = _extractStations(searchState);
+    final stations = ref.watch(fuelStationsProvider);
 
     return Scaffold(
       body: GestureDetector(
@@ -160,10 +159,4 @@ class _DrivingModeScreenState extends ConsumerState<DrivingModeScreen> {
     _mapController.move(LatLng(nearest.lat, nearest.lng), 15);
   }
 
-  List<Station> _extractStations(AsyncValue searchState) {
-    if (!searchState.hasValue) return [];
-    final result = searchState.value;
-    if (result == null) return [];
-    return result.data as List<Station>? ?? [];
-  }
 }

--- a/lib/features/map/presentation/widgets/inline_map.dart
+++ b/lib/features/map/presentation/widgets/inline_map.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/search_result_item.dart';
 import '../../../search/providers/search_provider.dart';
 import 'station_map_layers.dart';
 
@@ -38,9 +39,13 @@ class _InlineMapState extends ConsumerState<InlineMap> {
 
     return searchState.when(
       data: (result) {
-        final stations = result.data;
+        final List<SearchResultItem> allItems = result.data;
+        final stations = allItems
+            .whereType<FuelStationResult>()
+            .map((r) => r.station)
+            .toList();
 
-        if (stations.isEmpty) {
+        if (allItems.isEmpty) {
           return EmptyState(
             icon: Icons.map_outlined,
             title: AppLocalizations.of(context)?.searchToSeeMap ?? 'Search to see stations on the map',

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -9,6 +9,7 @@ import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/presentation/widgets/ev_map_overlay.dart';
 import '../../../ev/providers/ev_providers.dart';
+import '../../../search/domain/entities/search_result_item.dart';
 import 'station_map_layers.dart';
 
 /// Displays a map of nearby stations from the current search results.
@@ -35,9 +36,15 @@ class NearbyMapView extends ConsumerWidget {
 
     return searchState.when(
       data: (result) {
-        final stations = result.data;
+        // Extract fuel stations for map markers; EV stations are
+        // handled by the separate EvMapLayer overlay.
+        final allItems = result.data as List<SearchResultItem>;
+        final stations = allItems
+            .whereType<FuelStationResult>()
+            .map((r) => r.station)
+            .toList();
 
-        if (stations.isEmpty) {
+        if (allItems.isEmpty) {
           return EmptyState(
             icon: Icons.map_outlined,
             title: l10n?.startSearch ??

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -14,7 +14,6 @@ import '../../../route_search/domain/entities/route_info.dart';
 import '../../../route_search/presentation/widgets/route_input.dart';
 import '../../../route_search/providers/route_search_provider.dart';
 import '../../domain/entities/search_mode.dart';
-import '../../domain/entities/station.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
 import '../../providers/search_screen_ui_provider.dart';
@@ -224,10 +223,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
               const SizedBox(height: 8),
               Consumer(
                 builder: (context, ref, _) {
-                  final state = ref.watch(searchStateProvider);
-                  final stations = state.hasValue
-                      ? state.value!.data
-                      : const <Station>[];
+                  final stations = ref.watch(fuelStationsProvider);
                   if (stations.isEmpty) return const SizedBox.shrink();
                   return BrandFilterChips(stations: stations);
                 },

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -9,7 +9,6 @@ import '../../../profile/providers/profile_provider.dart';
 import '../../domain/entities/search_mode.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
-import 'ev_search_results_view.dart';
 import 'nearest_shortcut_card.dart';
 import 'route_results_view.dart';
 import 'search_results_list.dart';
@@ -35,17 +34,12 @@ class SearchResultsContent extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final searchMode = ref.watch(activeSearchModeProvider);
-    final isEv = ref.watch(isEvSearchProvider);
     final searchState = ref.watch(searchStateProvider);
 
     if (searchMode == SearchMode.route) {
       return const CustomScrollView(
         slivers: [RouteResultsView()],
       );
-    }
-
-    if (isEv) {
-      return EvSearchResultsView(onSearch: onGpsRetry);
     }
 
     // #494 — the nearest-stations shortcut only makes sense for users

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -14,6 +14,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../favorites/presentation/widgets/swipe_tutorial_banner.dart';
 import '../../../favorites/providers/favorites_provider.dart';
 import '../../domain/entities/fuel_type.dart';
+import '../../domain/entities/search_result_item.dart';
 import '../../domain/entities/station.dart';
 import '../../providers/selected_station_provider.dart';
 import '../../providers/ignored_stations_provider.dart';
@@ -25,12 +26,17 @@ import '../../../profile/providers/profile_provider.dart';
 import 'all_prices_station_card.dart';
 import 'brand_filter_chips.dart';
 import 'cross_border_banner.dart';
+import 'ev_station_card.dart';
 import 'sort_selector.dart';
 import 'swipeable_station_card.dart';
 
 /// Station list with sort controls, refresh, count bar, and search location header.
+///
+/// Accepts a unified [List<SearchResultItem>] that may contain both
+/// [FuelStationResult] and [EVStationResult]. Fuel-specific features
+/// (price sorting, brand filtering, cheapest flags) apply only to fuel items.
 class SearchResultsList extends ConsumerWidget {
-  final ServiceResult<List<Station>> result;
+  final ServiceResult<List<SearchResultItem>> result;
   final VoidCallback onRefresh;
 
   const SearchResultsList({
@@ -39,12 +45,9 @@ class SearchResultsList extends ConsumerWidget {
     required this.onRefresh,
   });
 
-  void _openStationInMaps(Station station) {
-    NavigationUtils.openInMaps(
-      station.lat, station.lng,
-      label: station.displayName,
-    );
-  }
+  /// Extracts fuel stations from the unified results list.
+  List<Station> _fuelStations(List<SearchResultItem> items) =>
+      items.whereType<FuelStationResult>().map((r) => r.station).toList();
 
   /// Computes which station has the cheapest price for each fuel type.
   Map<String, Map<FuelType, bool>> _computeCheapestFlags(List<Station> stations) {
@@ -93,25 +96,56 @@ class SearchResultsList extends ConsumerWidget {
     return (minP, maxP);
   }
 
-  List<Station> _sortStations(
-      List<Station> stations, SortMode sortMode, WidgetRef ref) {
-    final sorted = List<Station>.from(stations);
+  List<SearchResultItem> _sortItems(
+      List<SearchResultItem> items, SortMode sortMode, WidgetRef ref) {
+    final sorted = List<SearchResultItem>.from(items);
     final fuelType = ref.read(selectedFuelTypeProvider);
+
+    // EV items always sort by distance — no price data to sort on.
+    if (sorted.every((item) => item is EVStationResult)) {
+      sorted.sort((a, b) => a.dist.compareTo(b.dist));
+      return sorted;
+    }
 
     switch (sortMode) {
       case SortMode.distance:
         sorted.sort((a, b) => a.dist.compareTo(b.dist));
       case SortMode.price:
-        sorted.sort((a, b) => compareByPrice(a, b, fuelType));
+        sorted.sort((a, b) {
+          final sa = a is FuelStationResult ? a.station : null;
+          final sb = b is FuelStationResult ? b.station : null;
+          if (sa != null && sb != null) return compareByPrice(sa, sb, fuelType);
+          return a.dist.compareTo(b.dist);
+        });
       case SortMode.name:
-        sorted.sort((a, b) => compareByName(a, b));
+        sorted.sort((a, b) {
+          final sa = a is FuelStationResult ? a.station : null;
+          final sb = b is FuelStationResult ? b.station : null;
+          if (sa != null && sb != null) return compareByName(sa, sb);
+          return a.displayName.compareTo(b.displayName);
+        });
       case SortMode.open24h:
-        sorted.sort((a, b) => compareByOpen24h(a, b));
+        sorted.sort((a, b) {
+          final sa = a is FuelStationResult ? a.station : null;
+          final sb = b is FuelStationResult ? b.station : null;
+          if (sa != null && sb != null) return compareByOpen24h(sa, sb);
+          return a.dist.compareTo(b.dist);
+        });
       case SortMode.rating:
         final ratings = ref.read(stationRatingsProvider);
-        sorted.sort((a, b) => compareByRating(a, b, ratings));
+        sorted.sort((a, b) {
+          final sa = a is FuelStationResult ? a.station : null;
+          final sb = b is FuelStationResult ? b.station : null;
+          if (sa != null && sb != null) return compareByRating(sa, sb, ratings);
+          return a.dist.compareTo(b.dist);
+        });
       case SortMode.priceDistance:
-        sorted.sort((a, b) => compareByPriceDistance(a, b, fuelType));
+        sorted.sort((a, b) {
+          final sa = a is FuelStationResult ? a.station : null;
+          final sb = b is FuelStationResult ? b.station : null;
+          if (sa != null && sb != null) return compareByPriceDistance(sa, sb, fuelType);
+          return a.dist.compareTo(b.dist);
+        });
     }
     return sorted;
   }
@@ -175,7 +209,7 @@ class SearchResultsList extends ConsumerWidget {
               ref.read(selectedSortModeProvider.notifier).set(mode),
         ),
         _CollapsibleBrandFilters(
-          stations: result.data
+          stations: _fuelStations(result.data)
               .where((s) => !ignoredIds.contains(s.id))
               .toList(),
         ),
@@ -188,108 +222,146 @@ class SearchResultsList extends ConsumerWidget {
                   .where((s) => !ignoredIds.contains(s.id))
                   .toList();
 
-              // Apply brand and highway filters
+              // Apply fuel-specific filters to fuel items; EV items pass through.
               final selectedBrands = ref.watch(selectedBrandsProvider);
               final excludeHighway = ref.watch(excludeHighwayStationsProvider);
-              final brandFiltered = applyBrandFilter(
-                afterIgnored,
-                selectedBrands: selectedBrands,
-                excludeHighway: excludeHighway,
-              );
-              // #491 — apply amenity + open-only filters. These providers
-              // are written by the criteria screen but were previously
-              // read nowhere, so toggling WiFi / "Ouvertes uniquement" /
-              // any other amenity chip had zero visible effect.
-              final requiredAmenities =
-                  ref.watch(selectedAmenitiesProvider);
+              final requiredAmenities = ref.watch(selectedAmenitiesProvider);
               final openOnly = ref.watch(openOnlyFilterProvider);
-              final filtered = applyAmenityAndStatusFilters(
-                brandFiltered,
+
+              // Split into fuel + EV, filter fuel items, then recombine.
+              final fuelItems = afterIgnored.whereType<FuelStationResult>().toList();
+              final evItems = afterIgnored.whereType<EVStationResult>().toList();
+              final fuelFiltered = applyAmenityAndStatusFilters(
+                applyBrandFilter(
+                  fuelItems.map((r) => r.station).toList(),
+                  selectedBrands: selectedBrands,
+                  excludeHighway: excludeHighway,
+                ),
                 requiredAmenities: requiredAmenities,
                 openOnly: openOnly,
               );
-              final sorted = _sortStations(filtered, sortMode, ref);
+              final filteredFuelIds = fuelFiltered.map((s) => s.id).toSet();
+              final filtered = <SearchResultItem>[
+                ...fuelItems.where((r) => filteredFuelIds.contains(r.station.id)),
+                ...evItems,
+              ];
+
+              final sorted = _sortItems(filtered, sortMode, ref);
+              final fuelOnly = _fuelStations(sorted);
               final allPrices = ref.watch(allPricesViewEnabledProvider);
               final cheapestMap = allPrices
-                  ? _computeCheapestFlags(sorted)
+                  ? _computeCheapestFlags(fuelOnly)
                   : <String, Map<FuelType, bool>>{};
 
               // Compute price range for tier icons (a11y)
               final fuelType = ref.watch(selectedFuelTypeProvider);
-              final priceRange = _getPriceRange(sorted, fuelType);
+              final priceRange = _getPriceRange(fuelOnly, fuelType);
               final profileFuel = ref.watch(activeProfileProvider)?.preferredFuelType;
 
               return ListView.builder(
                 itemCount: sorted.length,
                 itemBuilder: (context, index) {
-                  final station = sorted[index];
-                  final isFav = ref.watch(isFavoriteProvider(station.id));
+                  final item = sorted[index];
+                  final isFav = ref.watch(isFavoriteProvider(item.id));
 
-                  if (allPrices) {
-                    return AllPricesStationCard(
-                      key: ValueKey('all-prices-${station.id}'),
+                  return switch (item) {
+                    FuelStationResult(:final station) => _buildFuelCard(
+                      context: context,
+                      ref: ref,
                       station: station,
                       isFavorite: isFav,
-                      cheapestFlags: cheapestMap[station.id] ?? const {},
-                      profileFuelType: profileFuel,
-                      onTap: () {
-                      if (isWideScreen(context)) {
-                        ref.read(selectedStationProvider.notifier).select(station.id);
-                      } else {
-                        context.push('/station/${station.id}');
-                      }
-                    },
-                      onFavoriteTap: () => ref
-                          .read(favoritesProvider.notifier)
-                          .toggle(station.id, stationData: station),
-                    );
-                  }
-
-                  final tier = priceTierOf(
-                    station.priceFor(fuelType),
-                    priceRange.$1,
-                    priceRange.$2,
-                  );
-
-                  final stationRating = ref.watch(stationRatingProvider(station.id));
-
-                  return SwipeableStationCard(
-                    key: ValueKey('station-${station.id}'),
-                    station: station,
-                    isFavorite: isFav,
-                    priceTier: tier,
-                    rating: stationRating,
-                    profileFuelType: profileFuel,
-                    onNavigate: () => _openStationInMaps(station),
-                    onIgnore: () {
-                      ref.read(ignoredStationsProvider.notifier).add(station.id);
-                      final l10n = AppLocalizations.of(context);
-                      SnackBarHelper.showWithUndo(
-                        context,
-                        l10n?.stationHidden(station.displayName) ?? '${station.displayName} hidden',
-                        undoLabel: l10n?.undo ?? 'Undo',
-                        onUndo: () => ref
-                            .read(ignoredStationsProvider.notifier)
-                            .remove(station.id),
-                      );
-                    },
-                    onTap: () {
-                      if (isWideScreen(context)) {
-                        ref.read(selectedStationProvider.notifier).select(station.id);
-                      } else {
-                        context.push('/station/${station.id}');
-                      }
-                    },
-                    onFavoriteTap: () => ref
-                        .read(favoritesProvider.notifier)
-                        .toggle(station.id, stationData: station),
-                  );
+                      allPrices: allPrices,
+                      cheapestMap: cheapestMap,
+                      fuelType: fuelType,
+                      priceRange: priceRange,
+                      profileFuel: profileFuel,
+                    ),
+                    EVStationResult() => EVStationCard(
+                      key: ValueKey('ev-${item.id}'),
+                      result: item,
+                      onTap: () => context.push('/ev-station', extra: item.station),
+                    ),
+                  };
                 },
               );
             }),
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildFuelCard({
+    required BuildContext context,
+    required WidgetRef ref,
+    required Station station,
+    required bool isFavorite,
+    required bool allPrices,
+    required Map<String, Map<FuelType, bool>> cheapestMap,
+    required FuelType fuelType,
+    required (double, double) priceRange,
+    required FuelType? profileFuel,
+  }) {
+    if (allPrices) {
+      return AllPricesStationCard(
+        key: ValueKey('all-prices-${station.id}'),
+        station: station,
+        isFavorite: isFavorite,
+        cheapestFlags: cheapestMap[station.id] ?? const {},
+        profileFuelType: profileFuel,
+        onTap: () {
+          if (isWideScreen(context)) {
+            ref.read(selectedStationProvider.notifier).select(station.id);
+          } else {
+            context.push('/station/${station.id}');
+          }
+        },
+        onFavoriteTap: () => ref
+            .read(favoritesProvider.notifier)
+            .toggle(station.id, stationData: station),
+      );
+    }
+
+    final tier = priceTierOf(
+      station.priceFor(fuelType),
+      priceRange.$1,
+      priceRange.$2,
+    );
+    final stationRating = ref.watch(stationRatingProvider(station.id));
+
+    return SwipeableStationCard(
+      key: ValueKey('station-${station.id}'),
+      station: station,
+      isFavorite: isFavorite,
+      priceTier: tier,
+      rating: stationRating,
+      profileFuelType: profileFuel,
+      onNavigate: () => NavigationUtils.openInMaps(
+        station.lat, station.lng,
+        label: station.displayName,
+      ),
+      onIgnore: () {
+        ref.read(ignoredStationsProvider.notifier).add(station.id);
+        final l10n = AppLocalizations.of(context);
+        SnackBarHelper.showWithUndo(
+          context,
+          l10n?.stationHidden(station.displayName) ?? '${station.displayName} hidden',
+          undoLabel: l10n?.undo ?? 'Undo',
+          onUndo: () => ref
+              .read(ignoredStationsProvider.notifier)
+              .remove(station.id),
+        );
+      },
+      onTap: () {
+        if (isWideScreen(context)) {
+          ref.read(selectedStationProvider.notifier).select(station.id);
+        } else {
+          context.push('/station/${station.id}');
+        }
+      },
+      onFavoriteTap: () => ref
+          .read(favoritesProvider.notifier)
+          .toggle(station.id, stationData: station),
     );
   }
 }

--- a/lib/features/search/providers/cross_border_provider.dart
+++ b/lib/features/search/providers/cross_border_provider.dart
@@ -4,7 +4,6 @@ import '../../../core/country/country_provider.dart';
 import '../../../core/location/user_position_provider.dart';
 import '../../../core/utils/station_extensions.dart';
 import '../domain/entities/cross_border_comparison.dart';
-import '../domain/entities/station.dart';
 import 'search_provider.dart';
 
 part 'cross_border_provider.g.dart';
@@ -25,15 +24,11 @@ List<CrossBorderComparison> crossBorderComparisons(Ref ref) {
   if (position == null) return const [];
 
   final country = ref.watch(activeCountryProvider);
-  final searchState = ref.watch(searchStateProvider);
   final fuelType = ref.watch(selectedFuelTypeProvider);
 
-  // Only compute when we have search results
-  List<Station>? stations;
-  if (searchState.hasValue) {
-    stations = searchState.value?.data;
-  }
-  if (stations == null || stations.isEmpty) return const [];
+  // Only compute when we have fuel station results
+  final stations = ref.watch(fuelStationsProvider);
+  if (stations.isEmpty) return const [];
 
   // Detect nearby borders
   final nearbyBorders = detectNearbyBorders(

--- a/lib/features/search/providers/cross_border_provider.g.dart
+++ b/lib/features/search/providers/cross_border_provider.g.dart
@@ -86,4 +86,4 @@ final class CrossBorderComparisonsProvider
 }
 
 String _$crossBorderComparisonsHash() =>
-    r'ba42ad765c767090256ac69c11f821138acc6207';
+    r'2b5ae2c92a8a7e804832789baa87b683a5800d22';

--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -9,6 +9,7 @@ import '../../../core/services/service_result.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../data/models/search_params.dart';
 import '../domain/entities/fuel_type.dart';
+import '../domain/entities/search_result_item.dart';
 import '../domain/entities/station.dart';
 import '../../profile/providers/profile_provider.dart';
 import 'ev_search_provider.dart';
@@ -42,7 +43,7 @@ class SearchState extends _$SearchState {
   }
 
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() {
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
     return AsyncValue.data(ServiceResult(
       data: const [],
       source: ServiceSource.cache,
@@ -120,15 +121,14 @@ class SearchState extends _$SearchState {
       final resolvedFuelType = fuelType ?? profile?.preferredFuelType ?? FuelType.all;
       final resolvedRadius = radiusKm ?? profile?.defaultSearchRadius ?? 10.0;
 
-      // EV dispatch: delegate to EVSearchState and return early.
-      // Reset own state so the UI doesn't show a stuck loading spinner.
+      // EV dispatch: delegate to EVSearchState, then copy wrapped results.
       if (resolvedFuelType == FuelType.electric) {
         await ref.read(eVSearchStateProvider.notifier).searchNearby(
               lat: position.latitude,
               lng: position.longitude,
               radiusKm: resolvedRadius,
             );
-        state = build();
+        _copyEvResults();
         return;
       }
 
@@ -165,7 +165,7 @@ class SearchState extends _$SearchState {
 
       final stationService = ref.read(stationServiceProvider);
       final result = await stationService.searchStations(params, cancelToken: cancelToken);
-      state = AsyncValue.data(result);
+      state = AsyncValue.data(_wrapFuelResult(result));
     });
   }
 
@@ -200,14 +200,13 @@ class SearchState extends _$SearchState {
       final resolvedRadius = radiusKm ?? profile?.defaultSearchRadius ?? 10.0;
 
       // EV dispatch: geocode the ZIP, then delegate to EVSearchState.
-      // Reset own state so the UI doesn't show a stuck loading spinner.
       if (resolvedFuelType == FuelType.electric) {
         await ref.read(eVSearchStateProvider.notifier).searchNearby(
               lat: coordsResult.data.lat,
               lng: coordsResult.data.lng,
               radiusKm: resolvedRadius,
             );
-        state = build();
+        _copyEvResults();
         return;
       }
 
@@ -248,13 +247,13 @@ class SearchState extends _$SearchState {
         ...result.errors,
       ];
 
-      state = AsyncValue.data(ServiceResult(
+      state = AsyncValue.data(_wrapFuelResult(ServiceResult(
         data: adjustedStations,
         source: result.source,
         fetchedAt: result.fetchedAt,
         isStale: result.isStale || coordsResult.isStale,
         errors: mergedErrors,
-      ));
+      )));
     });
   }
 
@@ -287,14 +286,13 @@ class SearchState extends _$SearchState {
       final resolvedRadius = radiusKm ?? profile?.defaultSearchRadius ?? 10.0;
 
       // EV dispatch: delegate to EVSearchState with the explicit coordinates.
-      // Reset own state so the UI doesn't show a stuck loading spinner.
       if (resolvedFuelType == FuelType.electric) {
         await ref.read(eVSearchStateProvider.notifier).searchNearby(
               lat: lat,
               lng: lng,
               radiusKm: resolvedRadius,
             );
-        state = build();
+        _copyEvResults();
         return;
       }
 
@@ -313,14 +311,44 @@ class SearchState extends _$SearchState {
       // Recalculate distances from user's known position
       final adjustedStations = _recalcDistances(result.data);
 
-      state = AsyncValue.data(ServiceResult(
+      state = AsyncValue.data(_wrapFuelResult(ServiceResult(
         data: adjustedStations,
         source: result.source,
         fetchedAt: result.fetchedAt,
         isStale: result.isStale,
         errors: result.errors,
-      ));
+      )));
     });
+  }
+
+  /// Wraps a fuel [ServiceResult<List<Station>>] as [List<SearchResultItem>].
+  ServiceResult<List<SearchResultItem>> _wrapFuelResult(
+    ServiceResult<List<Station>> result,
+  ) {
+    return ServiceResult(
+      data: result.data.map((s) => FuelStationResult(s) as SearchResultItem).toList(),
+      source: result.source,
+      fetchedAt: result.fetchedAt,
+      isStale: result.isStale,
+      errors: result.errors,
+    );
+  }
+
+  /// Copies EVSearchState results into this provider's state, wrapped as
+  /// [EVStationResult]. Called after [EVSearchState.searchNearby] completes.
+  void _copyEvResults() {
+    final evState = ref.read(eVSearchStateProvider);
+    evState.when(
+      data: (result) {
+        state = AsyncValue.data(ServiceResult(
+          data: result.data.map((cs) => EVStationResult(cs) as SearchResultItem).toList(),
+          source: result.source,
+          fetchedAt: result.fetchedAt,
+        ));
+      },
+      loading: () {},
+      error: (e, st) { state = AsyncValue.error(e, st); },
+    );
   }
 }
 
@@ -359,11 +387,16 @@ class SearchRadius extends _$SearchRadius {
   }
 }
 
-/// Whether the current search fuel type is electric.
+/// Extracts fuel [Station] objects from the unified search results.
 ///
-/// Used by UI widgets to decide between EV and fuel result views without
-/// coupling to `FuelType.electric` directly.
+/// Convenience for consumers that need [List<Station>] (cross-border
+/// comparisons, driving mode, station detail lookup, brand filter chips).
 @riverpod
-bool isEvSearch(Ref ref) {
-  return ref.watch(selectedFuelTypeProvider) == FuelType.electric;
+List<Station> fuelStations(Ref ref) {
+  final searchState = ref.watch(searchStateProvider);
+  if (!searchState.hasValue) return const [];
+  return searchState.value!.data
+      .whereType<FuelStationResult>()
+      .map((r) => r.station)
+      .toList();
 }

--- a/lib/features/search/providers/search_provider.g.dart
+++ b/lib/features/search/providers/search_provider.g.dart
@@ -42,7 +42,7 @@ final class SearchStateProvider
     extends
         $NotifierProvider<
           SearchState,
-          AsyncValue<ServiceResult<List<Station>>>
+          AsyncValue<ServiceResult<List<SearchResultItem>>>
         > {
   /// Manages the station search lifecycle and exposes results as [AsyncValue].
   ///
@@ -76,16 +76,20 @@ final class SearchStateProvider
   SearchState create() => SearchState();
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<ServiceResult<List<Station>>> value) {
+  Override overrideWithValue(
+    AsyncValue<ServiceResult<List<SearchResultItem>>> value,
+  ) {
     return $ProviderOverride(
       origin: this,
       providerOverride:
-          $SyncValueProvider<AsyncValue<ServiceResult<List<Station>>>>(value),
+          $SyncValueProvider<AsyncValue<ServiceResult<List<SearchResultItem>>>>(
+            value,
+          ),
     );
   }
 }
 
-String _$searchStateHash() => r'5f93b006140334ab797ef15b4c3b68f7ffd4b37d';
+String _$searchStateHash() => r'86cc44d3d1916e93b1c7deeded7e981a7bc722b9';
 
 /// Manages the station search lifecycle and exposes results as [AsyncValue].
 ///
@@ -102,25 +106,25 @@ String _$searchStateHash() => r'5f93b006140334ab797ef15b4c3b68f7ffd4b37d';
 /// (fresh cache -> API -> stale cache -> error).
 
 abstract class _$SearchState
-    extends $Notifier<AsyncValue<ServiceResult<List<Station>>>> {
-  AsyncValue<ServiceResult<List<Station>>> build();
+    extends $Notifier<AsyncValue<ServiceResult<List<SearchResultItem>>>> {
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build();
   @$mustCallSuper
   @override
   void runBuild() {
     final ref =
         this.ref
             as $Ref<
-              AsyncValue<ServiceResult<List<Station>>>,
-              AsyncValue<ServiceResult<List<Station>>>
+              AsyncValue<ServiceResult<List<SearchResultItem>>>,
+              AsyncValue<ServiceResult<List<SearchResultItem>>>
             >;
     final element =
         ref.element
             as $ClassProviderElement<
               AnyNotifier<
-                AsyncValue<ServiceResult<List<Station>>>,
-                AsyncValue<ServiceResult<List<Station>>>
+                AsyncValue<ServiceResult<List<SearchResultItem>>>,
+                AsyncValue<ServiceResult<List<SearchResultItem>>>
               >,
-              AsyncValue<ServiceResult<List<Station>>>,
+              AsyncValue<ServiceResult<List<SearchResultItem>>>,
               Object?,
               Object?
             >;
@@ -290,56 +294,57 @@ abstract class _$SearchRadius extends $Notifier<double> {
   }
 }
 
-/// Whether the current search fuel type is electric.
+/// Extracts fuel [Station] objects from the unified search results.
 ///
-/// Used by UI widgets to decide between EV and fuel result views without
-/// coupling to `FuelType.electric` directly.
+/// Convenience for consumers that need [List<Station>] (cross-border
+/// comparisons, driving mode, station detail lookup, brand filter chips).
 
-@ProviderFor(isEvSearch)
-final isEvSearchProvider = IsEvSearchProvider._();
+@ProviderFor(fuelStations)
+final fuelStationsProvider = FuelStationsProvider._();
 
-/// Whether the current search fuel type is electric.
+/// Extracts fuel [Station] objects from the unified search results.
 ///
-/// Used by UI widgets to decide between EV and fuel result views without
-/// coupling to `FuelType.electric` directly.
+/// Convenience for consumers that need [List<Station>] (cross-border
+/// comparisons, driving mode, station detail lookup, brand filter chips).
 
-final class IsEvSearchProvider extends $FunctionalProvider<bool, bool, bool>
-    with $Provider<bool> {
-  /// Whether the current search fuel type is electric.
+final class FuelStationsProvider
+    extends $FunctionalProvider<List<Station>, List<Station>, List<Station>>
+    with $Provider<List<Station>> {
+  /// Extracts fuel [Station] objects from the unified search results.
   ///
-  /// Used by UI widgets to decide between EV and fuel result views without
-  /// coupling to `FuelType.electric` directly.
-  IsEvSearchProvider._()
+  /// Convenience for consumers that need [List<Station>] (cross-border
+  /// comparisons, driving mode, station detail lookup, brand filter chips).
+  FuelStationsProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
-        name: r'isEvSearchProvider',
+        name: r'fuelStationsProvider',
         isAutoDispose: true,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
 
   @override
-  String debugGetCreateSourceHash() => _$isEvSearchHash();
+  String debugGetCreateSourceHash() => _$fuelStationsHash();
 
   @$internal
   @override
-  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+  $ProviderElement<List<Station>> $createElement($ProviderPointer pointer) =>
       $ProviderElement(pointer);
 
   @override
-  bool create(Ref ref) {
-    return isEvSearch(ref);
+  List<Station> create(Ref ref) {
+    return fuelStations(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(bool value) {
+  Override overrideWithValue(List<Station> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<bool>(value),
+      providerOverride: $SyncValueProvider<List<Station>>(value),
     );
   }
 }
 
-String _$isEvSearchHash() => r'f2280af5461fbac2ac8f7653f864f5401d692702';
+String _$fuelStationsHash() => r'5238084b6dd78061bafabf616c603bcf7b03077b';

--- a/lib/features/station_detail/providers/station_detail_provider.dart
+++ b/lib/features/station_detail/providers/station_detail_provider.dart
@@ -1,6 +1,7 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/service_result.dart';
+import '../../search/domain/entities/search_result_item.dart';
 import '../../search/domain/entities/station.dart';
 import '../../search/providers/search_provider.dart';
 
@@ -18,11 +19,12 @@ Future<ServiceResult<StationDetail>> stationDetail(
   if (searchState.hasValue) {
     final searchResults = searchState.value?.data ?? [];
     final fromSearch = searchResults
-        .where((s) => s.id == stationId)
+        .whereType<FuelStationResult>()
+        .where((r) => r.station.id == stationId)
         .firstOrNull;
     if (fromSearch != null) {
       return ServiceResult(
-        data: StationDetail(station: fromSearch),
+        data: StationDetail(station: fromSearch.station),
         source: ServiceSource.cache,
         fetchedAt: DateTime.now(),
       );

--- a/lib/features/station_detail/providers/station_detail_provider.g.dart
+++ b/lib/features/station_detail/providers/station_detail_provider.g.dart
@@ -66,7 +66,7 @@ final class StationDetailProvider
   }
 }
 
-String _$stationDetailHash() => r'0bad7bd62233085d192b3314f66b6afce6729192';
+String _$stationDetailHash() => r'1290aa920ec5f7264f23b25f0405fd5f11a10937';
 
 final class StationDetailFamily extends $Family
     with

--- a/test/accessibility/guideline_tests.dart
+++ b/test/accessibility/guideline_tests.dart
@@ -12,6 +12,7 @@ import 'package:tankstellen/features/favorites/presentation/screens/favorites_sc
 import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
 import 'package:tankstellen/features/profile/presentation/screens/privacy_dashboard_screen.dart';
 import 'package:tankstellen/features/profile/presentation/screens/profile_screen.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/screens/search_screen.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
@@ -33,7 +34,7 @@ class _FixedActiveLanguage extends ActiveLanguage {
 /// Fixed SearchState that returns empty results (no async work).
 class _EmptySearchState extends SearchState {
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() {
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
     return AsyncValue.data(ServiceResult(
       data: const [],
       source: ServiceSource.cache,

--- a/test/accessibility/rtl_layout_test.dart
+++ b/test/accessibility/rtl_layout_test.dart
@@ -8,6 +8,7 @@ import 'package:tankstellen/core/widgets/empty_state.dart';
 import 'package:tankstellen/features/favorites/presentation/screens/favorites_screen.dart';
 import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/screens/search_screen.dart';
 import 'package:tankstellen/features/search/presentation/widgets/sort_selector.dart';
@@ -31,7 +32,7 @@ class _FixedActiveLanguage extends ActiveLanguage {
 /// Fixed SearchState returning empty data.
 class _EmptySearchState extends SearchState {
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() {
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
     return AsyncValue.data(ServiceResult(
       data: const [],
       source: ServiceSource.cache,

--- a/test/app/landing_screen_integration_test.dart
+++ b/test/app/landing_screen_integration_test.dart
@@ -10,6 +10,7 @@ import 'package:tankstellen/features/favorites/presentation/screens/favorites_sc
 import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
 import 'package:tankstellen/features/profile/data/models/user_profile.dart';
 import 'package:tankstellen/features/profile/presentation/widgets/profile_landing_screen_dropdown.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/sort_selector.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
@@ -29,9 +30,9 @@ class _FixedActiveLanguage extends ActiveLanguage {
 /// nothing to look at.
 class _EmptySearchState extends SearchState {
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.data(
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => AsyncValue.data(
         ServiceResult(
-          data: [testStation],
+          data: [const FuelStationResult(testStation)],
           source: ServiceSource.cache,
           fetchedAt: DateTime.now(),
         ),

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -8,6 +8,7 @@ import 'package:tankstellen/core/language/language_provider.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
@@ -27,7 +28,7 @@ class _FixedActiveLanguage extends ActiveLanguage {
 /// Fixed SearchState returning empty data.
 class _EmptySearchState extends SearchState {
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() {
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
     return AsyncValue.data(ServiceResult(
       data: const [],
       source: ServiceSource.cache,

--- a/test/app/shell_screen_responsive_test.dart
+++ b/test/app/shell_screen_responsive_test.dart
@@ -7,6 +7,7 @@ import 'package:tankstellen/app/shell_screen.dart';
 import 'package:tankstellen/core/language/language_provider.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
@@ -25,7 +26,7 @@ class _FixedActiveLanguage extends ActiveLanguage {
 /// Fixed SearchState returning empty data.
 class _EmptySearchState extends SearchState {
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() {
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
     return AsyncValue.data(ServiceResult(
       data: const [],
       source: ServiceSource.cache,

--- a/test/app/shell_screen_test.dart
+++ b/test/app/shell_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:tankstellen/app/shell_screen.dart';
 import 'package:tankstellen/core/language/language_provider.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
@@ -25,7 +26,7 @@ class _FixedActiveLanguage extends ActiveLanguage {
 /// Fixed SearchState returning empty data.
 class _EmptySearchState extends SearchState {
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() {
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
     return AsyncValue.data(ServiceResult(
       data: const [],
       source: ServiceSource.cache,

--- a/test/features/driving/presentation/screens/driving_mode_screen_test.dart
+++ b/test/features/driving/presentation/screens/driving_mode_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:tankstellen/features/driving/presentation/widgets/safety_disclai
 import 'package:tankstellen/features/driving/presentation/widgets/driving_marker_builder.dart';
 import 'package:tankstellen/features/driving/presentation/widgets/driving_mode_fab.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
 
@@ -382,7 +383,7 @@ List<Object> _drivingScreenOverrides() {
 /// A search state notifier that returns empty data.
 class _EmptySearchState extends SearchState {
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() {
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
     return AsyncValue.data(ServiceResult(
       data: const [],
       source: ServiceSource.cache,

--- a/test/features/map/presentation/screens/map_screen_test.dart
+++ b/test/features/map/presentation/screens/map_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/map/presentation/screens/map_screen.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
 
@@ -20,12 +21,12 @@ import '../../../../helpers/pump_app.dart';
 /// arrives.
 class _SeedableSearchState extends SearchState {
   _SeedableSearchState(this._seed);
-  AsyncValue<ServiceResult<List<Station>>> _seed;
+  AsyncValue<ServiceResult<List<SearchResultItem>>> _seed;
 
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() => _seed;
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => _seed;
 
-  void emit(AsyncValue<ServiceResult<List<Station>>> next) {
+  void emit(AsyncValue<ServiceResult<List<SearchResultItem>>> next) {
     _seed = next;
     state = next;
   }
@@ -80,7 +81,7 @@ void main() {
 
       final seedable = _SeedableSearchState(
         AsyncValue.data(ServiceResult(
-          data: const <Station>[],
+          data: const <SearchResultItem>[],
           source: ServiceSource.cache,
           fetchedAt: DateTime.now(),
         )),
@@ -99,8 +100,8 @@ void main() {
 
       // Emit a non-empty result — triggers the listener.
       seedable.emit(AsyncValue.data(ServiceResult(
-        data: const <Station>[
-          Station(
+        data: const <SearchResultItem>[
+          FuelStationResult(Station(
             id: 'pt-42',
             name: 'GALP',
             brand: 'GALP',
@@ -112,7 +113,7 @@ void main() {
             dist: 1.0,
             e5: 1.6,
             isOpen: true,
-          ),
+          )),
         ],
         source: ServiceSource.portugalApi,
         fetchedAt: DateTime.now(),

--- a/test/features/search/presentation/widgets/search_results_content_test.dart
+++ b/test/features/search/presentation/widgets/search_results_content_test.dart
@@ -6,6 +6,7 @@ import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/widgets/shimmer_placeholder.dart';
 import 'package:tankstellen/features/profile/domain/entities/user_profile.dart';
 import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/nearest_shortcut_card.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_results_content.dart';
@@ -139,12 +140,12 @@ void main() {
 
 class _LoadingSearchState extends SearchState {
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() => const AsyncValue.loading();
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => const AsyncValue.loading();
 }
 
 class _EmptySearchState extends SearchState {
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.data(
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => AsyncValue.data(
         ServiceResult(
           data: const [],
           source: ServiceSource.cache,
@@ -158,9 +159,9 @@ class _LoadedSearchState extends SearchState {
   final List<Station> _stations;
 
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() => AsyncValue.data(
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => AsyncValue.data(
         ServiceResult(
-          data: _stations,
+          data: _stations.map((s) => FuelStationResult(s) as SearchResultItem).toList(),
           source: ServiceSource.cache,
           fetchedAt: DateTime.now(),
         ),

--- a/test/features/search/presentation/widgets/search_results_list_filter_test.dart
+++ b/test/features/search/presentation/widgets/search_results_list_filter_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/domain/entities/station_amenity.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_results_list.dart';
@@ -81,12 +82,12 @@ Future<void> _pumpList(
   await pumpApp(
     tester,
     SearchResultsList(
-      result: ServiceResult<List<Station>>(
+      result: ServiceResult<List<SearchResultItem>>(
         data: const [
-          _totalWifiOpen,
-          _essoShopClosed,
-          _essoWifiOpen,
-          _independentOpen,
+          FuelStationResult(_totalWifiOpen),
+          FuelStationResult(_essoShopClosed),
+          FuelStationResult(_essoWifiOpen),
+          FuelStationResult(_independentOpen),
         ],
         source: ServiceSource.cache,
         fetchedAt: DateTime(2026, 4, 14),

--- a/test/features/search/providers/cross_border_provider_test.dart
+++ b/test/features/search/providers/cross_border_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:tankstellen/core/country/country_provider.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/cross_border_provider.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
@@ -208,9 +209,9 @@ class _FakeSearchState extends SearchState {
   _FakeSearchState(this._stations);
 
   @override
-  AsyncValue<ServiceResult<List<Station>>> build() {
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
     return AsyncValue.data(ServiceResult(
-      data: _stations,
+      data: _stations.map((s) => FuelStationResult(s) as SearchResultItem).toList(),
       source: ServiceSource.cache,
       fetchedAt: DateTime.now(),
     ));

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -680,25 +680,30 @@ void main() {
     });
   });
 
-  group('isEvSearchProvider', () {
-    test('returns true when selectedFuelType is electric', () {
-      final container = createContainer();
-      container.read(selectedFuelTypeProvider.notifier).select(FuelType.electric);
+  group('fuelStationsProvider', () {
+    test('extracts fuel stations from search results', () async {
+      when(() => mockStationService.searchStations(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: [testStation],
+                source: ServiceSource.tankerkoenigApi,
+                fetchedAt: DateTime.now(),
+              ));
 
-      expect(container.read(isEvSearchProvider), isTrue);
+      final container = createContainer();
+      await container.read(searchStateProvider.notifier).searchByCoordinates(
+            lat: 52.52, lng: 13.41, fuelType: FuelType.e10,
+          );
+
+      final stations = container.read(fuelStationsProvider);
+      expect(stations.length, 1);
+      expect(stations.first.id, 'test-1');
     });
 
-    test('returns false for non-electric fuel types', () {
+    test('returns empty list when no search results', () {
       final container = createContainer();
-      container.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
-
-      expect(container.read(isEvSearchProvider), isFalse);
-    });
-
-    test('returns false for FuelType.all', () {
-      final container = createContainer();
-      // Default is FuelType.all
-      expect(container.read(isEvSearchProvider), isFalse);
+      final stations = container.read(fuelStationsProvider);
+      expect(stations, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary
- **SearchState now returns `List<SearchResultItem>`** (sealed class) instead of `List<Station>` — fuel results wrapped as `FuelStationResult`, EV as `EVStationResult`
- **Results list uses switch on sealed type** to render `StationCard` vs `EVStationCard` from the same list — no more fuel-type fork in rendering
- **Added `fuelStationsProvider`** — derived provider for consumers needing `List<Station>` (map, driving mode, cross-border, brand filters)
- Updated 12 test fakes + 2 test files for the type change

Closes #543

## Test plan
- [x] `flutter analyze` passes (zero warnings)
- [x] `flutter test` passes (3688 tests, 0 regressions)
- [x] `fuelStationsProvider` tests: extract fuel stations, empty results
- [ ] Manual testing: search with E10 → fuel cards render; switch to Electric → EV cards render from same results list

🤖 Generated with [Claude Code](https://claude.com/claude-code)