### PR TITLE
chore(release): bump build number to +5065

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 11 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 5.0.0+5064
+version: 5.0.0+5065
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
Release bump for Samsung test build. Includes: #729 ARB parity, #730 unknown-QR actions, #731 Argentina HTTPS, #732 EV key provider, #733 step 1 adapter registry, #734 OBD2 scaffolding, #735 QR scanner torch + guidance, #737 dead payment-chip fix.