### PR TITLE
feat(vehicle): engine fields on VehicleProfile for speed-density fallback (#812 phase 2 schema)

### DIFF
--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'2edb4d01fc0d3db00d9e21ef9720c01d9058635f';
+String _$syncStateHash() => r'5e4b05167e93e50daff104b9216da4426205ae22';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/features/alerts/providers/alert_provider.g.dart
+++ b/lib/features/alerts/providers/alert_provider.g.dart
@@ -83,7 +83,7 @@ final class AlertNotifierProvider
   }
 }
 
-String _$alertNotifierHash() => r'257a9ac9f47ad19ed30d9d5daad65a1f05c3ff15';
+String _$alertNotifierHash() => r'02f0012d204217a9e97145c5085a1ea1c68511bb';
 
 abstract class _$AlertNotifier extends $Notifier<List<PriceAlert>> {
   List<PriceAlert> build();

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'8a34baee13673cf2db56fe041331bfbc0f3cc59d';
+String _$tripRecordingHash() => r'8a9fa9c61361135d9fee2f95ed54ef508e43c2db';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/favorites/providers/favorites_provider.g.dart
+++ b/lib/features/favorites/providers/favorites_provider.g.dart
@@ -68,7 +68,7 @@ final class FavoritesProvider
   }
 }
 
-String _$favoritesHash() => r'eeaeaaf2b3ab96588c1b76279fb72409c6f0414e';
+String _$favoritesHash() => r'6c85fc766234ed476d7f503a32c1b4c3e5c82325';
 
 /// Manages the user's list of favorite station IDs.
 ///

--- a/lib/features/itinerary/providers/itinerary_provider.g.dart
+++ b/lib/features/itinerary/providers/itinerary_provider.g.dart
@@ -53,7 +53,7 @@ final class ItineraryNotifierProvider
   }
 }
 
-String _$itineraryNotifierHash() => r'121a37c112a0b3fef3f602c699f30efafb6f5939';
+String _$itineraryNotifierHash() => r'ef67aedfd8c7c110edda45d6b84505b175fd249f';
 
 /// Manages saved itineraries with local-first strategy:
 /// - Save locally first, then sync to DB

--- a/lib/features/profile/providers/profile_provider.g.dart
+++ b/lib/features/profile/providers/profile_provider.g.dart
@@ -41,7 +41,7 @@ final class ActiveProfileProvider
   }
 }
 
-String _$activeProfileHash() => r'e672e0a69d969b8b2e3153b38310594f93841285';
+String _$activeProfileHash() => r'4765ff10fe161bcf4e29a4b7a07c665031037515';
 
 abstract class _$ActiveProfile extends $Notifier<UserProfile?> {
   UserProfile? build();

--- a/lib/features/search/providers/ignored_stations_provider.g.dart
+++ b/lib/features/search/providers/ignored_stations_provider.g.dart
@@ -65,7 +65,7 @@ final class IgnoredStationsProvider
   }
 }
 
-String _$ignoredStationsHash() => r'468acd69e52460f46f633be68a4092c01f19efa8';
+String _$ignoredStationsHash() => r'7f656b4ccdb9b582c0306f0441bf2a97acb67676';
 
 /// Manages the user's list of ignored (hidden) station IDs.
 ///

--- a/lib/features/search/providers/station_rating_provider.g.dart
+++ b/lib/features/search/providers/station_rating_provider.g.dart
@@ -65,7 +65,7 @@ final class StationRatingsProvider
   }
 }
 
-String _$stationRatingsHash() => r'6c0eeabc75319deede924805414702c37a194837';
+String _$stationRatingsHash() => r'40d01d4275737d48ff2f47a2ff760de775c09a03';
 
 /// Manages station ratings (1-5 stars) with three privacy levels:
 ///

--- a/lib/features/sync/providers/data_transparency_provider.g.dart
+++ b/lib/features/sync/providers/data_transparency_provider.g.dart
@@ -44,7 +44,7 @@ final class DataTransparencyControllerProvider
 }
 
 String _$dataTransparencyControllerHash() =>
