### PR TITLE
test(widgets): cover PriceWarningBadge states (#561)

### DIFF
--- a/test/core/widgets/price_warning_badge_test.dart
+++ b/test/core/widgets/price_warning_badge_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/price_sanity.dart';
+import 'package:tankstellen/core/widgets/price_warning_badge.dart';
+
+import '../../helpers/pump_app.dart';
+
+void main() {
+  group('PriceWarningBadge', () {
+    testWidgets('renders nothing when result is ok', (tester) async {
+      await pumpApp(
+        tester,
+        const PriceWarningBadge(result: PriceSanityResult.ok),
+      );
+      // ok → SizedBox.shrink, no icon
+      expect(find.byType(Icon), findsNothing);
+      expect(find.byType(Tooltip), findsNothing);
+    });
+
+    testWidgets('shows orange warning + tooltip for suspiciousLow',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const PriceWarningBadge(
+          result: PriceSanityResult.suspiciousLow,
+        ),
+      );
+      final icon = tester.widget<Icon>(find.byIcon(Icons.warning_amber));
+      expect(icon.color, Colors.orange);
+      final tip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tip.message, contains('low'));
+    });
+
+    testWidgets('shows red warning + tooltip for suspiciousHigh',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const PriceWarningBadge(
+          result: PriceSanityResult.suspiciousHigh,
+        ),
+      );
+      final icon = tester.widget<Icon>(find.byIcon(Icons.warning_amber));
+      expect(icon.color, Colors.red);
+      final tip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tip.message, contains('high'));
+    });
+
+    testWidgets('shows trending_up + tooltip for aboveAverage',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const PriceWarningBadge(
+          result: PriceSanityResult.aboveAverage,
+        ),
+      );
+      final icon = tester.widget<Icon>(find.byIcon(Icons.trending_up));
+      expect(icon.color, Colors.orange);
+      final tip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tip.message, contains('average'));
+    });
+
+    testWidgets('uses a compact 14-px icon size', (tester) async {
+      // Keeps the badge readable at the card density the station list
+      // uses — the visual contract here is intentional and worth
+      // pinning so a future theme refactor doesn't accidentally bloat
+      // the row.
+      await pumpApp(
+        tester,
+        const PriceWarningBadge(
+          result: PriceSanityResult.suspiciousLow,
+        ),
+      );
+      final icon = tester.widget<Icon>(find.byIcon(Icons.warning_amber));
+      expect(icon.size, 14);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds 5 widget tests for the previously zero-coverage \`PriceWarningBadge\`.

### Coverage
- \`ok\` → renders nothing (SizedBox.shrink)
- \`suspiciousLow\` → orange \`warning_amber\` icon + \"low\" tooltip
- \`suspiciousHigh\` → red \`warning_amber\` icon + \"high\" tooltip
- \`aboveAverage\` → orange \`trending_up\` icon + \"average\" tooltip
- 14-px icon size pinned so a future theme refactor can't bloat the station row

## Test plan
- [x] \`flutter test test/core/widgets/price_warning_badge_test.dart\` (5 passing)
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues
- [x] \`flutter test\` — 3873 tests pass

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)