### PR TITLE
feat(achievements): priceWin badge — beat the station 30-day avg (#781)

### DIFF
--- a/lib/features/achievements/domain/achievement.dart
+++ b/lib/features/achievements/domain/achievement.dart
@@ -25,6 +25,11 @@ enum AchievementId {
   /// is rolling: any 7-day stretch in the log qualifies, not just
   /// the most recent one.
   ecoWeek,
+
+  /// At least one logged fill-up beat the station's 30-day average
+  /// price for that fuel type by ≥5 %. Rewards the "save at the
+  /// pump" lens directly — the user timed their visit well.
+  priceWin,
 }
 
 /// An achievement the user has earned. `earnedAt` is the moment the

--- a/lib/features/achievements/domain/achievement_engine.dart
+++ b/lib/features/achievements/domain/achievement_engine.dart
@@ -14,11 +14,15 @@ class AchievementEngine {
   static const double _zeroHarshMinDistanceKm = 10.0;
 
   /// Evaluate every rule and return the set of badge ids currently
-  /// earned based on [trips] and [fillUps]. Order is deterministic
-  /// (iteration order of [AchievementId.values]).
+  /// earned based on [trips] and [fillUps]. [hasPriceWin] is a
+  /// pre-computed flag — the price-history lookup lives outside
+  /// the engine so it stays a pure function, trivially testable.
+  /// Order is deterministic (iteration order of
+  /// [AchievementId.values]).
   Set<AchievementId> evaluate({
     required List<TripHistoryEntry> trips,
     required List<FillUp> fillUps,
+    bool hasPriceWin = false,
   }) {
     final earned = <AchievementId>{};
     if (trips.isNotEmpty) {
@@ -35,6 +39,9 @@ class AchievementEngine {
     }
     if (_hasEcoWeekStreak(trips)) {
       earned.add(AchievementId.ecoWeek);
+    }
+    if (hasPriceWin) {
+      earned.add(AchievementId.priceWin);
     }
     return earned;
   }

--- a/lib/features/achievements/domain/price_win_detector.dart
+++ b/lib/features/achievements/domain/price_win_detector.dart
@@ -1,0 +1,44 @@
+import '../../consumption/domain/entities/fill_up.dart';
+import '../../price_history/data/repositories/price_history_repository.dart';
+
+/// Pure predicate: did this fill-up beat the station's 30-day
+/// average price for the fuel type by at least [winMarginPct]? (#781)
+///
+/// Split out from the Riverpod layer so the engine stays
+/// testable with a fake [PriceHistoryRepository] injected. The
+/// engine itself receives only the resulting bool, keeping its
+/// inputs to simple data.
+///
+/// Returns false when:
+/// - The station has no recorded history yet (stats.avg is 0)
+/// - The fill-up's own `pricePerLiter` is 0 (malformed entry)
+/// - The fill-up carries no `stationId` (user didn't attribute it)
+bool isPriceWin(
+  FillUp fillUp,
+  PriceHistoryRepository repo, {
+  double winMarginPct = 0.05,
+}) {
+  final stationId = fillUp.stationId;
+  if (stationId == null || stationId.isEmpty) return false;
+  final paid = fillUp.pricePerLiter;
+  if (paid <= 0) return false;
+  final stats = repo.getStats(stationId, fillUp.fuelType, days: 30);
+  final avg = stats.avg;
+  if (avg == null || avg <= 0) return false;
+  final margin = (avg - paid) / avg;
+  return margin >= winMarginPct;
+}
+
+/// Scan [fillUps] for any entry that qualifies as a price win.
+/// Short-circuits on the first win — we only need to know whether
+/// the badge is earned, not how many fill-ups contributed.
+bool anyPriceWin(
+  Iterable<FillUp> fillUps,
+  PriceHistoryRepository repo, {
+  double winMarginPct = 0.05,
+}) {
+  for (final f in fillUps) {
+    if (isPriceWin(f, repo, winMarginPct: winMarginPct)) return true;
+  }
+  return false;
+}

--- a/lib/features/achievements/presentation/widgets/badge_shelf.dart
+++ b/lib/features/achievements/presentation/widgets/badge_shelf.dart
@@ -131,6 +131,11 @@ class _BadgeTile extends StatelessWidget {
           Icons.event_available,
           l?.achievementEcoWeek ?? 'Eco week',
         );
+      case AchievementId.priceWin:
+        return (
+          Icons.savings,
+          l?.achievementPriceWin ?? 'Price win',
+        );
     }
   }
 
@@ -151,6 +156,9 @@ class _BadgeTile extends StatelessWidget {
       case AchievementId.ecoWeek:
         return l?.achievementEcoWeekDesc ??
             'Drive 7 consecutive days with at least one smooth trip each day.';
+      case AchievementId.priceWin:
+        return l?.achievementPriceWinDesc ??
+            'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
     }
   }
 }