-    r'597a78d6a36b719e18b87b268552333bcee2ff63';
+    r'3fdd280505f24ef2e63e1f2988bada5127a1825d';
 
 abstract class _$DataTransparencyController
     extends $Notifier<DataTransparencyState> {

--- a/lib/features/sync/providers/link_device_provider.g.dart
+++ b/lib/features/sync/providers/link_device_provider.g.dart
@@ -42,7 +42,7 @@ final class LinkDeviceControllerProvider
 }
 
 String _$linkDeviceControllerHash() =>
-    r'969f3e1f9a6290557883e1ff7c5d93b27e144cb5';
+    r'ba1275e6f78b156094aa2039806277d33d831635';
 
 abstract class _$LinkDeviceController extends $Notifier<LinkDeviceState> {
   LinkDeviceState build();

--- a/lib/features/vehicle/domain/entities/vehicle_profile.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.dart
@@ -93,6 +93,27 @@ abstract class VehicleProfile with _$VehicleProfile {
     double? tankCapacityL,
     String? preferredFuelType,
 
+    // Engine parameters for the speed-density fuel-rate fallback
+    // (#812). Only populated when the VIN decoder or the user's
+    // manual onboarding entry provides them. `readFuelRateLPerHour`
+    // on a vehicle without these falls back to its generic 1.0 L /
+    // η_v 0.85 defaults — still better than the NO DATA blanks the
+    // Peugeot 107 class was producing before #810.
+    //
+    //   engineDisplacementCc: total swept volume in cubic
+    //     centimetres (e.g. 998 for a 1.0 L 1KR-FE). Null when
+    //     unknown — the math falls back to 1000 cc.
+    //   engineCylinders: used by future features (firing-event-
+    //     based fuel estimation, engine-stress indicators). No
+    //     default — null is honest.
+    //   volumetricEfficiency: 0.60–0.95 range. Default 0.85 is
+    //     reasonable for a typical NA petrol engine at cruise.
+    //     Adaptive calibration (#815) will narrow this per vehicle
+    //     from tankful reconciliation.
+    int? engineDisplacementCc,
+    int? engineCylinders,
+    @Default(0.85) double volumetricEfficiency,
+
     // OBD2 adapter pairing (#784). Persisted so the app can
     // transparently reconnect on launch without prompting the user
     // again. Both fields are nullable — unpaired vehicles carry

--- a/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
@@ -292,7 +292,24 @@ mixin _$VehicleProfile {
 
  String get id; String get name;@VehicleTypeJsonConverter() VehicleType get type;// EV fields
  double? get batteryKwh; double? get maxChargingKw;@ConnectorTypeSetConverter() Set<ConnectorType> get supportedConnectors;@ChargingPreferencesJsonConverter() ChargingPreferences get chargingPreferences;// Combustion fields
- double? get tankCapacityL; String? get preferredFuelType;// OBD2 adapter pairing (#784). Persisted so the app can
+ double? get tankCapacityL; String? get preferredFuelType;// Engine parameters for the speed-density fuel-rate fallback
+// (#812). Only populated when the VIN decoder or the user's
+// manual onboarding entry provides them. `readFuelRateLPerHour`
+// on a vehicle without these falls back to its generic 1.0 L /
+// η_v 0.85 defaults — still better than the NO DATA blanks the
+// Peugeot 107 class was producing before #810.
+//
+//   engineDisplacementCc: total swept volume in cubic
+//     centimetres (e.g. 998 for a 1.0 L 1KR-FE). Null when
+//     unknown — the math falls back to 1000 cc.
+//   engineCylinders: used by future features (firing-event-
+//     based fuel estimation, engine-stress indicators). No
+//     default — null is honest.
+//   volumetricEfficiency: 0.60–0.95 range. Default 0.85 is
+//     reasonable for a typical NA petrol engine at cruise.
+//     Adaptive calibration (#815) will narrow this per vehicle
+//     from tankful reconciliation.
+ int? get engineDisplacementCc; int? get engineCylinders; double get volumetricEfficiency;// OBD2 adapter pairing (#784). Persisted so the app can
 // transparently reconnect on launch without prompting the user
 // again. Both fields are nullable — unpaired vehicles carry
 // null. The MAC is the stable key; the name is the label shown
@@ -310,16 +327,16 @@ $VehicleProfileCopyWith<VehicleProfile> get copyWith => _$VehicleProfileCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,obd2AdapterMac,obd2AdapterName);
+int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,obd2AdapterMac,obd2AdapterName);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName)';
 }
 
 
