### PR TITLE
feat(obd2): Obd2ConnectionService — scan + connect with typed errors

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_facade.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import 'adapter_registry.dart';
+import 'elm_byte_channel.dart';
+import 'flutter_blue_plus_elm_channel.dart';
+
+/// Thin façade over flutter_blue_plus for the connection service
+/// (#741). Keeps the plugin API pinned to a small surface we can
+/// fake in tests — the connection service only ever talks to this
+/// interface, never to `FlutterBluePlus` directly. Rebinding to a
+/// different BLE backend (e.g. flutter_reactive_ble or a desktop
+/// serial shim) is a matter of swapping the implementation.
+abstract class BluetoothFacade {
+  /// Emit scan results for devices advertising any of [serviceUuids].
+  /// The stream continues until [stopScan] is called. Each emitted
+  /// list contains the accumulated candidates so far, not just the
+  /// delta, so the UI can render "found N adapters" without
+  /// accumulating separately.
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout,
+  });
+
+  Future<void> stopScan();
+
+  /// Open a byte channel to the device identified by [deviceId] using
+  /// the given [profile] UUIDs. The returned channel is un-opened;
+  /// the transport layer calls `open()` to run the GATT dance.
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile);
+}
+
+/// Production façade — the only place in the codebase that directly
+/// imports `flutter_blue_plus` for the OBD2 flow (apart from the
+/// existing `FlutterBluePlusElmChannel`).
+class PluginBluetoothFacade implements BluetoothFacade {
+  const PluginBluetoothFacade();
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) {
+    final controller = StreamController<List<Obd2AdapterCandidate>>();
+    final accumulated = <String, Obd2AdapterCandidate>{};
+
+    // Start the real plugin scan.
+    FlutterBluePlus.startScan(
+      withServices: serviceUuids.map(Guid.new).toList(),
+      timeout: timeout,
+    );
+
+    final sub = FlutterBluePlus.scanResults.listen(
+      (results) {
+        for (final r in results) {
+          final candidate = Obd2AdapterCandidate(
+            deviceId: r.device.remoteId.str,
+            deviceName: r.advertisementData.advName.isEmpty
+                ? r.device.platformName
+                : r.advertisementData.advName,
+            advertisedServiceUuids:
+                r.advertisementData.serviceUuids.map((g) => g.str).toList(),
+            rssi: r.rssi,
+          );
+          accumulated[candidate.deviceId] = candidate;
+        }
+        controller.add(accumulated.values.toList());
+      },
+      onError: controller.addError,
+    );
+
+    // Clean up when the caller cancels or the timeout elapses.
+    controller.onCancel = () async {
+      await sub.cancel();
+      await FlutterBluePlus.stopScan();
+    };
+    Timer(timeout, () async {
+      await FlutterBluePlus.stopScan();
+      await controller.close();
+    });
+
+    return controller.stream;
+  }
+
+  @override
+  Future<void> stopScan() => FlutterBluePlus.stopScan();
+
+  @override
+  ElmByteChannel channelFor(
+    String deviceId,
+    Obd2AdapterProfile profile,
+  ) {
+    final device = BluetoothDevice.fromId(deviceId);
+    return FlutterBluePlusElmChannel(
+      device,
+      uuids: Elm327BleUuids(
+        service: Guid(profile.serviceUuid),
+        writeChar: Guid(profile.writeCharUuid),
+        notifyChar: Guid(profile.notifyCharUuid),
+      ),
+    );
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_connection_errors.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_errors.dart
@@ -1,0 +1,48 @@
+/// Typed errors for the OBD2 connection flow (#741).
+///
+/// Replaces the former catch-all `Exception('OBD-II error: …')` so the
+/// UI can render an actionable message for each failure mode. Each
+/// type carries a terse message meant to slot into a localised
+/// snackbar via the existing `l10n` keys (added alongside #742).
+sealed class Obd2ConnectionError implements Exception {
+  final String message;
+  const Obd2ConnectionError(this.message);
+
+  @override
+  String toString() => '$runtimeType: $message';
+}
+
+/// User refused to grant BLUETOOTH_SCAN / BLUETOOTH_CONNECT on
+/// Android 12+, or location on older targets. The UI should offer a
+/// "grant" button and — on `permanentlyDenied` — deep-link into
+/// system settings.
+class Obd2PermissionDenied extends Obd2ConnectionError {
+  const Obd2PermissionDenied([super.message = 'Bluetooth permission denied']);
+}
+
+/// The scan window expired without any known adapter responding.
+/// Usually means the vLinker is off, out of range, or the wrong
+/// service UUID for its firmware variant.
+class Obd2ScanTimeout extends Obd2ConnectionError {
+  const Obd2ScanTimeout(
+      [super.message = 'No OBD2 adapter found in range']);
+}
+
+/// BLE GATT connection succeeded but the ELM327 init sequence
+/// (ATZ → ATE0 → ATSP0 → …) never completed. The adapter is
+/// paired at the OS level but unresponsive — usually because the
+/// vehicle ignition is off or the chip is in a bad state.
+class Obd2AdapterUnresponsive extends Obd2ConnectionError {
+  const Obd2AdapterUnresponsive([
+    super.message = 'Adapter did not answer — turn the ignition on and retry',
+  ]);
+}
+
+/// ATZ returned something unrecognisable. Most often this is a
+/// counterfeit ELM327 clone whose firmware lies about its
+/// capability string. The app keeps the channel open but surfaces
+/// the raw string for debugging.
+class Obd2ProtocolInitFailed extends Obd2ConnectionError {
+  const Obd2ProtocolInitFailed(String rawResponse)
+      : super('Adapter returned unexpected init string: $rawResponse');
+}

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'adapter_registry.dart';
+import 'bluetooth_facade.dart';
+import 'bluetooth_obd2_transport.dart';
+import 'obd2_connection_errors.dart';
+import 'obd2_permissions.dart';
+import 'obd2_service.dart';
+
+part 'obd2_connection_service.g.dart';
+
+/// Binds scan results to the adapter registry and hands back a ready
+/// [Obd2Service] on connect (#741).
+///
+/// Intentionally platform-free: every plugin interaction goes through
+/// the [BluetoothFacade] seam and every permission call through
+/// [Obd2Permissions]. Tests inject fakes for both and drive the full
+/// happy + error paths without a Bluetooth stack.
+class Obd2ConnectionService {
+  final Obd2AdapterRegistry registry;
+  final Obd2Permissions permissions;
+  final BluetoothFacade bluetooth;
+
+  /// Cached ranked candidates from the most recent scan. Consumed by
+  /// [reconnectLast] when the caller wants to rehydrate the highest-
+  /// RSSI adapter without opening the picker again.
+  List<ResolvedObd2Candidate> _lastRanked = const [];
+
+  Obd2ConnectionService({
+    required this.registry,
+    required this.permissions,
+    required this.bluetooth,
+  });
+
+  /// Stream of ranked, profile-matched candidates for the picker UI.
+  /// Emits the accumulated list on every scan-results change.
+  /// Throws [Obd2PermissionDenied] when the runtime permission grant
+  /// is missing, [Obd2ScanTimeout] when the scan window elapses with
+  /// zero known adapters seen.
+  Stream<List<ResolvedObd2Candidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    final state = await permissions.request();
+    if (state != Obd2PermissionState.granted) {
+      throw const Obd2PermissionDenied();
+    }
+
+    var sawAny = false;
+    final stream = bluetooth.scan(
+      serviceUuids: registry.allServiceUuids,
+      timeout: timeout,
+    );
+    await for (final batch in stream) {
+      final ranked = registry.rank(batch);
+      if (ranked.isNotEmpty) sawAny = true;
+      _lastRanked = ranked;
+      yield ranked;
+    }
+    if (!sawAny) {
+      throw const Obd2ScanTimeout();
+    }
+  }
+
+  /// Connect to the specific [candidate]. Opens the BLE channel, runs
+  /// the ELM327 init sequence via [Obd2Service.connect], returns the
+  /// ready service. Surfaces [Obd2AdapterUnresponsive] when the init
+  /// fails (channel is closed before the error is rethrown).
+  Future<Obd2Service> connect(ResolvedObd2Candidate candidate) async {
+    final channel =
+        bluetooth.channelFor(candidate.candidate.deviceId, candidate.profile);
+    final transport = BluetoothObd2Transport(channel);
+    final service = Obd2Service(transport);
+    final ok = await service.connect();
+    if (!ok) {
+      await service.disconnect();
+      throw const Obd2AdapterUnresponsive();
+    }
+    return service;
+  }
+
+  /// Convenience entry point — picks the highest-RSSI candidate from
+  /// the last scan batch and connects. Returns null when no usable
+  /// candidate is cached (e.g. the user hasn't scanned yet this
+  /// session). Useful for the "first in-car test" flow that skips
+  /// the picker UI (#742).
+  Future<Obd2Service?> connectBest() async {
+    if (_lastRanked.isEmpty) return null;
+    try {
+      return await connect(_lastRanked.first);
+    } on Obd2ConnectionError catch (e) {
+      debugPrint('Obd2ConnectionService.connectBest failed: $e');
+      rethrow;
+    }
+  }
+}
+
+@Riverpod(keepAlive: true)
+Obd2ConnectionService obd2Connection(Ref ref) {
+  return Obd2ConnectionService(
+    registry: Obd2AdapterRegistry.defaults(),
+    permissions: ref.watch(obd2PermissionsProvider),
+    bluetooth: const PluginBluetoothFacade(),
+  );
+}

