### PR TITLE
fix(l10n): French Privacy Dashboard + Add-fill-up; scan button word-wrap

### DIFF
--- a/lib/features/consumption/presentation/widgets/fill_up_input_buttons.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_input_buttons.dart
@@ -44,7 +44,12 @@ class FillUpInputButtons extends StatelessWidget {
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
                 : const Icon(Icons.document_scanner),
-            label: Text(l?.scanReceipt ?? 'Scan receipt'),
+            label: Text(
+              l?.scanReceipt ?? 'Scan receipt',
+              maxLines: 2,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.visible,
+            ),
           ),
         ),
         if (onScanPump != null) ...[
@@ -60,7 +65,12 @@ class FillUpInputButtons extends StatelessWidget {
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
                   : const Icon(Icons.local_gas_station),
-              label: Text(l?.scanPump ?? 'Scan pump'),
+              label: Text(
+                l?.scanPump ?? 'Scan pump',
+                maxLines: 2,
+                textAlign: TextAlign.center,
+                overflow: TextOverflow.visible,
+              ),
             ),
           ),
         ],
@@ -75,7 +85,12 @@ class FillUpInputButtons extends StatelessWidget {
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
                 : const Icon(Icons.bluetooth),
-            label: Text(l?.obdConnect ?? 'OBD-II'),
+            label: Text(
+              l?.obdConnect ?? 'OBD-II',
+              maxLines: 2,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.visible,
+            ),
           ),
         ),
       ],

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -68,8 +68,9 @@ class _PrivacyDashboardScreenState
             onPressed: _exportErrorLog,
             icon: const Icon(Icons.bug_report_outlined),
             label: Text(
-              'Copy error log to clipboard '
-              '(${ref.watch(traceStorageProvider).count})',
+              l?.privacyCopyErrorLog(ref.watch(traceStorageProvider).count) ??
+                  'Copy error log to clipboard '
+                      '(${ref.watch(traceStorageProvider).count})',
             ),
           ),
           const SizedBox(height: 12),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -646,6 +646,11 @@
   "privacyExportCsvButton": "Alle Daten als CSV exportieren",
   "privacyExportCsvSuccess": "CSV-Daten in die Zwischenablage exportiert",
   "privacyDeleteButton": "Alle Daten löschen",
+  "privacyCopyErrorLog": "Fehlerprotokoll in Zwischenablage kopieren ({count})",
+  "@privacyCopyErrorLog": {
+    "description": "Button that copies recorded error traces to the clipboard. count = number of traces buffered.",
+    "placeholders": { "count": { "type": "int" } }
+  },
   "privacyDeleteTitle": "Alle Daten löschen?",
   "privacyDeleteBody": "Dies löscht unwiderruflich:\n\n- Alle Favoriten und Stationsdaten\n- Alle Suchprofile\n- Alle Preisalarme\n- Allen Preisverlauf\n- Alle zwischengespeicherten Daten\n- Ihren API-Schlüssel\n- Alle App-Einstellungen\n\nDie App wird auf den Ausgangszustand zurückgesetzt. Diese Aktion kann nicht rückgängig gemacht werden.",
   "privacyDeleteConfirm": "Alles löschen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -654,6 +654,11 @@
   "privacyExportCsvButton": "Export all data as CSV",
   "privacyExportCsvSuccess": "CSV data exported to clipboard",
   "privacyDeleteButton": "Delete all data",
+  "privacyCopyErrorLog": "Copy error log to clipboard ({count})",
+  "@privacyCopyErrorLog": {
+    "description": "Button that copies recorded error traces to the clipboard. count = number of traces buffered.",
+    "placeholders": { "count": { "type": "int" } }
+  },
   "privacyDeleteTitle": "Delete all data?",
   "privacyDeleteBody": "This will permanently delete:\n\n- All favorites and station data\n- All search profiles\n- All price alerts\n- All price history\n- All cached data\n- Your API key\n- All app settings\n\nThe app will reset to its initial state. This action cannot be undone.",
   "privacyDeleteConfirm": "Delete everything",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -816,5 +816,30 @@
   "profileDefaultVehicleNone": "Aucun par défaut",
   "profileFuelFromVehicleHint": "Le carburant est dérivé de votre véhicule par défaut. Supprimez le véhicule pour choisir un carburant directement.",
   "consumptionNoVehicleTitle": "Ajoutez d'abord un véhicule",
