### PR TITLE
refactor(sync): extract ItinerariesSync from SyncService (#727)

### DIFF
--- a/lib/core/data/impl/supabase_sync_repository.dart
+++ b/lib/core/data/impl/supabase_sync_repository.dart
@@ -1,5 +1,6 @@
 import '../../sync/alerts_sync.dart';
 import '../../sync/ignored_stations_sync.dart';
+import '../../sync/itineraries_sync.dart';
 import '../../sync/price_history_sync.dart';
 import '../../sync/ratings_sync.dart';
 import '../../sync/supabase_client.dart';
@@ -71,14 +72,14 @@ class SupabaseSyncRepository implements SyncRepository {
 
   @override
   Future<bool> saveItinerary(SavedItinerary itinerary) =>
-      SyncService.saveItinerary(itinerary);
+      ItinerariesSync.save(itinerary);
 
   @override
   Future<List<SavedItinerary>> fetchItineraries() =>
-      SyncService.fetchItineraries();
+      ItinerariesSync.fetchAll();
 
   @override
-  Future<bool> deleteItinerary(String id) => SyncService.deleteItinerary(id);
+  Future<bool> deleteItinerary(String id) => ItinerariesSync.delete(id);
 
   // ── Data Management ──
 

--- a/lib/core/sync/itineraries_sync.dart
+++ b/lib/core/sync/itineraries_sync.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/foundation.dart';
+
+import '../../features/itinerary/domain/entities/saved_itinerary.dart';
+import '../utils/json_extensions.dart';
+import 'supabase_client.dart';
+
+/// Saved-itinerary sync with Supabase, pulled out of [SyncService]
+/// (#727).
+///
+/// Unlike the other merge-style sync classes, itineraries are
+/// one-way from the server's perspective: local provider holds the
+/// source of truth and push explicitly via [save] / [delete] on
+/// every user action, then reconciles with [fetchAll] on login.
+/// Deduplication happens at the caller (the itinerary provider
+/// unions the local list with `fetchAll`'s return before rendering).
+class ItinerariesSync {
+  ItinerariesSync._();
+
+  /// Save or update an itinerary on the server. Returns `true` on
+  /// success, `false` when unauthenticated or the upsert fails —
+  /// mirrors the original contract so the itinerary provider's
+  /// "synced?" badge keeps working.
+  static Future<bool> save(SavedItinerary itinerary) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return false;
+
+    try {
+      await client.from('itineraries').upsert({
+        'id': itinerary.id,
+        'user_id': userId,
+        'name': itinerary.name,
+        'waypoints': itinerary.waypoints,
+        'distance_km': itinerary.distanceKm,
+        'duration_minutes': itinerary.durationMinutes,
+        'avoid_highways': itinerary.avoidHighways,
+        'fuel_type': itinerary.fuelType,
+        'selected_station_ids': itinerary.selectedStationIds,
+        'updated_at': DateTime.now().toIso8601String(),
+      }, onConflict: 'id');
+      debugPrint('ItinerariesSync.save: saved "${itinerary.name}"');
+      return true;
+    } catch (e) {
+      debugPrint('ItinerariesSync.save FAILED: $e');
+      return false;
+    }
+  }
+
+  /// Fetch every itinerary owned by the authenticated user. Returns
+  /// an empty list when unauthenticated or the query fails — the
+  /// provider keeps showing whatever was in local cache.
+  static Future<List<SavedItinerary>> fetchAll() async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return [];
+
+    try {
+      final rows = await client
+          .from('itineraries')
+          .select()
+          .eq('user_id', userId)
+          .order('updated_at', ascending: false);
+
+      return rows.map((r) {
+        final createdAtStr = r.getString('created_at');
+        final updatedAtStr = r.getString('updated_at');
+        return SavedItinerary(
+          id: r.getString('id') ?? '',
+          name: r.getString('name') ?? '',
+          waypoints: r.getList<Map<String, dynamic>>('waypoints'),
+          distanceKm: r.getDouble('distance_km') ?? 0.0,
+          durationMinutes: r.getDouble('duration_minutes') ?? 0.0,
+          avoidHighways: r.getBool('avoid_highways') ?? false,
+          fuelType: r.getString('fuel_type') ?? 'e10',
+          selectedStationIds: r.getList<String>('selected_station_ids'),
+          createdAt: createdAtStr != null
+              ? DateTime.tryParse(createdAtStr) ?? DateTime.now()
+              : DateTime.now(),
+          updatedAt: updatedAtStr != null
+              ? DateTime.tryParse(updatedAtStr) ?? DateTime.now()
+              : DateTime.now(),
+        );
+      }).toList();
+    } catch (e) {
+      debugPrint('ItinerariesSync.fetchAll FAILED: $e');
+      return [];
+    }
+  }
+
+  /// Delete a single itinerary from the server. Returns `true` on
+  /// success, `false` when unauthenticated or the delete fails.
+  static Future<bool> delete(String itineraryId) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return false;
+
+    try {
+      await client
+          .from('itineraries')
+          .delete()
+          .eq('id', itineraryId)
+          .eq('user_id', userId);
+      return true;
+    } catch (e) {
+      debugPrint('ItinerariesSync.delete FAILED: $e');
+      return false;
+    }
+  }
+}

