### PR TITLE
feat(settings): theme mode switcher — Light / Dark / Follow system

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../core/country/country_switch_listener.dart';
 import '../core/language/language_provider.dart';
+import '../core/theme/theme_mode_provider.dart';
 import '../features/widget/presentation/widget_click_listener.dart';
 import '../l10n/app_localizations.dart';
 import 'router.dart';
@@ -34,6 +35,7 @@ class TankstellenApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
     final language = ref.watch(activeLanguageProvider);
+    final themeMode = ref.watch(themeModeSettingProvider);
 
     return MaterialApp.router(
       // Keying on language.code forces a full rebuild whenever the user
@@ -43,7 +45,7 @@ class TankstellenApp extends ConsumerWidget {
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
-      themeMode: ThemeMode.system,
+      themeMode: themeMode,
       routerConfig: router,
       locale: language.locale,
       localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/lib/core/theme/theme_mode_provider.dart
+++ b/lib/core/theme/theme_mode_provider.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'theme_mode_provider.g.dart';
+
+/// Persisted theme-mode preference (#752).
+///
+/// Stored as a plain string in SharedPreferences rather than Hive —
+/// the value is device-local (not profile-bound), read on startup
+/// before any Hive box is open, and tiny. SharedPreferences is the
+/// right tool for this kind of "one-string-per-device" setting.
+///
+/// The pattern mirrors `activeLanguageProvider` — the app's other
+/// strictly-device-local preference.
+@Riverpod(keepAlive: true)
+class ThemeModeSetting extends _$ThemeModeSetting {
+  static const _prefsKey = 'settings.themeMode';
+
+  @override
+  ThemeMode build() {
+    _load();
+    return ThemeMode.system;
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    final restored = _parse(raw);
+    if (restored != state) state = restored;
+  }
+
+  Future<void> set(ThemeMode mode) async {
+    state = mode;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, _serialize(mode));
+  }
+
+  static ThemeMode _parse(String? raw) {
+    switch (raw) {
+      case 'light':
+        return ThemeMode.light;
+      case 'dark':
+        return ThemeMode.dark;
+      case 'system':
+      default:
+        return ThemeMode.system;
+    }
+  }
+
+  static String _serialize(ThemeMode mode) => switch (mode) {
+        ThemeMode.light => 'light',
+        ThemeMode.dark => 'dark',
+        ThemeMode.system => 'system',
+      };
+}

--- a/lib/core/theme/theme_mode_provider.g.dart
+++ b/lib/core/theme/theme_mode_provider.g.dart
@@ -1,0 +1,99 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'theme_mode_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Persisted theme-mode preference (#752).
+///
+/// Stored as a plain string in SharedPreferences rather than Hive —
+/// the value is device-local (not profile-bound), read on startup
+/// before any Hive box is open, and tiny. SharedPreferences is the
+/// right tool for this kind of "one-string-per-device" setting.
+///
+/// The pattern mirrors `activeLanguageProvider` — the app's other
+/// strictly-device-local preference.
+
+@ProviderFor(ThemeModeSetting)
+final themeModeSettingProvider = ThemeModeSettingProvider._();
+
+/// Persisted theme-mode preference (#752).
+///
+/// Stored as a plain string in SharedPreferences rather than Hive —
+/// the value is device-local (not profile-bound), read on startup
+/// before any Hive box is open, and tiny. SharedPreferences is the
+/// right tool for this kind of "one-string-per-device" setting.
+///
+/// The pattern mirrors `activeLanguageProvider` — the app's other
+/// strictly-device-local preference.
+final class ThemeModeSettingProvider
+    extends $NotifierProvider<ThemeModeSetting, ThemeMode> {
+  /// Persisted theme-mode preference (#752).
+  ///
+  /// Stored as a plain string in SharedPreferences rather than Hive —
+  /// the value is device-local (not profile-bound), read on startup
+  /// before any Hive box is open, and tiny. SharedPreferences is the
+  /// right tool for this kind of "one-string-per-device" setting.
+  ///
+  /// The pattern mirrors `activeLanguageProvider` — the app's other
+  /// strictly-device-local preference.
+  ThemeModeSettingProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'themeModeSettingProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$themeModeSettingHash();
+
+  @$internal
+  @override
+  ThemeModeSetting create() => ThemeModeSetting();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ThemeMode value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ThemeMode>(value),
+    );
+  }
+}
+
+String _$themeModeSettingHash() => r'391748e063daef817d379f2abdebd42cbe07c8ff';
+
+/// Persisted theme-mode preference (#752).
+///
+/// Stored as a plain string in SharedPreferences rather than Hive —
+/// the value is device-local (not profile-bound), read on startup
+/// before any Hive box is open, and tiny. SharedPreferences is the
+/// right tool for this kind of "one-string-per-device" setting.
+///
+/// The pattern mirrors `activeLanguageProvider` — the app's other
+/// strictly-device-local preference.
+
+abstract class _$ThemeModeSetting extends $Notifier<ThemeMode> {
+  ThemeMode build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<ThemeMode, ThemeMode>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<ThemeMode, ThemeMode>,
+              ThemeMode,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/core/theme/theme_mode_tile.dart
+++ b/lib/core/theme/theme_mode_tile.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../l10n/app_localizations.dart';
+import 'theme_mode_provider.dart';
+
+/// Settings tile + radio sheet for the theme-mode preference (#752).
+///
+/// Same Card + ListTile shape as `SettingsMenuTile`, but the tap opens
+/// a bottom sheet with three radio rows (Light / Dark / Follow system)
+/// instead of navigating to a new screen — a full screen for a single
+/// 3-option choice would be heavy.
+class ThemeModeTile extends ConsumerWidget {
+  const ThemeModeTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
+    final mode = ref.watch(themeModeSettingProvider);
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        key: const Key('themeModeTile'),
+        leading: Icon(_iconFor(mode), size: 20),
+        title: Text(
+          l?.themeSettingTitle ?? 'Theme',
+          style: theme.textTheme.titleSmall
+              ?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        subtitle: Text(
+          _labelFor(mode, l),
+          style: theme.textTheme.bodySmall,
+        ),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: () => _openPicker(context, ref),
+      ),
+    );
+  }
+
+  Future<void> _openPicker(BuildContext context, WidgetRef ref) async {
+    final picked = await showModalBottomSheet<ThemeMode>(
+      context: context,
+      showDragHandle: true,
+      builder: (ctx) => _ThemeModePickerSheet(
+        current: ref.read(themeModeSettingProvider),
+      ),
+    );
+    if (picked != null) {
+      await ref.read(themeModeSettingProvider.notifier).set(picked);
+    }
+  }
+
+  static IconData _iconFor(ThemeMode mode) => switch (mode) {
+        ThemeMode.light => Icons.light_mode,
+        ThemeMode.dark => Icons.dark_mode,
+        ThemeMode.system => Icons.smartphone,
+      };
+
+  static String _labelFor(ThemeMode mode, AppLocalizations? l) =>
+      switch (mode) {
+        ThemeMode.light => l?.themeModeLight ?? 'Light',
+        ThemeMode.dark => l?.themeModeDark ?? 'Dark',
+        ThemeMode.system => l?.themeModeSystem ?? 'Follow system',
+      };
+}
+
+class _ThemeModePickerSheet extends StatelessWidget {
+  final ThemeMode current;
+  const _ThemeModePickerSheet({required this.current});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+        child: RadioGroup<ThemeMode>(
+          groupValue: current,
+          onChanged: (v) {
+            if (v != null) Navigator.of(context).pop(v);
+          },
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Text(
+                  l?.themeSettingTitle ?? 'Theme',
+                  style: Theme.of(context).textTheme.titleLarge,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              _option(
+                mode: ThemeMode.light,
+                icon: Icons.light_mode,
+                label: l?.themeModeLight ?? 'Light',
+                keyValue: 'themeModeOptionLight',
+              ),
+              _option(
+                mode: ThemeMode.dark,
+                icon: Icons.dark_mode,
+                label: l?.themeModeDark ?? 'Dark',
+                keyValue: 'themeModeOptionDark',
+              ),
+              _option(
+                mode: ThemeMode.system,
+                icon: Icons.smartphone,
+                label: l?.themeModeSystem ?? 'Follow system',
+                keyValue: 'themeModeOptionSystem',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _option({
+    required ThemeMode mode,
+    required IconData icon,
+    required String label,
+    required String keyValue,
+  }) {
+    return RadioListTile<ThemeMode>(
+      key: Key(keyValue),
+      value: mode,
+      title: Row(
+        children: [
+          Icon(icon, size: 20),
+          const SizedBox(width: 8),
+          Text(label),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../../core/theme/theme_mode_tile.dart';
 import '../../../consent/presentation/widgets/consent_settings_section.dart';
 import '../widgets/about_section.dart';
 import '../widgets/api_key_section.dart';
@@ -85,6 +86,10 @@ class ProfileScreen extends ConsumerWidget {
                 'Track fill-ups and calculate L/100km',
             onTap: () => context.push('/consumption'),
           ),
+          const SizedBox(height: 8),
+
+          // Theme mode — light / dark / follow system (#752).
+          const ThemeModeTile(),
           const SizedBox(height: 8),
 
           // Storage & Cache

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -808,6 +808,10 @@
   "obdPickerTitle": "OBD2-Adapter wählen",
   "obdPickerScanning": "Suche nach Adaptern…",
   "obdPickerConnecting": "Verbinden…",
+  "themeSettingTitle": "Design",
+  "themeModeLight": "Hell",
+  "themeModeDark": "Dunkel",
+  "themeModeSystem": "Systemeinstellung",
   "obdOdometerRead": "Kilometerstand gelesen: {km} km",
   "@obdOdometerRead": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -835,6 +835,10 @@
   "obdPickerTitle": "Pick an OBD2 adapter",
   "obdPickerScanning": "Scanning for adapters…",
   "obdPickerConnecting": "Connecting…",
+  "themeSettingTitle": "Theme",
+  "themeModeLight": "Light",
+  "themeModeDark": "Dark",
+  "themeModeSystem": "Follow system",
   "obdOdometerRead": "Odometer read: {km} km",
   "@obdOdometerRead": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -729,6 +729,10 @@
   "obdPickerTitle": "Choisir un adaptateur OBD2",
   "obdPickerScanning": "Recherche d'adaptateurs…",
   "obdPickerConnecting": "Connexion…",
+  "themeSettingTitle": "Thème",
+  "themeModeLight": "Clair",
+  "themeModeDark": "Sombre",
+  "themeModeSystem": "Suivre le système",
   "obdOdometerRead": "Compteur lu : {km} km",
   "@obdOdometerRead": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3577,6 +3577,30 @@ abstract class AppLocalizations {
   /// **'Connecting…'**
   String get obdPickerConnecting;
 
+  /// No description provided for @themeSettingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Theme'**
+  String get themeSettingTitle;
+
+  /// No description provided for @themeModeLight.
+  ///
+  /// In en, this message translates to:
+  /// **'Light'**
+  String get themeModeLight;
+
+  /// No description provided for @themeModeDark.
+  ///
+  /// In en, this message translates to:
+  /// **'Dark'**
+  String get themeModeDark;
+
+  /// No description provided for @themeModeSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'Follow system'**
+  String get themeModeSystem;
+
   /// No description provided for @obdOdometerRead.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1881,6 +1881,18 @@ class AppLocalizationsBg extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1881,6 +1881,18 @@ class AppLocalizationsCs extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1879,6 +1879,18 @@ class AppLocalizationsDa extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1893,6 +1893,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get obdPickerConnecting => 'Verbinden…';
 
   @override
+  String get themeSettingTitle => 'Design';
+
+  @override
+  String get themeModeLight => 'Hell';
+
+  @override
+  String get themeModeDark => 'Dunkel';
+
+  @override
+  String get themeModeSystem => 'Systemeinstellung';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Kilometerstand gelesen: $km km';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1883,6 +1883,18 @@ class AppLocalizationsEl extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1874,6 +1874,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1882,6 +1882,18 @@ class AppLocalizationsEs extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1876,6 +1876,18 @@ class AppLocalizationsEt extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1879,6 +1879,18 @@ class AppLocalizationsFi extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1890,6 +1890,18 @@ class AppLocalizationsFr extends AppLocalizations {
   String get obdPickerConnecting => 'Connexion…';
 
   @override
+  String get themeSettingTitle => 'Thème';
+
+  @override
+  String get themeModeLight => 'Clair';
+
+  @override
+  String get themeModeDark => 'Sombre';
+
+  @override
+  String get themeModeSystem => 'Suivre le système';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Compteur lu : $km km';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1878,6 +1878,18 @@ class AppLocalizationsHr extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1883,6 +1883,18 @@ class AppLocalizationsHu extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1882,6 +1882,18 @@ class AppLocalizationsIt extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1880,6 +1880,18 @@ class AppLocalizationsLt extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1882,6 +1882,18 @@ class AppLocalizationsLv extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1878,6 +1878,18 @@ class AppLocalizationsNb extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1883,6 +1883,18 @@ class AppLocalizationsNl extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1881,6 +1881,18 @@ class AppLocalizationsPl extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1882,6 +1882,18 @@ class AppLocalizationsPt extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1881,6 +1881,18 @@ class AppLocalizationsRo extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1882,6 +1882,18 @@ class AppLocalizationsSk extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1876,6 +1876,18 @@ class AppLocalizationsSl extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1880,6 +1880,18 @@ class AppLocalizationsSv extends AppLocalizations {
   String get obdPickerConnecting => 'Connecting…';
 
   @override
+  String get themeSettingTitle => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'Follow system';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/test/core/theme/theme_mode_provider_test.dart
+++ b/test/core/theme/theme_mode_provider_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tankstellen/core/theme/theme_mode_provider.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const {});
+  });
+
+  group('themeModeSettingProvider (#752)', () {
+    test('defaults to ThemeMode.system on first launch', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(themeModeSettingProvider), ThemeMode.system);
+    });
+
+    test('restores a previously-persisted ThemeMode on startup', () async {
+      SharedPreferences.setMockInitialValues(const {
+        'settings.themeMode': 'dark',
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // _load fires async on build; give the microtask queue a chance.
+      container.read(themeModeSettingProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(container.read(themeModeSettingProvider), ThemeMode.dark);
+    });
+
+    test('set() updates the in-memory state and persists to prefs',
+        () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await container
+          .read(themeModeSettingProvider.notifier)
+          .set(ThemeMode.light);
+
+      expect(container.read(themeModeSettingProvider), ThemeMode.light);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('settings.themeMode'), 'light');
+    });
+
+    test('set(system) persists the system keyword', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await container
+          .read(themeModeSettingProvider.notifier)
+          .set(ThemeMode.system);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('settings.themeMode'), 'system');
+    });
+
+    test('unknown persisted value falls back to system', () async {
+      SharedPreferences.setMockInitialValues(const {
+        'settings.themeMode': 'bogus',
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(themeModeSettingProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(container.read(themeModeSettingProvider), ThemeMode.system);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Replaces the hardcoded \`themeMode: ThemeMode.system\` in \`TankstellenApp\` with a user-controllable preference. New tile on the Settings screen opens a modal bottom sheet with three RadioListTile options (wrapped in RadioGroup — the non-deprecated API post Flutter 3.32).

Persistence via SharedPreferences (device-local). Default is system.

## Test plan
- [x] 5 unit tests for provider behaviour
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4635 passing (1 pre-existing flaky Argentina network test on Windows)

Closes #752