-  "consumptionNoVehicleBody": "Les pleins sont attribués à un véhicule. Ajoutez votre voiture pour commencer à suivre la consommation."
+  "consumptionNoVehicleBody": "Les pleins sont attribués à un véhicule. Ajoutez votre voiture pour commencer à suivre la consommation.",
+  "addFillUp": "Ajouter un plein",
+  "fillUpDate": "Date",
+  "liters": "Litres",
+  "odometerKm": "Compteur (km)",
+  "notesOptional": "Notes (facultatif)",
+  "privacyDashboardTitle": "Tableau de bord Confidentialité",
+  "privacyPriceHistory": "Stations avec historique des prix",
+  "privacyProfiles": "Profils de recherche",
+  "privacyItineraries": "Itinéraires enregistrés",
+  "privacyCacheEntries": "Entrées en cache",
+  "privacyApiKey": "Clé API enregistrée",
+  "privacyEvApiKey": "Clé API VE enregistrée",
+  "privacyEstimatedSize": "Stockage estimé",
+  "privacySyncedData": "Synchronisation cloud (TankSync)",
+  "privacySyncDisabled": "La synchronisation cloud est désactivée. Toutes les données restent uniquement sur cet appareil.",
+  "privacyExportButton": "Exporter toutes les données en JSON",
+  "privacyExportCsvButton": "Exporter toutes les données en CSV",
+  "privacyDeleteButton": "Tout supprimer",
+  "privacyCopyErrorLog": "Copier le journal d'erreurs ({count})",
+  "@privacyCopyErrorLog": {
+    "description": "Button that copies recorded error traces to the clipboard. count = number of traces buffered.",
+    "placeholders": { "count": { "type": "int" } }
+  },
+  "yes": "Oui",
+  "no": "Non"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2810,6 +2810,12 @@ abstract class AppLocalizations {
   /// **'Delete all data'**
   String get privacyDeleteButton;
 
+  /// Button that copies recorded error traces to the clipboard. count = number of traces buffered.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy error log to clipboard ({count})'**
+  String privacyCopyErrorLog(int count);
+
   /// No description provided for @privacyDeleteTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1457,6 +1457,11 @@ class AppLocalizationsBg extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1457,6 +1457,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1455,6 +1455,11 @@ class AppLocalizationsDa extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1469,6 +1469,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get privacyDeleteButton => 'Alle Daten löschen';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Fehlerprotokoll in Zwischenablage kopieren ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Alle Daten löschen?';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1459,6 +1459,11 @@ class AppLocalizationsEl extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1450,6 +1450,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1458,6 +1458,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1452,6 +1452,11 @@ class AppLocalizationsEt extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1455,6 +1455,11 @@ class AppLocalizationsFi extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1389,7 +1389,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get alertStatsThisWeek => 'Cette semaine';
 
   @override
-  String get privacyDashboardTitle => 'Privacy Dashboard';
+  String get privacyDashboardTitle => 'Tableau de bord Confidentialité';
 
   @override
   String get privacyDashboardSubtitle => 'View, export, or delete your data';
@@ -1408,32 +1408,32 @@ class AppLocalizationsFr extends AppLocalizations {
   String get privacyRatings => 'Station ratings';
 
   @override
-  String get privacyPriceHistory => 'Price history stations';
+  String get privacyPriceHistory => 'Stations avec historique des prix';
 
   @override
-  String get privacyProfiles => 'Search profiles';
+  String get privacyProfiles => 'Profils de recherche';
 
   @override
-  String get privacyItineraries => 'Saved routes';
+  String get privacyItineraries => 'Itinéraires enregistrés';
 
   @override
-  String get privacyCacheEntries => 'Cache entries';
+  String get privacyCacheEntries => 'Entrées en cache';
 
   @override
-  String get privacyApiKey => 'API key stored';
+  String get privacyApiKey => 'Clé API enregistrée';
 
   @override
-  String get privacyEvApiKey => 'EV API key stored';
+  String get privacyEvApiKey => 'Clé API VE enregistrée';
 
   @override
-  String get privacyEstimatedSize => 'Estimated storage';
+  String get privacyEstimatedSize => 'Stockage estimé';
 
   @override
-  String get privacySyncedData => 'Cloud sync (TankSync)';
+  String get privacySyncedData => 'Synchronisation cloud (TankSync)';
 
   @override
   String get privacySyncDisabled =>
-      'Cloud sync is disabled. All data stays on this device only.';
+      'La synchronisation cloud est désactivée. Toutes les données restent uniquement sur cet appareil.';
 
   @override
   String get privacySyncMode => 'Sync mode';
@@ -1449,19 +1449,24 @@ class AppLocalizationsFr extends AppLocalizations {
   String get privacyViewServerData => 'View server data';
 
   @override
-  String get privacyExportButton => 'Export all data as JSON';
+  String get privacyExportButton => 'Exporter toutes les données en JSON';
 
   @override
   String get privacyExportSuccess => 'Data exported to clipboard';
 
   @override
-  String get privacyExportCsvButton => 'Export all data as CSV';
+  String get privacyExportCsvButton => 'Exporter toutes les données en CSV';
 
   @override
   String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
 
   @override
-  String get privacyDeleteButton => 'Delete all data';
+  String get privacyDeleteButton => 'Tout supprimer';
+
+  @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copier le journal d\'erreurs ($count)';
+  }
 
   @override
   String get privacyDeleteTitle => 'Delete all data?';
@@ -1474,10 +1479,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get privacyDeleteConfirm => 'Delete everything';
 
   @override
-  String get yes => 'Yes';
+  String get yes => 'Oui';
 
   @override
-  String get no => 'No';
+  String get no => 'Non';
 
   @override
   String get amenities => 'Équipements';
@@ -1618,7 +1623,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get consumptionStatsTitle => 'Consumption stats';
 
   @override
-  String get addFillUp => 'Add fill-up';
+  String get addFillUp => 'Ajouter un plein';
 
   @override
   String get noFillUpsTitle => 'No fill-ups yet';
@@ -1631,13 +1636,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fillUpDate => 'Date';
 
   @override
-  String get liters => 'Liters';
+  String get liters => 'Litres';
 
   @override
-  String get odometerKm => 'Odometer (km)';
+  String get odometerKm => 'Compteur (km)';
 
   @override
-  String get notesOptional => 'Notes (optional)';
+  String get notesOptional => 'Notes (facultatif)';
 
   @override
   String get stationPreFilled => 'Station pre-filled';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1454,6 +1454,11 @@ class AppLocalizationsHr extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1459,6 +1459,11 @@ class AppLocalizationsHu extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1458,6 +1458,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1456,6 +1456,11 @@ class AppLocalizationsLt extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1458,6 +1458,11 @@ class AppLocalizationsLv extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1454,6 +1454,11 @@ class AppLocalizationsNb extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1459,6 +1459,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1457,6 +1457,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1458,6 +1458,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1457,6 +1457,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1458,6 +1458,11 @@ class AppLocalizationsSk extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1452,6 +1452,11 @@ class AppLocalizationsSl extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1456,6 +1456,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get privacyDeleteButton => 'Delete all data';
 
   @override
+  String privacyCopyErrorLog(int count) {
+    return 'Copy error log to clipboard ($count)';
+  }
+
+  @override
   String get privacyDeleteTitle => 'Delete all data?';
 
   @override

--- a/test/features/consumption/presentation/widgets/fill_up_input_buttons_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_input_buttons_test.dart
@@ -100,5 +100,37 @@ void main() {
       await tester.pump();
       expect(pressed, isTrue);
     });
+
+    testWidgets(
+      'scan button labels allow 2-line word-wrap so long locale strings '
+      '(e.g. French "Scanner le reçu") break at spaces, not mid-word (#799)',
+      (tester) async {
+        await pumpButtons(tester, scanning: false, obdReading: false);
+
+        // The three label-Text widgets: "Scan receipt" + "OBD-II"
+        // (the optional "Scan pump" button is off in pumpButtons' helper).
+        final labels = tester
+            .widgetList<Text>(find.descendant(
+              of: find.byType(OutlinedButton),
+              matching: find.byType(Text),
+            ))
+            .toList();
+
+        // Two buttons × 1 label each = 2 Text widgets. The maxLines:2 +
+        // textAlign:center + overflow:visible combo is what lets French
+        // labels (longer than their English equivalents) render on two
+        // clean word-broken lines instead of the mid-syllable break
+        // reported in the bug — "Scanner / le reçu" vs "Scann / er le / reçu".
+        expect(labels, hasLength(greaterThanOrEqualTo(2)));
+        for (final label in labels) {
+          expect(label.maxLines, 2,
+              reason: 'label "${label.data}" should allow 2-line wrap');
+          expect(label.textAlign, TextAlign.center,
+              reason: 'label "${label.data}" should center-align across wrap');
+          expect(label.overflow, TextOverflow.visible,
+              reason: 'label "${label.data}" should not ellipsise on wrap');
+        }
+      },
+    );
   });
 }

