### PR TITLE
feat(achievements): ecoWeek badge — 7-day smooth-driving streak (#781)

### DIFF
--- a/lib/features/achievements/domain/achievement.dart
+++ b/lib/features/achievements/domain/achievement.dart
@@ -18,6 +18,13 @@ enum AchievementId {
   /// at least 10 km of distance. Rewards smooth driving, not just
   /// short drives that trivially have no events.
   zeroHarshTrip,
+
+  /// Seven consecutive calendar days, each with at least one trip
+  /// of ≥10 km and zero harsh events. Rewards sustained smooth
+  /// driving — a single good day isn't enough. The streak window
+  /// is rolling: any 7-day stretch in the log qualifies, not just
+  /// the most recent one.
+  ecoWeek,
 }
 
 /// An achievement the user has earned. `earnedAt` is the moment the

--- a/lib/features/achievements/domain/achievement_engine.dart
+++ b/lib/features/achievements/domain/achievement_engine.dart
@@ -33,6 +33,9 @@ class AchievementEngine {
     if (_anyZeroHarshTrip(trips)) {
       earned.add(AchievementId.zeroHarshTrip);
     }
+    if (_hasEcoWeekStreak(trips)) {
+      earned.add(AchievementId.ecoWeek);
+    }
     return earned;
   }
 
@@ -44,6 +47,38 @@ class AchievementEngine {
           s.harshAccelerations == 0) {
         return true;
       }
+    }
+    return false;
+  }
+
+  /// Check every 7-consecutive-day window in the log. For each
+  /// window, if each of the 7 calendar days has at least one trip
+  /// that qualifies as "eco" (≥10 km, zero harsh events), the
+  /// streak counts. The rolling window means once the user earns
+  /// the badge it stays earned, even if next week they skip a day.
+  bool _hasEcoWeekStreak(List<TripHistoryEntry> trips) {
+    final ecoDays = <DateTime>{};
+    for (final t in trips) {
+      final s = t.summary;
+      final startedAt = s.startedAt;
+      if (startedAt == null) continue;
+      if (s.distanceKm < _zeroHarshMinDistanceKm) continue;
+      if (s.harshBrakes != 0 || s.harshAccelerations != 0) continue;
+      ecoDays.add(DateTime(startedAt.year, startedAt.month, startedAt.day));
+    }
+    if (ecoDays.length < 7) return false;
+    final sorted = ecoDays.toList()..sort();
+    var streak = 1;
+    for (var i = 1; i < sorted.length; i++) {
+      final gap = sorted[i].difference(sorted[i - 1]).inDays;
+      if (gap == 1) {
+        streak++;
+        if (streak >= 7) return true;
+      } else if (gap > 1) {
+        streak = 1;
+      }
+      // gap == 0 would mean duplicate same-day; impossible since the
+      // set dedupes. Fall through.
     }
     return false;
   }

--- a/lib/features/achievements/presentation/widgets/badge_shelf.dart
+++ b/lib/features/achievements/presentation/widgets/badge_shelf.dart
@@ -126,6 +126,11 @@ class _BadgeTile extends StatelessWidget {
         return (Icons.military_tech, l?.achievementTenTrips ?? '10 trips');
       case AchievementId.zeroHarshTrip:
         return (Icons.spa, l?.achievementZeroHarsh ?? 'Smooth driver');
+      case AchievementId.ecoWeek:
+        return (
+          Icons.event_available,
+          l?.achievementEcoWeek ?? 'Eco week',
+        );
     }
   }
 
@@ -143,6 +148,9 @@ class _BadgeTile extends StatelessWidget {
       case AchievementId.zeroHarshTrip:
         return l?.achievementZeroHarshDesc ??
             'Complete a trip of 10 km or more with no harsh braking or acceleration.';
+      case AchievementId.ecoWeek:
+        return l?.achievementEcoWeekDesc ??
+            'Drive 7 consecutive days with at least one smooth trip each day.';
     }
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -847,6 +847,8 @@
   "achievementTenTripsDesc": "Zeichne 10 OBD2-Fahrten auf.",
   "achievementZeroHarsh": "Ruhiger Fahrer",
   "achievementZeroHarshDesc": "Schließe eine Fahrt von mindestens 10 km ohne starkes Bremsen oder Beschleunigen ab.",
