### PR TITLE
refactor(consumption): extract FillUpVehicleDropdown widget (#727)

### DIFF
--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -22,6 +22,7 @@ import '../widgets/fill_up_date_row.dart';
 import '../widgets/fill_up_input_buttons.dart';
 import '../widgets/fill_up_notes_field.dart';
 import '../widgets/fill_up_numeric_field.dart';
+import '../widgets/fill_up_vehicle_dropdown.dart';
 
 /// Form to add a new [FillUp] entry.
 class AddFillUpScreen extends ConsumerStatefulWidget {
@@ -381,27 +382,12 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
             // when at least one vehicle exists (empty-state above). Fuel is
             // ALWAYS derived from the selected vehicle, never picked
             // directly here.
-            DropdownButtonFormField<String>(
-              initialValue: _vehicleId,
-              decoration: InputDecoration(
-                labelText: l?.fillUpVehicleLabel ?? 'Vehicle',
-                prefixIcon: const Icon(Icons.directions_car_outlined),
-              ),
-              items: vehicles
-                  .map(
-                    (v) => DropdownMenuItem<String>(
-                      value: v.id,
-                      child: Text(v.name),
-                    ),
-                  )
-                  .toList(),
-              validator: (v) =>
-                  v == null ? (l?.fillUpVehicleRequired ?? 'Required') : null,
-              onChanged: (v) {
-                if (v == null) return;
+            FillUpVehicleDropdown(
+              vehicleId: _vehicleId,
+              vehicles: vehicles,
+              onChanged: (id, selected) {
                 setState(() {
-                  _vehicleId = v;
-                  final selected = vehicles.firstWhere((x) => x.id == v);
+                  _vehicleId = id;
                   final derived = _fuelForVehicle(selected);
                   if (derived != null) _fuelType = derived;
                 });

--- a/lib/features/consumption/presentation/widgets/fill_up_vehicle_dropdown.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_vehicle_dropdown.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+
+/// Mandatory vehicle picker on the Add-Fill-Up form (#713).
+///
+/// Renders a `DropdownButtonFormField` over [vehicles], enforces a
+/// non-null selection via the form validator, and calls [onChanged]
+/// with BOTH the id and the resolved [VehicleProfile]. Handing the
+/// profile back lets the caller derive the default fuel type in
+/// the same setState (the fuel picker below the dropdown reacts on
+/// vehicle-switch per #698 — fuel is always the vehicle's fuel).
+///
+/// Pulled out of `add_fill_up_screen.dart` (#727) so the screen's
+/// `build` method drops a 25-line inline block and the dropdown can
+/// be rendered and tapped in isolation by widget tests.
+class FillUpVehicleDropdown extends StatelessWidget {
+  final String? vehicleId;
+  final List<VehicleProfile> vehicles;
+  final void Function(String id, VehicleProfile selected) onChanged;
+
+  const FillUpVehicleDropdown({
+    super.key,
+    required this.vehicleId,
+    required this.vehicles,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return DropdownButtonFormField<String>(
+      initialValue: vehicleId,
+      decoration: InputDecoration(
+        labelText: l?.fillUpVehicleLabel ?? 'Vehicle',
+        prefixIcon: const Icon(Icons.directions_car_outlined),
+      ),
+      items: vehicles
+          .map(
+            (v) => DropdownMenuItem<String>(
+              value: v.id,
+              child: Text(v.name),
+            ),
+          )
+          .toList(),
+      validator: (v) =>
+          v == null ? (l?.fillUpVehicleRequired ?? 'Required') : null,
+      onChanged: (v) {
+        if (v == null) return;
+        final selected = vehicles.firstWhere((x) => x.id == v);
+        onChanged(v, selected);
+      },
+    );
+  }
+}

--- a/test/features/consumption/presentation/widgets/fill_up_vehicle_dropdown_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_vehicle_dropdown_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_vehicle_dropdown.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Tests for [FillUpVehicleDropdown] (#727 extract from
+/// `add_fill_up_screen.dart`). The parent screen's setState + fuel
+/// derivation happen in the callback; the widget itself just renders
+/// the dropdown and forwards the picked value + resolved
+/// [VehicleProfile].
+void main() {
+  const vehicles = <VehicleProfile>[
+    VehicleProfile(id: 'veh-peugeot', name: 'Peugeot 107'),
+    VehicleProfile(id: 'veh-renault', name: 'Renault Clio'),
+  ];
+
+  Future<void> pumpDropdown(
+    WidgetTester tester, {
+    String? vehicleId,
+    void Function(String id, VehicleProfile selected)? onChanged,
+    Locale locale = const Locale('en'),
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Form(
+            child: FillUpVehicleDropdown(
+              vehicleId: vehicleId,
+              vehicles: vehicles,
+              onChanged: onChanged ?? (_, _) {},
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders the localised label and car icon', (tester) async {
+    await pumpDropdown(tester, vehicleId: 'veh-peugeot');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Vehicle'), findsOneWidget);
+    expect(find.byIcon(Icons.directions_car_outlined), findsOneWidget);
+  });
+
+  testWidgets('preselects the initial vehicle', (tester) async {
+    await pumpDropdown(tester, vehicleId: 'veh-peugeot');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Peugeot 107'), findsOneWidget);
+  });
+
+  testWidgets(
+      'forwards both id AND resolved VehicleProfile on change — '
+      'the parent screen needs the VehicleProfile to derive the default fuel',
+      (tester) async {
+    String? capturedId;
+    VehicleProfile? capturedProfile;
+    await pumpDropdown(
+      tester,
+      vehicleId: 'veh-peugeot',
+      onChanged: (id, profile) {
+        capturedId = id;
+        capturedProfile = profile;
+      },
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FillUpVehicleDropdown));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Renault Clio').last);
+    await tester.pumpAndSettle();
+
+    expect(capturedId, 'veh-renault');
+    expect(capturedProfile?.name, 'Renault Clio');
+  });
+
+  testWidgets(
+      'validator rejects a null selection (the field is mandatory per #713)',
+      (tester) async {
+    final formKey = GlobalKey<FormState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Form(
+            key: formKey,
+            child: FillUpVehicleDropdown(
+              vehicleId: null,
+              vehicles: vehicles,
+              onChanged: (_, _) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(formKey.currentState!.validate(), isFalse);
+    await tester.pump();
+    // ARB key `fillUpVehicleRequired` resolves to this on English locale.
+    expect(find.text('Vehicle is required'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Third widget extract from `add_fill_up_screen.dart` after `FillUpDateRow` (PR #806) and `FillUpNotesField` (PR #807). The vehicle dropdown is slightly richer than its siblings — it owns the form validator and has to hand the resolved `VehicleProfile` back to the caller (fuel picker below derives the default fuel from it per #698).

## What changed

- **New**: `lib/features/consumption/presentation/widgets/fill_up_vehicle_dropdown.dart` (58 LOC) — `FillUpVehicleDropdown` with `vehicleId`, `vehicles`, `onChanged(id, selected)`.
- **`add_fill_up_screen.dart`**: 25-line inline `DropdownButtonFormField<String>` becomes a 10-line call site. Screen goes 647 → 629 LOC.
- **Callback shape**: keeps setState + fuel derivation *inside the parent screen* (the widget doesn't know about `_fuelType` or `_fuelForVehicle`). Widget is pure render + validator.
- **New test**: 4 cases — English label, initial preselection, onChanged forwards id + profile, validator rejects null.

## Test plan

- [x] `flutter analyze` (strict) — clean
- [x] `flutter test test/features/consumption/presentation/widgets/fill_up_vehicle_dropdown_test.dart` — 4/4 pass
- [x] `flutter test test/features/consumption` — no regressions in the screen's existing tests

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)