### PR TITLE
fix(ev): EV favorites not appearing — stale provider IDs

### DIFF
--- a/lib/features/favorites/providers/ev_favorites_provider.dart
+++ b/lib/features/favorites/providers/ev_favorites_provider.dart
@@ -58,13 +58,14 @@ class EvFavoriteStations extends _$EvFavoriteStations {
   @override
   List<ChargingStation> build() {
     // Watch the unified provider so we rebuild when favoritesProvider.toggleEv()
-    // writes to EV storage (#552). Without this, the Favorites tab never sees
-    // newly-added EV favorites.
+    // writes to EV storage (#552). The evFavoritesProvider is keepAlive and
+    // never re-reads storage after its initial build, so we read EV IDs
+    // directly from storage here to get fresh data after every mutation.
     ref.watch(favoritesProvider);
-    final favoriteIds = ref.watch(evFavoritesProvider);
+    final storage = ref.read(storageRepositoryProvider);
+    final favoriteIds = storage.getEvFavoriteIds();
     if (favoriteIds.isEmpty) return const [];
 
-    final storage = ref.read(storageRepositoryProvider);
     final stations = <ChargingStation>[];
 
     for (final id in favoriteIds) {


### PR DESCRIPTION
## Summary
- **`EvFavoriteStations.build()` now reads EV IDs directly from storage** instead of from the stale `evFavoritesProvider` (which is `keepAlive` and never re-reads after initial build)
- Root cause: `favoritesProvider.toggleEv()` writes to Hive, `_reload()` updates its own state, `EvFavoriteStations` rebuilds (watches `favoritesProvider`), but reads stale IDs from `evFavoritesProvider` which still has the old empty list

Closes #552

## Test plan
- [x] `flutter analyze` passes
- [x] All 41 favorites tests pass
- [ ] Add EV favorite → appears on Favorites tab immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)