### PR TITLE
fix(a11y): unblock PrivacyDashboardScreen guideline tests (#566)

### DIFF
--- a/lib/core/error_tracing/storage/trace_storage.dart
+++ b/lib/core/error_tracing/storage/trace_storage.dart
@@ -54,7 +54,13 @@ class TraceStorage {
 
   Future<void> delete(String id) => _box.delete(id);
   Future<void> clearAll() => _box.clear();
-  int get count => _box.length;
+
+  /// Number of persisted traces, or 0 when the box is not yet open.
+  /// Returning 0 instead of throwing lets widgets read `count` during
+  /// their first build in environments (tests, headless builds) where
+  /// `TraceStorage.init()` hasn't been called — production goes through
+  /// AppInitializer which always calls `init()`.
+  int get count => Hive.isBoxOpen(_boxName) ? _box.length : 0;
 
   /// Serialises every persisted trace into a single JSON document the
   /// user can email or attach to a GitHub issue. Used by the privacy

--- a/test/accessibility/guideline_tests.dart
+++ b/test/accessibility/guideline_tests.dart
@@ -348,7 +348,9 @@ void main() {
       List<Object> _overrides() {
         final test = standardTestOverrides();
         when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+        when(() => test.mockStorage.hasCustomApiKey()).thenReturn(false);
         when(() => test.mockStorage.hasEvApiKey()).thenReturn(false);
+        when(() => test.mockStorage.hasCustomEvApiKey()).thenReturn(false);
         when(() => test.mockStorage.favoriteCount).thenReturn(0);
         when(() => test.mockStorage.alertCount).thenReturn(0);
         when(() => test.mockStorage.profileCount).thenReturn(0);


### PR DESCRIPTION
## Summary
Two `androidTapTargetGuideline` / `labeledTapTargetGuideline` tests for `PrivacyDashboardScreen` were failing on master — not for a11y reasons, but because the screen couldn't even build in the test harness:

1. **`TraceStorage.count` threw `HiveError(\"box not found\")`** when `error_traces` wasn't opened. Tests don't run `AppInitializer`, so the box stays closed. Fix: `count` now returns 0 when the box is not yet open. Production still goes through `AppInitializer` → `TraceStorage.init()`.

2. **`MockStorageRepository.hasCustomApiKey()` + `hasCustomEvApiKey()`** were not stubbed in the `PrivacyDashboard` `_overrides()`. Mocktail returned null and `ConfigVerificationWidget` cast to bool → crash. Fix: stub both to `false`.

Net: two previously-failing guideline tests now pass. Closes the last automated item of the #566 androidTapTargetGuideline audit line (every screen in `guideline_tests.dart` is green).

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero new warnings/errors
- [x] `flutter test test/accessibility/guideline_tests.dart` — 16/16 pass (was 14/16 with 2 failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)