### PR TITLE
feat(obd2): trip recording — live polling + save as fill-up

### DIFF
--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../domain/trip_recorder.dart';
+import 'obd2_service.dart';
+
+/// Live read-out from the currently-recording trip (#726).
+///
+/// Emitted on every poll tick so the recording screen can show the
+/// user speed / RPM / distance / estimated fuel without having to
+/// ask the recorder for a full summary each time.
+@immutable
+class TripLiveReading {
+  final double? speedKmh;
+  final double? rpm;
+  final double? fuelRateLPerHour;
+  final double? fuelLevelPercent;
+  final double? engineLoadPercent;
+  final double distanceKmSoFar;
+  final double? fuelLitersSoFar;
+  final Duration elapsed;
+  final double? odometerStartKm;
+  final double? odometerNowKm;
+
+  const TripLiveReading({
+    this.speedKmh,
+    this.rpm,
+    this.fuelRateLPerHour,
+    this.fuelLevelPercent,
+    this.engineLoadPercent,
+    required this.distanceKmSoFar,
+    this.fuelLitersSoFar,
+    required this.elapsed,
+    this.odometerStartKm,
+    this.odometerNowKm,
+  });
+
+  /// Live L/100 km estimate — uses trip-so-far totals, so early
+  /// samples are noisy and converge as the trip progresses. Returns
+  /// null when the car doesn't surface a fuel-rate PID.
+  double? get liveAvgLPer100Km {
+    if (fuelLitersSoFar == null || distanceKmSoFar < 0.01) return null;
+    return fuelLitersSoFar! / distanceKmSoFar * 100.0;
+  }
+}
+
+/// Drives the polling loop that feeds an [Obd2Service]'s live PIDs
+/// into a [TripRecorder] (#726).
+///
+/// Not a Riverpod notifier — kept as a plain class so the recording
+/// screen owns the lifecycle (start on screen mount, stop on tap).
+/// The screen subscribes to [live] for UI updates and calls [stop]
+/// to finalise the trip.
+///
+/// Polling cadence is 1 Hz — faster than that doesn't improve the
+/// derived metrics (RPM/speed integration is already smooth at 1 Hz
+/// for typical driving), and most cheap ELM327 clones can't answer
+/// 5 PIDs reliably inside a 500 ms window.
+class TripRecordingController {
+  final Obd2Service _service;
+  final TripRecorder _recorder;
+  final Duration _pollInterval;
+  final DateTime Function() _now;
+
+  final StreamController<TripLiveReading> _liveController =
+      StreamController<TripLiveReading>.broadcast();
+
+  Timer? _timer;
+  DateTime? _startedAt;
+  double? _odometerStartKm;
+  double? _odometerLatestKm;
+  double _fuelLitersSoFar = 0;
+  bool _fuelRateSeen = false;
+  bool _polling = false;
+
+  TripRecordingController({
+    required Obd2Service service,
+    TripRecorder? recorder,
+    Duration pollInterval = const Duration(seconds: 1),
+    DateTime Function()? now,
+  })  : _service = service,
+        _recorder = recorder ?? TripRecorder(),
+        _pollInterval = pollInterval,
+        _now = now ?? DateTime.now;
+
+  /// Live metrics stream — subscribe to update the recording UI.
+  Stream<TripLiveReading> get live => _liveController.stream;
+
+  bool get isRecording => _timer != null;
+
+  /// Start polling. Reads the odometer ONCE to pin the trip start;
+  /// subsequent ticks read speed/RPM/fuel-rate/etc. Safe to call
+  /// multiple times — no-op when already recording.
+  Future<void> start() async {
+    if (_timer != null) return;
+    _startedAt = _now();
+    _odometerStartKm = await _service.readOdometerKm();
+    _odometerLatestKm = _odometerStartKm;
+    _timer = Timer.periodic(_pollInterval, (_) => _pollOnce());
+  }
+
+  /// Stop the polling loop and return the accumulated summary.
+  /// Idempotent — calling twice returns the same summary.
+  Future<TripSummary> stop() async {
+    _timer?.cancel();
+    _timer = null;
+    await _liveController.close();
+    return _recorder.buildSummary();
+  }
+
+  /// Odometer reading at trip start. Null when the adapter can't
+  /// read the odometer (no PID A6, no PID 31 fallback, unknown
+  /// manufacturer). Exposed so the save-as-fill-up flow can pre-fill
+  /// the "odometer" field with the END km — which is start + the
+  /// recorder's accumulated distance.
+  double? get odometerStartKm => _odometerStartKm;
+
+  /// Latest odometer reading read during the trip. Returns null
+  /// until the first successful odometer poll. The recording UI
+  /// doesn't poll the odometer every tick (it's an expensive Mode
+  /// 22 query on some cars) — just once at start and once near the
+  /// end via [refreshOdometer].
+  double? get odometerLatestKm => _odometerLatestKm;
+
+  /// Refresh the odometer reading. Call this just before [stop] so
+  /// the save-as-fill-up gets a ground-truth end km rather than a
+  /// derived value.
+  Future<void> refreshOdometer() async {
+    final km = await _service.readOdometerKm();
+    if (km != null) _odometerLatestKm = km;
+  }
+
+  Future<void> _pollOnce() async {
+    if (_polling) return; // previous tick still in flight — skip
+    _polling = true;
+    try {
+      final speed = await _service.readSpeedKmh();
+      final rpm = await _service.readRpm();
+      final fuelRate = await _service.readFuelRateLPerHour();
+      final engineLoad = await _service.readEngineLoad();
+      final fuelLevel = await _service.readFuelLevelPercent();
+      final sample = TripSample(
+        timestamp: _now(),
+        speedKmh: (speed ?? 0).toDouble(),
+        rpm: rpm ?? 0,
+        fuelRateLPerHour: fuelRate,
+      );
+      _recorder.onSample(sample);
+      if (fuelRate != null) {
+        _fuelRateSeen = true;
+        // The recorder integrates fuel rate internally (private), but
+        // we also track a copy here for the live UI readout. Uses the
+        // same Δt as the recorder — a single-tick lag is invisible.
+        _fuelLitersSoFar =
+            (_recorder.buildSummary().fuelLitersConsumed) ?? _fuelLitersSoFar;
+      }
+      final reading = TripLiveReading(
+        speedKmh: sample.speedKmh,
+        rpm: sample.rpm,
+        fuelRateLPerHour: fuelRate,
+        fuelLevelPercent: fuelLevel,
+        engineLoadPercent: engineLoad,
+        distanceKmSoFar: _recorder.buildSummary().distanceKm,
+        fuelLitersSoFar: _fuelRateSeen ? _fuelLitersSoFar : null,
+        elapsed: _now().difference(_startedAt ?? _now()),
+        odometerStartKm: _odometerStartKm,
+        odometerNowKm: _odometerLatestKm,
+      );
+      if (!_liveController.isClosed) _liveController.add(reading);
+    } catch (e) {
+      debugPrint('TripRecordingController poll error: $e');
+    } finally {
+      _polling = false;
+    }
+  }
+}

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -27,6 +27,10 @@ class TripSummary {
   /// Average fuel consumption in L/100 km. Null when the trip carried
   /// no fuel-rate samples (cars without PID 5E / MAF).
   final double? avgLPer100Km;
+  /// Estimated fuel burned during the trip, in litres. Null when the
+  /// trip carried no fuel-rate samples. This is what the "save as
+  /// fill-up" flow pre-fills into the liters field (#726).
+  final double? fuelLitersConsumed;
   final DateTime? startedAt;
   final DateTime? endedAt;
 
@@ -38,6 +42,7 @@ class TripSummary {
     required this.harshBrakes,
     required this.harshAccelerations,
     this.avgLPer100Km,
+    this.fuelLitersConsumed,
     this.startedAt,
     this.endedAt,
   });
