### PR TITLE
refactor(sync): extract AlertsSync from SyncService (#727)

### DIFF
--- a/lib/core/data/impl/supabase_sync_repository.dart
+++ b/lib/core/data/impl/supabase_sync_repository.dart
@@ -1,3 +1,4 @@
+import '../../sync/alerts_sync.dart';
 import '../../sync/price_history_sync.dart';
 import '../../sync/ratings_sync.dart';
 import '../../sync/supabase_client.dart';
@@ -56,7 +57,7 @@ class SupabaseSyncRepository implements SyncRepository {
 
   @override
   Future<List<PriceAlert>> syncAlerts(List<PriceAlert> localAlerts) =>
-      SyncService.syncAlerts(localAlerts);
+      AlertsSync.merge(localAlerts);
 
   // ── Price History ──
 

--- a/lib/core/sync/alerts_sync.dart
+++ b/lib/core/sync/alerts_sync.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/foundation.dart';
+
+import '../../features/alerts/data/models/price_alert.dart';
+import '../utils/json_extensions.dart';
+import 'supabase_client.dart';
+
+/// Price-alert sync with Supabase, pulled out of [SyncService] (#727).
+///
+/// Bidirectional merge:
+///   - local-only alerts upload to the `alerts` table (`id`-conflict
+///     upsert so replaying an already-synced alert is a no-op).
+///   - server-only alerts download and the caller returns a merged
+///     `[localAlerts, ...downloaded]` list.
+///
+/// Unauthenticated / offline paths return the input list unchanged —
+/// the alert UI keeps working on pure-local state.
+class AlertsSync {
+  AlertsSync._();
+
+  /// Merge [localAlerts] with the user's `alerts` rows on Supabase.
+  /// Returns the superset ([local] + server-only downloaded).
+  static Future<List<PriceAlert>> merge(List<PriceAlert> localAlerts) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) {
+      debugPrint('AlertsSync.merge: not authenticated');
+      return localAlerts;
+    }
+
+    try {
+      final serverRows =
+          await client.from('alerts').select().eq('user_id', userId);
+      final serverAlertIds = serverRows
+          .map((r) => r.getString('id'))
+          .whereType<String>()
+          .toSet();
+      final localAlertIds = localAlerts.map((a) => a.id).toSet();
+
+      debugPrint('AlertsSync.merge: local=${localAlertIds.length}, '
+          'server=${serverAlertIds.length}');
+
+      // Upload local-only alerts.
+      final localOnly =
+          localAlerts.where((a) => !serverAlertIds.contains(a.id)).toList();
+      if (localOnly.isNotEmpty) {
+        final rows = localOnly
+            .map((a) => {
+                  'id': a.id,
+                  'user_id': userId,
+                  'station_id': a.stationId,
+                  'station_name': a.stationName,
+                  'fuel_type': a.fuelType.name,
+                  'target_price': a.targetPrice,
+                  'is_active': a.isActive,
+                  'created_at': a.createdAt.toIso8601String(),
+                })
+            .toList();
+        await client.from('alerts').upsert(rows, onConflict: 'id');
+        debugPrint('AlertsSync.merge: uploaded ${localOnly.length} alerts');
+      }
+
+      // Download server-only alerts.
+      final serverOnly = serverRows
+          .where((r) => !localAlertIds.contains(r.getString('id')));
+      final downloaded = serverOnly.map((r) {
+        return PriceAlert.fromJson({
+          'id': r.getString('id') ?? '',
+          'stationId': r.getString('station_id') ?? '',
+          'stationName': r.getString('station_name') ?? '',
+          'fuelType': r.getString('fuel_type') ?? '',
+          'targetPrice': r.getDouble('target_price') ?? 0.0,
+          'isActive': r.getBool('is_active') ?? true,
+          'createdAt': r.getString('created_at') ?? '',
+        });
+      }).toList();
+
+      return [...localAlerts, ...downloaded];
+    } catch (e) {
+      debugPrint('AlertsSync.merge FAILED: $e');
+      return localAlerts;
+    }
+  }
+}

--- a/lib/core/sync/sync_after_change_mixin.dart
+++ b/lib/core/sync/sync_after_change_mixin.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'alerts_sync.dart';
 import 'sync_provider.dart';
 import 'sync_service.dart';
 
