### PR TITLE
fix(a11y): group Semantics label on EV connector chips (#566)

### DIFF
--- a/lib/features/search/presentation/widgets/ev_connector_chips.dart
+++ b/lib/features/search/presentation/widgets/ev_connector_chips.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../../../l10n/app_localizations.dart';
+
 /// Compact wrap of colored "pills" identifying the connector types on
 /// an EV charging station (e.g. CCS, Type 2, CHAdeMO, Tesla). Each pill
 /// is colored to match its connector family and the wrap is bounded to
@@ -9,6 +11,11 @@ import 'package:flutter/material.dart';
 /// drops the inline Wrap block (and the private `_connectorColor`
 /// helper) and so the color mapping can be exercised by widget tests in
 /// isolation.
+///
+/// Accessibility (#566): the whole wrap is merged into a single
+/// `Semantics` node announcing "Available connectors: CCS, Type 2, …"
+/// so TalkBack/VoiceOver read the chip group as one coherent label
+/// instead of emitting a stream of isolated chip texts.
 class EvConnectorChips extends StatelessWidget {
   final List<String> connectors;
   final int maxConnectors;
@@ -32,27 +39,40 @@ class EvConnectorChips extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Wrap(
-      spacing: 4,
-      runSpacing: 2,
-      children: connectors.take(maxConnectors).map((type) {
-        final color = colorFor(type);
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-          decoration: BoxDecoration(
-            color: color.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Text(
-            type,
-            style: TextStyle(
-              fontSize: 10,
-              fontWeight: FontWeight.w600,
-              color: color,
-            ),
-          ),
-        );
-      }).toList(),
+    final visible = connectors.take(maxConnectors).toList();
+    final l10n = AppLocalizations.of(context);
+    final semanticLabel = visible.isEmpty
+        ? (l10n?.evConnectorsNone ?? 'No connector information')
+        : '${l10n?.evConnectorsLabel ?? "Available connectors"}: '
+            '${visible.join(", ")}';
+
+    return Semantics(
+      container: true,
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: Wrap(
+          spacing: 4,
+          runSpacing: 2,
+          children: visible.map((type) {
+            final color = colorFor(type);
+            return Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                type,
+                style: TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w600,
+                  color: color,
+                ),
+              ),
+            );
+          }).toList(),
+        ),
+      ),
     );
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -817,6 +817,8 @@
   "tooltipUseGps": "GPS-Standort verwenden",
   "tooltipShowPassword": "Passwort anzeigen",
   "tooltipHidePassword": "Passwort verbergen",
+  "evConnectorsLabel": "Verfügbare Steckertypen",
+  "evConnectorsNone": "Keine Steckerinformationen",
   "switchToEmail": "Zu E-Mail wechseln",
   "switchToEmailSubtitle": "Daten behalten, Anmeldung von anderen Geräten",
   "switchToAnonymousAction": "Zu anonym wechseln",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -822,6 +822,8 @@
   "tooltipUseGps": "Use GPS location",
   "tooltipShowPassword": "Show password",
   "tooltipHidePassword": "Hide password",
+  "evConnectorsLabel": "Available connectors",
+  "evConnectorsNone": "No connector information",
   "switchToEmail": "Switch to email",
   "switchToEmailSubtitle": "Keep data, add sign-in from other devices",
   "switchToAnonymousAction": "Switch to anonymous",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3577,6 +3577,18 @@ abstract class AppLocalizations {
   /// **'Hide password'**
   String get tooltipHidePassword;
 
+  /// No description provided for @evConnectorsLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Available connectors'**
+  String get evConnectorsLabel;
+
+  /// No description provided for @evConnectorsNone.
+  ///
+  /// In en, this message translates to:
+  /// **'No connector information'**
+  String get evConnectorsNone;
+
   /// No description provided for @switchToEmail.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1859,6 +1859,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1859,6 +1859,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1857,6 +1857,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1871,6 +1871,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tooltipHidePassword => 'Passwort verbergen';
 
   @override
+  String get evConnectorsLabel => 'Verfügbare Steckertypen';
+
+  @override
+  String get evConnectorsNone => 'Keine Steckerinformationen';
+
+  @override
   String get switchToEmail => 'Zu E-Mail wechseln';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1861,6 +1861,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1852,6 +1852,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1860,6 +1860,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1854,6 +1854,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1857,6 +1857,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1866,6 +1866,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Passer à l\'e-mail';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1856,6 +1856,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1861,6 +1861,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1860,6 +1860,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1858,6 +1858,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1860,6 +1860,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1856,6 +1856,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1861,6 +1861,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1859,6 +1859,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1860,6 +1860,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1859,6 +1859,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1860,6 +1860,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1854,6 +1854,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1858,6 +1858,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get tooltipHidePassword => 'Hide password';
 
   @override
+  String get evConnectorsLabel => 'Available connectors';
+
+  @override
+  String get evConnectorsNone => 'No connector information';
+
+  @override
   String get switchToEmail => 'Switch to email';
 
   @override

--- a/test/features/search/presentation/widgets/ev_connector_chips_test.dart
+++ b/test/features/search/presentation/widgets/ev_connector_chips_test.dart
@@ -67,5 +67,30 @@ void main() {
         findsNothing,
       );
     });
+
+    testWidgets(
+        'exposes a group Semantics label listing connectors (#566 a11y)',
+        (tester) async {
+      await pumpChips(tester, connectors: const ['CCS', 'Type 2']);
+      final handle = tester.ensureSemantics();
+
+      // Parent Semantics announces the whole group — no chip-by-chip spam.
+      expect(
+        find.bySemanticsLabel('Available connectors: CCS, Type 2'),
+        findsOneWidget,
+      );
+      handle.dispose();
+    });
+
+    testWidgets('empty list still exposes "no information" Semantics label',
+        (tester) async {
+      await pumpChips(tester, connectors: const []);
+      final handle = tester.ensureSemantics();
+      expect(
+        find.bySemanticsLabel('No connector information'),
+        findsOneWidget,
+      );
+      handle.dispose();
+    });
   });
 }


### PR DESCRIPTION
## Summary
TalkBack/VoiceOver previously read each colored chip as an isolated text label — \"CCS\", \"Type 2\", \"CHAdeMO\" — with no context that they describe the station's available connectors.

Wrapped the `Wrap` in a container `Semantics` with a single group label (\"Available connectors: CCS, Type 2, …\") and used `ExcludeSemantics` on the chip subtree so the group label replaces the chip-by-chip stream. Empty connector lists announce \"No connector information\" so the widget never goes silent.

Added `evConnectorsLabel` / `evConnectorsNone` to `app_en.arb` + `app_de.arb`. Added two widget tests (`find.bySemanticsLabel`) as regression guard.

Closes one sub-item of #566 (EV connector chip semantics). Epic remains open for map marker labels, androidTapTargetGuideline audit, and CLAUDE.md accessibility docs.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero new warnings/errors
- [x] `flutter test test/features/search/presentation/widgets/ev_connector_chips_test.dart` — 7/7 pass (5 existing + 2 new semantics tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)