--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import '../../features/itinerary/domain/entities/saved_itinerary.dart';
 import '../utils/json_extensions.dart';
 import 'supabase_client.dart';
 
@@ -130,95 +129,6 @@ class SyncService {
     } catch (e) {
       debugPrint('SyncService.fetchAllUserData FAILED: $e');
       return {'error': e.toString()};
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Itineraries
-  // ---------------------------------------------------------------------------
-
-  /// Save or update an itinerary on the server.
-  static Future<bool> saveItinerary(SavedItinerary itinerary) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) return false;
-
-    try {
-      await client.from('itineraries').upsert({
-        'id': itinerary.id,
-        'user_id': userId,
-        'name': itinerary.name,
-        'waypoints': itinerary.waypoints,
-        'distance_km': itinerary.distanceKm,
-        'duration_minutes': itinerary.durationMinutes,
-        'avoid_highways': itinerary.avoidHighways,
-        'fuel_type': itinerary.fuelType,
-        'selected_station_ids': itinerary.selectedStationIds,
-        'updated_at': DateTime.now().toIso8601String(),
-      }, onConflict: 'id');
-      debugPrint('SyncService.saveItinerary: saved "${itinerary.name}"');
-      return true;
-    } catch (e) {
-      debugPrint('SyncService.saveItinerary FAILED: $e');
-      return false;
-    }
-  }
-
-  /// Fetch all itineraries for the current user.
-  static Future<List<SavedItinerary>> fetchItineraries() async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) return [];
-
-    try {
-      final rows = await client
-          .from('itineraries')
-          .select()
-          .eq('user_id', userId)
-          .order('updated_at', ascending: false);
-
-      return rows.map((r) {
-        final createdAtStr = r.getString('created_at');
-        final updatedAtStr = r.getString('updated_at');
-        return SavedItinerary(
-          id: r.getString('id') ?? '',
-          name: r.getString('name') ?? '',
-          waypoints: r.getList<Map<String, dynamic>>('waypoints'),
-          distanceKm: r.getDouble('distance_km') ?? 0.0,
-          durationMinutes: r.getDouble('duration_minutes') ?? 0.0,
-          avoidHighways: r.getBool('avoid_highways') ?? false,
-          fuelType: r.getString('fuel_type') ?? 'e10',
-          selectedStationIds: r.getList<String>('selected_station_ids'),
-          createdAt: createdAtStr != null
-              ? DateTime.tryParse(createdAtStr) ?? DateTime.now()
-              : DateTime.now(),
-          updatedAt: updatedAtStr != null
-              ? DateTime.tryParse(updatedAtStr) ?? DateTime.now()
-              : DateTime.now(),
-        );
-      }).toList();
-    } catch (e) {
-      debugPrint('SyncService.fetchItineraries FAILED: $e');
-      return [];
-    }
-  }
-
-  /// Delete an itinerary from the server.
-  static Future<bool> deleteItinerary(String itineraryId) async {
-    final client = _client;
-    final userId = _authenticatedUserId;
-    if (client == null || userId == null) return false;
-
-    try {
-      await client
-          .from('itineraries')
-          .delete()
-          .eq('id', itineraryId)
-          .eq('user_id', userId);
-      return true;
-    } catch (e) {
-      debugPrint('SyncService.deleteItinerary FAILED: $e');
-      return false;
     }
   }
 

--- a/lib/features/itinerary/providers/itinerary_provider.dart
+++ b/lib/features/itinerary/providers/itinerary_provider.dart
@@ -4,7 +4,7 @@ import 'package:uuid/uuid.dart';
 
 import '../../../core/data/storage_repository.dart';
 import '../../../core/storage/storage_providers.dart';
-import '../../../core/sync/sync_service.dart';
+import '../../../core/sync/itineraries_sync.dart';
 import '../../../core/sync/sync_provider.dart';
 import '../domain/entities/saved_itinerary.dart';
 import '../../route_search/domain/entities/route_info.dart';
