### PR TITLE
feat(payment): unknown-QR dialog — Copy + Report actions

### DIFF
--- a/lib/features/payment/presentation/widgets/unknown_qr_dialog.dart
+++ b/lib/features/payment/presentation/widgets/unknown_qr_dialog.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../../core/constants/app_constants.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Dialog shown when a scanned QR code doesn't match any classification
+/// (not a URL, not a known payment scheme, not an EPC Girocode). Lets
+/// the user copy the raw text and share a report so the scheme catalog
+/// can grow in the next release (#725).
+class UnknownQrDialog extends StatelessWidget {
+  final String raw;
+
+  /// Clipboard side-effect, injectable for tests. When `null`, the
+  /// widget uses [Clipboard.setData] directly.
+  final Future<void> Function(String text)? clipboardWriter;
+
+  /// Share side-effect, injectable for tests. Returning normally
+  /// counts as "shared".
+  final Future<void> Function(String text, String subject)? onShare;
+
+  const UnknownQrDialog({
+    super.key,
+    required this.raw,
+    this.clipboardWriter,
+    this.onShare,
+  });
+
+  Future<void> _writeClipboard(String text) {
+    final fn = clipboardWriter;
+    if (fn != null) return fn(text);
+    return Clipboard.setData(ClipboardData(text: text));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return AlertDialog(
+      title: Text(l10n?.qrPaymentUnknownTitle ?? 'Unrecognised code'),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxHeight: 240),
+        child: SingleChildScrollView(
+          child: SelectableText(raw),
+        ),
+      ),
+      actions: [
+        TextButton.icon(
+          key: const Key('unknownQrCopy'),
+          onPressed: () async {
+            await _writeClipboard(raw);
+            if (!context.mounted) return;
+            Navigator.of(context).pop();
+            SnackBarHelper.showSuccess(
+              context,
+              l10n?.qrPaymentCopiedRaw ?? 'Copied to clipboard',
+            );
+          },
+          icon: const Icon(Icons.copy),
+          label: Text(l10n?.qrPaymentCopyRaw ?? 'Copy raw text'),
+        ),
+        TextButton.icon(
+          key: const Key('unknownQrReport'),
+          onPressed: () async {
+            final share = onShare;
+            Navigator.of(context).pop();
+            final body = _buildReportBody(raw);
+            if (share != null) {
+              await share(body, 'Tankstellen: unrecognised payment QR');
+            }
+          },
+          icon: const Icon(Icons.flag_outlined),
+          label: Text(l10n?.qrPaymentReport ?? 'Report this scan'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n?.cancel ?? 'Cancel'),
+        ),
+      ],
+    );
+  }
+
+  static String _buildReportBody(String raw) {
+    return 'Tankstellen unrecognised payment QR\n'
+        '===================================\n'
+        'App version: ${AppConstants.appVersion}\n'
+        '\n'
+        'Raw QR contents\n'
+        '---------------\n'
+        '$raw\n';
+  }
+}

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -17,8 +17,10 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
+import 'package:share_plus/share_plus.dart';
 import '../../../payment/domain/qr_payment_decoder.dart';
 import '../../../payment/presentation/scan_payment_dispatcher.dart';
+import '../../../payment/presentation/widgets/unknown_qr_dialog.dart';
 import '../../../sync/presentation/widgets/qr_scanner_screen.dart';
 import '../../providers/station_detail_provider.dart';
 import '../widgets/price_history_section.dart';
@@ -325,23 +327,15 @@ class StationDetailScreen extends ConsumerWidget {
           }
         }
       case ScanPaymentOutcome.unknown:
+        final unknown = target as QrPaymentUnknown;
         await showDialog<void>(
           context: context,
-          builder: (ctx) {
-            final unknown = target as QrPaymentUnknown;
-            return AlertDialog(
-              title: Text(
-                l10n?.qrPaymentUnknownTitle ?? 'Unrecognised code',
-              ),
-              content: SelectableText(unknown.raw),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(ctx).pop(),
-                  child: Text(l10n?.cancel ?? 'Cancel'),
-                ),
-              ],
-            );
-          },
+          builder: (ctx) => UnknownQrDialog(
+            raw: unknown.raw,
+            onShare: (text, subject) => SharePlus.instance.share(
+              ShareParams(text: text, subject: subject),
+            ),
+          ),
         );
     }
   }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -795,6 +795,8 @@
   "qrPaymentLaunchFailed": "Keine App kann diesen Code öffnen",
   "qrPaymentUnknownTitle": "Code nicht erkannt",
   "qrPaymentCopyRaw": "Rohtext kopieren",
+  "qrPaymentCopiedRaw": "In Zwischenablage kopiert",
+  "qrPaymentReport": "Scan melden",
   "qrPaymentEpcCopied": "Bankdaten kopiert — in Banking-App einfügen",
   "vehicleFuelNotSet": "Nicht gesetzt",
   "wizardVehicleTapToEdit": "Zum Bearbeiten tippen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -822,6 +822,8 @@
   "qrPaymentLaunchFailed": "No app available to open this code",
   "qrPaymentUnknownTitle": "Unrecognised code",
   "qrPaymentCopyRaw": "Copy raw text",
+  "qrPaymentCopiedRaw": "Copied to clipboard",
+  "qrPaymentReport": "Report this scan",
   "qrPaymentEpcCopied": "Bank details copied — paste into your banking app",
   "vehicleFuelNotSet": "Not set",
   "wizardVehicleTapToEdit": "Tap to edit",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -716,6 +716,8 @@
   "qrPaymentLaunchFailed": "Aucune application ne peut ouvrir ce code",
   "qrPaymentUnknownTitle": "Code non reconnu",
   "qrPaymentCopyRaw": "Copier le texte brut",
