### PR TITLE
test(widgets): cover PrivacyDataRow + CalculatorEmptyHint (#561)

### DIFF
--- a/test/features/calculator/presentation/widgets/calculator_empty_hint_test.dart
+++ b/test/features/calculator/presentation/widgets/calculator_empty_hint_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/calculator/presentation/widgets/calculator_empty_hint.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('CalculatorEmptyHint', () {
+    testWidgets('renders the calculator icon and hint text',
+        (tester) async {
+      await pumpApp(tester, const CalculatorEmptyHint());
+
+      expect(find.byIcon(Icons.calculate_outlined), findsOneWidget);
+      expect(
+        find.textContaining('Enter distance'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hint text is centered', (tester) async {
+      await pumpApp(tester, const CalculatorEmptyHint());
+      final text = tester.widget<Text>(
+        find.textContaining('Enter distance'),
+      );
+      expect(text.textAlign, TextAlign.center);
+    });
+
+    testWidgets('uses a large 64-px icon so the empty state is obvious',
+        (tester) async {
+      await pumpApp(tester, const CalculatorEmptyHint());
+      final icon = tester.widget<Icon>(
+        find.byIcon(Icons.calculate_outlined),
+      );
+      expect(icon.size, 64);
+    });
+  });
+}

--- a/test/features/profile/presentation/widgets/privacy_dashboard/privacy_data_row_test.dart
+++ b/test/features/profile/presentation/widgets/privacy_dashboard/privacy_data_row_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/profile/presentation/widgets/privacy_dashboard/privacy_data_row.dart';
+
+import '../../../../../helpers/pump_app.dart';
+
+void main() {
+  group('PrivacyDataRow', () {
+    testWidgets('renders icon, label and value', (tester) async {
+      await pumpApp(
+        tester,
+        const PrivacyDataRow(
+          icon: Icons.lock,
+          label: 'API key',
+          value: 'Configured',
+        ),
+      );
+
+      expect(find.byIcon(Icons.lock), findsOneWidget);
+      expect(find.text('API key'), findsOneWidget);
+      expect(find.text('Configured'), findsOneWidget);
+    });
+
+    testWidgets('value text is bolder than label', (tester) async {
+      // The visual contract: the value ("Configured" / "12 items")
+      // should draw the eye, so it's rendered with a heavier weight
+      // than the label. Tests pin this so a theme-only refactor
+      // can't silently level them out.
+      await pumpApp(
+        tester,
+        const PrivacyDataRow(
+          icon: Icons.lock,
+          label: 'API key',
+          value: 'Configured',
+        ),
+      );
+      final valueText = tester.widget<Text>(find.text('Configured'));
+      final labelText = tester.widget<Text>(find.text('API key'));
+      final valueWeight = valueText.style?.fontWeight;
+      final labelWeight = labelText.style?.fontWeight ?? FontWeight.w400;
+      expect(valueWeight, FontWeight.w600);
+      expect(valueWeight!.value, greaterThan(labelWeight.value));
+    });
+
+    testWidgets('icon uses the compact 18-px size', (tester) async {
+      await pumpApp(
+        tester,
+        const PrivacyDataRow(
+          icon: Icons.storage,
+          label: 'Favorites',
+          value: '12',
+        ),
+      );
+      final icon = tester.widget<Icon>(find.byIcon(Icons.storage));
+      expect(icon.size, 18);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Two small zero-coverage presentation widgets gain widget tests.

### PrivacyDataRow (3 tests)
- icon + label + value all render
- value font weight (w600) is heavier than the label weight — pins the visual contract
- compact 18-px icon size is pinned

### CalculatorEmptyHint (3 tests)
- calculator icon + hint text render
- text is centered
- 64-px icon size makes the empty state obvious

## Test plan
- [x] Both test files pass (6 tests total)
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues
- [x] \`flutter test\` — 3879 tests pass

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)