### PR TITLE
feat(payment): deep-link to payment apps from station detail (#586)

### DIFF
--- a/lib/core/utils/payment_app_launcher.dart
+++ b/lib/core/utils/payment_app_launcher.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/foundation.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Describes a branded payment/loyalty app for a fuel station brand.
+///
+/// The app is opened by tapping a "Pay with X" button on the station
+/// detail screen. If the app is not installed, the Play Store page is
+/// opened instead so the user can install it.
+@immutable
+class PaymentApp {
+  /// User-facing product name (e.g. "Shell App", "BPme", "Aral Pay").
+  final String displayName;
+
+  /// Android package ID used to build the Play Store URL
+  /// (e.g. `com.shell.sitibv.shellgoplus`).
+  final String androidPackageId;
+
+  /// Optional direct URL scheme that deep-links into the app when
+  /// it is installed. `null` means we always fall back to the Play
+  /// Store and let Android route to the app if it is present.
+  final String? appScheme;
+
+  const PaymentApp({
+    required this.displayName,
+    required this.androidPackageId,
+    this.appScheme,
+  });
+}
+
+/// Maps a station brand to its branded payment app, or `null` if the
+/// brand has no known paying app.
+///
+/// Match is case-insensitive and matches any substring so that brand
+/// variations like "Shell Express" or "TotalEnergies Access" still
+/// resolve to the parent app.
+PaymentApp? paymentAppForBrand(String brand) {
+  final normalized = brand.trim().toLowerCase();
+  if (normalized.isEmpty) return null;
+  for (final entry in _brandPaymentApps.entries) {
+    if (normalized.contains(entry.key)) return entry.value;
+  }
+  return null;
+}
+
+/// Launches a payment app, preferring a deep-link into the app when
+/// its scheme is known and installed; otherwise falls back to the
+/// Play Store so the user can install it.
+///
+/// Returns `true` if something was launched, `false` if all attempts
+/// failed (e.g. no browser or market app on the device).
+class PaymentAppLauncher {
+  PaymentAppLauncher._();
+
+  /// The injection points below let tests override the launch/probe
+  /// functions without having to plumb through a plugin mock. They
+  /// reset to the real `url_launcher` functions after each test via
+  /// [resetForTesting].
+  @visibleForTesting
+  static Future<bool> Function(Uri uri, {LaunchMode mode}) launcher =
+      _defaultLauncher;
+  @visibleForTesting
+  static Future<bool> Function(Uri uri) probe = _defaultProbe;
+
+  @visibleForTesting
+  static void resetForTesting() {
+    launcher = _defaultLauncher;
+    probe = _defaultProbe;
+  }
+
+  static Future<bool> _defaultLauncher(Uri uri, {LaunchMode? mode}) =>
+      launchUrl(uri, mode: mode ?? LaunchMode.externalApplication);
+
+  static Future<bool> _defaultProbe(Uri uri) => canLaunchUrl(uri);
+
+  /// Attempts to open [app]. Strategy:
+  /// 1. If [app.appScheme] is set and the device reports it can
+  ///    launch, deep-link directly into the app.
+  /// 2. Otherwise, launch the `market:` URI so the Play Store opens
+  ///    the app when installed, or the app's install page otherwise.
+  /// 3. Fall back to the web Play Store URL so the flow still works
+  ///    on devices without the Play Store (desktop tests, emulators
+  ///    without Google services).
+  static Future<bool> open(PaymentApp app) async {
+    final scheme = app.appScheme;
+    if (scheme != null && scheme.isNotEmpty) {
+      final schemeUri = Uri.parse(scheme);
+      try {
+        if (await probe(schemeUri)) {
+          final launched = await launcher(
+            schemeUri,
+            mode: LaunchMode.externalApplication,
+          );
+          if (launched) return true;
+        }
+      } on Exception catch (e) {
+        debugPrint('PaymentAppLauncher scheme failed: $e');
+      }
+    }
+
+    final marketUri =
+        Uri.parse('market://details?id=${app.androidPackageId}');
+    try {
+      final launched = await launcher(
+        marketUri,
+        mode: LaunchMode.externalApplication,
+      );
+      if (launched) return true;
+    } on Exception catch (e) {
+      debugPrint('PaymentAppLauncher market failed: $e');
+    }
+
+    final webUri = playStoreWebUrl(app);
+    try {
+      return await launcher(webUri, mode: LaunchMode.externalApplication);
+    } on Exception catch (e) {
+      debugPrint('PaymentAppLauncher web fallback failed: $e');
+      return false;
+    }
+  }
+
+  /// Public web Play Store URL for a payment app. Safe to share in
+  /// other surfaces (email, copy-to-clipboard).
+  static Uri playStoreWebUrl(PaymentApp app) => Uri.parse(
+      'https://play.google.com/store/apps/details?id=${app.androidPackageId}');
+}
+
+const _brandPaymentApps = {
+  'shell': PaymentApp(
+    displayName: 'Shell App',
+    androidPackageId: 'com.shell.sitibv.shellgoplus',
+  ),
+  'bp': PaymentApp(
+    displayName: 'BPme',
+    androidPackageId: 'com.bp.bpme',
+  ),
+  'aral': PaymentApp(
+    displayName: 'Aral Pay',
+    androidPackageId: 'de.aral.arelion',
+  ),
+  'totalenergies': PaymentApp(
+    displayName: 'TotalEnergies',
+    androidPackageId: 'com.totalenergies.servicesapp',
+  ),
+  'total': PaymentApp(
+    displayName: 'TotalEnergies',
+    androidPackageId: 'com.totalenergies.servicesapp',
+  ),
+  'esso': PaymentApp(
+    displayName: 'Esso Extras',
+    androidPackageId: 'com.exxonmobil.xsell',
+  ),
+  'omv': PaymentApp(
+    displayName: 'OMV Drive',
+    androidPackageId: 'at.omv.business.drive',
+  ),
+  'eni': PaymentApp(
+    displayName: 'Eni Station+',
+    androidPackageId: 'it.eni.stationplus',
+  ),
+  'repsol': PaymentApp(
+    displayName: 'Waylet',
+    androidPackageId: 'com.waylet',
+  ),
+};

--- a/lib/features/search/presentation/widgets/pay_with_app_button.dart
+++ b/lib/features/search/presentation/widgets/pay_with_app_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/utils/payment_app_launcher.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// A "Pay with X" button surfaced on the station detail screen when
+/// the station's brand has a known branded payment app.
+///
+/// Renders nothing when the brand is unknown or blank. Tap opens the
+/// app if installed, otherwise falls back to the Play Store so users
+/// can install it. Layout matches the filled-tonal affordance used
+/// elsewhere in the detail screen.
+class PayWithAppButton extends StatelessWidget {
+  final String brand;
+
+  /// Override for tests; production uses [PaymentAppLauncher.open].
+  final Future<bool> Function(PaymentApp app)? onLaunch;
+
+  const PayWithAppButton({
+    super.key,
+    required this.brand,
+    this.onLaunch,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final app = paymentAppForBrand(brand);
+    if (app == null) return const SizedBox.shrink();
+
+    final l10n = AppLocalizations.of(context);
+    final label = l10n?.payWithApp(app.displayName) ??
+        'Pay with ${app.displayName}';
+
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: FilledButton.tonalIcon(
+        onPressed: () => _launch(app),
+        icon: const Icon(Icons.open_in_new),
+        label: Text(label),
+      ),
+    );
+  }
+
+  Future<void> _launch(PaymentApp app) async {
+    final launcher = onLaunch ?? PaymentAppLauncher.open;
+    try {
+      await launcher(app);
+    } on Exception catch (e) {
+      debugPrint('PayWithAppButton launch failed: $e');
+    }
+  }
+}

--- a/lib/features/station_detail/presentation/widgets/station_info_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_info_section.dart
@@ -6,6 +6,7 @@ import '../../../../core/utils/station_extensions.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../search/presentation/widgets/amenity_chips.dart';
+import '../../../search/presentation/widgets/pay_with_app_button.dart';
 import '../../../search/presentation/widgets/payment_method_chips.dart';
 
 /// Address, opening hours, fuels, services, and location info for a station.
@@ -109,6 +110,8 @@ class StationInfoSection extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           PaymentMethodChips(brand: station.brand, maxVisible: 8),
+          const SizedBox(height: 8),
+          PayWithAppButton(brand: station.brand),
           const SizedBox(height: 24),
         ],
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -658,6 +658,7 @@
   "paymentMethodContactless": "Kontaktlos",
   "paymentMethodFuelCard": "Tankkarte",
   "paymentMethodApp": "App",