+  "qrPaymentCopiedRaw": "Copié dans le presse-papiers",
+  "qrPaymentReport": "Signaler ce scan",
   "qrPaymentEpcCopied": "Coordonnées copiées — collez dans votre app bancaire",
   "vehicleFuelNotSet": "Non défini",
   "wizardVehicleTapToEdit": "Toucher pour modifier",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3499,6 +3499,18 @@ abstract class AppLocalizations {
   /// **'Copy raw text'**
   String get qrPaymentCopyRaw;
 
+  /// No description provided for @qrPaymentCopiedRaw.
+  ///
+  /// In en, this message translates to:
+  /// **'Copied to clipboard'**
+  String get qrPaymentCopiedRaw;
+
+  /// No description provided for @qrPaymentReport.
+  ///
+  /// In en, this message translates to:
+  /// **'Report this scan'**
+  String get qrPaymentReport;
+
   /// No description provided for @qrPaymentEpcCopied.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1839,6 +1839,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1839,6 +1839,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1837,6 +1837,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1850,6 +1850,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Rohtext kopieren';
 
   @override
+  String get qrPaymentCopiedRaw => 'In Zwischenablage kopiert';
+
+  @override
+  String get qrPaymentReport => 'Scan melden';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bankdaten kopiert — in Banking-App einfügen';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1841,6 +1841,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1832,6 +1832,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1840,6 +1840,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1834,6 +1834,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1837,6 +1837,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1848,6 +1848,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copier le texte brut';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copié dans le presse-papiers';
+
+  @override
+  String get qrPaymentReport => 'Signaler ce scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Coordonnées copiées — collez dans votre app bancaire';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1836,6 +1836,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1841,6 +1841,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1840,6 +1840,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1838,6 +1838,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1840,6 +1840,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1836,6 +1836,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1841,6 +1841,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1839,6 +1839,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1840,6 +1840,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1839,6 +1839,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1840,6 +1840,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1834,6 +1834,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1838,6 +1838,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get qrPaymentCopyRaw => 'Copy raw text';
 
   @override
+  String get qrPaymentCopiedRaw => 'Copied to clipboard';
+
+  @override
+  String get qrPaymentReport => 'Report this scan';
+
+  @override
   String get qrPaymentEpcCopied =>
       'Bank details copied — paste into your banking app';
 

--- a/test/features/payment/presentation/widgets/unknown_qr_dialog_test.dart
+++ b/test/features/payment/presentation/widgets/unknown_qr_dialog_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/payment/presentation/widgets/unknown_qr_dialog.dart';
+
+void main() {
+  group('UnknownQrDialog (#725)', () {
+    testWidgets('renders the raw text verbatim', (tester) async {
+      await _pump(tester, raw: 'weird://gibberish/xyz?a=1&b=2');
+      expect(find.text('weird://gibberish/xyz?a=1&b=2'), findsOneWidget);
+    });
+
+    testWidgets('Copy button writes raw to clipboard and pops dialog',
+        (tester) async {
+      final writes = <String>[];
+      await _pump(
+        tester,
+        raw: 'weird-raw',
+        clipboardWriter: (text) async => writes.add(text),
+      );
+      await tester.tap(find.byKey(const Key('unknownQrCopy')));
+      await tester.pumpAndSettle();
+      expect(writes.single, 'weird-raw');
+      expect(find.byType(UnknownQrDialog), findsNothing);
+    });
+
+    testWidgets('Report button calls onShare with a report body including the raw text',
+        (tester) async {
+      String? capturedText;
+      String? capturedSubject;
+      await _pump(
+        tester,
+        raw: 'mystery://pay/abc',
+        onShare: (text, subject) async {
+          capturedText = text;
+          capturedSubject = subject;
+        },
+      );
+      await tester.tap(find.byKey(const Key('unknownQrReport')));
+      await tester.pumpAndSettle();
+      expect(capturedText, contains('mystery://pay/abc'));
+      expect(capturedText, contains('App version:'));
+      expect(capturedSubject, contains('unrecognised payment QR'));
+      expect(find.byType(UnknownQrDialog), findsNothing);
+    });
+
+    testWidgets('Cancel button pops without any side effects',
+        (tester) async {
+      final writes = <String>[];
+      var shareCalled = false;
+      await _pump(
+        tester,
+        raw: 'x',
+        clipboardWriter: (t) async => writes.add(t),
+        onShare: (_, _) async => shareCalled = true,
+      );
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(writes, isEmpty);
+      expect(shareCalled, isFalse);
+      expect(find.byType(UnknownQrDialog), findsNothing);
+    });
+  });
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required String raw,
+  Future<void> Function(String text)? clipboardWriter,
+  Future<void> Function(String text, String subject)? onShare,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (ctx) => Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () => showDialog<void>(
+                context: ctx,
+                builder: (_) => UnknownQrDialog(
+                  raw: raw,
+                  clipboardWriter: clipboardWriter,
+                  onShare: onShare,
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
## Summary
Unknown QR codes previously showed raw text in a SelectableText with only a Cancel button. New \`UnknownQrDialog\` offers three actions: Copy to clipboard, Report this scan (share_plus with pre-filled body + app version), Cancel.

## Test plan
- [x] 4 new widget tests covering render / copy / report / cancel
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` passes

Closes #725