### PR TITLE
fix(receipt): parse French TotalEnergies format — qty × fuel-code, 3-decimal unit price

### DIFF
--- a/lib/features/consumption/data/receipt_parser.dart
+++ b/lib/features/consumption/data/receipt_parser.dart
@@ -240,20 +240,33 @@ class ReceiptParser {
   /// Detect the fuel product code on the receipt. Supports European labels
   /// like "SP95-E10", "Super E10", "E10", "Gazole", "Diesel", "E85",
   /// "GPL", "GNV/CNG", etc.
+  ///
+  /// French retailers (TotalEnergies, Intermarché) emit compound codes
+  /// with no separator — `SP95E5`, `SP95E10`, `SP98E5` — which the old
+  /// `sp95-e10` / `\be10\b` regexes missed because there was no word
+  /// boundary between the `5` and the `e10`. The compound forms now
+  /// have explicit patterns; order still matters (E10 before E5 before
+  /// E85 so longer codes win).
   FuelType? _extractFuelType(String text) {
     final lower = text.toLowerCase();
-    // Order matters: e10 before e5 so "e10" doesn't slip through as "e".
-    if (RegExp(r'\be10\b|sp95-e10|super\s*e10').hasMatch(lower)) {
+    // E85 first — "e85" contains "e5" as a substring-via-boundary edge
+    // case on some OCR outputs where the 8 reads as 3 or falls out.
+    if (RegExp(r'\be85\b|sp95\s*-?\s*e?\s*85|bio\s*[eé]thanol')
+        .hasMatch(lower)) {
+      return FuelType.e85;
+    }
+    // E10 — match compound (SP95E10, SP95-E10, SP95 E10) and standalone.
+    if (RegExp(r'sp95\s*-?\s*e\s*10|sp95e10|\be10\b|super\s*e10')
+        .hasMatch(lower)) {
       return FuelType.e10;
     }
-    if (RegExp(r'\be5\b|sp95(?!\s*-?e10)|super\s*e5').hasMatch(lower)) {
+    // E5 — SP95 without an E10 suffix, or compound SP95E5.
+    if (RegExp(r'sp95\s*-?\s*e\s*5\b|sp95e5\b|\be5\b|sp95(?!\s*-?\s*e\s*10)|super\s*e5')
+        .hasMatch(lower)) {
       return FuelType.e5;
     }
     if (RegExp(r'\be98\b|sp98|super\s*98').hasMatch(lower)) {
       return FuelType.e98;
-    }
-    if (RegExp(r'\be85\b|bio\s*[eé]thanol').hasMatch(lower)) {
-      return FuelType.e85;
     }
     if (RegExp(r'diesel\s*premium|premium\s*diesel|gazole\s*premium')
         .hasMatch(lower)) {
@@ -291,6 +304,16 @@ class ReceiptParser {
       // "VOLUME : 42.35" / "Volume: 42,35" / "Quantité = 5.27"
       RegExp(
         r'(?:volume|quantit[eé])\s*[:=]?\s*(\d{1,3}[.,]\d{1,3})',
+        caseSensitive: false,
+      ),
+      // "5,00 x SP95E5" / "42,50 X GAZOLE" / "10,00 × SP98" — French
+      // line-item format used by TotalEnergies, Intermarché and many
+      // independents (user report 2026-04-21, #801). Fuel codes after
+      // `x` are the French standard: SP95/SP98/E85/GAZOLE/GPL with
+      // compound E5/E10 suffixes.
+      RegExp(
+        r'(\d{1,3}[.,]\d{1,3})\s*[xX×]\s*'
+        r'(?:sp95e?5|sp95e10|sp98e?5|sp95|sp98|e85|gazole|gpl|gplc|b7|diesel|go)\b',
         caseSensitive: false,
       ),
     ];
@@ -343,15 +366,31 @@ class ReceiptParser {
       // Filter obvious non-totals: nobody's total is < 1 €, nobody's
       // total is > 10 000 €.
       if (value < 1 || value > 10000) continue;
+      // #801 — 3-decimal European amounts like `1,990 €` are fuel
+      // price-per-liter, never totals. Without this guard on the
+      // TotalEnergies receipt the parser grabbed `1,990 €` as the
+      // total and the user saw 1.99 € in the form instead of 9.95 €.
+      // Totals are always 2-decimal in EUR.
+      if (_decimalDigitCount(raw) >= 3 && value < 5) continue;
       if (best == null || value > best) best = value;
     }
     return best;
   }
 
+  /// Count decimal digits in a European-formatted decimal string
+  /// (accepts `.` or `,` as separator). Returns 0 when no separator
+  /// is found. Used to distinguish 3-decimal fuel prices from
+  /// 2-decimal totals without trusting `double` precision.
+  int _decimalDigitCount(String raw) {
+    final sepIndex = raw.lastIndexOf(RegExp(r'[.,]'));
+    if (sepIndex < 0) return 0;
+    return raw.length - sepIndex - 1;
+  }
+
   /// Matches price-per-liter: "1.899 €/L", "€ 1,999/L", "PU: 1,899",
   /// "PRIX/L 1.899", "Prix unit. = 2,028 EUR", "Literpreis: 1.799".
   double? _extractPricePerLiter(String text) {
-    return _matchFirst(text, [
+    final labelled = _matchFirst(text, [
       // "1.899 €/L" or "1,899 EUR/L" — also "1.999 €/ℓ" (U+2113).
       RegExp(r'(\d+[.,]\d{2,3})\s*(?:€|EUR)\s*/\s*[lL\u2113]'),
       // "€ 1.999/L" or "EUR 1,999/L" / "€ 1.999/ℓ" — currency before number.
@@ -365,6 +404,30 @@ class ReceiptParser {
         caseSensitive: false,
       ),
     ]);
+    if (labelled != null) return labelled;
+
+    // #801 — TotalEnergies / independent French receipts often emit
+    // the unit price as a bare `1,990 €` (3-decimal digits, no `/L`
+    // suffix) on the line below a `QTY x FUELCODE` item line. Without
+    // this heuristic the amount was either missed entirely or grabbed
+    // as the total. 3 decimal digits + euro suffix + plausible
+    // fuel-price range (0.5-3.0 €/L) is a strong enough signal to
+    // accept without the explicit `/L` marker.
+    // Note on the lookbehind-free check: `\b` after `€` doesn't hold
+    // (both `€` and a trailing space are non-word chars in Dart
+    // regex, so no boundary sits between them). The negative
+    // lookahead for `/L` is the only disambiguator we need — any
+    // 3-decimal euro amount NOT followed by `/L` is the unit price.
+    final bareFuelPrice =
+        RegExp(r'(\d+[.,]\d{3})\s*(?:€|EUR)(?!\s*/\s*[lLℓ])');
+    for (final match in bareFuelPrice.allMatches(text)) {
+      final raw = match.group(1);
+      if (raw == null) continue;
+      final value = _parseDecimal(raw);
+      if (value == null) continue;
+      if (value >= 0.5 && value <= 3.0) return value;
+    }
+    return null;
   }
 
   /// Matches common date formats: DD/MM/YYYY, DD.MM.YYYY, DD-MM-YYYY,

--- a/test/features/consumption/data/receipt_parser_test.dart
+++ b/test/features/consumption/data/receipt_parser_test.dart
@@ -371,6 +371,89 @@ Date 19-04-2026 15:19:27
       test('returns null for an unrecognised product string', () {
         expect(parser.parse('Kerosene jet').fuelType, isNull);
       });
+
+      // #801 — French compound fuel codes have no separator between
+      // SP95 / SP98 and the E5 / E10 / E85 suffix on TotalEnergies and
+      // some Intermarché receipts. The original `sp95-e10` / `\be10\b`
+      // regexes relied on a word boundary between `5` and `e10` that
+      // doesn't exist in `sp95e10`.
+      test('recognises compound SP95E5 → FuelType.e5 (#801)', () {
+        expect(parser.parse('SP95E5 1,990 €').fuelType, FuelType.e5);
+      });
+
+      test('recognises compound SP95E10 → FuelType.e10 (#801)', () {
+        expect(parser.parse('SP95E10 1,899 €').fuelType, FuelType.e10);
+      });
+
+      test('recognises compound SP98E5 → FuelType.e98 (#801)', () {
+        // SP98E5 is the French label for SP98 with up to 5% ethanol;
+        // the app's fuel taxonomy groups this under e98.
+        expect(parser.parse('SP98E5 2,050 €').fuelType, FuelType.e98);
+      });
+    });
+
+    // -------------------------------------------------------------------
+    // #801 — TotalEnergies French receipt format
+    //
+    // Real receipt from a user report (21/04/26 Pézenas). The fuel line
+    // uses the `QTY x FUELCODE` format with no unit label on the price,
+    // no `/L` marker, and a three-column TTC / H.T. / TVA total block.
+    // Before the fix the parser grabbed `1,990 €` as the total and left
+    // liters empty.
+    // -------------------------------------------------------------------
+    group('TotalEnergies French receipt (#801)', () {
+      const receiptText = '''
+TotalEnergies
+SARL GAUTRAND PNEUS
+26 AVENUE DE PEZENAS 34120
+FRANCE
+Ticket de vente
+Pompe 04
+5,00 x SP95E5
+1,990 €
+9,95
+TVA inclusive TTC
+Taux M 20,00%   TTC     H.T.    TVA
+                9,95    8,29    1,66
+Total CB                        9,95
+Total H.T.                      8,29
+Date Heure  Num Ticket
+21/04/26 16:52:10 59533 11 0001 624
+''';
+
+      test('extracts liters from "5,00 x SP95E5" line-item', () {
+        final result = parser.parse(receiptText);
+        expect(result.liters, closeTo(5.00, 0.01));
+      });
+
+      test('extracts price-per-liter from bare "1,990 €" (no /L suffix)', () {
+        final result = parser.parse(receiptText);
+        expect(result.pricePerLiter, closeTo(1.990, 0.001));
+      });
+
+      test('extracts total cost as 9,95 (not the 1,990 unit price)', () {
+        final result = parser.parse(receiptText);
+        // Before the fix this was 1.99 — the parser grabbed the
+        // price-per-liter as the total because both have a € suffix
+        // and `1,990` normalises to 1.99 as a Dart double. The
+        // 3-decimal-excluded-from-heuristic fix closes that window.
+        expect(result.totalCost, closeTo(9.95, 0.01));
+      });
+
+      test('detects SP95E5 as FuelType.e5', () {
+        final result = parser.parse(receiptText);
+        expect(result.fuelType, FuelType.e5);
+      });
+
+      test('detects the 21/04/26 receipt date', () {
+        final result = parser.parse(receiptText);
+        expect(result.date, DateTime(2026, 4, 21));
+      });
+
+      test('extracts the TotalEnergies station brand', () {
+        final result = parser.parse(receiptText);
+        expect(result.stationName?.toLowerCase(), contains('total'));
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes **#801**. On the French TotalEnergies receipt the user scanned (5,00 L of SP95E5 at 1,990 €/L, total 9,95 €), the parser returned: liters=null, total=1.99 €, fuel=null/default. Four underlying parser gaps — fixed here.

## What changed

| Gap | Before | After |
|---|---|---|
| `QTY x FUELCODE` line | unmatched | recognised as quantity + fuel context |
| Bare 3-decimal `€` amount | grabbed as total | accepted as price-per-liter |
| 3-decimal amounts in total heuristic | picked as total | skipped when < 5 € |
| Compound fuel codes (SP95E5, SP95E10, SP98E5) | missed | mapped to e5 / e10 / e98 |

The total (9,95 €) is derived by the existing `liters × pricePerLiter ≈ totalCost` reconciliation path once liters + price-per-liter land — no new total-extraction regex needed for this receipt class.

## Out of scope

- TTC-vs-H.T. column-block parsing (no receipt in the corpus currently needs it).
- Per-station overrides + scan-error reporting — tracked in #759.
- Station brand/address enrichment — only minor bump here (first-line `TotalEnergies` already matches).

## Test plan

- [x] 6 new tests on the exact TotalEnergies receipt text from the user report (21/04/26 Pézenas): liters=5.00, price/liter=1.990, total=9.95, fuel=e5, date=2026-04-21, brand contains *total*.
- [x] 3 compound-fuel-code tests: SP95E5 → e5, SP95E10 → e10, SP98E5 → e98.
- [x] All 40 existing parser tests still pass (regression-free).
- [x] `flutter analyze --no-fatal-infos` — clean.
- [x] `flutter test` — 4797 / 4797 pass, 1 skip.
- [ ] Manual device: rescan the Pézenas receipt in the app, confirm Liters / Coût total / fuel type auto-populate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)