### PR TITLE
refactor(sync): extract IgnoredStationsSync from SyncService (#727)

### DIFF
--- a/lib/core/data/impl/supabase_sync_repository.dart
+++ b/lib/core/data/impl/supabase_sync_repository.dart
@@ -1,4 +1,5 @@
 import '../../sync/alerts_sync.dart';
+import '../../sync/ignored_stations_sync.dart';
 import '../../sync/price_history_sync.dart';
 import '../../sync/ratings_sync.dart';
 import '../../sync/supabase_client.dart';
@@ -37,7 +38,7 @@ class SupabaseSyncRepository implements SyncRepository {
 
   @override
   Future<List<String>> syncIgnoredStations(List<String> localIds) =>
-      SyncService.syncIgnoredStations(localIds);
+      IgnoredStationsSync.merge(localIds);
 
   // ── Ratings ──
 

--- a/lib/core/sync/ignored_stations_sync.dart
+++ b/lib/core/sync/ignored_stations_sync.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/foundation.dart';
+
+import '../utils/json_extensions.dart';
+import 'supabase_client.dart';
+
+/// Ignored-stations sync with Supabase, pulled out of [SyncService] (#727).
+///
+/// Same bidirectional-merge pattern as favorites: upload local-only
+/// ids (idempotent via `(user_id, station_id)` upsert conflict), then
+/// return the union of local + server sets. Unauthenticated path
+/// returns the input unchanged — the feature keeps working on pure
+/// local state when the user isn't signed in.
+class IgnoredStationsSync {
+  IgnoredStationsSync._();
+
+  /// Merge [localIgnoredIds] with the user's `ignored_stations` rows
+  /// on Supabase. Returns the superset (local ∪ server).
+  static Future<List<String>> merge(List<String> localIgnoredIds) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) {
+      debugPrint('IgnoredStationsSync.merge: not authenticated');
+      return localIgnoredIds;
+    }
+
+    try {
+      final serverRows = await client
+          .from('ignored_stations')
+          .select('station_id')
+          .eq('user_id', userId);
+      final serverIds = serverRows
+          .map((r) => r.getString('station_id'))
+          .whereType<String>()
+          .toSet();
+      final localIds = localIgnoredIds.toSet();
+
+      debugPrint('IgnoredStationsSync.merge: local=${localIds.length}, '
+          'server=${serverIds.length}');
+
+      // Upload local-only ids.
+      final localOnly = localIds.difference(serverIds);
+      if (localOnly.isNotEmpty) {
+        final rows = localOnly
+            .map((id) => {'user_id': userId, 'station_id': id})
+            .toList();
+        await client
+            .from('ignored_stations')
+            .upsert(rows, onConflict: 'user_id,station_id');
+        debugPrint(
+            'IgnoredStationsSync.merge: uploaded ${localOnly.length}');
+      }
+
+      return localIds.union(serverIds).toList();
+    } catch (e) {
+      debugPrint('IgnoredStationsSync.merge FAILED: $e');
+      return localIgnoredIds;
+    }
+  }
+}

--- a/lib/core/sync/sync_provider.dart
+++ b/lib/core/sync/sync_provider.dart
@@ -6,6 +6,7 @@ import '../storage/storage_providers.dart';
 import 'community_config.dart';
 import 'supabase_client.dart';
 import 'sync_config.dart';
+import 'ignored_stations_sync.dart';
 import 'ratings_sync.dart';
 import 'sync_service.dart';
 
