### PR TITLE
refactor(sync): extract VehiclesSync from SyncService (#727)

### DIFF
--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -3,7 +3,6 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../features/consumption/domain/entities/fill_up.dart';
 import '../../features/itinerary/domain/entities/saved_itinerary.dart';
-import '../../features/vehicle/domain/entities/vehicle_profile.dart';
 import '../utils/json_extensions.dart';
 import 'supabase_client.dart';
 
@@ -236,95 +235,6 @@ class SyncService {
     await client.from('price_reports').delete().eq('reporter_id', userId);
     await client.from('vehicles').delete().eq('user_id', userId);
     await client.from('fill_ups').delete().eq('user_id', userId);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Vehicles (#713)
-  // ---------------------------------------------------------------------------
-
-  /// Two-way sync of vehicles: uploads local-only, downloads server-only.
-  /// Profiles are NOT synced (each device keeps its own defaulting).
-  static Future<List<VehicleProfile>> syncVehicles(
-    List<VehicleProfile> localVehicles,
-  ) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) {
-      debugPrint('SyncService.syncVehicles: not authenticated');
-      return localVehicles;
-    }
-
-    try {
-      final serverRows = await client
-          .from('vehicles')
-          .select('id, data')
-          .eq('user_id', userId);
-
-      final serverIds = serverRows
-          .map((r) => r.getString('id'))
-          .whereType<String>()
-          .toSet();
-      final localIds = localVehicles.map((v) => v.id).toSet();
-
-      debugPrint(
-          'SyncService.syncVehicles: local=${localIds.length}, server=${serverIds.length}');
-
-      // Upload local-only vehicles.
-      final localOnly =
-          localVehicles.where((v) => !serverIds.contains(v.id)).toList();
-      if (localOnly.isNotEmpty) {
-        final rows = localOnly
-            .map((v) => {
-                  'id': v.id,
-                  'user_id': userId,
-                  'data': v.toJson(),
-                  'updated_at': DateTime.now().toIso8601String(),
-                })
-            .toList();
-        await client
-            .from('vehicles')
-            .upsert(rows, onConflict: 'user_id,id');
-        debugPrint(
-            'SyncService.syncVehicles: uploaded ${localOnly.length} new vehicles');
-      }
-
-      // Download server-only vehicles.
-      final downloaded = serverRows
-          .where((r) => !localIds.contains(r.getString('id')))
-          .map((r) {
-        final data = r['data'];
-        if (data is Map<String, dynamic>) {
-          try {
-            return VehicleProfile.fromJson(data);
-          } catch (e) {
-            debugPrint('SyncService.syncVehicles decode failed: $e');
-            return null;
-          }
-        }
-        return null;
-      }).whereType<VehicleProfile>().toList();
-
-      return [...localVehicles, ...downloaded];
-    } catch (e) {
-      debugPrint('SyncService.syncVehicles FAILED: $e');
-      return localVehicles;
-    }
-  }
-
-  /// Remove a single vehicle from the server (called on explicit delete).
-  static Future<void> deleteVehicle(String vehicleId) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) return;
-    try {
-      await client
-          .from('vehicles')
-          .delete()
-          .eq('user_id', userId)
-          .eq('id', vehicleId);
-    } catch (e) {
-      debugPrint('SyncService.deleteVehicle FAILED: $e');
-    }
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/core/sync/vehicles_sync.dart
+++ b/lib/core/sync/vehicles_sync.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/foundation.dart';
+
+import '../../features/vehicle/domain/entities/vehicle_profile.dart';
+import '../utils/json_extensions.dart';
+import 'supabase_client.dart';
+
+/// Per-vehicle profile sync with Supabase (#713), pulled out of
+/// [SyncService] (#727).
+///
+/// Vehicles are the one sync concern where the server row carries a
+/// full domain JSON blob (engine fuel type, display name, flex-fuel
+/// config, per-vehicle defaults) rather than a bare id — the
+/// download branch decodes each row back into a [VehicleProfile]
+/// and appends it to the local list.
+///
+/// Per-device `UserProfile`s are NOT synced (each device keeps its
+/// own defaulting), only the `VehicleProfile`s. That invariant is
+/// what the merge rule here preserves.
+class VehiclesSync {
+  VehiclesSync._();
+
+  /// Merge [localVehicles] with the user's `vehicles` rows on
+  /// Supabase. Returns the superset (local + server-only downloaded).
+  /// Unauthenticated path returns the input unchanged.
+  static Future<List<VehicleProfile>> merge(
+    List<VehicleProfile> localVehicles,
+  ) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) {
+      debugPrint('VehiclesSync.merge: not authenticated');
+      return localVehicles;
+    }
+
+    try {
+      final serverRows = await client
+          .from('vehicles')
+          .select('id, data')
+          .eq('user_id', userId);
+
+      final serverIds = serverRows
+          .map((r) => r.getString('id'))
+          .whereType<String>()
+          .toSet();
+      final localIds = localVehicles.map((v) => v.id).toSet();
+
+      debugPrint('VehiclesSync.merge: local=${localIds.length}, '
+          'server=${serverIds.length}');
+
+      // Upload local-only vehicles.
+      final localOnly =
+          localVehicles.where((v) => !serverIds.contains(v.id)).toList();
+      if (localOnly.isNotEmpty) {
+        final rows = localOnly
+            .map((v) => {
+                  'id': v.id,
+                  'user_id': userId,
+                  'data': v.toJson(),
+                  'updated_at': DateTime.now().toIso8601String(),
+                })
+            .toList();
+        await client
+            .from('vehicles')
+            .upsert(rows, onConflict: 'user_id,id');
+        debugPrint('VehiclesSync.merge: uploaded ${localOnly.length} '
+            'new vehicles');
+      }
+
+      // Download server-only vehicles.
+      final downloaded = serverRows
+          .where((r) => !localIds.contains(r.getString('id')))
+          .map((r) {
+        final data = r['data'];
+        if (data is Map<String, dynamic>) {
+          try {
+            return VehicleProfile.fromJson(data);
+          } catch (e) {
+            debugPrint('VehiclesSync.merge decode failed: $e');
+            return null;
+          }
+        }
+        return null;
+      }).whereType<VehicleProfile>().toList();
+
+      return [...localVehicles, ...downloaded];
+    } catch (e) {
+      debugPrint('VehiclesSync.merge FAILED: $e');
+      return localVehicles;
+    }
+  }
+
+  /// Remove a single vehicle from the server (called on explicit
+  /// delete from the vehicle list screen). Silent on failure — the
+  /// local delete already happened and there's nothing the caller
+  /// can do about a transient network blip.
+  static Future<void> delete(String vehicleId) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return;
+    try {
+      await client
+          .from('vehicles')
+          .delete()
+          .eq('user_id', userId)
+          .eq('id', vehicleId);
+    } catch (e) {
+      debugPrint('VehiclesSync.delete FAILED: $e');
+    }
+  }
+}

