### PR TITLE
refactor(consumption): extract FillUpNotesField widget (#727)

### DIFF
--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -20,6 +20,7 @@ import '../../providers/consumption_providers.dart';
 import '../widgets/bad_scan_report_sheet.dart';
 import '../widgets/fill_up_date_row.dart';
 import '../widgets/fill_up_input_buttons.dart';
+import '../widgets/fill_up_notes_field.dart';
 import '../widgets/fill_up_numeric_field.dart';
 
 /// Form to add a new [FillUp] entry.
@@ -439,20 +440,7 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
               validator: _positiveNumberValidator,
             ),
             const SizedBox(height: 12),
-            TextFormField(
-              controller: _notesCtrl,
-              decoration: InputDecoration(
-                labelText: l?.notesOptional ?? 'Notes (optional)',
-                prefixIcon: const Icon(Icons.edit_note),
-                alignLabelWithHint: true,
-                border: const OutlineInputBorder(),
-              ),
-              // Larger notes area — user requested more room (#695).
-              minLines: 4,
-              maxLines: 8,
-              keyboardType: TextInputType.multiline,
-              textInputAction: TextInputAction.newline,
-            ),
+            FillUpNotesField(controller: _notesCtrl),
             const SizedBox(height: 24),
             FilledButton.icon(
               onPressed: _save,

--- a/lib/features/consumption/presentation/widgets/fill_up_notes_field.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_notes_field.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Multi-line "Notes (optional)" text field on the Add-Fill-Up form.
+///
+/// Larger-than-default area (4–8 lines) per user request in #695 so
+/// the field invites a real memo rather than a one-liner. Uses a
+/// multiline keyboard and routes `Enter` to insert a newline instead
+/// of submitting the form.
+///
+/// Pulled out of `add_fill_up_screen.dart` (#727) so the screen's
+/// `build` method drops a 14-line inline block and the field's
+/// behaviour (line limits, keyboard type, newline action) can be
+/// verified by widget tests in isolation.
+class FillUpNotesField extends StatelessWidget {
+  final TextEditingController controller;
+
+  const FillUpNotesField({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return TextFormField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: l?.notesOptional ?? 'Notes (optional)',
+        prefixIcon: const Icon(Icons.edit_note),
+        alignLabelWithHint: true,
+        border: const OutlineInputBorder(),
+      ),
+      minLines: 4,
+      maxLines: 8,
+      keyboardType: TextInputType.multiline,
+      textInputAction: TextInputAction.newline,
+    );
+  }
+}

--- a/test/features/consumption/presentation/widgets/fill_up_notes_field_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_notes_field_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_notes_field.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  group('FillUpNotesField', () {
+    Future<void> pumpField(
+      WidgetTester tester, {
+      required TextEditingController controller,
+      Locale locale = const Locale('en'),
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          locale: locale,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: FillUpNotesField(controller: controller)),
+        ),
+      );
+    }
+
+    testWidgets('renders the localised label and the edit-note icon',
+        (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await pumpField(tester, controller: controller);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Notes (optional)'), findsOneWidget);
+      expect(find.byIcon(Icons.edit_note), findsOneWidget);
+    });
+
+    testWidgets('renders the French ARB label on fr locale', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await pumpField(
+        tester,
+        controller: controller,
+        locale: const Locale('fr'),
+      );
+      await tester.pumpAndSettle();
+
+      // App ships `notesOptional: "Notes (facultatif)"` in app_fr.arb
+      // (added in PR #803). The widget must route through the ARB
+      // rather than hard-coding English.
+      expect(find.text('Notes (facultatif)'), findsOneWidget);
+    });
+
+    testWidgets('forwards text entry through the controller', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await pumpField(tester, controller: controller);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField), 'pumped 30 L fast');
+      expect(controller.text, 'pumped 30 L fast');
+    });
+
+    testWidgets('field is multiline with minLines:4 and maxLines:8 '
+        '(#695 — user requested more room)', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await pumpField(tester, controller: controller);
+      await tester.pumpAndSettle();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.minLines, 4);
+      expect(field.maxLines, 8);
+      expect(field.keyboardType, TextInputType.multiline);
+      expect(field.textInputAction, TextInputAction.newline);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Next extract after PR #806 in the `add_fill_up_screen.dart` slimming campaign (#727). Same template: pull the section into `lib/features/consumption/presentation/widgets/`, localise via `AppLocalizations`, cover with focused widget tests.

## What changed

- **`lib/features/consumption/presentation/widgets/fill_up_notes_field.dart`** (new, 36 LOC) — the multi-line `TextFormField` that was inlined. Keeps the #695 constraints (`minLines: 4`, `maxLines: 8`, multiline keyboard, newline-on-enter).
- **`lib/features/consumption/presentation/screens/add_fill_up_screen.dart`** — 14-line inline block replaced by `FillUpNotesField(controller: _notesCtrl)` + one import.
- **`test/features/consumption/presentation/widgets/fill_up_notes_field_test.dart`** — 4 cases:
  - renders the English ARB label
  - renders the French ARB label (verifies localisation path)
  - forwards text entry to the controller
  - regression guard on `minLines: 4`, `maxLines: 8`, `keyboardType: multiline`, `textInputAction: newline` per #695

## Scope note

Screen now 647 LOC (664 → 659 → 647 across the last two PRs). Still above #727's <300 LOC target; obvious next extracts: the Vehicle dropdown block, the Save + Report-scan-error bottom block.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] `flutter test test/features/consumption/presentation/widgets/fill_up_notes_field_test.dart` — 4/4 pass
- [x] `flutter test test/features/consumption` — 417/417 pass (no regressions)
- [ ] Manual: open Add-fill-up, type a multi-line note, save, confirm it persists

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)