--- a/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
@@ -1,0 +1,57 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'obd2_connection_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(obd2Connection)
+final obd2ConnectionProvider = Obd2ConnectionProvider._();
+
+final class Obd2ConnectionProvider
+    extends
+        $FunctionalProvider<
+          Obd2ConnectionService,
+          Obd2ConnectionService,
+          Obd2ConnectionService
+        >
+    with $Provider<Obd2ConnectionService> {
+  Obd2ConnectionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'obd2ConnectionProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$obd2ConnectionHash();
+
+  @$internal
+  @override
+  $ProviderElement<Obd2ConnectionService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  Obd2ConnectionService create(Ref ref) {
+    return obd2Connection(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Obd2ConnectionService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Obd2ConnectionService>(value),
+    );
+  }
+}
+
+String _$obd2ConnectionHash() => r'25e66e13f6e8da5e47638fb23797e10feecc8985';

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -1,0 +1,249 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+
+void main() {
+  final registry = Obd2AdapterRegistry.defaults();
+
+  group('Obd2ConnectionService.scan (#741)', () {
+    test('throws Obd2PermissionDenied when the user refuses', () async {
+      final svc = _build(
+        permState: Obd2PermissionState.denied,
+        bt: _FakeFacade(batches: const [[]]),
+      );
+      await expectLater(svc.scan().toList(), throwsA(isA<Obd2PermissionDenied>()));
+    });
+
+    test('throws Obd2ScanTimeout when no known adapter is seen', () async {
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        // A phone in range that isn't an OBD2 adapter — registry.resolve
+        // returns null, so ranked batches are empty.
+        bt: _FakeFacade(batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'phone',
+              deviceName: 'Pixel 9',
+              advertisedServiceUuids: const [
+                '0000180f-0000-1000-8000-00805f9b34fb', // battery service
+              ],
+              rssi: -55,
+            ),
+          ],
+        ]),
+      );
+      await expectLater(svc.scan().toList(), throwsA(isA<Obd2ScanTimeout>()));
+    });
+
+    test('emits ranked vLinker candidate + completes without throwing',
+        () async {
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: _FakeFacade(batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'aa:bb',
+              deviceName: 'vLinker FS',
+              advertisedServiceUuids: const [],
+              rssi: -55,
+            ),
+          ],
+        ]),
+      );
+      final emitted = await svc.scan().toList();
+      expect(emitted, hasLength(1));
+      expect(emitted.single.single.profile.id, 'vlinker');
+    });
+
+    test('accumulates across batches and preserves RSSI ranking', () async {
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: _FakeFacade(batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'a',
+              deviceName: 'vLinker FS',
+              advertisedServiceUuids: const [],
+              rssi: -80,
+            ),
+          ],
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'a',
+              deviceName: 'vLinker FS',
+              advertisedServiceUuids: const [],
+              rssi: -80,
+            ),
+            Obd2AdapterCandidate(
+              deviceId: 'b',
+              deviceName: 'OBDLink MX+',
+              advertisedServiceUuids: const [],
+              rssi: -50,
+            ),
+          ],
+        ]),
+      );
+      final emitted = await svc.scan().toList();
+      expect(emitted.last.first.profile.id, 'obdlink-mx',
+          reason: 'strongest RSSI must rank first');
+    });
+  });
+
+  group('Obd2ConnectionService.connect (#741)', () {
+    test('returns a ready Obd2Service on successful init', () async {
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: _FakeFacade(
+          batches: const [[]],
+          channel: _FakeChannel(respondTo: _elmOkResponses()),
+        ),
+      );
+      final candidate = _resolvedVlinker(registry);
+      final ready = await svc.connect(candidate);
+      expect(ready.isConnected, isTrue);
+      await ready.disconnect();
+    });
+
+    test('throws Obd2AdapterUnresponsive when the init sequence fails',
+        () async {
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: _FakeFacade(
+          batches: const [[]],
+          // Channel never emits — BluetoothObd2Transport's 5 s timeout
+          // flips the service connect() to return false, which the
+          // connection service translates to the typed error.
+          channel: _FakeChannel(silent: true),
+        ),
+      );
+      final candidate = _resolvedVlinker(registry);
+      await expectLater(
+        svc.connect(candidate),
+        throwsA(isA<Obd2AdapterUnresponsive>()),
+      );
+    }, timeout: const Timeout(Duration(seconds: 30)));
+  });
+
+  group('Obd2ConnectionService.connectBest', () {
+    test('returns null when no scan has happened yet', () async {
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: _FakeFacade(batches: const [[]]),
+      );
+      expect(await svc.connectBest(), isNull);
+    });
+  });
+}
+
+// --- helpers ---------------------------------------------------------
+
+Obd2ConnectionService _build({
+  required Obd2PermissionState permState,
+  required BluetoothFacade bt,
+}) =>
+    Obd2ConnectionService(
+      registry: Obd2AdapterRegistry.defaults(),
+      permissions: _FakePermissions(permState),
+      bluetooth: bt,
+    );
+
+ResolvedObd2Candidate _resolvedVlinker(Obd2AdapterRegistry r) {
+  final candidate = Obd2AdapterCandidate(
+    deviceId: 'aa:bb',
+    deviceName: 'vLinker FS',
+    advertisedServiceUuids: const [],
+    rssi: -55,
+  );
+  return ResolvedObd2Candidate(
+    candidate: candidate,
+    profile: r.profiles.firstWhere((p) => p.id == 'vlinker'),
+  );
+}
+
+class _FakePermissions implements Obd2Permissions {
+  final Obd2PermissionState state;
+  _FakePermissions(this.state);
+  @override
+  Future<Obd2PermissionState> current() async => state;
+  @override
+  Future<Obd2PermissionState> request() async => state;
+}
+
+class _FakeFacade implements BluetoothFacade {
+  final List<List<Obd2AdapterCandidate>> batches;
+  final ElmByteChannel? channel;
+  _FakeFacade({required this.batches, this.channel});
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    for (final batch in batches) {
+      yield batch;
+    }
+  }
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(
+    String deviceId,
+    Obd2AdapterProfile profile,
+  ) =>
+      channel ?? _FakeChannel(silent: true);
+}
+
+/// Minimal channel that answers every write with the canonical ELM327
+/// OK prompt so the transport's init sequence completes. Silent mode
+/// never emits — useful for the unresponsive-adapter test.
+class _FakeChannel implements ElmByteChannel {
+  final bool silent;
+  final Map<String, String>? respondTo;
+  final StreamController<List<int>> _ctrl = StreamController.broadcast();
+  bool _open = false;
+
+  _FakeChannel({this.silent = false, this.respondTo});
+
+  @override
+  bool get isOpen => _open;
+
+  @override
+  Stream<List<int>> get incoming => _ctrl.stream;
+
+  @override
+  Future<void> open() async {
+    _open = true;
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    if (silent) return;
+    final cmd = String.fromCharCodes(bytes).trim();
+    final reply = respondTo?[cmd] ?? 'OK>';
+    _ctrl.add(reply.codeUnits);
+  }
+
+  @override
+  Future<void> close() async {
+    _open = false;
+    await _ctrl.close();
+  }
+}
+
+/// Canned init-sequence responses covering what `Elm327Protocol.initCommands`
+/// sends: ATZ, ATE0, ATL0, ATH0, ATSP0.
+Map<String, String> _elmOkResponses() => {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+    };


### PR DESCRIPTION
## Summary
Step 2 of #733. Glue between the adapter registry (#734), the permission façade (#740), and the existing ELM327 transport.

### Abstractions
- \`BluetoothFacade\` — thin seam over flutter_blue_plus (\`startScan\` / \`scanResults\` / \`stopScan\` + \`channelFor(deviceId, profile)\`). Production impl is the only place that touches the plugin for this flow; tests use a fake.
- \`Obd2ConnectionService\` — scan + connect + connectBest.
- Four typed errors: \`Obd2PermissionDenied\`, \`Obd2ScanTimeout\`, \`Obd2AdapterUnresponsive\`, \`Obd2ProtocolInitFailed\`.

### Test plan
- [x] 7 unit tests covering every error path + happy scan/connect
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4623 passing

Closes #741