### PR TITLE
fix: restore onboarding wizard bypassed by community key (#521)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -145,6 +145,12 @@ class AppInitializer {
     // Migrate existing profiles to include country/language.
     final profileRepo = ProfileRepository(storage);
     await profileRepo.migrateProfileCountryLanguage();
+
+    // Safety net: guarantee a default profile always exists (#555).
+    // The onboarding wizard calls ensureDefaultProfile() at completion,
+    // but if the wizard was ever skipped (e.g., by the #521 hasApiKey
+    // regression), the app would run without any profile.
+    await profileRepo.ensureDefaultProfile();
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/core/storage/stores/settings_hive_store.dart
+++ b/lib/core/storage/stores/settings_hive_store.dart
@@ -144,10 +144,13 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
   Future<void> putSetting(String key, dynamic value) =>
       _settings.put(key, value);
 
-  // Setup skip (demo mode)
+  // Setup completion — tracks whether the onboarding wizard has been completed
+  // or explicitly skipped. Must NOT depend on hasApiKey() because the bundled
+  // community key (#521) makes hasApiKey() always true, which permanently
+  // bypassed the wizard on fresh install (#555).
   @override
   bool get isSetupComplete =>
-      hasApiKey() || (_settings.get(StorageKeys.setupSkipped) == true);
+      _settings.get(StorageKeys.setupSkipped) == true;
 
   @override
   bool get isSetupSkipped => _settings.get(StorageKeys.setupSkipped) == true;

--- a/test/core/storage/hive_storage_test.dart
+++ b/test/core/storage/hive_storage_test.dart
@@ -320,14 +320,13 @@ void main() {
     });
 
     test(
-        '#521: isSetupComplete is true on a fresh install because the '
-        'community default key is always available', () {
-      // Before #521 this returned false until the user either set a
-      // custom key or explicitly skipped setup. Since the community
-      // key is bundled, there is no "unconfigured" starting state any
-      // more — the onboarding flow can jump straight to the landing
-      // screen.
-      expect(storage.isSetupComplete, isTrue);
+        '#555: isSetupComplete is false on fresh install — wizard must show',
+        () {
+      // #521 introduced a regression: hasApiKey() became always-true
+      // (community default key), and isSetupComplete depended on it.
+      // This bypassed the onboarding wizard entirely. The fix (#555)
+      // makes isSetupComplete depend only on the setupSkipped flag.
+      expect(storage.isSetupComplete, isFalse);
     });
   });
 


### PR DESCRIPTION
## Summary
- **Root cause**: `isSetupComplete` depended on `hasApiKey()`, which became always-true after #521 bundled a community default key — permanently bypassing the onboarding wizard on fresh install
- **Fix**: `isSetupComplete` now depends only on the `setupSkipped` flag
- **Safety net**: `ensureDefaultProfile()` runs at app startup so the app never runs without a profile
- **Test fix**: corrected the #521 test that enshrined the broken behavior

Fixes #555

## Test plan
- [x] `flutter analyze` passes
- [x] Storage tests pass (88 tests, including fresh-install assertion)
- [ ] Fresh install: GDPR consent → wizard shows (not search screen)
- [ ] Wizard completion creates default profile
- [ ] Existing installs with `setupSkipped=true` still skip wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)