### PR TITLE
fix(error): enrich auto-created issue reports with diagnostic context

### DIFF
--- a/lib/core/error_reporting/error_report_formatter.dart
+++ b/lib/core/error_reporting/error_report_formatter.dart
@@ -75,6 +75,31 @@ class ErrorReportFormatter {
       buf.writeln();
     }
 
+    // Diagnostic context — helps triage without a repro (#524).
+    final hasContext = p.networkState != null || p.searchContext != null;
+    if (hasContext) {
+      buf.writeln('## Context');
+      buf.writeln();
+      if (p.networkState != null) {
+        buf.writeln('- **Network:** ${p.networkState}');
+      }
+      if (p.searchContext != null) {
+        buf.writeln('- **Action:** ${p.searchContext}');
+      }
+      buf.writeln();
+    }
+
+    if (p.stackExcerpt != null && p.stackExcerpt!.isNotEmpty) {
+      buf.writeln('<details><summary>Stack trace (app frames only)</summary>');
+      buf.writeln();
+      buf.writeln('```');
+      buf.writeln(p.stackExcerpt);
+      buf.writeln('```');
+      buf.writeln();
+      buf.writeln('</details>');
+      buf.writeln();
+    }
+
     buf.writeln('## Steps to reproduce');
     buf.writeln();
     buf.writeln('<!-- Add any context about what you were doing -->');

--- a/lib/core/error_reporting/error_report_payload.dart
+++ b/lib/core/error_reporting/error_report_payload.dart
@@ -39,6 +39,15 @@ class ErrorReportPayload {
   /// Wall clock at which the error was captured.
   final DateTime capturedAt;
 
+  /// First few lines of the stack trace (sanitized, no file paths).
+  final String? stackExcerpt;
+
+  /// Network connectivity state at time of error (e.g. `wifi`, `mobile`, `none`).
+  final String? networkState;
+
+  /// What the user was doing (e.g. `GPS search`, `ZIP search 34120`).
+  final String? searchContext;
+
   const ErrorReportPayload({
     required this.errorType,
     required this.errorMessage,
@@ -50,6 +59,9 @@ class ErrorReportPayload {
     this.countryCode,
     this.sourceLabel,
     this.fallbackChain = const [],
+    this.stackExcerpt,
+    this.networkState,
+    this.searchContext,
   });
 
   /// Builds a payload from an error object, extracting structured fields
@@ -60,6 +72,9 @@ class ErrorReportPayload {
     required String platform,
     required String locale,
     String? countryCode,
+    String? networkState,
+    String? searchContext,
+    StackTrace? stackTrace,
   }) {
     int? statusCode;
     String? sourceLabel;
@@ -99,7 +114,25 @@ class ErrorReportPayload {
       platform: platform,
       locale: locale,
       capturedAt: DateTime.now(),
+      stackExcerpt: _extractStackExcerpt(stackTrace),
+      networkState: networkState,
+      searchContext: searchContext,
     );
+  }
+
+  /// Extracts a short, privacy-safe stack trace excerpt.
+  ///
+  /// Keeps only `package:tankstellen/` frames (no system or third-party
+  /// frames) and limits to 8 lines to fit in a GitHub URL.
+  static String? _extractStackExcerpt(StackTrace? trace) {
+    if (trace == null) return null;
+    final lines = trace.toString().split('\n')
+        .where((l) => l.contains('package:tankstellen/'))
+        .take(8)
+        .map((l) => l.trim())
+        .toList();
+    if (lines.isEmpty) return null;
+    return lines.join('\n');
   }
 
   /// Strips control characters and collapses whitespace so the message

--- a/lib/core/services/mixins/station_service_helpers.dart
+++ b/lib/core/services/mixins/station_service_helpers.dart
@@ -24,10 +24,15 @@ mixin StationServiceHelpers {
 
   /// Convert a [DioException] to an [ApiException] and throw it.
   ///
+  /// Includes the Dio exception type and request path so error reports
+  /// carry enough context to diagnose without a repro (#524).
+  ///
   /// Use in catch blocks: `on DioException catch (e) { throwApiException(e); }`
   Never throwApiException(DioException e, {String defaultMessage = 'Network error'}) {
+    final path = e.requestOptions.uri.replace(queryParameters: {}).path;
+    final detail = e.message ?? defaultMessage;
     throw ApiException(
-      message: e.message ?? defaultMessage,
+      message: '${e.type.name}: $detail (path: $path)',
       statusCode: e.response?.statusCode,
     );
   }

--- a/lib/core/services/widgets/service_status_banner.dart
+++ b/lib/core/services/widgets/service_status_banner.dart
@@ -77,12 +77,24 @@ class ServiceChainErrorWidget extends StatelessWidget {
   /// Optional country code to include in the report (e.g. `GB`).
   final String? countryCode;
 
+  /// What the user was doing when the error occurred (e.g. `GPS search`).
+  final String? searchContext;
+
+  /// Network connectivity at time of error (e.g. `wifi`, `mobile`, `none`).
+  final String? networkState;
+
+  /// Stack trace from the catch site, if available.
+  final StackTrace? stackTrace;
+
   const ServiceChainErrorWidget({
     super.key,
     required this.error,
     this.onRetry,
     this.reporter,
     this.countryCode,
+    this.searchContext,
+    this.networkState,
+    this.stackTrace,
   });
 
   /// Extract a short, user-friendly title from the error.
@@ -162,6 +174,9 @@ class ServiceChainErrorWidget extends StatelessWidget {
       platform: ErrorReporterContext.currentPlatform(),
       locale: ErrorReporterContext.currentLocale(context),
       countryCode: countryCode,
+      networkState: networkState,
+      searchContext: searchContext,
+      stackTrace: stackTrace,
     );
     (reporter ?? const ErrorReporter()).reportError(context, payload);
   }

--- a/lib/features/search/presentation/widgets/ev_search_results_view.dart
+++ b/lib/features/search/presentation/widgets/ev_search_results_view.dart
@@ -55,8 +55,13 @@ class EvSearchResultsView extends ConsumerWidget {
         );
       },
       loading: () => const ShimmerStationList(),
-      error: (error, _) =>
-          ServiceChainErrorWidget(error: error, onRetry: onSearch),
+      error: (error, stackTrace) =>
+          ServiceChainErrorWidget(
+            error: error,
+            onRetry: onSearch,
+            stackTrace: stackTrace,
+            searchContext: 'EV charging search',
+          ),
     );
   }
 }

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -77,8 +77,13 @@ class SearchResultsContent extends ConsumerWidget {
         return SearchResultsList(result: result, onRefresh: onGpsRetry);
       },
       loading: () => const ShimmerStationList(),
