### PR TITLE
fix(i18n): add ARB keys for report-feature TODOs (#838)

### DIFF
--- a/lib/features/report/domain/entities/report_type.dart
+++ b/lib/features/report/domain/entities/report_type.dart
@@ -130,22 +130,20 @@ enum ReportType {
         return l10n?.wrongE10Price ?? 'Prix Super E10 incorrect';
       case wrongDiesel:
         return l10n?.wrongDieselPrice ?? 'Prix Diesel incorrect';
-      // TODO: add ARB keys for the new types. Inline French fallback
-      // matches the primary user locale.
       case wrongE85:
-        return 'Prix E85 incorrect';
+        return l10n?.wrongE85Price ?? 'Wrong E85 price';
       case wrongE98:
-        return 'Prix Super 98 incorrect';
+        return l10n?.wrongE98Price ?? 'Wrong Super 98 price';
       case wrongLpg:
-        return 'Prix GPL incorrect';
+        return l10n?.wrongLpgPrice ?? 'Wrong LPG price';
       case wrongStatusOpen:
-        return l10n?.wrongStatusOpen ?? 'Affiché ouvert, mais fermé';
+        return l10n?.wrongStatusOpen ?? 'Shown as open, but closed';
       case wrongStatusClosed:
-        return l10n?.wrongStatusClosed ?? 'Affiché fermé, mais ouvert';
+        return l10n?.wrongStatusClosed ?? 'Shown as closed, but open';
       case wrongName:
-        return 'Nom de la station incorrect';
+        return l10n?.wrongStationName ?? 'Wrong station name';
       case wrongAddress:
-        return 'Adresse incorrecte';
+        return l10n?.wrongStationAddress ?? 'Wrong address';
     }
   }
 }

--- a/lib/features/report/presentation/screens/report_screen.dart
+++ b/lib/features/report/presentation/screens/report_screen.dart
@@ -91,10 +91,9 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
       return;
     }
     if (selectedType.needsText && _textController.text.trim().isEmpty) {
-      // TODO: add ARB key for 'enterCorrection'.
       SnackBarHelper.showError(
         context,
-        'Veuillez saisir la correction',
+        l10n?.enterCorrection ?? 'Please enter the correction',
       );
       return;
     }
