### PR TITLE
feat(obd2): MAP+IAT+RPM speed-density fuel-rate fallback for no-MAF cars (#800)

### DIFF
--- a/lib/features/consumption/data/obd2/elm327_protocol.dart
+++ b/lib/features/consumption/data/obd2/elm327_protocol.dart
@@ -150,6 +150,20 @@ class Elm327Protocol {
   /// (#717)
   static const mafCommand = '0110\r';
 
+  /// Request intake manifold absolute pressure (kPa). Mode 01, PID 0B.
+  /// Second-tier fallback for fuel-rate estimation (#800): when a car
+  /// has neither PID 5E nor a MAF sensor (e.g. Peugeot 107 1.0L 1KR-FE,
+  /// which is speed-density), combining MAP with IAT, RPM, engine
+  /// displacement and volumetric efficiency yields an approximate MAF
+  /// via the ideal gas law — which the existing MAF→fuel math can
+  /// then consume.
+  static const intakeManifoldPressureCommand = '010B\r';
+
+  /// Request intake air temperature (°C). Mode 01, PID 0F. Required
+  /// input to the speed-density fuel-rate estimation (#800). Formula:
+  /// °C = A − 40 (one-byte response).
+  static const intakeAirTempCommand = '010F\r';
+
   /// Request fuel tank level input (%). Mode 01, PID 2F. (#717)
   static const fuelTankLevelCommand = '012F\r';
 
@@ -319,6 +333,26 @@ class Elm327Protocol {
     final bytes = _parseModeOneBody(raw, 0x10, minBytes: 4);
     if (bytes == null) return null;
     return ((bytes[2] * 256) + bytes[3]) * 0.01;
+  }
+
+  /// Parse intake manifold absolute pressure from Mode 01 PID 0B
+  /// response (#800). Formula: kPa = A (single byte, raw value).
+  /// Response: "41 0B XX". Physical range 0–255 kPa — idle around
+  /// 30–40 kPa, wide-open throttle approaches atmospheric (~100 kPa)
+  /// on NA engines, and up to 200+ kPa on turbocharged engines.
+  static double? parseManifoldPressureKpa(String raw) {
+    final bytes = _parseModeOneBody(raw, 0x0B, minBytes: 3);
+    if (bytes == null) return null;
+    return bytes[2].toDouble();
+  }
+
+  /// Parse intake air temperature from Mode 01 PID 0F response (#800).
+  /// Formula: °C = A − 40 (single byte). Response: "41 0F XX". Range
+  /// −40 °C to 215 °C covers every drivable condition the sensor sees.
+  static double? parseIntakeAirTempCelsius(String raw) {
+    final bytes = _parseModeOneBody(raw, 0x0F, minBytes: 3);
+    if (bytes == null) return null;
+    return bytes[2].toDouble() - 40.0;
   }
 
   /// Helper for every "1 byte, scaled to percent" PID (04, 11, 2F).

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -143,23 +143,102 @@ class Obd2Service {
         label: 'throttle',
       );
 
-  /// Read engine fuel rate in L/h (#717). Falls back to deriving from
-  /// MAF when PID 5E is unsupported — MAF's fuel-rate estimate is a
-  /// useful approximation on older cars.
-  Future<double?> readFuelRateLPerHour() async {
+  /// Read engine fuel rate in L/h. Three-step fallback chain (#717, #800):
+  ///
+  ///   1. **PID 5E** — direct `engine fuel rate` reading. Modern ECUs
+  ///      (~2014+) answer directly. Best accuracy, preferred when
+  ///      supported.
+  ///   2. **PID 10 MAF** — derive fuel rate from mass air flow:
+  ///      `L/h = MAF_g_per_s × 3600 / (AFR × density)`. Accepted ~5–10 %
+  ///      error, still very usable. Fails on cars without a MAF sensor.
+  ///   3. **MAP + IAT + RPM speed-density** — when neither direct fuel
+  ///      rate nor MAF is available (e.g. Peugeot 107 1.0L 1KR-FE), use
+  ///      the ideal gas law to estimate air mass flow from intake
+  ///      manifold pressure, intake air temperature, engine RPM, engine
+  ///      displacement, and volumetric efficiency. Accepted ~10–15 %
+  ///      error — still infinitely better than the `—` placeholder the
+  ///      trip summary would otherwise show.
+  ///
+  /// [engineDisplacementCc] and [volumetricEfficiency] are per-vehicle
+  /// constants for the step-3 fallback. Defaults are tuned for a 1.0 L
+  /// NA petrol engine (matches the Peugeot 107 / Aygo / C1 class and
+  /// covers many other sub-1.2 L city cars). A follow-up PR will plumb
+  /// per-vehicle overrides from the vehicle profile.
+  Future<double?> readFuelRateLPerHour({
+    int engineDisplacementCc = 1000,
+    double volumetricEfficiency = 0.85,
+  }) async {
+    // Step 1: direct fuel-rate PID.
     final direct = await _readDouble(
       Elm327Protocol.engineFuelRateCommand,
       Elm327Protocol.parseFuelRateLPerHour,
       label: 'fuelRate',
     );
     if (direct != null) return direct;
+
+    // Step 2: MAF-based estimate.
     final maf = await readMafGramsPerSecond();
-    if (maf == null) return null;
-    // Stoichiometric petrol: ~14.7 g air per g fuel; petrol density
-    // ~0.74 kg/L. Fuel rate (L/h) = MAF (g/s) * 3600 / (14.7 * 740).
-    // Returns an approximation; good enough for trip averages on
-    // vehicles that lack direct PID 5E.
-    return maf * 3600.0 / (14.7 * 740.0);
+    if (maf != null) {
+      // Stoichiometric petrol: AFR 14.7, density ~740 g/L.
+      // L/h = MAF × 3600 / (14.7 × 740).
+      return maf * 3600.0 / (14.7 * 740.0);
+    }
+
+    // Step 3: speed-density fallback. Requires MAP + IAT + RPM.
+    final mapKpa = await readManifoldPressureKpa();
+    final iatCelsius = await readIntakeAirTempCelsius();
+    final rpm = await readRpm();
+    if (mapKpa == null || iatCelsius == null || rpm == null) return null;
+    return estimateFuelRateLPerHourFromMap(
+      mapKpa: mapKpa,
+      iatCelsius: iatCelsius,
+      rpm: rpm,
+      engineDisplacementCc: engineDisplacementCc,
+      volumetricEfficiency: volumetricEfficiency,
+    );
+  }
+
+  /// Pure-math speed-density fuel-rate estimator (#800). Split out so
+  /// unit tests can verify the formula without mocking the transport.
+  ///
+  /// Formula:
+  ///   air_flow_g_per_s = (MAP_Pa × displacement_m³ × (RPM / 120) × η_v)
+  ///                      / (R × IAT_K)
+  ///   fuel_rate_L_per_h = air_flow_g_per_s × 3600 / (AFR × density)
+  ///
+  /// R = 287 J/(kg·K) is the specific gas constant for dry air.
+  /// `RPM / 120` converts crank revolutions to intake strokes per
+  /// second on a 4-stroke engine (one intake per 2 crank revs).
+  /// Returns null when any input is non-positive — the ideal gas law
+  /// breaks down at 0 K / 0 pressure and callers should surface "no
+  /// data" rather than a bogus number.
+  static double? estimateFuelRateLPerHourFromMap({
+    required double mapKpa,
+    required double iatCelsius,
+    required double rpm,
+    required int engineDisplacementCc,
+    required double volumetricEfficiency,
+    double afr = 14.7,
+    double fuelDensityGPerL = 740.0,
+  }) {
+    final iatKelvin = iatCelsius + 273.15;
+    if (mapKpa <= 0 ||
+        iatKelvin <= 0 ||
+        rpm <= 0 ||
+        engineDisplacementCc <= 0 ||
+        volumetricEfficiency <= 0) {
+      return null;
+    }
+    const gasConstant = 287.0; // J/(kg·K), dry air
+    final mapPa = mapKpa * 1000.0;
+    final displacementM3 = engineDisplacementCc / 1_000_000.0;
+    final intakesPerSecond = rpm / 120.0;
+    // Kilograms of air per second (ideal gas law × VE).
+    final airMassKgPerS =
+        (mapPa * displacementM3 * intakesPerSecond * volumetricEfficiency) /
+            (gasConstant * iatKelvin);
+    final airMassGPerS = airMassKgPerS * 1000.0;
+    return airMassGPerS * 3600.0 / (afr * fuelDensityGPerL);
   }
 
   /// Read mass air flow in g/s. (#717)
@@ -167,6 +246,20 @@ class Obd2Service {
         Elm327Protocol.mafCommand,
         Elm327Protocol.parseMafGramsPerSecond,
         label: 'maf',
+      );
+
+  /// Read intake manifold absolute pressure (kPa). (#800)
+  Future<double?> readManifoldPressureKpa() => _readDouble(
+        Elm327Protocol.intakeManifoldPressureCommand,
+        Elm327Protocol.parseManifoldPressureKpa,
+        label: 'manifoldPressure',
+      );
+
+  /// Read intake air temperature (°C). (#800)
+  Future<double?> readIntakeAirTempCelsius() => _readDouble(
+        Elm327Protocol.intakeAirTempCommand,
+        Elm327Protocol.parseIntakeAirTempCelsius,
+        label: 'intakeAirTemp',
       );
 
   /// Read fuel tank level, 0–100 %. (#717)

--- a/test/features/consumption/data/obd2/elm327_protocol_test.dart
+++ b/test/features/consumption/data/obd2/elm327_protocol_test.dart
@@ -75,6 +75,60 @@ void main() {
       });
     });
 
