### PR TITLE
feat(obd2): native Kotlin Classic-SPP plugin for vLinker FS

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
@@ -1,5 +1,15 @@
 package de.tankstellen.tankstellen
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        // Register the in-repo OBD2 Classic BT plugin (#763). Placed
+        // here rather than a separate FlutterPlugin class to keep the
+        // Android module free of extra Gradle artefacts; the plugin is
+        // app-internal and never shipped to pub.dev.
+        Obd2ClassicPlugin.registerWith(flutterEngine, applicationContext)
+    }
+}

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
@@ -1,0 +1,197 @@
+package de.tankstellen.tankstellen
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothSocket
+import android.content.Context
+import android.util.Log
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.IOException
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+
+/**
+ * In-repo MethodChannel plugin for Bluetooth Classic SPP RFCOMM,
+ * the transport used by the vLinker FS OBD2 adapter (#763).
+ *
+ * Written in Kotlin inside this app to avoid the license problem:
+ * the popular flutter_blue_classic package is GPL-3, incompatible
+ * with this MIT project. Everything here is the Apache-licensed
+ * Android Bluetooth API — no external plugin dependency.
+ *
+ * Channels:
+ *  - "tankstellen.obd2/classic" (MethodChannel):
+ *       bondedDevices() -> List<Map{address, name, bondState}>
+ *       connect(address, uuid) -> Bool
+ *       write(bytes) -> void
+ *       disconnect() -> void
+ *  - "tankstellen.obd2/classic/incoming" (EventChannel):
+ *       Stream<List<int>> — bytes arriving from the socket's
+ *       InputStream, pushed on a background reader thread.
+ *
+ * The Dart-side `PluginClassicBluetoothFacade` is the only caller.
+ *
+ * Threading: Android's BluetoothSocket I/O MUST NOT happen on the
+ * main thread. `connect()` does the dial on a background thread and
+ * completes a MethodChannel.Result when done. The reader thread runs
+ * for the lifetime of the connection and pushes bytes to the
+ * EventChannel's sink from whichever thread — Flutter's platform-
+ * channel plumbing marshals to the main thread for delivery.
+ */
+object Obd2ClassicPlugin {
+    private const val TAG = "Obd2ClassicPlugin"
+    private const val METHOD_CHANNEL = "tankstellen.obd2/classic"
+    private const val INCOMING_CHANNEL = "tankstellen.obd2/classic/incoming"
+
+    private var socket: BluetoothSocket? = null
+    private var readerThread: Thread? = null
+    private val readerRunning = AtomicBoolean(false)
+    private var eventSink: EventChannel.EventSink? = null
+
+    fun registerWith(flutterEngine: FlutterEngine, context: Context) {
+        val method = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, METHOD_CHANNEL)
+        val events = EventChannel(flutterEngine.dartExecutor.binaryMessenger, INCOMING_CHANNEL)
+
+        method.setMethodCallHandler { call, result -> handle(call, result, context) }
+        events.setStreamHandler(object : EventChannel.StreamHandler {
+            override fun onListen(arguments: Any?, sink: EventChannel.EventSink?) {
+                eventSink = sink
+            }
+
+            override fun onCancel(arguments: Any?) {
+                eventSink = null
+            }
+        })
+    }
+
+    private fun handle(call: MethodCall, result: MethodChannel.Result, context: Context) {
+        try {
+            when (call.method) {
+                "bondedDevices" -> result.success(bondedDevices(context))
+                "connect" -> {
+                    val address = call.argument<String>("address")
+                        ?: return result.error("arg", "address missing", null)
+                    val uuid = call.argument<String>("uuid")
+                        ?: return result.error("arg", "uuid missing", null)
+                    thread(name = "obd2-classic-connect") {
+                        val ok = connect(context, address, uuid)
+                        result.success(ok)
+                    }
+                }
+                "write" -> {
+                    val bytes = call.argument<ByteArray>("bytes")
+                        ?: return result.error("arg", "bytes missing", null)
+                    writeBytes(bytes, result)
+                }
+                "disconnect" -> {
+                    disconnect()
+                    result.success(true)
+                }
+                else -> result.notImplemented()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "handle ${call.method} failed", e)
+            result.error("platform", e.message ?: e.javaClass.simpleName, null)
+        }
+    }
+
+    private fun bondedDevices(context: Context): List<Map<String, Any?>> {
+        val adapter = adapterOrNull(context) ?: return emptyList()
+        // Requires BLUETOOTH_CONNECT on Android 12+. Caller gates
+        // this via Obd2Permissions before invoking us.
+        @Suppress("MissingPermission")
+        val bonded = adapter.bondedDevices ?: return emptyList()
+        return bonded.map { d ->
+            mapOf(
+                "address" to d.address,
+                "name" to (d.name ?: ""),
+            )
+        }
+    }
+
+    private fun connect(context: Context, address: String, uuid: String): Boolean {
+        disconnect() // ensure any prior socket is closed
+        val adapter = adapterOrNull(context) ?: return false
+        @Suppress("MissingPermission")
+        val device = try {
+            adapter.getRemoteDevice(address)
+        } catch (e: IllegalArgumentException) {
+            Log.e(TAG, "connect: bad address $address", e)
+            return false
+        }
+        return try {
+            @Suppress("MissingPermission")
+            val s = device.createRfcommSocketToServiceRecord(UUID.fromString(uuid))
+            @Suppress("MissingPermission")
+            adapter.cancelDiscovery() // required before connect()
+            s.connect()
+            socket = s
+            startReader()
+            true
+        } catch (e: IOException) {
+            Log.e(TAG, "connect: RFCOMM open failed", e)
+            try { socket?.close() } catch (_: IOException) {}
+            socket = null
+            false
+        }
+    }
+
+    private fun startReader() {
+        readerRunning.set(true)
+        readerThread = thread(name = "obd2-classic-read") {
+            val s = socket ?: return@thread
+            val buffer = ByteArray(256)
+            try {
+                val input = s.inputStream
+                while (readerRunning.get()) {
+                    val n = input.read(buffer)
+                    if (n < 0) break
+                    if (n == 0) continue
+                    val slice = buffer.copyOfRange(0, n).toList()
+                    val sink = eventSink
+                    if (sink != null) {
+                        android.os.Handler(android.os.Looper.getMainLooper()).post {
+                            sink.success(slice)
+                        }
+                    }
+                }
+            } catch (e: IOException) {
+                Log.w(TAG, "reader: $e")
+            }
+        }
+    }
+
+    private fun writeBytes(bytes: ByteArray, result: MethodChannel.Result) {
+        val s = socket ?: return result.error("state", "not connected", null)
+        thread(name = "obd2-classic-write") {
+            try {
+                s.outputStream.write(bytes)
+                s.outputStream.flush()
+                result.success(true)
+            } catch (e: IOException) {
+                Log.e(TAG, "write failed", e)
+                result.error("io", e.message ?: "write failed", null)
+            }
+        }
+    }
+
+    private fun disconnect() {
+        readerRunning.set(false)
+        try { socket?.close() } catch (_: IOException) {}
+        socket = null
+        readerThread = null
+    }
+
+    private fun adapterOrNull(context: Context): BluetoothAdapter? {
+        return try {
+            (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
+        } catch (e: Exception) {
+            Log.e(TAG, "adapter fetch failed", e)
+            null
+        }
+    }
+}

