### PR TITLE
feat(consumption): smart auto-fill from station detail

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -19,6 +19,7 @@ import '../features/carbon/presentation/screens/carbon_dashboard_screen.dart';
 import '../features/report/presentation/screens/report_screen.dart';
 import '../features/consumption/presentation/screens/add_fill_up_screen.dart';
 import '../features/consumption/presentation/screens/consumption_screen.dart';
+import '../features/search/domain/entities/fuel_type.dart';
 import '../features/price_history/presentation/screens/price_history_screen.dart';
 import '../features/search/presentation/screens/ev_station_detail_screen.dart';
 import '../features/search/domain/entities/charging_station.dart';
@@ -222,13 +223,21 @@ GoRouter router(Ref ref) {
           final extra = state.extra;
           String? stationId;
           String? stationName;
+          FuelType? fuelType;
+          double? pricePerLiter;
           if (extra is Map) {
             stationId = extra['stationId']?.toString();
             stationName = extra['stationName']?.toString();
+            final ft = extra['fuelType'];
+            if (ft is FuelType) fuelType = ft;
+            final price = extra['pricePerLiter'];
+            if (price is num) pricePerLiter = price.toDouble();
           }
           return AddFillUpScreen(
             stationId: stationId,
             stationName: stationName,
+            preFilledFuelType: fuelType,
+            preFilledPricePerLiter: pricePerLiter,
           );
         },
       ),

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -19,7 +19,23 @@ class AddFillUpScreen extends ConsumerStatefulWidget {
   final String? stationId;
   final String? stationName;
 
-  const AddFillUpScreen({super.key, this.stationId, this.stationName});
+  /// Pre-selected fuel type from the station context (e.g. profile fuel type
+  /// when opened from a station detail screen). Defaults to [FuelType.e10]
+  /// when null.
+  final FuelType? preFilledFuelType;
+
+  /// Pre-filled price per liter. When set, the total cost auto-updates as
+  /// the user enters liters — turning the common "known-station" fill-up
+  /// into a two-tap flow (liters + odometer).
+  final double? preFilledPricePerLiter;
+
+  const AddFillUpScreen({
+    super.key,
+    this.stationId,
+    this.stationName,
+    this.preFilledFuelType,
+    this.preFilledPricePerLiter,
+  });
 
   @override
   ConsumerState<AddFillUpScreen> createState() => _AddFillUpScreenState();
@@ -32,10 +48,41 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
   final _odoCtrl = TextEditingController();
   final _notesCtrl = TextEditingController();
   DateTime _date = DateTime.now();
-  FuelType _fuelType = FuelType.e10;
+  late FuelType _fuelType = widget.preFilledFuelType ?? FuelType.e10;
   bool _scanning = false;
   bool _obdReading = false;
   ReceiptScanService? _scanService;
+
+  @override
+  void initState() {
+    super.initState();
+    final price = widget.preFilledPricePerLiter;
+    if (price != null) {
+      _litersCtrl.addListener(_recomputeCost);
+    }
+  }
+
+  /// Auto-fills the total cost based on the pre-filled price per liter
+  /// and the current liters input. Only runs when the user has not manually
+  /// typed a cost (empty field) — so we don't clobber a scanned receipt.
+  void _recomputeCost() {
+    final price = widget.preFilledPricePerLiter;
+    if (price == null) return;
+    final liters = double.tryParse(_litersCtrl.text.replaceAll(',', '.'));
+    if (liters == null || liters <= 0) return;
+    final current = double.tryParse(_costCtrl.text.replaceAll(',', '.'));
+    // Only overwrite if the user hasn't typed a custom cost. We detect
+    // "user-typed" by checking whether the current value matches a prior
+    // auto-fill: if the field is empty OR exactly matches the previous
+    // auto-computed value, we overwrite.
+    final autoCost = (liters * price).toStringAsFixed(2);
+    if (_costCtrl.text.isEmpty || current == _lastAutoCost) {
+      _costCtrl.text = autoCost;
+      _lastAutoCost = double.tryParse(autoCost);
+    }
+  }
+
+  double? _lastAutoCost;
 
   @override
   void dispose() {

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -11,10 +11,12 @@ import '../../../alerts/domain/entities/price_alert.dart';
 import '../../../alerts/presentation/widgets/create_alert_dialog.dart';
 import '../../../alerts/providers/alert_provider.dart';
 import '../../../favorites/providers/favorites_provider.dart';
+import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/brand_registry.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../../core/utils/navigation_utils.dart';
+import '../../../../core/utils/station_extensions.dart';
 import '../../providers/station_detail_provider.dart';
 import '../widgets/price_history_section.dart';
 import '../widgets/price_tile.dart';
@@ -215,6 +217,8 @@ class StationDetailScreen extends ConsumerWidget {
           if (station.e85 != null) PriceTile(label: 'E85', price: station.e85, fuelType: FuelType.e85),
           if (station.lpg != null) PriceTile(label: 'LPG', price: station.lpg, fuelType: FuelType.lpg),
           if (station.cng != null) PriceTile(label: 'CNG', price: station.cng, fuelType: FuelType.cng),
+          const SizedBox(height: 12),
+          _LogFillUpButton(station: station),
           const SizedBox(height: 16),
 
           // Address, opening hours, fuels, location (services moved to bottom)
@@ -261,5 +265,70 @@ class StationDetailScreen extends ConsumerWidget {
         SnackBarHelper.showSuccess(context, l10n?.alertCreated ?? 'Price alert created');
       }
     }
+  }
+}
+
+/// "Log fill-up here" button. Reads the active profile's preferred fuel
+/// type and the station's current price for that fuel, then navigates to
+/// [AddFillUpScreen] with both pre-filled so the user only needs to type
+/// liters and odometer.
+class _LogFillUpButton extends ConsumerWidget {
+  final Station station;
+
+  const _LogFillUpButton({required this.station});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profile = ref.watch(activeProfileProvider);
+    final preferredFuel = profile?.preferredFuelType;
+    // Fall back to any fuel the station reports if the profile fuel isn't
+    // available at this station (e.g. diesel-preferring user at a petrol-only
+    // bio station).
+    final pricedFuel = preferredFuel != null &&
+            station.priceFor(preferredFuel) != null
+        ? preferredFuel
+        : _firstAvailableFuel(station);
+    final pricePerLiter =
+        pricedFuel != null ? station.priceFor(pricedFuel) : null;
+    final stationName = station.brand.isNotEmpty &&
+            station.brand != 'Station' &&
+            station.brand != BrandRegistry.independentLabel
+        ? station.brand
+        : station.street;
+
+    return OutlinedButton.icon(
+      onPressed: () {
+        final extra = <String, Object>{
+          'stationId': station.id,
+          'stationName': stationName,
+        };
+        if (pricedFuel != null) extra['fuelType'] = pricedFuel;
+        if (pricePerLiter != null) extra['pricePerLiter'] = pricePerLiter;
+        context.push('/consumption/add', extra: extra);
+      },
+      icon: const Icon(Icons.local_gas_station_outlined),
+      label: Text(
+        AppLocalizations.of(context)?.addFillUp ?? 'Log fill-up here',
+      ),
+    );
+  }
+
+  /// Returns the first fuel type for which this station has a price, in a
+  /// predictable priority order. Used when the profile fuel isn't available
+  /// at the station, so the button can still pre-fill a reasonable default.
+  static FuelType? _firstAvailableFuel(Station s) {
+    const order = [
+      FuelType.e10,
+      FuelType.e5,
+      FuelType.diesel,
+      FuelType.e98,
+      FuelType.e85,
+      FuelType.lpg,
+      FuelType.cng,
+    ];
+    for (final f in order) {
+      if (s.priceFor(f) != null) return f;
+    }
+    return null;
   }
 }