+  "achievementEcoWeek": "Öko-Woche",
+  "achievementEcoWeekDesc": "Fahre 7 Tage in Folge mit mindestens einer ruhigen Fahrt pro Tag.",
   "obd2StatusConnected": "OBD2-Adapter: verbunden",
   "obd2StatusAttempting": "OBD2-Adapter: verbindet",
   "obd2StatusUnreachable": "OBD2-Adapter: nicht erreichbar",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -874,6 +874,8 @@
   "achievementTenTripsDesc": "Record 10 OBD2 trips.",
   "achievementZeroHarsh": "Smooth driver",
   "achievementZeroHarshDesc": "Complete a trip of 10 km or more with no harsh braking or acceleration.",
+  "achievementEcoWeek": "Eco week",
+  "achievementEcoWeekDesc": "Drive 7 consecutive days with at least one smooth trip each day.",
   "obd2StatusConnected": "OBD2 adapter: connected",
   "obd2StatusAttempting": "OBD2 adapter: connecting",
   "obd2StatusUnreachable": "OBD2 adapter: unreachable",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -768,6 +768,8 @@
   "achievementTenTripsDesc": "Enregistrez 10 trajets OBD2.",
   "achievementZeroHarsh": "Conduite souple",
   "achievementZeroHarshDesc": "Terminez un trajet d'au moins 10 km sans freinage ni accélération brusques.",
+  "achievementEcoWeek": "Semaine éco",
+  "achievementEcoWeekDesc": "Conduisez 7 jours d'affilée avec au moins un trajet souple par jour.",
   "obd2StatusConnected": "Adaptateur OBD2 : connecté",
   "obd2StatusAttempting": "Adaptateur OBD2 : connexion en cours",
   "obd2StatusUnreachable": "Adaptateur OBD2 : injoignable",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3811,6 +3811,18 @@ abstract class AppLocalizations {
   /// **'Complete a trip of 10 km or more with no harsh braking or acceleration.'**
   String get achievementZeroHarshDesc;
 
+  /// No description provided for @achievementEcoWeek.
+  ///
+  /// In en, this message translates to:
+  /// **'Eco week'**
+  String get achievementEcoWeek;
+
+  /// No description provided for @achievementEcoWeekDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Drive 7 consecutive days with at least one smooth trip each day.'**
+  String get achievementEcoWeekDesc;
+
   /// No description provided for @obd2StatusConnected.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2005,6 +2005,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2005,6 +2005,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2003,6 +2003,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2017,6 +2017,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Schließe eine Fahrt von mindestens 10 km ohne starkes Bremsen oder Beschleunigen ab.';
 
   @override
+  String get achievementEcoWeek => 'Öko-Woche';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Fahre 7 Tage in Folge mit mindestens einer ruhigen Fahrt pro Tag.';
+
+  @override
   String get obd2StatusConnected => 'OBD2-Adapter: verbunden';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2007,6 +2007,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1998,6 +1998,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2006,6 +2006,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2000,6 +2000,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2003,6 +2003,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2015,6 +2015,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Terminez un trajet d\'au moins 10 km sans freinage ni accélération brusques.';
 
   @override
+  String get achievementEcoWeek => 'Semaine éco';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Conduisez 7 jours d\'affilée avec au moins un trajet souple par jour.';
+
+  @override
   String get obd2StatusConnected => 'Adaptateur OBD2 : connecté';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2002,6 +2002,13 @@ class AppLocalizationsHr extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2007,6 +2007,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2006,6 +2006,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2004,6 +2004,13 @@ class AppLocalizationsLt extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2006,6 +2006,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2002,6 +2002,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2007,6 +2007,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2005,6 +2005,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2006,6 +2006,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2005,6 +2005,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2006,6 +2006,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2000,6 +2000,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2004,6 +2004,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Complete a trip of 10 km or more with no harsh braking or acceleration.';
 
   @override
+  String get achievementEcoWeek => 'Eco week';
+
+  @override
+  String get achievementEcoWeekDesc =>
+      'Drive 7 consecutive days with at least one smooth trip each day.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/test/features/achievements/domain/achievement_engine_test.dart
+++ b/test/features/achievements/domain/achievement_engine_test.dart
@@ -123,5 +123,80 @@ void main() {
         AchievementId.zeroHarshTrip,
       });
     });