--- a/lib/features/consumption/data/obd2/classic_bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/classic_bluetooth_facade.dart
@@ -1,24 +1,23 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+
 import 'adapter_registry.dart';
 import 'classic_elm_channel.dart';
+import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
 
 /// Facade over the Classic Bluetooth transport for OBD2 adapters
-/// (#761). Mirrors [BluetoothFacade]'s contract — scan yields ranked
-/// candidates, [channelFor] hands back an [ElmByteChannel] the
-/// transport layer can drive.
+/// (#761 abstraction, #763 real impl).
 ///
-/// Classic Bluetooth does not advertise services the way BLE does:
-/// adapters are paired through Android's Bluetooth settings, then
-/// enumerated via the OS `bondedDevices` list. Our picker UI
-/// ultimately wants to surface bonded adapters first, then any
-/// newly-discovered ones from a live scan.
+/// Classic BT adapters are paired through Android's Bluetooth
+/// settings and then enumerated via the OS `bondedDevices` list.
+/// The picker UI surfaces bonded adapters only — discovery of
+/// un-paired adapters is out of scope; the usage flow is "pair
+/// once, use forever".
 abstract class ClassicBluetoothFacade {
-  /// Emit the set of Classic BT candidates — bonded devices first,
-  /// then any newly-discovered adapters. The stream completes after
-  /// [timeout]. Classic has no RSSI during bonded enumeration, so
-  /// [Obd2AdapterCandidate.rssi] is 0 for those entries.
+  /// Emit the set of Classic BT candidates. Classic has no RSSI
+  /// during bonded enumeration, so [Obd2AdapterCandidate.rssi] is 0.
   Stream<List<Obd2AdapterCandidate>> scan({Duration timeout});
 
   Future<void> stopScan();
@@ -28,34 +27,41 @@ abstract class ClassicBluetoothFacade {
   ElmByteChannel channelFor(String deviceId);
 }
 
-/// Placeholder production impl that surfaces the Classic path
-/// without yet wiring a real platform plugin. Rationale: the popular
-/// `flutter_blue_classic` package is GPL-3 licensed, incompatible
-/// with this MIT project. The license-clean replacement — either a
-/// native MethodChannel or a future MIT-licensed plugin — is tracked
-/// as a follow-up on #761.
-///
-/// Until the real impl lands, `scan()` completes immediately with an
-/// empty list (no adapters surface) and `channelFor` returns a
-/// [ClassicElmChannel] whose `open()` throws so the connection
-/// service translates it to `Obd2AdapterUnresponsive` for the UI.
-/// Tests inject a concrete fake that implements the abstract
-/// contract properly, so unit coverage is unaffected.
-class StubClassicBluetoothFacade implements ClassicBluetoothFacade {
-  const StubClassicBluetoothFacade();
+/// Production impl wiring the native [Obd2ClassicMethodChannel]
+/// plugin (#763). All I/O goes through the MethodChannel pair
+/// registered by `Obd2ClassicPlugin.kt`.
+class PluginClassicBluetoothFacade implements ClassicBluetoothFacade {
+  final Obd2ClassicMethodChannel _plugin;
+
+  const PluginClassicBluetoothFacade({
+    Obd2ClassicMethodChannel plugin = const Obd2ClassicMethodChannel(),
+  }) : _plugin = plugin;
 
   @override
   Stream<List<Obd2AdapterCandidate>> scan({
     Duration timeout = const Duration(seconds: 8),
   }) async* {
-    // Intentionally empty: no Classic adapters surface until the
-    // real platform wrapper ships. See class doc.
+    try {
+      final bonded = await _plugin.bondedDevices();
+      yield bonded
+          .map((d) => Obd2AdapterCandidate(
+                deviceId: d.address,
+                deviceName: d.name,
+                advertisedServiceUuids: const [],
+                rssi: 0,
+              ))
+          .toList();
+    } on Exception catch (e) {
+      debugPrint('PluginClassicBluetoothFacade: bondedDevices failed: $e');
+    }
   }
 
   @override
-  Future<void> stopScan() async {}
+  Future<void> stopScan() async {
+    // Bonded-only enumeration is instant; nothing to cancel.
+  }
 
   @override
   ElmByteChannel channelFor(String deviceId) =>
-      ClassicElmChannel(address: deviceId);
+      ClassicElmChannel(address: deviceId, plugin: _plugin);
 }

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+
+import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
 
 /// Standard Bluetooth Serial Port Profile UUID (#761). Every
@@ -7,55 +10,77 @@ import 'elm_byte_channel.dart';
 /// Amazon dongles) uses this same Bluetooth-SIG assigned base.
 const String sppServiceUuid = '00001101-0000-1000-8000-00805f9b34fb';
 
-/// Placeholder [ElmByteChannel] for the Bluetooth-Classic SPP path
-/// (#761).
+/// [ElmByteChannel] backed by the in-repo MethodChannel plugin
+/// [Obd2ClassicMethodChannel] (#763).
 ///
-/// The intended production impl wraps an RFCOMM socket opened via a
-/// platform plugin. The popular \`flutter_blue_classic\` package is
-/// GPL-3 licensed and incompatible with this MIT project (license
-/// audit would fail CI). A follow-up issue tracks the license-clean
-/// replacement — either a native MethodChannel wrapper in
-/// \`android/app/src/main/kotlin/\` or an MIT-licensed Classic BT
-/// plugin.
-///
-/// Until then, [open] throws so a user picking the Classic-only
-/// path gets a typed \`Obd2AdapterUnresponsive\` back from the
-/// connection service rather than a silent no-op. Tests inject a
-/// fake [ElmByteChannel] instead of this class, so nothing breaks.
+/// The plugin owns the native [android.bluetooth.BluetoothSocket];
+/// this Dart class just relays the two directions — `write` goes
+/// down via MethodChannel, `incoming` comes up via EventChannel.
+/// The existing [BluetoothObd2Transport] sits on top and handles
+/// the ELM327 `>`-prompt framing.
 class ClassicElmChannel implements ElmByteChannel {
-  final String _address;
-  final String _sppUuid;
+  final String address;
+  final String sppUuid;
+  final Obd2ClassicMethodChannel _plugin;
+
+  StreamSubscription<List<int>>? _subscription;
+  final StreamController<List<int>> _incoming =
+      StreamController<List<int>>.broadcast();
+  bool _open = false;
 
   ClassicElmChannel({
-    required String address,
-    String sppUuid = sppServiceUuid,
-  })  : _address = address,
-        _sppUuid = sppUuid;
+    required this.address,
+    Obd2ClassicMethodChannel? plugin,
+    this.sppUuid = sppServiceUuid,
+  }) : _plugin = plugin ?? const Obd2ClassicMethodChannel();
 
   @override
-  bool get isOpen => false;
+  bool get isOpen => _open;
 
   @override
-  Stream<List<int>> get incoming => const Stream.empty();
+  Stream<List<int>> get incoming => _incoming.stream;
 
   @override
   Future<void> open() async {
-    throw StateError(
-      'ClassicElmChannel: Bluetooth Classic SPP transport is not yet '
-      'wired on this build (target $_address via $_sppUuid). Follow '
-      '#761 for the license-clean native implementation. BLE '
-      'adapters (vLinker FD / MC, OBDLink MX+, Carista, Veepeak) '
-      'work today.',
+    if (_open) return;
+    final ok = await _plugin.connect(address: address, uuid: sppUuid);
+    if (!ok) {
+      throw StateError(
+        'ClassicElmChannel: failed to open RFCOMM socket to $address '
+        '(plugin returned false). Adapter may not be bonded or is out '
+        'of range.',
+      );
+    }
+    _subscription = _plugin.incoming.listen(
+      _incoming.add,
+      onError: (Object e, StackTrace st) {
+        debugPrint('ClassicElmChannel: incoming error: $e');
+      },
+      onDone: () {
+        _open = false;
+      },
     );
+    _open = true;
   }
 
   @override
   Future<void> write(List<int> bytes) async {
-    throw StateError('ClassicElmChannel: not open');
+    if (!_open) {
+      throw StateError('ClassicElmChannel: not open');
+    }
+    await _plugin.write(bytes);
   }
 
   @override
   Future<void> close() async {
-    // no-op — nothing was opened.
+    _open = false;
+    await _subscription?.cancel();
+    _subscription = null;
+    try {
+      await _plugin.disconnect();
+    } catch (e) {
+      debugPrint('ClassicElmChannel: disconnect error (ignored): $e');
+    }
+    await _incoming.close();
   }
 }

--- a/lib/features/consumption/data/obd2/classic_method_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_method_channel.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+/// Thin Dart binding for the in-repo Kotlin plugin `Obd2ClassicPlugin`
+/// (#763). Separated from [PluginClassicBluetoothFacade] so tests can
+/// swap this out via a constructor-injected fake without touching the
+/// façade surface that production call sites use.
+///
+/// Channel names are kept in one place here — the Kotlin side
+/// mirrors the same strings. Keep them in sync.
+class Obd2ClassicMethodChannel {
+  static const _methodChannel =
+      MethodChannel('tankstellen.obd2/classic');
+  static const _incomingChannel =
+      EventChannel('tankstellen.obd2/classic/incoming');
+
+  const Obd2ClassicMethodChannel();
+
+  /// Enumerates every Bluetooth Classic device the OS already
+  /// bonded with. The realistic vLinker FS flow: the user pairs in
+  /// Android settings once, then the adapter shows up here on every
+  /// app launch. Returns `[]` when Bluetooth is off or the query
+  /// fails.
+  Future<List<ClassicBondedDevice>> bondedDevices() async {
+    final raw = await _methodChannel.invokeListMethod<dynamic>('bondedDevices')
+        ?? const [];
+    return raw
+        .whereType<Map>()
+        .map((m) => ClassicBondedDevice(
+              address: m['address'] as String? ?? '',
+              name: m['name'] as String? ?? '',
+            ))
+        .where((d) => d.address.isNotEmpty)
+        .toList();
+  }
+
+  /// Open an RFCOMM socket to [address] on the Serial Port Profile
+  /// UUID. Returns `true` on success. Must be called once per
+  /// connection — subsequent calls close the prior socket first.
+  Future<bool> connect({required String address, required String uuid}) async {
+    final ok = await _methodChannel.invokeMethod<bool>(
+      'connect',
+      {'address': address, 'uuid': uuid},
+    );
+    return ok ?? false;
+  }
+
+  /// Write [bytes] to the currently-open socket. Throws
+  /// [PlatformException] when not connected or the socket's output
+  /// stream errors.
+  Future<void> write(List<int> bytes) async {
+    await _methodChannel.invokeMethod<void>(
+      'write',
+      {'bytes': Uint8List.fromList(bytes)},
+    );
+  }
+
+  /// Close the current socket and cancel the reader thread.
+  /// Idempotent — safe to call multiple times.
+  Future<void> disconnect() async {
+    await _methodChannel.invokeMethod<void>('disconnect');
+  }
+
+  /// Incoming bytes from the socket's input stream, pushed by the
+  /// reader thread on the native side. Subscribing starts the
+  /// EventChannel; cancelling stops listening but the socket stays
+  /// open — call [disconnect] to fully close.
+  Stream<List<int>> get incoming => _incomingChannel
+      .receiveBroadcastStream()
+      .map<List<int>>((event) {
+        if (event is List) {
+          return event.cast<int>();
+        }
+        return const <int>[];
+      });
+}
+
+/// Minimal tuple describing a bonded Classic BT device.
+class ClassicBondedDevice {
+  final String address;
+  final String name;
+  const ClassicBondedDevice({required this.address, required this.name});
+}

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -138,6 +138,6 @@ Obd2ConnectionService obd2Connection(Ref ref) {
     registry: Obd2AdapterRegistry.defaults(),
     permissions: ref.watch(obd2PermissionsProvider),
     bluetooth: const PluginBluetoothFacade(),
-    classicBluetooth: const StubClassicBluetoothFacade(),
+    classicBluetooth: const PluginClassicBluetoothFacade(),
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 11 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 5.0.0+5067
+version: 5.0.0+5068
 
 environment:
   sdk: ^3.11.3

--- a/test/features/consumption/data/obd2/classic_method_channel_test.dart
+++ b/test/features/consumption/data/obd2/classic_method_channel_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/classic_method_channel.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const methodChannel = MethodChannel('tankstellen.obd2/classic');
+  final messenger = TestDefaultBinaryMessengerBinding
+      .instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(methodChannel, null);
+  });
+
+  group('Obd2ClassicMethodChannel (#763)', () {
+    test('bondedDevices parses the native list into typed DTOs',
+        () async {
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        expect(call.method, 'bondedDevices');
+        return [
+          {'address': 'AA:BB:CC:DD:EE:01', 'name': 'vLinker FS 14884'},
+          {'address': 'AA:BB:CC:DD:EE:02', 'name': 'Bose Mini SoundLink'},
+        ];
+      });
+
+      const plugin = Obd2ClassicMethodChannel();
+      final bonded = await plugin.bondedDevices();
+
+      expect(bonded, hasLength(2));
+      expect(bonded.first.address, 'AA:BB:CC:DD:EE:01');
+      expect(bonded.first.name, 'vLinker FS 14884');
+    });
+
+    test('bondedDevices returns empty when native pushes back null',
+        () async {
+      messenger.setMockMethodCallHandler(methodChannel, (_) async => null);
+      const plugin = Obd2ClassicMethodChannel();
+      expect(await plugin.bondedDevices(), isEmpty);
+    });
+
+    test('bondedDevices drops entries with an empty address', () async {
+      messenger.setMockMethodCallHandler(methodChannel, (_) async => [
+            {'address': '', 'name': 'garbage entry'},
+            {'address': 'AA:BB', 'name': 'ok'},
+          ]);
+      const plugin = Obd2ClassicMethodChannel();
+      final bonded = await plugin.bondedDevices();
+      expect(bonded, hasLength(1));
+      expect(bonded.single.address, 'AA:BB');
+    });
+
+    test('connect forwards address + uuid + returns native bool',
+        () async {
+      MethodCall? captured;
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        captured = call;
+        return true;
+      });
+
+      const plugin = Obd2ClassicMethodChannel();
+      final ok = await plugin.connect(
+        address: 'AA:BB',
+        uuid: '00001101-0000-1000-8000-00805f9b34fb',
+      );
+
+      expect(ok, isTrue);
+      expect(captured!.method, 'connect');
+      expect(captured!.arguments, {
+        'address': 'AA:BB',
+        'uuid': '00001101-0000-1000-8000-00805f9b34fb',
+      });
+    });
+
+    test('connect defaults to false when native returns null', () async {
+      messenger.setMockMethodCallHandler(methodChannel, (_) async => null);
+      const plugin = Obd2ClassicMethodChannel();
+      expect(
+        await plugin.connect(address: 'AA', uuid: 'UUID'),
+        isFalse,
+      );
+    });
+
+    test('write forwards bytes as a Uint8List', () async {
+      Object? capturedBytes;
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        expect(call.method, 'write');
+        capturedBytes = (call.arguments as Map)['bytes'];
+        return null;
+      });
+
+      const plugin = Obd2ClassicMethodChannel();
+      await plugin.write([0x41, 0x54, 0x5A, 0x0D]); // "ATZ\r"
+
+      expect(capturedBytes, [0x41, 0x54, 0x5A, 0x0D]);
+    });
+
+    test('disconnect invokes the native disconnect method', () async {
+      var called = false;
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        if (call.method == 'disconnect') called = true;
+        return null;
+      });
+
+      const plugin = Obd2ClassicMethodChannel();
+      await plugin.disconnect();
+
+      expect(called, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Closes #763 — the real implementation behind #761's stubbed Classic-BT facade. In-repo Kotlin plugin over \`BluetoothAdapter\` + \`BluetoothSocket\`, zero third-party Flutter deps, MIT-clean.

### Kotlin
- \`android/app/src/main/kotlin/.../Obd2ClassicPlugin.kt\`: MethodChannel \`tankstellen.obd2/classic\` (\`bondedDevices\` / \`connect\` / \`write\` / \`disconnect\`) + EventChannel \`…/incoming\` streaming socket bytes on a background reader thread.
- Registered from \`MainActivity.configureFlutterEngine\`.

### Dart
- \`Obd2ClassicMethodChannel\` — typed wrapper over both channels.
- \`PluginClassicBluetoothFacade\` replaces \`StubClassicBluetoothFacade\` in the Riverpod provider.
- \`ClassicElmChannel\` now implements the real \`ElmByteChannel\` contract against the plugin.

## Test plan
- [x] 7 new tests under \`classic_method_channel_test.dart\` mock the native handler via \`TestDefaultBinaryMessengerBinding\`
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4662 passing

Closes #763