### PR TITLE
feat(consumption): CSV export for fill-up history

### DIFF
--- a/lib/features/consumption/data/csv_exporter.dart
+++ b/lib/features/consumption/data/csv_exporter.dart
@@ -1,0 +1,76 @@
+import '../domain/entities/fill_up.dart';
+import '../../search/domain/entities/fuel_type.dart';
+
+/// Serializes a list of [FillUp] records into a spreadsheet-friendly CSV.
+///
+/// Used by the consumption screen "Export CSV" action. Output is a UTF-8
+/// string with a header row followed by one data row per fill-up, sorted
+/// oldest-first so power users can chart trends without re-sorting.
+///
+/// The format is deliberately conservative:
+/// - Period (`.`) as the decimal separator for Excel/LibreOffice compatibility
+/// - ISO-8601 dates (`YYYY-MM-DD HH:MM:SS`) — sortable as text
+/// - Comma delimiter with RFC 4180 quoting (fields containing commas,
+///   quotes, or newlines are wrapped in double quotes; internal quotes
+///   are doubled)
+class ConsumptionCsvExporter {
+  static const List<String> headers = [
+    'Date',
+    'Station',
+    'Fuel Type',
+    'Liters',
+    'Price per Liter',
+    'Total Cost',
+    'Odometer (km)',
+    'CO2 (kg)',
+    'Notes',
+  ];
+
+  /// Renders [fillUps] as a CSV string (header + data rows).
+  ///
+  /// An empty input returns just the header row (so the file is still
+  /// valid and self-describing).
+  static String toCsv(List<FillUp> fillUps) {
+    final buffer = StringBuffer();
+    buffer.writeln(headers.map(_escape).join(','));
+
+    final sorted = List<FillUp>.from(fillUps)
+      ..sort((a, b) => a.date.compareTo(b.date));
+
+    for (final f in sorted) {
+      buffer.writeln([
+        _formatDate(f.date),
+        f.stationName ?? '',
+        _fuelTypeLabel(f.fuelType),
+        _formatNumber(f.liters, 3),
+        _formatNumber(f.pricePerLiter, 3),
+        _formatNumber(f.totalCost, 2),
+        _formatNumber(f.odometerKm, 1),
+        _formatNumber(f.co2Kg, 2),
+        f.notes ?? '',
+      ].map(_escape).join(','));
+    }
+
+    return buffer.toString();
+  }
+
+  static String _formatDate(DateTime d) {
+    String two(int v) => v.toString().padLeft(2, '0');
+    return '${d.year}-${two(d.month)}-${two(d.day)} '
+        '${two(d.hour)}:${two(d.minute)}:${two(d.second)}';
+  }
+
+  static String _formatNumber(double v, int decimals) =>
+      v.toStringAsFixed(decimals);
+
+  static String _fuelTypeLabel(FuelType t) => t.apiValue;
+
+  /// RFC 4180 field escaping: wrap in quotes if the field contains the
+  /// delimiter, a quote, or a line break; double any embedded quotes.
+  static String _escape(String field) {
+    final needsQuoting =
+        field.contains(',') || field.contains('"') || field.contains('\n');
+    if (!needsQuoting) return field;
+    return '"${field.replaceAll('"', '""')}"';
+  }
+}

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/widgets/empty_state.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../data/csv_exporter.dart';
 import '../../providers/consumption_providers.dart';
 import '../widgets/consumption_stats_card.dart';
 import '../widgets/fill_up_card.dart';
