### PR TITLE
fix(au): point NSW unavailable message at #804, not closed #504

### DIFF
--- a/lib/core/services/impl/australia_station_service.dart
+++ b/lib/core/services/impl/australia_station_service.dart
@@ -23,8 +23,9 @@ import '../mixins/station_service_helpers.dart';
 /// introduced in #500 lets the user file a follow-up with the real
 /// context instead of a 404 blob.
 ///
-/// Tracking: #504 — restore real Australian fuel search, likely via a
-/// dedicated NSW API key onboarding flow.
+/// Tracking: #804 — restore real Australian fuel search, likely via a
+/// dedicated NSW API key onboarding flow. (Issue #504 was the older
+/// \"placeholder `apikey: 'empty'` header\" bug and is closed.)
 class AustraliaStationService
     with StationServiceHelpers
     implements StationService {
@@ -36,7 +37,7 @@ class AustraliaStationService
       'NSW FuelCheck is currently unavailable. The public '
       'FuelCheckApp/v2 endpoint has been retired and the replacement '
       'api.nsw.gov.au FuelCheck product requires OAuth2 client '
-      'credentials. Tracked in #504.';
+      'credentials. Tracked in #804.';
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(

--- a/test/core/services/impl/australia_station_service_test.dart
+++ b/test/core/services/impl/australia_station_service_test.dart
@@ -33,7 +33,7 @@ void main() {
     });
   });
 
-  group('searchStations (#504 unavailable stop-gap)', () {
+  group('searchStations (#804 unavailable stop-gap)', () {
     const params = SearchParams(lat: -33.87, lng: 151.21, radiusKm: 5);
 
     test('throws ApiException on every call', () async {
@@ -53,7 +53,7 @@ void main() {
         // pin them explicitly.
         expect(e.message, contains('NSW FuelCheck'));
         expect(e.message, contains('OAuth2'));
-        expect(e.message, contains('#504'));
+        expect(e.message, contains('#804'));
       }
     });
 


### PR DESCRIPTION
## What

Redirects the NSW FuelCheck \"unavailable\" error message and its source docstring from the closed tracking issue #504 to the active one, #804. Also updates the two test assertions that pin the tracking reference.

## Why

When a user in Australia attempts a station search, the app throws a descriptive `ApiException` and offers to file a bug report (auto-filled with the error text). Today that text says *\"Tracked in #504\"*, but #504 (\"placeholder `apikey: 'empty'` header\") was closed when the old endpoint went 404.

The current state — public `api.onegov.nsw.gov.au/FuelCheckApp/v2` retired, new `api.nsw.gov.au` product requires OAuth2 client credentials — is tracked in #804 (just re-triaged as the canonical NSW issue). Users clicking \"Report this issue\" will now file a comment against the right issue, and maintainers reading the in-code docstring land on the active tracker.

Closes #804 is **not** appropriate — #804 is the upstream-blocked work item, not something this PR resolves.

## Testing

- `flutter analyze` on both changed files: *No issues found!*
- `flutter test test/core/services/impl/australia_station_service_test.dart`: 7/7 pass, including the updated \"error message names OAuth2 and links the tracking issue\" assertion.

## Screenshots

n/a — string-only change to an error path.