### PR TITLE
test(report): cover CommunityBadge + NoBackendBanner (#561)

### DIFF
--- a/test/features/report/presentation/widgets/community_badge_test.dart
+++ b/test/features/report/presentation/widgets/community_badge_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/report/presentation/widgets/community_badge.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('CommunityBadge', () {
+    testWidgets('renders nothing when reportCount is 0', (tester) async {
+      await pumpApp(tester, const CommunityBadge(reportCount: 0));
+
+      expect(find.byIcon(Icons.people), findsNothing);
+      expect(find.byType(Tooltip), findsNothing);
+    });
+
+    testWidgets('renders people icon + count for any positive number',
+        (tester) async {
+      await pumpApp(tester, const CommunityBadge(reportCount: 3));
+
+      expect(find.byIcon(Icons.people), findsOneWidget);
+      expect(find.text('3'), findsOneWidget);
+    });
+
+    testWidgets('tooltip describes the 2-hour window', (tester) async {
+      await pumpApp(tester, const CommunityBadge(reportCount: 5));
+
+      final tip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tip.message, contains('5'));
+      expect(tip.message, contains('2 hours'));
+    });
+
+    testWidgets('uses compact 12-px icon + 10-px text so it fits in a card',
+        (tester) async {
+      await pumpApp(tester, const CommunityBadge(reportCount: 1));
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.people));
+      expect(icon.size, 12);
+      final text = tester.widget<Text>(find.text('1'));
+      expect(text.style?.fontSize, 10);
+      expect(text.style?.fontWeight, FontWeight.bold);
+    });
+  });
+}

--- a/test/features/report/presentation/widgets/no_backend_banner_test.dart
+++ b/test/features/report/presentation/widgets/no_backend_banner_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/report/presentation/widgets/no_backend_banner.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('NoBackendBanner', () {
+    testWidgets('renders the error icon and warning text',
+        (tester) async {
+      await pumpApp(tester, const NoBackendBanner());
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.textContaining('signalements'), findsOneWidget);
+      expect(
+        find.textContaining('TankSync'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('carries the valueKey used by the report screen tests',
+        (tester) async {
+      // report_screen.dart conditionally mounts this banner and the
+      // screen test locates it by this key — pin the contract here
+      // so a refactor can't silently change it.
+      await pumpApp(tester, const NoBackendBanner());
+      expect(find.byKey(const ValueKey('report-no-backend-banner')),
+          findsOneWidget);
+    });
+
+    testWidgets('uses the error-container colour scheme for alarm cue',
+        (tester) async {
+      await pumpApp(tester, const NoBackendBanner());
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.borderRadius, BorderRadius.circular(8));
+      // Background colour comes from Theme.errorContainer — just
+      // assert it's set to something non-default.
+      expect(decoration.color, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Two small zero-coverage report widgets gain widget tests.

### CommunityBadge (4 tests)
- 0 reports → renders nothing (SizedBox.shrink)
- Positive count → people icon + number
- Tooltip describes the \"last 2 hours\" window
- Compact 12-px icon + 10-px bold count keeps it card-sized

### NoBackendBanner (3 tests)
- Error icon + French warning text both render
- \`ValueKey('report-no-backend-banner')\` stays stable — the report-screen tests locate it by this key
- Rounded 8-px container with error-container background

## Test plan
- [x] 7 tests pass
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues
- [x] \`flutter test\` — 3902 tests pass

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)