### PR TITLE
feat(sync): opt-in toggle for baseline sharing (#780 phase 3)

### DIFF
--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -36,4 +36,9 @@ class StorageKeys {
   /// Riverpod / Supabase handshake from inside WorkManager.
   static const String ntfyEnabled = 'ntfy_enabled';
   static const String ntfyTopic = 'ntfy_topic';
+
+  /// #780 — opt-in switch for per-vehicle baseline sync. Defaults to
+  /// false (off) so users who only want favourite sync aren't
+  /// silently uploading driving data.
+  static const String syncBaselinesEnabled = 'sync_baselines_enabled';
 }

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -6,6 +6,8 @@ import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/storage/hive_boxes.dart';
+import '../../../core/storage/storage_keys.dart';
+import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/sync_service.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
@@ -379,6 +381,16 @@ class TripRecording extends _$TripRecording {
   /// payload unchanged.
   Future<void> _syncBaselineAfterFlush(String vehicleId) async {
     try {
+      // #780 phase 3 — honour the opt-in setting. Default false so
+      // users who never toggled it in the sync setup screen don't
+      // silently upload driving data. Ungated favourite sync etc.
+      // are unaffected.
+      final settings = ref.read(settingsStorageProvider);
+      final enabled = settings.getSetting(
+            StorageKeys.syncBaselinesEnabled,
+          ) ==
+          true;
+      if (!enabled) return;
       if (!Hive.isBoxOpen(HiveBoxes.obd2Baselines)) return;
       final box = Hive.box<String>(HiveBoxes.obd2Baselines);
       final key = 'baseline:$vehicleId';

--- a/lib/features/profile/presentation/widgets/privacy_dashboard/synced_data_card.dart
+++ b/lib/features/profile/presentation/widgets/privacy_dashboard/synced_data_card.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../../core/storage/storage_keys.dart';
+import '../../../../../core/storage/storage_providers.dart';
 import '../../../../../l10n/app_localizations.dart';
 import '../../../providers/privacy_data_provider.dart';
 import 'privacy_data_row.dart';
@@ -78,7 +81,7 @@ class _SyncDisabledBanner extends StatelessWidget {
   }
 }
 
-class _SyncEnabledBody extends StatelessWidget {
+class _SyncEnabledBody extends ConsumerWidget {
   final ThemeData theme;
   final AppLocalizations? l;
   final PrivacyDataSnapshot snapshot;
@@ -90,8 +93,11 @@ class _SyncEnabledBody extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final userId = snapshot.syncUserId;
+    final settings = ref.watch(settingsStorageProvider);
+    final baselineSyncOn =
+        settings.getSetting(StorageKeys.syncBaselinesEnabled) == true;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -114,6 +120,29 @@ class _SyncEnabledBody extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 8),
+        // #780 phase 3 — opt-in toggle for per-vehicle baseline sync.
+        // Default false; flips to true only when the user explicitly
+        // enables it here.
+        SwitchListTile(
+          key: const Key('syncBaselinesToggle'),
+          value: baselineSyncOn,
+          title: Text(
+            l?.syncBaselinesToggleTitle ?? 'Share learned vehicle profiles',
+          ),
+          subtitle: Text(
+            l?.syncBaselinesToggleSubtitle ??
+                'Upload per-vehicle consumption baselines so a second device can reuse them.',
+            style: theme.textTheme.bodySmall,
+          ),
+          onChanged: (v) async {
+            await settings.putSetting(
+              StorageKeys.syncBaselinesEnabled,
+              v,
+            );
+            ref.invalidate(settingsStorageProvider);
+          },
+          contentPadding: EdgeInsets.zero,
+        ),
         OutlinedButton.icon(
           onPressed: () => context.push('/data-transparency'),
           icon: const Icon(Icons.visibility, size: 18),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -856,6 +856,8 @@
   "achievementEcoWeekDesc": "Fahre 7 Tage in Folge mit mindestens einer ruhigen Fahrt pro Tag.",
   "achievementPriceWin": "Preis-Treffer",
   "achievementPriceWinDesc": "Trage eine Tankung ein, die den 30-Tage-Durchschnitt der Station um mindestens 5 % schlägt.",
+  "syncBaselinesToggleTitle": "Gelernte Fahrzeugprofile teilen",
+  "syncBaselinesToggleSubtitle": "Pro-Fahrzeug-Verbrauchsbaselines hochladen, damit ein zweites Gerät sie wiederverwenden kann.",
   "obd2StatusConnected": "OBD2-Adapter: verbunden",
   "obd2StatusAttempting": "OBD2-Adapter: verbindet",
   "obd2StatusUnreachable": "OBD2-Adapter: nicht erreichbar",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -883,6 +883,8 @@
   "achievementEcoWeekDesc": "Drive 7 consecutive days with at least one smooth trip each day.",
   "achievementPriceWin": "Price win",
   "achievementPriceWinDesc": "Log a fill-up that beats the station's 30-day average by 5 % or more.",
+  "syncBaselinesToggleTitle": "Share learned vehicle profiles",
+  "syncBaselinesToggleSubtitle": "Upload per-vehicle consumption baselines so a second device can reuse them.",
   "obd2StatusConnected": "OBD2 adapter: connected",
   "obd2StatusAttempting": "OBD2 adapter: connecting",
   "obd2StatusUnreachable": "OBD2 adapter: unreachable",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -777,6 +777,8 @@
   "achievementEcoWeekDesc": "Conduisez 7 jours d'affilée avec au moins un trajet souple par jour.",
   "achievementPriceWin": "Bon plan prix",
   "achievementPriceWinDesc": "Enregistrez un plein qui bat la moyenne sur 30 jours de la station d'au moins 5 %.",
+  "syncBaselinesToggleTitle": "Partager les profils de véhicules appris",
+  "syncBaselinesToggleSubtitle": "Téléverser les baselines de consommation par véhicule pour qu'un second appareil puisse les réutiliser.",
   "obd2StatusConnected": "Adaptateur OBD2 : connecté",
   "obd2StatusAttempting": "Adaptateur OBD2 : connexion en cours",
   "obd2StatusUnreachable": "Adaptateur OBD2 : injoignable",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3865,6 +3865,18 @@ abstract class AppLocalizations {
   /// **'Log a fill-up that beats the station\'s 30-day average by 5 % or more.'**
   String get achievementPriceWinDesc;
 
+  /// No description provided for @syncBaselinesToggleTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Share learned vehicle profiles'**
+  String get syncBaselinesToggleTitle;
+
+  /// No description provided for @syncBaselinesToggleSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Upload per-vehicle consumption baselines so a second device can reuse them.'**
+  String get syncBaselinesToggleSubtitle;
+
   /// No description provided for @obd2StatusConnected.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2035,6 +2035,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2035,6 +2035,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2033,6 +2033,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2047,6 +2047,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Trage eine Tankung ein, die den 30-Tage-Durchschnitt der Station um mindestens 5 % schlägt.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Gelernte Fahrzeugprofile teilen';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Pro-Fahrzeug-Verbrauchsbaselines hochladen, damit ein zweites Gerät sie wiederverwenden kann.';
+
+  @override
   String get obd2StatusConnected => 'OBD2-Adapter: verbunden';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2037,6 +2037,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2028,6 +2028,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2036,6 +2036,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2030,6 +2030,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2033,6 +2033,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2045,6 +2045,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Enregistrez un plein qui bat la moyenne sur 30 jours de la station d\'au moins 5 %.';
 
   @override
+  String get syncBaselinesToggleTitle =>
+      'Partager les profils de véhicules appris';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Téléverser les baselines de consommation par véhicule pour qu\'un second appareil puisse les réutiliser.';
+
+  @override
   String get obd2StatusConnected => 'Adaptateur OBD2 : connecté';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2032,6 +2032,13 @@ class AppLocalizationsHr extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2037,6 +2037,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2036,6 +2036,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2034,6 +2034,13 @@ class AppLocalizationsLt extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2036,6 +2036,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2032,6 +2032,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2037,6 +2037,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2035,6 +2035,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2036,6 +2036,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2035,6 +2035,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2036,6 +2036,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2030,6 +2030,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2034,6 +2034,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
 
   @override
+  String get syncBaselinesToggleTitle => 'Share learned vehicle profiles';
+
+  @override
+  String get syncBaselinesToggleSubtitle =>
+      'Upload per-vehicle consumption baselines so a second device can reuse them.';
+
+  @override
   String get obd2StatusConnected => 'OBD2 adapter: connected';
 
   @override


### PR DESCRIPTION
## Summary
Adds the user-visible switch for per-vehicle baseline sync. Default flips to **false** so users only upload driving data when they explicitly opt in.

- New `StorageKeys.syncBaselinesEnabled` (absent → treated as false; no migration)
- `TripRecording._syncBaselineAfterFlush` early-returns when the setting is off — the sync path from PR #790 is now inert until the user enables it
- `SwitchListTile` placed inside the Privacy Dashboard's Cloud-sync card (visible only when TankSync is connected, so it's not noise when the user hasn't set up sync at all)
- Toggling writes the setting and invalidates `settingsStorageProvider`

## Why default false
Phase 2 landed with sync always-on by convenience; defaulting to upload without asking doesn't match the app's privacy posture. The feature hasn't shipped to production yet so there are no existing opted-in users to migrate.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — 0 issues from this change (5 pre-existing info-level lints remain, non-blocking)
- [x] Manual read-through: toggle writes + invalidates; no trip-stop regression because the early-return is the first thing in `_syncBaselineAfterFlush` now
- [ ] No dedicated widget test — the toggle is a standard SwitchListTile wired to a real SettingsStorage and Riverpod, which isn't easy to mock without a full privacy-dashboard rig

Closes phase 3 of #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)