### PR TITLE
feat(obd2): adapter picker bottom sheet

### DIFF
--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -11,7 +11,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/obd2/obd2_connection_errors.dart';
-import '../../data/obd2/obd2_connection_service.dart';
+import '../widgets/obd2_adapter_picker.dart';
 import '../../data/receipt_scan_service.dart';
 import '../../domain/entities/fill_up.dart';
 import '../../providers/consumption_providers.dart';
@@ -219,24 +219,16 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     }
   }
 
-  /// Tap handler for the OBD-II button. First in-car path (#742) —
-  /// no picker UI yet: consume the first scan batch, pick the
-  /// highest-RSSI known adapter, connect, read the odometer. Picker
-  /// UI will replace this in #743.
+  /// Tap handler for the OBD-II button. Opens the adapter picker
+  /// (#743); on successful connect it reads the odometer via the
+  /// returned [Obd2Service] and fills the form. A null return (user
+  /// cancelled) is a no-op — no snackbar noise.
   Future<void> _readObd() async {
     setState(() => _obdReading = true);
     final l = AppLocalizations.of(context);
-    final connection = ref.read(obd2ConnectionProvider);
     try {
-      await connection.scan(timeout: const Duration(seconds: 8)).first;
-      if (!mounted) return;
-      final service = await connection.connectBest();
-      if (service == null) {
-        if (!mounted) return;
-        SnackBarHelper.show(
-            context, l?.obdNoAdapter ?? 'No OBD2 adapter in range');
-        return;
-      }
+      final service = await showObd2AdapterPicker(context);
+      if (service == null || !mounted) return;
       final km = await service.readOdometerKm();
       await service.disconnect();
       if (!mounted) return;
@@ -250,33 +242,8 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
         SnackBarHelper.show(
             context, l?.obdOdometerUnavailable ?? 'Could not read odometer');
       }
-    } on Obd2PermissionDenied {
-      if (mounted) {
-        SnackBarHelper.showError(
-          context,
-          l?.obdPermissionDenied ??
-              'Grant Bluetooth permission in system settings',
-        );
-      }
-    } on Obd2ScanTimeout {
-      if (mounted) {
-        SnackBarHelper.showError(
-          context,
-          l?.obdNoAdapter ?? 'No OBD2 adapter in range',
-        );
-      }
-    } on Obd2AdapterUnresponsive {
-      if (mounted) {
-        SnackBarHelper.showError(
-          context,
-          l?.obdAdapterUnresponsive ??
-              "Adapter didn't answer — turn the ignition on and retry",
-        );
-      }
     } on Obd2ConnectionError catch (e) {
-      if (mounted) {
-        SnackBarHelper.showError(context, e.message);
-      }
+      if (mounted) SnackBarHelper.showError(context, e.message);
     } finally {
       if (mounted) setState(() => _obdReading = false);
     }

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../data/obd2/adapter_registry.dart';
+import '../../data/obd2/obd2_connection_errors.dart';
+import '../../data/obd2/obd2_connection_service.dart';
+import '../../data/obd2/obd2_service.dart';
+
+/// Modal bottom sheet that drives the full scan → pick → connect flow
+/// (#743). Caller opens it with [showObd2AdapterPicker]; the future
+/// resolves with a ready [Obd2Service] when the user connects to one
+/// of the listed adapters, or `null` on cancel.
+///
+/// The sheet owns a simple state machine: scanning → selecting →
+/// connecting → done/error. Every transition is driven by the
+/// injected [Obd2ConnectionService], so widget tests swap it via a
+/// Riverpod override of `obd2ConnectionProvider` and drive the full
+/// flow without a BLE stack.
+Future<Obd2Service?> showObd2AdapterPicker(BuildContext context) {
+  return showModalBottomSheet<Obd2Service>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (_) => const Obd2AdapterPickerSheet(),
+  );
+}
+
+class Obd2AdapterPickerSheet extends ConsumerStatefulWidget {
+  const Obd2AdapterPickerSheet({super.key});
+
+  @override
+  ConsumerState<Obd2AdapterPickerSheet> createState() =>
+      _Obd2AdapterPickerSheetState();
+}
+
+enum _Phase { scanning, selecting, connecting, error }
+
+class _Obd2AdapterPickerSheetState
+    extends ConsumerState<Obd2AdapterPickerSheet> {
+  _Phase _phase = _Phase.scanning;
+  StreamSubscription<List<ResolvedObd2Candidate>>? _sub;
+  List<ResolvedObd2Candidate> _candidates = const [];
+  Obd2ConnectionError? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _startScan();
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  void _startScan() {
+    setState(() {
+      _phase = _Phase.scanning;
+      _candidates = const [];
+      _error = null;
+    });
+    final connection = ref.read(obd2ConnectionProvider);
+    _sub?.cancel();
+    _sub = connection.scan().listen(
+      (list) {
+        if (!mounted) return;
+        setState(() {
+          _candidates = list;
+          if (list.isNotEmpty) _phase = _Phase.selecting;
+        });
+      },
+      onError: (e, _) {
+        if (!mounted || e is! Obd2ConnectionError) return;
+        setState(() {
+          _error = e;
+          _phase = _Phase.error;
+        });
+      },
+    );
+  }
+
+  Future<void> _connect(ResolvedObd2Candidate candidate) async {
+    setState(() => _phase = _Phase.connecting);
+    try {
+      final service = await ref
+          .read(obd2ConnectionProvider)
+          .connect(candidate);
+      if (!mounted) return;
+      Navigator.of(context).pop(service);
+    } on Obd2ConnectionError catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e;
+        _phase = _Phase.error;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              l?.obdPickerTitle ?? 'Pick an OBD2 adapter',
+              style: Theme.of(context).textTheme.titleLarge,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            _buildBody(l),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(AppLocalizations? l) {
+    switch (_phase) {
+      case _Phase.scanning:
+        return Column(
+          key: const Key('obdPickerScanning'),
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: 12),
+            Text(l?.obdPickerScanning ?? 'Scanning for adapters…'),
+          ],
+        );
+      case _Phase.selecting:
+        return Column(
+          key: const Key('obdPickerSelecting'),
+          children: [
+            for (final c in _candidates)
+              ListTile(
+                key: Key('obdPickerItem_${c.candidate.deviceId}'),
+                leading: const Icon(Icons.bluetooth),
+                title: Text(c.candidate.deviceName.isEmpty
+                    ? c.profile.displayName
+                    : c.candidate.deviceName),
+                subtitle: Text(
+                  '${c.profile.displayName} · ${c.candidate.rssi} dBm',
+                ),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => _connect(c),
+              ),
+          ],
+        );
+      case _Phase.connecting:
+        return Column(
+          key: const Key('obdPickerConnecting'),
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: 12),
+            Text(l?.obdPickerConnecting ?? 'Connecting…'),
+          ],
+        );
+      case _Phase.error:
+        return Column(
+          key: const Key('obdPickerError'),
+          children: [
+            Icon(Icons.error_outline,
+                color: Theme.of(context).colorScheme.error, size: 48),
+            const SizedBox(height: 8),
+            Text(
+              _error?.message ?? 'Unknown error',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              key: const Key('obdPickerRetry'),
+              onPressed: _startScan,
+              icon: const Icon(Icons.refresh),
+              label: Text(l?.retry ?? 'Retry'),
+            ),
+          ],
+        );
+    }
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -805,6 +805,9 @@
   "obdOdometerUnavailable": "Kilometerstand konnte nicht gelesen werden",
   "obdPermissionDenied": "Bluetooth-Berechtigung in den Einstellungen erteilen",
   "obdAdapterUnresponsive": "Keine Antwort — Zündung einschalten und neu versuchen",
