### PR TITLE
refactor(ev): EVChargingService via keepAlive provider

### DIFF
--- a/lib/features/route_search/providers/route_search_provider.dart
+++ b/lib/features/route_search/providers/route_search_provider.dart
@@ -6,11 +6,10 @@ import '../../../core/error/exceptions.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/station_service.dart';
-import '../../../core/storage/storage_providers.dart';
 import '../../../core/country/country_provider.dart';
 import '../../../core/utils/station_extensions.dart';
 import '../../search/data/models/search_params.dart';
-import '../../search/data/services/ev_charging_service.dart';
+import '../../search/providers/ev_charging_service_provider.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/search_result_item.dart';
 import '../../profile/providers/profile_provider.dart';
@@ -206,15 +205,13 @@ class RouteSearchState extends _$RouteSearchState {
     RouteInfo route,
     double radiusKm,
   ) async {
-    final storage = ref.read(storageRepositoryProvider);
-    final apiKey = storage.getEvApiKey();
-    if (apiKey == null || apiKey.isEmpty) {
+    final service = ref.read(evChargingServiceProvider);
+    if (service == null) {
       throw const ApiException(message: 'OpenChargeMap API key required');
     }
 
     final geocoding = ref.read(geocodingChainProvider);
     final fallbackCountry = ref.read(activeCountryProvider).code;
-    final service = EVChargingService(apiKey: apiKey);
     final seen = <String>{};
     final results = <SearchResultItem>[];
 

--- a/lib/features/route_search/providers/route_search_provider.g.dart
+++ b/lib/features/route_search/providers/route_search_provider.g.dart
@@ -59,7 +59,7 @@ final class RouteSearchStateProvider
   }
 }
 
-String _$routeSearchStateHash() => r'7bd3d00bd3537007d901467b67b2fb8b99a12c18';
+String _$routeSearchStateHash() => r'23a677ec2692a63c3b087e4a9d9927b28f0d0afa';
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -8,9 +8,9 @@ import '../../../../core/widgets/star_rating.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../favorites/providers/favorites_provider.dart';
-import '../../data/services/ev_charging_service.dart';
 import '../../domain/entities/charging_station.dart';
 import '../../domain/entities/fuel_type.dart';
+import '../../providers/ev_charging_service_provider.dart';
 import '../../providers/station_rating_provider.dart';
 import '../widgets/ev_station_header_card.dart';
 import '../widgets/ev_station_info_cards.dart';
