### PR TITLE
feat(ui): champion chip filled color, prominent distance

### DIFF
--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -137,8 +137,9 @@ class AllPricesStationCard extends StatelessWidget {
                   ),
                   Text(
                     PriceFormatter.formatDistance(station.dist),
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      fontWeight: FontWeight.w600,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: theme.colorScheme.primary,
                     ),
                   ),
                 ],
@@ -219,15 +220,16 @@ class _FuelBadge extends StatelessWidget {
     final color = FuelColors.forType(fuelType);
 
     final isHighlighted = isProfileFuel && !isUnavailable;
+    final isChampion = isCheapest && !isUnavailable;
 
-    final borderColor = isCheapest ? Colors.green : color;
-    final bgColor = isCheapest
-        ? Colors.green.withValues(alpha: 0.1)
+    final borderColor = isChampion ? color : color;
+    final bgColor = isChampion
+        ? color
         : isHighlighted
             ? FuelColors.forType(fuelType).withValues(alpha: 0.22)
             : FuelColors.forTypeLight(fuelType);
 
-    final borderWidth = isCheapest ? 1.5 : (isHighlighted ? 1.5 : 0.5);
+    final borderWidth = isChampion ? 1.5 : (isHighlighted ? 1.5 : 0.5);
     final labelFontSize = isHighlighted ? 11.0 : 10.0;
     final priceFontSize = isHighlighted ? 13.0 : 11.0;
     final dotSize = isHighlighted ? 8.0 : 6.0;
@@ -261,7 +263,9 @@ class _FuelBadge extends StatelessWidget {
               shape: BoxShape.circle,
               color: isUnavailable
                   ? theme.colorScheme.onSurfaceVariant
-                  : color,
+                  : isChampion
+                      ? Colors.white
+                      : color,
             ),
           ),
           const SizedBox(width: 4),
@@ -269,10 +273,14 @@ class _FuelBadge extends StatelessWidget {
             label,
             style: TextStyle(
               fontSize: labelFontSize,
-              fontWeight: isHighlighted ? FontWeight.bold : FontWeight.w600,
+              fontWeight: isHighlighted || isChampion
+                  ? FontWeight.bold
+                  : FontWeight.w600,
               color: isUnavailable
                   ? theme.colorScheme.onSurfaceVariant
-                  : color,
+                  : isChampion
+                      ? Colors.white
+                      : color,
             ),
           ),
           const SizedBox(width: 4),