@@ -330,7 +347,7 @@ abstract mixin class $VehicleProfileCopyWith<$Res>  {
   factory $VehicleProfileCopyWith(VehicleProfile value, $Res Function(VehicleProfile) _then) = _$VehicleProfileCopyWithImpl;
 @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, String? obd2AdapterMac, String? obd2AdapterName
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, String? obd2AdapterMac, String? obd2AdapterName
 });
 
 
@@ -347,7 +364,7 @@ class _$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -358,7 +375,10 @@ as double?,supportedConnectors: null == supportedConnectors ? _self.supportedCon
 as Set<ConnectorType>,chargingPreferences: null == chargingPreferences ? _self.chargingPreferences : chargingPreferences // ignore: cast_nullable_to_non_nullable
 as ChargingPreferences,tankCapacityL: freezed == tankCapacityL ? _self.tankCapacityL : tankCapacityL // ignore: cast_nullable_to_non_nullable
 as double?,preferredFuelType: freezed == preferredFuelType ? _self.preferredFuelType : preferredFuelType // ignore: cast_nullable_to_non_nullable
-as String?,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2AdapterMac // ignore: cast_nullable_to_non_nullable
+as String?,engineDisplacementCc: freezed == engineDisplacementCc ? _self.engineDisplacementCc : engineDisplacementCc // ignore: cast_nullable_to_non_nullable
+as int?,engineCylinders: freezed == engineCylinders ? _self.engineCylinders : engineCylinders // ignore: cast_nullable_to_non_nullable
+as int?,volumetricEfficiency: null == volumetricEfficiency ? _self.volumetricEfficiency : volumetricEfficiency // ignore: cast_nullable_to_non_nullable
+as double,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2AdapterMac // ignore: cast_nullable_to_non_nullable
 as String?,obd2AdapterName: freezed == obd2AdapterName ? _self.obd2AdapterName : obd2AdapterName // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -454,10 +474,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  String? obd2AdapterMac,  String? obd2AdapterName)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  String? obd2AdapterMac,  String? obd2AdapterName)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.obd2AdapterMac,_that.obd2AdapterName);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.obd2AdapterMac,_that.obd2AdapterName);case _:
   return orElse();
 
 }
@@ -475,10 +495,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  String? obd2AdapterMac,  String? obd2AdapterName)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  String? obd2AdapterMac,  String? obd2AdapterName)  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile():
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.obd2AdapterMac,_that.obd2AdapterName);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.obd2AdapterMac,_that.obd2AdapterName);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -495,10 +515,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  String? obd2AdapterMac,  String? obd2AdapterName)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  String? obd2AdapterMac,  String? obd2AdapterName)?  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.obd2AdapterMac,_that.obd2AdapterName);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.obd2AdapterMac,_that.obd2AdapterName);case _:
   return null;
 
 }
@@ -510,7 +530,7 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 @JsonSerializable()
 
 class _VehicleProfile extends VehicleProfile {
-  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.obd2AdapterMac, this.obd2AdapterName}): _supportedConnectors = supportedConnectors,super._();
+  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.obd2AdapterMac, this.obd2AdapterName}): _supportedConnectors = supportedConnectors,super._();
   factory _VehicleProfile.fromJson(Map<String, dynamic> json) => _$VehicleProfileFromJson(json);
 
 @override final  String id;