@@ -38,15 +38,13 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
   Future<void> _refreshStation() async {
     setState(() => _isRefreshing = true);
     try {
-      final apiKeys = ref.read(apiKeyStorageProvider);
-      final apiKey = apiKeys.getEvApiKey();
-      if (apiKey == null || apiKey.isEmpty) {
+      final service = ref.read(evChargingServiceProvider);
+      if (service == null) {
         if (mounted) {
           setState(() => _isRefreshing = false);
         }
         return;
       }
-      final service = EVChargingService(apiKey: apiKey);
       final result = await service.searchStations(
         lat: _station.lat,
         lng: _station.lng,

--- a/lib/features/search/providers/ev_charging_service_provider.dart
+++ b/lib/features/search/providers/ev_charging_service_provider.dart
@@ -1,0 +1,31 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/storage/storage_providers.dart';
+import '../data/services/ev_charging_service.dart';
+
+part 'ev_charging_service_provider.g.dart';
+
+/// Exposes an [EVChargingService] instance bound to the user's
+/// OpenChargeMap API key (#728 part 2).
+///
+/// Previously each caller — `EVSearchState`, `RouteSearchProvider`,
+/// `EVStationDetailScreen._refreshStation` — constructed its own
+/// service inline, each time resolving the key from Hive and creating
+/// a fresh Dio. That meant a hot UI path (build / setState) touched
+/// secure storage and spun up a new HTTP client on every call, with
+/// no request coalescing across the three call sites.
+///
+/// This provider:
+/// * reads the EV API key from [apiKeyStorageProvider];
+/// * returns `null` when no key is set (callers surface the
+///   "configure your key" empty-state instead of throwing);
+/// * uses `keepAlive` so the service survives screen rebuilds and
+///   any cache / coalescing the service adds in the future applies
+///   across the whole app.
+@Riverpod(keepAlive: true)
+EVChargingService? evChargingService(Ref ref) {
+  final storage = ref.watch(apiKeyStorageProvider);
+  final apiKey = storage.getEvApiKey();
+  if (apiKey == null || apiKey.isEmpty) return null;
+  return EVChargingService(apiKey: apiKey);
+}

--- a/lib/features/search/providers/ev_charging_service_provider.g.dart
+++ b/lib/features/search/providers/ev_charging_service_provider.g.dart
@@ -1,0 +1,109 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ev_charging_service_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Exposes an [EVChargingService] instance bound to the user's
+/// OpenChargeMap API key (#728 part 2).
+///
+/// Previously each caller — `EVSearchState`, `RouteSearchProvider`,
+/// `EVStationDetailScreen._refreshStation` — constructed its own
+/// service inline, each time resolving the key from Hive and creating
+/// a fresh Dio. That meant a hot UI path (build / setState) touched
+/// secure storage and spun up a new HTTP client on every call, with
+/// no request coalescing across the three call sites.
+///
+/// This provider:
+/// * reads the EV API key from [apiKeyStorageProvider];
+/// * returns `null` when no key is set (callers surface the
+///   "configure your key" empty-state instead of throwing);
+/// * uses `keepAlive` so the service survives screen rebuilds and
+///   any cache / coalescing the service adds in the future applies
+///   across the whole app.
+
+@ProviderFor(evChargingService)
+final evChargingServiceProvider = EvChargingServiceProvider._();
+
+/// Exposes an [EVChargingService] instance bound to the user's
+/// OpenChargeMap API key (#728 part 2).
+///
+/// Previously each caller — `EVSearchState`, `RouteSearchProvider`,
+/// `EVStationDetailScreen._refreshStation` — constructed its own
+/// service inline, each time resolving the key from Hive and creating
+/// a fresh Dio. That meant a hot UI path (build / setState) touched
+/// secure storage and spun up a new HTTP client on every call, with
+/// no request coalescing across the three call sites.
+///
+/// This provider:
+/// * reads the EV API key from [apiKeyStorageProvider];
+/// * returns `null` when no key is set (callers surface the
+///   "configure your key" empty-state instead of throwing);
+/// * uses `keepAlive` so the service survives screen rebuilds and
+///   any cache / coalescing the service adds in the future applies
+///   across the whole app.
+
+final class EvChargingServiceProvider
+    extends
+        $FunctionalProvider<
+          EVChargingService?,
+          EVChargingService?,
+          EVChargingService?
+        >
+    with $Provider<EVChargingService?> {
+  /// Exposes an [EVChargingService] instance bound to the user's
+  /// OpenChargeMap API key (#728 part 2).
+  ///
+  /// Previously each caller — `EVSearchState`, `RouteSearchProvider`,
+  /// `EVStationDetailScreen._refreshStation` — constructed its own
+  /// service inline, each time resolving the key from Hive and creating
+  /// a fresh Dio. That meant a hot UI path (build / setState) touched
+  /// secure storage and spun up a new HTTP client on every call, with
+  /// no request coalescing across the three call sites.
+  ///
+  /// This provider:
+  /// * reads the EV API key from [apiKeyStorageProvider];
+  /// * returns `null` when no key is set (callers surface the
+  ///   "configure your key" empty-state instead of throwing);
+  /// * uses `keepAlive` so the service survives screen rebuilds and
+  ///   any cache / coalescing the service adds in the future applies
+  ///   across the whole app.
+  EvChargingServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'evChargingServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$evChargingServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<EVChargingService?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EVChargingService? create(Ref ref) {
+    return evChargingService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EVChargingService? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EVChargingService?>(value),
+    );
+  }
+}
+
+String _$evChargingServiceHash() => r'0e2375042bf9c47db0e5f60c0cb9d7e1bb37816b';

--- a/lib/features/search/providers/ev_search_provider.dart
+++ b/lib/features/search/providers/ev_search_provider.dart
@@ -3,10 +3,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/error/exceptions.dart';
 import '../../../core/services/service_result.dart';
-import '../../../core/storage/storage_providers.dart';
 import '../../../core/country/country_provider.dart';
-import '../data/services/ev_charging_service.dart';
 import '../domain/entities/charging_station.dart';
+import 'ev_charging_service_provider.dart';
 
 part 'ev_search_provider.g.dart';
 
@@ -33,14 +32,12 @@ class EVSearchState extends _$EVSearchState {
   }) async {
     state = const AsyncValue.loading();
     try {
-      final storage = ref.read(storageRepositoryProvider);
-      final apiKey = storage.getEvApiKey();
-      if (apiKey == null || apiKey.isEmpty) {
+      final service = ref.read(evChargingServiceProvider);
+      if (service == null) {
         throw const NoEvApiKeyException();
       }
 
       final country = ref.read(activeCountryProvider);
-      final service = EVChargingService(apiKey: apiKey);
       final result = await service.searchStations(
         lat: lat,
         lng: lng,

--- a/lib/features/search/providers/ev_search_provider.g.dart
+++ b/lib/features/search/providers/ev_search_provider.g.dart
@@ -65,7 +65,7 @@ final class EVSearchStateProvider
   }
 }
 
-String _$eVSearchStateHash() => r'1abeea9a16e07862249256998f86d58164047cba';
+String _$eVSearchStateHash() => r'b09eeb0ead926b23a5e29b8906387d180563a910';
 
 /// Manages EV charging station search, parallel to [SearchState] for fuel.
 ///

--- a/test/features/search/providers/ev_charging_service_provider_test.dart
+++ b/test/features/search/providers/ev_charging_service_provider_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/search/providers/ev_charging_service_provider.dart';
+
+void main() {
+  group('evChargingServiceProvider (#728 part 2)', () {
+    test('returns null when no EV API key is configured', () {
+      final container = ProviderContainer(overrides: [
+        apiKeyStorageProvider.overrideWith((_) => _FakeApiKeyStorage(null)),
+      ]);
+      addTearDown(container.dispose);
+
+      expect(container.read(evChargingServiceProvider), isNull);
+    });
+
+    test('returns null when the key string is empty', () {
+      final container = ProviderContainer(overrides: [
+        apiKeyStorageProvider.overrideWith((_) => _FakeApiKeyStorage('')),
+      ]);
+      addTearDown(container.dispose);
+
+      expect(container.read(evChargingServiceProvider), isNull);
+    });
+
+    test('returns an EVChargingService when a key is set', () {
+      final container = ProviderContainer(overrides: [
+        apiKeyStorageProvider.overrideWith(
+            (_) => _FakeApiKeyStorage('ocm-live-key')),
+      ]);
+      addTearDown(container.dispose);
+
+      final service = container.read(evChargingServiceProvider);
+      expect(service, isNotNull);
+      expect(service!.apiKey, 'ocm-live-key');
+    });
+
+    test('same reference returned on repeat reads (keepAlive)', () {
+      final container = ProviderContainer(overrides: [
+        apiKeyStorageProvider.overrideWith(
+            (_) => _FakeApiKeyStorage('ocm-live-key')),
+      ]);
+      addTearDown(container.dispose);
+
+      final a = container.read(evChargingServiceProvider);
+      final b = container.read(evChargingServiceProvider);
+      expect(identical(a, b), isTrue,
+          reason: 'keepAlive should cache the constructed service');
+    });
+  });
+}
+
+class _FakeApiKeyStorage implements ApiKeyStorage {
+  final String? _evKey;
+  _FakeApiKeyStorage(this._evKey);
+
+  @override
+  String? getEvApiKey() => _evKey;
+
+  @override
+  bool hasEvApiKey() => _evKey != null && _evKey.isNotEmpty;
+
+  @override
+  Future<void> setEvApiKey(String key) async {}
+
+  @override
+  Future<void> deleteEvApiKey() async {}
+
+  @override
+  String? getApiKey() => null;
+  @override
+  bool hasApiKey() => false;
+  @override
+  bool hasCustomApiKey() => false;
+  @override
+  bool hasCustomEvApiKey() => false;
+  @override
+  Future<void> setApiKey(String key) async {}
+  @override
+  Future<void> deleteApiKey() async {}
+  @override
+  String? getSupabaseAnonKey() => null;
+  @override
+  Future<void> setSupabaseAnonKey(String key) async {}
+  @override
+  Future<void> deleteSupabaseAnonKey() async {}
+}

--- a/test/features/search/providers/ev_charging_service_provider_test.dart
+++ b/test/features/search/providers/ev_charging_service_provider_test.dart
@@ -65,9 +65,6 @@ class _FakeApiKeyStorage implements ApiKeyStorage {
   Future<void> setEvApiKey(String key) async {}
 
   @override
-  Future<void> deleteEvApiKey() async {}
-
-  @override
   String? getApiKey() => null;
   @override
   bool hasApiKey() => false;


### PR DESCRIPTION
## Summary
Three call sites were each constructing \`EVChargingService\` inline (EVSearchState / RouteSearchProvider / EVStationDetailScreen._refreshStation), spinning up a fresh Dio + re-reading the OCM key on every call. Detail-screen call ran inside setState, putting secure-storage reads on the UI hot path.

New \`evChargingServiceProvider\` (keepAlive) returns an \`EVChargingService?\`, null when no key is set. Callers null-check and surface the configure-key empty state.

## Test plan
- [x] 4 new provider unit tests (null / empty / constructed / keepAlive identity)
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4599 green

Closes #728