### PR TITLE
feat(sync): per-situation baseline merge + Supabase schema (#780) — phase 1

### DIFF
--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -1,7 +1,10 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../features/alerts/data/models/price_alert.dart';
+import '../../features/consumption/data/baseline_sync.dart';
 import '../../features/consumption/domain/entities/fill_up.dart';
 import '../../features/itinerary/domain/entities/saved_itinerary.dart';
 import '../../features/vehicle/domain/entities/vehicle_profile.dart';
@@ -621,6 +624,90 @@ class SyncService {
           .eq('id', fillUpId);
     } catch (e) {
       debugPrint('SyncService.deleteFillUp FAILED: $e');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // OBD2 baselines (#780)
+  // ---------------------------------------------------------------------------
+
+  /// Two-way sync of the baseline payload for a single vehicle.
+  /// Merge rule is per-situation: for every driving situation, the
+  /// accumulator with the higher sample count wins. Returns the
+  /// merged JSON payload that callers should persist locally and
+  /// hand back to [BaselineStore]; returns the original [localJson]
+  /// unchanged when offline or unauthenticated.
+  ///
+  /// [totalSampleCountOverride] lets the caller supply a
+  /// pre-computed total — the Dart layer already counts samples for
+  /// the status UI, so we avoid decoding the JSON twice when it's
+  /// already available.
+  static Future<String?> syncVehicleBaseline({
+    required String vehicleId,
+    required String? localJson,
+    int? totalSampleCountOverride,
+  }) async {
+    final client = _client;
+    final userId = _authenticatedUserId;
+    if (client == null || userId == null) {
+      debugPrint('SyncService.syncVehicleBaseline: not authenticated');
+      return localJson;
+    }
+
+    try {
+      final serverRow = await client
+          .from('obd2_baselines')
+          .select('data')
+          .eq('user_id', userId)
+          .eq('vehicle_id', vehicleId)
+          .maybeSingle();
+
+      final serverData = serverRow == null
+          ? null
+          : (serverRow['data'] as Map?)?.cast<String, dynamic>();
+
+      final merged = mergeBaselineJson(
+        localJson,
+        serverData == null ? null : jsonEncode(serverData),
+      );
+      if (merged == null) return localJson;
+
+      final mergedDecoded =
+          (jsonDecode(merged) as Map).cast<String, dynamic>();
+      final total = totalSampleCountOverride ??
+          totalSampleCount(mergedDecoded);
+
+      await client.from('obd2_baselines').upsert(
+        {
+          'user_id': userId,
+          'vehicle_id': vehicleId,
+          'total_samples': total,
+          'data': mergedDecoded,
+          'updated_at': DateTime.now().toIso8601String(),
+        },
+        onConflict: 'user_id,vehicle_id',
+      );
+      return merged;
+    } catch (e) {
+      debugPrint('SyncService.syncVehicleBaseline FAILED: $e');
+      return localJson;
+    }
+  }
+
+  /// Remove a single vehicle's baseline from the server. Called on
+  /// explicit "Forget baseline" from the vehicle edit UI.
+  static Future<void> deleteVehicleBaseline(String vehicleId) async {
+    final client = _client;
+    final userId = _authenticatedUserId;
+    if (client == null || userId == null) return;
+    try {
+      await client
+          .from('obd2_baselines')
+          .delete()
+          .eq('user_id', userId)
+          .eq('vehicle_id', vehicleId);
+    } catch (e) {
+      debugPrint('SyncService.deleteVehicleBaseline FAILED: $e');
     }
   }
 }

--- a/lib/features/consumption/data/baseline_sync.dart
+++ b/lib/features/consumption/data/baseline_sync.dart
@@ -1,0 +1,123 @@
+/// Per-situation merge helpers for syncing OBD2 baselines (#780).
+///
+/// Baseline payloads shape (as produced by [BaselineStore.flush]):
+/// ```json
+/// {
+///   "version": 1,
+///   "perSituation": {
+///     "highwayCruise": {"n": 123, "mean": 6.5, "m2": 2.3},
+///     "urbanCruise":   {"n": 45,  "mean": 8.2, "m2": 4.1}
+///   }
+/// }
+/// ```
+///
+/// Merge rule: for each situation, pick the accumulator with the
+/// higher `n`. A device that drove more of that situation knows
+/// more — merging the raw Welford moments across devices would be
+/// numerically fine but requires shared samples, which we don't
+/// have. "Prefer more experience" is a safe, intuitive fallback.
+library;
+
+import 'dart:convert';
+
+/// Merge [local] and [server] baseline payloads per-situation. Both
+/// inputs are JSON-decoded maps with the shape above. Missing
+/// payloads (null) are treated as empty. Returns a brand-new map
+/// ready to be persisted locally and uploaded back to the server.
+Map<String, dynamic> mergeBaselinePayloads(
+  Map<String, dynamic>? local,
+  Map<String, dynamic>? server,
+) {
+  final localSit = _extractPerSituation(local);
+  final serverSit = _extractPerSituation(server);
+  final keys = {...localSit.keys, ...serverSit.keys};
+
+  final mergedSituations = <String, dynamic>{};
+  for (final key in keys) {
+    final l = localSit[key];
+    final s = serverSit[key];
+    mergedSituations[key] = _pickHigherN(l, s);
+  }
+
+  return {
+    'version': 1,
+    'perSituation': mergedSituations,
+  };
+}
+
+/// Total sample count summed across every situation. Exposed so the
+/// sync client can populate the `total_samples` column without
+/// re-summing in two places.
+int totalSampleCount(Map<String, dynamic> payload) {
+  final perSit = _extractPerSituation(payload);
+  var total = 0;
+  for (final acc in perSit.values) {
+    final n = acc['n'];
+    // `int` is a `num`, so check the specific type first and bail.
+    if (n is int) {
+      total += n;
+    } else if (n is num) {
+      total += n.toInt();
+    }
+  }
+  return total;
+}
+
+/// Convenience for callers that already hold the JSON string form
+/// that [BaselineStore] writes to Hive. Decodes, merges, re-encodes.
+/// Returns null when both inputs are null/empty.
+String? mergeBaselineJson(String? localJson, String? serverJson) {
+  final local = _tryDecode(localJson);
+  final server = _tryDecode(serverJson);
+  if (local == null && server == null) return null;
+  final merged = mergeBaselinePayloads(local, server);
+  return jsonEncode(merged);
+}
+
+Map<String, dynamic>? _tryDecode(String? raw) {
+  if (raw == null || raw.isEmpty) return null;
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is Map<String, dynamic>) return decoded;
+    if (decoded is Map) return Map<String, dynamic>.from(decoded);
+  } catch (_) {
+    // Fall through — caller treats as null.
+  }
+  return null;
+}
+
+Map<String, Map<String, dynamic>> _extractPerSituation(
+  Map<String, dynamic>? payload,
+) {
+  if (payload == null) return const {};
+  final raw = payload['perSituation'];
+  if (raw is! Map) return const {};
+  final out = <String, Map<String, dynamic>>{};
+  raw.forEach((k, v) {
+    if (k is String && v is Map) {
+      out[k] = Map<String, dynamic>.from(v);
+    }
+  });
+  return out;
+}
+
+Map<String, dynamic> _pickHigherN(
+  Map<String, dynamic>? a,
+  Map<String, dynamic>? b,
+) {
+  if (a == null) return b!;
+  if (b == null) return a;
+  final an = _readN(a);
+  final bn = _readN(b);
+  // Ties go to local (a) so the caller's own state is the tiebreaker
+  // — a device's latest in-memory values shouldn't be silently
+  // overwritten by an equally-aged server copy.
+  return an >= bn ? a : b;
+}
+
+int _readN(Map<String, dynamic> acc) {
+  final n = acc['n'];
+  if (n is int) return n;
+  if (n is num) return n.toInt();
+  return 0;
+}

