### PR TITLE
test(app): cover AppTheme light + dark (#561)

### DIFF
--- a/test/app/theme_test.dart
+++ b/test/app/theme_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/theme.dart';
+
+void main() {
+  group('AppTheme.light', () {
+    final theme = AppTheme.light();
+
+    test('uses Material 3', () {
+      expect(theme.useMaterial3, isTrue);
+    });
+
+    test('has light brightness', () {
+      expect(theme.brightness, Brightness.light);
+    });
+
+    test('primary colour lands in the blue family (bahamaBlue scheme)', () {
+      final p = theme.colorScheme.primary;
+      expect(p.b, greaterThan(p.r));
+    });
+  });
+
+  group('AppTheme.dark', () {
+    final theme = AppTheme.dark();
+
+    test('uses Material 3', () {
+      expect(theme.useMaterial3, isTrue);
+    });
+
+    test('has dark brightness', () {
+      expect(theme.brightness, Brightness.dark);
+    });
+
+    test('dark primary is also in the blue family', () {
+      final p = theme.colorScheme.primary;
+      expect(p.b, greaterThan(p.r));
+    });
+  });
+
+  test('light and dark have distinct brightness values', () {
+    expect(AppTheme.light().brightness, Brightness.light);
+    expect(AppTheme.dark().brightness, Brightness.dark);
+  });
+}


### PR DESCRIPTION
## Summary
7 tests for the previously zero-coverage \`AppTheme\`.

### Coverage
- \`light()\` and \`dark()\` both enable Material 3
- Brightness matches the variant (light/dark)
- Both primary colours land in the blue family (the \`bahamaBlue\` FlexScheme). Exact RGB is not pinned (package can tweak shades); only the hue family, so the brand identity can't accidentally flip to red or green.

## Test plan
- [x] 7 tests pass
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)