### PR TITLE
refactor(sync): extract BaselinesSync from SyncService (#727)

### DIFF
--- a/lib/core/sync/baselines_sync.dart
+++ b/lib/core/sync/baselines_sync.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../../features/consumption/data/baseline_sync.dart';
+import 'supabase_client.dart';
+
+/// Per-vehicle OBD2 baseline sync with Supabase (#780), pulled out of
+/// [SyncService] (#727).
+///
+/// Baselines are heavier than the other sync concerns: the payload
+/// is a JSON blob keyed by driving situation (per-situation
+/// accumulators the trip recorder builds), and the merge rule is
+/// "for every situation, the accumulator with the higher sample
+/// count wins". That merge logic lives in
+/// `features/consumption/data/baseline_sync.dart`
+/// (`mergeBaselineJson`, `totalSampleCount`) — we just wire it up to
+/// the Supabase `obd2_baselines` table here.
+class BaselinesSync {
+  BaselinesSync._();
+
+  /// Two-way merge of one vehicle's baseline. Returns the merged JSON
+  /// payload that callers should persist locally; returns the
+  /// original [localJson] unchanged when offline or unauthenticated,
+  /// so baseline recording keeps working without the cloud layer.
+  ///
+  /// [totalSampleCountOverride] lets the caller supply a pre-computed
+  /// total — the Dart layer already counts samples for the status UI,
+  /// so we avoid decoding the JSON twice when it's already available.
+  static Future<String?> merge({
+    required String vehicleId,
+    required String? localJson,
+    int? totalSampleCountOverride,
+  }) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) {
+      debugPrint('BaselinesSync.merge: not authenticated');
+      return localJson;
+    }
+
+    try {
+      final serverRow = await client
+          .from('obd2_baselines')
+          .select('data')
+          .eq('user_id', userId)
+          .eq('vehicle_id', vehicleId)
+          .maybeSingle();
+
+      final serverData = serverRow == null
+          ? null
+          : (serverRow['data'] as Map?)?.cast<String, dynamic>();
+
+      final merged = mergeBaselineJson(
+        localJson,
+        serverData == null ? null : jsonEncode(serverData),
+      );
+      if (merged == null) return localJson;
+
+      final mergedDecoded =
+          (jsonDecode(merged) as Map).cast<String, dynamic>();
+      final total =
+          totalSampleCountOverride ?? totalSampleCount(mergedDecoded);
+
+      await client.from('obd2_baselines').upsert(
+        {
+          'user_id': userId,
+          'vehicle_id': vehicleId,
+          'total_samples': total,
+          'data': mergedDecoded,
+          'updated_at': DateTime.now().toIso8601String(),
+        },
+        onConflict: 'user_id,vehicle_id',
+      );
+      return merged;
+    } catch (e) {
+      debugPrint('BaselinesSync.merge FAILED: $e');
+      return localJson;
+    }
+  }
+
+  /// Remove a single vehicle's baseline from the server. Called on
+  /// explicit "Forget baseline" from the vehicle edit UI. Silent on
+  /// failure — there's nothing the caller can do about a network
+  /// blip, and the local copy is already gone by the time this runs.
+  static Future<void> delete(String vehicleId) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return;
+    try {
+      await client
+          .from('obd2_baselines')
+          .delete()
+          .eq('user_id', userId)
+          .eq('vehicle_id', vehicleId);
+    } catch (e) {
+      debugPrint('BaselinesSync.delete FAILED: $e');
+    }
+  }
+}

--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -1,9 +1,6 @@
-import 'dart:convert';
-
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import '../../features/consumption/data/baseline_sync.dart';
 import '../../features/consumption/domain/entities/fill_up.dart';
 import '../../features/itinerary/domain/entities/saved_itinerary.dart';
 import '../../features/vehicle/domain/entities/vehicle_profile.dart';
