### PR TITLE
test(entities): cover SavedItinerary + CrossBorderComparison (#561)

### DIFF
--- a/test/features/itinerary/domain/entities/saved_itinerary_test.dart
+++ b/test/features/itinerary/domain/entities/saved_itinerary_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/itinerary/domain/entities/saved_itinerary.dart';
+
+void main() {
+  group('SavedItinerary — construction', () {
+    test('requires identity + route metrics and preserves them', () {
+      final created = DateTime.utc(2026, 4, 1, 10);
+      final updated = DateTime.utc(2026, 4, 2, 11);
+      final itinerary = SavedItinerary(
+        id: 'abc-123',
+        name: 'Weekend trip',
+        waypoints: const [
+          {'lat': 48.85, 'lng': 2.35, 'label': 'Paris'},
+          {'lat': 43.30, 'lng': 5.37, 'label': 'Marseille'},
+        ],
+        distanceKm: 776.4,
+        durationMinutes: 430.0,
+        createdAt: created,
+        updatedAt: updated,
+      );
+      expect(itinerary.id, 'abc-123');
+      expect(itinerary.name, 'Weekend trip');
+      expect(itinerary.waypoints.length, 2);
+      expect(itinerary.waypoints.first['label'], 'Paris');
+      expect(itinerary.distanceKm, 776.4);
+      expect(itinerary.durationMinutes, 430.0);
+      expect(itinerary.createdAt, created);
+      expect(itinerary.updatedAt, updated);
+    });
+
+    test('optional fields default to avoidHighways=false, fuelType=e10, empty stations',
+        () {
+      // Defaults matter because they land in the cloud-sync payload — a
+      // user who never picked a fuel type should not accidentally enshrine
+      // "diesel" server-side.
+      final itinerary = SavedItinerary(
+        id: 'x',
+        name: 'n',
+        waypoints: const [],
+        distanceKm: 0,
+        durationMinutes: 0,
+        createdAt: DateTime.utc(2026),
+        updatedAt: DateTime.utc(2026),
+      );
+      expect(itinerary.avoidHighways, isFalse);
+      expect(itinerary.fuelType, 'e10');
+      expect(itinerary.selectedStationIds, isEmpty);
+    });
+
+    test('overrides take precedence over defaults', () {
+      final itinerary = SavedItinerary(
+        id: 'x',
+        name: 'n',
+        waypoints: const [],
+        distanceKm: 0,
+        durationMinutes: 0,
+        avoidHighways: true,
+        fuelType: 'diesel',
+        selectedStationIds: const ['s1', 's2'],
+        createdAt: DateTime.utc(2026),
+        updatedAt: DateTime.utc(2026),
+      );
+      expect(itinerary.avoidHighways, isTrue);
+      expect(itinerary.fuelType, 'diesel');
+      expect(itinerary.selectedStationIds, ['s1', 's2']);
+    });
+  });
+
+  group('SavedItinerary — copyWith + equality', () {
+    test('copyWith(name:) only rewrites the name', () {
+      final original = SavedItinerary(
+        id: 'x',
+        name: 'old',
+        waypoints: const [],
+        distanceKm: 100,
+        durationMinutes: 60,
+        createdAt: DateTime.utc(2026, 1, 1),
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+      final updated = original.copyWith(name: 'new');
+      expect(updated.name, 'new');
+      expect(updated.id, 'x');
+      expect(updated.distanceKm, 100);
+      expect(updated.createdAt, original.createdAt);
+    });
+
+    test('two itineraries with identical fields are equal', () {
+      final a = SavedItinerary(
+        id: 'x',
+        name: 'n',
+        waypoints: const [],
+        distanceKm: 10,
+        durationMinutes: 5,
+        createdAt: DateTime.utc(2026, 2, 1),
+        updatedAt: DateTime.utc(2026, 2, 1),
+      );
+      final b = SavedItinerary(
+        id: 'x',
+        name: 'n',
+        waypoints: const [],
+        distanceKm: 10,
+        durationMinutes: 5,
+        createdAt: DateTime.utc(2026, 2, 1),
+        updatedAt: DateTime.utc(2026, 2, 1),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+
+  group('SavedItinerary — JSON round-trip', () {
+    test('fromJson(toJson(x)) == x for a fully-populated itinerary', () {
+      final original = SavedItinerary(
+        id: 'it-42',
+        name: 'Tour de France',
+        waypoints: const [
+          {'lat': 48.85, 'lng': 2.35},
+          {'lat': 43.30, 'lng': 5.37},
+        ],
+        distanceKm: 776.4,
+        durationMinutes: 430.0,
+        avoidHighways: true,
+        fuelType: 'diesel',
+        selectedStationIds: const ['s1', 's7'],
+        createdAt: DateTime.utc(2026, 4, 1, 10),
+        updatedAt: DateTime.utc(2026, 4, 2, 11),
+      );
+      final decoded = SavedItinerary.fromJson(original.toJson());
+      expect(decoded, equals(original));
+    });
+  });
+}

--- a/test/features/search/domain/entities/cross_border_comparison_test.dart
+++ b/test/features/search/domain/entities/cross_border_comparison_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/domain/entities/cross_border_comparison.dart';
+
+void main() {
+  group('CrossBorderComparison', () {
+    test('stores neighbor identity, currency, and comparison metrics', () {
+      const comparison = CrossBorderComparison(
+        neighborCode: 'FR',
+        neighborName: 'France',
+        neighborFlag: '🇫🇷',
+        neighborCurrency: '€',
+        currentAvgPrice: 1.679,
+        borderDistanceKm: 42.3,
+        stationCount: 27,
+      );
+      expect(comparison.neighborCode, 'FR');
+      expect(comparison.neighborName, 'France');
+      expect(comparison.neighborFlag, '🇫🇷');
+      expect(comparison.neighborCurrency, '€');
+      expect(comparison.currentAvgPrice, 1.679);
+      expect(comparison.borderDistanceKm, 42.3);
+      expect(comparison.stationCount, 27);
+    });
+
+    test('is const-constructible', () {
+      // The banner widget receives this by value; const-ness keeps
+      // rebuilds stable when the surrounding widget re-runs.
+      const a = CrossBorderComparison(
+        neighborCode: 'LU',
+        neighborName: 'Luxembourg',
+        neighborFlag: '🇱🇺',
+        neighborCurrency: '€',
+        currentAvgPrice: 1.499,
+        borderDistanceKm: 12.0,
+        stationCount: 8,
+      );
+      const b = CrossBorderComparison(
+        neighborCode: 'LU',
+        neighborName: 'Luxembourg',
+        neighborFlag: '🇱🇺',
+        neighborCurrency: '€',
+        currentAvgPrice: 1.499,
+        borderDistanceKm: 12.0,
+        stationCount: 8,
+      );
+      expect(identical(a, b), isTrue);
+    });
+
+    test('supports non-euro neighbors (GBP, CHF)', () {
+      // Border regions like CH↔DE / UK↔FR must surface non-euro currencies
+      // cleanly — pin that the symbol is a pass-through string, not
+      // implicitly euro.
+      const toUk = CrossBorderComparison(
+        neighborCode: 'GB',
+        neighborName: 'United Kingdom',
+        neighborFlag: '🇬🇧',
+        neighborCurrency: '£',
+        currentAvgPrice: 1.75,
+        borderDistanceKm: 35,
+        stationCount: 14,
+      );
+      expect(toUk.neighborCurrency, '£');
+
+      const toCh = CrossBorderComparison(
+        neighborCode: 'CH',
+        neighborName: 'Switzerland',
+        neighborFlag: '🇨🇭',
+        neighborCurrency: 'CHF',
+        currentAvgPrice: 1.85,
+        borderDistanceKm: 3,
+        stationCount: 6,
+      );
+      expect(toCh.neighborCurrency, 'CHF');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- 9 tests across two previously-uncovered domain entities.
- `SavedItinerary` — pins freezed defaults (guards cloud-sync payloads), copyWith, equality, and JSON round-trip.
- `CrossBorderComparison` — pins field preservation, const-ness, and non-euro currency pass-through.

## Test plan
- [x] `flutter test test/features/itinerary/ test/features/search/domain/entities/cross_border_comparison_test.dart` — 9/9 pass
- [x] `flutter analyze` — no issues

Part of #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)