### PR TITLE
refactor(report): extract ReportScreen subwidgets and ReportType enum

### DIFF
--- a/lib/features/report/domain/entities/report_type.dart
+++ b/lib/features/report/domain/entities/report_type.dart
@@ -1,0 +1,151 @@
+import '../../../../l10n/app_localizations.dart';
+
+/// The kind of correction the user is filing against a station.
+///
+/// Report types fall into three buckets:
+/// 1. **Price reports** (wrongE5, wrongE10, wrongDiesel, wrongE85,
+///    wrongE98, wrongLpg) — take a corrected price number.
+/// 2. **Status reports** (wrongStatusOpen, wrongStatusClosed) — no
+///    payload, just a flag.
+/// 3. **Metadata reports** (wrongName, wrongAddress) — take a free-text
+///    correction.
+///
+/// Routing also splits them: the first 5 (E5/E10/Diesel + status) can go
+/// to the Tankerkoenig complaint endpoint (DE-only, API key required);
+/// everything price-like also goes to TankSync; metadata types route to
+/// a pre-filled GitHub issue because they're almost always implementation
+/// bugs, not data corrections (#508).
+enum ReportType {
+  // Tankerkoenig-supported price reports. apiValue maps to the types
+  // the Tankerkoenig complaint endpoint recognises.
+  wrongE5('wrongPetrolPremium'),
+  wrongE10('wrongPetrolPremiumE10'),
+  wrongDiesel('wrongDiesel'),
+  // Additional price reports (#484). Tankerkoenig has no endpoint
+  // for these, so they route to TankSync only. The `apiValue` is a
+  // descriptive string for logging but is not sent to Tankerkoenig —
+  // `isTankerkoenigSupported` below controls which backends accept
+  // which types.
+  wrongE85('wrongPetrolE85'),
+  wrongE98('wrongPetrolPremiumE98'),
+  wrongLpg('wrongLpg'),
+  wrongStatusOpen('wrongStatusOpen'),
+  wrongStatusClosed('wrongStatusClosed'),
+  // Metadata reports (#484). These carry a free-text correction
+  // instead of a price. TankSync only.
+  wrongName('wrongName'),
+  wrongAddress('wrongAddress');
+
+  final String apiValue;
+  const ReportType(this.apiValue);
+
+  /// True when this report type needs the user to enter a corrected
+  /// price. Price input replaces the text input in the form.
+  bool get needsPrice =>
+      this == wrongE5 ||
+      this == wrongE10 ||
+      this == wrongDiesel ||
+      this == wrongE85 ||
+      this == wrongE98 ||
+      this == wrongLpg;
+
+  /// True when this report type is a free-text metadata correction
+  /// (new station name, new address). Takes a text input instead of
+  /// a price input.
+  ///
+  /// Since #508 these also route to GitHub instead of TankSync —
+  /// wrong metadata is almost always an implementation bug (the API
+  /// returned the wrong field, or our parser mapped it wrong), not
+  /// something a user correction can fix downstream.
+  bool get needsText => this == wrongName || this == wrongAddress;
+
+  /// True when this report type files a GitHub issue instead of hitting
+  /// a community-report backend. Station name and address corrections
+  /// are always implementation bugs — shipping them as community edits
+  /// just hides the upstream issue, so we route the user to the
+  /// pre-filled GitHub issue flow built in #500 instead.
+  bool get routesToGitHub => this == wrongName || this == wrongAddress;
+
+  /// True when this report type can be submitted to the Tankerkoenig
+  /// complaint endpoint. The endpoint supports the original 5 types
+  /// (E5, E10, diesel, status open, status closed). Everything else
+  /// is TankSync-only.
+  bool get isTankerkoenigSupported =>
+      this == wrongE5 ||
+      this == wrongE10 ||
+      this == wrongDiesel ||
+      this == wrongStatusOpen ||
+      this == wrongStatusClosed;
+
+  /// The Supabase `fuel_type` column value for this report. For price
+  /// reports this is the fuel code; for status and metadata reports
+  /// it's a descriptive identifier so analytics queries can filter
+  /// by report kind.
+  String get fuelTypeColumnValue {
+    switch (this) {
+      case wrongE5:
+        return 'e5';
+      case wrongE10:
+        return 'e10';
+      case wrongDiesel:
+        return 'diesel';
+      case wrongE85:
+        return 'e85';
+      case wrongE98:
+        return 'e98';
+      case wrongLpg:
+        return 'lpg';
+      case wrongStatusOpen:
+        return 'status_open';
+      case wrongStatusClosed:
+        return 'status_closed';
+      case wrongName:
+        return 'name';
+      case wrongAddress:
+        return 'address';
+    }
+  }
+
+  /// Returns the report types that should be visible on the report
+  /// screen for a given country.
+  ///
+  /// - Germany: all 10 types (Tankerkoenig community report covers
+  ///   prices and open/closed status; name/address still route to
+  ///   GitHub because they're implementation bugs).
+  /// - Everywhere else: only the 2 GitHub-routed types. The first 8
+  ///   (price + status) have no meaningful backend outside DE —
+  ///   Tankerkoenig is DE-only, and community price corrections don't
+  ///   feed back into the source-of-truth country APIs.
+  static List<ReportType> visibleForCountry(String countryCode) {
+    if (countryCode == 'DE') return ReportType.values;
+    return const [ReportType.wrongName, ReportType.wrongAddress];
+  }
+
+  /// Localized display name for this report type.
+  String displayName(AppLocalizations? l10n) {
+    switch (this) {
+      case wrongE5:
+        return l10n?.wrongE5Price ?? 'Prix Super E5 incorrect';
+      case wrongE10:
+        return l10n?.wrongE10Price ?? 'Prix Super E10 incorrect';
+      case wrongDiesel:
+        return l10n?.wrongDieselPrice ?? 'Prix Diesel incorrect';
+      // TODO: add ARB keys for the new types. Inline French fallback
+      // matches the primary user locale.
+      case wrongE85:
+        return 'Prix E85 incorrect';
+      case wrongE98:
+        return 'Prix Super 98 incorrect';
+      case wrongLpg:
+        return 'Prix GPL incorrect';
+      case wrongStatusOpen:
+        return l10n?.wrongStatusOpen ?? 'Affiché ouvert, mais fermé';
+      case wrongStatusClosed:
+        return l10n?.wrongStatusClosed ?? 'Affiché fermé, mais ouvert';
+      case wrongName:
+        return 'Nom de la station incorrect';
+      case wrongAddress:
+        return 'Adresse incorrecte';
+    }
+  }
+}

