### PR TITLE
fix(ev): EV favorites not visible on Favorites tab

### DIFF
--- a/lib/features/favorites/providers/ev_favorites_provider.dart
+++ b/lib/features/favorites/providers/ev_favorites_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../ev/domain/entities/charging_station.dart';
+import 'favorites_provider.dart';
 
 part 'ev_favorites_provider.g.dart';
 
@@ -56,6 +57,10 @@ bool isEvFavorite(Ref ref, String stationId) {
 class EvFavoriteStations extends _$EvFavoriteStations {
   @override
   List<ChargingStation> build() {
+    // Watch the unified provider so we rebuild when favoritesProvider.toggleEv()
+    // writes to EV storage (#552). Without this, the Favorites tab never sees
+    // newly-added EV favorites.
+    ref.watch(favoritesProvider);
     final favoriteIds = ref.watch(evFavoritesProvider);
     if (favoriteIds.isEmpty) return const [];
 

--- a/lib/features/favorites/providers/ev_favorites_provider.g.dart
+++ b/lib/features/favorites/providers/ev_favorites_provider.g.dart
@@ -196,7 +196,7 @@ final class EvFavoriteStationsProvider
 }
 
 String _$evFavoriteStationsHash() =>
-    r'5f94bec82bdf6fdfe0827fb5a05da110a2d66206';
+    r'b18370d4f3b4e1977cc686ec6c3d409f6a419d7c';
 
 /// Loads persisted EV station data for favorites.
 

--- a/test/features/favorites/providers/ev_favorites_provider_test.dart
+++ b/test/features/favorites/providers/ev_favorites_provider_test.dart
@@ -13,6 +13,13 @@ void main() {
 
   setUp(() {
     mockStorage = MockHiveStorage();
+    // Fuel favorites stubs (unified Favorites.build merges both lists)
+    when(() => mockStorage.getFavoriteIds()).thenReturn([]);
+    when(() => mockStorage.getFavoriteStationData(any())).thenReturn(null);
+    when(() => mockStorage.isFavorite(any())).thenReturn(false);
+    when(() => mockStorage.isEvFavorite(any())).thenReturn(false);
+    when(() => mockStorage.getSetting(any())).thenReturn(null);
+    // EV favorites stubs
     when(() => mockStorage.getEvFavoriteIds()).thenReturn([]);
     when(() => mockStorage.addEvFavorite(any())).thenAnswer((_) async {});
     when(() => mockStorage.removeEvFavorite(any())).thenAnswer((_) async {});


### PR DESCRIPTION
## Summary
- **`EvFavoriteStations.build()` now watches `favoritesProvider`** so it rebuilds when `toggleEv()` writes to EV storage
- Root cause: the unified `favoritesProvider.toggleEv()` wrote to EV storage but never invalidated `evFavoritesProvider`, so `EvFavoriteStations` never rebuilt

Fixes #552

## Test plan
- [x] `flutter analyze` passes
- [x] All 41 favorites tests pass
- [ ] Add EV favorite via detail screen → appears on Favorites tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)