### PR TITLE
test(ev): widget tests for EVStationDetailScreen favorite toggle

### DIFF
--- a/test/features/ev/presentation/screens/ev_station_detail_test.dart
+++ b/test/features/ev/presentation/screens/ev_station_detail_test.dart
@@ -1,8 +1,21 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/storage/stores/settings_hive_store.dart';
+import 'package:tankstellen/features/ev/presentation/screens/ev_station_detail_screen.dart';
+
+import '../../../../fixtures/ev_stations.dart';
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
 
 void main() {
-  group('EV Station', () {
+  setUpAll(() {
+    // mocktail requires registering fallback values for any() matchers
+    // against Map<String, dynamic> arguments.
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  group('EV Station API key', () {
     test('default EV API key is available', () {
       expect(SettingsHiveStore.defaultEvApiKey, isNotEmpty);
       expect(SettingsHiveStore.defaultEvApiKey, contains('-'));
@@ -16,21 +29,147 @@ void main() {
       );
       expect(uuidRegex.hasMatch(key), isTrue);
     });
+  });
 
-    test('station name does not contain Demo prefix', () {
-      // The demo fallback service generated names like "Demo Fast Charger".
-      // With the default API key, real data should be served.
-      // This is a guard to ensure demo naming is not used in production.
-      const demoNames = [
-        'Demo Fast Charger',
-        'Demo Destination Charger',
-        'Demo AC Point',
-        'Demo CHAdeMO',
-      ];
-      for (final name in demoNames) {
-        expect(name.startsWith('Demo'), isTrue,
-            reason: 'These are demo names — production stations should not have them');
-      }
+  group('EvStationDetailScreen favorite toggle', () {
+    testWidgets('shows outlined star when station is not favorited',
+        (tester) async {
+      final test = standardTestOverrides(favoriteIds: const []);
+      when(() => test.mockStorage.getRatings()).thenReturn(<String, int>{});
+
+      await pumpApp(
+        tester,
+        const EvStationDetailScreen(station: testEvStation),
+        overrides: test.overrides,
+      );
+
+      final appBarStar = find.descendant(
+        of: find.byType(AppBar),
+        matching: find.byIcon(Icons.star_border),
+      );
+      expect(appBarStar, findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.byIcon(Icons.star),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('shows filled amber star when station is favorited',
+        (tester) async {
+      final test = standardTestOverrides(favoriteIds: [testEvStation.id]);
+      when(() => test.mockStorage.getRatings()).thenReturn(<String, int>{});
+
+      await pumpApp(
+        tester,
+        const EvStationDetailScreen(station: testEvStation),
+        overrides: [
+          ...test.overrides,
+          isFavoriteOverride(testEvStation.id, true),
+        ],
+      );
+
+      final appBarStar = find.descendant(
+        of: find.byType(AppBar),
+        matching: find.byIcon(Icons.star),
+      );
+      expect(appBarStar, findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.byIcon(Icons.star_border),
+        ),
+        findsNothing,
+      );
+
+      final appBarIcon = tester.widget<Icon>(appBarStar);
+      expect(appBarIcon.color, Colors.amber);
+    });
+
+    testWidgets('tapping star calls toggle with rawJson containing station data',
+        (tester) async {
+      final test = standardTestOverrides(favoriteIds: const []);
+      when(() => test.mockStorage.getRatings()).thenReturn(<String, int>{});
+      when(() => test.mockStorage.addEvFavorite(any()))
+          .thenAnswer((_) async {});
+      when(() => test.mockStorage.saveEvFavoriteStationData(any(), any()))
+          .thenAnswer((_) async {});
+
+      await pumpApp(
+        tester,
+        const EvStationDetailScreen(station: testEvStation),
+        overrides: test.overrides,
+      );
+
+      await tester.tap(find.descendant(
+        of: find.byType(AppBar),
+        matching: find.byIcon(Icons.star_border),
+      ));
+      await tester.pump();
+
+      // Route 1: EV-prefixed ID goes to EV storage (not fuel).
+      verify(() => test.mockStorage.addEvFavorite(testEvStation.id))
+          .called(1);
+
+      // Route 2: station JSON is persisted so the favorites tab can render it.
+      verify(() => test.mockStorage.saveEvFavoriteStationData(
+            testEvStation.id,
+            testEvStation.toJson(),
+          )).called(1);
+    });
+
+    testWidgets('never routes EV station to fuel storage', (tester) async {
+      final test = standardTestOverrides(favoriteIds: const []);
+      when(() => test.mockStorage.getRatings()).thenReturn(<String, int>{});
+      when(() => test.mockStorage.addEvFavorite(any()))
+          .thenAnswer((_) async {});
+      when(() => test.mockStorage.saveEvFavoriteStationData(any(), any()))
+          .thenAnswer((_) async {});
+
+      await pumpApp(
+        tester,
+        const EvStationDetailScreen(station: testEvStation),
+        overrides: test.overrides,
+      );
+
+      await tester.tap(find.descendant(
+        of: find.byType(AppBar),
+        matching: find.byIcon(Icons.star_border),
+      ));
+      await tester.pump();
+
+      // Fuel storage must never be touched for ocm- IDs; this was the #552 bug.
+      verifyNever(() => test.mockStorage.addFavorite(any()));
+      verifyNever(() => test.mockStorage.saveFavoriteStationData(any(), any()));
+    });
+
+    testWidgets('tooltip reflects favorite state', (tester) async {
+      final test = standardTestOverrides(favoriteIds: const []);
+      when(() => test.mockStorage.getRatings()).thenReturn(<String, int>{});
+
+      await pumpApp(
+        tester,
+        const EvStationDetailScreen(station: testEvStation),
+        overrides: test.overrides,
+      );
+
+      // Not favorited → "Add to favorites"
+      expect(find.byTooltip('Add to favorites'), findsOneWidget);
+
+      // Re-pump with favorited override
+      await tester.pumpWidget(const SizedBox());
+      await pumpApp(
+        tester,
+        const EvStationDetailScreen(station: testEvStation),
+        overrides: [
+          ...test.overrides,
+          isFavoriteOverride(testEvStation.id, true),
+        ],
+      );
+
+      expect(find.byTooltip('Remove from favorites'), findsOneWidget);
     });
   });
 }

--- a/test/fixtures/ev_stations.dart
+++ b/test/fixtures/ev_stations.dart
@@ -1,0 +1,35 @@
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+
+/// Canonical EV test station. ID uses the `ocm-` prefix so that
+/// [Favorites.toggle] routes it to EV storage (not fuel storage).
+const testEvStation = ChargingStation(
+  id: 'ocm-test-1',
+  name: 'Test Fast Charger',
+  operator: 'Ionity',
+  latitude: 52.5200,
+  longitude: 13.4050,
+  address: 'Unter den Linden 1, 10117 Berlin',
+  connectors: [
+    EvConnector(
+      id: 'ocm-test-1-c1',
+      type: ConnectorType.ccs,
+      maxPowerKw: 350,
+      status: ConnectorStatus.available,
+    ),
+    EvConnector(
+      id: 'ocm-test-1-c2',
+      type: ConnectorType.type2,
+      maxPowerKw: 22,
+      status: ConnectorStatus.occupied,
+    ),
+  ],
+);
+
+const testEvStationMinimal = ChargingStation(
+  id: 'ocm-test-minimal',
+  name: 'Minimal Charger',
+  latitude: 48.8566,
+  longitude: 2.3522,
+);


### PR DESCRIPTION
## Summary
- Widget tests for the `EvStationDetailScreen` star toggle, locking in the #552/#559 bug path (EV ID routing, rawJson persistence).
- New `test/fixtures/ev_stations.dart` with canonical `testEvStation` (ocm- prefix, ev/ChargingStation type).
- Five tests: outlined/filled/amber icon states, tap routes to EV storage, fuel storage never touched, tooltip reflects state.

## Test plan
- [x] `flutter test test/features/ev/presentation/screens/ev_station_detail_test.dart` — 7/7 pass
- [x] `flutter test` — full suite 3703 pass
- [x] `flutter analyze --no-fatal-infos` — no new errors

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)