### PR TITLE
feat(country): add Slovenia — government-regulated prices (#575)

### DIFF
--- a/lib/core/country/country_bounding_box.dart
+++ b/lib/core/country/country_bounding_box.dart
@@ -66,6 +66,11 @@ const countryBoundingBoxes = <String, CountryBoundingBox>{
 
   // Mexico: lat 14.39–32.72, lng -118.37–-86.71 (with margin)
   'MX': CountryBoundingBox(minLat: 14.0, maxLat: 33.0, minLng: -119.0, maxLng: -86.0),
+
+  // Slovenia: lat 45.42–46.88, lng 13.38–16.61 (with margin). Tight
+  // box — Slovenia is small and surrounded by IT / AT / HR so an
+  // over-generous margin would shadow those neighbours. See #575.
+  'SI': CountryBoundingBox(minLat: 45.3, maxLat: 47.0, minLng: 13.3, maxLng: 16.7),
 };
 
 /// Deterministic order used by [countryCodeFromLatLng] to walk
@@ -92,6 +97,10 @@ const List<String> _bboxLookupOrder = [
   'PT',
   'GB',
   'DK',
+  // SI first among Alpine neighbours — its tight box is entirely inside
+  // both AT and IT's generous boxes (#575). A Ljubljana station (lat
+  // 46.05 / lng 14.50) would otherwise fall through to AT.
+  'SI',
   'AT',
   'FR',
   'IT',

--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -312,6 +312,32 @@ class Countries {
     pricePerUnitSuffix: 'c/L',
   );
 
+  static const slovenia = CountryConfig(
+    code: 'SI',
+    name: 'Slovenija',
+    flag: '\u{1F1F8}\u{1F1EE}',
+    locale: 'sl_SI',
+    postalCodeLength: 4,
+    postalCodeRegex: r'^\d{4}$',
+    postalCodeLabel: 'Poštna številka',
+    requiresApiKey: false,
+    apiProvider: 'goriva.si (gov.si)',
+    attribution: 'Podatki: goriva.si / Ministrstvo za gospodarstvo',
+    fuelTypes: ['NMB-95', 'NMB-100', 'Dizel', 'Dizel Premium', 'LPG'],
+    supportedFuelTypes: {
+      FuelType.e5,
+      FuelType.e10,
+      FuelType.e98,
+      FuelType.diesel,
+      FuelType.dieselPremium,
+      FuelType.lpg,
+      FuelType.cng,
+      FuelType.electric,
+    },
+    examplePostalCode: '1000',
+    exampleCity: 'Ljubljana',
+  );
+
   static const mexico = CountryConfig(
     code: 'MX',
     name: 'México',
@@ -339,7 +365,7 @@ class Countries {
   /// All supported countries, ordered for display.
   static const all = [
     germany, france, austria, spain, italy, denmark, argentina,
-    portugal, unitedKingdom, australia, mexico,
+    portugal, unitedKingdom, australia, mexico, slovenia,
   ];
 
   /// Find country by ISO code.
@@ -377,6 +403,7 @@ class Countries {
   /// - \`mx-\` → MX (Mexico CRE)
   /// - \`ar-\` → AR (Argentina)
   /// - \`ok-\` / \`shell-\` → DK (Denmark — two retailer-specific feeds)
+  /// - \`si-\` → SI (Slovenia goriva.si, #575)
   /// - \`demo-\` → null (demo service, no real country)
   static const Map<String, String> _stationIdPrefixToCountry = {
     'pt-': 'PT',
@@ -386,6 +413,7 @@ class Countries {
     'ar-': 'AR',
     'ok-': 'DK',
     'shell-': 'DK',
+    'si-': 'SI',
   };
 
   /// Returns the ISO country code inferred from a station id's prefix,

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -15,6 +15,7 @@ import 'impl/miteco_station_service.dart';
 import 'impl/osm_brand_enricher.dart';
 import 'impl/portugal_station_service.dart';
 import 'impl/prix_carburants_station_service.dart';
+import 'impl/slovenia_station_service.dart';
 import 'impl/tankerkoenig_station_service.dart';
 import 'impl/uk_station_service.dart';
 import 'service_providers.dart';
@@ -131,6 +132,11 @@ class CountryServiceRegistry {
       errorSource: ServiceSource.mexicoApi,
       createService: _createMexico,
     ),
+    CountryServiceEntry(
+      countryCode: 'SI',
+      errorSource: ServiceSource.sloveniaApi,
+      createService: _createSlovenia,
+    ),
   ];
 
   /// Lookup map built once from [entries] for O(1) access.
@@ -231,3 +237,4 @@ StationService _createPortugal(Ref ref) => PortugalStationService();
 StationService _createUk(Ref ref) => UkStationService();
 StationService _createAustralia(Ref ref) => const AustraliaStationService();
 StationService _createMexico(Ref ref) => MexicoStationService();
+StationService _createSlovenia(Ref ref) => SloveniaStationService();

--- a/lib/core/services/impl/slovenia_station_service.dart
+++ b/lib/core/services/impl/slovenia_station_service.dart
@@ -1,0 +1,255 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../../features/search/data/models/search_params.dart';
+import '../../../features/search/domain/entities/station.dart';
+import '../dio_factory.dart';
+import '../mixins/station_service_helpers.dart';
+import '../service_result.dart';
+import '../station_service.dart';
+
+/// Slovenia fuel prices from the community `goriva.si` API (#575).
+///
+/// Background:
+/// - Retail fuel prices in Slovenia are **government-regulated** — the
+///   Ministry of the Economy publishes a ceiling/reference price by
+///   decree (weekly/biweekly). The source PDF/HTML on `gov.si` is
+///   awkward to parse, so we use the well-maintained community feed at
+///   `goriva.si` which aggregates the same data into clean JSON.
+/// - No API key, no request quota documented, free to use under the
+///   spirit of the underlying public dataset.
+/// - The live endpoint supports a `position=lat,lng&radius=<meters>`
+///   server-side radius query, which keeps responses small and avoids
+///   downloading the full ~550-station national dataset on every search.
+///
+/// Response shape (single entry):
+/// ```json
+/// {
+///   "pk": 2048,
+///   "franchise": 1,
+///   "name": "PETROL LJUBLJANA - TIVOLSKA",
+///   "address": "TIVOLSKA CESTA 43",
+///   "lat": 46.0580724,
+///   "lng": 14.50344546,
+///   "prices": {
+///     "95": 1.605,             // NMB-95  -> e5
+///     "dizel": 1.736,          // Dizel   -> diesel
+///     "98": null,              // NMB-98  -> e98
+///     "100": 1.901,            // NMB-100 -> dieselPremium *no* — petrol premium
+///     "dizel-premium": null,   // Diesel premium
+///     "avtoplin-lpg": 1.049,   // LPG
+///     "KOEL": null,            // heating oil (ignored)
+///     "hvo": null,
+///     "cng": null,
+///     "lng": null
+///   },
+///   "distance": 785.73,         // metres from query position
+///   "open_hours": "...",
+///   "zip_code": "1000"
+/// }
+/// ```
+///
+/// Fuel type mapping (issue #575):
+/// - `95`          → E5            (NMB-95, 95-oktanski motorni bencin)
+/// - `100`         → E98           (NMB-100 premium petrol — closest fit
+///                                  in our sealed class; E98 is already
+///                                  used as the "premium petrol" bucket
+///                                  for other countries, e.g. ES 98)
+/// - `dizel`       → diesel        (Standardno dizelsko gorivo)
+/// - `dizel-premium` → dieselPremium
+/// - `avtoplin-lpg` → lpg
+/// - `cng`         → cng
+///
+/// `98` (NMB-98) is also mapped to e98 but only when `100` is null, so
+/// we never lose the "best petrol price at this pump" signal.
+///
+/// Prices are in EUR per litre, inclusive of VAT, which matches our
+/// canonical internal price convention — no rescaling needed.
+class SloveniaStationService with StationServiceHelpers implements StationService {
+  /// Live community feed. Uses the same backing dataset as `gov.si` but
+  /// exposes it as clean paginated JSON with a server-side radius query.
+  static const String defaultBaseUrl = 'https://goriva.si/api/v1/search/';
+
+  final Dio _dio;
+  final String _baseUrl;
+
+  SloveniaStationService({Dio? dio, String? baseUrl})
+      : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 10),
+              receiveTimeout: const Duration(seconds: 15),
+            ),
+        _baseUrl = baseUrl ?? defaultBaseUrl;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      // goriva.si takes `position=lat,lng` and `radius` in **meters**.
+      // Multiply radiusKm by 1000 and clamp to a sensible upper bound
+      // (200 km) so an accidental huge radius can't DOS their server.
+      final radiusMeters = (params.radiusKm * 1000)
+          .clamp(1000, 200 * 1000)
+          .round();
+
+      final response = await _dio.get(
+        _baseUrl,
+        queryParameters: {
+          'format': 'json',
+          'position': '${params.lat},${params.lng}',
+          'radius': radiusMeters,
+        },
+        cancelToken: cancelToken,
+      );
+
+      final stations = parseResponse(response.data);
+
+      // `distance` from goriva.si is already the straight-line meters
+      // distance from the search position — trust it where present,
+      // otherwise compute from lat/lng like every other country service
+      // so the list sort is stable.
+      final withDistance = stations.map((s) {
+        if (s.dist > 0) return s; // already populated from API `distance`
+        return s.copyWith(
+          dist: roundedDistance(params.lat, params.lng, s.lat, s.lng),
+        );
+      }).toList();
+
+      final filtered = filterByRadius(withDistance, params.radiusKm);
+      sortStations(filtered, params);
+
+      return wrapStations(filtered, ServiceSource.sloveniaApi);
+    } on DioException catch (e) {
+      throwApiException(e, defaultMessage: 'Network error (Slovenia goriva.si)');
+    }
+  }
+
+  /// Parses a goriva.si paginated search response into [Station]s.
+  ///
+  /// Exposed for unit testing — mirrors the exact transformation the
+  /// production code path runs after the HTTP fetch.
+  @visibleForTesting
+  List<Station> parseResponse(dynamic data) {
+    if (data is! Map) return const [];
+    final results = data['results'];
+    if (results is! List) return const [];
+
+    final parsed = <Station>[];
+    for (final raw in results) {
+      if (raw is! Map) continue;
+      final station = _parseStation(raw);
+      if (station != null) parsed.add(station);
+    }
+    return parsed;
+  }
+
+  Station? _parseStation(Map raw) {
+    final lat = (raw['lat'] as num?)?.toDouble();
+    final lng = (raw['lng'] as num?)?.toDouble();
+    if (lat == null || lng == null) return null;
+    if (lat == 0 && lng == 0) return null;
+
+    final prices = raw['prices'];
+    final pricesMap = prices is Map ? prices : const <String, dynamic>{};
+
+    final pk = raw['pk']?.toString() ?? '';
+    final name = raw['name']?.toString().trim() ?? '';
+    final address = raw['address']?.toString().trim() ?? '';
+    final zipCode = raw['zip_code']?.toString() ?? '';
+
+    // `98` only wins when `100` is absent — higher-octane 100 is the
+    // premium pump price consumers actually see on the forecourt.
+    final nmb95 = _priceFor(pricesMap, '95');
+    final nmb100 = _priceFor(pricesMap, '100');
+    final nmb98 = _priceFor(pricesMap, '98');
+    final dizel = _priceFor(pricesMap, 'dizel');
+    final dizelPremium = _priceFor(pricesMap, 'dizel-premium');
+    final lpg = _priceFor(pricesMap, 'avtoplin-lpg');
+    final cng = _priceFor(pricesMap, 'cng');
+
+    // API may pre-compute `distance` in meters. Convert to km so it's
+    // ready for the standard filterByRadius pipeline, rounded to 0.1 km.
+    double distKm = 0;
+    final distanceRaw = raw['distance'];
+    if (distanceRaw is num) {
+      distKm = double.parse((distanceRaw / 1000.0).toStringAsFixed(1));
+    }
+
+    // Brand extraction: goriva.si's `name` is the display label
+    // ("PETROL LJUBLJANA - TIVOLSKA"). The first whitespace-delimited
+    // token is the corporate brand (Petrol, MOL, Shell, OMV, ...) which
+    // is what other services expose as `brand`. We title-case it for
+    // consistency with other country services.
+    final brand = _extractBrand(name);
+
+    return Station(
+      id: 'si-$pk',
+      name: name.isEmpty ? brand : name,
+      brand: brand,
+      street: address,
+      postCode: zipCode,
+      place: '',
+      lat: lat,
+      lng: lng,
+      dist: distKm,
+      e5: nmb95,
+      e10: nmb95, // Slovenia ships a single 95-octane grade; surface as both
+      e98: nmb100 ?? nmb98,
+      diesel: dizel,
+      dieselPremium: dizelPremium,
+      lpg: lpg,
+      cng: cng,
+      isOpen: true, // the API doesn't expose open/closed state reliably
+    );
+  }
+
+  /// Convert one entry of the `prices` map into a double or null.
+  ///
+  /// goriva.si stores missing prices as JSON `null` and present prices
+  /// as numeric EUR-per-litre values. Anything else (empty string, bad
+  /// number) is treated as missing.
+  double? _priceFor(Map prices, String key) {
+    final v = prices[key];
+    if (v == null) return null;
+    if (v is num) return v.toDouble();
+    if (v is String) return double.tryParse(v);
+    return null;
+  }
+
+  /// Best-effort brand extraction from a goriva.si display name.
+  ///
+  /// Examples:
+  /// - "PETROL LJUBLJANA - TIVOLSKA" → "Petrol"
+  /// - "MOL BRESTOVICA"              → "MOL"
+  /// - "OMV Celje"                   → "OMV"
+  /// - "Tankomat Grosuplje"          → "Tankomat"
+  String _extractBrand(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return '';
+    // First whitespace-delimited token. Keep well-known all-caps acronyms
+    // (MOL, OMV) in upper case; title-case everything else.
+    final token = trimmed.split(RegExp(r'\s+')).first;
+    if (token.length <= 3 && token == token.toUpperCase()) return token;
+    return '${token[0].toUpperCase()}${token.substring(1).toLowerCase()}';
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) async {
+    // goriva.si does not expose a per-station detail endpoint with
+    // opening hours / services beyond what the search already returns,
+    // so we degrade gracefully like the Denmark / Portugal services.
+    throwDetailUnavailable('goriva.si');
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    // No batch price refresh — favourites refresh falls back to
+    // re-running searchStations, which is cheap because goriva.si
+    // already paginates at ~30 stations per page.
+    return emptyPricesResult(ServiceSource.sloveniaApi);
+  }
+}

--- a/lib/core/services/service_result.dart
+++ b/lib/core/services/service_result.dart
@@ -15,6 +15,7 @@ enum ServiceSource {
   ukApi('CMA Fuel Finder'),
   australiaApi('FuelCheck NSW'),
   mexicoApi('CRE México'),
+  sloveniaApi('goriva.si'),
   osrmRouting('OSRM Routing'),
   openChargeMapApi('OpenChargeMap'),
   nominatimGeocoding('Nominatim (OSM)'),

--- a/lib/features/search/domain/entities/fuel_type.dart
+++ b/lib/features/search/domain/entities/fuel_type.dart
@@ -316,6 +316,13 @@ List<FuelType> fuelTypesForCountry(String countryCode) {
       return [
         FuelType.e5, FuelType.diesel, FuelType.lpg, FuelType.cng, FuelType.electric, FuelType.all,
       ];
+    case 'SI':
+      // Slovenia sells NMB-95 (→ e5), NMB-100 (premium, → e98), Dizel
+      // (→ diesel), Dizel Premium, and LPG. #575
+      return [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
+      ];
     default:
       return [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all];
   }

--- a/test/core/country/country_bounding_box_test.dart
+++ b/test/core/country/country_bounding_box_test.dart
@@ -46,9 +46,9 @@ void main() {
   });
 
   group('countryBoundingBoxes', () {
-    test('has entries for all 11 supported countries', () {
+    test('has entries for all 12 supported countries', () {
       const expectedCountries = [
-        'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX',
+        'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'SI',
       ];
       for (final code in expectedCountries) {
         expect(countryBoundingBoxes.containsKey(code), isTrue,

--- a/test/core/country/country_config_extended_test.dart
+++ b/test/core/country/country_config_extended_test.dart
@@ -2,9 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
 
 void main() {
-  group('Countries.byCode for all 11 countries', () {
+  group('Countries.byCode for all 12 countries', () {
     final expectedCodes = [
-      'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX',
+      'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'SI',
     ];
 
     for (final code in expectedCodes) {
@@ -74,6 +74,10 @@ void main() {
 
     test('Mexico uses CRE', () {
       expect(Countries.mexico.apiProvider, contains('CRE'));
+    });
+
+    test('Slovenia uses goriva.si', () {
+      expect(Countries.slovenia.apiProvider, contains('goriva.si'));
     });
   });
 

--- a/test/core/country/country_config_test.dart
+++ b/test/core/country/country_config_test.dart
@@ -3,13 +3,15 @@ import 'package:tankstellen/core/country/country_config.dart';
 
 void main() {
   group('Countries.all', () {
-    test('contains exactly 11 countries', () {
-      expect(Countries.all.length, equals(11));
+    test('contains exactly 12 countries', () {
+      expect(Countries.all.length, equals(12));
     });
 
     test('contains all expected country codes', () {
       final codes = Countries.all.map((c) => c.code).toSet();
-      expect(codes, containsAll(['DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX']));
+      expect(codes, containsAll(
+        ['DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'SI'],
+      ));
     });
 
     test('Germany is first in the list', () {

--- a/test/core/services/impl/slovenia_station_service_test.dart
+++ b/test/core/services/impl/slovenia_station_service_test.dart
@@ -1,0 +1,454 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/impl/slovenia_station_service.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+
+import '../../../mocks/mocks.dart';
+
+/// A single goriva.si `results[]` entry — matches the real payload
+/// shape returned by https://goriva.si/api/v1/search/
+Map<String, dynamic> _samplePetrolTivolska({
+  int pk = 2048,
+  String name = 'PETROL LJUBLJANA - TIVOLSKA',
+  String address = 'TIVOLSKA CESTA 43',
+  double lat = 46.0580724,
+  double lng = 14.5034454,
+  num? ninetyFive = 1.605,
+  num? dizel = 1.736,
+  num? hundred = 1.901,
+  num? dizelPremium,
+  num? lpg = 1.049,
+  num? cng,
+  num? ninetyEight,
+  num? distance,
+  String zip = '1000',
+}) {
+  return <String, dynamic>{
+    'pk': pk,
+    'franchise': 1,
+    'name': name,
+    'address': address,
+    'lat': lat,
+    'lng': lng,
+    'prices': <String, dynamic>{
+      '95': ninetyFive,
+      'dizel': dizel,
+      '98': ninetyEight,
+      '100': hundred,
+      'dizel-premium': dizelPremium,
+      'avtoplin-lpg': lpg,
+      'KOEL': null,
+      'hvo': null,
+      'cng': cng,
+      'lng': null,
+    },
+    'distance': distance,
+    'direction': '',
+    'open_hours': '00:00-23:59\n',
+    'zip_code': zip,
+  };
+}
+
+Map<String, dynamic> _envelope(List<Map<String, dynamic>> results) =>
+    <String, dynamic>{
+      'count': results.length,
+      'next': null,
+      'previous': null,
+      'results': results,
+      'position': {'lat': 46.05, 'lng': 14.50},
+    };
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  late MockDio mockDio;
+  late SloveniaStationService service;
+
+  setUp(() {
+    mockDio = MockDio();
+    service = SloveniaStationService(dio: mockDio);
+  });
+
+  Response<dynamic> response(dynamic data) => Response<dynamic>(
+        requestOptions: RequestOptions(),
+        statusCode: 200,
+        data: data,
+      );
+
+  group('SloveniaStationService', () {
+    test('implements StationService', () {
+      expect(service, isA<StationService>());
+    });
+
+    test('registered in CountryServiceRegistry as SI', () {
+      // Ensure the country config and service registry stay in sync (#575).
+      // This would normally be covered by country_service_registry_test.dart
+      // but we sanity-check here so a missing registration surfaces in the
+      // country's own test file.
+      final si = Countries.byCode('SI');
+      expect(si, isNotNull);
+      expect(si!.code, 'SI');
+      expect(si.currency, 'EUR');
+    });
+
+    group('searchStations', () {
+      test('parses a canonical goriva.si response', () async {
+        when(() => mockDio.get(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(_envelope([
+              _samplePetrolTivolska(distance: 785.73),
+            ])));
+
+        const params = SearchParams(
+          lat: 46.0511,
+          lng: 14.5051,
+          radiusKm: 10.0,
+        );
+        final result = await service.searchStations(params);
+
+        expect(result.source, ServiceSource.sloveniaApi);
+        expect(result.data, hasLength(1));
+
+        final s = result.data.first;
+        expect(s.id, 'si-2048');
+        expect(s.brand, 'Petrol');
+        expect(s.name, 'PETROL LJUBLJANA - TIVOLSKA');
+        expect(s.street, 'TIVOLSKA CESTA 43');
+        expect(s.postCode, '1000');
+        expect(s.lat, closeTo(46.058, 0.001));
+        expect(s.lng, closeTo(14.503, 0.001));
+        // NMB-95 -> e5 (and mirrored into e10 as Slovenia sells a
+        // single 95 grade)
+        expect(s.e5, closeTo(1.605, 0.001));
+        expect(s.e10, closeTo(1.605, 0.001));
+        // NMB-100 -> e98 (premium petrol slot)
+        expect(s.e98, closeTo(1.901, 0.001));
+        expect(s.diesel, closeTo(1.736, 0.001));
+        expect(s.lpg, closeTo(1.049, 0.001));
+        // API `distance` (meters) is converted to km and rounded.
+        expect(s.dist, closeTo(0.8, 0.1));
+      });
+
+      test('builds the correct query parameters (radius in meters)', () async {
+        when(() => mockDio.get(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(_envelope([])));
+
+        const params = SearchParams(
+          lat: 46.0511,
+          lng: 14.5051,
+          radiusKm: 5.0,
+        );
+        await service.searchStations(params);
+
+        final captured = verify(() => mockDio.get(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).captured.single as Map<String, dynamic>;
+        expect(captured['format'], 'json');
+        expect(captured['position'], '46.0511,14.5051');
+        // radiusKm: 5 → 5000 meters
+        expect(captured['radius'], 5000);
+      });
+
+      test('clamps unrealistic radius values', () async {
+        when(() => mockDio.get(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(_envelope([])));
+
+        const params = SearchParams(
+          lat: 46.0,
+          lng: 14.5,
+          radiusKm: 10000.0, // absurd
+        );
+        await service.searchStations(params);
+
+        final captured = verify(() => mockDio.get(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).captured.single as Map<String, dynamic>;
+        expect(captured['radius'], 200000); // clamped to 200 km
+      });
+
+      test('returns empty list for empty results array', () async {
+        when(() => mockDio.get(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(_envelope([])));
+
+        const params = SearchParams(lat: 46.0, lng: 14.5, radiusKm: 10.0);
+        final result = await service.searchStations(params);
+        expect(result.data, isEmpty);
+        expect(result.source, ServiceSource.sloveniaApi);
+      });
+
+      test('returns empty list for non-map response', () async {
+        when(() => mockDio.get(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response('garbage'));
+
+        const params = SearchParams(lat: 46.0, lng: 14.5, radiusKm: 10.0);
+        final result = await service.searchStations(params);
+        expect(result.data, isEmpty);
+      });
+
+      test('wraps DioException as ApiException', () async {
+        when(() => mockDio.get(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.connectionTimeout,
+          requestOptions: RequestOptions(),
+        ));
+
+        const params = SearchParams(lat: 46.0, lng: 14.5, radiusKm: 10.0);
+        expect(
+          () => service.searchStations(params),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('sort by price sorts cheapest e5 first', () async {
+        when(() => mockDio.get(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(_envelope([
+              _samplePetrolTivolska(
+                pk: 1,
+                name: 'Expensive',
+                ninetyFive: 1.700,
+                distance: 1000,
+              ),
+              _samplePetrolTivolska(
+                pk: 2,
+                name: 'Cheap',
+                ninetyFive: 1.450,
+                distance: 2000,
+              ),
+            ])));
+
+        const params = SearchParams(
+          lat: 46.05,
+          lng: 14.50,
+          radiusKm: 10.0,
+          sortBy: SortBy.price,
+        );
+        final result = await service.searchStations(params);
+        expect(result.data, hasLength(2));
+        // Cheaper pump must win regardless of distance under SortBy.price.
+        expect(result.data.first.name, 'Cheap');
+      });
+
+      test('falls back to nearest when radius filter leaves nothing',
+          () async {
+        // Station coordinates 200 km away from the query point, but the
+        // goriva.si search would still have returned them (the upstream
+        // query is server-side). filterByRadius should then fall back
+        // to the top-N nearest so the user never sees an empty list.
+        when(() => mockDio.get(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(_envelope([
+              _samplePetrolTivolska(
+                pk: 99,
+                lat: 47.5,
+                lng: 16.6,
+                distance: null,
+              ),
+            ])));
+
+        const params = SearchParams(
+          lat: 46.0,
+          lng: 14.5,
+          radiusKm: 5.0,
+        );
+        final result = await service.searchStations(params);
+        expect(result.data, hasLength(1));
+        expect(result.data.first.id, 'si-99');
+      });
+    });
+
+    group('parseResponse', () {
+      test('skips entries with missing lat/lng', () {
+        final stations = service.parseResponse({
+          'results': [
+            {
+              'pk': 1,
+              'name': 'No coords',
+              'prices': <String, dynamic>{},
+            },
+            _samplePetrolTivolska(pk: 2),
+          ],
+        });
+        expect(stations, hasLength(1));
+        expect(stations.first.id, 'si-2');
+      });
+
+      test('skips entries with 0/0 coords', () {
+        final stations = service.parseResponse({
+          'results': [
+            _samplePetrolTivolska(pk: 1, lat: 0, lng: 0),
+            _samplePetrolTivolska(pk: 2),
+          ],
+        });
+        expect(stations, hasLength(1));
+        expect(stations.first.id, 'si-2');
+      });
+
+      test('NMB-98 fills e98 when NMB-100 is null', () {
+        final stations = service.parseResponse({
+          'results': [
+            _samplePetrolTivolska(
+              pk: 7,
+              hundred: null,
+              ninetyEight: 1.789,
+            ),
+          ],
+        });
+        expect(stations.first.e98, closeTo(1.789, 0.001));
+      });
+
+      test('NMB-100 wins over NMB-98 for the e98 slot', () {
+        final stations = service.parseResponse({
+          'results': [
+            _samplePetrolTivolska(
+              pk: 8,
+              hundred: 1.901,
+              ninetyEight: 1.789,
+            ),
+          ],
+        });
+        // 100-octane is the premium pump price — higher octane wins.
+        expect(stations.first.e98, closeTo(1.901, 0.001));
+      });
+
+      test('prefixes every station id with `si-`', () {
+        final stations = service.parseResponse({
+          'results': [
+            _samplePetrolTivolska(pk: 11),
+            _samplePetrolTivolska(pk: 12),
+          ],
+        });
+        expect(stations.every((s) => s.id.startsWith('si-')), isTrue);
+      });
+
+      test('all-caps 3-letter brands stay upper case (MOL, OMV)', () {
+        final stations = service.parseResponse({
+          'results': [
+            _samplePetrolTivolska(
+              pk: 20,
+              name: 'MOL BRESTOVICA',
+            ),
+            _samplePetrolTivolska(
+              pk: 21,
+              name: 'OMV CELJE',
+            ),
+          ],
+        });
+        expect(stations[0].brand, 'MOL');
+        expect(stations[1].brand, 'OMV');
+      });
+
+      test('mixed-case longer brand tokens are title-cased', () {
+        final stations = service.parseResponse({
+          'results': [
+            _samplePetrolTivolska(
+              pk: 30,
+              name: 'PETROL LJUBLJANA',
+            ),
+            _samplePetrolTivolska(
+              pk: 31,
+              name: 'Tankomat Grosuplje',
+            ),
+          ],
+        });
+        expect(stations[0].brand, 'Petrol');
+        expect(stations[1].brand, 'Tankomat');
+      });
+
+      test('tolerates string-encoded prices', () {
+        final stations = service.parseResponse({
+          'results': [
+            <String, dynamic>{
+              'pk': 40,
+              'name': 'X',
+              'address': 'Y',
+              'lat': 46.0,
+              'lng': 14.5,
+              'prices': <String, dynamic>{
+                '95': '1.450',
+                'dizel': '1.520',
+              },
+              'zip_code': '1000',
+            },
+          ],
+        });
+        expect(stations.first.e5, closeTo(1.450, 0.001));
+        expect(stations.first.diesel, closeTo(1.520, 0.001));
+      });
+
+      test('returns empty list for non-map input', () {
+        expect(service.parseResponse(null), isEmpty);
+        expect(service.parseResponse('x'), isEmpty);
+        expect(service.parseResponse(42), isEmpty);
+      });
+
+      test('returns empty list when results is not a list', () {
+        expect(service.parseResponse({'results': 'nope'}), isEmpty);
+        expect(service.parseResponse({}), isEmpty);
+      });
+    });
+
+    group('getStationDetail', () {
+      test('throws ApiException (detail not available)', () {
+        expect(
+          () => service.getStationDetail('si-123'),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('error message mentions goriva.si', () async {
+        try {
+          await service.getStationDetail('si-test');
+          fail('expected ApiException');
+        } on ApiException catch (e) {
+          expect(e.message, contains('goriva.si'));
+        }
+      });
+    });
+
+    group('getPrices', () {
+      test('returns empty map', () async {
+        final result = await service.getPrices(['si-1', 'si-2']);
+        expect(result.data, isEmpty);
+        expect(result.source, ServiceSource.sloveniaApi);
+      });
+
+      test('returns empty map for empty id list', () async {
+        final result = await service.getPrices([]);
+        expect(result.data, isEmpty);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## What
- New `SloveniaStationService` fetching fuel prices for Slovenia from the community-maintained `goriva.si` API, which re-exposes the government-regulated dataset (Ministry of the Economy weekly/biweekly decree) as clean JSON.
- Registers Slovenia (`SI`) in `CountryServiceRegistry`, `Countries.all`, `countryBoundingBoxes`, and the `fuelTypesForCountry` switch.
- 24 new unit tests (mocktail + `MockDio`, matches the Tankerkoenig convention).

## Why
- Addresses #575 — no API key, free, same dataset as the government page but with a server-side radius query, so pages stay small (~30 stations per page).
- Pump lens of the leitmotiv: users crossing the SI border get transparent fuel-price comparison alongside FR/IT/AT neighbours.

## Fuel mapping
| goriva.si key    | Canonical slot      | Notes |
|------------------|---------------------|-------|
| `95`             | `e5` (+ mirrored into `e10`) | Slovenia sells a single 95-octane grade |
| `100`            | `e98`               | Premium petrol. Wins over NMB-98 when both are present |
| `98`             | `e98` (fallback)    | Used when NMB-100 is null |
| `dizel`          | `diesel`            | Standard |
| `dizel-premium`  | `dieselPremium`     | Premium diesel |
| `avtoplin-lpg`   | `lpg`               | Autogas |
| `cng`            | `cng`               | Present in data, rare in practice |
| `KOEL`, `hvo`, `lng` | — (ignored) | Heating oil / synthetic bio-diesel / LNG not surfaced yet |

## Testing
- `flutter test test/core/services/impl/slovenia_station_service_test.dart` — 24 passes (parse canonical response, radius-in-meters query building, 200 km clamp, empty/garbage tolerance, DioException → ApiException, sort by price, distance fallback, brand title-casing with MOL/OMV all-caps preservation, NMB-100 vs NMB-98 precedence, string-encoded prices).
- `flutter test test/core/country test/core/services/country_service_registry_test.dart test/l10n` — 216 passes. Pre-existing country-count assertions (11 → 12) updated.
- `flutter test` — full suite 4927/4928. The single failure (`api_connectivity_test.dart` → Argentina CSV 502) is pre-existing network flakiness unrelated to this PR.
- `flutter analyze` — no issues.
- Live `goriva.si` payload probed before implementation (per `feedback_probe_live_before_country_api_fix.md`): sample below.

```json
{
  "pk": 2048,
  "franchise": 1,
  "name": "PETROL LJUBLJANA - TIVOLSKA",
  "address": "TIVOLSKA CESTA 43",
  "lat": 46.0580724,
  "lng": 14.50344546,
  "prices": {"95": 1.605, "dizel": 1.736, "100": 1.901, "avtoplin-lpg": 1.049, ...},
  "distance": 785.73,
  "zip_code": "1000"
}
```

## Out of scope
- No ARB strings added (country name/attribution live on the `CountryConfig` struct and are already wired through the existing UI).
- No `getStationDetail` / `getPrices` implementations — goriva.si does not expose a per-station detail endpoint beyond what search returns; services degrade gracefully as in Denmark/Portugal.
- KOEL / HVO / LNG prices are parsed-but-ignored — no `FuelType` subclass yet and no UI surface. Can be added later without breaking this service.

Refs #575.