### PR TITLE
fix(a11y): Semantics button label on map station markers (#566)

### DIFF
--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -43,11 +43,22 @@ class StationMarkerBuilder {
     final color = pastel ? _toPastel(baseColor) : baseColor;
     final brand = _truncateBrand(station.displayName);
 
+    // Accessibility (#566): TalkBack/VoiceOver read this as "Brand, price
+    // EUR per litre, double-tap to view details" — otherwise the marker is
+    // an opaque gesture target with no announced role or content.
+    final priceLabel = price != null
+        ? PriceFormatter.formatPrice(price)
+        : 'price unavailable';
+    final semanticLabel = '$brand, $priceLabel';
+
     return Marker(
       point: LatLng(station.lat, station.lng),
       width: kStationMarkerWidth,
       height: kStationMarkerHeight,
-      child: GestureDetector(
+      child: Semantics(
+        label: semanticLabel,
+        button: true,
+        child: GestureDetector(
         onTap: () => GoRouter.of(context).push('/station/${station.id}'),
         child: Tooltip(
           message: brand,
@@ -90,6 +101,7 @@ class StationMarkerBuilder {
             ),
           ),
         ),
+      ),
       ),
     );
   }

--- a/test/features/map/presentation/widgets/station_marker_test.dart
+++ b/test/features/map/presentation/widgets/station_marker_test.dart
@@ -64,7 +64,7 @@ void main() {
         SizedBox(
           width: marker.width,
           height: marker.height,
-          child: (marker.child as GestureDetector).child,
+          child: ((marker.child as Semantics).child as GestureDetector).child,
         ),
       );
 
@@ -100,7 +100,7 @@ void main() {
         SizedBox(
           width: marker.width,
           height: marker.height,
-          child: (marker.child as GestureDetector).child,
+          child: ((marker.child as Semantics).child as GestureDetector).child,
         ),
       );
 
@@ -121,7 +121,7 @@ void main() {
         SizedBox(
           width: marker.width,
           height: marker.height,
-          child: (marker.child as GestureDetector).child,
+          child: ((marker.child as Semantics).child as GestureDetector).child,
         ),
       );
 
@@ -143,13 +143,42 @@ void main() {
         SizedBox(
           width: marker.width,
           height: marker.height,
-          child: (marker.child as GestureDetector).child,
+          child: ((marker.child as Semantics).child as GestureDetector).child,
         ),
       );
 
       final container = tester.widget<Container>(find.byType(Container).last);
       final decoration = container.decoration! as BoxDecoration;
       expect(decoration.color!.a, closeTo(0.5, 0.01));
+    });
+
+    testWidgets(
+        'exposes a Semantics button label combining brand + price (#566)',
+        (tester) async {
+      final marker = StationMarkerBuilder.build(
+        tester.element(find.byType(Container).first),
+        testStation,
+        FuelType.e10,
+        1.50,
+        2.00,
+      );
+      await pumpApp(
+        tester,
+        SizedBox(
+          width: marker.width,
+          height: marker.height,
+          child: marker.child,
+        ),
+      );
+
+      final handle = tester.ensureSemantics();
+      // Assert the marker is announced as a button with brand + price.
+      // testStation has brand 'STAR' and e10 price 1.799.
+      expect(
+        find.bySemanticsLabel(RegExp(r'STAR.*1[.,]7')),
+        findsOneWidget,
+      );
+      handle.dispose();
     });
 
     testWidgets('color-codes marker by price tier', (tester) async {


### PR DESCRIPTION
## Summary
Before: map station markers were raw `GestureDetector`s wrapping a color-coded Container. Screen readers could neither announce the role (button) nor the content (brand + price), so TalkBack users panning the map got silence.

After: each marker is wrapped in `Semantics(label: 'Brand, price', button: true)`. TalkBack now reads \"STAR, 1,799 EUR, double-tap to activate\".

Updated existing `GestureDetector` casts in the marker test to walk through the new `Semantics` wrapper. Added a regression test using `find.bySemanticsLabel(RegExp(r'STAR.*1[.,]7'))`.

Closes the \"Map markers have no accessibility labels\" sub-item of #566. Epic still open for the androidTapTargetGuideline audit.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero new warnings/errors
- [x] `flutter test test/features/map/presentation/widgets/station_marker_test.dart` — 12/12 pass (11 existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)