@@ -530,6 +550,26 @@ class _VehicleProfile extends VehicleProfile {
 // Combustion fields
 @override final  double? tankCapacityL;
 @override final  String? preferredFuelType;
+// Engine parameters for the speed-density fuel-rate fallback
+// (#812). Only populated when the VIN decoder or the user's
+// manual onboarding entry provides them. `readFuelRateLPerHour`
+// on a vehicle without these falls back to its generic 1.0 L /
+// η_v 0.85 defaults — still better than the NO DATA blanks the
+// Peugeot 107 class was producing before #810.
+//
+//   engineDisplacementCc: total swept volume in cubic
+//     centimetres (e.g. 998 for a 1.0 L 1KR-FE). Null when
+//     unknown — the math falls back to 1000 cc.
+//   engineCylinders: used by future features (firing-event-
+//     based fuel estimation, engine-stress indicators). No
+//     default — null is honest.
+//   volumetricEfficiency: 0.60–0.95 range. Default 0.85 is
+//     reasonable for a typical NA petrol engine at cruise.
+//     Adaptive calibration (#815) will narrow this per vehicle
+//     from tankful reconciliation.
+@override final  int? engineDisplacementCc;
+@override final  int? engineCylinders;
+@override@JsonKey() final  double volumetricEfficiency;
 // OBD2 adapter pairing (#784). Persisted so the app can
 // transparently reconnect on launch without prompting the user
 // again. Both fields are nullable — unpaired vehicles carry
@@ -551,16 +591,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,obd2AdapterMac,obd2AdapterName);
+int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,obd2AdapterMac,obd2AdapterName);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName)';
 }
 
 
@@ -571,7 +611,7 @@ abstract mixin class _$VehicleProfileCopyWith<$Res> implements $VehicleProfileCo
   factory _$VehicleProfileCopyWith(_VehicleProfile value, $Res Function(_VehicleProfile) _then) = __$VehicleProfileCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, String? obd2AdapterMac, String? obd2AdapterName
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, String? obd2AdapterMac, String? obd2AdapterName
 });
 
 
@@ -588,7 +628,7 @@ class __$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,}) {
   return _then(_VehicleProfile(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -599,7 +639,10 @@ as double?,supportedConnectors: null == supportedConnectors ? _self._supportedCo
 as Set<ConnectorType>,chargingPreferences: null == chargingPreferences ? _self.chargingPreferences : chargingPreferences // ignore: cast_nullable_to_non_nullable
 as ChargingPreferences,tankCapacityL: freezed == tankCapacityL ? _self.tankCapacityL : tankCapacityL // ignore: cast_nullable_to_non_nullable
 as double?,preferredFuelType: freezed == preferredFuelType ? _self.preferredFuelType : preferredFuelType // ignore: cast_nullable_to_non_nullable
-as String?,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2AdapterMac // ignore: cast_nullable_to_non_nullable
+as String?,engineDisplacementCc: freezed == engineDisplacementCc ? _self.engineDisplacementCc : engineDisplacementCc // ignore: cast_nullable_to_non_nullable
+as int?,engineCylinders: freezed == engineCylinders ? _self.engineCylinders : engineCylinders // ignore: cast_nullable_to_non_nullable
+as int?,volumetricEfficiency: null == volumetricEfficiency ? _self.volumetricEfficiency : volumetricEfficiency // ignore: cast_nullable_to_non_nullable
+as double,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2AdapterMac // ignore: cast_nullable_to_non_nullable
 as String?,obd2AdapterName: freezed == obd2AdapterName ? _self.obd2AdapterName : obd2AdapterName // ignore: cast_nullable_to_non_nullable
 as String?,
   ));

--- a/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
@@ -46,6 +46,10 @@ _VehicleProfile _$VehicleProfileFromJson(Map<String, dynamic> json) =>
             ),
       tankCapacityL: (json['tankCapacityL'] as num?)?.toDouble(),
       preferredFuelType: json['preferredFuelType'] as String?,
+      engineDisplacementCc: (json['engineDisplacementCc'] as num?)?.toInt(),
+      engineCylinders: (json['engineCylinders'] as num?)?.toInt(),
+      volumetricEfficiency:
+          (json['volumetricEfficiency'] as num?)?.toDouble() ?? 0.85,
       obd2AdapterMac: json['obd2AdapterMac'] as String?,
       obd2AdapterName: json['obd2AdapterName'] as String?,
     );
@@ -65,6 +69,9 @@ Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
       ),
       'tankCapacityL': instance.tankCapacityL,
       'preferredFuelType': instance.preferredFuelType,
+      'engineDisplacementCc': instance.engineDisplacementCc,
+      'engineCylinders': instance.engineCylinders,
+      'volumetricEfficiency': instance.volumetricEfficiency,
       'obd2AdapterMac': instance.obd2AdapterMac,
       'obd2AdapterName': instance.obd2AdapterName,
     };

