### PR TITLE
feat(obd2): Welford per-vehicle baseline store + 5070 bump

### DIFF
--- a/lib/features/consumption/data/baseline_store.dart
+++ b/lib/features/consumption/data/baseline_store.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../domain/cold_start_baselines.dart';
+import '../domain/situation_classifier.dart';
+import 'welford.dart';
+
+/// Hive-backed per-vehicle per-situation baseline store (#769).
+///
+/// Every steady-state sample the recording provider observes gets
+/// fed in via [record]. The store updates a Welford accumulator for
+/// the right (vehicle, situation) cell and, at trip end, [flush]
+/// writes the accumulators back to disk.
+///
+/// Only steady-state situations are persisted — transients
+/// (`hardAccel`, `fuelCutCoast`) are events rather than stable
+/// baselines and always yield [ConsumptionBand.transient] anyway.
+///
+/// On read, [lookup] weights the learned mean against the
+/// cold-start default: 0 % learned weight for a brand-new vehicle,
+/// 100 % once the sample count for that situation reaches
+/// [fullConfidenceSamples] (default 30, ≈5 min of driving in that
+/// mode). The shape of the blend is linear — simple, predictable,
+/// no surprising S-curve artefacts.
+class BaselineStore {
+  /// Welford accumulators, keyed by vehicleId → situation name →
+  /// accumulator. Situations are stored by their enum `.name` string
+  /// to keep the Hive encoding version-independent of Dart enum
+  /// index ordering.
+  final Map<String, Map<String, WelfordAccumulator>> _cache = {};
+
+  /// Hive box where the per-vehicle baselines are persisted. Tests
+  /// can inject a fake implementing the same Box API.
+  final Box<String> _box;
+
+  final int fullConfidenceSamples;
+
+  BaselineStore({
+    required Box<String> box,
+    this.fullConfidenceSamples = 30,
+  }) : _box = box;
+
+  /// Box name used by the production wiring. Tests use their own
+  /// in-memory box with a different name so they don't collide.
+  static const String boxName = 'obd2_baselines';
+
+  /// Load all persisted baselines for [vehicleId] into the in-memory
+  /// cache. Idempotent — re-reading an already-cached vehicle is a
+  /// no-op. Called at trip start from the provider.
+  Future<void> loadVehicle(String vehicleId) async {
+    if (_cache.containsKey(vehicleId)) return;
+    final raw = _box.get(_keyFor(vehicleId));
+    if (raw == null || raw.isEmpty) {
+      _cache[vehicleId] = {};
+      return;
+    }
+    try {
+      final decoded = json.decode(raw) as Map<String, dynamic>;
+      final perSituation = decoded['perSituation'] as Map<String, dynamic>?;
+      final m = <String, WelfordAccumulator>{};
+      perSituation?.forEach((k, v) {
+        if (v is Map) {
+          m[k] = WelfordAccumulator.fromJson(Map<String, dynamic>.from(v));
+        }
+      });
+      _cache[vehicleId] = m;
+    } catch (e) {
+      debugPrint('BaselineStore.loadVehicle: corrupt payload '
+          'for $vehicleId — starting fresh: $e');
+      _cache[vehicleId] = {};
+    }
+  }
+
+  /// Feed one sample into the (vehicle, situation) accumulator.
+  /// Silently ignores transient situations — they don't have a
+  /// stable mean to learn.
+  void record({
+    required String vehicleId,
+    required DrivingSituation situation,
+    required double value,
+  }) {
+    if (situation == DrivingSituation.hardAccel ||
+        situation == DrivingSituation.fuelCutCoast) {
+      return;
+    }
+    final byVehicle = _cache.putIfAbsent(vehicleId, () => {});
+    final acc =
+        byVehicle.putIfAbsent(situation.name, () => WelfordAccumulator());
+    acc.update(value);
+  }
+
+  /// Look up the blended baseline for a (vehicle, situation) —
+  /// learned-weight ramps linearly from 0 to 1 across
+  /// [fullConfidenceSamples]. Returns the cold-start default unit,
+  /// so callers don't have to juggle L/h vs L/100 km.
+  SituationBaseline lookup({
+    required String vehicleId,
+    required DrivingSituation situation,
+    required ConsumptionFuelFamily fuelFamily,
+  }) {
+    final coldStart = coldStartBaseline(fuelFamily, situation);
+    final acc = _cache[vehicleId]?[situation.name];
+    if (acc == null || acc.n == 0) return coldStart;
+    final weight = (acc.n / fullConfidenceSamples).clamp(0.0, 1.0);
+    final blended = acc.mean * weight + coldStart.value * (1.0 - weight);
+    return SituationBaseline(blended, coldStart.unit);
+  }
+
+  /// Sample count for the (vehicle, situation) pair — useful for the
+  /// UI to show "learning…" until the learned weight is meaningful.
+  int sampleCount({
+    required String vehicleId,
+    required DrivingSituation situation,
+  }) =>
+      _cache[vehicleId]?[situation.name]?.n ?? 0;
+
+  /// Persist the vehicle's accumulators to disk. Called at trip end;
+  /// never mid-trip to keep 1 Hz polling off the I/O path.
+  Future<void> flush(String vehicleId) async {
+    final perSituation = _cache[vehicleId];
+    if (perSituation == null) return;
+    final payload = <String, dynamic>{
+      'version': 1,
+      'perSituation': {
+        for (final e in perSituation.entries) e.key: e.value.toJson(),
+      },
+    };
+    await _box.put(_keyFor(vehicleId), json.encode(payload));
+  }
+
+  /// Wipe every baseline for [vehicleId]. Exposed for a future
+  /// "reset baselines" setting; not used in normal flow.
+  Future<void> clear(String vehicleId) async {
+    _cache[vehicleId] = {};
+    await _box.delete(_keyFor(vehicleId));
+  }
+
+  String _keyFor(String vehicleId) => 'baseline:$vehicleId';
+}