--- a/lib/features/report/presentation/screens/report_screen.dart
+++ b/lib/features/report/presentation/screens/report_screen.dart
@@ -13,142 +13,13 @@ import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/community_report_service.dart';
+import '../../domain/entities/report_type.dart';
 import '../../providers/report_form_provider.dart';
+import '../widgets/no_backend_banner.dart';
+import '../widgets/report_input_section.dart';
+import '../widgets/report_type_list.dart';
 
-enum ReportType {
-  // Tankerkoenig-supported price reports. apiValue maps to the types
-  // the Tankerkoenig complaint endpoint recognises.
-  wrongE5('wrongPetrolPremium'),
-  wrongE10('wrongPetrolPremiumE10'),
-  wrongDiesel('wrongDiesel'),
-  // Additional price reports (#484). Tankerkoenig has no endpoint
-  // for these, so they route to TankSync only. The `apiValue` is a
-  // descriptive string for logging but is not sent to Tankerkoenig —
-  // `isTankerkoenigSupported` below controls which backends accept
-  // which types.
-  wrongE85('wrongPetrolE85'),
-  wrongE98('wrongPetrolPremiumE98'),
-  wrongLpg('wrongLpg'),
-  wrongStatusOpen('wrongStatusOpen'),
-  wrongStatusClosed('wrongStatusClosed'),
-  // Metadata reports (#484). These carry a free-text correction
-  // instead of a price. TankSync only.
-  wrongName('wrongName'),
-  wrongAddress('wrongAddress');
-
-  final String apiValue;
-  const ReportType(this.apiValue);
-
-  /// True when this report type needs the user to enter a corrected
-  /// price. Price input replaces the text input in the form.
-  bool get needsPrice =>
-      this == wrongE5 ||
-      this == wrongE10 ||
-      this == wrongDiesel ||
-      this == wrongE85 ||
-      this == wrongE98 ||
-      this == wrongLpg;
-
-  /// True when this report type is a free-text metadata correction
-  /// (new station name, new address). Takes a text input instead of
-  /// a price input.
-  ///
-  /// Since #508 these also route to GitHub instead of TankSync —
-  /// wrong metadata is almost always an implementation bug (the API
-  /// returned the wrong field, or our parser mapped it wrong), not
-  /// something a user correction can fix downstream.
-  bool get needsText => this == wrongName || this == wrongAddress;
-
-  /// True when this report type files a GitHub issue instead of hitting
-  /// a community-report backend. Station name and address corrections
-  /// are always implementation bugs — shipping them as community edits
-  /// just hides the upstream issue, so we route the user to the
-  /// pre-filled GitHub issue flow built in #500 instead.
-  bool get routesToGitHub => this == wrongName || this == wrongAddress;
-
-  /// True when this report type can be submitted to the Tankerkoenig
-  /// complaint endpoint. The endpoint supports the original 5 types
-  /// (E5, E10, diesel, status open, status closed). Everything else
-  /// is TankSync-only.
-  bool get isTankerkoenigSupported =>
-      this == wrongE5 ||
-      this == wrongE10 ||
-      this == wrongDiesel ||
-      this == wrongStatusOpen ||
-      this == wrongStatusClosed;
-
-  /// The Supabase `fuel_type` column value for this report. For price
-  /// reports this is the fuel code; for status and metadata reports
-  /// it's a descriptive identifier so analytics queries can filter
-  /// by report kind.
-  String get fuelTypeColumnValue {
-    switch (this) {
-      case wrongE5:
-        return 'e5';
-      case wrongE10:
-        return 'e10';
-      case wrongDiesel:
-        return 'diesel';
-      case wrongE85:
-        return 'e85';
-      case wrongE98:
-        return 'e98';
-      case wrongLpg:
-        return 'lpg';
-      case wrongStatusOpen:
-        return 'status_open';
-      case wrongStatusClosed:
-        return 'status_closed';
-      case wrongName:
-        return 'name';
-      case wrongAddress:
-        return 'address';
-    }
-  }
-
-  /// Returns the report types that should be visible on the report
-  /// screen for a given country.
-  ///
-  /// - Germany: all 10 types (Tankerkoenig community report covers
-  ///   prices and open/closed status; name/address still route to
-  ///   GitHub because they're implementation bugs).
-  /// - Everywhere else: only the 2 GitHub-routed types. The first 8
-  ///   (price + status) have no meaningful backend outside DE —
-  ///   Tankerkoenig is DE-only, and community price corrections don't
-  ///   feed back into the source-of-truth country APIs.
-  static List<ReportType> visibleForCountry(String countryCode) {
-    if (countryCode == 'DE') return ReportType.values;
-    return const [ReportType.wrongName, ReportType.wrongAddress];
-  }
-
-  /// Localized display name for this report type.
-  String displayName(AppLocalizations? l10n) {
-    switch (this) {
-      case wrongE5:
-        return l10n?.wrongE5Price ?? 'Prix Super E5 incorrect';
-      case wrongE10:
-        return l10n?.wrongE10Price ?? 'Prix Super E10 incorrect';
-      case wrongDiesel:
-        return l10n?.wrongDieselPrice ?? 'Prix Diesel incorrect';
-      // TODO: add ARB keys for the new types. Inline French fallback
-      // matches the primary user locale.
-      case wrongE85:
-        return 'Prix E85 incorrect';
-      case wrongE98:
-        return 'Prix Super 98 incorrect';
-      case wrongLpg:
-        return 'Prix GPL incorrect';
-      case wrongStatusOpen:
-        return l10n?.wrongStatusOpen ?? 'Affiché ouvert, mais fermé';
-      case wrongStatusClosed:
-        return l10n?.wrongStatusClosed ?? 'Affiché fermé, mais ouvert';
-      case wrongName:
-        return 'Nom de la station incorrect';
-      case wrongAddress:
-        return 'Adresse incorrecte';
-    }
-  }
-}
+export '../../domain/entities/report_type.dart';
 
 /// Screen for submitting a community report about a station. Form state
 /// (selected type, submission progress) lives in [reportFormControllerProvider];
