### PR TITLE
test(theme): cover FuelColors palette + Spacing scale (#561)

### DIFF
--- a/test/core/theme/fuel_colors_test.dart
+++ b/test/core/theme/fuel_colors_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/fuel_colors.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+void main() {
+  group('FuelColors.forType', () {
+    test('covers every concrete FuelType variant', () {
+      // Exhaustive switch coverage — the sealed FuelType hierarchy means
+      // adding a new variant without updating FuelColors would skip the
+      // switch arms. This pins every arm against a drift-free list.
+      final allTypes = <FuelType>[
+        FuelType.e5,
+        FuelType.e10,
+        FuelType.e98,
+        FuelType.diesel,
+        FuelType.dieselPremium,
+        FuelType.e85,
+        FuelType.lpg,
+        FuelType.cng,
+        FuelType.hydrogen,
+        FuelType.electric,
+        FuelType.all,
+      ];
+      for (final type in allTypes) {
+        final color = FuelColors.forType(type);
+        expect(color, isA<Color>(), reason: '$type should resolve to a Color');
+      }
+    });
+
+    test('each fuel type maps to a distinct color', () {
+      // Chart legibility depends on colors being unique across the palette.
+      final palette = <FuelType, Color>{
+        FuelType.e5: FuelColors.forType(FuelType.e5),
+        FuelType.e10: FuelColors.forType(FuelType.e10),
+        FuelType.e98: FuelColors.forType(FuelType.e98),
+        FuelType.diesel: FuelColors.forType(FuelType.diesel),
+        FuelType.dieselPremium: FuelColors.forType(FuelType.dieselPremium),
+        FuelType.e85: FuelColors.forType(FuelType.e85),
+        FuelType.lpg: FuelColors.forType(FuelType.lpg),
+        FuelType.cng: FuelColors.forType(FuelType.cng),
+        FuelType.hydrogen: FuelColors.forType(FuelType.hydrogen),
+        FuelType.electric: FuelColors.forType(FuelType.electric),
+        FuelType.all: FuelColors.forType(FuelType.all),
+      };
+      expect(palette.values.toSet().length, palette.length,
+          reason: 'Fuel type colors must be pairwise distinct');
+    });
+
+    test('diesel is orange, electric is teal (pinned brand signals)', () {
+      // These specific mappings surface in marketing screenshots and
+      // chart legends — callers should not silently re-tint them.
+      expect(FuelColors.forType(FuelType.diesel), const Color(0xFFFF9800));
+      expect(FuelColors.forType(FuelType.electric), const Color(0xFF009688));
+    });
+  });
+
+  group('FuelColors.forTypeLight', () {
+    test('returns the same hue with reduced alpha (0.15)', () {
+      final base = FuelColors.forType(FuelType.e5);
+      final light = FuelColors.forTypeLight(FuelType.e5);
+      expect(light.r, base.r);
+      expect(light.g, base.g);
+      expect(light.b, base.b);
+      expect(light.a, closeTo(0.15, 0.001));
+    });
+
+    test('works for every fuel type', () {
+      for (final type in <FuelType>[
+        FuelType.e5,
+        FuelType.e10,
+        FuelType.diesel,
+        FuelType.electric,
+        FuelType.all,
+      ]) {
+        final light = FuelColors.forTypeLight(type);
+        expect(light.a, closeTo(0.15, 0.001));
+      }
+    });
+  });
+}

--- a/test/core/theme/spacing_test.dart
+++ b/test/core/theme/spacing_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/spacing.dart';
+
+void main() {
+  group('Spacing — scale', () {
+    test('values form a strictly increasing ladder', () {
+      // The whole point of a scale is that consumers can reach for "one
+      // step up" without memorising the numbers. Pin the ordering so
+      // future renames can't silently flatten the scale.
+      final ladder = [
+        Spacing.xs,
+        Spacing.sm,
+        Spacing.md,
+        Spacing.lg,
+        Spacing.xl,
+        Spacing.xxl,
+        Spacing.xxxl,
+      ];
+      for (var i = 1; i < ladder.length; i++) {
+        expect(ladder[i], greaterThan(ladder[i - 1]),
+            reason: 'Ladder broke at index $i: ${ladder[i - 1]} → ${ladder[i]}');
+      }
+    });
+
+    test('xs is 2.0 and xxxl is 32.0 (pinned endpoints)', () {
+      expect(Spacing.xs, 2.0);
+      expect(Spacing.xxxl, 32.0);
+    });
+  });
+
+  group('Spacing — padding patterns', () {
+    test('screenPadding uses xl on all sides', () {
+      expect(Spacing.screenPadding, const EdgeInsets.all(Spacing.xl));
+    });
+
+    test('cardMargin has horizontal=md, vertical=xs', () {
+      expect(
+        Spacing.cardMargin,
+        const EdgeInsets.symmetric(
+          horizontal: Spacing.md,
+          vertical: Spacing.xs,
+        ),
+      );
+    });
+
+    test('listItemPadding has horizontal=lg, vertical=md', () {
+      expect(
+        Spacing.listItemPadding,
+        const EdgeInsets.symmetric(
+          horizontal: Spacing.lg,
+          vertical: Spacing.md,
+        ),
+      );
+    });
+
+    test('chipPadding has horizontal=lg, vertical=sm', () {
+      expect(
+        Spacing.chipPadding,
+        const EdgeInsets.symmetric(
+          horizontal: Spacing.lg,
+          vertical: Spacing.sm,
+        ),
+      );
+    });
+
+    test('sectionGap and cardGap are both SizedBoxes of height md', () {
+      expect(Spacing.sectionGap.height, Spacing.md);
+      expect(Spacing.cardGap.height, Spacing.md);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- 12 tests across two previously-uncovered theme utilities.
- Pins the FuelColors palette (exhaustive switch, distinct colors, brand-signal hues) and the Spacing scale/pattern constants.

## Test plan
- [x] `flutter test test/core/theme/` — 12/12 pass
- [x] `flutter analyze` — no issues

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)