### PR TITLE
refactor(sync): extract PriceHistorySync from SyncService (#727)

### DIFF
--- a/lib/core/data/impl/supabase_sync_repository.dart
+++ b/lib/core/data/impl/supabase_sync_repository.dart
@@ -1,3 +1,4 @@
+import '../../sync/price_history_sync.dart';
 import '../../sync/supabase_client.dart';
 import '../../sync/sync_service.dart';
 import '../sync_repository.dart';
@@ -61,7 +62,7 @@ class SupabaseSyncRepository implements SyncRepository {
   @override
   Future<List<Map<String, dynamic>>> fetchPriceHistory(String stationId,
           {int days = 30}) =>
-      SyncService.fetchPriceHistory(stationId, days: days);
+      PriceHistorySync.fetch(stationId, days: days);
 
   // ── Itineraries ──
 

--- a/lib/core/sync/price_history_sync.dart
+++ b/lib/core/sync/price_history_sync.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart';
+
+import 'supabase_client.dart';
+
+/// Server-side price history queries, pulled out of [SyncService] (#727).
+///
+/// Price history is a read-only path for clients — Supabase writes
+/// happen server-side via scheduled Edge Functions. Splitting this
+/// method into its own class removes ~28 LOC from `sync_service.dart`
+/// and keeps each sync concern in a file that answers a single
+/// question (*"what do I write back?"* for SyncService, *"what do I
+/// read?"* here).
+///
+/// No authentication gating: `price_snapshots` is readable by anon
+/// clients (RLS policy grants SELECT to `authenticated` and `anon`),
+/// so the only failure modes are network and Supabase being offline
+/// — both handled by returning an empty list.
+class PriceHistorySync {
+  PriceHistorySync._();
+
+  /// Fetch price history snapshots for [stationId] over the last
+  /// [days] days (default 30). Returns an empty list when the client
+  /// isn't configured or the fetch fails — callers must treat empty
+  /// as "no data" rather than "zero-price stations".
+  static Future<List<Map<String, dynamic>>> fetch(
+    String stationId, {
+    int days = 30,
+  }) async {
+    final client = TankSyncClient.client;
+    if (client == null) return [];
+
+    try {
+      final cutoff =
+          DateTime.now().subtract(Duration(days: days)).toIso8601String();
+      final rows = await client
+          .from('price_snapshots')
+          .select()
+          .eq('station_id', stationId)
+          .gte('recorded_at', cutoff)
+          .order('recorded_at', ascending: true);
+      return List<Map<String, dynamic>>.from(rows);
+    } catch (e) {
+      debugPrint('PriceHistorySync.fetch FAILED: $e');
+      return [];
+    }
+  }
+}

--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -215,33 +215,6 @@ class SyncService {
   }
 
   // ---------------------------------------------------------------------------
-  // Price History (server-side)
-  // ---------------------------------------------------------------------------
-
-  /// Fetch price history from server for a station.
-  static Future<List<Map<String, dynamic>>> fetchPriceHistory(
-    String stationId, {
-    int days = 30,
-  }) async {
-    final client = _client;
-    if (client == null) return [];
-
-    try {
-      final cutoff = DateTime.now().subtract(Duration(days: days)).toIso8601String();
-      final rows = await client
-          .from('price_snapshots')
-          .select()
-          .eq('station_id', stationId)
-          .gte('recorded_at', cutoff)
-          .order('recorded_at', ascending: true);
-      return List<Map<String, dynamic>>.from(rows);
-    } catch (e) {
-      debugPrint('SyncService.fetchPriceHistory FAILED: $e');
-      return [];
-    }
-  }
-
-  // ---------------------------------------------------------------------------
   // Alerts
   // ---------------------------------------------------------------------------
 

--- a/lib/features/station_detail/presentation/widgets/price_history_section.dart
+++ b/lib/features/station_detail/presentation/widgets/price_history_section.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/sync_provider.dart';
-import '../../../../core/sync/sync_service.dart';
+import '../../../../core/sync/price_history_sync.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../price_history/domain/entities/price_record.dart';
 import '../../../price_history/presentation/widgets/price_chart.dart';
@@ -71,7 +71,7 @@ class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
     }
 
     try {
-      final rows = await SyncService.fetchPriceHistory(widget.stationId);
+      final rows = await PriceHistorySync.fetch(widget.stationId);
       if (rows.isNotEmpty && mounted) {
         final storageMgmt = ref.read(storageManagementProvider);
         final records = rows.map((r) => {

--- a/test/core/sync/price_history_sync_test.dart
+++ b/test/core/sync/price_history_sync_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/price_history_sync.dart';
+
+/// Shape-only smoke tests for [PriceHistorySync] (#727 extract).
+///
+/// The method wraps a Supabase query; the ONLY behaviour this test
+/// can exercise without a live Supabase stack is the "client is
+/// null → return empty list" guard. That guard is the contract the
+/// rest of the codebase depends on (see
+/// `supabase_sync_repository_test.dart` for the same test at the
+/// repository layer) — any refactor that loses it is a regression.
+///
+/// Tests that require a real Supabase client live under
+/// `test/core/data/sync_repository_test.dart` with a `@Tags(['network'])`
+/// guard; we don't duplicate those here.
+void main() {
+  group('PriceHistorySync', () {
+    test('returns empty list when TankSync client is not configured',
+        () async {
+      // TankSyncClient isn't initialised in unit-test context, so
+      // `.client` resolves to null and `.fetch` takes the early return.
+      final rows = await PriceHistorySync.fetch('st-1');
+      expect(rows, isEmpty);
+    });
+
+    test('honours custom days parameter without throwing', () async {
+      // Days is passed to the server-side filter; the client-null guard
+      // still kicks in first. Any widening of the guard that breaks the
+      // named argument would trip this test.
+      final rows = await PriceHistorySync.fetch('st-1', days: 7);
+      expect(rows, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First chunk off `sync_service.dart` (713 LOC) per #727's oversized-file campaign. `fetchPriceHistory` is a clean candidate for extraction:

- read-only path (writes are server-side via scheduled Edge Functions)
- no auth coupling beyond the anon Supabase client
- no merge semantics shared with the favorites/alerts/ratings methods
- only 2 call sites — cheap to migrate without a facade

## What changed

- **`lib/core/sync/price_history_sync.dart`** (new, 49 LOC) — `PriceHistorySync.fetch(stationId, {days})` with the same body `SyncService.fetchPriceHistory` had, including the client-null guard and the try/catch.
- **`lib/core/sync/sync_service.dart`** — method + section divider deleted (713 → 685 LOC).
- **`lib/core/data/impl/supabase_sync_repository.dart`** — updated the one delegator to call `PriceHistorySync.fetch`.
- **`lib/features/station_detail/presentation/widgets/price_history_section.dart`** — swapped `SyncService.fetchPriceHistory` for `PriceHistorySync.fetch`.
- **`test/core/sync/price_history_sync_test.dart`** (new) — 2 cases pinning the client-null-guard contract.

## Not a facade

`SyncService.fetchPriceHistory` is deleted outright. A wrapper that just re-delegates would leave the line count savings half-paid and confuse future readers. The callers-update cost was 2 lines.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] `flutter test test/core/sync test/core/data` — 145/145 pass, existing `SupabaseSyncRepository` contract preserved
- [x] `flutter test` — 4802/4802 pass
- [ ] Manual: tap into a station detail, confirm price history chart still loads from TankSync when the user is connected

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)