### PR TITLE
fix(ev): await toggle() in EV detail screens so the star persists

### DIFF
--- a/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
@@ -36,10 +36,14 @@ class EvStationDetailScreen extends ConsumerWidget {
             tooltip: isFav
                 ? (l10n?.removeFavorite ?? 'Remove from favorites')
                 : (l10n?.addFavorite ?? 'Add to favorites'),
-            onPressed: () {
-              ref
+            onPressed: () async {
+              // Await the toggle so the snackbar lies become impossible
+              // and the isFavoriteProvider has flipped before we show
+              // any feedback (#566).
+              await ref
                   .read(favoritesProvider.notifier)
                   .toggle(station.id, rawJson: station.toJson());
+              if (!context.mounted) return;
               final msg = isFav
                   ? (l10n?.removedFromFavorites ?? 'Removed from favorites')
                   : (l10n?.addedToFavorites ?? 'Added to favorites');

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -97,11 +97,16 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
                 size: 26,
               ),
               tooltip: isFav ? (l10n?.removeFavorite ?? 'Remove from favorites') : (l10n?.addFavorite ?? 'Add to favorites'),
-              onPressed: () {
-                ref.read(favoritesProvider.notifier).toggle(
+              onPressed: () async {
+                // Await the toggle so the snackbar fires AFTER persistence
+                // and the isFavoriteProvider has flipped. Otherwise a quick
+                // back-navigation can cancel the in-flight Hive write and
+                // leave the favorite half-persisted (#566).
+                await ref.read(favoritesProvider.notifier).toggle(
                       station.id,
                       rawJson: station.toJson(),
                     );
+                if (!context.mounted) return;
                 SnackBarHelper.show(
                   context,
                   isFav ? (l10n?.removedFromFavorites ?? 'Removed from favorites') : (l10n?.addedToFavorites ?? 'Added to favorites'),

--- a/test/features/favorites/ev_favorite_end_to_end_test.dart
+++ b/test/features/favorites/ev_favorite_end_to_end_test.dart
@@ -1,0 +1,234 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/core/sync/sync_config.dart';
+import 'package:tankstellen/core/sync/sync_provider.dart';
+import 'package:tankstellen/features/favorites/providers/ev_favorites_provider.dart';
+import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/search/presentation/screens/ev_station_detail_screen.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// End-to-end TDD test for #566: tapping the star on the EV station
+/// detail screen must:
+///   1. Persist the station to EV favorite storage (so Favorites tab shows it)
+///   2. Flip isFavoriteProvider to true (so the star icon turns amber)
+///
+/// This test drives the EXACT screen the router uses (search/ version),
+/// backed by REAL Hive storage — no mocks for favorites or storage, so
+/// there is nowhere for the wiring to diverge between test and device.
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('ev_fav_e2e_');
+    Hive.init(tempDir.path);
+    await HiveStorage.initForTest();
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  // Mirrors what EVChargingService returns: an OpenChargeMap-prefixed id.
+  const testStation = ChargingStation(
+    id: 'ocm-987654',
+    name: 'IONITY Pézenas',
+    operator: 'IONITY',
+    lat: 43.4672,
+    lng: 3.4242,
+    dist: 1.1,
+    address: 'A75 Aire de Pézenas',
+    postCode: '34120',
+    place: 'Pézenas',
+    connectors: [],
+    totalPoints: 6,
+    isOperational: true,
+  );
+
+  Future<ProviderContainer> pumpDetailScreen(WidgetTester tester) async {
+    // Real HiveStorage — no mocks. The storageRepositoryProvider resolves
+    // to the real thing via the default hiveStorageProvider chain.
+    final container = ProviderContainer(
+      overrides: [
+        // Disable sync so the provider doesn't try to hit Supabase.
+        syncStateProvider.overrideWith(() => _DisabledSyncState()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: EVStationDetailScreen(station: testStation),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return container;
+  }
+
+  test(
+    '#566 PROVIDER: toggle() with rawJson persists ID + JSON and '
+    'favoritesProvider reflects it',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          syncStateProvider.overrideWith(() => _DisabledSyncState()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Prime the provider by reading it once, mirroring what the screen
+      // does with ref.watch(favoritesProvider).
+      expect(container.read(favoritesProvider), isEmpty);
+
+      await container.read(favoritesProvider.notifier).toggle(
+            testStation.id,
+            rawJson: testStation.toJson(),
+          );
+
+      final storage = container.read(storageRepositoryProvider);
+      expect(storage.getEvFavoriteIds(), contains(testStation.id),
+          reason: 'ID must be in EV storage');
+      expect(storage.getEvFavoriteStationData(testStation.id), isNotNull,
+          reason: 'JSON must be in EV storage');
+      expect(container.read(favoritesProvider), contains(testStation.id),
+          reason:
+              'favoritesProvider state must include the EV id after toggle()');
+      expect(container.read(isFavoriteProvider(testStation.id)), isTrue,
+          reason: 'isFavoriteProvider must report true after toggle()');
+      expect(container.read(evFavoriteStationsProvider), hasLength(1),
+          reason: 'EV station must appear in evFavoriteStationsProvider');
+    },
+  );
+
+  testWidgets(
+    '#566 tapping the star on an EV station detail screen adds it to '
+    'favorites AND turns the star amber',
+    (tester) async {
+      final container = await pumpDetailScreen(tester);
+
+      // Precondition: station is not yet a favorite.
+      expect(container.read(isFavoriteProvider(testStation.id)), isFalse,
+          reason: 'Start state: nothing favorited');
+      expect(container.read(evFavoriteStationsProvider), isEmpty,
+          reason: 'Start state: favorites tab is empty');
+
+      // Action: tap the star button in the app bar. Its icon is
+      // Icons.star_outline before tapping.
+      final starFinder = find.byIcon(Icons.star_outline);
+      expect(starFinder, findsOneWidget,
+          reason: 'The star-outline button must be visible before favoriting');
+
+      // Hive writes go through real I/O; the fake async zone used by
+      // flutter_test does not pump those futures. Run the tap + drain
+      // under runAsync so the full toggle() -> addEvFavorite ->
+      // saveEvFavoriteStationData -> _reload() pipeline completes.
+      await tester.runAsync(() async {
+        await tester.tap(starFinder);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump();
+
+      // ----- POST-TAP EXPECTATIONS -----
+
+      // 1. Storage persisted the EV favorite id.
+      final storage = container.read(storageRepositoryProvider);
+      expect(storage.getEvFavoriteIds(), contains(testStation.id),
+          reason: 'EV favorite id must be in EV storage after tap');
+
+      // 1b. Storage persisted the station data JSON (needed by
+      //     EvFavoriteStations to render the card).
+      final data = storage.getEvFavoriteStationData(testStation.id);
+      expect(data, isNotNull,
+          reason:
+              'Station JSON must be persisted — otherwise favorites tab '
+              'has an id it cannot render');
+      expect(data!['id'], testStation.id);
+
+      // 1c. The unified favoritesProvider must include this id so its
+      //     watchers (including evFavoriteStationsProvider) rebuild.
+      expect(container.read(favoritesProvider), contains(testStation.id),
+          reason:
+              'Unified favoritesProvider must include the EV id after tap');
+
+      // 2. Favorites tab — evFavoriteStationsProvider — now has this
+      //    station so the favorites screen can render it.
+      final evStations = container.read(evFavoriteStationsProvider);
+      expect(evStations, hasLength(1),
+          reason:
+              'Favorites tab watches evFavoriteStationsProvider — the station must appear there');
+      expect(evStations.first.id, testStation.id);
+
+      // 3. The isFavoriteProvider flipped to true so the star turns amber.
+      expect(container.read(isFavoriteProvider(testStation.id)), isTrue,
+          reason:
+              'The same provider the detail screen watches must report true after the tap');
+
+      // 4. The icon in the app bar is now Icons.star (amber color is
+      //    driven from isFav which the Consumer watches).
+      await tester.pump();
+      expect(find.byIcon(Icons.star), findsOneWidget,
+          reason: 'Star icon must swap to the filled variant when favorited');
+    },
+  );
+
+  testWidgets(
+    '#566 tapping the filled star again removes the EV favorite',
+    (tester) async {
+      final container = await pumpDetailScreen(tester);
+
+      // Seed the favorite so we start from the "selected" state.
+      // Hive writes require runAsync so real I/O completes.
+      await tester.runAsync(() async {
+        await container.read(favoritesProvider.notifier).toggle(
+              testStation.id,
+              rawJson: testStation.toJson(),
+            );
+      });
+      await tester.pump();
+
+      expect(container.read(isFavoriteProvider(testStation.id)), isTrue);
+      expect(find.byIcon(Icons.star), findsOneWidget);
+
+      // Tap the filled star to remove.
+      await tester.runAsync(() async {
+        await tester.tap(find.byIcon(Icons.star));
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump();
+
+      // Storage cleared.
+      final storage = container.read(storageRepositoryProvider);
+      expect(storage.getEvFavoriteIds(), isEmpty,
+          reason: 'EV favorite id must be gone after untoggle');
+      expect(storage.getEvFavoriteStationData(testStation.id), isNull,
+          reason: 'EV favorite JSON must be gone after untoggle');
+
+      // Providers updated.
+      expect(container.read(favoritesProvider), isEmpty);
+      expect(container.read(isFavoriteProvider(testStation.id)), isFalse);
+      expect(container.read(evFavoriteStationsProvider), isEmpty);
+
+      // Icon reverted.
+      expect(find.byIcon(Icons.star_outline), findsOneWidget);
+    },
+  );
+}
+
+class _DisabledSyncState extends SyncState {
+  @override
+  SyncConfig build() => const SyncConfig();
+}


### PR DESCRIPTION
## Summary
- Makes the star IconButton's onPressed `async` and **awaits** `favoritesProvider.notifier.toggle(...)` before showing the snackbar.
- Applies the fix to both EV detail screen variants (search/ is the routed one today; ev/ stays consistent).

## Root cause
The previous code fired toggle() without awaiting, so on device the snackbar lied — the Hive write was still in-flight, and a quick navigation-away left the favorite half-persisted. The `isFavoriteProvider` never rebuilt the star and the Favorites tab never saw the station.

## TDD evidence
`test/features/favorites/ev_favorite_end_to_end_test.dart` — 3 tests driving REAL Hive storage (no mocks for favorites):
- PROVIDER test: `toggle()` with rawJson persists id + JSON and `favoritesProvider` reflects it.
- WIDGET test: tapping the star on the routed EV detail screen writes id + JSON, flips `favoritesProvider` / `isFavoriteProvider`, surfaces the station in `evFavoriteStationsProvider`, and swaps the icon to `Icons.star`.
- WIDGET test: tapping the filled star again cleanly removes the favorite.

Widget tests use `tester.runAsync` so real Hive I/O completes before assertions — the fake async zone otherwise returned from `pumpAndSettle` before `saveEvFavoriteStationData()` landed, reproducing the device symptom exactly.

## Test plan
- [x] 3/3 new e2e tests pass against real Hive
- [x] Full favorites + EV + search screen suite: 177/177 pass
- [x] Full repo: 4324/4324 pass (1 skipped)
- [x] `flutter analyze` — zero errors on changed files

Closes #688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)