--- a/test/features/consumption/presentation/screens/add_fill_up_screen_prefill_test.dart
+++ b/test/features/consumption/presentation/screens/add_fill_up_screen_prefill_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/add_fill_up_screen.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_numeric_field.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+Finder _fieldByLabel(String label) => find.ancestor(
+      of: find.text(label),
+      matching: find.byType(FillUpNumericField),
+    );
+
+TextField _textFieldFor(WidgetTester tester, String label) {
+  final fillUpField = tester.widget<FillUpNumericField>(_fieldByLabel(label));
+  return tester.widget<TextField>(
+    find.descendant(
+      of: find.byWidget(fillUpField),
+      matching: find.byType(TextField),
+    ),
+  );
+}
+
+void main() {
+  group('AddFillUpScreen pre-fill (#581)', () {
+    testWidgets('station name card shown when stationName passed',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const AddFillUpScreen(
+          stationId: 'abc',
+          stationName: 'Total Castelnau',
+        ),
+      );
+
+      expect(find.text('Total Castelnau'), findsOneWidget);
+      expect(find.text('Station pre-filled'), findsOneWidget);
+    });
+
+    testWidgets('preFilledFuelType is selected in the dropdown',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const AddFillUpScreen(
+          stationId: 'abc',
+          stationName: 'Total',
+          preFilledFuelType: FuelType.diesel,
+        ),
+      );
+
+      // Dropdown initial value uses apiValue uppercased -> 'DIESEL'.
+      expect(find.text('DIESEL'), findsOneWidget);
+    });
+
+    testWidgets(
+        'pre-filled price auto-computes total cost when liters entered',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const AddFillUpScreen(
+          stationId: 'abc',
+          stationName: 'Total',
+          preFilledFuelType: FuelType.e10,
+          preFilledPricePerLiter: 1.859,
+        ),
+      );
+
+      final litersField = _textFieldFor(tester, 'Liters');
+      litersField.controller!.text = '40';
+      await tester.pump();
+
+      final costField = _textFieldFor(tester, 'Total cost');
+      // 40 * 1.859 = 74.36
+      expect(costField.controller!.text, '74.36');
+    });
+
+    testWidgets('auto-cost does not clobber a manually typed cost',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const AddFillUpScreen(
+          stationId: 'abc',
+          stationName: 'Total',
+          preFilledFuelType: FuelType.e10,
+          preFilledPricePerLiter: 2.0,
+        ),
+      );
+
+      final costField = _textFieldFor(tester, 'Total cost');
+      costField.controller!.text = '99.99'; // user typed
+      await tester.pump();
+
+      final litersField = _textFieldFor(tester, 'Liters');
+      litersField.controller!.text = '10';
+      await tester.pump();
+
+      // Manual 99.99 must not be overwritten by auto 20.00.
+      expect(costField.controller!.text, '99.99');
+    });
+
+    testWidgets('no auto-compute when preFilledPricePerLiter is null',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const AddFillUpScreen(
+          stationId: 'abc',
+          stationName: 'Total',
+        ),
+      );
+
+      final litersField = _textFieldFor(tester, 'Liters');
+      litersField.controller!.text = '40';
+      await tester.pump();
+
+      final costField = _textFieldFor(tester, 'Total cost');
+      expect(costField.controller!.text, '');
+    });
+
+    testWidgets('default fuel type is e10 when no pre-fill',
+        (tester) async {
+      await pumpApp(tester, const AddFillUpScreen());
+      expect(find.text('E10'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- New "Log fill-up here" button on the station detail screen (below the price tiles).
- Navigates to AddFillUpScreen with stationId, stationName, fuelType (from profile or first available), and pricePerLiter.
- AddFillUpScreen auto-computes total cost as liters * pre-filled price, without clobbering a manually typed cost.
- Two-tap logging for known stations: liters + odometer + save.

## Test plan
- [x] 6 new widget tests for AddFillUpScreen pre-fill (fuel type, price auto-compute, manual override, no-prefill default)
- [x] \`flutter test\` — full suite 3734 pass
- [x] \`flutter analyze --no-fatal-infos\` — no new errors

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)