-      error: (error, _) =>
-          ServiceChainErrorWidget(error: error, onRetry: onGpsRetry),
+      error: (error, stackTrace) =>
+          ServiceChainErrorWidget(
+            error: error,
+            onRetry: onGpsRetry,
+            stackTrace: stackTrace,
+            searchContext: 'Station search (${ref.read(selectedFuelTypeProvider).apiValue})',
+          ),
     );
   }
 }

--- a/test/core/services/mixins/station_service_helpers_test.dart
+++ b/test/core/services/mixins/station_service_helpers_test.dart
@@ -27,7 +27,8 @@ void main() {
       expect(
         () => helper.throwApiException(dioError),
         throwsA(isA<ApiException>()
-            .having((e) => e.message, 'message', 'Connection timeout')
+            .having((e) => e.message, 'message', contains('Connection timeout'))
+            .having((e) => e.message, 'has path', contains('path: /test'))
             .having((e) => e.statusCode, 'statusCode', 503)),
       );
     });
@@ -40,7 +41,7 @@ void main() {
         () =>
             helper.throwApiException(dioError, defaultMessage: 'Custom error'),
         throwsA(isA<ApiException>()
-            .having((e) => e.message, 'message', 'Custom error')),
+            .having((e) => e.message, 'message', contains('Custom error'))),
       );
     });
 
@@ -51,7 +52,8 @@ void main() {
       expect(
         () => helper.throwApiException(dioError),
         throwsA(isA<ApiException>()
-            .having((e) => e.message, 'message', 'Network error')),
+            .having((e) => e.message, 'message', contains('Network error'))
+            .having((e) => e.message, 'has path', contains('path: /test'))),
       );
     });
 

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -6,7 +6,6 @@ import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 import 'package:tankstellen/core/sync/sync_config.dart';
 import 'package:tankstellen/core/sync/sync_provider.dart';
-import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/favorites/providers/ev_favorites_provider.dart';
 import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
@@ -172,10 +171,7 @@ class _EmptyEvFavorites extends EvFavorites {
   List<String> build() => const [];
 }
 
-class _EmptyEvFavoriteStations extends EvFavoriteStations {
-  @override
-  List<ChargingStation> build() => const [];
-}
+
 
 /// SyncState that returns a disabled config (no sync, no Supabase calls).
 class _DisabledSyncState extends SyncState {


### PR DESCRIPTION
## Summary
- **`throwApiException` now includes DioException type + request path** — turns "Network error (status: null)" into "connectionTimeout: Network error (path: /v3/poi/)"
- **Error report payload gains 3 new fields**: `stackExcerpt` (app-only frames), `networkState`, `searchContext`
- **Issue body template** adds a Context section and collapsed stack trace
- **ServiceChainErrorWidget** passes stack trace and search context from catch sites

Closes #524

## Test plan
- [x] `flutter analyze` passes (zero warnings)
- [x] Error reporting tests pass (26 tests)
- [x] `throwApiException` tests updated for enriched message format
- [ ] Trigger an error in-app → tap "Report" → verify GitHub issue contains context + stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)