### PR TITLE
fix(565): standardize error UI + eliminate silent catch blocks

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -73,7 +73,9 @@ class AppInitializer {
       AppConstants.setRuntimeVersion(
         '${packageInfo.version}+${packageInfo.buildNumber}',
       );
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('PackageInfo.fromPlatform failed (#570): $e');
+    }
 
     StartupTimer.instance.mark('pre_run_app');
 

--- a/lib/features/consumption/data/receipt_parser.dart
+++ b/lib/features/consumption/data/receipt_parser.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 /// Structured fields extracted from a fuel receipt by [ReceiptParser].
 ///
 /// All fields are nullable because OCR is best-effort: any combination
@@ -124,7 +126,9 @@ class ReceiptParser {
         if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
           return DateTime(year, month, day);
         }
-      } catch (_) {}
+      } on FormatException catch (e) {
+        debugPrint('Receipt date parse failed for "${match.group(0)}": $e');
+      }
     }
     return null;
   }

--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -50,7 +50,9 @@ class ReceiptScanService {
       // Clean up temp file
       try {
         await File(image.path).delete();
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('Receipt temp-file cleanup failed at ${image.path}: $e');
+      }
     }
   }
 

--- a/lib/features/favorites/presentation/widgets/favorites_fuel_tab.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_fuel_tab.dart
@@ -102,27 +102,12 @@ class FavoritesFuelTab extends ConsumerWidget {
         );
       },
       loading: () => const FavoritesLoadingView(),
-      error: (error, _) => Semantics(
-        label: 'Error loading favorites: ${error.toString()}',
-        child: Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(Icons.error_outline, size: 48),
-              const SizedBox(height: 16),
-              Text(error.toString(), textAlign: TextAlign.center),
-              const SizedBox(height: 16),
-              FilledButton(
-                onPressed: () {
-                  ref
-                      .read(favoriteStationsProvider.notifier)
-                      .loadAndRefresh();
-                },
-                child: Text(l10n?.retry ?? 'Retry'),
-              ),
-            ],
-          ),
-        ),
+      error: (error, stackTrace) => ServiceChainErrorWidget(
+        error: error,
+        stackTrace: stackTrace,
+        searchContext: 'Favorites load',
+        onRetry: () =>
+            ref.read(favoriteStationsProvider.notifier).loadAndRefresh(),
       ),
     );
   }

--- a/lib/features/favorites/providers/favorites_provider.dart
+++ b/lib/features/favorites/providers/favorites_provider.dart
@@ -177,7 +177,9 @@ class FavoriteStations extends _$FavoriteStations {
       if (data != null) {
         try {
           stations.add(Station.fromJson(data));
-        } catch (_) {}
+        } catch (e) {
+          debugPrint('Skipping corrupt favorite $id: $e');
+        }
       }
     }
 

--- a/test/features/favorites/presentation/widgets/favorites_fuel_tab_test.dart
+++ b/test/features/favorites/presentation/widgets/favorites_fuel_tab_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/widgets/service_status_banner.dart';
 import 'package:tankstellen/features/search/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/favorites/presentation/widgets/favorites_fuel_tab.dart';
 import 'package:tankstellen/features/favorites/providers/ev_favorites_provider.dart';
@@ -122,7 +123,10 @@ void main() {
         ].cast(),
       );
 
-      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      // #565: favorites error branch now reuses ServiceChainErrorWidget so
+      // error UI is consistent across Search + Favorites + Alerts.
+      expect(find.byType(ServiceChainErrorWidget), findsOneWidget);
+      expect(find.byIcon(Icons.cloud_off), findsOneWidget);
       expect(find.text('Try again'), findsOneWidget);
     });
   });

--- a/test/lint/no_silent_catch_test.dart
+++ b/test/lint/no_silent_catch_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#565): no `catch (_) {}` (silent) or
+/// `catch (e) {}` (stored-but-unused) blocks in `lib/`. Silent catches
+/// hide root causes — replace with at least `debugPrint('context: $e')`
+/// or route through `TraceRecorder.recordError(e)`.
+///
+/// The scan uses a simple regex that tolerates optional whitespace and
+/// the Dart `on T catch` form. False positives should add a minimal log
+/// line rather than relaxing this scan.
+void main() {
+  test('no silent catch blocks in lib/ (#565)', () {
+    final offenders = <String>[];
+
+    // Matches `catch (_) {}` and `catch (e) {}` (with optional whitespace).
+    // Does NOT match catches that contain a statement — the body has to be
+    // literally empty (whitespace/newlines only) to qualify as "silent".
+    final silent = RegExp(
+      r'catch\s*\(\s*\w+\s*\)\s*\{\s*\}',
+    );
+
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      // Skip generated files — they don't follow handwritten conventions.
+      if (entity.path.endsWith('.g.dart') ||
+          entity.path.endsWith('.freezed.dart')) continue;
+
+      final src = entity.readAsStringSync();
+      for (final m in silent.allMatches(src)) {
+        final line = src.substring(0, m.start).split('\n').length;
+        offenders.add('${entity.path}:$line  ${m.group(0)}');
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'Silent catch hides the root cause. Replace with at least '
+          '`debugPrint("context: \$e")` so the reason ends up in logs. '
+          'Offending sites:\n${offenders.join("\n")}',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Addresses three of the #565 acceptance items:

1. **Favorites error branch now reuses `ServiceChainErrorWidget`** — same visual language as Search (cloud_off icon, \"Try again\" button, expandable Details, Report-this-issue action). Previously a bespoke Column with raw `error.toString()`.

2. **Zero silent `catch (_) {}` blocks in `lib/`** — replaced the four sites with `debugPrint` + context:
   - `receipt_parser.dart` — date parse failure logs the offending match
   - `receipt_scan_service.dart` — temp-file cleanup failure logs the path
   - `app_initializer.dart` — `PackageInfo.fromPlatform` fallback logs
   - `favorites_provider.dart` — per-station JSON parse failure logs which favorite was skipped

3. **Regression guard**: `test/lint/no_silent_catch_test.dart` scans `lib/` (excluding `.g.dart` / `.freezed.dart`) for `catch (_) {}` and `catch (e) {}` with empty bodies and fails if any slip in. Runs in ~50ms.

Remaining #565 items stay open: alerts screen error state, fresh-install integration test, isSetupComplete regression guard.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero new warnings/errors
- [x] `flutter test test/features/favorites/presentation/widgets/favorites_fuel_tab_test.dart` — 4/4 pass (error test now asserts ServiceChainErrorWidget)
- [x] `flutter test test/lint/no_silent_catch_test.dart` — 1/1 pass (0 silent catches)
- [x] `flutter test` — full suite 3735+ pass. One flaky test in `argentina_station_service_test.dart` (network-dependent, passes in isolation) is pre-existing on master, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)