### PR TITLE
feat(obd2): readFuelRateLPerHour honours the supported-PIDs cache (#811 phase 2)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -10,6 +10,14 @@ import 'obd2_transport.dart';
 class Obd2Service {
   final Obd2Transport _transport;
 
+  /// Per-connection cache of the Mode 01 PIDs the car supports,
+  /// populated by [discoverSupportedPids]. Reset on every new
+  /// [connect] — each session must re-discover because the user may
+  /// have switched cars since last time. `null` means "we haven't
+  /// asked the car yet, so don't trust this cache to reject PIDs"
+  /// (see [isPidSupported] for the exact semantics).
+  Set<int>? _supportedPids;
+
   Obd2Service(this._transport);
 
   /// `true` when the underlying [Obd2Transport] currently has an open
@@ -20,6 +28,10 @@ class Obd2Service {
   Future<bool> connect() async {
     try {
       await _transport.connect();
+
+      // Clear the per-connection supported-PIDs cache. A new session
+      // may be a different car / different adapter firmware.
+      _supportedPids = null;
 
       // Run initialization sequence
       for (final cmd in Elm327Protocol.initCommands) {
@@ -34,6 +46,20 @@ class Obd2Service {
       return false;
     }
   }
+
+  /// Whether [pid] is known to be supported by the connected vehicle
+  /// (#811). Key semantics:
+  ///
+  ///   - When [discoverSupportedPids] has NOT been called yet
+  ///     (cache is null), returns `true` — we don't know enough to
+  ///     reject the query, so let it go through and surface NO DATA
+  ///     naturally.
+  ///   - When the cache IS populated and [pid] is present, returns
+  ///     `true`.
+  ///   - When the cache IS populated and [pid] is absent, returns
+  ///     `false` — callers skip the query.
+  bool isPidSupported(int pid) =>
+      _supportedPids == null || _supportedPids!.contains(pid);
 
   /// Read the odometer value in km.
   ///
@@ -132,6 +158,11 @@ class Obd2Service {
   /// Returns an empty set when the adapter isn't connected or the
   /// first bitmap can't be read — the caller should fall back to
   /// blind querying.
+  ///
+  /// Also populates the internal per-connection cache, so subsequent
+  /// [isPidSupported] calls short-circuit queries for PIDs the car
+  /// doesn't implement. One walk per trip-recording session is
+  /// enough.
   Future<Set<int>> discoverSupportedPids() async {
     if (!_transport.isConnected) return const <int>{};
     final supported = <int>{};
@@ -156,6 +187,7 @@ class Obd2Service {
         break;
       }
     }
+    _supportedPids = supported;
     return supported;
   }
 
@@ -219,24 +251,38 @@ class Obd2Service {
     int engineDisplacementCc = 1000,
     double volumetricEfficiency = 0.85,
   }) async {
-    // Step 1: direct fuel-rate PID. Already post-trim — no correction.
-    final direct = await _readDouble(
-      Elm327Protocol.engineFuelRateCommand,
-      Elm327Protocol.parseFuelRateLPerHour,
-      label: 'fuelRate',
-    );
-    if (direct != null) return direct;
-
-    // Step 2: MAF-based estimate.
-    final maf = await readMafGramsPerSecond();
-    if (maf != null) {
-      // Stoichiometric petrol: AFR 14.7, density ~740 g/L.
-      // L/h = MAF × 3600 / (14.7 × 740).
-      final rate = maf * 3600.0 / (14.7 * 740.0);
-      return _applyFuelTrimCorrection(rate);
+    // Step 1: direct fuel-rate PID (already post-trim — no correction).
+    // Skipped when #811 discovery proved the car doesn't implement PID 5E.
+    if (isPidSupported(0x5E)) {
+      final direct = await _readDouble(
+        Elm327Protocol.engineFuelRateCommand,
+        Elm327Protocol.parseFuelRateLPerHour,
+        label: 'fuelRate',
+      );
+      if (direct != null) return direct;
     }
 
-    // Step 3: speed-density fallback. Requires MAP + IAT + RPM.
+    // Step 2: MAF-based estimate. Same short-circuit — a Peugeot 107
+    // without a MAF sensor returns empty set on PID 10, saves the
+    // Bluetooth round-trip on every tick.
+    if (isPidSupported(0x10)) {
+      final maf = await readMafGramsPerSecond();
+      if (maf != null) {
+        // Stoichiometric petrol: AFR 14.7, density ~740 g/L.
+        // L/h = MAF × 3600 / (14.7 × 740).
+        final rate = maf * 3600.0 / (14.7 * 740.0);
+        return _applyFuelTrimCorrection(rate);
+      }
+    }
+
+    // Step 3: speed-density fallback. Requires all three of MAP / IAT
+    // / RPM. If any one is known-unsupported, the step can't run and
+    // we surface null — there's no partial correction worth shipping.
+    if (!isPidSupported(0x0B) ||
+        !isPidSupported(0x0F) ||
+        !isPidSupported(0x0C)) {
+      return null;
+    }
     final mapKpa = await readManifoldPressureKpa();
     final iatCelsius = await readIntakeAirTempCelsius();
     final rpm = await readRpm();

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -156,6 +156,98 @@ void main() {
       expect(rate, closeTo(3.389, 0.01));
     });
 
+    group('readFuelRateLPerHour + supported-PID cache — #811 phase 2', () {
+      test(
+          'after discoverSupportedPids, unsupported PIDs are skipped — '
+          'Peugeot 107 case: only MAP+IAT+RPM, no 5E, no MAF', () async {
+        // Peugeot 107 exposes speed/RPM/load/coolant/throttle
+        // /MAP/IAT but neither PID 5E nor MAF. Bitmap: 0x08 on PID
+        // 0B (MAP), 0x02 on 0C (RPM), 0x08 on 0F (IAT). Easier to
+        // hand-craft: a bitmap that supports 0B, 0C, 0F exactly.
+        // bits-from-left (groupBase 0x00):
+        //   PID 0B → byte 1 bit 2 = 0x20
+        //   PID 0C → byte 1 bit 3 = 0x10
+        //   PID 0F → byte 1 bit 6 = 0x02
+        // → byte 1 = 0x32. All other bytes zero + no continuation.
+        final service = await _connected({
+          '0100': '41 00 00 32 00 00>', // PIDs 0B, 0C, 0F supported
+          // Speed-density step responses:
+          '010B': '41 0B 28>', // MAP 40 kPa
+          '010F': '41 0F 41>', // IAT 25 °C
+          '010C': '41 0C 0C 80>', // RPM 800
+          // 5E and 10 intentionally UNMOCKED — if the service tries
+          // them the fake transport returns NO DATA and costs a
+          // round-trip. That's exactly the wasted work the cache
+          // should prevent.
+        });
+        await service.discoverSupportedPids();
+        expect(service.isPidSupported(0x5E), isFalse);
+        expect(service.isPidSupported(0x10), isFalse);
+        expect(service.isPidSupported(0x0B), isTrue);
+
+        final rate = await service.readFuelRateLPerHour();
+        // Speed-density produced a non-null rate → the chain reached
+        // step 3 even though steps 1 and 2 were never queried.
+        expect(rate, isNotNull);
+        expect(rate, greaterThan(0));
+      });
+
+      test(
+          'when cache is not populated, legacy blind-query behavior — '
+          'every step still attempted', () async {
+        // discoverSupportedPids never called → cache stays null →
+        // isPidSupported returns true for every PID → all three
+        // steps query blindly, honouring NO DATA as before.
+        final service = await _connected({
+          '015E': 'NO DATA>',
+          '0110': 'NO DATA>',
+          '010B': 'NO DATA>',
+          '010F': 'NO DATA>',
+          '010C': 'NO DATA>',
+        });
+        expect(service.isPidSupported(0x5E), isTrue);
+        expect(await service.readFuelRateLPerHour(), isNull);
+      });
+
+      test(
+          'cache-clear on reconnect — supported-PIDs forgotten between '
+          'sessions', () async {
+        final service = await _connected({
+          '0100': '41 00 80 00 00 00>', // only PID 01
+        });
+        await service.discoverSupportedPids();
+        expect(service.isPidSupported(0x5E), isFalse);
+
+        await service.disconnect();
+        await service.connect(); // fresh session
+        expect(service.isPidSupported(0x5E), isTrue,
+            reason: 'cache should clear on connect so a new car / '
+                'new adapter firmware gets discovered fresh');
+      });
+
+      test(
+          'MAF supported but 5E not → step 2 wins, step 3 never runs',
+          () async {
+        // Supported-PIDs bitmap sets PID 10 (MAF) but not 5E.
+        // byte 1 bit 0 (= PID 09) through byte 1 bit 7 (= PID 16) —
+        // MAF is PID 0x10 = 16 → byte 1 bit 7 = 0x01.
+        final service = await _connected({
+          '0100': '41 00 00 01 00 00>',
+          '0110': '41 10 04 00>', // MAF = 10.24 g/s
+          '0106': 'NO DATA>',
+          '0107': 'NO DATA>',
+        });
+        await service.discoverSupportedPids();
+        expect(service.isPidSupported(0x5E), isFalse);
+        expect(service.isPidSupported(0x10), isTrue);
+
+        final rate = await service.readFuelRateLPerHour();
+        // MAF path (10.24 × 3600 / (14.7 × 740)) ≈ 3.389 L/h,
+        // no trim correction because trims are NO DATA.
+        expect(rate, closeTo(3.389, 0.01));
+      });
+    });
+
     group('discoverSupportedPids — #811', () {
       test('returns an empty set when the transport is disconnected',
           () async {


### PR DESCRIPTION
## Summary

Wires the supported-PID scan shipped in PR #828 into the fuel-rate fallback chain. When `discoverSupportedPids` has run, `readFuelRateLPerHour` short-circuits every step whose PID is known-unsupported — one saved Bluetooth round-trip per skipped step per tick.

## Concrete impact

Peugeot 107 class (no 5E, no MAF, only MAP+IAT+RPM): every 1-Hz poll was wasting ~200 ms on two NO-DATA queries before landing on the speed-density path. After this PR those are skipped outright.

## Per-connection cache semantics

- Field `_supportedPids` on `Obd2Service`, nullable.
- **Cleared on every `connect()`** — a new session may be a different car / adapter firmware, can't trust stale knowledge.
- `isPidSupported(int pid)` returns `true` when the cache is null (don't reject a query we haven't earned the right to skip). Only rejects when discovery ran AND the PID is absent.

## Call-site changes

- `readFuelRateLPerHour` guards each step on `isPidSupported`.
- Step 3 (speed-density) requires all three of MAP/IAT/RPM; if any one is known-unsupported, return null immediately rather than wasting two queries.
- **Legacy path preserved**: when the cache is null (discovery not run), every step attempts its query — identical to the pre-cache behavior.

## Test plan

- [x] `flutter analyze` (strict) — clean
- [x] 4 new tests: Peugeot 107 shape, cache-null fallback, cache-clear on reconnect, MAF-only path
- [x] All 153 existing OBD2 tests still pass
- [x] `flutter test` — 4896 pass, 1 pre-existing Argentina network flake, 1 skip

Refs #811 phase 2. Phase 3 (per-VIN Hive cache persistence) still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)