+
+    test('ecoWeek: 7 consecutive days with one zero-harsh ≥10 km '
+        'trip each earns the badge', () {
+      final base = DateTime(2026, 4, 1);
+      final trips = [
+        for (var i = 0; i < 7; i++)
+          _trip(km: 15, startedAt: base.add(Duration(days: i))),
+      ];
+      final earned = engine.evaluate(trips: trips, fillUps: const []);
+      expect(earned, contains(AchievementId.ecoWeek));
+    });
+
+    test('ecoWeek: 6 consecutive days is not enough', () {
+      final base = DateTime(2026, 4, 1);
+      final trips = [
+        for (var i = 0; i < 6; i++)
+          _trip(km: 15, startedAt: base.add(Duration(days: i))),
+      ];
+      final earned = engine.evaluate(trips: trips, fillUps: const []);
+      expect(earned, isNot(contains(AchievementId.ecoWeek)));
+    });
+
+    test('ecoWeek: a gap day breaks the streak', () {
+      final base = DateTime(2026, 4, 1);
+      final trips = [
+        // Days 0, 1, 2 — then skip day 3 — days 4..8 (5 more)
+        for (var i in [0, 1, 2, 4, 5, 6, 7, 8])
+          _trip(km: 15, startedAt: base.add(Duration(days: i))),
+      ];
+      final earned = engine.evaluate(trips: trips, fillUps: const []);
+      // The 4..8 run is only 5 days, not 7, and the 0..2 run is 3.
+      expect(earned, isNot(contains(AchievementId.ecoWeek)));
+    });
+
+    test('ecoWeek: a rolling 7-day window in older data still '
+        'counts — once earned, always earned, even if today has a '
+        'streak-breaking day', () {
+      final base = DateTime(2026, 1, 1);
+      final trips = [
+        // An old 7-day run
+        for (var i = 0; i < 7; i++)
+          _trip(km: 15, startedAt: base.add(Duration(days: i))),
+        // …followed by a harsh trip much later (doesn't unset the
+        // prior streak).
+        _trip(km: 20, harshBrakes: 2, startedAt: DateTime(2026, 4, 1)),
+      ];
+      final earned = engine.evaluate(trips: trips, fillUps: const []);
+      expect(earned, contains(AchievementId.ecoWeek));
+    });
+
+    test('ecoWeek: short trips in a 7-day run do not count — only '
+        '≥10 km zero-harsh trips flag a day as eco', () {
+      final base = DateTime(2026, 4, 1);
+      final trips = [
+        for (var i = 0; i < 7; i++)
+          _trip(km: 3, startedAt: base.add(Duration(days: i))),
+      ];
+      final earned = engine.evaluate(trips: trips, fillUps: const []);
+      expect(earned, isNot(contains(AchievementId.ecoWeek)));
+    });
+
+    test('ecoWeek: multiple trips in one day only count that day '
+        'once — 7 qualifying trips all on the same day are not a '
+        'week', () {
+      final base = DateTime(2026, 4, 1);
+      final trips = [
+        for (var i = 0; i < 7; i++)
+          _trip(
+            km: 15,
+            startedAt: base.add(Duration(hours: i * 2)),
+          ),
+      ];
+      final earned = engine.evaluate(trips: trips, fillUps: const []);
+      expect(earned, isNot(contains(AchievementId.ecoWeek)));
+    });
   });
 }


### PR DESCRIPTION
## Summary
Extends the phase-1 achievement engine with the `ecoWeek` badge called out in #781.

**Rule**: at least 7 consecutive calendar days, each with ≥1 trip of ≥10 km and zero harsh events.

**Design choices**
- Rolling window — any qualifying 7-day stretch in the log counts, not just the most recent. Once earned, a later bad day never unsets it (matches the "badges stick" policy from phase 1).
- Calendar-day bucketing — multi-trip days count once, so "7 good trips on the same day" is correctly not a week.
- `≥10 km, zero harsh` matches `zeroHarshTrip`'s "eco" definition — same bar, just sustained. Reuses the same threshold so the two badges feel consistent.

## What's left for priceWin
The second phase-2 badge (fill-up beats station 30-day avg by ≥5%) needs a new query layer over the price-history table. Deliberately not coupled in here so the achievement engine stays pure.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — 0 issues
- [x] `flutter test test/features/achievements/` — 18 tests pass (+6 new)
- [x] Rule coverage: 7-day earn, 6-day not earn, gap breaks streak, old streak still counts after later bad day, short trips don't flag, same-day dedupe

Part of #781 (phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)