### PR TITLE
fix(security): HTTPS for Argentina data feed + cross-service scan

### DIFF
--- a/lib/core/services/impl/argentina_station_service.dart
+++ b/lib/core/services/impl/argentina_station_service.dart
@@ -18,8 +18,12 @@ import '../utils/csv_parser.dart';
 /// Free, no API key. CSV with station-level prices + coordinates.
 /// Prices in ARS (Argentine Peso).
 class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin implements StationService {
+  // #728 — HTTPS only. The Secretaría de Energía CDN serves the same
+  // resource under TLS, so there's no reason to fetch the open-data
+  // CSV in clear text (MITM could inject malicious rows, and the
+  // integrity check downstream only catches the header schema).
   static const _csvUrl =
-      'http://datos.energia.gob.ar/dataset/'
+      'https://datos.energia.gob.ar/dataset/'
       '1c181390-5045-475e-94dc-410429be4b17/resource/'
       '80ac25de-a44a-4445-9215-090cf55cfda5/download/'
       'precios-en-surtidor-resolucin-3142016.csv';

--- a/test/security/no_plaintext_station_endpoints_test.dart
+++ b/test/security/no_plaintext_station_endpoints_test.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression guard — every country StationService implementation
+/// must use HTTPS for its upstream data feed. Plaintext feeds let an
+/// on-path attacker inject malicious price/station rows (CSV with
+/// bogus coordinates, XML with redirects, etc.); the integrity check
+/// on our side only validates header schemas, not content (#728).
+///
+/// This scans the lib/core/services/impl/ directory, reading each
+/// file and failing if any URL-shaped string literal uses the `http:`
+/// scheme. Tolerated: `http://schemas.*`, `http://www.w3.org/*`, and
+/// similar XML/schema namespace URIs that aren't fetched at runtime.
+void main() {
+  test('every StationService uses HTTPS for its upstream feed (#728)', () {
+    final dir = Directory('lib/core/services/impl');
+    final files = dir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('_station_service.dart'))
+        .toList();
+    expect(files, isNotEmpty,
+        reason: 'no station services found — wrong working directory?');
+
+    final offenders = <String>[];
+    // Match any http:// URL inside a string literal (either quote style).
+    final plainUrlRe = RegExp(
+      "'http://[^']+'" '|' '"http://[^"]+"',
+      caseSensitive: false,
+    );
+    final allowlistRe = RegExp(
+        r'schemas?\.|w3\.org|xmlns|dtd|xsl',
+        caseSensitive: false);
+
+    for (final file in files) {
+      final lines = file.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        final match = plainUrlRe.firstMatch(lines[i]);
+        if (match == null) continue;
+        final url = match.group(0)!;
+        if (allowlistRe.hasMatch(url)) continue;
+        offenders.add('${file.path}:${i + 1}: $url');
+      }
+    }
+    expect(offenders, isEmpty,
+        reason:
+            'Plaintext HTTP URLs in station services:\n${offenders.join('\n')}');
+  });
+}


### PR DESCRIPTION
## Summary
Argentina station service was fetching open-data CSV over plain HTTP. Same resource available under TLS on the same CDN. Switching to HTTPS + adding a regression test that fails on any http:// URL inside a \`*_station_service.dart\` string literal.

Scope: HTTPS fix only — the EV API-key provider move from #728 is a separate concern shipped later.

## Test plan
- [x] \`flutter test test/security/no_plaintext_station_endpoints_test.dart\` — passes
- [x] \`flutter analyze\` clean
- [ ] CI

Partial progress on #728 (HTTPS half).