--- a/supabase/migrations/20260421000001_obd2_baselines.sql
+++ b/supabase/migrations/20260421000001_obd2_baselines.sql
@@ -1,0 +1,28 @@
+-- Per-vehicle OBD2 consumption baselines (#780).
+--
+-- One JSON payload per (user, vehicle) pair holding the Welford
+-- accumulators keyed by driving situation. The `total_samples`
+-- column surfaces the summed sample count across every situation so
+-- server-side queries can pick a winner without decoding the JSON.
+--
+-- Merge rule on conflict: prefer the payload whose per-situation
+-- sample count is higher. The Dart client resolves this per
+-- situation (a device that drove more highway may have less urban
+-- data), so the server copy is authoritative only after the client
+-- has folded its own samples in.
+
+CREATE TABLE IF NOT EXISTS public.obd2_baselines (
+  vehicle_id TEXT NOT NULL,
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  total_samples INTEGER NOT NULL DEFAULT 0,
+  data JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, vehicle_id)
+);
+
+ALTER TABLE public.obd2_baselines ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY obd2_baselines_own ON public.obd2_baselines
+  FOR ALL USING (user_id = auth.uid());
+
+CREATE INDEX obd2_baselines_user_idx ON public.obd2_baselines(user_id);

--- a/test/features/consumption/data/baseline_sync_test.dart
+++ b/test/features/consumption/data/baseline_sync_test.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/baseline_sync.dart';
+
+Map<String, dynamic> _payload(Map<String, Map<String, num>> situations) {
+  return {
+    'version': 1,
+    'perSituation': {
+      for (final e in situations.entries)
+        e.key: {
+          'n': e.value['n'] ?? 0,
+          'mean': e.value['mean'] ?? 0.0,
+          'm2': e.value['m2'] ?? 0.0,
+        },
+    },
+  };
+}
+
+void main() {
+  group('mergeBaselinePayloads (#780)', () {
+    test('both null → empty perSituation, version preserved', () {
+      final merged = mergeBaselinePayloads(null, null);
+      expect(merged['version'], 1);
+      expect(merged['perSituation'], isEmpty);
+    });
+
+    test('local only → passthrough of every situation', () {
+      final local = _payload({
+        'highwayCruise': {'n': 10, 'mean': 6.5, 'm2': 1.0},
+      });
+      final merged = mergeBaselinePayloads(local, null);
+      final sit = merged['perSituation'] as Map<String, dynamic>;
+      expect(sit['highwayCruise']['n'], 10);
+      expect(sit['highwayCruise']['mean'], 6.5);
+    });
+
+    test('server only → passthrough of every situation', () {
+      final server = _payload({
+        'urbanCruise': {'n': 7, 'mean': 8.1, 'm2': 2.0},
+      });
+      final merged = mergeBaselinePayloads(null, server);
+      final sit = merged['perSituation'] as Map<String, dynamic>;
+      expect(sit['urbanCruise']['n'], 7);
+    });
+
+    test('both present, disjoint situations → union', () {
+      final local = _payload({
+        'highwayCruise': {'n': 10},
+      });
+      final server = _payload({
+        'urbanCruise': {'n': 20},
+      });
+      final merged = mergeBaselinePayloads(local, server);
+      final sit = merged['perSituation'] as Map<String, dynamic>;
+      expect(sit.keys.toSet(), {'highwayCruise', 'urbanCruise'});
+      expect(sit['highwayCruise']['n'], 10);
+      expect(sit['urbanCruise']['n'], 20);
+    });
+
+    test('overlapping situations → higher-n wins regardless of which '
+        'side it came from', () {
+      final local = _payload({
+        'highwayCruise': {'n': 5, 'mean': 7.0},
+        'urbanCruise': {'n': 100, 'mean': 8.0},
+      });
+      final server = _payload({
+        'highwayCruise': {'n': 50, 'mean': 6.0},
+        'urbanCruise': {'n': 10, 'mean': 9.0},
+      });
+      final merged = mergeBaselinePayloads(local, server);
+      final sit = merged['perSituation'] as Map<String, dynamic>;
+      // Server had more highway → server mean wins
+      expect(sit['highwayCruise']['n'], 50);
+      expect(sit['highwayCruise']['mean'], 6.0);
+      // Local had more urban → local mean wins
+      expect(sit['urbanCruise']['n'], 100);
+      expect(sit['urbanCruise']['mean'], 8.0);
+    });
+
+    test('tied n → local wins — a device should not be silently '
+        'overwritten by an equally-aged server copy', () {
+      final local = _payload({
+        'highwayCruise': {'n': 20, 'mean': 7.0},
+      });
+      final server = _payload({
+        'highwayCruise': {'n': 20, 'mean': 6.0},
+      });
+      final merged = mergeBaselinePayloads(local, server);
+      final sit = merged['perSituation'] as Map<String, dynamic>;
+      expect(sit['highwayCruise']['mean'], 7.0);
+    });
+  });
+
+  group('totalSampleCount (#780)', () {
+    test('sums n across every situation', () {
+      final payload = _payload({
+        'highwayCruise': {'n': 30},
+        'urbanCruise': {'n': 15},
+        'idle': {'n': 5},
+      });
+      expect(totalSampleCount(payload), 50);
+    });
+
+    test('empty payload → 0', () {
+      expect(totalSampleCount({'version': 1, 'perSituation': {}}), 0);
+    });
+  });
+
+  group('mergeBaselineJson (#780)', () {
+    test('both null/empty → null', () {
+      expect(mergeBaselineJson(null, null), isNull);
+      expect(mergeBaselineJson('', ''), isNull);
+    });
+
+    test('valid local + null server round-trips through JSON', () {
+      final local = jsonEncode(_payload({
+        'highwayCruise': {'n': 10, 'mean': 6.5, 'm2': 1.0},
+      }));
+      final merged = mergeBaselineJson(local, null);
+      expect(merged, isNotNull);
+      final decoded = jsonDecode(merged!) as Map;
+      expect((decoded['perSituation'] as Map)['highwayCruise']['n'], 10);
+    });
+
+    test('corrupt JSON on either side → treated as empty, no throw',
+        () {
+      final local = jsonEncode(_payload({
+        'highwayCruise': {'n': 10},
+      }));
+      final merged = mergeBaselineJson(local, '{not json');
+      expect(merged, isNotNull);
+      final decoded = jsonDecode(merged!) as Map;
+      expect((decoded['perSituation'] as Map)['highwayCruise']['n'], 10);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Phase-1 scaffolding for cross-device OBD2 baseline sync.

- **Migration** `20260421000001_obd2_baselines.sql` — `public.obd2_baselines` table (user_id, vehicle_id, total_samples, data JSONB, updated_at); RLS protected like the other per-user tables
- **Pure merge** `mergeBaselinePayloads` — per-situation higher-`n`-wins; ties go to local so a device's own state isn't silently overwritten by an equally-aged server copy
- **`totalSampleCount`** helper for populating the server-side `total_samples` column
- **`SyncService.syncVehicleBaseline`** — fetch → merge → upsert; returns merged JSON for the caller to persist locally via `BaselineStore`
- **`SyncService.deleteVehicleBaseline`** for "Forget baseline" flows

## Design rationale
The issue called for "higher sample count wins on merge". I took that literally per-situation rather than whole-payload — a device that drove a lot of highway can keep that even if a sibling device has more urban data. Same shape as the per-vehicle baseline model; minimally more code for meaningfully better fidelity.

## Deferred to phase 2
- Hooking `syncVehicleBaseline` into the trip-stop flow so newly learned samples upload automatically
- Opt-in toggle on the sync setup screen ("Share learned vehicle profiles")
- Automatic download on first pair from a second device

All three are plumbing on top of the merge function that ships here.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — 0 issues
- [x] `flutter test test/features/consumption/data/baseline_sync_test.dart` — 11 tests pass
- [x] Merge coverage: both null, local-only, server-only, disjoint, overlap (both directions), tie → local

Part of #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)