@@ -27,6 +30,22 @@ class ConsumptionScreen extends ConsumerWidget {
           onPressed: () => context.pop(),
         ),
         actions: [
+          IconButton(
+            key: const Key('export_csv'),
+            tooltip: 'Export CSV',
+            icon: const Icon(Icons.download_outlined),
+            onPressed: fillUps.isEmpty
+                ? null
+                : () async {
+                    final csv = ConsumptionCsvExporter.toCsv(fillUps);
+                    await Clipboard.setData(ClipboardData(text: csv));
+                    if (!context.mounted) return;
+                    SnackBarHelper.show(
+                      context,
+                      'CSV copied to clipboard — paste into a spreadsheet',
+                    );
+                  },
+          ),
           IconButton(
             key: const Key('open_carbon_dashboard'),
             tooltip: l?.carbonDashboardTitle ?? 'Carbon dashboard',

--- a/test/features/consumption/data/csv_exporter_test.dart
+++ b/test/features/consumption/data/csv_exporter_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/csv_exporter.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+void main() {
+  group('ConsumptionCsvExporter', () {
+    test('empty list returns header row only', () {
+      final csv = ConsumptionCsvExporter.toCsv([]);
+      final lines = csv.trim().split('\n');
+      expect(lines.length, 1);
+      expect(lines.first,
+          'Date,Station,Fuel Type,Liters,Price per Liter,Total Cost,Odometer (km),CO2 (kg),Notes');
+    });
+
+    test('headers match the spec from issue #583', () {
+      expect(ConsumptionCsvExporter.headers, [
+        'Date',
+        'Station',
+        'Fuel Type',
+        'Liters',
+        'Price per Liter',
+        'Total Cost',
+        'Odometer (km)',
+        'CO2 (kg)',
+        'Notes',
+      ]);
+    });
+
+    test('single fill-up renders all fields', () {
+      final fillUp = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 4, 15, 10, 30, 0),
+        liters: 45.12,
+        totalCost: 78.45,
+        odometerKm: 12345.6,
+        fuelType: FuelType.diesel,
+        stationName: 'Total Castelnau',
+      );
+
+      final csv = ConsumptionCsvExporter.toCsv([fillUp]);
+      final lines = csv.trim().split('\n');
+      expect(lines.length, 2);
+
+      final data = lines[1];
+      expect(data, contains('2026-04-15 10:30:00'));
+      expect(data, contains('Total Castelnau'));
+      expect(data, contains('diesel'));
+      expect(data, contains('45.120'));
+      expect(data, contains('78.45'));
+      expect(data, contains('12345.6'));
+    });
+
+    test('decimal formatting uses period (Excel/LibreOffice compatible)', () {
+      final fillUp = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 1, 1),
+        liters: 42.5,
+        totalCost: 65.25,
+        odometerKm: 10000,
+        fuelType: FuelType.e10,
+      );
+
+      final csv = ConsumptionCsvExporter.toCsv([fillUp]);
+      expect(csv.contains(','), isTrue);
+      expect(csv.contains('42.500'), isTrue,
+          reason: 'Liters formatted with 3 decimals and period separator');
+      expect(csv.contains('65.25'), isTrue,
+          reason: 'Total cost with 2 decimals');
+    });
+
+    test('rows are sorted oldest-first', () {
+      final newer = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 4, 10),
+        liters: 40,
+        totalCost: 60,
+        odometerKm: 100,
+        fuelType: FuelType.e10,
+      );
+      final older = FillUp(
+        id: '2',
+        date: DateTime.utc(2026, 1, 1),
+        liters: 40,
+        totalCost: 60,
+        odometerKm: 50,
+        fuelType: FuelType.e10,
+      );
+
+      final csv = ConsumptionCsvExporter.toCsv([newer, older]);
+      final lines = csv.trim().split('\n');
+      expect(lines[1], contains('2026-01-01'));
+      expect(lines[2], contains('2026-04-10'));
+    });
+
+    test('commas in station name are quoted per RFC 4180', () {
+      final fillUp = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 1, 1),
+        liters: 40,
+        totalCost: 60,
+        odometerKm: 100,
+        fuelType: FuelType.e10,
+        stationName: 'Total, Station A',
+      );
+
+      final csv = ConsumptionCsvExporter.toCsv([fillUp]);
+      expect(csv, contains('"Total, Station A"'));
+    });
+
+    test('double quotes in fields are escaped by doubling', () {
+      final fillUp = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 1, 1),
+        liters: 40,
+        totalCost: 60,
+        odometerKm: 100,
+        fuelType: FuelType.e10,
+        stationName: 'Bob\'s "Super" Gas',
+      );
+
+      final csv = ConsumptionCsvExporter.toCsv([fillUp]);
+      expect(csv, contains('"Bob\'s ""Super"" Gas"'));
+    });
+
+    test('newlines in notes are quoted', () {
+      final fillUp = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 1, 1),
+        liters: 40,
+        totalCost: 60,
+        odometerKm: 100,
+        fuelType: FuelType.e10,
+        notes: 'line1\nline2',
+      );
+
+      final csv = ConsumptionCsvExporter.toCsv([fillUp]);
+      expect(csv, contains('"line1\nline2"'));
+    });
+
+    test('missing optional fields render as empty', () {
+      final fillUp = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 1, 1, 12),
+        liters: 40,
+        totalCost: 60,
+        odometerKm: 100,
+        fuelType: FuelType.e10,
+      );
+
+      final csv = ConsumptionCsvExporter.toCsv([fillUp]);
+      final lines = csv.trim().split('\n');
+      // station and notes empty → two empty fields in the row
+      final fields = lines[1].split(',');
+      expect(fields.length, ConsumptionCsvExporter.headers.length);
+      expect(fields[1], ''); // Station
+      expect(fields.last, ''); // Notes
+    });
+
+    test('CO2 column uses 2 decimals', () {
+      final fillUp = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 1, 1),
+        liters: 50,
+        totalCost: 80,
+        odometerKm: 100,
+        fuelType: FuelType.diesel, // has CO2 factor
+      );
+
+      final csv = ConsumptionCsvExporter.toCsv([fillUp]);
+      final fields = csv.trim().split('\n')[1].split(',');
+      // 8th column (index 7) is CO2
+      final co2 = fields[7];
+      expect(RegExp(r'^\d+\.\d{2}$').hasMatch(co2), isTrue,
+          reason: 'CO2 field should have exactly 2 decimals: got "$co2"');
+    });
+  });
+}