@@ -204,7 +205,7 @@ class SyncState extends _$SyncState {
         final favIds = storage.getFavoriteIds();
         if (favIds.isNotEmpty) await SyncService.syncFavorites(favIds);
         final ignoredIds = storage.getIgnoredIds();
-        if (ignoredIds.isNotEmpty) await SyncService.syncIgnoredStations(ignoredIds);
+        if (ignoredIds.isNotEmpty) await IgnoredStationsSync.merge(ignoredIds);
         final ratings = storage.getRatings();
         for (final entry in ratings.entries) {
           await RatingsSync.upsert(entry.key, entry.value);

--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -98,51 +98,6 @@ class SyncService {
   }
 
   // ---------------------------------------------------------------------------
-  // Ignored Stations
-  // ---------------------------------------------------------------------------
-
-  /// Sync ignored stations: merges local and server sets.
-  static Future<List<String>> syncIgnoredStations(
-    List<String> localIgnoredIds,
-  ) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) {
-      debugPrint('SyncService.syncIgnoredStations: not authenticated');
-      return localIgnoredIds;
-    }
-
-    try {
-      final serverRows = await client
-          .from('ignored_stations')
-          .select('station_id')
-          .eq('user_id', userId);
-      final serverIds = serverRows
-          .map((r) => r.getString('station_id'))
-          .whereType<String>()
-          .toSet();
-      final localIds = localIgnoredIds.toSet();
-
-      debugPrint('SyncService.syncIgnoredStations: local=${localIds.length}, server=${serverIds.length}');
-
-      // Upload local-only
-      final localOnly = localIds.difference(serverIds);
-      if (localOnly.isNotEmpty) {
-        final rows = localOnly
-            .map((id) => {'user_id': userId, 'station_id': id})
-            .toList();
-        await client.from('ignored_stations').upsert(rows, onConflict: 'user_id,station_id');
-        debugPrint('SyncService.syncIgnoredStations: uploaded ${localOnly.length}');
-      }
-
-      return localIds.union(serverIds).toList();
-    } catch (e) {
-      debugPrint('SyncService.syncIgnoredStations FAILED: $e');
-      return localIgnoredIds;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
   // Data transparency
   // ---------------------------------------------------------------------------
 

--- a/lib/features/search/providers/ignored_stations_provider.dart
+++ b/lib/features/search/providers/ignored_stations_provider.dart
@@ -1,7 +1,7 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/storage/storage_providers.dart';
+import '../../../core/sync/ignored_stations_sync.dart';
 import '../../../core/sync/sync_helper.dart';
-import '../../../core/sync/sync_service.dart';
 
 part 'ignored_stations_provider.g.dart';
 
@@ -28,7 +28,7 @@ class IgnoredStations extends _$IgnoredStations {
     state = storage.getIgnoredIds();
 
     await SyncHelper.syncIfEnabled(ref, 'IgnoredStations.add',
-      () => SyncService.syncIgnoredStations(state),
+      () => IgnoredStationsSync.merge(state),
     );
   }
 
@@ -39,7 +39,7 @@ class IgnoredStations extends _$IgnoredStations {
     state = storage.getIgnoredIds();
 
     await SyncHelper.syncIfEnabled(ref, 'IgnoredStations.remove',
-      () => SyncService.syncIgnoredStations(state),
+      () => IgnoredStationsSync.merge(state),
     );
   }
 

--- a/test/core/sync/ignored_stations_sync_test.dart
+++ b/test/core/sync/ignored_stations_sync_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/ignored_stations_sync.dart';
+
+/// Contract tests for [IgnoredStationsSync] (#727 extract). The real
+/// bidirectional-merge path talks to Supabase; a pure unit test can
+/// only exercise the unauthenticated guard. Higher-fidelity coverage
+/// lives at the repository layer in
+/// `test/core/data/supabase_sync_repository_test.dart`.
+void main() {
+  group('IgnoredStationsSync auth guards', () {
+    test('merge returns the input list unchanged when unauthenticated',
+        () async {
+      final local = ['st-1', 'st-2', 'st-3'];
+      final result = await IgnoredStationsSync.merge(local);
+      expect(result, equals(local));
+    });
+
+    test('merge handles an empty list without errors', () async {
+      final result = await IgnoredStationsSync.merge(const <String>[]);
+      expect(result, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fourth chunk off `sync_service.dart` after #808 (PriceHistorySync), #809 (RatingsSync), and #819 (AlertsSync). Ignored stations are the simplest bidirectional merge — ids only, same shape as favorites — so this extract is almost mechanical.

## What changed

- **`lib/core/sync/ignored_stations_sync.dart`** (new, 60 LOC) — `IgnoredStationsSync.merge(localIds)`. Renamed for intent: it's a bidirectional merge, not a one-way sync.
- **`lib/core/sync/sync_service.dart`** — method + section header deleted (544 → 496 LOC).
- **Callers migrated (3 sites):**
  - `SupabaseSyncRepository.syncIgnoredStations` delegator (keeps interface name)
  - `IgnoredStations.add` / `.remove` (search providers)
  - `SyncProvider._performInitialSync` (login hydration)
- **`test/core/sync/ignored_stations_sync_test.dart`** (new, 2 cases) — client-null / empty-list contract pins.

## Session cumulative sync_service.dart reduction

| Start | After #808 | After #809 | After #819 | After this PR |
|---|---|---|---|---|
| 713 | 685 | 617 | 544 | **496** (−30 % cumulative) |

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] `flutter test test/core/sync test/core/data test/features/search` — 733/733 pass

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)