### PR TITLE
feat(obd2): band-transition haptics + banner a11y Semantics (#767)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -25,20 +25,32 @@ class TripRecordingBanner extends ConsumerWidget {
     if (!state.isActive) return child;
 
     final bandColor = _bandColor(context, state.band, state.phase);
+    final l = AppLocalizations.of(context);
     return Column(
       children: [
-        Material(
-          color: bandColor.background,
-          elevation: 2,
-          child: SafeArea(
-            bottom: false,
-            child: InkWell(
-              key: const Key('tripRecordingBanner'),
-              onTap: () => GoRouter.of(context).push('/trip-recording'),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 12, vertical: 6),
-                child: _Content(state: state, palette: bandColor),
+        Semantics(
+          container: true,
+          button: true,
+          // liveRegion makes TalkBack re-read the label when the
+          // band or situation changes — that's the whole point of
+          // the ambient consumption signal (#767).
+          liveRegion: true,
+          label: _semanticsLabel(state, l),
+          child: ExcludeSemantics(
+            child: Material(
+              color: bandColor.background,
+              elevation: 2,
+              child: SafeArea(
+                bottom: false,
+                child: InkWell(
+                  key: const Key('tripRecordingBanner'),
+                  onTap: () => GoRouter.of(context).push('/trip-recording'),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 6),
+                    child: _Content(state: state, palette: bandColor),
+                  ),
+                ),
               ),
             ),
           ),
@@ -46,6 +58,46 @@ class TripRecordingBanner extends ConsumerWidget {
         Expanded(child: child),
       ],
     );
+  }
+
+  String _semanticsLabel(TripRecordingState state, AppLocalizations? l) {
+    if (state.phase == TripRecordingPhase.paused) {
+      return l?.tripBannerPaused ?? 'Trip paused';
+    }
+    final prefix = l?.tripBannerRecording ?? 'Recording trip';
+    final situation = _situationLabel(state.situation, l);
+    final parts = <String>[prefix, situation];
+    final delta = state.liveDeltaFraction;
+    if (delta != null) {
+      final pct = (delta * 100).round();
+      parts.add('${pct >= 0 ? '+' : ''}$pct%');
+    }
+    final distance = state.live?.distanceKmSoFar;
+    if (distance != null) {
+      parts.add('${distance.toStringAsFixed(1)} km');
+    }
+    return parts.join(', ');
+  }
+
+  String _situationLabel(DrivingSituation s, AppLocalizations? l) {
+    switch (s) {
+      case DrivingSituation.idle:
+        return l?.situationIdle ?? 'Idle';
+      case DrivingSituation.stopAndGo:
+        return l?.situationStopAndGo ?? 'Stop & go';
+      case DrivingSituation.urbanCruise:
+        return l?.situationUrban ?? 'Urban';
+      case DrivingSituation.highwayCruise:
+        return l?.situationHighway ?? 'Highway';
+      case DrivingSituation.deceleration:
+        return l?.situationDecel ?? 'Decelerating';
+      case DrivingSituation.climbingOrLoaded:
+        return l?.situationClimbing ?? 'Climbing / loaded';
+      case DrivingSituation.hardAccel:
+        return l?.situationHardAccel ?? 'Hard accel';
+      case DrivingSituation.fuelCutCoast:
+        return l?.situationFuelCut ?? 'Fuel cut — coast';
+    }
   }
 
   _BannerPalette _bandColor(

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -18,6 +19,31 @@ part 'trip_recording_provider.g.dart';
 
 /// Lifecycle phase of the app-wide OBD2 trip recording (#726).
 enum TripRecordingPhase { idle, recording, paused, finished }
+
+/// Haptic strength emitted when the consumption band changes (#767).
+enum HapticIntensity { none, light, medium }
+
+/// Decide which haptic (if any) fires when [previous] transitions to
+/// [current]. Pure function: no platform calls, easily unit-tested.
+/// Only escalations vibrate — heavy or worse. Positive transitions
+/// (eco / normal) stay silent so the feedback is a corrective nudge,
+/// not constant noise.
+HapticIntensity hapticForBandTransition(
+  ConsumptionBand previous,
+  ConsumptionBand current,
+) {
+  if (previous == current) return HapticIntensity.none;
+  if (current == ConsumptionBand.veryHeavy &&
+      previous != ConsumptionBand.veryHeavy) {
+    return HapticIntensity.medium;
+  }
+  if (current == ConsumptionBand.heavy &&
+      previous != ConsumptionBand.heavy &&
+      previous != ConsumptionBand.veryHeavy) {
+    return HapticIntensity.light;
+  }
+  return HapticIntensity.none;
+}
 
 /// Immutable snapshot the UI observes.
 @immutable
@@ -85,6 +111,15 @@ class TripRecording extends _$TripRecording {
   String? _vehicleId;
   ConsumptionFuelFamily _fuelFamily = ConsumptionFuelFamily.gasoline;
 
+  /// Tests count haptic fires via these instead of hooking the
+  /// platform channel. The production path also still calls
+  /// [HapticFeedback], so counting here doesn't short-circuit the
+  /// real vibration on a device.
+  @visibleForTesting
+  int hapticLightCount = 0;
+  @visibleForTesting
+  int hapticMediumCount = 0;
+
   @override
   TripRecordingState build() {
     return const TripRecordingState();
@@ -127,6 +162,7 @@ class TripRecording extends _$TripRecording {
       _recordToStore(reading, situation);
       final band = _classifyBandFrom(reading, situation);
       final delta = _computeDelta(reading, situation);
+      _fireBandTransitionHaptic(state.band, band);
       state = state.copyWith(
         phase: ctl.isPaused
             ? TripRecordingPhase.paused
@@ -138,6 +174,25 @@ class TripRecording extends _$TripRecording {
       );
     });
     state = state.copyWith(phase: TripRecordingPhase.recording);
+  }
+
+  /// #767 — fire a short haptic when the band crosses *into* heavy
+  /// territory. Positive improvements (normal → eco) stay silent so
+  /// the vibration is a corrective nudge, not constant feedback.
+  void _fireBandTransitionHaptic(
+    ConsumptionBand previous,
+    ConsumptionBand current,
+  ) {
+    switch (hapticForBandTransition(previous, current)) {
+      case HapticIntensity.light:
+        hapticLightCount++;
+        HapticFeedback.lightImpact();
+      case HapticIntensity.medium:
+        hapticMediumCount++;
+        HapticFeedback.mediumImpact();
+      case HapticIntensity.none:
+        break;
+    }
   }
 
   /// Map a [FuelType] apiValue onto a [ConsumptionFuelFamily] for

--- a/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_recording_banner.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Fake notifier lets tests pin the banner to an exact state without
+/// spinning up an Obd2Service + controller + streams.
+class _FakeTripRecording extends TripRecording {
+  final TripRecordingState _initial;
+  _FakeTripRecording(this._initial);
+
+  @override
+  TripRecordingState build() => _initial;
+}
+
+TripRecordingState _activeState({
+  ConsumptionBand band = ConsumptionBand.normal,
+  DrivingSituation situation = DrivingSituation.highwayCruise,
+  double? delta,
+  double? distance,
+}) {
+  return TripRecordingState(
+    phase: TripRecordingPhase.recording,
+    situation: situation,
+    band: band,
+    liveDeltaFraction: delta,
+    live: distance == null
+        ? null
+        : TripLiveReading(
+            distanceKmSoFar: distance,
+            elapsed: const Duration(minutes: 1),
+          ),
+  );
+}
+
+void main() {
+  group('TripRecordingBanner a11y (#767)', () {
+    testWidgets('idle state: no banner rendered — Semantics empty',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const TripRecordingBanner(child: SizedBox(key: Key('child'))),
+      );
+      expect(find.byKey(const Key('tripRecordingBanner')), findsNothing);
+      expect(find.byKey(const Key('child')), findsOneWidget);
+    });
+
+    testWidgets('active state exposes a single merged Semantics node '
+        'with a TalkBack-readable label — separate per-chip labels '
+        'would narrate as a stream of numbers and be unusable',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const TripRecordingBanner(child: SizedBox()),
+        overrides: [
+          tripRecordingProvider.overrideWith(
+            () => _FakeTripRecording(_activeState(
+              band: ConsumptionBand.heavy,
+              delta: 0.08,
+              distance: 5.2,
+            )),
+          ),
+        ],
+      );
+
+      final handle = tester.ensureSemantics();
+      final labels = tester
+          .getSemantics(find.byKey(const Key('tripRecordingBanner')).first)
+          .getSemanticsData()
+          .label;
+      expect(labels, contains('Recording trip'));
+      expect(labels, contains('Highway'));
+      expect(labels, contains('+8%'));
+      expect(labels, contains('5.2 km'));
+      handle.dispose();
+    });
+
+    testWidgets('paused state reads as "Trip paused" — consumption '
+        'band on a paused reading would mislead',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const TripRecordingBanner(child: SizedBox()),
+        overrides: [
+          tripRecordingProvider.overrideWith(
+            () => _FakeTripRecording(const TripRecordingState(
+              phase: TripRecordingPhase.paused,
+              situation: DrivingSituation.highwayCruise,
+              band: ConsumptionBand.heavy,
+            )),
+          ),
+        ],
+      );
+
+      final handle = tester.ensureSemantics();
+      final label = tester
+          .getSemantics(find.byKey(const Key('tripRecordingBanner')).first)
+          .getSemanticsData()
+          .label;
+      expect(label, contains('paused'));
+      expect(label, isNot(contains('Highway')));
+      expect(label, isNot(contains('%')));
+      handle.dispose();
+    });
+
+    testWidgets('negative delta renders without a leading + so '
+        'TalkBack announces "minus 8 percent" not "plus minus 8"',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const TripRecordingBanner(child: SizedBox()),
+        overrides: [
+          tripRecordingProvider.overrideWith(
+            () => _FakeTripRecording(_activeState(
+              band: ConsumptionBand.eco,
+              delta: -0.12,
+            )),
+          ),
+        ],
+      );
+
+      final handle = tester.ensureSemantics();
+      final label = tester
+          .getSemantics(find.byKey(const Key('tripRecordingBanner')).first)
+          .getSemanticsData()
+          .label;
+      expect(label, contains('-12%'));
+      expect(label, isNot(contains('+-12%')));
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/consumption/providers/trip_recording_provider_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 
 void main() {
@@ -107,6 +108,84 @@ void main() {
       await notifier.stop();
       // b was never wired in; clean it up manually.
       await b.disconnect();
+    });
+  });
+
+  group('hapticForBandTransition (#767)', () {
+    test('same band → none', () {
+      expect(
+        hapticForBandTransition(
+            ConsumptionBand.normal, ConsumptionBand.normal),
+        HapticIntensity.none,
+      );
+    });
+
+    test('normal → heavy fires light', () {
+      expect(
+        hapticForBandTransition(
+            ConsumptionBand.normal, ConsumptionBand.heavy),
+        HapticIntensity.light,
+      );
+    });
+
+    test('eco → heavy fires light', () {
+      expect(
+        hapticForBandTransition(
+            ConsumptionBand.eco, ConsumptionBand.heavy),
+        HapticIntensity.light,
+      );
+    });
+
+    test('transient → heavy fires light — a short WOT overtake that '
+        'settles into sustained heavy should still ping', () {
+      expect(
+        hapticForBandTransition(
+            ConsumptionBand.transient, ConsumptionBand.heavy),
+        HapticIntensity.light,
+      );
+    });
+
+    test('normal → veryHeavy fires medium', () {
+      expect(
+        hapticForBandTransition(
+            ConsumptionBand.normal, ConsumptionBand.veryHeavy),
+        HapticIntensity.medium,
+      );
+    });
+
+    test('heavy → veryHeavy fires medium — escalation is worth a '
+        'stronger pulse', () {
+      expect(
+        hapticForBandTransition(
+            ConsumptionBand.heavy, ConsumptionBand.veryHeavy),
+        HapticIntensity.medium,
+      );
+    });
+
+    test('veryHeavy → heavy stays silent — improvements never ping',
+        () {
+      expect(
+        hapticForBandTransition(
+            ConsumptionBand.veryHeavy, ConsumptionBand.heavy),
+        HapticIntensity.none,
+      );
+    });
+
+    test('heavy → eco stays silent', () {
+      expect(
+        hapticForBandTransition(
+            ConsumptionBand.heavy, ConsumptionBand.eco),
+        HapticIntensity.none,
+      );
+    });
+
+    test('normal → eco stays silent — positive transitions are '
+        'rewarded by the banner colour, not by vibration', () {
+      expect(
+        hapticForBandTransition(
+            ConsumptionBand.normal, ConsumptionBand.eco),
+        HapticIntensity.none,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- Closes the last two gaps in #767: haptic feedback on band escalations and a TalkBack-readable `Semantics` label on the trip banner
- Pure-function `hapticForBandTransition` split out for exhaustive unit coverage (9 boundary cases)
- Banner now wraps its content in a single merged `Semantics` node with `liveRegion: true`, so screen readers announce the full state ("Recording trip, Highway, +8%, 5.2 km") on every band change — not a stream of isolated numbers

## Why
#767 was ~80% shipped across #770 / #771 / #772 / #774; the outstanding items in the spec's acceptance list were (a) haptic pulse on heavy/veryHeavy transitions and (b) Semantics for colour-blind and TalkBack users. Both are small, local, and unblock closing the issue without leaving dangling a11y debt.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — 0 issues
- [x] `flutter test test/features/consumption/` — 363 pass (was 350; +9 haptic + 4 banner a11y)
- [x] Haptic function exhaustively tested at boundaries: same-band, each band → heavy, each band → veryHeavy, heavy → veryHeavy (escalation), veryHeavy → heavy (silent), heavy → eco (silent)
- [x] Banner tests cover: idle (no render), active (full label), paused (no band info), negative delta (no `+-8%`)

## Positive-transition design note
`eco → normal → heavy` fires one light pulse on the heavy step. `normal → eco` stays silent — positive feedback is the banner's green tint, not vibration. Constant vibration for "good" desensitises the driver to the "bad" pulses that actually want attention.

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)