@@ -168,13 +167,12 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
 
       if (!canSubmitTankerkoenig && !canSubmitTankSync) {
         if (mounted) {
-          // TODO: localise via `reportNoBackendAvailable` ARB key when
-          // the next batch of l10n strings is added.
           SnackBarHelper.showError(
             context,
-            'Le signalement n\'a pas pu être envoyé : aucun service de '
-            'report n\'est configuré pour ce pays. Activez TankSync dans '
-            'les paramètres pour envoyer des signalements communautaires.',
+            l10n?.reportNoBackendAvailable ??
+                'The report could not be sent: no reporting service is '
+                    'configured for this country. Enable TankSync in Settings '
+                    'to send community reports.',
           );
         }
         return;
@@ -268,10 +266,9 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
       appBar: AppBar(
         // #484 — was "Signaler un prix" but two of the existing options
         // (open/closed status) are not about prices and the rework will
-        // add metadata-only report types. Generic "Signaler un problème"
+        // add metadata-only report types. Generic "Report a problem"
         // matches the actual scope.
-        // TODO: add `reportIssueTitle` ARB key for localisation.
-        title: const Text('Signaler un problème'),
+        title: Text(l10n?.reportIssueTitle ?? 'Report a problem'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           tooltip: l10n?.tooltipBack ?? 'Back',

--- a/lib/features/report/presentation/widgets/report_input_section.dart
+++ b/lib/features/report/presentation/widgets/report_input_section.dart
@@ -47,10 +47,9 @@ class ReportInputSection extends StatelessWidget {
           controller: textController,
           textCapitalization: TextCapitalization.sentences,
           decoration: InputDecoration(
-            // TODO: add ARB keys `correctName` / `correctAddress`.
             labelText: type == ReportType.wrongName
-                ? 'Nom correct de la station'
-                : 'Adresse correcte',
+                ? (l10n?.correctName ?? 'Correct station name')
+                : (l10n?.correctAddress ?? 'Correct address'),
             border: const OutlineInputBorder(),
           ),
         ),

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -191,15 +191,8 @@ class StationDetailScreen extends ConsumerWidget {
                       if (_isIndependentSentinel(station))
                         Padding(
                           padding: const EdgeInsets.only(top: 2),
-                          // TODO: localise via an `independentStation`
-                          // ARB key when the next batch of l10n keys
-                          // is added. Inline French fallback here
-                          // matches the primary user locale and the
-                          // inline fallback pattern used elsewhere on
-                          // this screen for strings not yet in the
-                          // ARB files.
                           child: Text(
-                            'Station indépendante',
+                            l10n?.independentStation ?? 'Independent station',
                             style: theme.textTheme.bodyMedium?.copyWith(
                               color: theme.colorScheme.onSurfaceVariant,
                               fontStyle: FontStyle.italic,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1157,5 +1157,16 @@
   "luxembourgFuelUnleaded98": "Super bleifrei 98",
   "luxembourgFuelDiesel": "Diesel",
   "luxembourgFuelLpg": "Autogas",
-  "luxembourgPricesUnavailable": "Luxemburgs regulierte Preise sind nicht verfügbar."
+  "luxembourgPricesUnavailable": "Luxemburgs regulierte Preise sind nicht verfügbar.",
+  "reportIssueTitle": "Problem melden",
+  "enterCorrection": "Bitte Korrektur eingeben",
+  "reportNoBackendAvailable": "Die Meldung konnte nicht gesendet werden: Für dieses Land ist kein Meldedienst konfiguriert. Aktivieren Sie TankSync in den Einstellungen, um Community-Meldungen zu senden.",
+  "correctName": "Korrekter Tankstellenname",
+  "correctAddress": "Korrekte Adresse",
+  "wrongE85Price": "Falscher E85 Preis",
+  "wrongE98Price": "Falscher Super 98 Preis",
+  "wrongLpgPrice": "Falscher LPG Preis",
+  "wrongStationName": "Falscher Tankstellenname",
+  "wrongStationAddress": "Falsche Adresse",
+  "independentStation": "Unabhängige Tankstelle"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1195,5 +1195,16 @@
   "luxembourgFuelUnleaded98": "Unleaded 98",
   "luxembourgFuelDiesel": "Diesel",
   "luxembourgFuelLpg": "LPG",
-  "luxembourgPricesUnavailable": "Luxembourg regulated prices are unavailable."
+  "luxembourgPricesUnavailable": "Luxembourg regulated prices are unavailable.",
+  "reportIssueTitle": "Report a problem",
+  "enterCorrection": "Please enter the correction",
+  "reportNoBackendAvailable": "The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.",
+  "correctName": "Correct station name",
+  "correctAddress": "Correct address",
+  "wrongE85Price": "Wrong E85 price",
+  "wrongE98Price": "Wrong Super 98 price",
+  "wrongLpgPrice": "Wrong LPG price",
+  "wrongStationName": "Wrong station name",
+  "wrongStationAddress": "Wrong address",
+  "independentStation": "Independent station"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5502,6 +5502,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Luxembourg regulated prices are unavailable.'**
   String get luxembourgPricesUnavailable;
+
+  /// No description provided for @reportIssueTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Report a problem'**
+  String get reportIssueTitle;
+
+  /// No description provided for @enterCorrection.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter the correction'**
+  String get enterCorrection;
+
+  /// No description provided for @reportNoBackendAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.'**
+  String get reportNoBackendAvailable;
+
+  /// No description provided for @correctName.
+  ///
+  /// In en, this message translates to:
+  /// **'Correct station name'**
+  String get correctName;
+
+  /// No description provided for @correctAddress.
+  ///
+  /// In en, this message translates to:
+  /// **'Correct address'**
+  String get correctAddress;
+
+  /// No description provided for @wrongE85Price.
+  ///
+  /// In en, this message translates to:
+  /// **'Wrong E85 price'**
+  String get wrongE85Price;
+
+  /// No description provided for @wrongE98Price.
+  ///
+  /// In en, this message translates to:
+  /// **'Wrong Super 98 price'**
+  String get wrongE98Price;
+
+  /// No description provided for @wrongLpgPrice.
+  ///
+  /// In en, this message translates to:
+  /// **'Wrong LPG price'**
+  String get wrongLpgPrice;
+
+  /// No description provided for @wrongStationName.
+  ///
+  /// In en, this message translates to:
+  /// **'Wrong station name'**
+  String get wrongStationName;
+
+  /// No description provided for @wrongStationAddress.
+  ///
+  /// In en, this message translates to:
+  /// **'Wrong address'**
+  String get wrongStationAddress;
+
+  /// No description provided for @independentStation.
+  ///
+  /// In en, this message translates to:
+  /// **'Independent station'**
+  String get independentStation;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2919,4 +2919,38 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2919,4 +2919,38 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2917,4 +2917,38 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2938,4 +2938,38 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxemburgs regulierte Preise sind nicht verfügbar.';
+
+  @override
+  String get reportIssueTitle => 'Problem melden';
+
+  @override
+  String get enterCorrection => 'Bitte Korrektur eingeben';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'Die Meldung konnte nicht gesendet werden: Für dieses Land ist kein Meldedienst konfiguriert. Aktivieren Sie TankSync in den Einstellungen, um Community-Meldungen zu senden.';
+
+  @override
+  String get correctName => 'Korrekter Tankstellenname';
+
+  @override
+  String get correctAddress => 'Korrekte Adresse';
+
+  @override
+  String get wrongE85Price => 'Falscher E85 Preis';
+
+  @override
+  String get wrongE98Price => 'Falscher Super 98 Preis';
+
+  @override
+  String get wrongLpgPrice => 'Falscher LPG Preis';
+
+  @override
+  String get wrongStationName => 'Falscher Tankstellenname';
+
+  @override
+  String get wrongStationAddress => 'Falsche Adresse';
+
+  @override
+  String get independentStation => 'Unabhängige Tankstelle';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2921,4 +2921,38 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2912,4 +2912,38 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2920,4 +2920,38 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2914,4 +2914,38 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2917,4 +2917,38 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2941,4 +2941,38 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2916,4 +2916,38 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2921,4 +2921,38 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2920,4 +2920,38 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2918,4 +2918,38 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2920,4 +2920,38 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2916,4 +2916,38 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2921,4 +2921,38 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2919,4 +2919,38 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2920,4 +2920,38 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2919,4 +2919,38 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2920,4 +2920,38 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2914,4 +2914,38 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2918,4 +2918,38 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get luxembourgPricesUnavailable =>
       'Luxembourg regulated prices are unavailable.';
+
+  @override
+  String get reportIssueTitle => 'Report a problem';
+
+  @override
+  String get enterCorrection => 'Please enter the correction';
+
+  @override
+  String get reportNoBackendAvailable =>
+      'The report could not be sent: no reporting service is configured for this country. Enable TankSync in Settings to send community reports.';
+
+  @override
+  String get correctName => 'Correct station name';
+
+  @override
+  String get correctAddress => 'Correct address';
+
+  @override
+  String get wrongE85Price => 'Wrong E85 price';
+
+  @override
+  String get wrongE98Price => 'Wrong Super 98 price';
+
+  @override
+  String get wrongLpgPrice => 'Wrong LPG price';
+
+  @override
+  String get wrongStationName => 'Wrong station name';
+
+  @override
+  String get wrongStationAddress => 'Wrong address';
+
+  @override
+  String get independentStation => 'Independent station';
 }

--- a/test/features/report/presentation/screens/report_screen_test.dart
+++ b/test/features/report/presentation/screens/report_screen_test.dart
@@ -11,7 +11,7 @@ import '../../../../helpers/pump_app.dart';
 
 void main() {
   group('ReportScreen', () {
-    testWidgets('renders Scaffold with the retitled "Signaler un problème"',
+    testWidgets('renders Scaffold with the retitled "Report a problem"',
         (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -25,9 +25,10 @@ void main() {
 
       expect(find.byType(Scaffold), findsAtLeast(1));
       // #484 — was "Report price" (misleading because status reports
-      // are not about prices). Retitled to the generic "Signaler un
-      // problème" that covers the whole scope.
-      expect(find.text('Signaler un problème'), findsOneWidget);
+      // are not about prices). Retitled to the generic "Report a
+      // problem" (via reportIssueTitle ARB key, #838) that covers the
+      // whole scope.
+      expect(find.text('Report a problem'), findsOneWidget);
     });
 
     testWidgets('renders all report type radio options', (tester) async {
@@ -226,7 +227,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Select wrongAddress
-      await tester.tap(find.text('Adresse incorrecte'));
+      await tester.tap(find.text('Wrong address'));
       await tester.pumpAndSettle();
 
       // Button still disabled without text.
@@ -306,8 +307,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await scrollToRadio(tester, 'Nom de la station incorrect');
-      await tester.tap(find.text('Nom de la station incorrect'));
+      await scrollToRadio(tester, 'Wrong station name');
+      await tester.tap(find.text('Wrong station name'));
       await tester.pumpAndSettle();
 
       expect(
@@ -334,8 +335,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await scrollToRadio(tester, 'Adresse incorrecte');
-      await tester.tap(find.text('Adresse incorrecte'));
+      await scrollToRadio(tester, 'Wrong address');
+      await tester.tap(find.text('Wrong address'));
       await tester.pumpAndSettle();
 
       expect(
@@ -359,8 +360,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await scrollToRadio(tester, 'Prix E85 incorrect');
-      await tester.tap(find.text('Prix E85 incorrect'));
+      await scrollToRadio(tester, 'Wrong E85 price');
+      await tester.tap(find.text('Wrong E85 price'));
       await tester.pumpAndSettle();
 
       expect(find.text('Correct price (e.g. 1.459)'), findsOneWidget);
@@ -385,8 +386,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await scrollToRadio(tester, 'Nom de la station incorrect');
-      await tester.tap(find.text('Nom de la station incorrect'));
+      await scrollToRadio(tester, 'Wrong station name');
+      await tester.tap(find.text('Wrong station name'));
       await tester.pumpAndSettle();
 
       // Scroll the button into view to assert its state.
@@ -511,7 +512,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Adresse incorrecte'));
+      await tester.tap(find.text('Wrong address'));
       await tester.pumpAndSettle();
 
       await tester.enterText(
@@ -556,11 +557,11 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.scrollUntilVisible(
-        find.text('Nom de la station incorrect'),
+        find.text('Wrong station name'),
         120,
         scrollable: find.byType(Scrollable).first,
       );
-      await tester.tap(find.text('Nom de la station incorrect'));
+      await tester.tap(find.text('Wrong station name'));
       await tester.pumpAndSettle();
 
       await tester.enterText(


### PR DESCRIPTION
## Summary

Removes all 6 `TODO: add ARB key` markers in the report feature plus the one `independentStation` TODO in `station_detail_screen.dart`. Previously these user-facing strings were hardcoded in French (primary user locale) with no fallback path through `AppLocalizations`, so the English fallback never fired and all other locales silently rendered French.

## Why

`fr` shipping as the default for strings that lack ARB coverage breaks translation completeness and is confusing for non-French users (DE, EN, etc.). Every user-facing string should route through the `l10n?.<key> ?? 'English fallback'` pattern.

## Changes

Added 11 ARB keys to `app_en.arb` and `app_de.arb` (other 21 locales fall back to English — the `localization_completeness_test.dart` gate only enforces en/de parity; coordinator handles full-locale roll-out separately):

- `reportIssueTitle` — AppBar title
- `enterCorrection` — snackbar validation error
- `reportNoBackendAvailable` — snackbar error when neither Tankerkoenig nor TankSync is configured
- `correctName` / `correctAddress` — TextField labels for metadata corrections
- `wrongE85Price` / `wrongE98Price` / `wrongLpgPrice` — new-fuel-type radio labels
- `wrongStationName` / `wrongStationAddress` — metadata-type radio labels
- `independentStation` — station-detail subtitle for non-branded stations

Regenerated `app_localizations*.dart` via `flutter gen-l10n`.

Files touched:
- `lib/features/report/presentation/screens/report_screen.dart`
- `lib/features/report/presentation/widgets/report_input_section.dart`
- `lib/features/report/domain/entities/report_type.dart`
- `lib/features/station_detail/presentation/screens/station_detail_screen.dart`
- `lib/l10n/app_en.arb` + `app_de.arb` (+ regenerated dart bindings)
- `test/features/report/presentation/screens/report_screen_test.dart` (updated literal string expectations from French -> English fallback)

## Test plan

- [x] `flutter gen-l10n` — succeeds
- [x] `flutter analyze` — zero issues
- [x] `flutter test` — only the pre-existing `API Connectivity Argentina` network-timeout failure remains (owned by parallel worker). All 8 previously-failing report-screen widget tests now pass.
- [x] `grep -nE 'TODO.*ARB|TODO.*localise|TODO.*localize' lib/features/report/ lib/features/station_detail/` returns empty

Closes #838