### PR TITLE
test(country): cover countrySwitchEvent branches (#561)

### DIFF
--- a/test/core/country/country_switch_event_test.dart
+++ b/test/core/country/country_switch_event_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/country/country_detection_provider.dart';
+import 'package:tankstellen/core/country/country_provider.dart';
+import 'package:tankstellen/core/country/country_switch_event.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+
+import '../../mocks/mocks.dart';
+
+class _FixedDetectedCountry extends DetectedCountry {
+  final String? _value;
+  _FixedDetectedCountry(this._value);
+
+  @override
+  String? build() => _value;
+}
+
+class _FixedActiveCountry extends ActiveCountry {
+  final CountryConfig _value;
+  _FixedActiveCountry(this._value);
+
+  @override
+  CountryConfig build() => _value;
+}
+
+const _frenchProfile = UserProfile(
+  id: 'p-fr',
+  name: 'France',
+  countryCode: 'FR',
+);
+
+const _germanProfile = UserProfile(
+  id: 'p-de',
+  name: 'Germany',
+  countryCode: 'DE',
+);
+
+void main() {
+  late MockHiveStorage mockStorage;
+
+  setUp(() {
+    mockStorage = MockHiveStorage();
+    when(() => mockStorage.getSetting(StorageKeys.autoSwitchProfile))
+        .thenReturn(false);
+  });
+
+  ProviderContainer createContainer({
+    String? detected,
+    CountryConfig active = Countries.france,
+    List<UserProfile> profiles = const [],
+  }) {
+    final c = ProviderContainer(overrides: [
+      hiveStorageProvider.overrideWithValue(mockStorage),
+      detectedCountryProvider.overrideWith(() => _FixedDetectedCountry(detected)),
+      activeCountryProvider.overrideWith(() => _FixedActiveCountry(active)),
+      allProfilesProvider.overrideWith((ref) => profiles),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('countrySwitchEvent', () {
+    test('returns null when no country is detected yet', () {
+      final c = createContainer(detected: null);
+      expect(c.read(countrySwitchEventProvider), isNull);
+    });
+
+    test('returns null when the detected country matches the active one',
+        () {
+      final c = createContainer(
+        detected: 'FR',
+        active: Countries.france,
+      );
+      expect(c.read(countrySwitchEventProvider), isNull);
+    });
+
+    test('returns "noProfile" when detected country has no matching profile',
+        () {
+      final c = createContainer(
+        detected: 'DE',
+        active: Countries.france,
+        profiles: const [_frenchProfile],
+      );
+
+      final ev = c.read(countrySwitchEventProvider);
+      expect(ev, isNotNull);
+      expect(ev!.action, CountrySwitchAction.noProfile);
+      expect(ev.detectedCountryCode, 'DE');
+      expect(ev.matchingProfile, isNull);
+    });
+
+    test('returns "suggest" when profile matches but auto-switch is off',
+        () {
+      when(() => mockStorage.getSetting(StorageKeys.autoSwitchProfile))
+          .thenReturn(false);
+
+      final c = createContainer(
+        detected: 'DE',
+        active: Countries.france,
+        profiles: const [_frenchProfile, _germanProfile],
+      );
+
+      final ev = c.read(countrySwitchEventProvider);
+      expect(ev, isNotNull);
+      expect(ev!.action, CountrySwitchAction.suggest);
+      expect(ev.matchingProfile?.id, 'p-de');
+    });
+
+    test('returns "autoSwitch" when profile matches AND autoSwitch is on',
+        () {
+      when(() => mockStorage.getSetting(StorageKeys.autoSwitchProfile))
+          .thenReturn(true);
+
+      final c = createContainer(
+        detected: 'DE',
+        active: Countries.france,
+        profiles: const [_germanProfile],
+      );
+
+      final ev = c.read(countrySwitchEventProvider);
+      expect(ev, isNotNull);
+      expect(ev!.action, CountrySwitchAction.autoSwitch);
+      expect(ev.matchingProfile?.id, 'p-de');
+    });
+
+    test('autoSwitch only fires when a matching profile EXISTS — no profile '
+        'still returns "noProfile" even with the flag on', () {
+      when(() => mockStorage.getSetting(StorageKeys.autoSwitchProfile))
+          .thenReturn(true);
+
+      final c = createContainer(
+        detected: 'IT',
+        active: Countries.france,
+        profiles: const [_frenchProfile],
+      );
+
+      expect(c.read(countrySwitchEventProvider)!.action,
+          CountrySwitchAction.noProfile);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
6 provider tests for the previously zero-coverage country-switch decision logic.

### Covered branches
- No detected country yet → null event
- Detected == active country → null event
- Detected country, matching profile exists, autoSwitch off → action: \`suggest\` (with the matching profile)
- Detected country, matching profile, autoSwitch on → action: \`autoSwitch\` (with the matching profile)
- Detected country, NO matching profile → action: \`noProfile\`
- autoSwitch only fires when a match exists — with the flag on but no profile, still returns \`noProfile\` (regression guard so the flag can't trigger blind switching)

Uses fake \`DetectedCountry\` / \`ActiveCountry\` notifier overrides plus a \`MockHiveStorage\` for the \`autoSwitchProfile\` setting.

## Test plan
- [x] 6 tests pass
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)