### PR TITLE
refactor(consumption): extract FillUpSaveActions widget (#727)

### DIFF
--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -22,6 +22,7 @@ import '../widgets/fill_up_date_row.dart';
 import '../widgets/fill_up_input_buttons.dart';
 import '../widgets/fill_up_notes_field.dart';
 import '../widgets/fill_up_numeric_field.dart';
+import '../widgets/fill_up_save_actions.dart';
 import '../widgets/fill_up_vehicle_dropdown.dart';
 
 /// Form to add a new [FillUp] entry.
@@ -428,19 +429,10 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
             const SizedBox(height: 12),
             FillUpNotesField(controller: _notesCtrl),
             const SizedBox(height: 24),
-            FilledButton.icon(
-              onPressed: _save,
-              icon: const Icon(Icons.save),
-              label: Text(l?.save ?? 'Save'),
+            FillUpSaveActions(
+              onSave: _save,
+              onReportBadScan: _lastScan != null ? _reportBadScan : null,
             ),
-            if (_lastScan != null) ...[
-              const SizedBox(height: 8),
-              TextButton.icon(
-                onPressed: _reportBadScan,
-                icon: const Icon(Icons.flag_outlined, size: 18),
-                label: Text(l?.reportScanError ?? 'Report scan error'),
-              ),
-            ],
             SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
           ],
         ),

--- a/lib/features/consumption/presentation/widgets/fill_up_save_actions.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_save_actions.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Bottom action block on the Add-Fill-Up form: the primary Save
+/// button plus the conditional "Report scan error" follow-up that
+/// only appears when the form was pre-filled from a receipt/pump
+/// scan (a non-null `_lastScan` on the parent screen).
+///
+/// Keeping the two buttons together in one widget mirrors how they
+/// relate visually — the report button is an affordance tied to
+/// the last scan, not a standalone action.
+///
+/// Pulled out of `add_fill_up_screen.dart` (#727) so the screen's
+/// `build` method drops the ~13-line inline block and the two
+/// buttons can be rendered in isolation by widget tests.
+class FillUpSaveActions extends StatelessWidget {
+  final VoidCallback onSave;
+
+  /// Non-null when the form was pre-filled from a scan; null when
+  /// the user is entering the fill-up manually. The report button
+  /// renders only when this is set.
+  final VoidCallback? onReportBadScan;
+
+  const FillUpSaveActions({
+    super.key,
+    required this.onSave,
+    this.onReportBadScan,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FilledButton.icon(
+          onPressed: onSave,
+          icon: const Icon(Icons.save),
+          label: Text(l?.save ?? 'Save'),
+        ),
+        if (onReportBadScan != null) ...[
+          const SizedBox(height: 8),
+          TextButton.icon(
+            onPressed: onReportBadScan,
+            icon: const Icon(Icons.flag_outlined, size: 18),
+            label: Text(l?.reportScanError ?? 'Report scan error'),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/test/features/consumption/presentation/widgets/fill_up_save_actions_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_save_actions_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_save_actions.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester, {
+    required VoidCallback onSave,
+    VoidCallback? onReportBadScan,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: FillUpSaveActions(
+            onSave: onSave,
+            onReportBadScan: onReportBadScan,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders only the Save button when onReportBadScan is null',
+      (tester) async {
+    await pump(tester, onSave: () {});
+    await tester.pumpAndSettle();
+
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.byIcon(Icons.save), findsOneWidget);
+    expect(find.text('Report scan error'), findsNothing);
+    expect(find.byIcon(Icons.flag_outlined), findsNothing);
+  });
+
+  testWidgets('renders both buttons when onReportBadScan is supplied',
+      (tester) async {
+    await pump(tester, onSave: () {}, onReportBadScan: () {});
+    await tester.pumpAndSettle();
+
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.text('Report scan error'), findsOneWidget);
+    expect(find.byIcon(Icons.flag_outlined), findsOneWidget);
+  });
+
+  testWidgets('Save tap fires onSave', (tester) async {
+    var saved = false;
+    await pump(tester, onSave: () => saved = true);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Save'));
+    expect(saved, isTrue);
+  });
+
+  testWidgets(
+      'Report-scan-error tap fires onReportBadScan (regression guard — '
+      'this affordance only exists after a scan)', (tester) async {
+    var reported = false;
+    await pump(
+      tester,
+      onSave: () {},
+      onReportBadScan: () => reported = true,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Report scan error'));
+    expect(reported, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Fourth widget extract from `add_fill_up_screen.dart` (after `FillUpDateRow` PR #806, `FillUpNotesField` PR #807, `FillUpVehicleDropdown` PR #826). The Save + conditional *Report-scan-error* block travels naturally as a single widget — the report affordance is a follow-up tied to the last scan, not a standalone action.

## What changed

- **New**: `lib/features/consumption/presentation/widgets/fill_up_save_actions.dart` (52 LOC) — `FillUpSaveActions` with required `onSave` and optional `onReportBadScan`. The report button renders only when `onReportBadScan` is non-null (self-documenting contract).
- **`add_fill_up_screen.dart`**: 13-line inline block → 4-line call site. Screen goes **629 → 625 LOC**.
- **New test**: 4 cases — Save-only render, both-buttons render, onSave tap fires, onReportBadScan tap fires.

## Session cumulative `add_fill_up_screen.dart` reduction

| Start | #806 | #807 | #826 | This PR |
|---|---|---|---|---|
| 664 | 659 | 647 | 629 | **625** |

Still above the 300-LOC target — remaining content is mostly the async scan/OBD orchestration methods (`_scanReceipt`, `_scanPumpDisplay`, `_readObd`, `_save`, `_reportBadScan`). Those are state-heavy and worth their own PRs.

## Test plan

- [x] `flutter analyze` (strict) — clean
- [x] `flutter test test/features/consumption/presentation/widgets/fill_up_save_actions_test.dart` — 4/4 pass

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)