@@ -23,7 +24,7 @@ mixin SyncAfterChangeMixin {
     try {
       final syncState = ref.read(syncStateProvider);
       if (syncState.enabled) {
-        await SyncService.syncAlerts(alerts as dynamic);
+        await AlertsSync.merge(alerts as dynamic);
       }
     } catch (e) {
       debugPrint('SyncAfterChange: alerts sync failed: $e');

--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import '../../features/alerts/data/models/price_alert.dart';
 import '../../features/consumption/data/baseline_sync.dart';
 import '../../features/consumption/domain/entities/fill_up.dart';
 import '../../features/itinerary/domain/entities/saved_itinerary.dart';
@@ -140,74 +139,6 @@ class SyncService {
     } catch (e) {
       debugPrint('SyncService.syncIgnoredStations FAILED: $e');
       return localIgnoredIds;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Alerts
-  // ---------------------------------------------------------------------------
-
-  /// Sync alerts: merges local and server sets.
-  static Future<List<PriceAlert>> syncAlerts(
-    List<PriceAlert> localAlerts,
-  ) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) {
-      debugPrint('SyncService.syncAlerts: not authenticated');
-      return localAlerts;
-    }
-
-    try {
-      final serverRows =
-          await client.from('alerts').select().eq('user_id', userId);
-      final serverAlertIds = serverRows
-          .map((r) => r.getString('id'))
-          .whereType<String>()
-          .toSet();
-      final localAlertIds = localAlerts.map((a) => a.id).toSet();
-
-      debugPrint('SyncService.syncAlerts: local=${localAlertIds.length}, server=${serverAlertIds.length}');
-
-      // Upload local-only alerts
-      final localOnly =
-          localAlerts.where((a) => !serverAlertIds.contains(a.id)).toList();
-      if (localOnly.isNotEmpty) {
-        final rows = localOnly
-            .map((a) => {
-                  'id': a.id,
-                  'user_id': userId,
-                  'station_id': a.stationId,
-                  'station_name': a.stationName,
-                  'fuel_type': a.fuelType.name,
-                  'target_price': a.targetPrice,
-                  'is_active': a.isActive,
-                  'created_at': a.createdAt.toIso8601String(),
-                })
-            .toList();
-        await client.from('alerts').upsert(rows, onConflict: 'id');
-        debugPrint('SyncService.syncAlerts: uploaded ${localOnly.length} alerts');
-      }
-
-      // Download server-only alerts
-      final serverOnly =
-          serverRows.where((r) => !localAlertIds.contains(r.getString('id')));
-      final downloaded = serverOnly.map((r) {
-        return PriceAlert.fromJson({
-          'id': r.getString('id') ?? '',
-          'stationId': r.getString('station_id') ?? '',
-          'stationName': r.getString('station_name') ?? '',
-          'fuelType': r.getString('fuel_type') ?? '',
-          'targetPrice': r.getDouble('target_price') ?? 0.0,
-          'isActive': r.getBool('is_active') ?? true,
-          'createdAt': r.getString('created_at') ?? '',
-        });
-      }).toList();
-
-      return [...localAlerts, ...downloaded];
-    } catch (e) {
-      debugPrint('SyncService.syncAlerts FAILED: $e');
-      return localAlerts;
     }
   }
 

--- a/lib/features/alerts/providers/alert_provider.dart
+++ b/lib/features/alerts/providers/alert_provider.dart
@@ -3,7 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/background/background_service.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/sync_provider.dart';
-import '../../../core/sync/sync_service.dart';
+import '../../../core/sync/alerts_sync.dart';
 import '../data/models/price_alert.dart';
 import '../data/repositories/alert_repository.dart';
 
@@ -80,7 +80,7 @@ class AlertNotifier extends _$AlertNotifier {
     try {
       final syncState = ref.read(syncStateProvider);
       if (syncState.enabled) {
-        await SyncService.syncAlerts(state);
+        await AlertsSync.merge(state);
       }
     } catch (e) {
       debugPrint('AlertProvider: sync failed: $e');

--- a/lib/features/sync/providers/data_transparency_provider.dart
+++ b/lib/features/sync/providers/data_transparency_provider.dart
@@ -3,6 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/sync/supabase_client.dart';
 import '../../../core/sync/sync_provider.dart';
+import '../../../core/sync/alerts_sync.dart';
 import '../../../core/sync/sync_service.dart';
 import '../../alerts/providers/alert_provider.dart';
 import '../../favorites/providers/favorites_provider.dart';
@@ -119,7 +120,7 @@ class DataTransparencyController extends _$DataTransparencyController {
 
       final alerts = ref.read(alertProvider);
       debugPrint('DataTransparency: syncing ${alerts.length} local alerts');
-      await SyncService.syncAlerts(alerts);
+      await AlertsSync.merge(alerts);
     } catch (e) {
       debugPrint('DataTransparency: force sync failed: $e');
     }

--- a/lib/features/sync/providers/link_device_provider.dart
+++ b/lib/features/sync/providers/link_device_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/sync/supabase_client.dart';
+import '../../../core/sync/alerts_sync.dart';
 import '../../../core/sync/sync_service.dart';
 import '../../alerts/data/models/price_alert.dart';
 import '../../alerts/providers/alert_provider.dart';
@@ -165,7 +166,7 @@ class LinkDeviceController extends _$LinkDeviceController {
       // 7. Sync merged data back to our server account. Profile is NOT
       // synced — each device keeps its own local profile + defaulting.
       await SyncService.syncFavorites(ref.read(favoritesProvider));
-      await SyncService.syncAlerts(ref.read(alertProvider));
+      await AlertsSync.merge(ref.read(alertProvider));
       await SyncService.syncVehicles(ref.read(vehicleProfileListProvider));
       await SyncService.syncFillUps(ref.read(fillUpListProvider));
 

--- a/test/core/sync/alerts_sync_test.dart
+++ b/test/core/sync/alerts_sync_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/alerts_sync.dart';
+import 'package:tankstellen/features/alerts/data/models/price_alert.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Contract tests for [AlertsSync] (#727 extract). The real bidirectional
+/// merge talks to Supabase; a pure unit test can only exercise the
+/// unauthenticated guard (client null → input passed through). Higher-
+/// fidelity coverage lives in
+/// `test/core/data/supabase_sync_repository_test.dart` at the
+/// repository layer (preserved unchanged across this refactor).
+void main() {
+  group('AlertsSync auth guards', () {
+    test('merge returns the input list unchanged when unauthenticated',
+        () async {
+      final local = [
+        PriceAlert(
+          id: 'a1',
+          stationId: 'st-1',
+          stationName: 'Shell Pomerols',
+          fuelType: FuelType.e10,
+          targetPrice: 1.75,
+          isActive: true,
+          createdAt: DateTime(2026, 4, 21),
+        ),
+      ];
+      final result = await AlertsSync.merge(local);
+      expect(result, equals(local));
+    });
+
+    test('merge handles an empty list without errors', () async {
+      final result = await AlertsSync.merge(const <PriceAlert>[]);
+      expect(result, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Third chunk off `sync_service.dart` after #808 (PriceHistorySync) and #809 (RatingsSync). Same template: pull a cohesive method group into a dedicated file, rename for intent, migrate callers to the new class.

## What changed

- **`lib/core/sync/alerts_sync.dart`** (new, 84 LOC) — `AlertsSync.merge(localAlerts)` with the same bidirectional-merge body. Renamed from `syncAlerts` because the method is a merge, not a one-way sync.
- **`lib/core/sync/sync_service.dart`** — 62-line method + section header + unused `PriceAlert` import all deleted (617 → 544 LOC).
- **Callers migrated (5 sites):**
  - `SupabaseSyncRepository` — delegator (keeps its repository-interface name, public contract unchanged)
  - `SyncAfterChangeMixin.syncAlertsIfConnected`
  - `AlertProvider._syncAlertsIfConnected`
  - `LinkDeviceProvider` (post-import resync)
  - `DataTransparencyProvider` (force-sync action)
- **`test/core/sync/alerts_sync_test.dart`** (new, 2 cases) — pin the client-null guard + empty-list guard.

## Session cumulative sync_service.dart reduction

| Start | After #808 | After #809 | After this PR |
|---|---|---|---|
| 713 | 685 | 617 | **544** (−24 %) |

Remaining candidate blocks: Ignored Stations (~40 LOC), Vehicles, Fill-ups, Baselines, Data-transparency.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] `flutter test test/core/sync test/core/data test/features/alerts` — 236/236 pass
- [x] `SupabaseSyncRepository` test preserved unchanged (repository contract untouched)

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)