@@ -56,7 +56,7 @@ class ItineraryNotifier extends _$ItineraryNotifier {
     if (!syncState.enabled) return;
 
     try {
-      final serverItineraries = await SyncService.fetchItineraries();
+      final serverItineraries = await ItinerariesSync.fetchAll();
       if (serverItineraries.isEmpty) return;
 
       final storage = ref.read(storageRepositoryProvider);
@@ -80,7 +80,7 @@ class ItineraryNotifier extends _$ItineraryNotifier {
       final serverIds = serverItineraries.map((i) => i.id).toSet();
       for (final localItem in state) {
         if (!serverIds.contains(localItem.id)) {
-          await SyncService.saveItinerary(localItem);
+          await ItinerariesSync.save(localItem);
         }
       }
 
@@ -127,7 +127,7 @@ class ItineraryNotifier extends _$ItineraryNotifier {
 
     // 2. Sync to server (non-blocking)
     try {
-      await SyncService.saveItinerary(itinerary);
+      await ItinerariesSync.save(itinerary);
     } catch (e) {
       debugPrint('ItineraryNotifier.saveRoute sync FAILED: $e');
     }
@@ -144,7 +144,7 @@ class ItineraryNotifier extends _$ItineraryNotifier {
 
     // 2. Delete from server
     try {
-      await SyncService.deleteItinerary(id);
+      await ItinerariesSync.delete(id);
     } catch (e) {
       debugPrint('ItineraryNotifier.delete sync FAILED: $e');
     }

--- a/test/core/sync/itineraries_sync_test.dart
+++ b/test/core/sync/itineraries_sync_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/itineraries_sync.dart';
+import 'package:tankstellen/features/itinerary/domain/entities/saved_itinerary.dart';
+
+/// Contract tests for [ItinerariesSync] (#727 extract). Higher-
+/// fidelity coverage lives at the repository-contract level; these
+/// pin the unauthenticated guards for each method.
+void main() {
+  group('ItinerariesSync auth guards', () {
+    test('save returns false when unauthenticated', () async {
+      final itinerary = SavedItinerary(
+        id: 'it-1',
+        name: 'Pomerols → Castelnau',
+        waypoints: const [],
+        distanceKm: 15.0,
+        durationMinutes: 20.0,
+        avoidHighways: false,
+        fuelType: 'e10',
+        selectedStationIds: const [],
+        createdAt: DateTime(2026, 4, 22),
+        updatedAt: DateTime(2026, 4, 22),
+      );
+      final result = await ItinerariesSync.save(itinerary);
+      expect(result, isFalse);
+    });
+
+    test('fetchAll returns empty list when unauthenticated', () async {
+      final result = await ItinerariesSync.fetchAll();
+      expect(result, isEmpty);
+    });
+
+    test('delete returns false when unauthenticated', () async {
+      final result = await ItinerariesSync.delete('it-1');
+      expect(result, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Eighth chunk off `sync_service.dart`. Itineraries are a three-method CRUD group (`save` / `fetchAll` / `delete`) over the `itineraries` Supabase table — unlike the merge-style classes, itineraries are one-way from the server's perspective (local provider holds source of truth).

## What changed

- **`lib/core/sync/itineraries_sync.dart`** (new, 114 LOC) — `ItinerariesSync.save` / `.fetchAll` / `.delete`.
- **`lib/core/sync/sync_service.dart`** — three methods + section header + unused `SavedItinerary` import deleted (238 → 134 LOC).
- **Callers migrated (4 sites across 2 files):** `SupabaseSyncRepository`'s three delegators + `ItineraryNotifier._loadAndMerge` / `.saveRoute` / `.delete`.
- **`test/core/sync/itineraries_sync_test.dart`** (new, 3 cases) — client-null guard coverage per method.

## Session cumulative sync_service.dart reduction

| Start | #808 | #809 | #819 | #820 | #821 | #822 | #823 | This PR |
|---|---|---|---|---|---|---|---|---|
| 713 | 685 | 617 | 544 | 496 | 415 | 320 | 238 | **134** (−81 %) |

`sync_service.dart` is down to two method groups: Favorites (`syncFavorites` + `deleteFavorite`) and the Data-management block (`fetchAllUserData` + `deleteAllUserData`). A final cleanup PR could retire the class entirely.

## Test plan

- [x] `flutter analyze` (strict) — clean
- [x] `flutter test test/core/sync test/features/itinerary` — 144/144 pass

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)