@@ -365,7 +236,6 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final theme = Theme.of(context);
     final form = ref.watch(reportFormControllerProvider);
     final selectedType = form.selectedType;
 
@@ -411,92 +281,21 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          // #484 — banner telling the user that no reporting backend is
-          // available for their country/config. Previously the form
-          // accepted their input and silently failed on submit.
-          //
-          // #508 — hide the banner when the user only sees GitHub-routed
-          // types (non-DE case), because there's nothing to configure
-          // and the form still works.
           if (!hasAnyBackend && !allVisibleRouteToGitHub) ...[
-            Container(
-              key: const ValueKey('report-no-backend-banner'),
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.errorContainer,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Row(
-                children: [
-                  Icon(Icons.error_outline,
-                      size: 20, color: theme.colorScheme.onErrorContainer),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    // TODO: `reportNoBackendBanner` ARB key for localisation.
-                    child: Text(
-                      'Les signalements ne sont pas disponibles dans ce pays '
-                      'pour le moment. Activez TankSync dans les paramètres '
-                      'pour envoyer des signalements communautaires, ou '
-                      'ajoutez une clé API Tankerkoenig si vous êtes en '
-                      'Allemagne.',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onErrorContainer,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
+            const NoBackendBanner(),
             const SizedBox(height: 16),
           ],
-          Text(
-            l10n?.whatsWrong ?? "What's wrong?",
-            style: theme.textTheme.titleMedium,
+          ...buildReportTypeList(
+            context,
+            ref,
+            visibleTypes: visibleTypes,
+            hasAnyBackend: hasAnyBackend,
           ),
-          const SizedBox(height: 12),
-          ...visibleTypes.map(
-            (type) => RadioListTile<ReportType>(
-              value: type,
-              groupValue: selectedType,
-              title: Text(type.displayName(l10n)),
-              // #508 — GitHub-routed types are always selectable. The
-              // legacy price/status types remain gated on an available
-              // Tankerkoenig/TankSync backend.
-              onChanged: (type.routesToGitHub || hasAnyBackend)
-                  ? (v) => ref
-                      .read(reportFormControllerProvider.notifier)
-                      .selectType(v)
-                  : null,
-            ),
+          ReportInputSection(
+            selectedType: selectedType,
+            priceController: _priceController,
+            textController: _textController,
           ),
-          if (selectedType != null && selectedType.needsPrice) ...[
-            const SizedBox(height: 16),
-            TextField(
-              controller: _priceController,
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
-              decoration: InputDecoration(
-                labelText: l10n?.correctPrice ?? 'Correct price (e.g. 1.459)',
-                prefixText: '\u20ac ',
-                border: const OutlineInputBorder(),
-              ),
-            ),
-          ],
-          if (selectedType != null && selectedType.needsText) ...[
-            const SizedBox(height: 16),
-            TextField(
-              key: const ValueKey('report-correction-text-field'),
-              controller: _textController,
-              textCapitalization: TextCapitalization.sentences,
-              decoration: InputDecoration(
-                // TODO: add ARB keys `correctName` / `correctAddress`.
-                labelText: selectedType == ReportType.wrongName
-                    ? 'Nom correct de la station'
-                    : 'Adresse correcte',
-                border: const OutlineInputBorder(),
-              ),
-            ),
-          ],
           const SizedBox(height: 24),
           FilledButton(
             onPressed: selectedType != null &&

--- a/lib/features/report/presentation/widgets/no_backend_banner.dart
+++ b/lib/features/report/presentation/widgets/no_backend_banner.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+/// Banner shown on the report screen when neither Tankerkoenig nor
+/// TankSync is configured for the active country — previously the form
+/// accepted input and silently failed (#484).
+///
+/// Hidden when the only visible report types route directly to GitHub
+/// (non-DE case) — there's nothing to configure and the form still works.
+class NoBackendBanner extends StatelessWidget {
+  const NoBackendBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      key: const ValueKey('report-no-backend-banner'),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.error_outline,
+              size: 20, color: theme.colorScheme.onErrorContainer),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              'Les signalements ne sont pas disponibles dans ce pays '
+              'pour le moment. Activez TankSync dans les paramètres '
+              'pour envoyer des signalements communautaires, ou '
+              'ajoutez une clé API Tankerkoenig si vous êtes en '
+              'Allemagne.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/report/presentation/widgets/report_input_section.dart
+++ b/lib/features/report/presentation/widgets/report_input_section.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../screens/report_screen.dart' show ReportType;
+
+/// The dynamic input field below the radio list: a price TextField for
+/// price reports, a free-text TextField for metadata corrections, or
+/// nothing for status reports.
+class ReportInputSection extends StatelessWidget {
+  final ReportType? selectedType;
+  final TextEditingController priceController;
+  final TextEditingController textController;
+
+  const ReportInputSection({
+    super.key,
+    required this.selectedType,
+    required this.priceController,
+    required this.textController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final type = selectedType;
+    if (type == null) return const SizedBox.shrink();
+
+    if (type.needsPrice) {
+      return Padding(
+        padding: const EdgeInsets.only(top: 16),
+        child: TextField(
+          controller: priceController,
+          keyboardType:
+              const TextInputType.numberWithOptions(decimal: true),
+          decoration: InputDecoration(
+            labelText: l10n?.correctPrice ?? 'Correct price (e.g. 1.459)',
+            prefixText: '\u20ac ',
+            border: const OutlineInputBorder(),
+          ),
+        ),
+      );
+    }
+
+    if (type.needsText) {
+      return Padding(
+        padding: const EdgeInsets.only(top: 16),
+        child: TextField(
+          key: const ValueKey('report-correction-text-field'),
+          controller: textController,
+          textCapitalization: TextCapitalization.sentences,
+          decoration: InputDecoration(
+            // TODO: add ARB keys `correctName` / `correctAddress`.
+            labelText: type == ReportType.wrongName
+                ? 'Nom correct de la station'
+                : 'Adresse correcte',
+            border: const OutlineInputBorder(),
+          ),
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/features/report/presentation/widgets/report_type_list.dart
+++ b/lib/features/report/presentation/widgets/report_type_list.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/report_type.dart';
+import '../../providers/report_form_provider.dart';
+
+/// Builds the "What's wrong?" header plus one radio per report type.
+///
+/// Returns a flat list of widgets (header + N radios) rather than a single
+/// Column so the caller's scrollable parent (usually a ListView) sees each
+/// radio as a direct child. Wrapping them in a Column caused scroll-extent
+/// math to misbehave on tall lists (#571 regression in refactor).
+///
+/// GitHub-routed types (wrongName / wrongAddress) are always selectable;
+/// legacy price/status types are disabled when no Tankerkoenig / TankSync
+/// backend is available so the user can't submit into the void (#508).
+List<Widget> buildReportTypeList(
+  BuildContext context,
+  WidgetRef ref, {
+  required List<ReportType> visibleTypes,
+  required bool hasAnyBackend,
+}) {
+  final theme = Theme.of(context);
+  final l10n = AppLocalizations.of(context);
+  final selectedType = ref.watch(reportFormControllerProvider).selectedType;
+
+  return [
+    Text(
+      l10n?.whatsWrong ?? "What's wrong?",
+      style: theme.textTheme.titleMedium,
+    ),
+    const SizedBox(height: 12),
+    ...visibleTypes.map(
+      (type) => RadioListTile<ReportType>(
+        value: type,
+        groupValue: selectedType,
+        title: Text(type.displayName(l10n)),
+        onChanged: (type.routesToGitHub || hasAnyBackend)
+            ? (v) => ref
+                .read(reportFormControllerProvider.notifier)
+                .selectType(v)
+            : null,
+      ),
+    ),
+  ];
+}


### PR DESCRIPTION
## Summary
- ReportType enum → \`domain/entities/report_type.dart\` (re-exported from report_screen.dart for backward compat)
- NoBackendBanner widget → new file
- ReportInputSection widget (price vs text field) → new file
- buildReportTypeList (List<Widget>) → new file

ReportScreen size: 520 → 319 LOC.

## Why a top-level function instead of a third widget?
Wrapping 10 RadioListTiles in a Column inside the screen's ListView broke scroll-extent math — \`tester.scrollUntilVisible\` couldn't reach the last radios. Returning \`List<Widget>\` and spreading into the ListView preserves the original layout.

## Test plan
- [x] Report tests 27/27 pass
- [x] Full suite 3728 pass
- [x] \`flutter analyze\` — no new issues (2 pre-existing deprecations)

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)