### PR TITLE
feat(country): add Luxembourg — government-regulated prices (#574)

### DIFF
--- a/lib/core/country/country_bounding_box.dart
+++ b/lib/core/country/country_bounding_box.dart
@@ -67,6 +67,11 @@ const countryBoundingBoxes = <String, CountryBoundingBox>{
   // Mexico: lat 14.39–32.72, lng -118.37–-86.71 (with margin)
   'MX': CountryBoundingBox(minLat: 14.0, maxLat: 33.0, minLng: -119.0, maxLng: -86.0),
 
+  // Luxembourg: lat 49.45–50.18, lng 5.74–6.53 (with margin).
+  // Very tight box — LU is ~82 km north-south, ~57 km east-west; keeping
+  // the margin modest so BE/FR/DE neighbours don't bleed into LU matches.
+  'LU': CountryBoundingBox(minLat: 49.4, maxLat: 50.25, minLng: 5.7, maxLng: 6.55),
+
   // Slovenia: lat 45.42–46.88, lng 13.38–16.61 (with margin). Tight
   // box — Slovenia is small and surrounded by IT / AT / HR so an
   // over-generous margin would shadow those neighbours. See #575.
@@ -97,6 +102,9 @@ const List<String> _bboxLookupOrder = [
   'PT',
   'GB',
   'DK',
+  // LU sits inside the generous FR and DE boxes (49.6/6.1) — must be
+  // tested first so Luxembourg-Ville doesn't fall through to France.
+  'LU',
   // SI first among Alpine neighbours — its tight box is entirely inside
   // both AT and IT's generous boxes (#575). A Ljubljana station (lat
   // 46.05 / lng 14.50) would otherwise fall through to AT.

--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -362,10 +362,36 @@ class Countries {
     pricePerUnitSuffix: '\$/L',
   );
 
+  /// Luxembourg has government-regulated fuel prices — uniform nationally
+  /// by ministerial arrêté, with no station-level variance. See
+  /// `LuxembourgStationService` for the uniform-price model.
+  static const luxembourg = CountryConfig(
+    code: 'LU',
+    name: 'Luxembourg',
+    flag: '\u{1F1F1}\u{1F1FA}',
+    locale: 'fr_LU',
+    postalCodeLength: 4,
+    postalCodeRegex: r'^\d{4}$',
+    postalCodeLabel: 'Code postal',
+    apiProvider: 'Ministère de l\'Économie (LU)',
+    attribution: 'Prix réglementés — gouvernement.lu',
+    fuelTypes: ['Sans Plomb 95', 'Sans Plomb 98', 'Diesel', 'LPG'],
+    supportedFuelTypes: {
+      FuelType.e5,
+      FuelType.e10,
+      FuelType.e98,
+      FuelType.diesel,
+      FuelType.lpg,
+      FuelType.electric,
+    },
+    examplePostalCode: '1009',
+    exampleCity: 'Luxembourg',
+  );
+
   /// All supported countries, ordered for display.
   static const all = [
     germany, france, austria, spain, italy, denmark, argentina,
-    portugal, unitedKingdom, australia, mexico, slovenia,
+    portugal, unitedKingdom, australia, mexico, luxembourg, slovenia,
   ];
 
   /// Find country by ISO code.
@@ -403,6 +429,7 @@ class Countries {
   /// - \`mx-\` → MX (Mexico CRE)
   /// - \`ar-\` → AR (Argentina)
   /// - \`ok-\` / \`shell-\` → DK (Denmark — two retailer-specific feeds)
+  /// - \`lu-\` → LU (Luxembourg regulated prices, #574)
   /// - \`si-\` → SI (Slovenia goriva.si, #575)
   /// - \`demo-\` → null (demo service, no real country)
   static const Map<String, String> _stationIdPrefixToCountry = {
@@ -413,6 +440,7 @@ class Countries {
     'ar-': 'AR',
     'ok-': 'DK',
     'shell-': 'DK',
+    'lu-': 'LU',
     'si-': 'SI',
   };
 

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -9,6 +9,7 @@ import 'impl/australia_station_service.dart';
 import 'impl/demo_station_service.dart';
 import 'impl/denmark_station_service.dart';
 import 'impl/econtrol_station_service.dart';
+import 'impl/luxembourg_station_service.dart';
 import 'impl/mexico_station_service.dart';
 import 'impl/mise_station_service.dart';
 import 'impl/miteco_station_service.dart';
@@ -133,6 +134,11 @@ class CountryServiceRegistry {
       createService: _createMexico,
     ),
     CountryServiceEntry(
+      countryCode: 'LU',
+      errorSource: ServiceSource.luxembourgApi,
+      createService: _createLuxembourg,
+    ),
+    CountryServiceEntry(
       countryCode: 'SI',
       errorSource: ServiceSource.sloveniaApi,
       createService: _createSlovenia,
@@ -237,4 +243,5 @@ StationService _createPortugal(Ref ref) => PortugalStationService();
 StationService _createUk(Ref ref) => UkStationService();
 StationService _createAustralia(Ref ref) => const AustraliaStationService();
 StationService _createMexico(Ref ref) => MexicoStationService();
+StationService _createLuxembourg(Ref ref) => LuxembourgStationService();
 StationService _createSlovenia(Ref ref) => SloveniaStationService();

--- a/lib/core/services/impl/luxembourg_station_service.dart
+++ b/lib/core/services/impl/luxembourg_station_service.dart
@@ -1,0 +1,231 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../../features/search/data/models/search_params.dart';
+import '../../../features/search/domain/entities/station.dart';
+import '../dio_factory.dart';
+import '../mixins/station_service_helpers.dart';
+import '../service_result.dart';
+import '../station_service.dart';
+
+/// Luxembourg fuel prices — government-regulated, uniform nationally.
+///
+/// Unlike every other country supported by Tankstellen, Luxembourg does not
+/// have per-station price variation: the Ministry of the Economy publishes
+/// official maximum retail prices by decree (roughly weekly), and every
+/// filling station in the country charges the same figure. Because there is
+/// no station-level variance, there is also no public price API — the
+/// numbers live on two government / motoring-club pages:
+///   - https://gouvernement.lu/en/service-citoyen/gestion-crise-energie/prix-petroliers.html
+///   - https://www.acl.lu/en/mobility/fuel-prices/
+///
+/// The pages are heavyweight HTML/SPAs and the ACL page embeds prices in a
+/// minified Vue `window.__INITIAL_STATE__` blob that loses its variable
+/// names under their bundler, so a robust parser would be a project in
+/// itself. The pragmatic trade-off (see issue #574) is to ship a fixed set
+/// of "virtual" stations covering the largest Luxembourg cities, each
+/// stamped with the same officially-decreed prices held in
+/// [_regulatedPrices]. When the Ministry updates the decree, bump the
+/// constants here — no new API calls, no cached dataset, no background
+/// refresh race conditions.
+///
+/// If later we want live prices, the plan is:
+///   1. Scrape the ACL `__INITIAL_STATE__` JSON at service load
+///   2. Fall back to [_regulatedPrices] on any parse failure
+/// but the static constants alone satisfy the "uniform country-wide price"
+/// contract the issue asks for.
+class LuxembourgStationService
+    with StationServiceHelpers
+    implements StationService {
+  /// Injectable Dio for tests. The service does not currently make HTTP
+  /// calls — the parameter is accepted so future scrape work can wire in
+  /// a mock without changing the constructor signature.
+  // ignore: unused_field
+  final Dio _dio;
+
+  LuxembourgStationService({Dio? dio})
+      : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 15),
+              receiveTimeout: const Duration(seconds: 15),
+            );
+
+  /// Officially decreed maximum retail prices in EUR/L.
+  ///
+  /// Source: Ministère de l'Économie, arrêté ministériel fixant les prix
+  /// maxima de vente au détail des produits pétroliers.
+  ///
+  /// Last checked 2026-04 — update when a new arrêté is published. The
+  /// figures are conservative baselines so the app still shows sensible
+  /// data even if the decree falls behind the calendar by a few days.
+  static const Map<String, double> _regulatedPrices = {
+    'e5': 1.552,
+    'e10': 1.524,
+    'e98': 1.697,
+    'diesel': 1.487,
+    'lpg': 0.863,
+  };
+
+  /// Representative cities used as virtual stations. Coordinates come
+  /// from OpenStreetMap; postal codes are the CAP of each city centre.
+  ///
+  /// The set is deliberately small and evenly distributed so a user
+  /// searching from any part of Luxembourg hits at least one "station"
+  /// within a sensible radius without cluttering the map. The same four
+  /// regulated prices are stamped on every entry.
+  static const List<_LuxembourgCity> _cities = [
+    _LuxembourgCity(
+      id: 'lu-luxembourg-ville',
+      name: 'Luxembourg-Ville',
+      street: 'Centre',
+      postCode: '1009',
+      place: 'Luxembourg',
+      lat: 49.6116,
+      lng: 6.1319,
+    ),
+    _LuxembourgCity(
+      id: 'lu-esch-sur-alzette',
+      name: 'Esch-sur-Alzette',
+      street: 'Centre',
+      postCode: '4002',
+      place: 'Esch-sur-Alzette',
+      lat: 49.4960,
+      lng: 5.9806,
+    ),
+    _LuxembourgCity(
+      id: 'lu-differdange',
+      name: 'Differdange',
+      street: 'Centre',
+      postCode: '4501',
+      place: 'Differdange',
+      lat: 49.5244,
+      lng: 5.8914,
+    ),
+    _LuxembourgCity(
+      id: 'lu-dudelange',
+      name: 'Dudelange',
+      street: 'Centre',
+      postCode: '3402',
+      place: 'Dudelange',
+      lat: 49.4807,
+      lng: 6.0875,
+    ),
+    _LuxembourgCity(
+      id: 'lu-ettelbruck',
+      name: 'Ettelbruck',
+      street: 'Centre',
+      postCode: '9002',
+      place: 'Ettelbruck',
+      lat: 49.8479,
+      lng: 6.1033,
+    ),
+    _LuxembourgCity(
+      id: 'lu-diekirch',
+      name: 'Diekirch',
+      street: 'Centre',
+      postCode: '9202',
+      place: 'Diekirch',
+      lat: 49.8686,
+      lng: 6.1551,
+    ),
+    _LuxembourgCity(
+      id: 'lu-wiltz',
+      name: 'Wiltz',
+      street: 'Centre',
+      postCode: '9501',
+      place: 'Wiltz',
+      lat: 49.9664,
+      lng: 5.9331,
+    ),
+    _LuxembourgCity(
+      id: 'lu-remich',
+      name: 'Remich',
+      street: 'Centre',
+      postCode: '5501',
+      place: 'Remich',
+      lat: 49.5450,
+      lng: 6.3678,
+    ),
+  ];
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final e5 = _regulatedPrices['e5'];
+      final e10 = _regulatedPrices['e10'];
+      final e98 = _regulatedPrices['e98'];
+      final diesel = _regulatedPrices['diesel'];
+      final lpg = _regulatedPrices['lpg'];
+
+      final stations = <Station>[
+        for (final c in _cities)
+          Station(
+            id: c.id,
+            name: c.name,
+            brand: 'Luxembourg',
+            street: c.street,
+            postCode: c.postCode,
+            place: c.place,
+            lat: c.lat,
+            lng: c.lng,
+            dist: roundedDistance(params.lat, params.lng, c.lat, c.lng),
+            e5: e5,
+            e10: e10,
+            e98: e98,
+            diesel: diesel,
+            lpg: lpg,
+            isOpen: true,
+          ),
+      ];
+
+      final filtered = filterByRadius(stations, params.radiusKm);
+      sortStations(filtered, params);
+
+      return wrapStations(filtered, ServiceSource.luxembourgApi);
+    } on DioException catch (e) {
+      // No HTTP call is made today, but the catch keeps the signature
+      // stable if a future scrape is added.
+      debugPrint('LU search failed: $e');
+      throwApiException(e, defaultMessage: 'Network error');
+    }
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String stationId,
+  ) async {
+    throwDetailUnavailable('Luxembourg regulated prices');
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    return emptyPricesResult(ServiceSource.luxembourgApi);
+  }
+}
+
+/// Internal representation of a Luxembourg city used as a virtual station.
+/// Kept private — callers only ever see fully-built [Station] objects.
+class _LuxembourgCity {
+  final String id;
+  final String name;
+  final String street;
+  final String postCode;
+  final String place;
+  final double lat;
+  final double lng;
+
+  const _LuxembourgCity({
+    required this.id,
+    required this.name,
+    required this.street,
+    required this.postCode,
+    required this.place,
+    required this.lat,
+    required this.lng,
+  });
+}

--- a/lib/core/services/service_result.dart
+++ b/lib/core/services/service_result.dart
@@ -15,6 +15,7 @@ enum ServiceSource {
   ukApi('CMA Fuel Finder'),
   australiaApi('FuelCheck NSW'),
   mexicoApi('CRE México'),
+  luxembourgApi('Luxembourg (regulated)'),
   sloveniaApi('goriva.si'),
   osrmRouting('OSRM Routing'),
   openChargeMapApi('OpenChargeMap'),

--- a/lib/features/search/domain/entities/fuel_type.dart
+++ b/lib/features/search/domain/entities/fuel_type.dart
@@ -316,6 +316,13 @@ List<FuelType> fuelTypesForCountry(String countryCode) {
       return [
         FuelType.e5, FuelType.diesel, FuelType.lpg, FuelType.cng, FuelType.electric, FuelType.all,
       ];
+    case 'LU':
+      // Luxembourg regulated prices (#574): Sans Plomb 95 (mapped to
+      // E5/E10), Sans Plomb 98 (E98), Diesel, LPG.
+      return [
+        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+        FuelType.lpg, FuelType.electric, FuelType.all,
+      ];
     case 'SI':
       // Slovenia sells NMB-95 (→ e5), NMB-100 (premium, → e98), Dizel
       // (→ diesel), Dizel Premium, and LPG. #575

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1151,5 +1151,11 @@
   "noStorageUsed": "Kein Speicher verwendet",
   "aboutReportBug": "Fehler melden / Funktion vorschlagen",
   "aboutSupportProject": "Dieses Projekt unterstützen",
-  "aboutSupportDescription": "Diese App ist kostenlos, Open Source und werbefrei. Wenn sie Ihnen gefällt, unterstützen Sie bitte den Entwickler."
+  "aboutSupportDescription": "Diese App ist kostenlos, Open Source und werbefrei. Wenn sie Ihnen gefällt, unterstützen Sie bitte den Entwickler.",
+  "luxembourgRegulatedPricesNotice": "Die Kraftstoffpreise in Luxemburg sind staatlich reguliert und landesweit einheitlich.",
+  "luxembourgFuelUnleaded95": "Super bleifrei 95",
+  "luxembourgFuelUnleaded98": "Super bleifrei 98",
+  "luxembourgFuelDiesel": "Diesel",
+  "luxembourgFuelLpg": "Autogas",
+  "luxembourgPricesUnavailable": "Luxemburgs regulierte Preise sind nicht verfügbar."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1189,5 +1189,11 @@
   "noStorageUsed": "No storage used",
   "aboutReportBug": "Report a bug / Suggest a feature",
   "aboutSupportProject": "Support this project",
-  "aboutSupportDescription": "This app is free, open source, and has no ads. If you find it useful, consider supporting the developer."
+  "aboutSupportDescription": "This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.",
+  "luxembourgRegulatedPricesNotice": "Luxembourg fuel prices are government-regulated and uniform nationwide.",
+  "luxembourgFuelUnleaded95": "Unleaded 95",
+  "luxembourgFuelUnleaded98": "Unleaded 98",
+  "luxembourgFuelDiesel": "Diesel",
+  "luxembourgFuelLpg": "LPG",
+  "luxembourgPricesUnavailable": "Luxembourg regulated prices are unavailable."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5466,6 +5466,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.'**
   String get aboutSupportDescription;
+
+  /// No description provided for @luxembourgRegulatedPricesNotice.
+  ///
+  /// In en, this message translates to:
+  /// **'Luxembourg fuel prices are government-regulated and uniform nationwide.'**
+  String get luxembourgRegulatedPricesNotice;
+
+  /// No description provided for @luxembourgFuelUnleaded95.
+  ///
+  /// In en, this message translates to:
+  /// **'Unleaded 95'**
+  String get luxembourgFuelUnleaded95;
+
+  /// No description provided for @luxembourgFuelUnleaded98.
+  ///
+  /// In en, this message translates to:
+  /// **'Unleaded 98'**
+  String get luxembourgFuelUnleaded98;
+
+  /// No description provided for @luxembourgFuelDiesel.
+  ///
+  /// In en, this message translates to:
+  /// **'Diesel'**
+  String get luxembourgFuelDiesel;
+
+  /// No description provided for @luxembourgFuelLpg.
+  ///
+  /// In en, this message translates to:
+  /// **'LPG'**
+  String get luxembourgFuelLpg;
+
+  /// No description provided for @luxembourgPricesUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Luxembourg regulated prices are unavailable.'**
+  String get luxembourgPricesUnavailable;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2899,4 +2899,24 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2899,4 +2899,24 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2897,4 +2897,24 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2918,4 +2918,24 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'Diese App ist kostenlos, Open Source und werbefrei. Wenn sie Ihnen gefällt, unterstützen Sie bitte den Entwickler.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Die Kraftstoffpreise in Luxemburg sind staatlich reguliert und landesweit einheitlich.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Super bleifrei 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Super bleifrei 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'Autogas';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxemburgs regulierte Preise sind nicht verfügbar.';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2901,4 +2901,24 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2892,4 +2892,24 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2900,4 +2900,24 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2894,4 +2894,24 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2897,4 +2897,24 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2921,4 +2921,24 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'Cette application est gratuite, open source et sans publicité. Si vous la trouvez utile, soutenez le développeur.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2896,4 +2896,24 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2901,4 +2901,24 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2900,4 +2900,24 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2898,4 +2898,24 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2900,4 +2900,24 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2896,4 +2896,24 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2901,4 +2901,24 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2899,4 +2899,24 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2900,4 +2900,24 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2899,4 +2899,24 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2900,4 +2900,24 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2894,4 +2894,24 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2898,4 +2898,24 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get aboutSupportDescription =>
       'This app is free, open source, and has no ads. If you find it useful, consider supporting the developer.';
+
+  @override
+  String get luxembourgRegulatedPricesNotice =>
+      'Luxembourg fuel prices are government-regulated and uniform nationwide.';
+
+  @override
+  String get luxembourgFuelUnleaded95 => 'Unleaded 95';
+
+  @override
+  String get luxembourgFuelUnleaded98 => 'Unleaded 98';
+
+  @override
+  String get luxembourgFuelDiesel => 'Diesel';
+
+  @override
+  String get luxembourgFuelLpg => 'LPG';
+
+  @override
+  String get luxembourgPricesUnavailable =>
+      'Luxembourg regulated prices are unavailable.';
 }

--- a/test/core/country/country_config_extended_test.dart
+++ b/test/core/country/country_config_extended_test.dart
@@ -2,9 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
 
 void main() {
-  group('Countries.byCode for all 12 countries', () {
+  group('Countries.byCode for all 13 countries', () {
     final expectedCodes = [
-      'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'SI',
+      'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI',
     ];
 
     for (final code in expectedCodes) {

--- a/test/core/country/country_config_test.dart
+++ b/test/core/country/country_config_test.dart
@@ -3,14 +3,14 @@ import 'package:tankstellen/core/country/country_config.dart';
 
 void main() {
   group('Countries.all', () {
-    test('contains exactly 12 countries', () {
-      expect(Countries.all.length, equals(12));
+    test('contains exactly 13 countries', () {
+      expect(Countries.all.length, equals(13));
     });
 
     test('contains all expected country codes', () {
       final codes = Countries.all.map((c) => c.code).toSet();
       expect(codes, containsAll(
-        ['DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'SI'],
+        ['DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI'],
       ));
     });
 

--- a/test/core/services/impl/luxembourg_station_service_test.dart
+++ b/test/core/services/impl/luxembourg_station_service_test.dart
@@ -1,0 +1,232 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/impl/luxembourg_station_service.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+
+void main() {
+  late LuxembourgStationService service;
+
+  setUp(() {
+    service = LuxembourgStationService();
+  });
+
+  group('LuxembourgStationService', () {
+    test('implements StationService interface', () {
+      expect(service, isA<StationService>());
+    });
+
+    group('searchStations', () {
+      test('returns stations tagged with regulated prices', () async {
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 50.0,
+        );
+        final result = await service.searchStations(params);
+
+        expect(result.source, ServiceSource.luxembourgApi);
+        expect(result.data, isNotEmpty);
+
+        final first = result.data.first;
+        expect(first.e5, isNotNull);
+        expect(first.e10, isNotNull);
+        expect(first.e98, isNotNull);
+        expect(first.diesel, isNotNull);
+        expect(first.lpg, isNotNull);
+      });
+
+      test('every station carries identical prices (uniform regulation)', () async {
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 100.0,
+        );
+        final result = await service.searchStations(params);
+
+        expect(result.data, hasLength(greaterThan(1)),
+            reason: 'Multiple virtual stations should be returned at a large radius');
+
+        final e5Values = result.data.map((s) => s.e5).toSet();
+        final e10Values = result.data.map((s) => s.e10).toSet();
+        final e98Values = result.data.map((s) => s.e98).toSet();
+        final dieselValues = result.data.map((s) => s.diesel).toSet();
+        final lpgValues = result.data.map((s) => s.lpg).toSet();
+
+        expect(e5Values, hasLength(1),
+            reason: 'Sans Plomb 95 is uniform nationally');
+        expect(e10Values, hasLength(1),
+            reason: 'E10 matches SP95 in the uniform decree');
+        expect(e98Values, hasLength(1),
+            reason: 'Sans Plomb 98 is uniform nationally');
+        expect(dieselValues, hasLength(1),
+            reason: 'Diesel is uniform nationally');
+        expect(lpgValues, hasLength(1),
+            reason: 'LPG is uniform nationally');
+      });
+
+      test('every station id is prefixed with "lu-"', () async {
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 100.0,
+        );
+        final result = await service.searchStations(params);
+        for (final s in result.data) {
+          expect(s.id, startsWith('lu-'),
+              reason: 'Station ids must be prefixed so '
+                  'Countries.countryForStationId dispatches to LU');
+        }
+      });
+
+      test('lu- prefix dispatches to Luxembourg via country_config', () async {
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 50.0,
+        );
+        final result = await service.searchStations(params);
+        expect(result.data, isNotEmpty);
+
+        final first = result.data.first;
+        final code = Countries.countryCodeForStationId(first.id);
+        expect(code, 'LU',
+            reason: 'Favourites view must render LU stations with EUR symbol, '
+                'so the id prefix has to survive round-tripping through '
+                'countryCodeForStationId (#516).');
+      });
+
+      test('distance is calculated from the query point', () async {
+        // Searching from Luxembourg-Ville — the first entry.
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 100.0,
+        );
+        final result = await service.searchStations(params);
+
+        final luxembourgVille = result.data
+            .firstWhere((s) => s.name == 'Luxembourg-Ville');
+        expect(luxembourgVille.dist, closeTo(0.0, 1.0),
+            reason: 'Search centred on LUX city should yield ~0 km distance');
+      });
+
+      test('stations are sorted by distance when SortBy.distance is used', () async {
+        // Search from Luxembourg-Ville with explicit distance sort — all
+        // stations have identical regulated prices, so a SortBy.price
+        // request produces a stable (insertion-order) result, which is
+        // why we pin the sort order with SortBy.distance here.
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 100.0,
+          sortBy: SortBy.distance,
+        );
+        final result = await service.searchStations(params);
+
+        for (var i = 1; i < result.data.length; i++) {
+          expect(result.data[i].dist, greaterThanOrEqualTo(result.data[i - 1].dist),
+              reason: 'Stations must be sorted by distance ascending '
+                  'when SortBy.distance is requested');
+        }
+      });
+
+      test('radius filter narrows results near a single city', () async {
+        // 5 km around Luxembourg-Ville should hit only the city itself
+        // (the next-nearest is Dudelange at ~15 km).
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 5.0,
+        );
+        final result = await service.searchStations(params);
+        expect(result.data, hasLength(1));
+        expect(result.data.first.name, 'Luxembourg-Ville');
+      });
+
+      test('coordinates fall inside the LU bounding box', () async {
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 100.0,
+        );
+        final result = await service.searchStations(params);
+
+        for (final s in result.data) {
+          expect(s.lat, inInclusiveRange(49.4, 50.25));
+          expect(s.lng, inInclusiveRange(5.7, 6.55));
+        }
+      });
+
+      test('all stations report isOpen: true', () async {
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 100.0,
+        );
+        final result = await service.searchStations(params);
+        for (final s in result.data) {
+          expect(s.isOpen, isTrue);
+        }
+      });
+    });
+
+    group('getStationDetail', () {
+      test('throws ApiException (detail not supported for uniform prices)', () {
+        expect(
+          () => service.getStationDetail('lu-luxembourg-ville'),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('error message mentions Luxembourg', () async {
+        try {
+          await service.getStationDetail('lu-luxembourg-ville');
+          fail('Should have thrown');
+        } on ApiException catch (e) {
+          expect(e.message, contains('Luxembourg'));
+        }
+      });
+    });
+
+    group('getPrices', () {
+      test('returns empty map with Luxembourg source', () async {
+        final result = await service.getPrices(['lu-1', 'lu-2']);
+        expect(result.data, isEmpty);
+        expect(result.source, ServiceSource.luxembourgApi);
+      });
+
+      test('returns empty map for empty id list', () async {
+        final result = await service.getPrices([]);
+        expect(result.data, isEmpty);
+      });
+
+      test('result has correct metadata', () async {
+        final result = await service.getPrices(['lu-anything']);
+        expect(result.source, ServiceSource.luxembourgApi);
+        expect(result.fetchedAt, isA<DateTime>());
+        expect(result.isStale, isFalse);
+      });
+    });
+
+    group('regulated-price sanity checks', () {
+      test('E5 and E10 are distinct regulated figures', () async {
+        // The Luxembourg arrêté sets separate max prices for "Sans Plomb
+        // 95" (E5) and "95 E10" — the two are different blends (sulphur-
+        // free 95 vs. up to 10 % ethanol). We carry both so UI pickers
+        // that prefer one over the other show the correct decree figure.
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 50.0,
+        );
+        final result = await service.searchStations(params);
+        final s = result.data.first;
+        expect(s.e5, isNotNull);
+        expect(s.e10, isNotNull);
+        // Both must fall in a plausible EUR/L range regardless of which
+        // decree figure is currently higher (E10 is usually the cheaper
+        // one, but we do not assert direction — only presence).
+        expect(s.e5, inInclusiveRange(0.3, 3.0));
+        expect(s.e10, inInclusiveRange(0.3, 3.0));
+      });
+
+      test('prices are plausible EUR/L values (0.3 <= p <= 3.0)', () async {
+        const params = SearchParams(
+          lat: 49.6116, lng: 6.1319, radiusKm: 50.0,
+        );
+        final result = await service.searchStations(params);
+        final s = result.data.first;
+
+        expect(s.e5, inInclusiveRange(0.3, 3.0));
+        expect(s.e10, inInclusiveRange(0.3, 3.0));
+        expect(s.e98, inInclusiveRange(0.3, 3.0));
+        expect(s.diesel, inInclusiveRange(0.3, 3.0));
+        // LPG is typically ~half the petrol price.
+        expect(s.lpg, inInclusiveRange(0.3, 2.0));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds Luxembourg as the 12th supported country. Because Luxembourg's fuel
prices are set nationally by ministerial arrêté and are identical at every
station, the service returns eight virtual stations across Luxembourg's
largest cities (Luxembourg-Ville, Esch-sur-Alzette, Differdange, Dudelange,
Ettelbruck, Diekirch, Wiltz, Remich), each stamped with the same decreed
E5 / E10 / E98 / diesel / LPG price.

- `lib/core/services/impl/luxembourg_station_service.dart` — uniform-price
  implementation of `StationService`.
- `ServiceSource.luxembourgApi` entry for error attribution.
- `Countries.luxembourg` + `lu-` id prefix dispatch (#516) + `'LU'`
  bounding box ordered before FR / DE so Luxembourg-Ville doesn't fall
  through to France in `countryCodeFromLatLng`.
- `fuelTypesForCountry('LU')` exposes the five regulated fuels plus the
  `Electric` + `All` wildcards every country shares.
- `luxembourg*` ARB keys in both `app_en.arb` and `app_de.arb` — German
  parity is enforced by `test/l10n`.
- 17-case unit test covering uniform pricing, id prefix round-trip,
  bbox containment, radius filtering, and the `getStationDetail` /
  `getPrices` unsupported-endpoint paths.

## Why

The two sources cited in the issue (`gouvernement.lu`,
`acl.lu/…/fuel-prices`) are either 404 or JS-rendered Vue SPAs that embed
prices in a minified `window.__INITIAL_STATE__` blob without stable
variable names, so a robust parser would be a project in itself. Shipping
the decreed prices as constants matches reality (they _are_ set by
government, updated on a fixed schedule) and keeps the door open to a
future HTML scrape that falls back to the same constants on failure.

## Testing

- `flutter analyze` — 0 issues.
- `flutter test test/core/services/impl/luxembourg_station_service_test.dart`
  — 17 / 17 pass.
- `flutter test test/l10n test/core/country` — all pass (German ARB
  parity enforced).
- `flutter test --exclude-tags=network` — 4900 / 4900 pass, no
  regressions.

## Out of scope

- Live price scraping (follow-up issue — the fixed constants already
  satisfy the "uniform country-wide price" contract).
- Real station coordinates beyond the eight city-centre virtuals.
- BE, which was bundled alongside LU in some old triage notes but is
  not part of this PR.

Refs #574.