+    group('parseManifoldPressureKpa (PID 0B) — #800 speed-density input', () {
+      test('parses idle vacuum at 30 kPa', () {
+        expect(
+          Elm327Protocol.parseManifoldPressureKpa('41 0B 1E>'),
+          closeTo(30.0, 0.01),
+        );
+      });
+
+      test('parses wide-open throttle at ~100 kPa on an NA engine', () {
+        expect(
+          Elm327Protocol.parseManifoldPressureKpa('41 0B 64>'),
+          closeTo(100.0, 0.01),
+        );
+      });
+
+      test('parses turbocharged boost at 200 kPa', () {
+        expect(
+          Elm327Protocol.parseManifoldPressureKpa('41 0B C8>'),
+          closeTo(200.0, 0.01),
+        );
+      });
+
+      test('returns null on NO DATA', () {
+        expect(Elm327Protocol.parseManifoldPressureKpa('NO DATA>'), isNull);
+      });
+    });
+
+    group('parseIntakeAirTempCelsius (PID 0F) — #800 speed-density input', () {
+      test('parses -40 °C at raw 0x00 (sensor minimum)', () {
+        expect(
+          Elm327Protocol.parseIntakeAirTempCelsius('41 0F 00>'),
+          closeTo(-40.0, 0.01),
+        );
+      });
+
+      test('parses 20 °C at raw 0x3C (typical ambient)', () {
+        expect(
+          Elm327Protocol.parseIntakeAirTempCelsius('41 0F 3C>'),
+          closeTo(20.0, 0.01),
+        );
+      });
+
+      test('parses 215 °C at raw 0xFF (sensor maximum)', () {
+        expect(
+          Elm327Protocol.parseIntakeAirTempCelsius('41 0F FF>'),
+          closeTo(215.0, 0.01),
+        );
+      });
+
+      test('returns null on NO DATA', () {
+        expect(Elm327Protocol.parseIntakeAirTempCelsius('NO DATA>'), isNull);
+      });
+    });
+
     group('command constants', () {
       test('expose the new PIDs for the service layer', () {
         expect(Elm327Protocol.engineLoadCommand, '0104\r');
@@ -82,6 +136,9 @@ void main() {
         expect(Elm327Protocol.engineFuelRateCommand, '015E\r');
         expect(Elm327Protocol.mafCommand, '0110\r');
         expect(Elm327Protocol.fuelTankLevelCommand, '012F\r');
+        // #800 speed-density fallback PIDs:
+        expect(Elm327Protocol.intakeManifoldPressureCommand, '010B\r');
+        expect(Elm327Protocol.intakeAirTempCommand, '010F\r');
       });
     });
   });

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -49,12 +49,163 @@ void main() {
 
     test(
         'readFuelRateLPerHour returns null when neither PID 5E nor MAF '
-        'are supported', () async {
+        'are supported AND the speed-density PIDs also fail', () async {
+      // All three fallback tiers unsupported → final null. No change
+      // to this contract after #800 added step 3 — only the path to
+      // null grew an extra branch.
       final service = await _connected({
         '015E': 'NO DATA>',
         '0110': 'NO DATA>',
+        '010B': 'NO DATA>',
+        '010F': 'NO DATA>',
+        '010C': 'NO DATA>',
       });
       expect(await service.readFuelRateLPerHour(), isNull);
+    });
+
+    test(
+        'readFuelRateLPerHour falls back to speed-density (MAP+IAT+RPM) '
+        'when neither PID 5E nor MAF are supported — #800 Peugeot 107 path',
+        () async {
+      // Peugeot 107 1.0L 1KR-FE ground truth: no 5E, no MAF, but MAP
+      // + IAT + RPM all present. At idle (RPM 800, MAP 40 kPa, IAT
+      // 25 °C) the speed-density estimate should land in a plausible
+      // range around 0.5–1.5 L/h — not null, not zero, not insane.
+      final service = await _connected({
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 28>', // MAP = 40 kPa (idle vacuum)
+        '010F': '41 0F 41>', // IAT = 25 °C (raw 0x41 = 65, 65−40 = 25)
+        '010C': '41 0C 0C 80>', // RPM = ((12×256)+128)/4 = 800
+      });
+      final rate = await service.readFuelRateLPerHour();
+      expect(rate, isNotNull);
+      expect(rate, greaterThan(0.2));
+      expect(rate, lessThan(3.0));
+    });
+
+    test(
+        'readFuelRateLPerHour speed-density step returns null when any '
+        'of MAP/IAT/RPM is missing — all three required', () async {
+      // MAP present but IAT missing → step 3 bails out rather than
+      // making up a temperature. Callers see the honest null and the
+      // trip summary shows "—".
+      final service = await _connected({
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 40>',
+        '010F': 'NO DATA>',
+        '010C': '41 0C 0C 80>',
+      });
+      expect(await service.readFuelRateLPerHour(), isNull);
+    });
+
+    test('readManifoldPressureKpa parses PID 0B', () async {
+      final service = await _connected({'010B': '41 0B 64>'});
+      expect(await service.readManifoldPressureKpa(), closeTo(100.0, 0.01));
+    });
+
+    test('readIntakeAirTempCelsius parses PID 0F', () async {
+      final service = await _connected({'010F': '41 0F 3C>'});
+      expect(
+        await service.readIntakeAirTempCelsius(),
+        closeTo(20.0, 0.01),
+      );
+    });
+
+    group('estimateFuelRateLPerHourFromMap — #800 speed-density math', () {
+      test('typical Peugeot 107 cruise: 2500 RPM, 65 kPa, 30 °C → '
+          '~3–5 L/h (plausible cruise consumption)', () {
+        final rate = Obd2Service.estimateFuelRateLPerHourFromMap(
+          mapKpa: 65,
+          iatCelsius: 30,
+          rpm: 2500,
+          engineDisplacementCc: 1000,
+          volumetricEfficiency: 0.85,
+        );
+        expect(rate, isNotNull);
+        expect(rate, greaterThan(2.5));
+        expect(rate, lessThan(6.0));
+      });
+
+      test('returns null when any input is non-positive', () {
+        expect(
+          Obd2Service.estimateFuelRateLPerHourFromMap(
+            mapKpa: 0, // can't have 0 kPa physically
+            iatCelsius: 25,
+            rpm: 800,
+            engineDisplacementCc: 1000,
+            volumetricEfficiency: 0.85,
+          ),
+          isNull,
+        );
+        expect(
+          Obd2Service.estimateFuelRateLPerHourFromMap(
+            mapKpa: 40,
+            iatCelsius: -273.15, // 0 K — breaks ideal gas law
+            rpm: 800,
+            engineDisplacementCc: 1000,
+            volumetricEfficiency: 0.85,
+          ),
+          isNull,
+        );
+        expect(
+          Obd2Service.estimateFuelRateLPerHourFromMap(
+            mapKpa: 40,
+            iatCelsius: 25,
+            rpm: 0, // engine off
+            engineDisplacementCc: 1000,
+            volumetricEfficiency: 0.85,
+          ),
+          isNull,
+        );
+      });
+
+      test('scales linearly with displacement (2.0 L burns 2× the fuel '
+          'of a 1.0 L at the same operating point)', () {
+        final small = Obd2Service.estimateFuelRateLPerHourFromMap(
+          mapKpa: 50,
+          iatCelsius: 20,
+          rpm: 2000,
+          engineDisplacementCc: 1000,
+          volumetricEfficiency: 0.85,
+        )!;
+        final big = Obd2Service.estimateFuelRateLPerHourFromMap(
+          mapKpa: 50,
+          iatCelsius: 20,
+          rpm: 2000,
+          engineDisplacementCc: 2000,
+          volumetricEfficiency: 0.85,
+        )!;
+        expect(big / small, closeTo(2.0, 0.01));
+      });
+
+      test('matches the stoichiometric MAF path on the same underlying '
+          'air-mass flow — formulas agree when given equivalent inputs', () {
+        // Hand-compute the air mass flow for known inputs, then verify
+        // both the speed-density method and the MAF-based formula
+        // agree on the resulting fuel rate.
+        const mapKpa = 100.0;
+        const iatCelsius = 25.0;
+        const rpm = 3000.0;
+        const displacementCc = 1000;
+        const ve = 0.85;
+        const r = 287.0;
+        const iatK = iatCelsius + 273.15;
+        const displacementM3 = displacementCc / 1_000_000.0;
+        const airKgPerS = (mapKpa * 1000 * displacementM3 * (rpm / 120) * ve) /
+            (r * iatK);
+        const airGPerS = airKgPerS * 1000;
+        const expectedFromMaf = airGPerS * 3600 / (14.7 * 740);
+        final fromMap = Obd2Service.estimateFuelRateLPerHourFromMap(
+          mapKpa: mapKpa,
+          iatCelsius: iatCelsius,
+          rpm: rpm,
+          engineDisplacementCc: displacementCc,
+          volumetricEfficiency: ve,
+        )!;
+        expect(fromMap, closeTo(expectedFromMaf, 0.001));
+      });
     });
 
     test('readMafGramsPerSecond parses PID 10', () async {


### PR DESCRIPTION
## Summary

Partial fix for **#800**. Extends `Obd2Service.readFuelRateLPerHour`'s fallback chain with a third step so the Peugeot 107 / Aygo / C1 class (Toyota 1KR-FE 1.0 L, speed-density fuelling, **no MAF sensor**) produces real fuel data instead of the `—` placeholder seen in the original bug report screenshots.

## Fallback chain now

1. **PID `015E`** — direct engine fuel rate. Modern ECUs (~2014+) answer directly. Unchanged.
2. **PID `0110` MAF** → `L/h = MAF × 3600 / (AFR × density)`. Unchanged.
3. **NEW — PID `010B` MAP + `010F` IAT + `010C` RPM** speed-density via the ideal gas law. Runs only when both 5E and MAF return `NO DATA`.

Math:
```
air_kg_per_s = (MAP_Pa × displacement_m³ × RPM / 120 × η_v) / (R × IAT_K)
fuel_rate_L_per_h = air_kg_per_s × 1000 × 3600 / (AFR × density)
```

`R = 287 J/(kg·K)`, `RPM/120` = intake strokes per second on a 4-stroke, `AFR = 14.7` and `density = 740 g/L` for petrol. Defaults hit a generic 1.0 L NA petrol engine (`engineDisplacementCc = 1000`, `η_v = 0.85`) — per-vehicle overrides are the **next PR's** job; that one needs a Hive migration + vehicle-profile UI and is deliberately out of scope here.

## Scope note

This PR is the minimum-viable speed-density fallback. Deliberately out of scope (will be follow-ups):

- Per-vehicle `engineDisplacementCc` + `volumetricEfficiency` profile fields with the VIN-based auto-detection the user outlined in #800.
- PID support negotiation via Service 01 PID 00 — right now the step-3 path is attempted every tick regardless; a supported-PIDs cache would cut bandwidth in the ~95% of cars where it's never needed.
- Fuel-trim-based adaptive η_v calibration.
- Priority-tiered polling (the user sketched a 5 Hz / 1 Hz / 10–30 s split).

I'll file these as separate issues in a follow-up comment so the plan is preserved.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] `flutter test test/features/consumption/data/obd2/` — all pass including 17 new cases:
  - Parser round-trips for MAP at 30/100/200 kPa, IAT at −40/20/215 °C
  - `NO DATA` guards on both parsers
  - Command-constant pins for `010B` / `010F`
  - Service integration: speed-density path returns plausible 0.2–3 L/h at Peugeot 107 idle (MAP 40, IAT 25, RPM 800)
  - Service integration: null when any of MAP/IAT/RPM is missing
  - Pure-math estimator: cruise ~3–5 L/h, linear scaling with displacement, agreement with MAF path on equivalent inputs
- [ ] Manual on Peugeot 107: connect adapter, start a trip, confirm `Carburant utilisé` and `Moyenne` no longer show `—`

Refs #800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)