### PR TITLE
test(services): cover ServiceConfig + named configs (#561)

### DIFF
--- a/test/core/services/service_config_test.dart
+++ b/test/core/services/service_config_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/constants/app_constants.dart';
+import 'package:tankstellen/core/services/service_config.dart';
+
+void main() {
+  group('ServiceConfig (defaults)', () {
+    test('applies 10-second default timeouts for connect and receive', () {
+      const cfg = ServiceConfig(baseUrl: 'https://example.com');
+      expect(cfg.connectTimeout, const Duration(seconds: 10));
+      expect(cfg.receiveTimeout, const Duration(seconds: 10));
+    });
+
+    test('defaults to empty headers + null apiKeyParamName', () {
+      const cfg = ServiceConfig(baseUrl: 'https://example.com');
+      expect(cfg.headers, isEmpty);
+      expect(cfg.apiKeyParamName, isNull);
+    });
+
+    test('accepts explicit headers + apiKeyParamName', () {
+      const cfg = ServiceConfig(
+        baseUrl: 'https://example.com',
+        apiKeyParamName: 'apikey',
+        headers: {'X-Test': '1'},
+      );
+      expect(cfg.apiKeyParamName, 'apikey');
+      expect(cfg.headers['X-Test'], '1');
+    });
+  });
+
+  group('ServiceConfigs.tankerkoenig', () {
+    test('points at creativecommons.tankerkoenig.de', () {
+      expect(ServiceConfigs.tankerkoenig.baseUrl,
+          'https://creativecommons.tankerkoenig.de/json');
+    });
+
+    test('uses the "apikey" query parameter for key injection', () {
+      expect(ServiceConfigs.tankerkoenig.apiKeyParamName, 'apikey');
+    });
+
+    test('sends the app User-Agent so upstream can identify us', () {
+      expect(ServiceConfigs.tankerkoenig.headers['User-Agent'],
+          AppConstants.userAgent);
+    });
+  });
+
+  group('ServiceConfigs.nominatim', () {
+    test('points at nominatim.openstreetmap.org', () {
+      expect(ServiceConfigs.nominatim.baseUrl,
+          'https://nominatim.openstreetmap.org');
+    });
+
+    test('has no API key parameter (keyless service)', () {
+      expect(ServiceConfigs.nominatim.apiKeyParamName, isNull);
+    });
+
+    test('sends the User-Agent — required by OSM usage policy', () {
+      // Nominatim will rate-limit or block requests with no UA;
+      // pin the contract so a refactor can't accidentally drop it.
+      expect(ServiceConfigs.nominatim.headers['User-Agent'],
+          AppConstants.userAgent);
+    });
+  });
+
+  group('ServiceConfigs.osrm', () {
+    test('uses 30s receive timeout for routing', () {
+      // Routing responses can be large for long cross-country
+      // routes; the default 10s is too tight.
+      expect(ServiceConfigs.osrm.receiveTimeout,
+          const Duration(seconds: 30));
+    });
+
+    test('has no API key (public OSRM demo server)', () {
+      expect(ServiceConfigs.osrm.apiKeyParamName, isNull);
+    });
+  });
+
+  group('ServiceConfigs.openChargeMap', () {
+    test('points at api.openchargemap.io/v3', () {
+      expect(ServiceConfigs.openChargeMap.baseUrl,
+          'https://api.openchargemap.io/v3');
+    });
+
+    test('uses the "key" query parameter for key injection', () {
+      expect(ServiceConfigs.openChargeMap.apiKeyParamName, 'key');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
13 tests for the previously zero-coverage \`ServiceConfig\` and the four named configurations the app ships with.

### ServiceConfig defaults
- 10 s connect + receive timeouts
- empty headers + null \`apiKeyParamName\` by default
- explicit headers + \`apiKeyParamName\` flow through

### tankerkoenig
- \`baseUrl\`: creativecommons.tankerkoenig.de/json
- \`apiKeyParamName\`: \`\"apikey\"\` (not \`\"key\"\` — differs from OCM)
- User-Agent from \`AppConstants.userAgent\`

### nominatim
- \`baseUrl\`: nominatim.openstreetmap.org
- No API key (keyless)
- User-Agent pinned — required by OSM usage policy

### osrm
- 30 s receive timeout (default 10 s is too tight for long routes)
- No API key (public demo server)

### openChargeMap
- \`baseUrl\`: api.openchargemap.io/v3
- \`apiKeyParamName\`: \`\"key\"\` (distinct from tankerkoenig's \`\"apikey\"\`)

## Test plan
- [x] 13 tests pass
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues
- [x] \`flutter test\` — 3947 tests pass

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)