### PR TITLE
fix(map): evictErrorTileStrategy — kill the persistent gray-tile bug

### DIFF
--- a/lib/core/services/impl/flutter_map_provider.dart
+++ b/lib/core/services/impl/flutter_map_provider.dart
@@ -50,6 +50,9 @@ class FlutterMapProvider implements MapProvider {
     return TileLayer(
       urlTemplate: config.urlTemplate,
       userAgentPackageName: config.userAgent ?? '',
+      // #757 — evict failed tiles once off-screen, retry on next pan.
+      evictErrorTileStrategy:
+          EvictErrorTileStrategy.notVisibleRespectMargin,
     );
   }
 

--- a/lib/features/driving/presentation/widgets/driving_map_view.dart
+++ b/lib/features/driving/presentation/widgets/driving_map_view.dart
@@ -43,6 +43,11 @@ class DrivingMapView extends StatelessWidget {
           TileLayer(
             urlTemplate: AppConstants.osmTileUrl,
             userAgentPackageName: AppConstants.osmUserAgent,
+            // #757 — evict failed tiles once off-screen so the next
+            // pan retries cleanly. See station_map_layers.dart for
+            // the full rationale.
+            evictErrorTileStrategy:
+                EvictErrorTileStrategy.notVisibleRespectMargin,
           ),
         ],
       );
@@ -80,6 +85,9 @@ class DrivingMapView extends StatelessWidget {
         TileLayer(
           urlTemplate: AppConstants.osmTileUrl,
           userAgentPackageName: AppConstants.osmUserAgent,
+          // #757 — evict failed tiles off-screen so the next pan retries.
+          evictErrorTileStrategy:
+              EvictErrorTileStrategy.notVisibleRespectMargin,
         ),
         MarkerLayer(markers: markers),
         const RichAttributionWidget(

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -98,6 +98,25 @@ class StationMapLayers extends StatelessWidget {
               userAgentPackageName: AppConstants.osmUserAgent,
               maxNativeZoom: 19,
               maxZoom: 19,
+              // #757 — kill the persistent-gray-tile bug at its root.
+              // Default NetworkTileProvider caches failed fetches in
+              // TileImageManager and the same (z,x,y) is never
+              // re-requested even on redraw, so a single transient
+              // 429/503 from the OSM tile server leaves a permanent
+              // gray square in the user's viewport. With
+              // `notVisibleRespectMargin`, the failed tile is
+              // evicted as soon as it scrolls out of the keepBuffer
+              // margin — the next pan retries cleanly. Every prior
+              // map-bug PR (#496, #532, #696, #707, #709, #711)
+              // attacked symptoms; this is the root cause.
+              evictErrorTileStrategy:
+                  EvictErrorTileStrategy.notVisibleRespectMargin,
+              errorTileCallback: (tile, error, stackTrace) {
+                debugPrint(
+                    'TileLayer error at (z:${tile.coordinates.z} '
+                    'x:${tile.coordinates.x} y:${tile.coordinates.y}): '
+                    '$error');
+              },
             ),
             // Route polyline (if in route search mode)
             if (routePolyline != null && routePolyline!.isNotEmpty)

--- a/test/features/map/tile_layer_eviction_strategy_test.dart
+++ b/test/features/map/tile_layer_eviction_strategy_test.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Enforces that every `TileLayer` in the codebase sets an
+/// `evictErrorTileStrategy`. Default is `EvictErrorTileStrategy.none`,
+/// which caches failed tile fetches and never retries them — the
+/// root cause of the persistent-gray-tile user reports (#757).
+///
+/// Pattern mirrors `test/security/no_plaintext_station_endpoints_test.dart`
+/// — a lightweight AST-free grep scan over the lib/ tree. The bug
+/// class it prevents (a new `TileLayer` instance without the
+/// eviction strategy) is high-frequency enough to warrant the
+/// explicit static check.
+void main() {
+  test('every TileLayer(...) sets evictErrorTileStrategy (#757)', () {
+    final libRoot = Directory('lib');
+    final offenders = <String>[];
+
+    for (final entity in libRoot.listSync(recursive: true)) {
+      if (entity is! File) continue;
+      if (!entity.path.endsWith('.dart')) continue;
+      final text = entity.readAsStringSync();
+      // Token-boundary match: `TileLayer(` preceded by a non-word
+      // char (space / newline / `[` / `,` / `(`). Avoids the
+      // `buildTileLayer(` false positive in the MapProvider
+      // abstraction.
+      final tokenRe = RegExp(r'(?<![A-Za-z0-9_])TileLayer\(');
+      for (final match in tokenRe.allMatches(text)) {
+        final idx = match.start;
+        {
+        // Find the matching close paren; naive but sufficient for
+        // well-formed Dart. The TileLayer constructor is short and
+        // balanced.
+        final end = _matchingCloseParen(text, idx + 'TileLayer('.length - 1);
+        if (end < 0) {
+          offenders.add('${entity.path} near char $idx: '
+              'unbalanced TileLayer(...) — cannot verify strategy');
+          continue;
+        }
+        final snippet = text.substring(idx, end + 1);
+        if (!snippet.contains('evictErrorTileStrategy')) {
+          final line = _lineNumber(text, idx);
+          offenders.add('${entity.path}:$line — TileLayer without '
+              'evictErrorTileStrategy');
+        }
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: offenders.join('\n'),
+    );
+  });
+}
+
+int _matchingCloseParen(String text, int openIdx) {
+  var depth = 0;
+  for (var i = openIdx; i < text.length; i++) {
+    final c = text[i];
+    if (c == '(') depth++;
+    if (c == ')') {
+      depth--;
+      if (depth == 0) return i;
+    }
+  }
+  return -1;
+}
+
+int _lineNumber(String text, int index) {
+  var line = 1;
+  for (var i = 0; i < index; i++) {
+    if (text.codeUnitAt(i) == 0x0A) line++;
+  }
+  return line;
+}


### PR DESCRIPTION
## Summary
Minimum fix for #757. Every previous map-bug PR (#496, #532, #696, #707, #709, #711) attacked symptoms. None touched \`TileLayer.evictErrorTileStrategy\` — the root cause is that \`flutter_map\`'s default caches failed tile fetches forever. A single transient 429/503 from the OSM tile server leaves a permanent gray square in the viewport.

Set \`evictErrorTileStrategy: EvictErrorTileStrategy.notVisibleRespectMargin\` on every \`TileLayer\` in the app so failed tiles get evicted as soon as they scroll past the \`keepBuffer\` margin; next draw re-requests.

\`errorTileCallback\` on the primary layer debugPrints the failing tile coordinates for observability.

## Test plan
- [x] New \`tile_layer_eviction_strategy_test.dart\` — grep-scans every \`lib/**/*.dart\` for \`TileLayer(\` and fails if any instance omits the strategy. Same pattern as the plaintext-URL scan.
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4636 passing

## Not in this PR (follow-ups on #757)
- \`RetryNetworkTileProvider\` with backoff on 429/503
- \`flutter_map_tile_caching\` disk cache
- \`TileLayer\` reset stream wired to country-switch + cache-clear
- Cleanup of the legacy \`onMapReady\` jiggle / subtree-rebuild hacks now that the root cause is addressed

Partial progress on #757 — issue stays open for the follow-ups.