### PR TITLE
test(vehicle): cover VehicleCombustionSection (#561)

### DIFF
--- a/test/features/vehicle/presentation/widgets/vehicle_combustion_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_combustion_section_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_combustion_section.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Rejects empty/non-numeric input — matches the shape of the real
+/// validator the EditVehicleScreen hands down.
+String? _requireNumber(String? v) {
+  if (v == null || v.trim().isEmpty) return 'Required';
+  if (double.tryParse(v.replaceAll(',', '.')) == null) {
+    return 'Not a number';
+  }
+  return null;
+}
+
+void main() {
+  group('VehicleCombustionSection', () {
+    testWidgets('renders section title, tank field, fuel type field',
+        (tester) async {
+      final tank = TextEditingController();
+      final fuel = TextEditingController();
+      addTearDown(tank.dispose);
+      addTearDown(fuel.dispose);
+
+      await pumpApp(
+        tester,
+        VehicleCombustionSection(
+          tankController: tank,
+          fuelTypeController: fuel,
+          numberValidator: _requireNumber,
+        ),
+      );
+
+      expect(find.text('Combustion'), findsOneWidget);
+      expect(find.text('Tank capacity (L)'), findsOneWidget);
+      expect(find.text('Preferred fuel'), findsOneWidget);
+    });
+
+    testWidgets('user-typed tank capacity flows to the controller',
+        (tester) async {
+      final tank = TextEditingController();
+      final fuel = TextEditingController();
+      addTearDown(tank.dispose);
+      addTearDown(fuel.dispose);
+
+      await pumpApp(
+        tester,
+        VehicleCombustionSection(
+          tankController: tank,
+          fuelTypeController: fuel,
+          numberValidator: _requireNumber,
+        ),
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Tank capacity (L)'),
+        '55',
+      );
+      expect(tank.text, '55');
+    });
+
+    testWidgets('user-typed preferred fuel flows to the controller',
+        (tester) async {
+      final tank = TextEditingController();
+      final fuel = TextEditingController();
+      addTearDown(tank.dispose);
+      addTearDown(fuel.dispose);
+
+      await pumpApp(
+        tester,
+        VehicleCombustionSection(
+          tankController: tank,
+          fuelTypeController: fuel,
+          numberValidator: _requireNumber,
+        ),
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Preferred fuel'),
+        'Diesel',
+      );
+      expect(fuel.text, 'Diesel');
+    });
+
+    testWidgets('tank field runs the injected numberValidator on submit',
+        (tester) async {
+      final tank = TextEditingController();
+      final fuel = TextEditingController();
+      final formKey = GlobalKey<FormState>();
+      addTearDown(tank.dispose);
+      addTearDown(fuel.dispose);
+
+      await pumpApp(
+        tester,
+        Form(
+          key: formKey,
+          child: VehicleCombustionSection(
+            tankController: tank,
+            fuelTypeController: fuel,
+            numberValidator: _requireNumber,
+          ),
+        ),
+      );
+
+      // Empty on submit → validator fires.
+      expect(formKey.currentState!.validate(), isFalse);
+      await tester.pump();
+      expect(find.text('Required'), findsOneWidget);
+
+      // Non-numeric fails too.
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Tank capacity (L)'),
+        'abc',
+      );
+      expect(formKey.currentState!.validate(), isFalse);
+      await tester.pump();
+      expect(find.text('Not a number'), findsOneWidget);
+
+      // Valid number passes.
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Tank capacity (L)'),
+        '55',
+      );
+      expect(formKey.currentState!.validate(), isTrue);
+    });
+
+    testWidgets('fuel type field shows its example hint text',
+        (tester) async {
+      // The hint "e.g. Diesel, E10" is a small UX contract —
+      // pin it so a casual edit doesn't accidentally drop the
+      // example that users rely on to know what format to type.
+      final tank = TextEditingController();
+      final fuel = TextEditingController();
+      addTearDown(tank.dispose);
+      addTearDown(fuel.dispose);
+
+      await pumpApp(
+        tester,
+        VehicleCombustionSection(
+          tankController: tank,
+          fuelTypeController: fuel,
+          numberValidator: _requireNumber,
+        ),
+      );
+
+      expect(find.text('e.g. Diesel, E10'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
5 widget tests for the previously zero-coverage combustion section of the vehicle edit form.

### Coverage
- Renders section title, tank field, fuel type field
- User-typed tank capacity flows to the tank controller
- User-typed preferred fuel flows to the fuel controller
- Tank field runs the injected \`numberValidator\` on form submit — empty rejected (\"Required\"), non-numeric rejected (\"Not a number\"), valid number accepted
- \"e.g. Diesel, E10\" hint text is pinned so a casual edit doesn't drop the example users rely on

## Test plan
- [x] 5 tests pass
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues
- [x] \`flutter test\` — 3923 tests pass

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)