@@ -155,6 +160,7 @@ class TripRecorder {
       harshBrakes: _harshBrakes,
       harshAccelerations: _harshAccels,
       avgLPer100Km: avgLPer100Km,
+      fuelLitersConsumed: _hadFuelRate ? _fuelLiters : null,
       startedAt: _startedAt,
       endedAt: _endedAt,
     );

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -12,6 +12,7 @@ import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/obd2/obd2_connection_errors.dart';
 import '../widgets/obd2_adapter_picker.dart';
+import 'trip_recording_screen.dart';
 import '../../data/receipt_scan_service.dart';
 import '../../domain/entities/fill_up.dart';
 import '../../providers/consumption_providers.dart';
@@ -220,27 +221,44 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
   }
 
   /// Tap handler for the OBD-II button. Opens the adapter picker
-  /// (#743); on successful connect it reads the odometer via the
-  /// returned [Obd2Service] and fills the form. A null return (user
-  /// cancelled) is a no-op — no snackbar noise.
+  /// (#743); on successful connect, pushes the trip-recording
+  /// screen (#726) which polls live PIDs, lets the user stop when
+  /// done, and returns a [TripSaveResult] that pre-fills the
+  /// odometer + litres fields. A null return (user cancelled or
+  /// discarded the trip) is a no-op.
   Future<void> _readObd() async {
     setState(() => _obdReading = true);
     final l = AppLocalizations.of(context);
     try {
       final service = await showObd2AdapterPicker(context);
       if (service == null || !mounted) return;
-      final km = await service.readOdometerKm();
+      final result = await Navigator.of(context).push<TripSaveResult?>(
+        MaterialPageRoute(
+          builder: (_) => TripRecordingScreen(service: service),
+        ),
+      );
+      // Screen owns the service lifecycle — disconnect once it pops.
       await service.disconnect();
-      if (!mounted) return;
-      if (km != null) {
-        setState(() => _odoCtrl.text = km.round().toString());
+      if (!mounted || result == null) return;
+      setState(() {
+        if (result.odometerKm != null) {
+          _odoCtrl.text = result.odometerKm!.round().toString();
+        }
+        if (result.litersConsumed != null) {
+          _litersCtrl.text = result.litersConsumed!.toStringAsFixed(2);
+        }
+      });
+      if (result.odometerKm != null) {
         SnackBarHelper.showSuccess(
           context,
-          l?.obdOdometerRead(km.round()) ?? 'Odometer read: ${km.round()} km',
+          l?.obdOdometerRead(result.odometerKm!.round()) ??
+              'Odometer read: ${result.odometerKm!.round()} km',
         );
       } else {
         SnackBarHelper.show(
-            context, l?.obdOdometerUnavailable ?? 'Could not read odometer');
+          context,
+          l?.obdOdometerUnavailable ?? 'Could not read odometer',
+        );
       }
     } on Obd2ConnectionError catch (e) {
       if (mounted) SnackBarHelper.showError(context, e.message);

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -1,0 +1,277 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../data/obd2/obd2_service.dart';
+import '../../data/obd2/trip_recording_controller.dart';
+import '../../domain/trip_recorder.dart';
+
+/// Result returned when the user saves a recorded trip as a fill-up
+/// (#726). Null means the user cancelled or discarded.
+class TripSaveResult {
+  /// Latest odometer reading, in km. Populates the fill-up form's
+  /// odometer field. Null when the car doesn't expose the odometer.
+  final double? odometerKm;
+
+  /// Estimated litres consumed during the trip. Populates the
+  /// fill-up form's litres field. Null when the car doesn't expose
+  /// a fuel-rate PID.
+  final double? litersConsumed;
+
+  final TripSummary summary;
+
+  const TripSaveResult({
+    required this.odometerKm,
+    required this.litersConsumed,
+    required this.summary,
+  });
+}
+
+/// Full-screen trip recorder. Starts polling the already-connected
+/// [Obd2Service] in [initState], streams live metrics, and on Stop
+/// shows a summary with options to save as a fill-up or discard.
+class TripRecordingScreen extends StatefulWidget {
+  final Obd2Service service;
+
+  const TripRecordingScreen({super.key, required this.service});
+
+  @override
+  State<TripRecordingScreen> createState() => _TripRecordingScreenState();
+}
+
+class _TripRecordingScreenState extends State<TripRecordingScreen> {
+  late final TripRecordingController _controller;
+  StreamSubscription<TripLiveReading>? _sub;
+  TripLiveReading? _latest;
+  TripSummary? _summary;
+  bool _stopping = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TripRecordingController(service: widget.service);
+    _sub = _controller.live.listen((r) {
+      if (!mounted) return;
+      setState(() => _latest = r);
+    });
+    _controller.start();
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    // If the user backs out without saving, make sure the polling
+    // timer stops — the Obd2Service stays alive, owned by the caller.
+    if (_controller.isRecording) {
+      unawaited(_controller.stop());
+    }
+    super.dispose();
+  }
+
+  Future<void> _onStop() async {
+    if (_stopping) return;
+    setState(() => _stopping = true);
+    await _controller.refreshOdometer();
+    final summary = await _controller.stop();
+    if (!mounted) return;
+    setState(() {
+      _summary = summary;
+      _stopping = false;
+    });
+  }
+
+  void _onSave() {
+    final s = _summary!;
+    final oStart = _controller.odometerStartKm;
+    final oNow = _controller.odometerLatestKm;
+    // End-of-trip km preference order:
+    //   1. Latest odometer read from the ECU — ground truth.
+    //   2. Start km + recorder-integrated distance — derived fallback
+    //      when the car never answered the odometer PID a second
+    //      time.
+    //   3. Null — neither number is meaningful; the form stays blank.
+    final endKm = oNow ??
+        (oStart != null ? oStart + s.distanceKm : null);
+    Navigator.of(context).pop(
+      TripSaveResult(
+        odometerKm: endKm,
+        litersConsumed: s.fuelLitersConsumed,
+        summary: s,
+      ),
+    );
+  }
+
+  void _onDiscard() {
+    Navigator.of(context).pop(null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final summary = _summary;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          summary == null
+              ? (l?.tripRecordingTitle ?? 'Recording trip')
+              : (l?.tripSummaryTitle ?? 'Trip summary'),
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: summary == null
+              ? _buildRecording(context, l)
+              : _buildSummary(context, l, summary),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRecording(BuildContext context, AppLocalizations? l) {
+    final r = _latest;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _MetricCard(
+          icon: Icons.route,
+          label: l?.tripMetricDistance ?? 'Distance',
+          value: r == null
+              ? '—'
+              : '${r.distanceKmSoFar.toStringAsFixed(2)} km',
+        ),
+        const SizedBox(height: 8),
+        _MetricCard(
+          icon: Icons.speed,
+          label: l?.tripMetricSpeed ?? 'Speed',
+          value: r?.speedKmh == null
+              ? '—'
+              : '${r!.speedKmh!.toStringAsFixed(0)} km/h',
+        ),
+        const SizedBox(height: 8),
+        _MetricCard(
+          icon: Icons.local_gas_station,
+          label: l?.tripMetricFuelUsed ?? 'Fuel used',
+          value: r?.fuelLitersSoFar == null
+              ? '—'
+              : '${r!.fuelLitersSoFar!.toStringAsFixed(2)} L',
+        ),
+        const SizedBox(height: 8),
+        _MetricCard(
+          icon: Icons.eco,
+          label: l?.tripMetricAvgConsumption ?? 'Avg',
+          value: r?.liveAvgLPer100Km == null
+              ? '—'
+              : '${r!.liveAvgLPer100Km!.toStringAsFixed(1)} L/100 km',
+        ),
+        const SizedBox(height: 8),
+        _MetricCard(
+          icon: Icons.timer,
+          label: l?.tripMetricElapsed ?? 'Elapsed',
+          value: r == null ? '—' : _formatElapsed(r.elapsed),
+        ),
+        const Spacer(),
+        FilledButton.icon(
+          key: const Key('tripStopButton'),
+          onPressed: _stopping ? null : _onStop,
+          icon: _stopping
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.stop_circle_outlined),
+          label: Text(l?.tripStop ?? 'Stop recording'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSummary(
+    BuildContext context,
+    AppLocalizations? l,
+    TripSummary s,
+  ) {
+    final liters = s.fuelLitersConsumed;
+    final endKm = _controller.odometerLatestKm ??
+        ((_controller.odometerStartKm ?? 0) + s.distanceKm);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _MetricCard(
+          icon: Icons.route,
+          label: l?.tripMetricDistance ?? 'Distance',
+          value: '${s.distanceKm.toStringAsFixed(2)} km',
+        ),
+        const SizedBox(height: 8),
+        _MetricCard(
+          icon: Icons.local_gas_station,
+          label: l?.tripMetricFuelUsed ?? 'Fuel used',
+          value: liters == null ? '—' : '${liters.toStringAsFixed(2)} L',
+        ),
+        const SizedBox(height: 8),
+        _MetricCard(
+          icon: Icons.eco,
+          label: l?.tripMetricAvgConsumption ?? 'Avg',
+          value: s.avgLPer100Km == null
+              ? '—'
+              : '${s.avgLPer100Km!.toStringAsFixed(1)} L/100 km',
+        ),
+        const SizedBox(height: 8),
+        _MetricCard(
+          icon: Icons.speed,
+          label: l?.tripMetricOdometer ?? 'Odometer',
+          value: '${endKm.toStringAsFixed(0)} km',
+        ),
+        const Spacer(),
+        FilledButton.icon(
+          key: const Key('tripSaveButton'),
+          onPressed: _onSave,
+          icon: const Icon(Icons.save),
+          label: Text(l?.tripSaveAsFillUp ?? 'Save as fill-up'),
+        ),
+        const SizedBox(height: 8),
+        TextButton(
+          key: const Key('tripDiscardButton'),
+          onPressed: _onDiscard,
+          child: Text(l?.tripDiscard ?? 'Discard'),
+        ),
+      ],
+    );
+  }
+
+  static String _formatElapsed(Duration d) {
+    final m = d.inMinutes;
+    final s = d.inSeconds % 60;
+    return '${m.toString()}:${s.toString().padLeft(2, '0')}';
+  }
+}
+
+class _MetricCard extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  const _MetricCard({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: Icon(icon, size: 28),
+        title: Text(label, style: theme.textTheme.bodySmall),
+        trailing: Text(
+          value,
+          style: theme.textTheme.titleLarge
+              ?.copyWith(fontFeatures: const [FontFeature.tabularFigures()]),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -812,6 +812,17 @@
   "themeModeLight": "Hell",
   "themeModeDark": "Dunkel",
   "themeModeSystem": "Systemeinstellung",
+  "tripRecordingTitle": "Fahrt wird aufgezeichnet",
+  "tripSummaryTitle": "Fahrtzusammenfassung",
+  "tripMetricDistance": "Strecke",
+  "tripMetricSpeed": "Geschwindigkeit",
+  "tripMetricFuelUsed": "Verbraucht",
+  "tripMetricAvgConsumption": "Ø",
+  "tripMetricElapsed": "Dauer",
+  "tripMetricOdometer": "Kilometerstand",
+  "tripStop": "Aufzeichnung beenden",
+  "tripSaveAsFillUp": "Als Tankfüllung speichern",
+  "tripDiscard": "Verwerfen",
   "obdOdometerRead": "Kilometerstand gelesen: {km} km",
   "@obdOdometerRead": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -839,6 +839,17 @@
   "themeModeLight": "Light",
   "themeModeDark": "Dark",
   "themeModeSystem": "Follow system",
+  "tripRecordingTitle": "Recording trip",
+  "tripSummaryTitle": "Trip summary",
+  "tripMetricDistance": "Distance",
+  "tripMetricSpeed": "Speed",
+  "tripMetricFuelUsed": "Fuel used",
+  "tripMetricAvgConsumption": "Avg",
+  "tripMetricElapsed": "Elapsed",
+  "tripMetricOdometer": "Odometer",
+  "tripStop": "Stop recording",
+  "tripSaveAsFillUp": "Save as fill-up",
+  "tripDiscard": "Discard",
   "obdOdometerRead": "Odometer read: {km} km",
   "@obdOdometerRead": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -733,6 +733,17 @@
   "themeModeLight": "Clair",
   "themeModeDark": "Sombre",
   "themeModeSystem": "Suivre le système",
+  "tripRecordingTitle": "Enregistrement du trajet",
+  "tripSummaryTitle": "Résumé du trajet",
+  "tripMetricDistance": "Distance",
+  "tripMetricSpeed": "Vitesse",
+  "tripMetricFuelUsed": "Carburant utilisé",
+  "tripMetricAvgConsumption": "Moyenne",
+  "tripMetricElapsed": "Durée",
+  "tripMetricOdometer": "Compteur",
+  "tripStop": "Arrêter l'enregistrement",
+  "tripSaveAsFillUp": "Enregistrer comme plein",
+  "tripDiscard": "Abandonner",
   "obdOdometerRead": "Compteur lu : {km} km",
   "@obdOdometerRead": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3601,6 +3601,72 @@ abstract class AppLocalizations {
   /// **'Follow system'**
   String get themeModeSystem;
 
+  /// No description provided for @tripRecordingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording trip'**
+  String get tripRecordingTitle;
+
+  /// No description provided for @tripSummaryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Trip summary'**
+  String get tripSummaryTitle;
+
+  /// No description provided for @tripMetricDistance.
+  ///
+  /// In en, this message translates to:
+  /// **'Distance'**
+  String get tripMetricDistance;
+
+  /// No description provided for @tripMetricSpeed.
+  ///
+  /// In en, this message translates to:
+  /// **'Speed'**
+  String get tripMetricSpeed;
+
+  /// No description provided for @tripMetricFuelUsed.
+  ///
+  /// In en, this message translates to:
+  /// **'Fuel used'**
+  String get tripMetricFuelUsed;
+
+  /// No description provided for @tripMetricAvgConsumption.
+  ///
+  /// In en, this message translates to:
+  /// **'Avg'**
+  String get tripMetricAvgConsumption;
+
+  /// No description provided for @tripMetricElapsed.
+  ///
+  /// In en, this message translates to:
+  /// **'Elapsed'**
+  String get tripMetricElapsed;
+
+  /// No description provided for @tripMetricOdometer.
+  ///
+  /// In en, this message translates to:
+  /// **'Odometer'**
+  String get tripMetricOdometer;
+
+  /// No description provided for @tripStop.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop recording'**
+  String get tripStop;
+
+  /// No description provided for @tripSaveAsFillUp.
+  ///
+  /// In en, this message translates to:
+  /// **'Save as fill-up'**
+  String get tripSaveAsFillUp;
+
+  /// No description provided for @tripDiscard.
+  ///
+  /// In en, this message translates to:
+  /// **'Discard'**
+  String get tripDiscard;
+
   /// No description provided for @obdOdometerRead.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1893,6 +1893,39 @@ class AppLocalizationsBg extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1893,6 +1893,39 @@ class AppLocalizationsCs extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1891,6 +1891,39 @@ class AppLocalizationsDa extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1905,6 +1905,39 @@ class AppLocalizationsDe extends AppLocalizations {
   String get themeModeSystem => 'Systemeinstellung';
 
   @override
+  String get tripRecordingTitle => 'Fahrt wird aufgezeichnet';
+
+  @override
+  String get tripSummaryTitle => 'Fahrtzusammenfassung';
+
+  @override
+  String get tripMetricDistance => 'Strecke';
+
+  @override
+  String get tripMetricSpeed => 'Geschwindigkeit';
+
+  @override
+  String get tripMetricFuelUsed => 'Verbraucht';
+
+  @override
+  String get tripMetricAvgConsumption => 'Ø';
+
+  @override
+  String get tripMetricElapsed => 'Dauer';
+
+  @override
+  String get tripMetricOdometer => 'Kilometerstand';
+
+  @override
+  String get tripStop => 'Aufzeichnung beenden';
+
+  @override
+  String get tripSaveAsFillUp => 'Als Tankfüllung speichern';
+
+  @override
+  String get tripDiscard => 'Verwerfen';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Kilometerstand gelesen: $km km';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1895,6 +1895,39 @@ class AppLocalizationsEl extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1886,6 +1886,39 @@ class AppLocalizationsEn extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1894,6 +1894,39 @@ class AppLocalizationsEs extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1888,6 +1888,39 @@ class AppLocalizationsEt extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1891,6 +1891,39 @@ class AppLocalizationsFi extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1902,6 +1902,39 @@ class AppLocalizationsFr extends AppLocalizations {
   String get themeModeSystem => 'Suivre le système';
 
   @override
+  String get tripRecordingTitle => 'Enregistrement du trajet';
+
+  @override
+  String get tripSummaryTitle => 'Résumé du trajet';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Vitesse';
+
+  @override
+  String get tripMetricFuelUsed => 'Carburant utilisé';
+
+  @override
+  String get tripMetricAvgConsumption => 'Moyenne';
+
+  @override
+  String get tripMetricElapsed => 'Durée';
+
+  @override
+  String get tripMetricOdometer => 'Compteur';
+
+  @override
+  String get tripStop => 'Arrêter l\'enregistrement';
+
+  @override
+  String get tripSaveAsFillUp => 'Enregistrer comme plein';
+
+  @override
+  String get tripDiscard => 'Abandonner';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Compteur lu : $km km';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1890,6 +1890,39 @@ class AppLocalizationsHr extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1895,6 +1895,39 @@ class AppLocalizationsHu extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1894,6 +1894,39 @@ class AppLocalizationsIt extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1892,6 +1892,39 @@ class AppLocalizationsLt extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1894,6 +1894,39 @@ class AppLocalizationsLv extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1890,6 +1890,39 @@ class AppLocalizationsNb extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1895,6 +1895,39 @@ class AppLocalizationsNl extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1893,6 +1893,39 @@ class AppLocalizationsPl extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1894,6 +1894,39 @@ class AppLocalizationsPt extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1893,6 +1893,39 @@ class AppLocalizationsRo extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1894,6 +1894,39 @@ class AppLocalizationsSk extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1888,6 +1888,39 @@ class AppLocalizationsSl extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1892,6 +1892,39 @@ class AppLocalizationsSv extends AppLocalizations {
   String get themeModeSystem => 'Follow system';
 
   @override
+  String get tripRecordingTitle => 'Recording trip';
+
+  @override
+  String get tripSummaryTitle => 'Trip summary';
+
+  @override
+  String get tripMetricDistance => 'Distance';
+
+  @override
+  String get tripMetricSpeed => 'Speed';
+
+  @override
+  String get tripMetricFuelUsed => 'Fuel used';
+
+  @override
+  String get tripMetricAvgConsumption => 'Avg';
+
+  @override
+  String get tripMetricElapsed => 'Elapsed';
+
+  @override
+  String get tripMetricOdometer => 'Odometer';
+
+  @override
+  String get tripStop => 'Stop recording';
+
+  @override
+  String get tripSaveAsFillUp => 'Save as fill-up';
+
+  @override
+  String get tripDiscard => 'Discard';
+
+  @override
   String obdOdometerRead(int km) {
     return 'Odometer read: $km km';
   }

--- a/test/features/consumption/data/obd2/trip_recording_controller_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
+
+void main() {
+  group('TripRecordingController (#726)', () {
+    test('start() reads the odometer once and exposes it as '
+        'odometerStartKm', () async {
+      // Hand-crafted raw ELM327 responses: Mode 01 PID A6 encodes the
+      // odometer at 1/10 km resolution (value / 10). Bytes
+      // `00 01 6A 2C` = 0x16A2C = 92 716 raw → 9271.6 km.
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        '01A6': '41 A6 00 01 6A 2C>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final ctl = TripRecordingController(
+        service: service,
+        pollInterval: const Duration(minutes: 1), // never ticks in-test
+      );
+      await ctl.start();
+      await ctl.stop();
+
+      expect(ctl.odometerStartKm, closeTo(9271.6, 0.01));
+    });
+
+    test('stop() returns a non-null TripSummary even when no sample '
+        'was ever recorded', () async {
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        '01A6': 'NO DATA>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final ctl = TripRecordingController(
+        service: service,
+        pollInterval: const Duration(minutes: 1),
+      );
+      await ctl.start();
+      final summary = await ctl.stop();
+
+      expect(summary.distanceKm, 0);
+      expect(summary.fuelLitersConsumed, isNull);
+      expect(ctl.odometerStartKm, isNull);
+    });
+
+    test('refreshOdometer() pulls a fresh reading before stop()',
+        () async {
+      // Transport returns two different values on successive 01A6 calls
+      // so we can assert refreshOdometer picks up the second one.
+      var call = 0;
+      final transport = _SequencedTransport(
+        init: {
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+        },
+        onOdometer: () {
+          call++;
+          return call == 1
+              ? '41 A6 00 01 6A 2C>' // 92716 km at start
+              : '41 A6 00 01 6A 3E>'; // 92734 km later
+        },
+      );
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final ctl = TripRecordingController(
+        service: service,
+        pollInterval: const Duration(minutes: 1),
+      );
+      await ctl.start();
+      expect(ctl.odometerStartKm, closeTo(9271.6, 0.01));
+      await ctl.refreshOdometer();
+      expect(ctl.odometerLatestKm, closeTo(9273.4, 0.01));
+      await ctl.stop();
+    });
+  });
+}
+
+/// Transport that serves canned responses for the init + a custom
+/// lambda for every `01A6` call. Used to simulate the odometer
+/// changing during the trip.
+class _SequencedTransport implements Obd2Transport {
+  final Map<String, String> init;
+  final String Function() onOdometer;
+  _SequencedTransport({required this.init, required this.onOdometer});
+
+  bool _connected = false;
+  @override
+  Future<void> connect() async => _connected = true;
+  @override
+  Future<void> disconnect() async => _connected = false;
+  @override
+  bool get isConnected => _connected;
+  @override
+  Future<String> sendCommand(String command) async {
+    final key = command.trim();
+    if (key == '01A6') return onOdometer();
+    return init[key] ?? 'NO DATA>';
+  }
+}


### PR DESCRIPTION
## Summary
Completes the loop started in #763: after the vLinker FS connects, the OBD-II button now opens a trip-recording screen polling the car at 1 Hz. Tap Stop → summary shows distance / fuel / avg / end km → Save as fill-up pre-fills odometer + litres on the Add fill-up form.

### Pieces
- \`TripRecordingController\` drives a 1 Hz polling loop feeding TripRecorder + a live stream.
- \`TripRecordingScreen\` — recording phase (live metrics + Stop) → summary phase (Save/Discard).
- \`add_fill_up_screen._readObd\` now pushes the recording screen and consumes its \`TripSaveResult\` to pre-fill the form.
- \`TripSummary\` exposes \`fuelLitersConsumed\` (was private; now usable for save-as-fill-up).

### PIDs already wired by \`Obd2Service\` and used here
Speed (0D), RPM (0C), engine load (04), fuel rate (5E with MAF-based fallback using the 14.7:1 A/F ratio + 740 g/L density), fuel level (2F), odometer (A6 → 31 → manufacturer Mode 22 via VIN WMI).

## Test plan
- [x] 3 controller tests — odometer on start, empty-summary on silent stop, refreshOdometer update
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4665 passing

Partial progress on #726 — Hive persistence for a trip-history screen + polish in follow-ups.