### PR TITLE
feat(sync): auto-sync baseline on trip stop (#780)

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -6,6 +6,7 @@ import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/storage/hive_boxes.dart';
+import '../../../core/sync/sync_service.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/baseline_store.dart';
@@ -339,6 +340,13 @@ class TripRecording extends _$TripRecording {
       } catch (e) {
         debugPrint('TripRecording.stop: baseline flush failed: $e');
       }
+      // #780 — fold in the server copy once the local flush lands.
+      // `syncVehicleBaseline` returns the merged JSON; if the merge
+      // changed anything, we rewrite Hive and reload so the next
+      // trip sees the higher-confidence per-situation accumulators.
+      // Entirely best-effort: offline, unauthenticated, or sync
+      // errors all return the local payload unchanged.
+      await _syncBaselineAfterFlush(vid);
     }
     _store = null;
     _vehicleId = null;
@@ -360,6 +368,35 @@ class TripRecording extends _$TripRecording {
   /// [StoppedTripResult] (saves as fill-up or discards).
   void reset() {
     state = const TripRecordingState();
+  }
+
+  /// #780 — merge local + server baselines for [vehicleId] via the
+  /// sync service. Called after the Hive flush so the payload on
+  /// disk is what actually gets sent, and the merged result (higher
+  /// per-situation sample counts) overwrites disk for the next
+  /// trip. No-op when the Hive box is closed or the sync client
+  /// is offline/unauthenticated — both paths return the input
+  /// payload unchanged.
+  Future<void> _syncBaselineAfterFlush(String vehicleId) async {
+    try {
+      if (!Hive.isBoxOpen(HiveBoxes.obd2Baselines)) return;
+      final box = Hive.box<String>(HiveBoxes.obd2Baselines);
+      final key = 'baseline:$vehicleId';
+      final localJson = box.get(key);
+      final merged = await SyncService.syncVehicleBaseline(
+        vehicleId: vehicleId,
+        localJson: localJson,
+      );
+      if (merged != null && merged != localJson) {
+        await box.put(key, merged);
+        // No in-memory cache refresh needed — _store is nulled out
+        // right after this call and the next trip creates a fresh
+        // BaselineStore whose loadVehicle reads the merged JSON
+        // from disk.
+      }
+    } catch (e) {
+      debugPrint('TripRecording.stop: baseline sync failed: $e');
+    }
   }
 
   Future<void> _saveToHistory(TripSummary summary) async {


### PR DESCRIPTION
## Summary
Wires the #787 baseline sync into `TripRecording.stop()` so per-vehicle Welford accumulators automatically upload + merge after every trip — no user action, no explicit "Sync now" button.

Path: flush baselines to Hive (#769) → read fresh JSON → call `SyncService.syncVehicleBaseline` → write merged result back. Next trip's `BaselineStore` picks up the merged file from disk.

## Behavior
- **Offline / unauthenticated** → the sync method returns the local payload unchanged; no Hive rewrite.
- **First device, empty server** → upload only; merged == local.
- **Second device with richer server data** → the server's higher-`n` situations overwrite the local cells.
- **Any error** → `debugPrint` + swallow. Never blocks the `stop()` teardown.

## Scope note
The opt-in toggle on the sync-setup screen ("Share learned vehicle profiles") is deferred to a separate PR. For now the behavior matches the other TankSync features — it just kicks in when the user is signed into sync. Fine as a default since baselines aren't PII.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — 0 issues from this change (pre-existing info-level lints in PR #789's test file remain, non-blocking under `--no-fatal-infos`)
- [x] `flutter test test/features/consumption/providers/` — 35 tests pass. The existing start/stop round-trip test now also exercises the sync no-op path when `TankSyncClient.client` is null
- [x] Verified the new `_syncBaselineAfterFlush` only rewrites Hive when the merged JSON actually differs, so no-op syncs don't thrash disk

Part of #780 (phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)