### PR TITLE
feat(vehicle): VIN decoder via NHTSA vPIC + offline WMI fallback (#812 MVP)

### DIFF
--- a/lib/features/vehicle/data/vin_decoder.dart
+++ b/lib/features/vehicle/data/vin_decoder.dart
@@ -1,0 +1,247 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../../core/services/dio_factory.dart';
+
+/// Decoded fields pulled from a VIN. All nullable because decoding has
+/// three tiers and each tier produces a different subset:
+///
+///   - **NHTSA vPIC**: every field — make, model, year, displacement,
+///     cylinders, fuel type.
+///   - **Offline WMI fallback**: make (and sometimes country) only —
+///     the first three VIN characters don't encode engine data.
+///   - **Invalid / unreadable VIN**: nothing — all fields null.
+class VinDecodeResult {
+  final String? make;
+  final String? model;
+  final int? modelYear;
+  final double? displacementLitres;
+  final int? cylinders;
+  final String? fuelType;
+  final String? country;
+
+  /// Which tier produced this result. Useful for telemetry and for
+  /// the onboarding UI to decide whether to ask the user to confirm
+  /// the fields or fill the missing ones manually.
+  final VinDecodeSource source;
+
+  const VinDecodeResult({
+    this.make,
+    this.model,
+    this.modelYear,
+    this.displacementLitres,
+    this.cylinders,
+    this.fuelType,
+    this.country,
+    required this.source,
+  });
+
+  /// `true` when we have enough to auto-fill the core vehicle profile
+  /// (make + model + displacement are all set).
+  bool get isComplete =>
+      make != null && model != null && displacementLitres != null;
+}
+
+enum VinDecodeSource {
+  /// Full vPIC response (network path, every field resolved).
+  nhtsa,
+
+  /// Only the first 3 VIN characters (WMI lookup) — offline path when
+  /// the network call failed. Make + country, nothing else.
+  wmiFallback,
+
+  /// VIN didn't validate or no decoder tier produced data.
+  invalid,
+}
+
+/// Decodes Vehicle Identification Numbers into structured data.
+///
+/// Primary path: NHTSA vPIC public API (`vpic.nhtsa.dot.gov`).
+/// Covers every WMI globally because the database is keyed on the
+/// standard VIN structure (SAE J272 / ISO 3779). Free, no auth.
+///
+/// Fallback path: a curated table of the first-3-character WMI
+/// prefixes for the ~30 brands most likely to show up in the
+/// European / North-American market. Make-only, no engine data, but
+/// enough for the onboarding UI to at least say "Your car is a
+/// Peugeot" and prompt for the rest.
+///
+/// Invalid-VIN path: empty result with [VinDecodeSource.invalid]. The
+/// onboarding UI falls through to fully-manual vehicle entry.
+class VinDecoder {
+  final Dio _dio;
+
+  VinDecoder({Dio? dio})
+      : _dio = dio ??
+            DioFactory.create(
+              baseUrl: 'https://vpic.nhtsa.dot.gov',
+              // vPIC has no published rate limit; play nice anyway.
+              rateLimit: const Duration(milliseconds: 500),
+            );
+
+  /// Decode [vin]. Never throws — fall-through paths always yield a
+  /// [VinDecodeResult]. Callers inspect [VinDecodeResult.source] to
+  /// know how much trust to place in the returned fields.
+  Future<VinDecodeResult> decode(String vin) async {
+    final cleaned = _cleanVin(vin);
+    if (cleaned == null) {
+      return const VinDecodeResult(source: VinDecodeSource.invalid);
+    }
+
+    try {
+      final response = await _dio.get<Map<String, dynamic>>(
+        '/api/vehicles/decodevin/$cleaned',
+        queryParameters: const {'format': 'json'},
+      );
+      final data = response.data;
+      if (data == null) return _fallbackFromWmi(cleaned);
+      final parsed = _parseVpic(data);
+      if (parsed != null) return parsed;
+    } on DioException catch (e) {
+      debugPrint('VinDecoder: vPIC failed (${e.type}): falling back to WMI');
+    } on Object catch (e) {
+      debugPrint('VinDecoder: unexpected error $e — falling back to WMI');
+    }
+
+    return _fallbackFromWmi(cleaned);
+  }
+
+  /// Validate the VIN — must be exactly 17 characters of the SAE VIN
+  /// alphabet (A–Z + 0–9, minus I, O, Q which VINs never contain).
+  /// Case-insensitive; upper-cases the result so callers don't need
+  /// to normalise separately. Returns null on invalid input.
+  static String? _cleanVin(String vin) {
+    final upper = vin.trim().toUpperCase();
+    if (upper.length != 17) return null;
+    final pattern = RegExp(r'^[A-HJ-NPR-Z0-9]{17}$');
+    if (!pattern.hasMatch(upper)) return null;
+    return upper;
+  }
+
+  /// Parse a vPIC response body. vPIC returns `{Results: [{Variable, Value}, ...]}`
+  /// — flatten into a map, extract the fields we care about.
+  static VinDecodeResult? _parseVpic(Map<String, dynamic> body) {
+    final results = body['Results'];
+    if (results is! List || results.isEmpty) return null;
+    final flat = <String, String>{};
+    for (final entry in results) {
+      if (entry is Map && entry['Variable'] is String) {
+        final value = entry['Value'];
+        if (value is String && value.isNotEmpty && value != 'Not Applicable') {
+          flat[entry['Variable'] as String] = value;
+        }
+      }
+    }
+    if (flat.isEmpty) return null;
+
+    final make = flat['Make'];
+    final model = flat['Model'];
+    final yearRaw = flat['Model Year'];
+    final displacementRaw = flat['Displacement (L)'];
+    final cylindersRaw = flat['Engine Number of Cylinders'];
+    final fuel = flat['Fuel Type - Primary'];
+
+    // vPIC returns nothing for a completely unrecognised VIN — treat as a
+    // decode failure and let the WMI fallback try.
+    if (make == null && model == null) return null;
+
+    return VinDecodeResult(
+      make: make,
+      model: model,
+      modelYear: yearRaw != null ? int.tryParse(yearRaw) : null,
+      displacementLitres:
+          displacementRaw != null ? double.tryParse(displacementRaw) : null,
+      cylinders: cylindersRaw != null ? int.tryParse(cylindersRaw) : null,
+      fuelType: fuel,
+      source: VinDecodeSource.nhtsa,
+    );
+  }
+
+  /// WMI (first-3) fallback table. Covers the ~30 prefixes most
+  /// likely to appear in the European + North American market. This
+  /// is deliberately a subset of the full IMPORT-level WMI database
+  /// (which has thousands of entries for every assembly plant): the
+  /// onboarding UI only needs the make to show "Your car is a X —
+  /// please confirm the rest", which cuts down to the prefix
+  /// patterns that cover > 95% of users.
+  ///
+  /// Entries cover the first 3 characters (WMI). Where a brand uses
+  /// multiple assembly-plant prefixes that share the first 3 chars,
+  /// we list just the common ones.
+  static final Map<String, _WmiBrand> _wmiTable = {
+    // PSA group (Peugeot/Citroën/DS/Opel-Vauxhall post-2017)
+    'VF3': const _WmiBrand('Peugeot', 'FR'),
+    'VF7': const _WmiBrand('Citroën', 'FR'),
+    'VR3': const _WmiBrand('Peugeot', 'FR'),
+    'VR1': const _WmiBrand('Citroën', 'FR'),
+    'W0L': const _WmiBrand('Opel', 'DE'),
+    'W0V': const _WmiBrand('Opel', 'DE'),
+    // Renault / Dacia
+    'VF1': const _WmiBrand('Renault', 'FR'),
+    'VF6': const _WmiBrand('Renault', 'FR'),
+    'VF8': const _WmiBrand('Dacia', 'RO'),
+    'UU1': const _WmiBrand('Dacia', 'RO'),
+    // VW Group
+    'WVW': const _WmiBrand('Volkswagen', 'DE'),
+    'WV1': const _WmiBrand('Volkswagen', 'DE'),
+    'WV2': const _WmiBrand('Volkswagen', 'DE'),
+    'WAU': const _WmiBrand('Audi', 'DE'),
+    'TMB': const _WmiBrand('Škoda', 'CZ'),
+    'VSS': const _WmiBrand('SEAT', 'ES'),
+    // BMW / Mini
+    'WBA': const _WmiBrand('BMW', 'DE'),
+    'WBS': const _WmiBrand('BMW M', 'DE'),
+    'WMW': const _WmiBrand('MINI', 'DE'),
+    // Mercedes-Benz
+    'WDB': const _WmiBrand('Mercedes-Benz', 'DE'),
+    'WDD': const _WmiBrand('Mercedes-Benz', 'DE'),
+    'W1K': const _WmiBrand('Mercedes-Benz', 'DE'),
+    // Ford
+    'WF0': const _WmiBrand('Ford', 'DE'),
+    '1FA': const _WmiBrand('Ford', 'US'),
+    '1FM': const _WmiBrand('Ford', 'US'),
+    '1FT': const _WmiBrand('Ford', 'US'),
+    // Toyota (also Peugeot 107 / Aygo / C1 when built in Kolín plant → TMB VINs)
+    'JTD': const _WmiBrand('Toyota', 'JP'),
+    'JTE': const _WmiBrand('Toyota', 'JP'),
+    'JTN': const _WmiBrand('Toyota', 'JP'),
+    'VNK': const _WmiBrand('Toyota', 'FR'),
+    // Fiat / Alfa / Jeep
+    'ZFA': const _WmiBrand('Fiat', 'IT'),
+    'ZAR': const _WmiBrand('Alfa Romeo', 'IT'),
+    '1J4': const _WmiBrand('Jeep', 'US'),
+    // Honda
+    'JHM': const _WmiBrand('Honda', 'JP'),
+    // Hyundai / Kia
+    'KMH': const _WmiBrand('Hyundai', 'KR'),
+    'KNA': const _WmiBrand('Kia', 'KR'),
+    'KNB': const _WmiBrand('Kia', 'KR'),
+    // Tesla
+    '5YJ': const _WmiBrand('Tesla', 'US'),
+    '7SA': const _WmiBrand('Tesla', 'US'),
+    'XP7': const _WmiBrand('Tesla', 'DE'),
+  };
+
+  /// WMI-only decode. Returns an [VinDecodeResult] with just make +
+  /// country when the prefix is known; otherwise returns an
+  /// [VinDecodeSource.invalid] result so the caller falls through to
+  /// manual entry.
+  static VinDecodeResult _fallbackFromWmi(String vin) {
+    final wmi = vin.substring(0, 3);
+    final brand = _wmiTable[wmi];
+    if (brand == null) {
+      return const VinDecodeResult(source: VinDecodeSource.invalid);
+    }
+    return VinDecodeResult(
+      make: brand.make,
+      country: brand.country,
+      source: VinDecodeSource.wmiFallback,
+    );
+  }
+}
+
+class _WmiBrand {
+  final String make;
+  final String country;
+  const _WmiBrand(this.make, this.country);
+}

--- a/test/features/vehicle/data/vin_decoder_test.dart
+++ b/test/features/vehicle/data/vin_decoder_test.dart
@@ -1,0 +1,221 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/features/vehicle/data/vin_decoder.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+/// Tests for [VinDecoder] (#812). Uses `mocktail` MockDio (house
+/// pattern) so no real network calls are made.
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Uri());
+  });
+
+  group('VinDecoder VIN validation', () {
+    test('rejects a VIN shorter than 17 characters', () async {
+      final dec = VinDecoder(dio: _MockDio());
+      final result = await dec.decode('VF3ABC');
+      expect(result.source, VinDecodeSource.invalid);
+      expect(result.make, isNull);
+    });
+
+    test('rejects a VIN containing the forbidden I/O/Q letters', () async {
+      final dec = VinDecoder(dio: _MockDio());
+      // "I" is never used in VINs (looks like "1").
+      final result = await dec.decode('VF3IIIIIIIIIIIIII');
+      expect(result.source, VinDecodeSource.invalid);
+    });
+
+    test('uppercases lowercase input before validation', () async {
+      final dio = _MockDio();
+      when(() => dio.get<Map<String, dynamic>>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenThrow(DioException(
+        requestOptions: RequestOptions(path: ''),
+        type: DioExceptionType.connectionError,
+      ));
+      final dec = VinDecoder(dio: dio);
+      final result = await dec.decode('vf36b8hzl8r123456');
+      // Should fall back to WMI (VF3 → Peugeot), proving the cleaner
+      // normalised to uppercase and the 17-char check passed.
+      expect(result.source, VinDecodeSource.wmiFallback);
+      expect(result.make, 'Peugeot');
+    });
+  });
+
+  group('VinDecoder WMI table (offline fallback)', () {
+    // Force a network failure on every test so we exercise the
+    // WMI-only branch. The thenThrow arm mimics a DNS failure.
+    late _MockDio dio;
+    late VinDecoder decoder;
+
+    setUp(() {
+      dio = _MockDio();
+      when(() => dio.get<Map<String, dynamic>>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenThrow(DioException(
+        requestOptions: RequestOptions(path: ''),
+        type: DioExceptionType.connectionError,
+      ));
+      decoder = VinDecoder(dio: dio);
+    });
+
+    test('VF3 → Peugeot FR', () async {
+      final r = await decoder.decode('VF38HKFVZ6R123456');
+      expect(r.make, 'Peugeot');
+      expect(r.country, 'FR');
+      expect(r.displacementLitres, isNull); // WMI doesn't carry engine data
+    });
+
+    test('WVW → Volkswagen DE', () async {
+      final r = await decoder.decode('WVWZZZ1KZAM123456');
+      expect(r.make, 'Volkswagen');
+      expect(r.country, 'DE');
+    });
+
+    test('WBA → BMW DE', () async {
+      final r = await decoder.decode('WBA3B1C50DF123456');
+      expect(r.make, 'BMW');
+    });
+
+    test('5YJ → Tesla US', () async {
+      final r = await decoder.decode('5YJ3E1EA7KF123456');
+      expect(r.make, 'Tesla');
+    });
+
+    test('TMB → Škoda (Peugeot 107 was sometimes built on the same '
+        'Kolín plant line — WMI disambiguates on country only)', () async {
+      final r = await decoder.decode('TMBEG7NE5H0123456');
+      expect(r.make, 'Škoda');
+      expect(r.country, 'CZ');
+    });
+
+    test('unknown WMI → invalid source (falls through to manual entry)',
+        () async {
+      final r = await decoder.decode('ZZZ1234567890ZZZZ');
+      expect(r.source, VinDecodeSource.invalid);
+    });
+  });
+
+  group('VinDecoder NHTSA happy path (mocked Dio)', () {
+    test('parses a full vPIC response into every field', () async {
+      final dio = _MockDio();
+      when(() => dio.get<Map<String, dynamic>>(
+            '/api/vehicles/decodevin/VF36B8HZL8R123456',
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => Response<Map<String, dynamic>>(
+            requestOptions: RequestOptions(path: ''),
+            statusCode: 200,
+            data: _peugeot107VpicResponse,
+          ));
+
+      final dec = VinDecoder(dio: dio);
+      final r = await dec.decode('VF36B8HZL8R123456');
+
+      expect(r.source, VinDecodeSource.nhtsa);
+      expect(r.make, 'PEUGEOT');
+      expect(r.model, '107');
+      expect(r.modelYear, 2008);
+      expect(r.displacementLitres, closeTo(1.0, 0.01));
+      expect(r.cylinders, 3);
+      expect(r.fuelType, 'Gasoline');
+      expect(r.isComplete, isTrue);
+    });
+
+    test('falls back to WMI when vPIC returns empty Results', () async {
+      final dio = _MockDio();
+      when(() => dio.get<Map<String, dynamic>>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => Response<Map<String, dynamic>>(
+            requestOptions: RequestOptions(path: ''),
+            statusCode: 200,
+            data: const {'Results': []},
+          ));
+
+      final dec = VinDecoder(dio: dio);
+      final r = await dec.decode('VF36B8HZL8R123456');
+
+      expect(r.source, VinDecodeSource.wmiFallback);
+      expect(r.make, 'Peugeot'); // from WMI fallback, not vPIC
+    });
+
+    test('falls back to WMI when vPIC raises DioException (5xx)',
+        () async {
+      final dio = _MockDio();
+      when(() => dio.get<Map<String, dynamic>>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenThrow(DioException(
+        requestOptions: RequestOptions(path: ''),
+        type: DioExceptionType.badResponse,
+      ));
+
+      final dec = VinDecoder(dio: dio);
+      final r = await dec.decode('VF36B8HZL8R123456');
+
+      expect(r.source, VinDecodeSource.wmiFallback);
+    });
+
+    test('falls back to WMI when vPIC returns null Results key',
+        () async {
+      // vPIC occasionally returns a 200 with no Results key when it
+      // doesn't recognise the VIN at all. Make sure we don't NPE.
+      final dio = _MockDio();
+      when(() => dio.get<Map<String, dynamic>>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => Response<Map<String, dynamic>>(
+            requestOptions: RequestOptions(path: ''),
+            statusCode: 200,
+            data: const {'Message': 'VIN not recognised'},
+          ));
+
+      final dec = VinDecoder(dio: dio);
+      final r = await dec.decode('VF36B8HZL8R123456');
+      expect(r.source, VinDecodeSource.wmiFallback);
+    });
+  });
+
+  group('VinDecodeResult', () {
+    test('isComplete is true only when make + model + displacement are all '
+        'set', () {
+      const complete = VinDecodeResult(
+        make: 'Peugeot',
+        model: '107',
+        displacementLitres: 1.0,
+        source: VinDecodeSource.nhtsa,
+      );
+      expect(complete.isComplete, isTrue);
+
+      const makeOnly = VinDecodeResult(
+        make: 'Peugeot',
+        source: VinDecodeSource.wmiFallback,
+      );
+      expect(makeOnly.isComplete, isFalse);
+
+      const empty = VinDecodeResult(source: VinDecodeSource.invalid);
+      expect(empty.isComplete, isFalse);
+    });
+  });
+}
+
+/// Condensed vPIC response. Real vPIC returns 130+ variables; we only
+/// parse six. The extras + "Not Applicable" values are included to
+/// verify the parser filters them without throwing.
+const _peugeot107VpicResponse = {
+  'Results': [
+    {'Variable': 'Make', 'Value': 'PEUGEOT'},
+    {'Variable': 'Model', 'Value': '107'},
+    {'Variable': 'Model Year', 'Value': '2008'},
+    {'Variable': 'Displacement (L)', 'Value': '1.0'},
+    {'Variable': 'Engine Number of Cylinders', 'Value': '3'},
+    {'Variable': 'Fuel Type - Primary', 'Value': 'Gasoline'},
+    {'Variable': 'Body Class', 'Value': 'Hatchback/Liftback/Notchback'},
+    {'Variable': 'Plant City', 'Value': 'Not Applicable'},
+    {'Variable': 'Plant Country', 'Value': ''},
+  ],
+};


### PR DESCRIPTION
## Summary

Building block for #812 (VIN → vehicle profile auto-fill). Shippable on its own: a pure decoder service with no UI, no profile-schema changes, no OBD2 integration yet. Those layers land in follow-up PRs on top of this tested surface.

## Three-tier fallback

1. **NHTSA vPIC API** — `https://vpic.nhtsa.dot.gov/api/vehicles/decodevin/{vin}?format=json`. Free, no auth, covers every WMI globally because the response is keyed on the ISO 3779 / SAE J272 VIN structure. Returns make, model, year, displacement, cylinders, fuel type.
2. **Offline WMI table** — ~35 prefix entries covering the European + North American brands most likely to appear (PSA, VW Group, BMW, Mercedes, Ford, Toyota, Fiat, Hyundai/Kia, Tesla). Make + country only — no engine data in the WMI. Runs when the network path errors out.
3. **Invalid-VIN path** — empty `VinDecodeResult(source: invalid)`. Caller's cue to drop into manual vehicle entry.

The decoder never throws. Every error path yields a `VinDecodeResult` with a `source` enum — `nhtsa` / `wmiFallback` / `invalid` — so downstream UI can badge "Confirm your car:" vs "Please enter your vehicle details."

## What's deliberately not in this PR

- **Vehicle profile schema extension** (`engineDisplacementCc`, `cylinderCount`, `volumetricEfficiency`, `curbWeightKg`) — needs a Hive migration. Follow-up in #812 phase 2.
- **Onboarding flow UI** — tracked as #816.
- **Plumbing into `Obd2Service.readFuelRateLPerHour`** — waits on the profile schema.

Shipping the decoder early gets the public API stabilised and tested before the heavier migrations pile on.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] 14 unit tests covering:
  - VIN validation (short, forbidden I/O/Q chars, lowercase normalisation)
  - WMI table: VF3 → Peugeot FR, WVW → VW DE, WBA → BMW, 5YJ → Tesla, TMB → Škoda CZ, unknown → invalid
  - NHTSA happy path: full vPIC response parses every field
  - Graceful fallback on 5xx, empty Results, missing Results key, DNS failure — all land on WMI
  - `VinDecodeResult.isComplete` contract
- [x] Full `flutter test` — 4823/4823 pass (1 pre-existing Argentina network flake, 1 skip)

Refs #800, #812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)