+  "obdPickerTitle": "OBD2-Adapter wählen",
+  "obdPickerScanning": "Suche nach Adaptern…",
+  "obdPickerConnecting": "Verbinden…",
   "obdOdometerRead": "Kilometerstand gelesen: {km} km",
   "@obdOdometerRead": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -832,6 +832,9 @@
   "obdOdometerUnavailable": "Could not read odometer",
   "obdPermissionDenied": "Grant Bluetooth permission in system settings",
   "obdAdapterUnresponsive": "Adapter didn't answer — turn the ignition on and retry",
+  "obdPickerTitle": "Pick an OBD2 adapter",
+  "obdPickerScanning": "Scanning for adapters…",
+  "obdPickerConnecting": "Connecting…",
   "obdOdometerRead": "Odometer read: {km} km",
   "@obdOdometerRead": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -726,6 +726,9 @@
   "obdOdometerUnavailable": "Impossible de lire le compteur",
   "obdPermissionDenied": "Accorder la permission Bluetooth dans les paramètres",
   "obdAdapterUnresponsive": "Pas de réponse — mettez le contact et réessayez",
+  "obdPickerTitle": "Choisir un adaptateur OBD2",
+  "obdPickerScanning": "Recherche d'adaptateurs…",
+  "obdPickerConnecting": "Connexion…",
   "obdOdometerRead": "Compteur lu : {km} km",
   "@obdOdometerRead": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3559,6 +3559,24 @@ abstract class AppLocalizations {
   /// **'Adapter didn\'t answer — turn the ignition on and retry'**
   String get obdAdapterUnresponsive;
 
+  /// No description provided for @obdPickerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick an OBD2 adapter'**
+  String get obdPickerTitle;
+
+  /// No description provided for @obdPickerScanning.
+  ///
+  /// In en, this message translates to:
+  /// **'Scanning for adapters…'**
+  String get obdPickerScanning;
+
+  /// No description provided for @obdPickerConnecting.
+  ///
+  /// In en, this message translates to:
+  /// **'Connecting…'**
+  String get obdPickerConnecting;
+
   /// No description provided for @obdOdometerRead.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1872,6 +1872,15 @@ class AppLocalizationsBg extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1872,6 +1872,15 @@ class AppLocalizationsCs extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1870,6 +1870,15 @@ class AppLocalizationsDa extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1884,6 +1884,15 @@ class AppLocalizationsDe extends AppLocalizations {
       'Keine Antwort — Zündung einschalten und neu versuchen';
 
   @override
+  String get obdPickerTitle => 'OBD2-Adapter wählen';
+
+  @override
+  String get obdPickerScanning => 'Suche nach Adaptern…';
+
+  @override
+  String get obdPickerConnecting => 'Verbinden…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Kilometerstand gelesen: $km km';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1874,6 +1874,15 @@ class AppLocalizationsEl extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1865,6 +1865,15 @@ class AppLocalizationsEn extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1873,6 +1873,15 @@ class AppLocalizationsEs extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1867,6 +1867,15 @@ class AppLocalizationsEt extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1870,6 +1870,15 @@ class AppLocalizationsFi extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1881,6 +1881,15 @@ class AppLocalizationsFr extends AppLocalizations {
       'Pas de réponse — mettez le contact et réessayez';
 
   @override
+  String get obdPickerTitle => 'Choisir un adaptateur OBD2';
+
+  @override
+  String get obdPickerScanning => 'Recherche d\'adaptateurs…';
+
+  @override
+  String get obdPickerConnecting => 'Connexion…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Compteur lu : $km km';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1869,6 +1869,15 @@ class AppLocalizationsHr extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1874,6 +1874,15 @@ class AppLocalizationsHu extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1873,6 +1873,15 @@ class AppLocalizationsIt extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1871,6 +1871,15 @@ class AppLocalizationsLt extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1873,6 +1873,15 @@ class AppLocalizationsLv extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1869,6 +1869,15 @@ class AppLocalizationsNb extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1874,6 +1874,15 @@ class AppLocalizationsNl extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1872,6 +1872,15 @@ class AppLocalizationsPl extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1873,6 +1873,15 @@ class AppLocalizationsPt extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1872,6 +1872,15 @@ class AppLocalizationsRo extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1873,6 +1873,15 @@ class AppLocalizationsSk extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1867,6 +1867,15 @@ class AppLocalizationsSl extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1871,6 +1871,15 @@ class AppLocalizationsSv extends AppLocalizations {
       'Adapter didn\'t answer — turn the ignition on and retry';
 
   @override
+  String get obdPickerTitle => 'Pick an OBD2 adapter';
+
+  @override
+  String get obdPickerScanning => 'Scanning for adapters…';
+
+  @override
+  String get obdPickerConnecting => 'Connecting…';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/obd2_adapter_picker.dart';
+
+void main() {
+  group('Obd2AdapterPickerSheet (#743)', () {
+    testWidgets('shows the scanning state on open', (tester) async {
+      final svc = _buildService(const [[]]);
+      await _pump(tester, svc);
+      expect(find.byKey(const Key('obdPickerScanning')), findsOneWidget);
+    });
+
+    testWidgets('renders the ranked candidates once scan emits',
+        (tester) async {
+      final svc = _buildService([
+        [
+          _scanHit(name: 'vLinker FS', rssi: -55),
+          _scanHit(name: 'OBDLink MX+', rssi: -40),
+        ],
+      ]);
+      await _pump(tester, svc);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.byKey(const Key('obdPickerSelecting')), findsOneWidget);
+      // OBDLink is stronger → ranks first by RSSI.
+      expect(find.text('OBDLink MX+'), findsOneWidget);
+      expect(find.text('vLinker FS'), findsOneWidget);
+    });
+
+    testWidgets('tapping a candidate transitions to connecting state',
+        (tester) async {
+      final svc = _buildService([
+        [_scanHit(name: 'vLinker FS', rssi: -55)],
+      ]);
+      await _pump(tester, svc);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.text('vLinker FS'));
+      await tester.pump(); // state flip only — don't settle, the silent
+      // channel intentionally leaves a pending 5 s timeout that
+      // eventually surfaces as Obd2AdapterUnresponsive; we're only
+      // asserting the optimistic "connecting" state got rendered.
+      expect(find.byKey(const Key('obdPickerConnecting')), findsOneWidget);
+      // Drain the transport's 5s timeout so the test harness exits cleanly.
+      await tester.pump(const Duration(seconds: 6));
+      await tester.pump();
+    });
+
+    testWidgets('shows the retry button + error message on permission denied',
+        (tester) async {
+      final svc = Obd2ConnectionService(
+        registry: Obd2AdapterRegistry.defaults(),
+        permissions: _FakePermissions(Obd2PermissionState.denied),
+        bluetooth: _StreamingFacade(const []),
+      );
+      await _pump(tester, svc);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('obdPickerError')), findsOneWidget);
+      expect(find.byKey(const Key('obdPickerRetry')), findsOneWidget);
+      expect(find.textContaining('permission', findRichText: false),
+          findsOneWidget);
+    });
+  });
+}
+
+// --- helpers ---------------------------------------------------------
+
+Future<void> _pump(
+  WidgetTester tester,
+  Obd2ConnectionService svc,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
+      child: const MaterialApp(
+        home: Scaffold(body: Obd2AdapterPickerSheet()),
+      ),
+    ),
+  );
+}
+
+Obd2ConnectionService _buildService(
+    List<List<Obd2AdapterCandidate>> batches) {
+  return Obd2ConnectionService(
+    registry: Obd2AdapterRegistry.defaults(),
+    permissions: _FakePermissions(Obd2PermissionState.granted),
+    bluetooth: _StreamingFacade(batches),
+  );
+}
+
+Obd2AdapterCandidate _scanHit({required String name, int rssi = -60}) =>
+    Obd2AdapterCandidate(
+      deviceId: 'id-$name',
+      deviceName: name,
+      advertisedServiceUuids: const [],
+      rssi: rssi,
+    );
+
+class _FakePermissions implements Obd2Permissions {
+  final Obd2PermissionState state;
+  _FakePermissions(this.state);
+  @override
+  Future<Obd2PermissionState> current() async => state;
+  @override
+  Future<Obd2PermissionState> request() async => state;
+}
+
+class _StreamingFacade implements BluetoothFacade {
+  final List<List<Obd2AdapterCandidate>> batches;
+  _StreamingFacade(this.batches);
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    for (final batch in batches) {
+      yield batch;
+    }
+  }
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(
+    String deviceId,
+    Obd2AdapterProfile profile,
+  ) =>
+      _SilentChannel();
+}
+
+/// Silent channel — never answers, so the transport's init sequence
+/// eventually times out. Used only by the "connecting" test; it's
+/// there to prove the transition fires, not to complete the connect.
+class _SilentChannel implements ElmByteChannel {
+  final StreamController<List<int>> _ctrl = StreamController.broadcast();
+  bool _open = false;
+  @override
+  bool get isOpen => _open;
+  @override
+  Stream<List<int>> get incoming => _ctrl.stream;
+  @override
+  Future<void> open() async {
+    _open = true;
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {}
+  @override
+  Future<void> close() async {
+    _open = false;
+    await _ctrl.close();
+  }
+}


### PR DESCRIPTION
## Summary
Step 3 of #733 — the picker polish on top of #742's auto-pick. Users with more than one adapter (vLinker in the car + OBDLink on the workbench) can now pick explicitly.

Four state bottom sheet:
- scanning — spinner + copy
- selecting — ranked list of candidates with RSSI and profile name, tap to connect
- connecting — spinner + copy
- error — typed \`Obd2ConnectionError\` message + Retry

\`showObd2AdapterPicker(context)\` returns the ready \`Obd2Service\`. \`_readObd\` now opens the picker instead of \`connectBest()\`.

## Test plan
- [x] 4 widget tests with provider-overridden fake connection service
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4630 passing (1 pre-existing flaky Argentina network test unrelated)

Closes #743. With #740 + #741 + #742 + #743 all merged, the full OBD2 in-car test path is live.