--- a/test/i18n/arb_key_parity_test.dart
+++ b/test/i18n/arb_key_parity_test.dart
@@ -115,9 +115,9 @@ String _localeFromPath(String p) {
 /// accidental removals. Locales left out of this map cause the test
 /// to fail, forcing an explicit decision on new locales.
 const Map<String, int> _baseline = {
-  'en': 799,
-  'de': 799,
-  'fr': 596,
+  'en': 800,
+  'de': 800,
+  'fr': 617,
   'bg': 300,
   'cs': 300,
   'da': 300,


### PR DESCRIPTION
## Summary

Closes **#799** — on French locale, core screens leaked English strings and the Add-fill-up scan buttons broke French labels mid-syllable.

## Root causes

1. **20 ARB keys missing from `app_fr.arb`**. Widgets use `l?.key ?? 'English fallback'`, so a missing French key silently renders the English literal. Adding the keys was enough for 20 of the 21 strings.
2. **One hard-coded English `Text` at `privacy_dashboard_screen.dart:71`** (*Copy error log to clipboard (N)*). Added new `privacyCopyErrorLog({count})` key with int placeholder in `app_en.arb` / `app_de.arb` / `app_fr.arb` and routed the widget through it.
3. **`FillUpInputButtons` broke labels mid-word**. The 3-button `Row` gives each `Expanded` button ~1/3 of the screen — too narrow for `"Scanner le reçu"` on one line. With no whitespace fitting, `Text`'s default wrap fell back to character boundaries (→ `Scann / er le / reçu`). Added `maxLines: 2`, `textAlign: TextAlign.center`, `overflow: TextOverflow.visible` on the three labels so Flutter word-wraps at the space (→ `Scanner / le reçu`).

## What changed

- `lib/l10n/app_en.arb`, `lib/l10n/app_de.arb` — new key `privacyCopyErrorLog`
- `lib/l10n/app_fr.arb` — 21 new keys (20 strings + `privacyCopyErrorLog`)
- `lib/l10n/app_localizations*.dart` — regenerated by `flutter gen-l10n`
- `lib/features/profile/presentation/screens/privacy_dashboard_screen.dart` — routed error-log button through ARB
- `lib/features/consumption/presentation/widgets/fill_up_input_buttons.dart` — `maxLines: 2` on the three scan/OBD labels
- `test/i18n/arb_key_parity_test.dart` — baselines bumped: `en 799→800`, `de 799→800`, `fr 596→617`
- `test/features/consumption/.../fill_up_input_buttons_test.dart` — regression test asserting the three labels carry the wrap config so a future refactor can't silently regress

## Out of scope (deferred)

- *Adapter: set protocol* English leak on OBD2 progress ring — that string comes from the OBD2 lib's status machine, not ARB. Needs a state→locale mapping layer; tracked in #799 out-of-scope note.
- l10n audit of the other 21 locales — fr was the specific user-reported case; broader cleanup belongs to #495's bigger translation push.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean (0 issues)
- [x] `flutter test test/i18n test/l10n test/features/consumption test/features/profile` — all green
- [x] Full `flutter test` — 4787 pass, 1 pre-existing flaky network test (`Argentina — Energía CSV is reachable`), 1 skip
- [x] ARB parity test's German-hard-gate still enforced; French drift baseline locked at new count
- [ ] Manual device check on fr-FR — Privacy Dashboard and Add-fill-up render fully in French; scan buttons show *Scanner / le reçu* on two clean word-broken lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)