### PR TITLE
fix(receipt): accept ℓ (U+2113) as litre unit on French receipts

### DIFF
--- a/lib/features/consumption/data/receipt_parser.dart
+++ b/lib/features/consumption/data/receipt_parser.dart
@@ -280,8 +280,14 @@ class ReceiptParser {
   /// "20.00" from "TVA 20.00 %" or year fragments from a date).
   double? _extractLiters(String text) {
     final patterns = [
-      // "42.35 L" / "42,35 l" / "5.24L" / "42.35 litres"
-      RegExp(r'(\d{1,3}[.,]\d{1,3})\s*(?:l(?:itres?)?|L)\b'),
+      // "42.35 L" / "42,35 l" / "5.24L" / "42.35 litres" / "5.24 ℓ".
+      // The U+2113 script `ℓ` symbol is what French thermal printers
+      // use for the litre unit — ML Kit OCR passes it through verbatim
+      // and Latin-only [lL] silently misses it (user report 2026-04-20
+      // on a Super U Pomerols receipt). The \b anchor is dropped for
+      // ℓ because Dart regex treats the character as non-word, so the
+      // original word boundary never held anyway.
+      RegExp(r'(\d{1,3}[.,]\d{1,3})\s*(?:l(?:itres?)?\b|L\b|\u2113)'),
       // "VOLUME : 42.35" / "Volume: 42,35" / "Quantité = 5.27"
       RegExp(
         r'(?:volume|quantit[eé])\s*[:=]?\s*(\d{1,3}[.,]\d{1,3})',
@@ -346,13 +352,14 @@ class ReceiptParser {
   /// "PRIX/L 1.899", "Prix unit. = 2,028 EUR", "Literpreis: 1.799".
   double? _extractPricePerLiter(String text) {
     return _matchFirst(text, [
-      // "1.899 €/L" or "1,899 EUR/L"
-      RegExp(r'(\d+[.,]\d{2,3})\s*(?:€|EUR)\s*/\s*[lL]'),
-      // "€ 1.999/L" or "EUR 1,999/L" — currency before number
-      RegExp(r'(?:€|EUR)\s*(\d+[.,]\d{2,3})\s*/\s*[lL]'),
-      // Labels: PRIX/L, PU, Preis/L, Literpreis, Prix unit(.), Preis je Liter
+      // "1.899 €/L" or "1,899 EUR/L" — also "1.999 €/ℓ" (U+2113).
+      RegExp(r'(\d+[.,]\d{2,3})\s*(?:€|EUR)\s*/\s*[lL\u2113]'),
+      // "€ 1.999/L" or "EUR 1,999/L" / "€ 1.999/ℓ" — currency before number.
+      RegExp(r'(?:€|EUR)\s*(\d+[.,]\d{2,3})\s*/\s*[lL\u2113]'),
+      // Labels: PRIX/L, PU, Preis/L, Literpreis, Prix unit(.), Preis je Liter.
+      // Also accepts `ℓ` in place of `l` in the slash-L forms.
       RegExp(
-        r'(?:prix\s*/\s*l|prix\s*unit\.?|pu|preis\s*/\s*l|'
+        r'(?:prix\s*/\s*[l\u2113]|prix\s*unit\.?|pu|preis\s*/\s*[l\u2113]|'
         r'preis\s*je\s*liter|literpreis)'
         r'\s*[:=]?\s*€?\s*(\d+[.,]\d{2,3})',
         caseSensitive: false,

--- a/test/features/consumption/data/receipt_parser_test.dart
+++ b/test/features/consumption/data/receipt_parser_test.dart
@@ -294,6 +294,41 @@ Prix € 1.999/L
         final result = parser.parse('TVA 20.00 % 1.74 EUR\nVolume 5.24 L');
         expect(result.liters, closeTo(5.24, 0.01));
       });
+
+      // User report 2026-04-20: Super U Pomerols receipt came back with
+      // liters empty even though the paper clearly showed "Volume 5.24 ℓ".
+      // French receipts use the typography U+2113 (ℓ, "script small l")
+      // for the unit symbol, and ML Kit OCR passes it through verbatim.
+      // Our regex only accepted Latin l/L, so Volume extraction — and
+      // the price-per-liter-based reconcile fallback — both silently
+      // returned null.
+      test('accepts the typographic ℓ (U+2113) as the litre unit symbol',
+          () {
+        final result = parser.parse('SP95-E10 5.24 ℓ');
+        expect(result.liters, closeTo(5.24, 0.01));
+      });
+
+      test('Super U receipt with ℓ extracts liters, not null (regression)',
+          () {
+        const receipt = '''
+SUPER U
+CHEMIN DU PORTROU
+34810 POMEROLS
+QUITTANCE COPIE
+Date 19-04-2026 15:19:27
+* Pompe 3      SP95-E10
+  Volume         5.24 ℓ
+  Prix     € 1.999/ℓ
+  TOT TTC  € 10.47
+* TVA 20.00 %    € 1.74
+  Net            € 8.73
+''';
+        final result = parser.parse(receipt);
+        expect(result.liters, closeTo(5.24, 0.01));
+        expect(result.totalCost, closeTo(10.47, 0.01));
+        expect(result.pricePerLiter, closeTo(1.999, 0.001));
+        expect(result.brandLayout, 'super_u');
+      });
     });
 
     group('brand layout dispatch', () {


### PR DESCRIPTION
## Bug
User scanned a Super U Pomerols receipt; the Liters field came back empty even though the paper clearly showed \"Volume 5.24 ℓ\". Cost (10.47) and price-per-litre regexes both failed the same way — the symbol on French thermal printers is U+2113 \"script small l\" (ℓ), not Latin l/L. ML Kit OCR passes it through verbatim; our regex only matched \`[lL]\`, so both \`Volume 5.24 ℓ\` and \`€ 1.999/ℓ\` silently returned null and the reconcile fallback couldn't derive liters either.

## Fix
- Extend both \`_extractLiters\` and \`_extractPricePerLiter\` character classes to \`[lL\u2113]\`.
- Drop the \`\b\` boundary when ℓ is the candidate (it's non-word in Dart regex, so the boundary never held anyway).

## Why tests missed it
Every fixture used ASCII \`L\` because they were hand-typed, not harvested from real OCR output. ℓ and L look nearly identical in proportional fonts.

## Test plan
- [x] Two new tests under 'liter extraction robustness' — minimal \`5.24 ℓ\` and full Super U receipt body verbatim
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4611 passing