@@ -415,87 +412,4 @@ class SyncService {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // OBD2 baselines (#780)
-  // ---------------------------------------------------------------------------
-
-  /// Two-way sync of the baseline payload for a single vehicle.
-  /// Merge rule is per-situation: for every driving situation, the
-  /// accumulator with the higher sample count wins. Returns the
-  /// merged JSON payload that callers should persist locally and
-  /// hand back to [BaselineStore]; returns the original [localJson]
-  /// unchanged when offline or unauthenticated.
-  ///
-  /// [totalSampleCountOverride] lets the caller supply a
-  /// pre-computed total — the Dart layer already counts samples for
-  /// the status UI, so we avoid decoding the JSON twice when it's
-  /// already available.
-  static Future<String?> syncVehicleBaseline({
-    required String vehicleId,
-    required String? localJson,
-    int? totalSampleCountOverride,
-  }) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) {
-      debugPrint('SyncService.syncVehicleBaseline: not authenticated');
-      return localJson;
-    }
-
-    try {
-      final serverRow = await client
-          .from('obd2_baselines')
-          .select('data')
-          .eq('user_id', userId)
-          .eq('vehicle_id', vehicleId)
-          .maybeSingle();
-
-      final serverData = serverRow == null
-          ? null
-          : (serverRow['data'] as Map?)?.cast<String, dynamic>();
-
-      final merged = mergeBaselineJson(
-        localJson,
-        serverData == null ? null : jsonEncode(serverData),
-      );
-      if (merged == null) return localJson;
-
-      final mergedDecoded =
-          (jsonDecode(merged) as Map).cast<String, dynamic>();
-      final total = totalSampleCountOverride ??
-          totalSampleCount(mergedDecoded);
-
-      await client.from('obd2_baselines').upsert(
-        {
-          'user_id': userId,
-          'vehicle_id': vehicleId,
-          'total_samples': total,
-          'data': mergedDecoded,
-          'updated_at': DateTime.now().toIso8601String(),
-        },
-        onConflict: 'user_id,vehicle_id',
-      );
-      return merged;
-    } catch (e) {
-      debugPrint('SyncService.syncVehicleBaseline FAILED: $e');
-      return localJson;
-    }
-  }
-
-  /// Remove a single vehicle's baseline from the server. Called on
-  /// explicit "Forget baseline" from the vehicle edit UI.
-  static Future<void> deleteVehicleBaseline(String vehicleId) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) return;
-    try {
-      await client
-          .from('obd2_baselines')
-          .delete()
-          .eq('user_id', userId)
-          .eq('vehicle_id', vehicleId);
-    } catch (e) {
-      debugPrint('SyncService.deleteVehicleBaseline FAILED: $e');
-    }
-  }
 }

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -8,7 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/storage/hive_boxes.dart';
 import '../../../core/storage/storage_keys.dart';
 import '../../../core/storage/storage_providers.dart';
-import '../../../core/sync/sync_service.dart';
+import '../../../core/sync/baselines_sync.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/baseline_store.dart';
@@ -395,7 +395,7 @@ class TripRecording extends _$TripRecording {
       final box = Hive.box<String>(HiveBoxes.obd2Baselines);
       final key = 'baseline:$vehicleId';
       final localJson = box.get(key);
-      final merged = await SyncService.syncVehicleBaseline(
+      final merged = await BaselinesSync.merge(
         vehicleId: vehicleId,
         localJson: localJson,
       );

--- a/test/core/sync/baselines_sync_test.dart
+++ b/test/core/sync/baselines_sync_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/baselines_sync.dart';
+
+/// Contract tests for [BaselinesSync] (#727 extract). The real
+/// bidirectional merge talks to Supabase + runs `mergeBaselineJson`;
+/// a pure unit test can only exercise the unauthenticated guard
+/// (TankSyncClient null → inputs passed through).
+void main() {
+  group('BaselinesSync auth guards', () {
+    test('merge returns the localJson unchanged when unauthenticated',
+        () async {
+      const localJson = '{"cruise-flat":{"samples":12,"lPer100":6.1}}';
+      final result = await BaselinesSync.merge(
+        vehicleId: 'veh-1',
+        localJson: localJson,
+      );
+      expect(result, localJson);
+    });
+
+    test('merge returns null when localJson is null and unauthenticated',
+        () async {
+      final result = await BaselinesSync.merge(
+        vehicleId: 'veh-1',
+        localJson: null,
+      );
+      expect(result, isNull);
+    });
+
+    test('delete is a no-op when unauthenticated', () async {
+      // Silent on failure by design — shouldn't throw, shouldn't
+      // leave the process in a bad state.
+      await BaselinesSync.delete('veh-1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fifth chunk off `sync_service.dart` after #808 / #809 / #819 / #820. OBD2 baseline sync (#780) owns a per-vehicle JSON payload with a situation-keyed merge rule — heavier than the other merge paths, but just as cleanly separable.

## What changed

- **`lib/core/sync/baselines_sync.dart`** (new, 101 LOC) — `BaselinesSync.merge` (two-way JSON merge) + `BaselinesSync.delete`. Renamed from `syncVehicleBaseline` / `deleteVehicleBaseline` for consistency with the other sync classes.
- **`lib/core/sync/sync_service.dart`** — both methods + section header + now-unused `dart:convert` and `baseline_sync.dart` imports deleted (496 → 415 LOC).
- **Callers migrated (1 site):** `TripRecordingProvider.endTrip` was the only external consumer. `deleteVehicleBaseline` had no external callers and moved to the new class unchanged.
- **`test/core/sync/baselines_sync_test.dart`** (new, 3 cases) — client-null guard for both `merge` and `delete`.

## Session cumulative sync_service.dart reduction

| Start | #808 | #809 | #819 | #820 | This PR |
|---|---|---|---|---|---|
| 713 | 685 | 617 | 544 | 496 | **415** (−42 %) |

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] `flutter test test/core/sync test/features/consumption` — 570/570 pass
- [x] `TripRecordingProvider` existing baseline test preserved

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)