### PR TITLE
refactor(sync): extract FillUpsSync from SyncService (#727)

### DIFF
--- a/lib/core/sync/fill_ups_sync.dart
+++ b/lib/core/sync/fill_ups_sync.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/foundation.dart';
+
+import '../../features/consumption/domain/entities/fill_up.dart';
+import '../utils/json_extensions.dart';
+import 'supabase_client.dart';
+
+/// Per-fill-up consumption-log sync with Supabase (#713), pulled out
+/// of [SyncService] (#727).
+///
+/// Same shape as [VehiclesSync]: the server row carries a full
+/// [FillUp] JSON blob and the download branch decodes each row back
+/// into the domain entity. Merge rule: dedupe by id (both directions
+/// idempotent via `(user_id, id)` upsert conflict). The extra
+/// `vehicle_id` + `recorded_at` columns are for server-side
+/// filtering — clients only read the `data` blob.
+class FillUpsSync {
+  FillUpsSync._();
+
+  /// Merge [localFillUps] with the user's `fill_ups` rows on
+  /// Supabase. Returns the superset (local + server-only downloaded).
+  /// Unauthenticated path returns the input unchanged.
+  static Future<List<FillUp>> merge(List<FillUp> localFillUps) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) {
+      debugPrint('FillUpsSync.merge: not authenticated');
+      return localFillUps;
+    }
+
+    try {
+      final serverRows = await client
+          .from('fill_ups')
+          .select('id, data')
+          .eq('user_id', userId);
+
+      final serverIds = serverRows
+          .map((r) => r.getString('id'))
+          .whereType<String>()
+          .toSet();
+      final localIds = localFillUps.map((f) => f.id).toSet();
+
+      debugPrint('FillUpsSync.merge: local=${localIds.length}, '
+          'server=${serverIds.length}');
+
+      // Upload local-only fill-ups.
+      final localOnly =
+          localFillUps.where((f) => !serverIds.contains(f.id)).toList();
+      if (localOnly.isNotEmpty) {
+        final rows = localOnly
+            .map((f) => {
+                  'id': f.id,
+                  'user_id': userId,
+                  'vehicle_id': f.vehicleId,
+                  'recorded_at': f.date.toIso8601String(),
+                  'data': f.toJson(),
+                  'updated_at': DateTime.now().toIso8601String(),
+                })
+            .toList();
+        await client
+            .from('fill_ups')
+            .upsert(rows, onConflict: 'user_id,id');
+        debugPrint('FillUpsSync.merge: uploaded ${localOnly.length} '
+            'new fill-ups');
+      }
+
+      // Download server-only fill-ups.
+      final downloaded = serverRows
+          .where((r) => !localIds.contains(r.getString('id')))
+          .map((r) {
+        final data = r['data'];
+        if (data is Map<String, dynamic>) {
+          try {
+            return FillUp.fromJson(data);
+          } catch (e) {
+            debugPrint('FillUpsSync.merge decode failed: $e');
+            return null;
+          }
+        }
+        return null;
+      }).whereType<FillUp>().toList();
+
+      return [...localFillUps, ...downloaded];
+    } catch (e) {
+      debugPrint('FillUpsSync.merge FAILED: $e');
+      return localFillUps;
+    }
+  }
+
+  /// Remove a single fill-up from the server (called on explicit
+  /// delete from the consumption log). Silent on failure.
+  static Future<void> delete(String fillUpId) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return;
+    try {
+      await client
+          .from('fill_ups')
+          .delete()
+          .eq('user_id', userId)
+          .eq('id', fillUpId);
+    } catch (e) {
+      debugPrint('FillUpsSync.delete FAILED: $e');
+    }
+  }
+}

--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import '../../features/consumption/domain/entities/fill_up.dart';
 import '../../features/itinerary/domain/entities/saved_itinerary.dart';
 import '../utils/json_extensions.dart';
 import 'supabase_client.dart';
@@ -237,89 +236,5 @@ class SyncService {
     await client.from('fill_ups').delete().eq('user_id', userId);
   }
 