--- a/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/consumption_screen.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+class _FixedFillUpList extends FillUpList {
+  final List<FillUp> _value;
+  _FixedFillUpList(this._value);
+
+  @override
+  List<FillUp> build() => _value;
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester, {
+  required List<FillUp> fillUps,
+}) async {
+  final router = GoRouter(
+    initialLocation: '/consumption',
+    routes: [
+      GoRoute(
+        path: '/consumption',
+        builder: (_, __) => const ConsumptionScreen(),
+      ),
+      // Minimal stubs so pushes in the screen don't crash.
+      GoRoute(path: '/consumption/add', builder: (_, __) => const SizedBox()),
+      GoRoute(path: '/carbon', builder: (_, __) => const SizedBox()),
+    ],
+  );
+
+  await pumpApp(
+    tester,
+    MaterialApp.router(routerConfig: router),
+    overrides: [
+      fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    // Capture clipboard writes in-memory so we can assert on them.
+    _InMemoryClipboard.install();
+  });
+
+  tearDown(() {
+    _InMemoryClipboard.uninstall();
+  });
+
+  group('ConsumptionScreen CSV export (#583)', () {
+    testWidgets('export button is disabled when the list is empty',
+        (tester) async {
+      await _pumpScreen(tester, fillUps: const []);
+
+      final button = tester.widget<IconButton>(
+        find.byKey(const Key('export_csv')),
+      );
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('export button writes CSV to the clipboard', (tester) async {
+      final fillUp = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 4, 15, 10, 0),
+        liters: 40,
+        totalCost: 60,
+        odometerKm: 12345,
+        fuelType: FuelType.diesel,
+        stationName: 'Total',
+      );
+
+      await _pumpScreen(tester, fillUps: [fillUp]);
+
+      await tester.tap(find.byKey(const Key('export_csv')));
+      await tester.pump();
+
+      final copied = _InMemoryClipboard.lastWrite;
+      expect(copied, isNotNull);
+      expect(copied!, contains('Date,Station,Fuel Type'),
+          reason: 'Clipboard must contain the CSV header row.');
+      expect(copied, contains('Total'));
+      expect(copied, contains('diesel'));
+    });
+
+    testWidgets('shows confirmation snackbar after copy', (tester) async {
+      final fillUp = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 4, 15),
+        liters: 40,
+        totalCost: 60,
+        odometerKm: 10000,
+        fuelType: FuelType.e10,
+      );
+
+      await _pumpScreen(tester, fillUps: [fillUp]);
+      await tester.tap(find.byKey(const Key('export_csv')));
+      await tester.pump();
+
+      expect(
+        find.textContaining('CSV copied to clipboard'),
+        findsOneWidget,
+      );
+    });
+  });
+}
+
+/// Intercepts `Clipboard.setData` calls via the platform channel so tests
+/// can assert the copied text without hitting a real clipboard.
+class _InMemoryClipboard {
+  static String? lastWrite;
+
+  static void install() {
+    lastWrite = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        final args = call.arguments as Map<dynamic, dynamic>;
+        lastWrite = args['text'] as String?;
+      }
+      return null;
+    });
+  }
+
+  static void uninstall() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  }
+}


### PR DESCRIPTION
## Summary
- New download icon on the consumption screen app bar copies an RFC 4180 CSV to the clipboard.
- Pure-Dart ConsumptionCsvExporter — no new deps.
- Period decimal separator, ISO-8601 dates, oldest-first ordering.
- Button disabled when the list is empty.

EV charging rows will be added with #582 when that data model lands.

## Test plan
- [x] 10 unit tests for CSV serialization (empty, headers, decimals, escaping, sort order, quoting)
- [x] 3 widget tests for the export button (disabled state, clipboard write, snackbar)
- [x] \`flutter test\` — full suite 3716 pass
- [x] \`flutter analyze --no-fatal-infos\` — no new errors

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)