### PR TITLE
feat(map): OsmRetryClient — retry 429 + Retry-After for tile fetches

### DIFF
--- a/lib/features/map/data/osm_retry_client.dart
+++ b/lib/features/map/data/osm_retry_client.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+/// HTTP client wrapper that retries failed OSM tile fetches (#757).
+///
+/// flutter_map 8.x already ships with `http.RetryClient` wrapping the
+/// default [http.Client], but that retries only on 5xx — not on 429,
+/// connection errors, or timeouts. The OSM tile server issues 429
+/// under load and expects clients to obey `Retry-After`.
+///
+/// This client adds:
+/// - Retry on 429, 5xx, [SocketException], and [TimeoutException].
+/// - Exponential backoff with ±20% jitter (200 ms, 800 ms, 3.2 s).
+/// - `Retry-After` header respected when present (either seconds or
+///   an HTTP-date).
+/// - Capped at 3 attempts total — beyond that the failed tile goes
+///   into [TileLayer.errorTileCallback] and is evicted by the
+///   `notVisibleRespectMargin` strategy landed in #758.
+///
+/// The backoff + Retry-After math is deterministic given a seeded
+/// [math.Random], which is what the unit tests inject. In production
+/// the seeded constructor is unused; [OsmRetryClient] defaults to an
+/// unseeded [math.Random].
+class OsmRetryClient extends http.BaseClient {
+  final http.Client _inner;
+  final int _maxAttempts;
+  final Duration _baseDelay;
+  final math.Random _random;
+
+  /// Sleep hook, injected so tests can fast-forward without real delays.
+  final Future<void> Function(Duration) _sleep;
+
+  OsmRetryClient({
+    http.Client? inner,
+    int maxAttempts = 3,
+    Duration baseDelay = const Duration(milliseconds: 200),
+    math.Random? random,
+    Future<void> Function(Duration)? sleep,
+  })  : _inner = inner ?? http.Client(),
+        _maxAttempts = maxAttempts,
+        _baseDelay = baseDelay,
+        _random = random ?? math.Random(),
+        _sleep = sleep ?? _defaultSleep;
+
+  static Future<void> _defaultSleep(Duration d) => Future.delayed(d);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    // The `http` package exposes BaseRequest but a streamed request can
+    // only be sent once. Materialise it to bytes so each retry rebuilds
+    // an identical request — safe for our GET-only tile URLs.
+    final bodyBytes = await request.finalize().toBytes();
+    Object? lastError;
+    http.StreamedResponse? lastResponse;
+
+    for (var attempt = 0; attempt < _maxAttempts; attempt++) {
+      final fresh = http.Request(request.method, request.url)
+        ..headers.addAll(request.headers)
+        ..bodyBytes = bodyBytes;
+
+      try {
+        final response = await _inner.send(fresh);
+        if (response.statusCode < 500 && response.statusCode != 429) {
+          return response;
+        }
+        lastResponse = response;
+      } on SocketException catch (e) {
+        lastError = e;
+      } on TimeoutException catch (e) {
+        lastError = e;
+      } on http.ClientException catch (e) {
+        lastError = e;
+      }
+
+      if (attempt == _maxAttempts - 1) break;
+      final delay = _nextDelay(attempt, lastResponse?.headers);
+      debugPrint(
+          'OsmRetryClient: ${request.url} attempt ${attempt + 1} failed '
+          '(${lastError ?? 'HTTP ${lastResponse?.statusCode}'}), '
+          'retry in ${delay.inMilliseconds} ms');
+      await _sleep(delay);
+    }
+
+    if (lastResponse != null) return lastResponse;
+    throw lastError ?? http.ClientException('OsmRetryClient: retries exhausted');
+  }
+
+  /// Compute the delay before the next attempt. Honours `Retry-After`
+  /// when present (OSM's preferred rate-limit signal), otherwise
+  /// exponential backoff with ±20% jitter.
+  @visibleForTesting
+  Duration nextDelayForTest(int attempt, Map<String, String>? headers) =>
+      _nextDelay(attempt, headers);
+
+  Duration _nextDelay(int attempt, Map<String, String>? headers) {
+    final retryAfter = _parseRetryAfter(headers?['retry-after']);
+    if (retryAfter != null) return retryAfter;
+    final baseMs = _baseDelay.inMilliseconds * math.pow(4, attempt).toInt();
+    final jitter = (baseMs * 0.2 * (_random.nextDouble() * 2 - 1)).toInt();
+    return Duration(milliseconds: math.max(0, baseMs + jitter));
+  }
+
+  /// Parse a `Retry-After` header. Accepts either seconds (e.g. `"60"`)
+  /// or an HTTP-date (`"Wed, 21 Oct 2026 07:28:00 GMT"`).
+  static Duration? _parseRetryAfter(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    final seconds = int.tryParse(raw.trim());
+    if (seconds != null) return Duration(seconds: seconds);
+    try {
+      final when = HttpDate.parse(raw);
+      final diff = when.difference(DateTime.now());
+      return diff.isNegative ? Duration.zero : diff;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../../../core/constants/app_constants.dart';
+import '../../data/osm_retry_client.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
@@ -98,6 +99,11 @@ class StationMapLayers extends StatelessWidget {
               userAgentPackageName: AppConstants.osmUserAgent,
               maxNativeZoom: 19,
               maxZoom: 19,
+              // #757 phase 2 — retry 429s and transient errors with
+              // Retry-After respect. Default RetryClient in flutter_map
+              // only handles 5xx; adding 429 + connection errors cuts
+              // down the gray-tile rate under load.
+              tileProvider: NetworkTileProvider(httpClient: OsmRetryClient()),
               // #757 — kill the persistent-gray-tile bug at its root.
               // Default NetworkTileProvider caches failed fetches in
               // TileImageManager and the same (z,x,y) is never

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -848,7 +848,7 @@ packages:
     source: hosted
     version: "1.0.2"
   http:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   connectivity_plus: ^7.1.1
   shared_preferences: ^2.5.5
   url_launcher: ^6.3.1
+  http: ^1.3.0
   share_plus: ^12.0.2
   flutter_blue_plus: ^1.35.5
   permission_handler: ^12.0.0+1
@@ -79,9 +80,6 @@ dev_dependencies:
   freezed: ^3.2.5
   json_serializable: ^6.13.0
   riverpod_generator: ^4.0.3
-
-  # URL reachability test (#539)
-  http: ^1.3.0
 
   # Testing
   mocktail: ^1.0.5

--- a/test/features/map/data/osm_retry_client_test.dart
+++ b/test/features/map/data/osm_retry_client_test.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:tankstellen/features/map/data/osm_retry_client.dart';
+
+void main() {
+  group('OsmRetryClient (#757)', () {
+    test('passes 200 through without retrying', () async {
+      final inner = _FakeClient(
+        responses: [_resp(200, body: 'tile-bytes')],
+      );
+      final slept = <Duration>[];
+      final client = OsmRetryClient(
+        inner: inner,
+        sleep: (d) async => slept.add(d),
+      );
+
+      final res = await client.get(Uri.parse('https://tile/1/2/3.png'));
+      expect(res.statusCode, 200);
+      expect(inner.sentCount, 1);
+      expect(slept, isEmpty);
+    });
+
+    test('retries on 5xx, returns 200 after 2 failures', () async {
+      final inner = _FakeClient(responses: [
+        _resp(503),
+        _resp(500),
+        _resp(200, body: 'ok'),
+      ]);
+      final slept = <Duration>[];
+      final client = OsmRetryClient(
+        inner: inner,
+        random: math.Random(0),
+        sleep: (d) async => slept.add(d),
+      );
+
+      final res = await client.get(Uri.parse('https://tile'));
+      expect(res.statusCode, 200);
+      expect(inner.sentCount, 3);
+      expect(slept, hasLength(2));
+    });
+
+    test('retries on 429 specifically — built-in RetryClient does not',
+        () async {
+      final inner = _FakeClient(responses: [
+        _resp(429),
+        _resp(200, body: 'ok'),
+      ]);
+      final client = OsmRetryClient(
+        inner: inner,
+        sleep: (_) async {},
+      );
+
+      final res = await client.get(Uri.parse('https://tile'));
+      expect(res.statusCode, 200);
+      expect(inner.sentCount, 2);
+    });
+
+    test('honours Retry-After seconds header over exponential backoff',
+        () async {
+      final inner = _FakeClient(responses: [
+        _resp(429, headers: {'retry-after': '7'}),
+        _resp(200),
+      ]);
+      Duration? sleptFor;
+      final client = OsmRetryClient(
+        inner: inner,
+        sleep: (d) async => sleptFor = d,
+      );
+
+      await client.get(Uri.parse('https://tile'));
+      expect(sleptFor, const Duration(seconds: 7));
+    });
+
+    test('Retry-After HTTP-date — sleeps the parsed interval', () async {
+      // Use a future time so parseRetryAfter produces a positive delay.
+      final future = DateTime.now().toUtc().add(const Duration(seconds: 3));
+      final raw = HttpDate.format(future);
+      final inner = _FakeClient(responses: [
+        _resp(503, headers: {'retry-after': raw}),
+        _resp(200),
+      ]);
+      Duration? sleptFor;
+      final client = OsmRetryClient(
+        inner: inner,
+        sleep: (d) async => sleptFor = d,
+      );
+
+      await client.get(Uri.parse('https://tile'));
+      expect(sleptFor, isNotNull);
+      expect(sleptFor!.inSeconds, inInclusiveRange(0, 4));
+    });
+
+    test('surfaces SocketException after exhausting retries', () async {
+      final inner = _FakeClient(errors: [
+        const SocketException('blip'),
+        const SocketException('blip'),
+        const SocketException('blip'),
+      ]);
+      final client = OsmRetryClient(
+        inner: inner,
+        maxAttempts: 3,
+        sleep: (_) async {},
+      );
+
+      await expectLater(
+        client.get(Uri.parse('https://tile')),
+        throwsA(isA<SocketException>()),
+      );
+      expect(inner.sentCount, 3);
+    });
+
+    test('caps attempts at maxAttempts', () async {
+      final inner = _FakeClient(responses: List.filled(10, _resp(503)));
+      final client = OsmRetryClient(
+        inner: inner,
+        maxAttempts: 3,
+        sleep: (_) async {},
+      );
+
+      final res = await client.get(Uri.parse('https://tile'));
+      expect(res.statusCode, 503);
+      expect(inner.sentCount, 3);
+    });
+
+    test('nextDelayForTest grows exponentially and stays non-negative',
+        () {
+      final client = OsmRetryClient(
+        inner: _FakeClient(responses: []),
+        random: math.Random(42),
+        sleep: (_) async {},
+      );
+      final d0 = client.nextDelayForTest(0, null);
+      final d1 = client.nextDelayForTest(1, null);
+      final d2 = client.nextDelayForTest(2, null);
+      expect(d0.inMilliseconds, greaterThanOrEqualTo(0));
+      expect(d1.inMilliseconds, greaterThan(d0.inMilliseconds));
+      expect(d2.inMilliseconds, greaterThan(d1.inMilliseconds));
+    });
+  });
+}
+
+// --- helpers ----------------------------------------------------------
+
+http.StreamedResponse _resp(
+  int status, {
+  String body = '',
+  Map<String, String> headers = const {},
+}) {
+  return http.StreamedResponse(
+    Stream<List<int>>.value(body.codeUnits),
+    status,
+    headers: headers,
+  );
+}
+
+class _FakeClient extends http.BaseClient {
+  final List<http.StreamedResponse> responses;
+  final List<Object> errors;
+  int sentCount = 0;
+
+  _FakeClient({
+    this.responses = const [],
+    this.errors = const [],
+  });
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final idx = sentCount++;
+    if (idx < errors.length) throw errors[idx];
+    if (idx < responses.length) return responses[idx];
+    throw StateError('FakeClient exhausted after $idx calls');
+  }
+}


### PR DESCRIPTION
## Summary
Phase 2 of #757. \`flutter_map\` 8.x wraps tile fetches in \`http.RetryClient\`, but that retries only on 5xx. OSM issues 429 under load with \`Retry-After\` headers the default client ignores.

\`OsmRetryClient\` retries on **429 / 5xx / SocketException / TimeoutException**, honours **Retry-After** (seconds or HTTP-date), exponential backoff with ±20% jitter, caps at 3 attempts. Combined with #758's \`evictErrorTileStrategy\`, this cuts the gray-tile rate materially under load.

Wired into the primary station-map \`TileLayer\`. Driving-map stays on default (short-lived surface).

## Test plan
- [x] 8 unit tests with injected sleep hook and fake \`http.Client\`
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4649 passing

Partial progress on #757 — reset-on-country-switch + legacy-hack cleanup remain.