--- a/lib/features/sync/providers/link_device_provider.dart
+++ b/lib/features/sync/providers/link_device_provider.dart
@@ -4,6 +4,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/sync/supabase_client.dart';
 import '../../../core/sync/alerts_sync.dart';
 import '../../../core/sync/sync_service.dart';
+import '../../../core/sync/vehicles_sync.dart';
 import '../../alerts/data/models/price_alert.dart';
 import '../../alerts/providers/alert_provider.dart';
 import '../../consumption/domain/entities/fill_up.dart';
@@ -167,7 +168,7 @@ class LinkDeviceController extends _$LinkDeviceController {
       // synced — each device keeps its own local profile + defaulting.
       await SyncService.syncFavorites(ref.read(favoritesProvider));
       await AlertsSync.merge(ref.read(alertProvider));
-      await SyncService.syncVehicles(ref.read(vehicleProfileListProvider));
+      await VehiclesSync.merge(ref.read(vehicleProfileListProvider));
       await SyncService.syncFillUps(ref.read(fillUpListProvider));
 
       state = LinkDeviceState(

--- a/test/core/sync/vehicles_sync_test.dart
+++ b/test/core/sync/vehicles_sync_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/vehicles_sync.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+/// Contract tests for [VehiclesSync] (#727 extract). Higher-fidelity
+/// coverage of the bidirectional-merge + decode path would require
+/// mocking Supabase; these tests pin the unauthenticated guard.
+void main() {
+  group('VehiclesSync auth guards', () {
+    test('merge returns the input list unchanged when unauthenticated',
+        () async {
+      final local = <VehicleProfile>[
+        const VehicleProfile(id: 'veh-1', name: 'Peugeot 107'),
+      ];
+      final result = await VehiclesSync.merge(local);
+      expect(result, equals(local));
+    });
+
+    test('merge handles an empty list without errors', () async {
+      final result = await VehiclesSync.merge(const <VehicleProfile>[]);
+      expect(result, isEmpty);
+    });
+
+    test('delete is a no-op when unauthenticated', () async {
+      await VehiclesSync.delete('veh-1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Sixth chunk off `sync_service.dart`. Vehicles are the only sync concern where the server row carries a full domain JSON blob (the `VehicleProfile` with engine fuel type, display name, flex-fuel config, per-vehicle defaults) rather than a bare id — the download branch decodes each row back into a `VehicleProfile`.

## What changed

- **`lib/core/sync/vehicles_sync.dart`** (new, 105 LOC) — `VehiclesSync.merge` (two-way vehicle sync + decode) + `VehiclesSync.delete`.
- **`lib/core/sync/sync_service.dart`** — both methods + section header + now-unused `VehicleProfile` import deleted (415 → 320 LOC).
- **Callers migrated (1 site):** `LinkDeviceProvider` post-import resync. `deleteVehicle` had no external callers and moved unchanged.
- **`test/core/sync/vehicles_sync_test.dart`** (new, 3 cases) — client-null guard for `merge` (with + without data) and `delete`.

## Session cumulative sync_service.dart reduction

| Start | #808 | #809 | #819 | #820 | #821 | This PR |
|---|---|---|---|---|---|---|
| 713 | 685 | 617 | 544 | 496 | 415 | **320** (−55 %) |

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] `flutter test test/core/sync test/features/vehicle` — 185/185 pass

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)