+  "payWithApp": "Mit {app} bezahlen",
   "drivingMode": "Fahrmodus",
   "drivingExit": "Beenden",
   "drivingNearestStation": "Nächste",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -663,6 +663,11 @@
   "paymentMethodContactless": "Contactless",
   "paymentMethodFuelCard": "Fuel Card",
   "paymentMethodApp": "App",
+  "payWithApp": "Pay with {app}",
+  "@payWithApp": {
+    "description": "Button label to open a branded station payment app",
+    "placeholders": { "app": { "type": "String", "example": "Shell App" } }
+  },
   "drivingMode": "Driving Mode",
   "drivingExit": "Exit",
   "drivingNearestStation": "Nearest",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -461,6 +461,7 @@
   "paymentMethodContactless": "Sans contact",
   "paymentMethodFuelCard": "Carte carburant",
   "paymentMethodApp": "Appli",
+  "payWithApp": "Payer avec {app}",
   "nearestStations": "Stations les plus proches",
   "nearestStationsHint": "Trouver les stations les plus proches avec votre position actuelle",
   "openOnlyFilter": "Ouvertes uniquement",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2882,6 +2882,12 @@ abstract class AppLocalizations {
   /// **'App'**
   String get paymentMethodApp;
 
+  /// Button label to open a branded station payment app
+  ///
+  /// In en, this message translates to:
+  /// **'Pay with {app}'**
+  String payWithApp(String app);
+
   /// No description provided for @drivingMode.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1491,6 +1491,11 @@ class AppLocalizationsBg extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1491,6 +1491,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1489,6 +1489,11 @@ class AppLocalizationsDa extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1503,6 +1503,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Mit $app bezahlen';
+  }
+
+  @override
   String get drivingMode => 'Fahrmodus';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1493,6 +1493,11 @@ class AppLocalizationsEl extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1484,6 +1484,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1492,6 +1492,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1486,6 +1486,11 @@ class AppLocalizationsEt extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1489,6 +1489,11 @@ class AppLocalizationsFi extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1498,6 +1498,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get paymentMethodApp => 'Appli';
 
   @override