-  // ---------------------------------------------------------------------------
-  // Consumption logs / fill-ups (#713)
-  // ---------------------------------------------------------------------------
-
-  /// Two-way sync of fill-ups (consumption log): uploads local-only,
-  /// downloads server-only. Deduplication by id.
-  static Future<List<FillUp>> syncFillUps(List<FillUp> localFillUps) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) {
-      debugPrint('SyncService.syncFillUps: not authenticated');
-      return localFillUps;
-    }
-
-    try {
-      final serverRows = await client
-          .from('fill_ups')
-          .select('id, data')
-          .eq('user_id', userId);
-
-      final serverIds = serverRows
-          .map((r) => r.getString('id'))
-          .whereType<String>()
-          .toSet();
-      final localIds = localFillUps.map((f) => f.id).toSet();
-
-      debugPrint(
-          'SyncService.syncFillUps: local=${localIds.length}, server=${serverIds.length}');
-
-      final localOnly =
-          localFillUps.where((f) => !serverIds.contains(f.id)).toList();
-      if (localOnly.isNotEmpty) {
-        final rows = localOnly
-            .map((f) => {
-                  'id': f.id,
-                  'user_id': userId,
-                  'vehicle_id': f.vehicleId,
-                  'recorded_at': f.date.toIso8601String(),
-                  'data': f.toJson(),
-                  'updated_at': DateTime.now().toIso8601String(),
-                })
-            .toList();
-        await client.from('fill_ups').upsert(rows, onConflict: 'user_id,id');
-        debugPrint(
-            'SyncService.syncFillUps: uploaded ${localOnly.length} new fill-ups');
-      }
-
-      final downloaded = serverRows
-          .where((r) => !localIds.contains(r.getString('id')))
-          .map((r) {
-        final data = r['data'];
-        if (data is Map<String, dynamic>) {
-          try {
-            return FillUp.fromJson(data);
-          } catch (e) {
-            debugPrint('SyncService.syncFillUps decode failed: $e');
-            return null;
-          }
-        }
-        return null;
-      }).whereType<FillUp>().toList();
-
-      return [...localFillUps, ...downloaded];
-    } catch (e) {
-      debugPrint('SyncService.syncFillUps FAILED: $e');
-      return localFillUps;
-    }
-  }
-
-  /// Remove a single fill-up from the server (called on explicit delete).
-  static Future<void> deleteFillUp(String fillUpId) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) return;
-    try {
-      await client
-          .from('fill_ups')
-          .delete()
-          .eq('user_id', userId)
-          .eq('id', fillUpId);
-    } catch (e) {
-      debugPrint('SyncService.deleteFillUp FAILED: $e');
-    }
-  }
 
 }

--- a/lib/features/sync/providers/link_device_provider.dart
+++ b/lib/features/sync/providers/link_device_provider.dart
@@ -3,6 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/sync/supabase_client.dart';
 import '../../../core/sync/alerts_sync.dart';
+import '../../../core/sync/fill_ups_sync.dart';
 import '../../../core/sync/sync_service.dart';
 import '../../../core/sync/vehicles_sync.dart';
 import '../../alerts/data/models/price_alert.dart';
@@ -169,7 +170,7 @@ class LinkDeviceController extends _$LinkDeviceController {
       await SyncService.syncFavorites(ref.read(favoritesProvider));
       await AlertsSync.merge(ref.read(alertProvider));
       await VehiclesSync.merge(ref.read(vehicleProfileListProvider));
-      await SyncService.syncFillUps(ref.read(fillUpListProvider));
+      await FillUpsSync.merge(ref.read(fillUpListProvider));
 
       state = LinkDeviceState(
         result:

--- a/test/core/sync/fill_ups_sync_test.dart
+++ b/test/core/sync/fill_ups_sync_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/fill_ups_sync.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Contract tests for [FillUpsSync] (#727 extract). Higher-fidelity
+/// tests of the merge + decode path would require mocking Supabase;
+/// these pin the unauthenticated guard for both `merge` and `delete`.
+void main() {
+  group('FillUpsSync auth guards', () {
+    test('merge returns the input list unchanged when unauthenticated',
+        () async {
+      final local = <FillUp>[
+        FillUp(
+          id: 'f-1',
+          vehicleId: 'veh-1',
+          date: DateTime(2026, 4, 22),
+          liters: 5.0,
+          totalCost: 9.95,
+          odometerKm: 123456,
+          fuelType: FuelType.e5,
+        ),
+      ];
+      final result = await FillUpsSync.merge(local);
+      expect(result, equals(local));
+    });
+
+    test('merge handles an empty list without errors', () async {
+      final result = await FillUpsSync.merge(const <FillUp>[]);
+      expect(result, isEmpty);
+    });
+
+    test('delete is a no-op when unauthenticated', () async {
+      await FillUpsSync.delete('f-1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Seventh chunk off `sync_service.dart`. Fill-ups are the last full-JSON sync concern — same shape as vehicles (server row carries a `FillUp` blob, download branch decodes).

## What changed

- **`lib/core/sync/fill_ups_sync.dart`** (new, 109 LOC) — `FillUpsSync.merge` + `FillUpsSync.delete`.
- **`lib/core/sync/sync_service.dart`** — both methods + section header + unused `FillUp` import deleted (320 → 238 LOC).
- **Callers migrated (1 site):** `LinkDeviceProvider` post-import resync. `deleteFillUp` had no external callers and moved unchanged.
- **`test/core/sync/fill_ups_sync_test.dart`** (new, 3 cases) — client-null guard coverage.

## Session cumulative sync_service.dart reduction

| Start | #808 | #809 | #819 | #820 | #821 | #822 | This PR |
|---|---|---|---|---|---|---|---|
| 713 | 685 | 617 | 544 | 496 | 415 | 320 | **238** (−67 %) |

At 238 LOC `sync_service.dart` is roughly right-sized as a Favorites/Itineraries/auth-helper host — remaining extract queue is diminishing returns.

## Test plan

- [x] `flutter analyze` (strict) — clean
- [x] `flutter test test/core/sync/fill_ups_sync_test.dart` — 3/3 pass

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)