### PR TITLE
chore(release): bump build number to +5066

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 11 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 5.0.0+5065
+version: 5.0.0+5066
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
Samsung test build for the full OBD2 stack (#740 permissions, #741 connection service, #742 real BLE wiring, #743 picker bottom sheet) + #739 ℓ receipt fix.