@@ -285,9 +293,11 @@ class _FuelBadge extends StatelessWidget {
               fontWeight: FontWeight.bold,
               color: isUnavailable
                   ? theme.colorScheme.onSurfaceVariant
-                  : isHighlighted
-                      ? color
-                      : theme.colorScheme.onSurface,
+                  : isChampion
+                      ? Colors.white
+                      : isHighlighted
+                          ? color
+                          : theme.colorScheme.onSurface,
             ),
           ),
         ],

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -446,22 +446,27 @@ class _ViewToggleButton extends ConsumerWidget {
     final allPrices = ref.watch(allPricesViewEnabledProvider);
     final l10n = AppLocalizations.of(context);
 
+    final label = allPrices
+        ? (l10n?.switchToCompactView ?? 'Switch to compact view')
+        : (l10n?.switchToAllPricesView ?? 'Switch to all-prices view');
+
     return Semantics(
-      label: allPrices
-          ? (l10n?.switchToCompactView ?? 'Switch to compact view')
-          : (l10n?.switchToAllPricesView ?? 'Switch to all-prices view'),
+      label: label,
       button: true,
-      child: InkWell(
-        onTap: () => ref
-            .read(allPricesViewEnabledProvider.notifier)
-            .toggle(),
-        borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-          child: Icon(
-            allPrices ? Icons.view_list : Icons.view_agenda,
-            size: 18,
-            color: Theme.of(context).colorScheme.primary,
+      child: Tooltip(
+        message: label,
+        child: InkWell(
+          onTap: () => ref
+              .read(allPricesViewEnabledProvider.notifier)
+              .toggle(),
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            child: Icon(
+              allPrices ? Icons.view_list : Icons.view_agenda,
+              size: 18,
+              color: Theme.of(context).colorScheme.primary,
+            ),
           ),
         ),
       ),

--- a/test/features/search/presentation/widgets/all_prices_station_card_test.dart
+++ b/test/features/search/presentation/widgets/all_prices_station_card_test.dart
@@ -186,6 +186,108 @@ void main() {
       expect(find.text('Diesel'), findsOneWidget);
     });
 
+    group('champion (cheapest) chip styling (#572)', () {
+      testWidgets('champion chip has filled fuel-type background', (tester) async {
+        await pumpApp(
+          tester,
+          const AllPricesStationCard(
+            station: testStation,
+            cheapestFlags: {FuelType.diesel: true},
+          ),
+        );
+
+        final dieselColor = FuelColors.forType(FuelType.diesel);
+        // Find the Diesel label — walk up to the outer badge Container.
+        final labelFinder = find.text('Diesel');
+        expect(labelFinder, findsOneWidget);
+        final badgeContainer = find
+            .ancestor(
+              of: labelFinder,
+              matching: find.byWidgetPredicate((w) {
+                if (w is Container && w.decoration is BoxDecoration) {
+                  final dec = w.decoration as BoxDecoration;
+                  return dec.borderRadius != null && dec.border is Border;
+                }
+                return false;
+              }),
+            )
+            .first;
+
+        final container = tester.widget<Container>(badgeContainer);
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.color, dieselColor,
+            reason: 'Champion chip must use filled fuel-type color, not light alpha.');
+      });
+
+      testWidgets('champion chip text is white for contrast', (tester) async {
+        await pumpApp(
+          tester,
+          const AllPricesStationCard(
+            station: testStation,
+            cheapestFlags: {FuelType.diesel: true},
+          ),
+        );
+
+        final labelWidget = tester.widget<Text>(find.text('Diesel'));
+        expect(labelWidget.style?.color, Colors.white);
+        expect(labelWidget.style?.fontWeight, FontWeight.bold);
+      });
+
+      testWidgets('non-champion chip does not use white text', (tester) async {
+        await pumpApp(
+          tester,
+          const AllPricesStationCard(station: testStation),
+        );
+
+        // Without cheapestFlags, no chip is a champion; label uses the
+        // fuel-type color on a light tinted background (not white-on-solid).
+        final labelWidget = tester.widget<Text>(find.text('Diesel'));
+        expect(labelWidget.style?.color, isNot(Colors.white),
+            reason: 'Non-champion chip must not use white text.');
+      });
+
+      testWidgets('unavailable fuel never becomes champion (cheapestFlag ignored)',
+          (tester) async {
+        const stationWithUnavailable = Station(
+          id: 'u1',
+          name: 'u',
+          brand: 'TOT',
+          street: 's',
+          postCode: '1',
+          place: 'p',
+          lat: 0,
+          lng: 0,
+          e5: 1.5,
+          isOpen: true,
+          unavailableFuels: ['diesel'],
+        );
+
+        await pumpApp(
+          tester,
+          const AllPricesStationCard(
+            station: stationWithUnavailable,
+            cheapestFlags: {FuelType.diesel: true},
+          ),
+        );
+
+        final diesel = tester.widget<Text>(find.text('Diesel'));
+        expect(diesel.style?.color, isNot(Colors.white),
+            reason: 'Out-of-stock fuel must not render as champion.');
+      });
+    });
+
+    group('distance prominence (#572)', () {
+      testWidgets('distance uses bold bodyMedium style', (tester) async {
+        await pumpApp(
+          tester,
+          const AllPricesStationCard(station: testStation),
+        );
+
+        final distanceText = tester.widget<Text>(find.textContaining('km'));
+        expect(distanceText.style?.fontWeight, FontWeight.bold);
+      });
+    });
+
     testWidgets('renders station with all fuel types', (tester) async {
       const fullStation = Station(
         id: 'full-station',


### PR DESCRIPTION
## Summary
- Champion (cheapest) chip: filled fuel-type background with white text — visible at a glance.
- Distance: bold bodyMedium in primary color (was bodySmall w600).
- View toggle button: added Tooltip alongside the existing Semantics label.

All per #564 user feedback.

## Test plan
- [x] \`flutter test test/features/search/presentation/widgets/all_prices_station_card_test.dart\` — 26/26 pass (5 new tests for champion styling + distance)
- [x] \`flutter test\` — full suite 3708 pass
- [x] \`flutter analyze --no-fatal-infos\` — no new errors

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)