--- a/lib/features/consumption/data/welford.dart
+++ b/lib/features/consumption/data/welford.dart
@@ -1,0 +1,73 @@
+import 'dart:math' as math;
+
+/// Online running-mean + running-variance accumulator via Welford's
+/// algorithm (#769).
+///
+/// Numerically stable, O(1) per sample, no sample-history stored.
+/// This is how we learn per-vehicle per-situation baselines for the
+/// consumption banner without having to buffer every trip's samples.
+///
+/// State fits in three doubles — `n`, `mean`, `m2` — so a full
+/// baseline set for 6 situations × any number of vehicles is < 1 kB
+/// on disk.
+class WelfordAccumulator {
+  int n;
+  double mean;
+
+  /// Sum of squared deviations from the mean. Divided by `n-1` on
+  /// read to get the sample variance. Kept as a separate term so the
+  /// update math stays numerically stable — subtracting squared
+  /// means directly loses precision for small variances.
+  double m2;
+
+  WelfordAccumulator({this.n = 0, this.mean = 0, this.m2 = 0});
+
+  /// Reset to the zero state. Used when a vehicle's baseline is
+  /// explicitly cleared (e.g. after a major engine service).
+  void reset() {
+    n = 0;
+    mean = 0;
+    m2 = 0;
+  }
+
+  /// Feed one sample. Classic Welford:
+  ///
+  /// ```
+  /// n' = n + 1
+  /// delta = x - mean
+  /// mean' = mean + delta / n'
+  /// m2' = m2 + delta * (x - mean')
+  /// ```
+  ///
+  /// Update order matters — the second delta has to use the NEW
+  /// mean, not the old one, or the variance drifts.
+  void update(double x) {
+    n += 1;
+    final delta = x - mean;
+    mean += delta / n;
+    final delta2 = x - mean;
+    m2 += delta * delta2;
+  }
+
+  /// Sample variance. Requires at least 2 samples — returns 0 with
+  /// a single sample (zero spread by definition) rather than NaN
+  /// from the 0/0 division.
+  double get variance => n < 2 ? 0.0 : m2 / (n - 1);
+
+  /// Sample standard deviation.
+  double get stddev => math.sqrt(variance);
+
+  Map<String, dynamic> toJson() => {
+        'n': n,
+        'mean': mean,
+        'm2': m2,
+      };
+
+  factory WelfordAccumulator.fromJson(Map<String, dynamic> json) {
+    return WelfordAccumulator(
+      n: (json['n'] as num?)?.toInt() ?? 0,
+      mean: (json['mean'] as num?)?.toDouble() ?? 0.0,
+      m2: (json['m2'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 11 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 5.0.0+5069
+version: 5.0.0+5070
 
 environment:
   sdk: ^3.11.3

--- a/test/features/consumption/data/baseline_store_test.dart
+++ b/test/features/consumption/data/baseline_store_test.dart
@@ -1,0 +1,196 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/consumption/data/baseline_store.dart';
+import 'package:tankstellen/features/consumption/data/welford.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late Box<String> box;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('baseline_store_test_');
+    Hive.init(tmpDir.path);
+    box = await Hive.openBox<String>(
+      'test_${DateTime.now().microsecondsSinceEpoch}',
+    );
+  });
+
+  tearDown(() async {
+    await box.deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  group('BaselineStore (#769)', () {
+    test('empty vehicle returns the cold-start default', () async {
+      final store = BaselineStore(box: box);
+      await store.loadVehicle('car-a');
+      final b = store.lookup(
+        vehicleId: 'car-a',
+        situation: DrivingSituation.highwayCruise,
+        fuelFamily: ConsumptionFuelFamily.gasoline,
+      );
+      expect(b.value, 6.0);
+      expect(b.unit, BaselineUnit.lPer100Km);
+    });
+
+    test('record() ignores transient situations', () async {
+      final store = BaselineStore(box: box);
+      await store.loadVehicle('car-a');
+      store.record(
+        vehicleId: 'car-a',
+        situation: DrivingSituation.hardAccel,
+        value: 30.0,
+      );
+      store.record(
+        vehicleId: 'car-a',
+        situation: DrivingSituation.fuelCutCoast,
+        value: 0.0,
+      );
+      expect(
+        store.sampleCount(
+          vehicleId: 'car-a',
+          situation: DrivingSituation.hardAccel,
+        ),
+        0,
+      );
+      expect(
+        store.sampleCount(
+          vehicleId: 'car-a',
+          situation: DrivingSituation.fuelCutCoast,
+        ),
+        0,
+      );
+    });
+
+    test('blended weight ramps 0 → 1 linearly across '
+        'fullConfidenceSamples', () async {
+      final store =
+          BaselineStore(box: box, fullConfidenceSamples: 10);
+      await store.loadVehicle('car-a');
+      for (var i = 0; i < 5; i++) {
+        store.record(
+          vehicleId: 'car-a',
+          situation: DrivingSituation.highwayCruise,
+          value: 10.0,
+        );
+      }
+      final b = store.lookup(
+        vehicleId: 'car-a',
+        situation: DrivingSituation.highwayCruise,
+        fuelFamily: ConsumptionFuelFamily.gasoline,
+      );
+      // 5/10 weight → 10 × 0.5 + 6 × 0.5 = 8.0
+      expect(b.value, closeTo(8.0, 1e-9));
+    });
+
+    test('reaches full learned value at fullConfidenceSamples',
+        () async {
+      final store =
+          BaselineStore(box: box, fullConfidenceSamples: 10);
+      await store.loadVehicle('car-a');
+      for (var i = 0; i < 10; i++) {
+        store.record(
+          vehicleId: 'car-a',
+          situation: DrivingSituation.highwayCruise,
+          value: 10.0,
+        );
+      }
+      final b = store.lookup(
+        vehicleId: 'car-a',
+        situation: DrivingSituation.highwayCruise,
+        fuelFamily: ConsumptionFuelFamily.gasoline,
+      );
+      expect(b.value, closeTo(10.0, 1e-9));
+    });
+
+    test('multi-vehicle: baselines are isolated per vehicle',
+        () async {
+      final store =
+          BaselineStore(box: box, fullConfidenceSamples: 10);
+      await store.loadVehicle('car-a');
+      await store.loadVehicle('car-b');
+      for (var i = 0; i < 10; i++) {
+        store.record(
+          vehicleId: 'car-a',
+          situation: DrivingSituation.highwayCruise,
+          value: 10.0,
+        );
+        store.record(
+          vehicleId: 'car-b',
+          situation: DrivingSituation.highwayCruise,
+          value: 5.0,
+        );
+      }
+      expect(
+        store.lookup(
+          vehicleId: 'car-a',
+          situation: DrivingSituation.highwayCruise,
+          fuelFamily: ConsumptionFuelFamily.gasoline,
+        ).value,
+        closeTo(10.0, 1e-9),
+      );
+      expect(
+        store.lookup(
+          vehicleId: 'car-b',
+          situation: DrivingSituation.highwayCruise,
+          fuelFamily: ConsumptionFuelFamily.gasoline,
+        ).value,
+        closeTo(5.0, 1e-9),
+      );
+    });
+
+    test('flush() + fresh load round-trips the accumulators',
+        () async {
+      final store =
+          BaselineStore(box: box, fullConfidenceSamples: 10);
+      await store.loadVehicle('car-a');
+      for (var i = 0; i < 10; i++) {
+        store.record(
+          vehicleId: 'car-a',
+          situation: DrivingSituation.highwayCruise,
+          value: 7.0,
+        );
+      }
+      await store.flush('car-a');
+
+      final fresh =
+          BaselineStore(box: box, fullConfidenceSamples: 10);
+      await fresh.loadVehicle('car-a');
+      final b = fresh.lookup(
+        vehicleId: 'car-a',
+        situation: DrivingSituation.highwayCruise,
+        fuelFamily: ConsumptionFuelFamily.gasoline,
+      );
+      expect(b.value, closeTo(7.0, 1e-9));
+    });
+
+    test('corrupt persisted payload is tolerated — cold-start default',
+        () async {
+      await box.put('baseline:car-a', 'this is not JSON');
+      final store = BaselineStore(box: box);
+      await store.loadVehicle('car-a');
+      final b = store.lookup(
+        vehicleId: 'car-a',
+        situation: DrivingSituation.highwayCruise,
+        fuelFamily: ConsumptionFuelFamily.gasoline,
+      );
+      expect(b.value, 6.0);
+    });
+
+    test('WelfordAccumulator sanity — defence against forked math',
+        () {
+      final w = WelfordAccumulator();
+      w.update(1);
+      w.update(2);
+      w.update(3);
+      expect(w.mean, closeTo(2.0, 1e-10));
+    });
+  });
+}

--- a/test/features/consumption/data/welford_test.dart
+++ b/test/features/consumption/data/welford_test.dart
@@ -1,0 +1,73 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/welford.dart';
+
+void main() {
+  group('WelfordAccumulator (#769)', () {
+    test('starts at zero', () {
+      final w = WelfordAccumulator();
+      expect(w.n, 0);
+      expect(w.mean, 0);
+      expect(w.m2, 0);
+      expect(w.variance, 0);
+    });
+
+    test('single sample has zero variance, mean == sample', () {
+      final w = WelfordAccumulator();
+      w.update(7.5);
+      expect(w.n, 1);
+      expect(w.mean, closeTo(7.5, 1e-10));
+      expect(w.variance, 0);
+    });
+
+    test('converges on the true mean and variance of a known set', () {
+      // Dataset: [2, 4, 4, 4, 5, 5, 7, 9] — classic Wikipedia example.
+      // Mean = 5. Sample variance (n-1) = 32/7 ≈ 4.57142857.
+      final w = WelfordAccumulator();
+      for (final v in const [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]) {
+        w.update(v);
+      }
+      expect(w.n, 8);
+      expect(w.mean, closeTo(5.0, 1e-10));
+      expect(w.variance, closeTo(32.0 / 7.0, 1e-10));
+      expect(w.stddev, closeTo(math.sqrt(32.0 / 7.0), 1e-10));
+    });
+
+    test('survives a large range without catastrophic cancellation', () {
+      // Classic numerical-stability edge case: samples clustered far
+      // from zero with a tiny spread. A naive (sumSq / n - mean²)
+      // implementation loses all precision here; Welford survives.
+      final w = WelfordAccumulator();
+      for (var i = 0; i < 1000; i++) {
+        w.update(1e9 + i * 0.1);
+      }
+      // Sample variance (n-1 divisor) for [0, 0.1, …, 99.9]:
+      //   var = sum((xi - mean)²) / 999 ≈ 834.16666…
+      // Derived analytically from the uniform-spacing formula; not a
+      // hand-wave. Tolerance is loose because the 1 × 10^9 offset
+      // exercises double-precision catastrophic-cancellation edges.
+      expect(w.variance, closeTo(834.16666666, 1.0));
+    });
+
+    test('toJson / fromJson round-trips without loss', () {
+      final w = WelfordAccumulator();
+      for (final v in const [1.0, 2.0, 3.0, 4.0, 5.0]) {
+        w.update(v);
+      }
+      final restored = WelfordAccumulator.fromJson(w.toJson());
+      expect(restored.n, w.n);
+      expect(restored.mean, w.mean);
+      expect(restored.m2, w.m2);
+    });
+
+    test('reset() clears every accumulator field', () {
+      final w = WelfordAccumulator();
+      w.update(42);
+      w.reset();
+      expect(w.n, 0);
+      expect(w.mean, 0);
+      expect(w.m2, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Phase 2 of #767. Math + persistence for learning per-vehicle consumption baselines. Integration into the provider is a follow-up — this PR ships the store in isolation so the numerical stability and Hive round-trip can ride green CI before the wiring adds risk.

### What ships
- \`WelfordAccumulator\` — three-double online mean + variance, numerically stable even with 1 × 10⁹ offsets.
- \`BaselineStore\` — Hive-backed per-vehicle per-situation accumulator map. \`record\`, \`lookup\`, \`flush\`, \`clear\`. Schema versioned (\`version: 1\`).
- Cold-start blending — learned weight ramps linearly 0 → 1 across \`fullConfidenceSamples\` (default 30, ≈5 min).

## Test plan
- [x] 6 Welford tests — zero state, single sample, Wikipedia example convergence, large-offset numerical stability, JSON round-trip, reset
- [x] 8 BaselineStore tests — empty → cold-start default, transient drop, linear blend ramp, full confidence, per-vehicle isolation, flush/reload round-trip, corrupt payload tolerance, sanity
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 4702 passing (1 pre-existing flaky Argentina network test on Windows)

Partial progress on #769 — provider wiring in a follow-up once the vehicle-profile plumbing is ready.