--- a/test/features/vehicle/domain/vehicle_profile_test.dart
+++ b/test/features/vehicle/domain/vehicle_profile_test.dart
@@ -79,6 +79,60 @@ void main() {
           {ConnectorType.ccs, ConnectorType.type2});
     });
 
+    group('engine parameters for speed-density fallback (#812)', () {
+      test('defaults: no displacement/cylinders, η_v 0.85', () {
+        const v = VehicleProfile(id: 'abc', name: 'Car');
+        expect(v.engineDisplacementCc, isNull);
+        expect(v.engineCylinders, isNull);
+        expect(v.volumetricEfficiency, 0.85);
+      });
+
+      test('round-trips engine params through JSON — Peugeot 107 case', () {
+        const v = VehicleProfile(
+          id: 'peugeot-107',
+          name: 'Peugeot 107',
+          type: VehicleType.combustion,
+          engineDisplacementCc: 998,
+          engineCylinders: 3,
+          volumetricEfficiency: 0.80,
+        );
+        final restored = VehicleProfile.fromJson(v.toJson());
+        expect(restored.engineDisplacementCc, 998);
+        expect(restored.engineCylinders, 3);
+        expect(restored.volumetricEfficiency, closeTo(0.80, 0.001));
+      });
+
+      test('legacy JSON without engine fields still decodes — '
+          'backward compat on existing Hive profiles', () {
+        // Payload older than #812 — no engine keys at all. Must
+        // round-trip cleanly with the defaults filled in.
+        final json = {'id': 'old', 'name': 'Old'};
+        final v = VehicleProfile.fromJson(json);
+        expect(v.engineDisplacementCc, isNull);
+        expect(v.engineCylinders, isNull);
+        expect(v.volumetricEfficiency, 0.85);
+      });
+
+      test('copyWith lets callers update engine params without touching '
+          'unrelated fields', () {
+        const v = VehicleProfile(
+          id: 'x',
+          name: 'Corolla',
+          type: VehicleType.combustion,
+          tankCapacityL: 45,
+        );
+        final updated = v.copyWith(
+          engineDisplacementCc: 1600,
+          engineCylinders: 4,
+          volumetricEfficiency: 0.88,
+        );
+        expect(updated.tankCapacityL, 45);
+        expect(updated.engineDisplacementCc, 1600);
+        expect(updated.engineCylinders, 4);
+        expect(updated.volumetricEfficiency, 0.88);
+      });
+    });
+
     test('copyWith preserves unspecified fields', () {
       const v = VehicleProfile(
         id: 'a',


### PR DESCRIPTION
## Summary

Schema foundation for #812 phase 2. Adds three nullable-with-default fields to `VehicleProfile` so the speed-density fuel-rate math in `Obd2Service` can eventually read per-vehicle constants instead of the hardcoded 1.0 L / η_v 0.85 defaults shipped in PR #810.

## New fields

| Field | Type | Default | Notes |
|---|---|---|---|
| `engineDisplacementCc` | `int?` | null | e.g. 998 for the Peugeot 107 1.0L 1KR-FE. Null → math falls back to 1000 cc on read. |
| `engineCylinders` | `int?` | null | Reserved for firing-event-based fuel estimation (not yet wired). |
| `volumetricEfficiency` | `double` | 0.85 | Always present on decoded profiles. Adaptive calibration via tankful reconciliation (#815) will narrow per vehicle over time. |

## Backward compat

`json_serializable` emits defaults for missing keys, so pre-#812 Hive payloads decode cleanly with nulls on the new fields and η_v = 0.85. Covered by a dedicated "legacy JSON" test case.

## Out of scope (will be separate PRs)

- **Plumbing the profile values into `readFuelRateLPerHour`** at the trip-recording layer. Requires the controller to know about the active vehicle.
- **Onboarding UI** that auto-fills from the VIN decoder (PR #817) — that's #816.
- **Adaptive η_v learning** — #815.

## Test plan

- [x] `dart run build_runner build --delete-conflicting-outputs` — regenerates `.freezed.dart` and `.g.dart` cleanly.
- [x] `flutter analyze` (strict) — clean.
- [x] `flutter test test/features/vehicle` — 63/63 pass (4 new).
- [x] Full `flutter test` — 4900/4900 pass (1 Argentina flake, 1 skip).

Refs #812 phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)