+  String payWithApp(String app) {
+    return 'Payer avec $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1488,6 +1488,11 @@ class AppLocalizationsHr extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1493,6 +1493,11 @@ class AppLocalizationsHu extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1492,6 +1492,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1490,6 +1490,11 @@ class AppLocalizationsLt extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1492,6 +1492,11 @@ class AppLocalizationsLv extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1488,6 +1488,11 @@ class AppLocalizationsNb extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1493,6 +1493,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1491,6 +1491,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1492,6 +1492,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1491,6 +1491,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1492,6 +1492,11 @@ class AppLocalizationsSk extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1486,6 +1486,11 @@ class AppLocalizationsSl extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1490,6 +1490,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get paymentMethodApp => 'App';
 
   @override
+  String payWithApp(String app) {
+    return 'Pay with $app';
+  }
+
+  @override
   String get drivingMode => 'Driving Mode';
 
   @override

--- a/test/core/utils/payment_app_launcher_test.dart
+++ b/test/core/utils/payment_app_launcher_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/payment_app_launcher.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+void main() {
+  group('paymentAppForBrand', () {
+    test('returns null for unknown brand', () {
+      expect(paymentAppForBrand('Unknown Station'), isNull);
+    });
+
+    test('returns null for empty or whitespace brand', () {
+      expect(paymentAppForBrand(''), isNull);
+      expect(paymentAppForBrand('   '), isNull);
+    });
+
+    test('returns Shell App for Shell brand', () {
+      final app = paymentAppForBrand('Shell');
+      expect(app, isNotNull);
+      expect(app!.displayName, 'Shell App');
+      expect(app.androidPackageId, contains('shell'));
+    });
+
+    test('matches brand variations case-insensitively', () {
+      expect(paymentAppForBrand('SHELL')?.displayName, 'Shell App');
+      expect(paymentAppForBrand('Shell Express')?.displayName, 'Shell App');
+      expect(paymentAppForBrand('shell')?.displayName, 'Shell App');
+    });
+
+    test('maps TotalEnergies and Total to the same app', () {
+      expect(paymentAppForBrand('Total')?.displayName, 'TotalEnergies');
+      expect(paymentAppForBrand('TotalEnergies')?.displayName,
+          'TotalEnergies');
+      expect(paymentAppForBrand('TotalEnergies Access')?.displayName,
+          'TotalEnergies');
+    });
+
+    test('maps Repsol to Waylet', () {
+      expect(paymentAppForBrand('Repsol')?.displayName, 'Waylet');
+    });
+
+    test('returns defined apps for all supported brands', () {
+      const brands = ['Shell', 'BP', 'Aral', 'Total', 'Esso', 'OMV',
+          'Eni', 'Repsol'];
+      for (final brand in brands) {
+        final app = paymentAppForBrand(brand);
+        expect(app, isNotNull, reason: '$brand should map to an app');
+        expect(app!.androidPackageId, isNotEmpty,
+            reason: '$brand app needs a package ID');
+      }
+    });
+  });
+
+  group('PaymentAppLauncher.playStoreWebUrl', () {
+    test('uses Play Store web format with the package ID', () {
+      const app = PaymentApp(
+        displayName: 'Test App',
+        androidPackageId: 'com.example.app',
+      );
+      final url = PaymentAppLauncher.playStoreWebUrl(app);
+      expect(url.toString(),
+          'https://play.google.com/store/apps/details?id=com.example.app');
+    });
+  });
+
+  group('PaymentAppLauncher.open', () {
+    tearDown(() => PaymentAppLauncher.resetForTesting());
+
+    test('opens app scheme when probe returns true', () async {
+      final calls = <Uri>[];
+      PaymentAppLauncher.probe = (uri) async => true;
+      PaymentAppLauncher.launcher = (uri, {LaunchMode? mode}) async {
+        calls.add(uri);
+        return true;
+      };
+
+      const app = PaymentApp(
+        displayName: 'Test',
+        androidPackageId: 'com.example.test',
+        appScheme: 'testapp://pay',
+      );
+
+      final result = await PaymentAppLauncher.open(app);
+
+      expect(result, isTrue);
+      expect(calls, hasLength(1));
+      expect(calls.single.scheme, 'testapp');
+    });
+
+    test('falls back to market URI when scheme probe returns false',
+        () async {
+      final calls = <Uri>[];
+      PaymentAppLauncher.probe = (uri) async => false;
+      PaymentAppLauncher.launcher = (uri, {LaunchMode? mode}) async {
+        calls.add(uri);
+        return true;
+      };
+
+      const app = PaymentApp(
+        displayName: 'Test',
+        androidPackageId: 'com.example.test',
+        appScheme: 'testapp://pay',
+      );
+
+      final result = await PaymentAppLauncher.open(app);
+
+      expect(result, isTrue);
+      expect(calls.single.scheme, 'market');
+      expect(calls.single.toString(), contains('com.example.test'));
+    });
+
+    test('goes straight to market when no scheme is provided',
+        () async {
+      final calls = <Uri>[];
+      PaymentAppLauncher.probe = (uri) async => true;
+      PaymentAppLauncher.launcher = (uri, {LaunchMode? mode}) async {
+        calls.add(uri);
+        return true;
+      };
+
+      const app = PaymentApp(
+        displayName: 'Test',
+        androidPackageId: 'com.example.test',
+      );
+
+      final result = await PaymentAppLauncher.open(app);
+
+      expect(result, isTrue);
+      expect(calls.single.scheme, 'market');
+    });
+
+    test('falls through to web Play Store when market launch fails',
+        () async {
+      final calls = <Uri>[];
+      PaymentAppLauncher.probe = (uri) async => false;
+      PaymentAppLauncher.launcher = (uri, {LaunchMode? mode}) async {
+        calls.add(uri);
+        return uri.scheme == 'https';
+      };
+
+      const app = PaymentApp(
+        displayName: 'Test',
+        androidPackageId: 'com.example.test',
+      );
+
+      final result = await PaymentAppLauncher.open(app);
+
+      expect(result, isTrue);
+      expect(calls.map((u) => u.scheme).toList(), ['market', 'https']);
+      expect(calls.last.host, 'play.google.com');
+    });
+
+    test('returns false when nothing can be launched', () async {
+      PaymentAppLauncher.probe = (uri) async => false;
+      PaymentAppLauncher.launcher = (uri, {LaunchMode? mode}) async {
+        return false;
+      };
+
+      const app = PaymentApp(
+        displayName: 'Test',
+        androidPackageId: 'com.example.test',
+      );
+
+      final result = await PaymentAppLauncher.open(app);
+      expect(result, isFalse);
+    });
+  });
+}

--- a/test/features/search/presentation/widgets/pay_with_app_button_test.dart
+++ b/test/features/search/presentation/widgets/pay_with_app_button_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/payment_app_launcher.dart';
+import 'package:tankstellen/features/search/presentation/widgets/pay_with_app_button.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('PayWithAppButton', () {
+    testWidgets('renders nothing for unknown brand', (tester) async {
+      await pumpApp(
+        tester,
+        const PayWithAppButton(brand: 'Local Independent'),
+      );
+
+      expect(find.byType(FilledButton), findsNothing);
+      expect(find.byType(TextButton), findsNothing);
+    });
+
+    testWidgets('renders nothing for empty brand', (tester) async {
+      await pumpApp(tester, const PayWithAppButton(brand: ''));
+      expect(find.byType(FilledButton), findsNothing);
+    });
+
+    testWidgets('shows Pay with Shell App button for Shell brand',
+        (tester) async {
+      await pumpApp(tester, const PayWithAppButton(brand: 'Shell'));
+      expect(find.textContaining('Shell App'), findsOneWidget);
+      expect(find.byIcon(Icons.open_in_new), findsOneWidget);
+    });
+
+    testWidgets('shows Pay with BPme button for BP brand', (tester) async {
+      await pumpApp(tester, const PayWithAppButton(brand: 'BP'));
+      expect(find.textContaining('BPme'), findsOneWidget);
+    });
+
+    testWidgets('tap invokes launcher with the mapped app', (tester) async {
+      PaymentApp? launched;
+      await pumpApp(
+        tester,
+        PayWithAppButton(
+          brand: 'Aral',
+          onLaunch: (app) async {
+            launched = app;
+            return true;
+          },
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.open_in_new));
+      await tester.pump();
+
+      expect(launched, isNotNull);
+      expect(launched!.displayName, 'Aral Pay');
+    });
+
+    testWidgets('swallows launcher exceptions without crashing',
+        (tester) async {
+      await pumpApp(
+        tester,
+        PayWithAppButton(
+          brand: 'Shell',
+          onLaunch: (app) async => throw Exception('no browser'),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.open_in_new));
+      await tester.pump();
+
+      // Test passes if no exception bubbles up.
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- New \`PaymentApp\` class + \`paymentAppForBrand(brand)\` mapping (Shell, BP, Aral, Total/TotalEnergies, Esso, OMV, Eni, Repsol/Waylet).
- New \`PaymentAppLauncher.open(app)\` with 3-step fallback: app scheme (if installed) → \`market://details?id=\` → web Play Store URL.
- New \`PayWithAppButton\` widget; hidden for unknown brands, shown below payment method chips on station detail.
- EN/DE/FR strings, others fall back to English \"Pay with {app}\".

## Why
Natural follow-on to #588 — after showing *which* payment methods a station accepts, offer a one-tap path into the brand's app (Shell App, BPme, Aral Pay, Waylet, ...) so travelers can actually pay with it. The launcher never processes payments itself; it's a router, which keeps compliance scope minimal.

## Test plan
- [x] \`flutter test test/core/utils/payment_app_launcher_test.dart\` (13 unit tests — brand mapping + all 3 launch fallbacks)
- [x] \`flutter test test/features/search/presentation/widgets/pay_with_app_button_test.dart\` (6 widget tests)
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues
- [x] \`flutter test\` — 3784 tests pass

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)