### PR TITLE
docs: adopt "Smarter pump. Smarter drive. Save twice." leitmotiv

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # Tankstellen — Project Context for Claude Code
 
+## Product leitmotiv
+
+**Every feature must help the user either pay less AT the pump or burn less fuel BEHIND the wheel. Both reduce CO₂ — that's the point. If a feature satisfies neither lens, it doesn't belong in Tankstellen.**
+
+Slogan: *Smarter pump. Smarter drive. Save twice.*
+
+When reviewing or scoping a feature, ask: *which lens does this serve?* Price/availability features serve the pump. Consumption-logging, eco-feedback, and driving-behaviour features serve the wheel. Convenience features (payment deep-links, QR scans, icon polish) are fine to ship but don't let them crowd out work on either savings lens.
+
 ## What is this project?
 
 Free, open-source fuel price comparison app for Europe and beyond

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # Tankstellen
 
-**Free fuel price comparison app for Europe and beyond** — 11 countries, 23 languages, privacy-first.
+> **Smarter pump. Smarter drive. Save twice.**
+>
+> Every litre saved at the pump is a litre not burned on the road — and a kilogram of CO₂ you kept out of the air. Tankstellen is built to help you save both ways: cheaper fuel _and_ leaner driving.
 
 [![CI](https://github.com/fdittgen-png/tankstellen/actions/workflows/ci.yml/badge.svg)](https://github.com/fdittgen-png/tankstellen/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Flutter](https://img.shields.io/badge/Flutter-3.41-blue.svg)](https://flutter.dev)
 
-Tankstellen helps drivers find the cheapest fuel nearby, along a route, or in a specific city. It aggregates real-time prices from official government APIs — no scraping, no tracking, no ads.
+**Free fuel-price comparison for Europe and beyond** — 11 countries, 23 languages, privacy-first.
+
+Tankstellen helps drivers find the cheapest fuel nearby, along a route, or in a specific city, _and_ track their real consumption so they can drive it down over time. It aggregates real-time prices from official government APIs — no scraping, no tracking, no ads.
+
+### The two savings lenses
+
+1. **At the pump.** Live price comparison across countries, along your route, with alerts when prices drop.
+2. **Behind the wheel.** Fill-up log, consumption stats, CO₂ dashboard, and the signals you need to drive more economically over time.
+
+Every feature in the app serves at least one of these two lenses. Features that serve neither don't belong.
 
 ## Features
 


### PR DESCRIPTION
## Summary
The product's original motto (*mit Tankstellen sparen*) collapsed two distinct savings channels — cheaper pump prices **and** lower consumption while driving — into one word, and said nothing explicit about CO₂. This reframes both.

### README
- Leads with the new tagline **Smarter pump. Smarter drive. Save twice.**
- Makes the two savings lenses explicit — at the pump (price search, alerts) and behind the wheel (fill-up log, consumption, CO₂ dashboard)
- Adds the rule that every feature must serve at least one of these lenses

### CLAUDE.md
- New **Product leitmotiv** section at the top:
  > Every feature must help the user either pay less AT the pump or burn less fuel BEHIND the wheel. Both reduce CO₂ — that's the point. If a feature satisfies neither lens, it doesn't belong in Tankstellen.
- Review question for future PRs: *\"which lens does this serve?\"*

## Follow-up
- #676 filed: per-fill-up eco-score — closes the \"how economically did I drive?\" gap that the current UI doesn't answer. This is the feature most directly implied by the new slogan.

## Test plan
- [x] \`flutter analyze --no-fatal-infos\` — zero new issues (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)