### PR TITLE
chore(test): clear info-level lint warnings

### DIFF
--- a/test/features/achievements/domain/price_win_detector_test.dart
+++ b/test/features/achievements/domain/price_win_detector_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/achievements/domain/price_win_detector.dart';
 import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
 import 'package:tankstellen/features/price_history/data/repositories/price_history_repository.dart';
-import 'package:tankstellen/features/price_history/domain/entities/price_stats.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
 /// Stub repo that returns a caller-controlled `avg` per (station,

--- a/test/features/consumption/presentation/widgets/vehicle_adapter_section_test.dart
+++ b/test/features/consumption/presentation/widgets/vehicle_adapter_section_test.dart
@@ -14,7 +14,7 @@ void main() {
         VehicleAdapterSection(
           adapterMac: null,
           adapterName: null,
-          onPaired: (_, __) => pairTaps++,
+          onPaired: (_, _) => pairTaps++,
           onForget: () {},
         ),
       );
@@ -37,7 +37,7 @@ void main() {
         VehicleAdapterSection(
           adapterMac: 'AA:BB:CC:DD:EE:FF',
           adapterName: 'vLinker FS 1234',
-          onPaired: (_, __) {},
+          onPaired: (_, _) {},
           onForget: () => forgetTaps++,
         ),
       );
@@ -61,7 +61,7 @@ void main() {
         VehicleAdapterSection(
           adapterMac: 'AA:BB',
           adapterName: '',
-          onPaired: (_, __) {},
+          onPaired: (_, _) {},
           onForget: () {},
         ),
       );
@@ -77,7 +77,7 @@ void main() {
         VehicleAdapterSection(
           adapterMac: '',
           adapterName: 'ghost',
-          onPaired: (_, __) {},
+          onPaired: (_, _) {},
           onForget: () {},
         ),
       );


### PR DESCRIPTION
## Summary
Noise-only cleanup in two test files; no behaviour changes.

- `vehicle_adapter_section_test.dart`: `(_, __)` → `(_, _)`. Dart 3.7+ allows repeating `_` as wildcard params, so the extra underscore is redundant.
- `price_win_detector_test.dart`: drops the explicit `price_stats.dart` import — already re-exported from `price_history_repository.dart`.

Both were flagged `info` by analyze and non-blocking under `--no-fatal-infos`. Clearing them so the next feature PR inherits a quiet analyze output.

## Test plan
- [x] `flutter analyze --no-fatal-infos` — 0 issues
- [x] `flutter test test/features/achievements/domain/price_win_detector_test.dart` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)