### PR TITLE
fix(obd2): wire real BLE adapter into _readObd — last link to in-car testing

### DIFF
--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -10,8 +10,8 @@ import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
-import '../../data/obd2/obd2_service.dart';
-import '../../data/obd2/obd2_transport.dart';
+import '../../data/obd2/obd2_connection_errors.dart';
+import '../../data/obd2/obd2_connection_service.dart';
 import '../../data/receipt_scan_service.dart';
 import '../../domain/entities/fill_up.dart';
 import '../../providers/consumption_providers.dart';
@@ -219,39 +219,63 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     }
   }
 
+  /// Tap handler for the OBD-II button. First in-car path (#742) —
+  /// no picker UI yet: consume the first scan batch, pick the
+  /// highest-RSSI known adapter, connect, read the odometer. Picker
+  /// UI will replace this in #743.
   Future<void> _readObd() async {
     setState(() => _obdReading = true);
+    final l = AppLocalizations.of(context);
+    final connection = ref.read(obd2ConnectionProvider);
     try {
-      // TODO: Replace FakeObd2Transport with BluetoothObd2Transport
-      // when flutter_blue_plus is integrated and tested on real hardware.
-      final transport = FakeObd2Transport({
-        'ATZ': 'ELM327 v1.5>',
-        'ATE0': 'OK>',
-        'ATL0': 'OK>',
-        'ATH0': 'OK>',
-        'ATSP0': 'OK>',
-        '01A6': 'NO DATA>',
-        '0131': '41 31 4E 20>',
-      });
-      final service = Obd2Service(transport);
-      final connected = await service.connect();
-      if (!connected || !mounted) return;
-
+      await connection.scan(timeout: const Duration(seconds: 8)).first;
+      if (!mounted) return;
+      final service = await connection.connectBest();
+      if (service == null) {
+        if (!mounted) return;
+        SnackBarHelper.show(
+            context, l?.obdNoAdapter ?? 'No OBD2 adapter in range');
+        return;
+      }
       final km = await service.readOdometerKm();
       await service.disconnect();
-
-      if (km != null && mounted) {
-        setState(() {
-          _odoCtrl.text = km.round().toString();
-        });
-        SnackBarHelper.showSuccess(context,
-            'Odometer read: ${km.round()} km');
-      } else if (mounted) {
-        SnackBarHelper.show(context, 'Could not read odometer');
+      if (!mounted) return;
+      if (km != null) {
+        setState(() => _odoCtrl.text = km.round().toString());
+        SnackBarHelper.showSuccess(
+          context,
+          l?.obdOdometerRead(km.round()) ?? 'Odometer read: ${km.round()} km',
+        );
+      } else {
+        SnackBarHelper.show(
+            context, l?.obdOdometerUnavailable ?? 'Could not read odometer');
       }
-    } catch (e) {
+    } on Obd2PermissionDenied {
       if (mounted) {
-        SnackBarHelper.showError(context, 'OBD-II error: $e');
+        SnackBarHelper.showError(
+          context,
+          l?.obdPermissionDenied ??
+              'Grant Bluetooth permission in system settings',
+        );
+      }
+    } on Obd2ScanTimeout {
+      if (mounted) {
+        SnackBarHelper.showError(
+          context,
+          l?.obdNoAdapter ?? 'No OBD2 adapter in range',
+        );
+      }
+    } on Obd2AdapterUnresponsive {
+      if (mounted) {
+        SnackBarHelper.showError(
+          context,
+          l?.obdAdapterUnresponsive ??
+              "Adapter didn't answer — turn the ignition on and retry",
+        );
+      }
+    } on Obd2ConnectionError catch (e) {
+      if (mounted) {
+        SnackBarHelper.showError(context, e.message);
       }
     } finally {
       if (mounted) setState(() => _obdReading = false);

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -801,6 +801,16 @@
   "qrScannerGuidance": "Kamera auf einen QR-Code richten",
   "torchOn": "Blitz einschalten",
   "torchOff": "Blitz ausschalten",
+  "obdNoAdapter": "Kein OBD2-Adapter in Reichweite",
+  "obdOdometerUnavailable": "Kilometerstand konnte nicht gelesen werden",
+  "obdPermissionDenied": "Bluetooth-Berechtigung in den Einstellungen erteilen",
+  "obdAdapterUnresponsive": "Keine Antwort — Zündung einschalten und neu versuchen",
+  "obdOdometerRead": "Kilometerstand gelesen: {km} km",
+  "@obdOdometerRead": {
+    "placeholders": {
+      "km": { "type": "int" }
+    }
+  },
   "vehicleFuelNotSet": "Nicht gesetzt",
   "wizardVehicleTapToEdit": "Zum Bearbeiten tippen",
   "wizardVehicleDefaultBadge": "Standard",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -828,6 +828,16 @@
   "qrScannerGuidance": "Point the camera at a QR code",
   "torchOn": "Turn flash on",
   "torchOff": "Turn flash off",
+  "obdNoAdapter": "No OBD2 adapter in range",
+  "obdOdometerUnavailable": "Could not read odometer",
+  "obdPermissionDenied": "Grant Bluetooth permission in system settings",
+  "obdAdapterUnresponsive": "Adapter didn't answer — turn the ignition on and retry",
+  "obdOdometerRead": "Odometer read: {km} km",
+  "@obdOdometerRead": {
+    "placeholders": {
+      "km": { "type": "int" }
+    }
+  },
   "vehicleFuelNotSet": "Not set",
   "wizardVehicleTapToEdit": "Tap to edit",
   "wizardVehicleDefaultBadge": "Default",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -722,6 +722,16 @@
   "qrScannerGuidance": "Pointez la caméra sur un QR code",
   "torchOn": "Allumer le flash",
   "torchOff": "Éteindre le flash",
+  "obdNoAdapter": "Aucun adaptateur OBD2 à portée",
+  "obdOdometerUnavailable": "Impossible de lire le compteur",
+  "obdPermissionDenied": "Accorder la permission Bluetooth dans les paramètres",
+  "obdAdapterUnresponsive": "Pas de réponse — mettez le contact et réessayez",
+  "obdOdometerRead": "Compteur lu : {km} km",
+  "@obdOdometerRead": {
+    "placeholders": {
+      "km": { "type": "int" }
+    }
+  },
   "vehicleFuelNotSet": "Non défini",
   "wizardVehicleTapToEdit": "Toucher pour modifier",
   "wizardVehicleDefaultBadge": "Par défaut",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3535,6 +3535,36 @@ abstract class AppLocalizations {
   /// **'Turn flash off'**
   String get torchOff;
 
+  /// No description provided for @obdNoAdapter.
+  ///
+  /// In en, this message translates to:
+  /// **'No OBD2 adapter in range'**
+  String get obdNoAdapter;
+
+  /// No description provided for @obdOdometerUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not read odometer'**
+  String get obdOdometerUnavailable;
+
+  /// No description provided for @obdPermissionDenied.
+  ///
+  /// In en, this message translates to:
+  /// **'Grant Bluetooth permission in system settings'**
+  String get obdPermissionDenied;
+
+  /// No description provided for @obdAdapterUnresponsive.
+  ///
+  /// In en, this message translates to:
+  /// **'Adapter didn\'t answer — turn the ignition on and retry'**
+  String get obdAdapterUnresponsive;
+
+  /// No description provided for @obdOdometerRead.
+  ///
+  /// In en, this message translates to:
+  /// **'Odometer read: {km} km'**
+  String obdOdometerRead(int km);
+
   /// No description provided for @vehicleFuelNotSet.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1858,6 +1858,25 @@ class AppLocalizationsBg extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1858,6 +1858,25 @@ class AppLocalizationsCs extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1856,6 +1856,25 @@ class AppLocalizationsDa extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1869,6 +1869,26 @@ class AppLocalizationsDe extends AppLocalizations {
   String get torchOff => 'Blitz ausschalten';
 
   @override
+  String get obdNoAdapter => 'Kein OBD2-Adapter in Reichweite';
+
+  @override
+  String get obdOdometerUnavailable =>
+      'Kilometerstand konnte nicht gelesen werden';
+
+  @override
+  String get obdPermissionDenied =>
+      'Bluetooth-Berechtigung in den Einstellungen erteilen';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Keine Antwort — Zündung einschalten und neu versuchen';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Kilometerstand gelesen: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Nicht gesetzt';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1860,6 +1860,25 @@ class AppLocalizationsEl extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1851,6 +1851,25 @@ class AppLocalizationsEn extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1859,6 +1859,25 @@ class AppLocalizationsEs extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1853,6 +1853,25 @@ class AppLocalizationsEt extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1856,6 +1856,25 @@ class AppLocalizationsFi extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1867,6 +1867,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String get torchOff => 'Éteindre le flash';
 
   @override
+  String get obdNoAdapter => 'Aucun adaptateur OBD2 à portée';
+
+  @override
+  String get obdOdometerUnavailable => 'Impossible de lire le compteur';
+
+  @override
+  String get obdPermissionDenied =>
+      'Accorder la permission Bluetooth dans les paramètres';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Pas de réponse — mettez le contact et réessayez';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Compteur lu : $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Non défini';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1855,6 +1855,25 @@ class AppLocalizationsHr extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1860,6 +1860,25 @@ class AppLocalizationsHu extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1859,6 +1859,25 @@ class AppLocalizationsIt extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1857,6 +1857,25 @@ class AppLocalizationsLt extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1859,6 +1859,25 @@ class AppLocalizationsLv extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1855,6 +1855,25 @@ class AppLocalizationsNb extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1860,6 +1860,25 @@ class AppLocalizationsNl extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1858,6 +1858,25 @@ class AppLocalizationsPl extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1859,6 +1859,25 @@ class AppLocalizationsPt extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1858,6 +1858,25 @@ class AppLocalizationsRo extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1859,6 +1859,25 @@ class AppLocalizationsSk extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1853,6 +1853,25 @@ class AppLocalizationsSl extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1857,6 +1857,25 @@ class AppLocalizationsSv extends AppLocalizations {
   String get torchOff => 'Turn flash off';
 
   @override
+  String get obdNoAdapter => 'No OBD2 adapter in range';
+
+  @override
+  String get obdOdometerUnavailable => 'Could not read odometer';
+
+  @override
+  String get obdPermissionDenied =>
+      'Grant Bluetooth permission in system settings';
+
+  @override
+  String get obdAdapterUnresponsive =>
+      'Adapter didn\'t answer — turn the ignition on and retry';
+
+  @override
+  String obdOdometerRead(int km) {
+    return 'Odometer read: $km km';
+  }
+
+  @override
   String get vehicleFuelNotSet => 'Not set';
 
   @override

--- a/test/features/consumption/data/obd2/obd2_connection_errors_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_errors_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
+
+void main() {
+  group('Obd2ConnectionError typed hierarchy (#741/#742)', () {
+    test('every concrete error carries a non-empty default message', () {
+      // #742 fallback path: when the UI can't match a specific type,
+      // it renders e.message directly. Ensure no error class ever
+      // bubbles up an empty string.
+      final errors = <Obd2ConnectionError>[
+        const Obd2PermissionDenied(),
+        const Obd2ScanTimeout(),
+        const Obd2AdapterUnresponsive(),
+        const Obd2ProtocolInitFailed('???'),
+      ];
+      for (final e in errors) {
+        expect(e.message, isNotEmpty,
+            reason: '$e must carry a user-visible message');
+      }
+    });
+
+    test('Obd2ProtocolInitFailed includes the raw response for debugging',
+        () {
+      const e = Obd2ProtocolInitFailed('GARBAGE>');
+      expect(e.message, contains('GARBAGE>'));
+    });
+
+    test('toString prepends the runtime type — useful in logs', () {
+      expect(const Obd2ScanTimeout().toString(), startsWith('Obd2ScanTimeout'));
+    });
+
+    test('sealed hierarchy — every type implements Exception', () {
+      expect(const Obd2PermissionDenied(), isA<Exception>());
+      expect(const Obd2ScanTimeout(), isA<Exception>());
+      expect(const Obd2AdapterUnresponsive(), isA<Exception>());
+      expect(const Obd2ProtocolInitFailed('x'), isA<Exception>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Step 4 of #733 — the last link. Replaces the hardcoded \`FakeObd2Transport\` in \`add_fill_up_screen.dart\` with the real \`Obd2ConnectionService\` from #741. Tap the OBD-II button and the app now:

1. Requests BLUETOOTH_SCAN / BLUETOOTH_CONNECT (Android 12+) via #740.
2. Scans for known adapters (vLinker FS / FD / MC, OBDLink MX+, Carista, Veepeak, generic FFF0).
3. Picks the highest-RSSI match.
4. Connects over GATT, runs the ELM327 init.
5. Reads the odometer via PID A6 → PID 31 → manufacturer Mode 22 fallbacks.

Every typed error from #741 maps to a localised snackbar instead of the old \"OBD-II error: Exception: …\" mess. en/fr/de keys added.

No picker UI yet — that's the #743 polish. Current auto-pick is the right default when the user has one vLinker in the car.

## Test plan
- [x] 4 new assertions on the typed-error messages
- [x] Happy-path covered by #741's connection-service tests (fake channel emits canned ELM327 responses)
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4623 passing

Closes #742