### PR TITLE
fix(a11y): tooltips on password-visibility IconButtons + regression scan (#566)

### DIFF
--- a/lib/features/sync/presentation/widgets/auth_form_widget.dart
+++ b/lib/features/sync/presentation/widgets/auth_form_widget.dart
@@ -164,6 +164,9 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
                   form.showPassword ? Icons.visibility_off : Icons.visibility,
                   size: 18,
                 ),
+                tooltip: form.showPassword
+                    ? (l10n?.tooltipHidePassword ?? 'Hide password')
+                    : (l10n?.tooltipShowPassword ?? 'Show password'),
                 onPressed: notifier.togglePassword,
               ),
             ),
@@ -194,6 +197,9 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
                         : Icons.visibility,
                     size: 18,
                   ),
+                  tooltip: form.showConfirm
+                      ? (l10n?.tooltipHidePassword ?? 'Hide password')
+                      : (l10n?.tooltipShowPassword ?? 'Show password'),
                   onPressed: notifier.toggleConfirm,
                 ),
               ),

--- a/lib/features/sync/presentation/widgets/email_auth_card.dart
+++ b/lib/features/sync/presentation/widgets/email_auth_card.dart
@@ -99,6 +99,9 @@ class EmailAuthCard extends StatelessWidget {
                     showPassword ? Icons.visibility_off : Icons.visibility,
                     size: 18,
                   ),
+                  tooltip: showPassword
+                      ? (l10n?.tooltipHidePassword ?? 'Hide password')
+                      : (l10n?.tooltipShowPassword ?? 'Show password'),
                   onPressed: onTogglePassword,
                 ),
               ),
@@ -127,6 +130,9 @@ class EmailAuthCard extends StatelessWidget {
                       showConfirm ? Icons.visibility_off : Icons.visibility,
                       size: 18,
                     ),
+                    tooltip: showConfirm
+                        ? (l10n?.tooltipHidePassword ?? 'Hide password')
+                        : (l10n?.tooltipShowPassword ?? 'Show password'),
                     onPressed: onToggleConfirm,
                   ),
                 ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -815,6 +815,8 @@
   "tooltipClose": "Schließen",
   "tooltipClearSearch": "Sucheingabe löschen",
   "tooltipUseGps": "GPS-Standort verwenden",
+  "tooltipShowPassword": "Passwort anzeigen",
+  "tooltipHidePassword": "Passwort verbergen",
   "switchToEmail": "Zu E-Mail wechseln",
   "switchToEmailSubtitle": "Daten behalten, Anmeldung von anderen Geräten",
   "switchToAnonymousAction": "Zu anonym wechseln",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -820,6 +820,8 @@
   "tooltipClose": "Close",
   "tooltipClearSearch": "Clear search input",
   "tooltipUseGps": "Use GPS location",
+  "tooltipShowPassword": "Show password",
+  "tooltipHidePassword": "Hide password",
   "switchToEmail": "Switch to email",
   "switchToEmailSubtitle": "Keep data, add sign-in from other devices",
   "switchToAnonymousAction": "Switch to anonymous",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3565,6 +3565,18 @@ abstract class AppLocalizations {
   /// **'Use GPS location'**
   String get tooltipUseGps;
 
+  /// No description provided for @tooltipShowPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Show password'**
+  String get tooltipShowPassword;
+
+  /// No description provided for @tooltipHidePassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide password'**
+  String get tooltipHidePassword;
+
   /// No description provided for @switchToEmail.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1853,6 +1853,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1853,6 +1853,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1851,6 +1851,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1865,6 +1865,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tooltipUseGps => 'GPS-Standort verwenden';
 
   @override
+  String get tooltipShowPassword => 'Passwort anzeigen';
+
+  @override
+  String get tooltipHidePassword => 'Passwort verbergen';
+
+  @override
   String get switchToEmail => 'Zu E-Mail wechseln';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1855,6 +1855,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1846,6 +1846,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1854,6 +1854,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1848,6 +1848,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1851,6 +1851,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1860,6 +1860,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tooltipUseGps => 'Utiliser la position GPS';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Passer à l\'e-mail';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1850,6 +1850,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1855,6 +1855,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1854,6 +1854,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1852,6 +1852,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1854,6 +1854,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1850,6 +1850,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1855,6 +1855,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1853,6 +1853,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1854,6 +1854,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1853,6 +1853,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1854,6 +1854,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1848,6 +1848,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1852,6 +1852,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get tooltipUseGps => 'Use GPS location';
 
   @override
+  String get tooltipShowPassword => 'Show password';
+
+  @override
+  String get tooltipHidePassword => 'Hide password';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/test/accessibility/icon_button_tooltip_coverage_test.dart
+++ b/test/accessibility/icon_button_tooltip_coverage_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#566): every `IconButton(...)` in `lib/`
+/// must have a `tooltip:` parameter. A missing tooltip fails accessibility
+/// for TalkBack/VoiceOver users because the button has no accessible name.
+///
+/// The scan is a balanced-paren walk so nested IconButtons and multi-line
+/// declarations are handled correctly. If this test fails, add a `tooltip:`
+/// parameter to the reported line — prefer a localized key from app_en.arb
+/// with an English fallback.
+void main() {
+  test('every IconButton in lib/ has a tooltip (#566)', () {
+    final offenders = <String>[];
+
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final src = entity.readAsStringSync();
+
+      for (final match in RegExp(r'IconButton\s*\(').allMatches(src)) {
+        final start = match.start;
+        int openParen = src.indexOf('(', start);
+        int depth = 0;
+        int? end;
+        for (int i = openParen; i < src.length; i++) {
+          final c = src[i];
+          if (c == '(') depth++;
+          if (c == ')') {
+            depth--;
+            if (depth == 0) {
+              end = i;
+              break;
+            }
+          }
+        }
+        if (end == null) continue;
+
+        final body = src.substring(start, end + 1);
+        if (!body.contains('tooltip:')) {
+          final line = src.substring(0, start).split('\n').length;
+          offenders.add('${entity.path}:$line');
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'IconButton without tooltip: breaks TalkBack/VoiceOver. '
+          'Add `tooltip: l10n?.tooltipX ?? "X"` at these sites:\n'
+          '${offenders.join("\n")}',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
#566 acceptance item 1: *Every IconButton has a tooltip.* The four password-visibility toggles in sync forms (`auth_form_widget.dart` and `email_auth_card.dart`) lacked tooltips — breaks TalkBack/VoiceOver because the button had no accessible name.

Added `tooltipShowPassword` / `tooltipHidePassword` to `app_en.arb` + `app_de.arb`; other locales fall back to English until translated.

Added `test/accessibility/icon_button_tooltip_coverage_test.dart` — a balanced-paren static scan of `lib/` that fails if any `IconButton(...)` without `tooltip:` slips in. Confirms all 46 current IconButtons pass.

Does **not** close #566 — the epic still has EV connector-chip semantics + androidTapTargetGuideline audit + CLAUDE.md accessibility doc as remaining acceptance items.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero new warnings/errors
- [x] `flutter test test/accessibility/icon_button_tooltip_coverage_test.dart` — 1/1 pass (46 IconButtons, 0 without tooltip)
- [x] `flutter test` — full suite 3735 pass (+1 new scan, 1 skipped unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)