### PR TITLE
fix(widget): invalidate search cache on country switch (#753 phase 1)

### DIFF
--- a/lib/features/profile/providers/profile_provider.dart
+++ b/lib/features/profile/providers/profile_provider.dart
@@ -1,4 +1,5 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../../search/providers/search_provider.dart';
 import '../domain/entities/user_profile.dart';
 import '../data/repositories/profile_repository.dart';
 
@@ -19,8 +20,20 @@ class ActiveProfile extends _$ActiveProfile {
 
   Future<void> switchProfile(String id) async {
     final repo = ref.read(profileRepositoryProvider);
+    final previousCountryCode = state?.countryCode;
     await repo.setActiveProfile(id);
-    state = repo.getActiveProfile();
+    final next = repo.getActiveProfile();
+    state = next;
+    // #753 — a country switch leaves the previous country's search
+    // results in cache. If the user then taps a widget/deep-link with
+    // a colliding numeric station id, `stationDetailProvider` would
+    // serve the old-country match before falling through to the API.
+    // Resetting search state here closes that window for every
+    // switch path (auto-detect, suggest dialog, manual in Settings).
+    if (previousCountryCode != null &&
+        previousCountryCode != next?.countryCode) {
+      ref.invalidate(searchStateProvider);
+    }
   }
 
   Future<void> updateProfile(UserProfile profile) async {

--- a/test/features/profile/providers/profile_provider_country_switch_test.dart
+++ b/test/features/profile/providers/profile_provider_country_switch_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/features/profile/data/repositories/profile_repository.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+
+/// Regression tests for #753 — tapping a home-screen widget row opened
+/// the wrong station. One confirmed vector: after a country switch, the
+/// previous country's search cache remained live. `stationDetailProvider`
+/// prefers the search-state cache over the API, so a colliding numeric
+/// station id (e.g. `75001` in France vs Tankerkönig) would return the
+/// wrong station's detail.
+///
+/// The fix: `ActiveProfile.switchProfile` invalidates `searchStateProvider`
+/// whenever the new profile's country differs from the previous one.
+/// These tests lock the behavior so a future refactor cannot silently
+/// reintroduce the regression.
+void main() {
+  group('ActiveProfile.switchProfile — country-change invalidation (#753)',
+      () {
+    test('cross-country switch invalidates searchStateProvider', () async {
+      final storage = _InMemoryHiveStorage();
+      final repo = ProfileRepository(storage);
+      final de = await repo.createProfile(name: 'DE', countryCode: 'DE');
+      final fr = await repo.createProfile(name: 'FR', countryCode: 'FR');
+      await repo.setActiveProfile(de.id);
+
+      final container = ProviderContainer(overrides: [
+        profileRepositoryProvider.overrideWithValue(repo),
+      ]);
+      addTearDown(container.dispose);
+
+      // Capture initial state so we can prove the provider was rebuilt
+      // (identity changes on rebuild; ref.invalidate disposes + re-runs build).
+      final before = container.read(searchStateProvider);
+
+      await container
+          .read(activeProfileProvider.notifier)
+          .switchProfile(fr.id);
+      await Future.microtask(() {});
+
+      final after = container.read(searchStateProvider);
+      expect(container.read(activeProfileProvider)?.countryCode, 'FR');
+      expect(
+        identical(before, after),
+        isFalse,
+        reason:
+            'switchProfile from DE to FR must invalidate searchStateProvider '
+            '(a rebuilt AsyncValue is a different instance)',
+      );
+    });
+
+    test('same-country switch does NOT invalidate searchStateProvider',
+        () async {
+      final storage = _InMemoryHiveStorage();
+      final repo = ProfileRepository(storage);
+      final de1 = await repo.createProfile(name: 'DE1', countryCode: 'DE');
+      final de2 = await repo.createProfile(name: 'DE2', countryCode: 'DE');
+      await repo.setActiveProfile(de1.id);
+
+      final container = ProviderContainer(overrides: [
+        profileRepositoryProvider.overrideWithValue(repo),
+      ]);
+      addTearDown(container.dispose);
+
+      final before = container.read(searchStateProvider);
+
+      await container
+          .read(activeProfileProvider.notifier)
+          .switchProfile(de2.id);
+      await Future.microtask(() {});
+
+      final after = container.read(searchStateProvider);
+      expect(container.read(activeProfileProvider)?.id, de2.id);
+      expect(
+        identical(before, after),
+        isTrue,
+        reason:
+            'same-country switch must preserve searchStateProvider — '
+            'invalidating here would discard the user\'s in-flight search',
+      );
+    });
+
+    test('first-ever switch (no previous country) does not invalidate',
+        () async {
+      // Scenario: fresh install, first profile has no countryCode set yet.
+      // switchProfile to a profile with a country should NOT invalidate
+      // (there is no stale cross-country cache to protect against).
+      final storage = _InMemoryHiveStorage();
+      final repo = ProfileRepository(storage);
+      final noCountry = await repo.createProfile(name: 'Nameless');
+      final de = await repo.createProfile(name: 'DE', countryCode: 'DE');
+      await repo.setActiveProfile(noCountry.id);
+
+      final container = ProviderContainer(overrides: [
+        profileRepositoryProvider.overrideWithValue(repo),
+      ]);
+      addTearDown(container.dispose);
+
+      final before = container.read(searchStateProvider);
+
+      await container
+          .read(activeProfileProvider.notifier)
+          .switchProfile(de.id);
+      await Future.microtask(() {});
+
+      final after = container.read(searchStateProvider);
+      expect(
+        identical(before, after),
+        isTrue,
+        reason:
+            'switching from a no-country profile should not invalidate — '
+            'there is no previous country whose cache could pollute',
+      );
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// In-memory HiveStorage fake — mirrors the fake used in profile_provider_test.
+// Re-declared here so the two test files stay independently runnable.
+// ---------------------------------------------------------------------------
+
+class _InMemoryHiveStorage extends Mock implements HiveStorage {
+  final Map<String, Map<String, dynamic>> _profiles = {};
+  String? _activeProfileId;
+  final Map<String, dynamic> _settings = {};
+
+  @override
+  String? getActiveProfileId() => _activeProfileId;
+
+  @override
+  Future<void> setActiveProfileId(String id) async {
+    _activeProfileId = id;
+  }
+
+  @override
+  Map<String, dynamic>? getProfile(String id) {
+    final data = _profiles[id];
+    if (data == null) return null;
+    return Map<String, dynamic>.from(data);
+  }
+
+  @override
+  List<Map<String, dynamic>> getAllProfiles() {
+    return _profiles.values
+        .map((p) => Map<String, dynamic>.from(p))
+        .toList();
+  }
+
+  @override
+  Future<void> saveProfile(String id, Map<String, dynamic> profile) async {
+    _profiles[id] = Map<String, dynamic>.from(profile);
+  }
+
+  @override
+  Future<void> deleteProfile(String id) async {
+    _profiles.remove(id);
+  }
+
+  @override
+  int get profileCount => _profiles.length;
+
+  @override
+  dynamic getSetting(String key) => _settings[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    _settings[key] = value;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of **#753** — widget row taps opening the wrong station.

One hypothesis in #753 was that `stationDetailProvider` preferred `searchStateProvider`'s cache over the API, so a widget tap on a station id that collides across countries (e.g. raw numeric `75001` in France vs a same-suffix cached German station) would resolve to the stale previous-country result.

This PR closes that window by having `ActiveProfile.switchProfile` invalidate `searchStateProvider` whenever the new profile's country differs from the previous one. Every profile-switch path (auto-detect, suggest dialog, manual Settings) routes through `switchProfile`, so this one change covers all of them.

## What changed

- `lib/features/profile/providers/profile_provider.dart` — capture `previousCountryCode` before the state flip, call `ref.invalidate(searchStateProvider)` when it changes.
- Test: `test/features/profile/providers/profile_provider_country_switch_test.dart` (new, 3 cases).

## What's deliberately **not** in this PR

The other #753 hypotheses each carry their own risk:

- **Country-prefix audit** of DE / FR / AT / ES / IT station services. Globally unique ids solve the collision root cause but need a Hive migration for existing favorites/alerts/widget JSON. Separate PR.
- **Widget URI country context.** Requires native Android PendingIntent changes. Separate PR.
- **Widget row JSON ordering parity** with the in-app favorites view. Separate PR.

Landing this one fix now gets the user back to a correct-by-default state for the cross-country-after-switch case while the riskier work is triaged.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] `flutter test test/features/profile/providers/profile_provider_country_switch_test.dart` — 3/3 pass
- [x] `flutter test` — full suite green except one pre-existing flaky network-reachability test (Argentina Energía CSV endpoint) unrelated to this change
- [ ] Manual: search in DE profile → switch to FR profile → detail lookup no longer hits DE cache

Refs #753 — issue stays open for phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)