--- a/lib/features/achievements/providers/achievements_provider.dart
+++ b/lib/features/achievements/providers/achievements_provider.dart
@@ -4,9 +4,11 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/storage/hive_boxes.dart';
 import '../../consumption/providers/consumption_providers.dart';
 import '../../consumption/providers/trip_history_provider.dart';
+import '../../price_history/providers/price_history_provider.dart';
 import '../data/achievements_repository.dart';
 import '../domain/achievement.dart';
 import '../domain/achievement_engine.dart';
+import '../domain/price_win_detector.dart';
 
 part 'achievements_provider.g.dart';
 
@@ -41,7 +43,16 @@ class Achievements extends _$Achievements {
     final trips = ref.watch(tripHistoryListProvider);
     final fillUps = ref.watch(fillUpListProvider);
     final engine = ref.watch(achievementEngineProvider);
-    final earnedIds = engine.evaluate(trips: trips, fillUps: fillUps);
+    // #781 — priceWin detection lives here (not inside the engine)
+    // so the pure engine stays trivially testable. The repo read is
+    // cheap: Hive-backed, already loaded per station.
+    final priceRepo = ref.watch(priceHistoryRepositoryProvider);
+    final hasPriceWin = anyPriceWin(fillUps, priceRepo);
+    final earnedIds = engine.evaluate(
+      trips: trips,
+      fillUps: fillUps,
+      hasPriceWin: hasPriceWin,
+    );
     // Fire-and-forget persistence so the build is synchronous.
     // The repository merges idempotently — re-runs are cheap.
     repo.mergeEarned(earnedIds, now: DateTime.now());

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -854,6 +854,8 @@
   "achievementZeroHarshDesc": "Schließe eine Fahrt von mindestens 10 km ohne starkes Bremsen oder Beschleunigen ab.",
   "achievementEcoWeek": "Öko-Woche",
   "achievementEcoWeekDesc": "Fahre 7 Tage in Folge mit mindestens einer ruhigen Fahrt pro Tag.",
+  "achievementPriceWin": "Preis-Treffer",
+  "achievementPriceWinDesc": "Trage eine Tankung ein, die den 30-Tage-Durchschnitt der Station um mindestens 5 % schlägt.",
   "obd2StatusConnected": "OBD2-Adapter: verbunden",
   "obd2StatusAttempting": "OBD2-Adapter: verbindet",
   "obd2StatusUnreachable": "OBD2-Adapter: nicht erreichbar",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -881,6 +881,8 @@
   "achievementZeroHarshDesc": "Complete a trip of 10 km or more with no harsh braking or acceleration.",
   "achievementEcoWeek": "Eco week",
   "achievementEcoWeekDesc": "Drive 7 consecutive days with at least one smooth trip each day.",
+  "achievementPriceWin": "Price win",
+  "achievementPriceWinDesc": "Log a fill-up that beats the station's 30-day average by 5 % or more.",
   "obd2StatusConnected": "OBD2 adapter: connected",
   "obd2StatusAttempting": "OBD2 adapter: connecting",
   "obd2StatusUnreachable": "OBD2 adapter: unreachable",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -775,6 +775,8 @@
   "achievementZeroHarshDesc": "Terminez un trajet d'au moins 10 km sans freinage ni accélération brusques.",
   "achievementEcoWeek": "Semaine éco",
   "achievementEcoWeekDesc": "Conduisez 7 jours d'affilée avec au moins un trajet souple par jour.",
+  "achievementPriceWin": "Bon plan prix",
+  "achievementPriceWinDesc": "Enregistrez un plein qui bat la moyenne sur 30 jours de la station d'au moins 5 %.",
   "obd2StatusConnected": "Adaptateur OBD2 : connecté",
   "obd2StatusAttempting": "Adaptateur OBD2 : connexion en cours",
   "obd2StatusUnreachable": "Adaptateur OBD2 : injoignable",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3853,6 +3853,18 @@ abstract class AppLocalizations {
   /// **'Drive 7 consecutive days with at least one smooth trip each day.'**
   String get achievementEcoWeekDesc;
 
+  /// No description provided for @achievementPriceWin.
+  ///
+  /// In en, this message translates to:
+  /// **'Price win'**
+  String get achievementPriceWin;
+
+  /// No description provided for @achievementPriceWinDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Log a fill-up that beats the station\'s 30-day average by 5 % or more.'**
+  String get achievementPriceWinDesc;
+
   /// No description provided for @obd2StatusConnected.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2028,6 +2028,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2028,6 +2028,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2026,6 +2026,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2040,6 +2040,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Fahre 7 Tage in Folge mit mindestens einer ruhigen Fahrt pro Tag.';
 
   @override
+  String get achievementPriceWin => 'Preis-Treffer';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Trage eine Tankung ein, die den 30-Tage-Durchschnitt der Station um mindestens 5 % schlägt.';
+
+  @override
   String get obd2StatusConnected => 'OBD2-Adapter: verbunden';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2030,6 +2030,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2021,6 +2021,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2029,6 +2029,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2023,6 +2023,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2026,6 +2026,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2038,6 +2038,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Conduisez 7 jours d\'affilée avec au moins un trajet souple par jour.';
 
   @override
+  String get achievementPriceWin => 'Bon plan prix';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Enregistrez un plein qui bat la moyenne sur 30 jours de la station d\'au moins 5 %.';
+
+  @override
   String get obd2StatusConnected => 'Adaptateur OBD2 : connecté';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2025,6 +2025,13 @@ class AppLocalizationsHr extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2030,6 +2030,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2029,6 +2029,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2027,6 +2027,13 @@ class AppLocalizationsLt extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2029,6 +2029,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2025,6 +2025,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2030,6 +2030,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2028,6 +2028,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2029,6 +2029,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2028,6 +2028,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2029,6 +2029,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2023,6 +2023,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2027,6 +2027,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Drive 7 consecutive days with at least one smooth trip each day.';
 
   @override
+  String get achievementPriceWin => 'Price win';
+
+  @override
+  String get achievementPriceWinDesc =>
+      'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/test/features/achievements/domain/price_win_detector_test.dart
+++ b/test/features/achievements/domain/price_win_detector_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/achievements/domain/price_win_detector.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/price_history/data/repositories/price_history_repository.dart';
+import 'package:tankstellen/features/price_history/domain/entities/price_stats.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Stub repo that returns a caller-controlled `avg` per (station,
+/// fuel) pair. Keeps the predicate under test fully isolated from
+/// Hive + the real `getHistory` implementation.
+class _StubRepo implements PriceHistoryRepository {
+  final Map<String, double?> avgByKey;
+  _StubRepo(this.avgByKey);
+
+  @override
+  PriceStats getStats(String stationId, FuelType fuelType, {int days = 7}) {
+    final avg = avgByKey['$stationId:${fuelType.apiValue}'];
+    return PriceStats(avg: avg);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation inv) => super.noSuchMethod(inv);
+}
+
+FillUp _fillUp({
+  String id = 'a',
+  String? stationId = 'st1',
+  double liters = 40,
+  double totalCost = 60,
+  FuelType fuelType = FuelType.e10,
+}) {
+  return FillUp(
+    id: id,
+    stationId: stationId,
+    stationName: 'Station',
+    date: DateTime(2026, 1, 1),
+    liters: liters,
+    totalCost: totalCost,
+    odometerKm: 10000,
+    fuelType: fuelType,
+  );
+}
+
+void main() {
+  group('isPriceWin (#781)', () {
+    test('no stationId on the fill-up → never a win (the user did '
+        'not attribute it to a pump; no avg to compare to)', () {
+      final repo = _StubRepo({'st1:e10': 1.80});
+      final win = isPriceWin(_fillUp(stationId: null), repo);
+      expect(win, isFalse);
+    });
+
+    test('zero pricePerLiter → not a win (malformed entry)', () {
+      final repo = _StubRepo({'st1:e10': 1.80});
+      final win = isPriceWin(
+        _fillUp(liters: 40, totalCost: 0),
+        repo,
+      );
+      expect(win, isFalse);
+    });
+
+    test('station has no history yet → not a win (avg unknown)', () {
+      final repo = _StubRepo({});
+      final win = isPriceWin(_fillUp(), repo);
+      expect(win, isFalse);
+    });
+
+    test('avg 0 → not a win — defensive against empty or broken '
+        'history payloads', () {
+      final repo = _StubRepo({'st1:e10': 0.0});
+      final win = isPriceWin(_fillUp(), repo);
+      expect(win, isFalse);
+    });
+
+    test('paid exactly equals avg → not a win (0 % margin)', () {
+      final repo = _StubRepo({'st1:e10': 1.50});
+      final win = isPriceWin(
+        _fillUp(liters: 40, totalCost: 60), // 1.50 per L
+        repo,
+      );
+      expect(win, isFalse);
+    });
+
+    test('paid 4 % below avg → not a win (below the 5 % threshold)',
+        () {
+      final repo = _StubRepo({'st1:e10': 1.50});
+      // pricePerLiter = 60 / 41.67 ≈ 1.440 → 4 % below.
+      final win = isPriceWin(
+        _fillUp(liters: 41.67, totalCost: 60),
+        repo,
+      );
+      expect(win, isFalse);
+    });
+
+    test('paid 6 % below avg → wins (beats the 5 % threshold)', () {
+      final repo = _StubRepo({'st1:e10': 1.50});
+      // pricePerLiter = 1.41 → 6 % below.
+      final win = isPriceWin(
+        _fillUp(liters: 42.553, totalCost: 60),
+        repo,
+      );
+      expect(win, isTrue);
+    });
+
+    test('custom threshold is respected — stricter margin can '
+        'disqualify a 6 % beat', () {
+      final repo = _StubRepo({'st1:e10': 1.50});
+      final win = isPriceWin(
+        _fillUp(liters: 42.553, totalCost: 60),
+        repo,
+        winMarginPct: 0.08,
+      );
+      expect(win, isFalse);
+    });
+
+    test('fuel-type mismatch looks up a different avg — diesel '
+        'fill-up against e10 avg returns 0 and does not win', () {
+      final repo = _StubRepo({'st1:e10': 1.50, 'st1:diesel': 0.0});
+      final win = isPriceWin(
+        _fillUp(fuelType: FuelType.diesel),
+        repo,
+      );
+      expect(win, isFalse);
+    });
+  });
+
+  group('anyPriceWin (#781)', () {
+    test('empty list → false', () {
+      final repo = _StubRepo({'st1:e10': 1.50});
+      expect(anyPriceWin(const [], repo), isFalse);
+    });
+
+    test('none win → false; one wins → true (short-circuits on the '
+        'first)', () {
+      final repo = _StubRepo({'st1:e10': 1.50, 'st2:e10': 1.50});
+      final losers = [
+        _fillUp(id: 'a', stationId: 'st1', liters: 40, totalCost: 60),
+        _fillUp(id: 'b', stationId: 'st2', liters: 40, totalCost: 60),
+      ];
+      expect(anyPriceWin(losers, repo), isFalse);
+
+      final withWinner = [
+        ...losers,
+        _fillUp(id: 'c', stationId: 'st1', liters: 43, totalCost: 60),
+      ];
+      expect(anyPriceWin(withWinner, repo), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Closes phase 2 of #781 with the last pending badge. `priceWin` fires when the user logs a fill-up whose `pricePerLiter` beats the station's 30-day avg for that fuel type by ≥5 %.

## Design
- **Pure engine stays pure.** The new `isPriceWin(fillUp, repo)` + `anyPriceWin(fillUps, repo)` helpers live in `lib/features/achievements/domain/price_win_detector.dart`. The `Achievements` notifier does the repo lookup and passes a single `hasPriceWin` bool into `engine.evaluate`.
- **Defensive guards.** null/zero avg, zero paid, missing stationId, and fuel-type mismatch all return false — the badge never earns from malformed data.
- **Matches the "save at the pump" leitmotiv directly** — no trip, no gamification curlicue, just "you shopped well."

## Test plan
- [x] `flutter analyze --no-fatal-infos` — 0 issues (existing info-level lints from earlier PRs remain, non-blocking)
- [x] `flutter test test/features/achievements/` — 29 tests pass (+11 new price-win cases covering every guard + the threshold boundary)
- [x] Coverage: no stationId → false, zero-paid → false, empty history → false, avg == 0 → false, paid == avg → false, 4 % below → false, 6 % below → true, custom threshold respected, fuel-type mismatch → false, `anyPriceWin` short-circuits

Closes phase 2 of #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)