### PR TITLE
test(route-search): pin RouteSearchStrategyType enum (#561)

### DIFF
--- a/test/features/route_search/domain/route_search_strategy_test.dart
+++ b/test/features/route_search/domain/route_search_strategy_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/route_search/domain/route_search_strategy.dart';
+
+void main() {
+  group('RouteSearchStrategyType', () {
+    test('three strategies are defined: uniform, cheapest, balanced', () {
+      // Guards against a silent new strategy being added without
+      // updating the strategy-factory + l10n keys elsewhere.
+      expect(
+        RouteSearchStrategyType.values.map((s) => s.key).toSet(),
+        {'uniform', 'cheapest', 'balanced'},
+      );
+    });
+
+    test('keys are stable (used as persistence tokens)', () {
+      // The `key` is what gets stored in the profile; renaming it
+      // would orphan existing user data, so pin the exact strings.
+      expect(RouteSearchStrategyType.uniform.key, 'uniform');
+      expect(RouteSearchStrategyType.cheapest.key, 'cheapest');
+      expect(RouteSearchStrategyType.balanced.key, 'balanced');
+    });
+
+    test('every strategy has a non-empty distinct l10nKey', () {
+      final l10nKeys =
+          RouteSearchStrategyType.values.map((s) => s.l10nKey).toSet();
+      expect(l10nKeys.length, RouteSearchStrategyType.values.length);
+      for (final k in l10nKeys) {
+        expect(k, isNotEmpty);
+      }
+    });
+
+    test('l10nKeys follow the *Search naming convention', () {
+      // Pinned so ARB lookups continue working — the UI looks up
+      // this exact key.
+      for (final s in RouteSearchStrategyType.values) {
+        expect(s.l10nKey, endsWith('Search'),
+            reason: '${s.name} l10nKey should end with "Search"');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
4 tests for the zero-coverage route-search strategy enum.

### Coverage
- Exactly three strategies: \`uniform\`, \`cheapest\`, \`balanced\` (guards against a silent addition without updating the factory + l10n keys elsewhere)
- Persistence keys pinned to stable strings — renaming would orphan existing user profile data
- Every strategy has a non-empty distinct \`l10nKey\`
- \`l10nKeys\` follow the \`*Search\` convention so ARB lookups keep working

## Test plan
- [x] 4 tests pass
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)