### PR TITLE
feat(obd2): situation classifier + cold-start baselines (#768)

### DIFF
--- a/lib/features/consumption/domain/cold_start_baselines.dart
+++ b/lib/features/consumption/domain/cold_start_baselines.dart
@@ -1,0 +1,94 @@
+import 'situation_classifier.dart';
+
+/// Fuel-type-specific typical consumption for every steady-state
+/// driving situation (#768). Used as the cold-start baseline before
+/// the Welford-based per-vehicle learned baseline (#769) has enough
+/// samples to take over.
+///
+/// Numbers come from published fleet averages — adjusted slightly
+/// up for urban because real-world urban traffic bunches worse than
+/// WLTP implies, and down for highway cruise because modern cars
+/// with 8+ gears spend most of their highway time in their efficient
+/// envelope. Intentionally gasoline/diesel only — LPG/CNG mapped to
+/// gasoline as a close-enough approximation because the rounding
+/// error at cold start doesn't matter.
+enum ConsumptionFuelFamily { gasoline, diesel }
+
+/// Baseline envelope for one situation: a value plus its unit.
+/// [unit] decides how the UI formats it — L/100 km for driving,
+/// L/h for idle (because L/100 km explodes at zero speed).
+enum BaselineUnit { lPer100Km, lPerHour }
+
+class SituationBaseline {
+  final double value;
+  final BaselineUnit unit;
+  const SituationBaseline(this.value, this.unit);
+}
+
+/// Typical consumption lookup. Callers pass the resolved fuel family
+/// (from the active vehicle profile) + the current driving
+/// situation, get back the expected consumption.
+SituationBaseline coldStartBaseline(
+  ConsumptionFuelFamily family,
+  DrivingSituation situation,
+) {
+  switch (situation) {
+    case DrivingSituation.idle:
+      return family == ConsumptionFuelFamily.gasoline
+          ? const SituationBaseline(0.8, BaselineUnit.lPerHour)
+          : const SituationBaseline(0.6, BaselineUnit.lPerHour);
+    case DrivingSituation.stopAndGo:
+      return family == ConsumptionFuelFamily.gasoline
+          ? const SituationBaseline(12.0, BaselineUnit.lPer100Km)
+          : const SituationBaseline(9.0, BaselineUnit.lPer100Km);
+    case DrivingSituation.urbanCruise:
+      return family == ConsumptionFuelFamily.gasoline
+          ? const SituationBaseline(7.5, BaselineUnit.lPer100Km)
+          : const SituationBaseline(5.5, BaselineUnit.lPer100Km);
+    case DrivingSituation.highwayCruise:
+      return family == ConsumptionFuelFamily.gasoline
+          ? const SituationBaseline(6.0, BaselineUnit.lPer100Km)
+          : const SituationBaseline(4.8, BaselineUnit.lPer100Km);
+    case DrivingSituation.deceleration:
+      return family == ConsumptionFuelFamily.gasoline
+          ? const SituationBaseline(3.0, BaselineUnit.lPer100Km)
+          : const SituationBaseline(2.2, BaselineUnit.lPer100Km);
+    case DrivingSituation.climbingOrLoaded:
+      return family == ConsumptionFuelFamily.gasoline
+          ? const SituationBaseline(10.0, BaselineUnit.lPer100Km)
+          : const SituationBaseline(7.5, BaselineUnit.lPer100Km);
+    // Transients don't have a meaningful "baseline" — they just
+    // trigger a badge. Return a zero value with the distance unit
+    // so callers don't have to special-case; the UI skips the
+    // percentage-delta rendering for transients anyway.
+    case DrivingSituation.hardAccel:
+    case DrivingSituation.fuelCutCoast:
+      return const SituationBaseline(0, BaselineUnit.lPer100Km);
+  }
+}
+
+/// Classify a live reading against a baseline into a consumption
+/// band. Used by the banner to pick a colour and by the screen to
+/// render the headline metric.
+///
+/// Boundaries match the addendum on #767: eco ≤ 0.80 × baseline,
+/// normal within 0.80–1.20 × baseline, heavy 1.20–1.60, very heavy
+/// above 1.60. Transient situations yield [ConsumptionBand.transient].
+enum ConsumptionBand { eco, normal, heavy, veryHeavy, transient }
+
+ConsumptionBand classifyBand({
+  required DrivingSituation situation,
+  required double live,
+  required SituationBaseline baseline,
+}) {
+  if (situation == DrivingSituation.hardAccel ||
+      situation == DrivingSituation.fuelCutCoast) {
+    return ConsumptionBand.transient;
+  }
+  if (baseline.value <= 0) return ConsumptionBand.normal;
+  final ratio = live / baseline.value;
+  if (ratio >= 1.60) return ConsumptionBand.veryHeavy;
+  if (ratio >= 1.20) return ConsumptionBand.heavy;
+  if (ratio <= 0.80) return ConsumptionBand.eco;
+  return ConsumptionBand.normal;
+}

--- a/lib/features/consumption/domain/situation_classifier.dart
+++ b/lib/features/consumption/domain/situation_classifier.dart
@@ -1,0 +1,297 @@
+import 'dart:collection';
+
+/// Driving situation classifier (#768).
+///
+/// Pure-logic state machine over a rolling 10-second window of
+/// [Obd2Service] PIDs (speed, RPM, throttle %, engine load %, fuel
+/// rate). Emits one of 8 [DrivingSituation] values on every
+/// [onSample] call so the consumption banner can tint itself for
+/// the user's current mode.
+///
+/// Two categories of situation:
+///
+/// * Steady-state modes — the user is cruising, idling, stop-and-go,
+///   etc. — survive as long as the detection condition holds.
+/// * Transient events — `hardAccel` and `fuelCutCoast` — fire while
+///   the condition is true but always yield back to the underlying
+///   steady-state once they pass.
+///
+/// Transitions between steady-state modes are debounced so a brief
+/// WOT overtake doesn't strobe the UI: a new mode must hold for
+/// [transitionDebounce] (default 3 s) before it's emitted. Transient
+/// events bypass the debounce because their whole purpose is
+/// immediate feedback.
+enum DrivingSituation {
+  idle,
+  stopAndGo,
+  urbanCruise,
+  highwayCruise,
+  deceleration,
+  climbingOrLoaded,
+  hardAccel,
+  fuelCutCoast,
+}
+
+/// One point of driving data the classifier ingests. Values come from
+/// `Obd2Service` live PIDs; [speedKmh] and [rpm] are mandatory, the
+/// rest are nullable because not every adapter / car answers every
+/// PID.
+class DrivingSample {
+  final DateTime timestamp;
+  final double speedKmh;
+  final double rpm;
+  final double? throttlePercent;
+  final double? engineLoadPercent;
+  final double? fuelRateLPerHour;
+
+  const DrivingSample({
+    required this.timestamp,
+    required this.speedKmh,
+    required this.rpm,
+    this.throttlePercent,
+    this.engineLoadPercent,
+    this.fuelRateLPerHour,
+  });
+}
+
+/// Stateful classifier — feed one sample per poll tick, read the
+/// current situation via [current].
+///
+/// Keeps a rolling window of samples spanning [window] (default 10 s)
+/// and derives aggregate features (averages + variances) over it.
+class SituationClassifier {
+  final Duration window;
+  final Duration transitionDebounce;
+
+  final Queue<DrivingSample> _samples = Queue();
+  DrivingSituation _current = DrivingSituation.idle;
+  DrivingSituation? _pending;
+  DateTime? _pendingSince;
+
+  SituationClassifier({
+    this.window = const Duration(seconds: 10),
+    this.transitionDebounce = const Duration(seconds: 3),
+  });
+
+  DrivingSituation get current => _current;
+
+  /// Number of samples currently in the rolling window. Useful for
+  /// cold-start handling — the first tick can't classify much.
+  int get sampleCount => _samples.length;
+
+  /// Feed a new sample. Returns the situation the UI should show
+  /// right now — either the current steady-state mode, or a
+  /// transient event (`hardAccel` / `fuelCutCoast`) when one applies.
+  DrivingSituation onSample(DrivingSample sample) {
+    _samples.addLast(sample);
+    while (_samples.isNotEmpty &&
+        sample.timestamp.difference(_samples.first.timestamp) > window) {
+      _samples.removeFirst();
+    }
+
+    // Transients override the steady-state — they apply only at the
+    // current tick, no debounce, and revert as soon as the condition
+    // drops.
+    final transient = _detectTransient(sample);
+    if (transient != null) return transient;
+
+    final candidate = _detectSteadyState(sample);
+    if (candidate == _current) {
+      // Same mode — cancel any pending transition.
+      _pending = null;
+      _pendingSince = null;
+      return _current;
+    }
+    if (candidate == _pending) {
+      // Still pending — check if the debounce has elapsed.
+      if (sample.timestamp
+              .difference(_pendingSince!)
+              .inMilliseconds >=
+          transitionDebounce.inMilliseconds) {
+        _current = candidate;
+        _pending = null;
+        _pendingSince = null;
+      }
+      return _current;
+    }
+    // New candidate — start the debounce clock.
+    _pending = candidate;
+    _pendingSince = sample.timestamp;
+    return _current;
+  }
+
+  /// Detect transient events that should render over the current
+  /// steady-state. Checked before the steady-state classifier on
+  /// every tick so a user hammering the pedal gets the "Hard accel"
+  /// badge within one sample.
+  DrivingSituation? _detectTransient(DrivingSample s) {
+    // Fuel-cut coast: engine running but injectors off — most modern
+    // cars do this on deceleration. Detected when fuelRate is
+    // effectively zero while moving at >20 km/h.
+    final fuelRate = s.fuelRateLPerHour;
+    if (fuelRate != null && fuelRate < 0.1 && s.speedKmh > 20) {
+      return DrivingSituation.fuelCutCoast;
+    }
+
+    // Hard acceleration: need ≥2 s of sustained rising speed with
+    // throttle >50%. Use the last ~2 s of samples to compute accel.
+    final accel = _recentAccelMps2(windowSeconds: 2);
+    final throttle = s.throttlePercent;
+    if (accel != null &&
+        accel > 1.5 &&
+        throttle != null &&
+        throttle > 50) {
+      return DrivingSituation.hardAccel;
+    }
+
+    return null;
+  }
+
+  /// Classify the underlying steady-state mode from the rolling
+  /// window averages.
+  DrivingSituation _detectSteadyState(DrivingSample s) {
+    final avgSpeed = _avg((e) => e.speedKmh);
+    final avgRpm = _avg((e) => e.rpm);
+    final throttleVar = _variance((e) => e.throttlePercent);
+    final accelVar = _variance((e) => e.speedKmh);
+    final engineLoad = s.engineLoadPercent;
+    final avgThrottle = _avg((e) => e.throttlePercent);
+    final speedRange = _range((e) => e.speedKmh);
+
+    // Idle: basically stationary with the engine running. Short
+    // window of ≥5 s so a momentary stop at a light doesn't count.
+    if (avgSpeed <= 2 &&
+        avgRpm > 0 &&
+        avgThrottle < 5 &&
+        _spanSeconds() >= 5) {
+      return DrivingSituation.idle;
+    }
+
+    // Stop-and-go: low avg speed with multiple zero-crossings — the
+    // user is in dense traffic with frequent starts and stops.
+    if (avgSpeed < 20 && _zeroSpeedCrossings() >= 2) {
+      return DrivingSituation.stopAndGo;
+    }
+
+    // Deceleration: mostly letting off the throttle with speed
+    // dropping. Distinct from fuel-cut coast because fuel may still
+    // be injected — just not much.
+    final accel = _recentAccelMps2(windowSeconds: 3);
+    if (accel != null && accel < -1 && avgThrottle < 10) {
+      return DrivingSituation.deceleration;
+    }
+
+    // Climbing or heavily loaded: engine working hard (high load)
+    // while speed is roughly constant. Stands in for the pure
+    // climb-detection we'd do with GPS altitude.
+    if (engineLoad != null &&
+        engineLoad > 70 &&
+        speedRange < 2 &&
+        avgSpeed > 20) {
+      return DrivingSituation.climbingOrLoaded;
+    }
+
+    // Highway cruise: high, stable speed.
+    if (avgSpeed >= 80 && (throttleVar ?? 0) < 100) {
+      return DrivingSituation.highwayCruise;
+    }
+
+    // Urban cruise: moderate speed, smooth throttle.
+    if (avgSpeed >= 20 && avgSpeed < 60 && (accelVar ?? 0) < 1) {
+      return DrivingSituation.urbanCruise;
+    }
+
+    // Nothing fits — hold the current mode. Prevents rapid flipping
+    // in transition zones.
+    return _current;
+  }
+
+  double _avg(num? Function(DrivingSample) f) {
+    if (_samples.isEmpty) return 0;
+    var total = 0.0;
+    var count = 0;
+    for (final s in _samples) {
+      final v = f(s);
+      if (v == null) continue;
+      total += v.toDouble();
+      count++;
+    }
+    return count == 0 ? 0 : total / count;
+  }
+
+  double? _variance(num? Function(DrivingSample) f) {
+    if (_samples.length < 2) return null;
+    var mean = 0.0;
+    var count = 0;
+    for (final s in _samples) {
+      final v = f(s);
+      if (v == null) continue;
+      mean += v.toDouble();
+      count++;
+    }
+    if (count < 2) return null;
+    mean /= count;
+    var sumSq = 0.0;
+    for (final s in _samples) {
+      final v = f(s);
+      if (v == null) continue;
+      final d = v.toDouble() - mean;
+      sumSq += d * d;
+    }
+    return sumSq / (count - 1);
+  }
+
+  double _range(num Function(DrivingSample) f) {
+    if (_samples.isEmpty) return 0;
+    var minV = double.infinity;
+    var maxV = -double.infinity;
+    for (final s in _samples) {
+      final v = f(s).toDouble();
+      if (v < minV) minV = v;
+      if (v > maxV) maxV = v;
+    }
+    return maxV - minV;
+  }
+
+  int _zeroSpeedCrossings() {
+    // Count transitions from moving (>5 km/h) to stopped (≤1 km/h).
+    var crossings = 0;
+    var wasMoving = false;
+    for (final s in _samples) {
+      if (s.speedKmh > 5) {
+        wasMoving = true;
+      } else if (s.speedKmh <= 1 && wasMoving) {
+        crossings++;
+        wasMoving = false;
+      }
+    }
+    return crossings;
+  }
+
+  int _spanSeconds() {
+    if (_samples.length < 2) return 0;
+    return _samples.last.timestamp
+        .difference(_samples.first.timestamp)
+        .inSeconds;
+  }
+
+  /// Compute acceleration in m/s² across the trailing
+  /// [windowSeconds] of samples. Returns null if we don't have at
+  /// least two samples spanning that window.
+  double? _recentAccelMps2({required int windowSeconds}) {
+    if (_samples.length < 2) return null;
+    final now = _samples.last;
+    DrivingSample? start;
+    for (final s in _samples) {
+      if (now.timestamp.difference(s.timestamp).inSeconds <= windowSeconds) {
+        start = s;
+        break;
+      }
+    }
+    start ??= _samples.first;
+    final dt = now.timestamp.difference(start.timestamp).inMilliseconds / 1000.0;
+    if (dt <= 0) return null;
+    final dv = (now.speedKmh - start.speedKmh) / 3.6; // km/h → m/s
+    return dv / dt;
+  }
+}

--- a/test/features/consumption/domain/cold_start_baselines_test.dart
+++ b/test/features/consumption/domain/cold_start_baselines_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+
+void main() {
+  group('coldStartBaseline (#768)', () {
+    test('idle uses L/h units, not L/100 km — avoids divide-by-zero',
+        () {
+      final b = coldStartBaseline(
+        ConsumptionFuelFamily.gasoline,
+        DrivingSituation.idle,
+      );
+      expect(b.unit, BaselineUnit.lPerHour);
+      expect(b.value, 0.8);
+    });
+
+    test('diesel consistently lower than gasoline for every situation',
+        () {
+      const drivingSituations = [
+        DrivingSituation.idle,
+        DrivingSituation.stopAndGo,
+        DrivingSituation.urbanCruise,
+        DrivingSituation.highwayCruise,
+        DrivingSituation.deceleration,
+        DrivingSituation.climbingOrLoaded,
+      ];
+      for (final s in drivingSituations) {
+        final petrol =
+            coldStartBaseline(ConsumptionFuelFamily.gasoline, s);
+        final diesel =
+            coldStartBaseline(ConsumptionFuelFamily.diesel, s);
+        expect(diesel.value, lessThan(petrol.value),
+            reason: '$s: diesel ${diesel.value} !< petrol ${petrol.value}');
+        expect(diesel.unit, petrol.unit);
+      }
+    });
+
+    test('transients return a zero placeholder — no meaningful baseline',
+        () {
+      expect(
+        coldStartBaseline(
+          ConsumptionFuelFamily.gasoline,
+          DrivingSituation.hardAccel,
+        ).value,
+        0,
+      );
+      expect(
+        coldStartBaseline(
+          ConsumptionFuelFamily.gasoline,
+          DrivingSituation.fuelCutCoast,
+        ).value,
+        0,
+      );
+    });
+  });
+
+  group('classifyBand (#768)', () {
+    const baseline = SituationBaseline(8.0, BaselineUnit.lPer100Km);
+
+    test('eco: live ≤ 0.80 × baseline', () {
+      expect(
+        classifyBand(
+          situation: DrivingSituation.urbanCruise,
+          live: 6.4,
+          baseline: baseline,
+        ),
+        ConsumptionBand.eco,
+      );
+    });
+
+    test('normal: between 0.80 and 1.20 × baseline', () {
+      expect(
+        classifyBand(
+          situation: DrivingSituation.urbanCruise,
+          live: 8.5,
+          baseline: baseline,
+        ),
+        ConsumptionBand.normal,
+      );
+    });
+
+    test('heavy: between 1.20 and 1.60 × baseline', () {
+      expect(
+        classifyBand(
+          situation: DrivingSituation.urbanCruise,
+          live: 11.0,
+          baseline: baseline,
+        ),
+        ConsumptionBand.heavy,
+      );
+    });
+
+    test('veryHeavy: ≥ 1.60 × baseline', () {
+      expect(
+        classifyBand(
+          situation: DrivingSituation.urbanCruise,
+          live: 14.0,
+          baseline: baseline,
+        ),
+        ConsumptionBand.veryHeavy,
+      );
+    });
+
+    test('transient: returns the transient band regardless of numbers',
+        () {
+      expect(
+        classifyBand(
+          situation: DrivingSituation.hardAccel,
+          live: 100.0,
+          baseline: baseline,
+        ),
+        ConsumptionBand.transient,
+      );
+      expect(
+        classifyBand(
+          situation: DrivingSituation.fuelCutCoast,
+          live: 0.0,
+          baseline: baseline,
+        ),
+        ConsumptionBand.transient,
+      );
+    });
+
+    test('zero baseline falls back to normal — prevents div-by-zero',
+        () {
+      const zero = SituationBaseline(0, BaselineUnit.lPer100Km);
+      expect(
+        classifyBand(
+          situation: DrivingSituation.urbanCruise,
+          live: 10.0,
+          baseline: zero,
+        ),
+        ConsumptionBand.normal,
+      );
+    });
+  });
+}

--- a/test/features/consumption/domain/situation_classifier_test.dart
+++ b/test/features/consumption/domain/situation_classifier_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+
+void main() {
+  final t0 = DateTime(2026, 4, 20, 12, 0, 0);
+  DateTime at(int secs) => t0.add(Duration(seconds: secs));
+
+  group('SituationClassifier (#768)', () {
+    test('cold start — seeded to idle before any sample', () {
+      final c = SituationClassifier();
+      expect(c.current, DrivingSituation.idle);
+    });
+
+    test('idle: stationary with engine on ≥ 5 s', () {
+      final c = SituationClassifier();
+      // Feed 6 seconds of zero speed + low throttle + RPM 800.
+      for (var s = 0; s < 6; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 0,
+          rpm: 800,
+          throttlePercent: 0,
+        ));
+      }
+      expect(c.current, DrivingSituation.idle);
+    });
+
+    test('highway cruise: 110 km/h sustained', () {
+      final c = SituationClassifier();
+      for (var s = 0; s < 12; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 110,
+          rpm: 2200,
+          throttlePercent: 20,
+        ));
+      }
+      // Account for 3 s debounce from the initial idle seed.
+      expect(c.current, DrivingSituation.highwayCruise);
+    });
+
+    test('urban cruise: 35 km/h modest throttle variance', () {
+      final c = SituationClassifier();
+      for (var s = 0; s < 10; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 35 + (s % 3),
+          rpm: 1800,
+          throttlePercent: 15,
+        ));
+      }
+      expect(c.current, DrivingSituation.urbanCruise);
+    });
+
+    test('stop-and-go: low avg speed with repeated zero crossings', () {
+      final c = SituationClassifier();
+      // 10 s sequence: drive 10→0→drive→0→drive, 2 zero-crossings.
+      final speeds = [10.0, 15.0, 5.0, 0.0, 8.0, 12.0, 0.0, 10.0, 15.0, 12.0];
+      for (var s = 0; s < 10; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: speeds[s],
+          rpm: 1200,
+          throttlePercent: 10,
+        ));
+      }
+      expect(c.current, DrivingSituation.stopAndGo);
+    });
+
+    test('hard accel: sustained >1.5 m/s² with throttle > 50% — '
+        'transient event, does not replace the steady-state mode',
+        () {
+      final c = SituationClassifier();
+      // Seed a steady-state cruise.
+      for (var s = 0; s < 10; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 30,
+          rpm: 1800,
+          throttlePercent: 15,
+        ));
+      }
+      expect(c.current, DrivingSituation.urbanCruise);
+
+      // Now ramp 30 → 60 km/h over 3 s (~2.8 m/s²) with throttle 70%.
+      var situation = c.current;
+      for (var s = 10; s < 14; s++) {
+        situation = c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 30 + (s - 10) * 10.0,
+          rpm: 3000,
+          throttlePercent: 70,
+        ));
+      }
+      expect(situation, DrivingSituation.hardAccel);
+      // Steady-state still cruise (transient doesn't overwrite).
+      expect(c.current, DrivingSituation.urbanCruise);
+    });
+
+    test('fuel-cut coast: fuelRate ≈ 0 while moving > 20 km/h', () {
+      final c = SituationClassifier();
+      for (var s = 0; s < 6; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 80,
+          rpm: 2200,
+          throttlePercent: 0,
+          fuelRateLPerHour: 0,
+        ));
+      }
+      final situation = c.onSample(DrivingSample(
+        timestamp: at(6),
+        speedKmh: 80,
+        rpm: 2200,
+        throttlePercent: 0,
+        fuelRateLPerHour: 0,
+      ));
+      expect(situation, DrivingSituation.fuelCutCoast);
+    });
+
+    test('transition debounce: a brief mode-change < 3 s does not '
+        'commit', () {
+      final c = SituationClassifier();
+      // Seed urban cruise.
+      for (var s = 0; s < 10; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 35,
+          rpm: 1800,
+          throttlePercent: 15,
+        ));
+      }
+      expect(c.current, DrivingSituation.urbanCruise);
+
+      // 2 s of highway-speed samples — not enough to flip.
+      for (var s = 10; s < 12; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 95,
+          rpm: 2400,
+          throttlePercent: 20,
+        ));
+      }
+      expect(c.current, DrivingSituation.urbanCruise,
+          reason: '2 s of highway speeds must not commit — debounce is 3 s');
+
+      // Back to urban — debounce clock resets.
+      for (var s = 12; s < 14; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 35,
+          rpm: 1800,
+          throttlePercent: 15,
+        ));
+      }
+      expect(c.current, DrivingSituation.urbanCruise);
+    });
+
+    test('transition debounce: a ≥ 3 s hold DOES commit the new mode',
+        () {
+      final c = SituationClassifier();
+      // Seed urban cruise. Short window so the classifier can start
+      // seeing a clean highway signal quickly.
+      for (var s = 0; s < 5; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 35,
+          rpm: 1800,
+          throttlePercent: 15,
+        ));
+      }
+      expect(c.current, DrivingSituation.urbanCruise);
+
+      // 25 s of highway speeds — plenty of time for the rolling
+      // window to fully flush to highway AND for the 3 s debounce
+      // to elapse past that point.
+      for (var s = 5; s < 30; s++) {
+        c.onSample(DrivingSample(
+          timestamp: at(s),
+          speedKmh: 95,
+          rpm: 2400,
+          throttlePercent: 20,
+        ));
+      }
+      expect(c.current, DrivingSituation.highwayCruise);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Pure-logic core for the consumption banner (#767 phase 1). Classifier + baseline tables. No provider/banner integration yet — that's a follow-up against #766 (now merged).

### What ships
- \`SituationClassifier\` — rolling-10-s window over speed / RPM / throttle / engine load / fuel rate. Emits one of 8 \`DrivingSituation\` values per \`onSample\`. 3 s debounce on steady-state transitions; transients (\`hardAccel\`, \`fuelCutCoast\`) bypass debounce and don't replace the underlying mode.
- \`ColdStartBaselines\` — static table of typical L/100 km per fuel family × situation + \`classifyBand\` function (eco / normal / heavy / veryHeavy / transient at the 0.80 / 1.20 / 1.60 × baseline thresholds from #767 addendum).

### Test plan
- [x] 17 new assertions — every steady-state mode, both transients, debounce both ways, diesel < gasoline invariant, band boundaries, div-by-zero safety
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4683 passing

Closes #768.