### PR TITLE
fix(ar): surface expired-TLS upstream error (#837)

### DIFF
--- a/lib/core/error/error_localizer.dart
+++ b/lib/core/error/error_localizer.dart
@@ -35,6 +35,15 @@ class ErrorLocalizer {
           'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
     }
 
+    if (error is UpstreamCertificateException) {
+      // ARB message carries a `{host}` placeholder so the user knows who to
+      // contact. Fallback mirrors the ARB wording in English (#837).
+      return l10n?.errorUpstreamCertExpired(error.host) ??
+          'Upstream data provider (${error.host}) is serving an expired or '
+              'invalid TLS certificate — the app cannot load data from this '
+              'provider until they fix it. Please contact ${error.host}.';
+    }
+
     if (error is ServiceChainExhaustedException) {
       return l10n?.errorAllServicesFailed ?? 'Could not load data. Check your connection and try again.';
     }

--- a/lib/core/error/exceptions.dart
+++ b/lib/core/error/exceptions.dart
@@ -60,6 +60,40 @@ class NoEvApiKeyException extends AppException {
   String toString() => message;
 }
 
+/// Thrown when an upstream provider serves an invalid, expired, or otherwise
+/// untrusted TLS certificate. We never bypass cert validation (MITM risk), so
+/// the only remedy is to surface a clear, actionable message telling the user
+/// that the data provider — not the app — is misconfigured, and (if known)
+/// which host is affected so the user can contact the data source (#837).
+class UpstreamCertificateException extends AppException {
+  /// Upstream hostname whose certificate failed validation (e.g.
+  /// `datos.energia.gob.ar`). Used in the localized message so the user
+  /// knows which provider to contact.
+  final String host;
+
+  /// Country code (ISO-3166-1 alpha-2, lowercase) of the affected provider,
+  /// e.g. `ar`. Lets the UI prefix the message with the country name.
+  final String? countryCode;
+
+  /// Underlying error detail (usually the Dio / X509 error text) for
+  /// diagnostics — NOT shown to the user as-is.
+  final String? detail;
+
+  const UpstreamCertificateException({
+    required this.host,
+    this.countryCode,
+    this.detail,
+  });
+
+  @override
+  String get message =>
+      'Upstream certificate invalid or expired for $host'
+      '${detail == null ? '' : ' ($detail)'}.';
+
+  @override
+  String toString() => 'UpstreamCertificateException: $message';
+}
+
 /// Thrown when every service in a fallback chain has failed,
 /// including the cache. Carries accumulated errors from each step
 /// so the UI can report exactly what went wrong.

--- a/lib/core/services/impl/argentina_station_service.dart
+++ b/lib/core/services/impl/argentina_station_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'argentina_fuel_classifier.dart';
 import '../../../features/search/data/models/search_params.dart';
 import '../../../features/search/domain/entities/station.dart';
+import '../../error/exceptions.dart';
 import '../../utils/geo_utils.dart';
 import '../dio_factory.dart';
 import '../mixins/cached_dataset_mixin.dart';
@@ -28,11 +29,21 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
       '80ac25de-a44a-4445-9215-090cf55cfda5/download/'
       'precios-en-surtidor-resolucin-3142016.csv';
 
-  final Dio _dio = DioFactory.create(
-    connectTimeout: const Duration(seconds: 20),
-    receiveTimeout: const Duration(seconds: 60),
-    responseType: ResponseType.plain,
-  );
+  /// Default production constructor.
+  ArgentinaStationService()
+      : _dio = DioFactory.create(
+          connectTimeout: const Duration(seconds: 20),
+          receiveTimeout: const Duration(seconds: 60),
+          responseType: ResponseType.plain,
+        );
+
+  /// Test-only constructor that accepts a preconfigured [Dio] (usually with
+  /// a [MockAdapter]) so the cert-error classification path (#837) can be
+  /// driven without hitting the network.
+  @visibleForTesting
+  ArgentinaStationService.withDio(this._dio);
+
+  final Dio _dio;
 
   // Cache parsed stations
   List<_RawStation>? _cachedStations;
@@ -129,8 +140,44 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
 
       return wrapStations(stations, ServiceSource.argentinaApi);
     } on DioException catch (e) {
+      _throwCertificateOrApiException(e); // #837 — classify cert errors first.
       throwApiException(e, defaultMessage: 'Error de red');
     }
+  }
+
+  /// #837 — if [e] is a TLS/certificate error, throw the specific
+  /// [UpstreamCertificateException] so the UI can blame the data provider
+  /// (not the app). Otherwise, return normally and let the caller fall back
+  /// to [throwApiException].
+  void _throwCertificateOrApiException(DioException e) {
+    if (_isCertificateError(e)) {
+      throw UpstreamCertificateException(
+        host: _csvHost,
+        countryCode: 'ar',
+        detail: e.message,
+      );
+    }
+  }
+
+  /// Hostname of the Argentina open-data CSV — kept in a constant so the
+  /// certificate error message names the exact provider the user should
+  /// contact (#837).
+  static const _csvHost = 'datos.energia.gob.ar';
+
+  /// Detect whether a [DioException] is a TLS/certificate validation
+  /// failure. Dio 5.x signals most cert errors via
+  /// [DioExceptionType.badCertificate], but on some platforms a bad cert
+  /// arrives under [DioExceptionType.unknown] with an `HandshakeException`
+  /// / `TlsException` wrapped in [DioException.error] — we match both.
+  static bool _isCertificateError(DioException e) {
+    if (e.type == DioExceptionType.badCertificate) return true;
+    if (e.type != DioExceptionType.unknown) return false;
+    final haystack = '${e.error ?? ''} ${e.message ?? ''}'.toUpperCase();
+    return haystack.contains('CERT') ||
+        haystack.contains('X509') ||
+        haystack.contains('SSL') ||
+        haystack.contains('TLS') ||
+        haystack.contains('HANDSHAKE');
   }
 
   Future<void> _ensureDataLoaded({CancelToken? cancelToken}) async {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1014,6 +1014,12 @@
   "ratingDescPrivate": "Mit Ihrer Datenbank synchronisiert (nicht für andere sichtbar)",
   "ratingDescShared": "Für alle Nutzer Ihrer Datenbank sichtbar",
   "errorNoEvApiKey": "OpenChargeMap-API-Schlüssel nicht konfiguriert. Fügen Sie einen in den Einstellungen hinzu, um Ladestationen zu suchen.",
+  "errorUpstreamCertExpired": "Der Datenanbieter ({host}) verwendet ein abgelaufenes oder ungültiges TLS-Zertifikat. Die App kann von dieser Quelle keine Daten laden, bis der Anbieter das Problem behebt. Bitte wenden Sie sich an {host}.",
+  "@errorUpstreamCertExpired": {
+    "placeholders": {
+      "host": { "type": "String" }
+    }
+  },
   "offlineLabel": "Offline",
   "fallbackSummary": "{failed} nicht verfügbar. Verwende {current}.",
   "errorTitleApiKey": "API-Schlüssel erforderlich",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1041,6 +1041,12 @@
   "ratingDescPrivate": "Synced with your database (not visible to others)",
   "ratingDescShared": "Visible to all users of your database",
   "errorNoEvApiKey": "OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.",
+  "errorUpstreamCertExpired": "The data provider ({host}) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact {host}.",
+  "@errorUpstreamCertExpired": {
+    "placeholders": {
+      "host": { "type": "String" }
+    }
+  },
   "offlineLabel": "Offline",
   "fallbackSummary": "{failed} unavailable. Using {current}.",
   "@fallbackSummary": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4675,6 +4675,12 @@ abstract class AppLocalizations {
   /// **'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.'**
   String get errorNoEvApiKey;
 
+  /// No description provided for @errorUpstreamCertExpired.
+  ///
+  /// In en, this message translates to:
+  /// **'The data provider ({host}) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact {host}.'**
+  String errorUpstreamCertExpired(String host);
+
   /// No description provided for @offlineLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2469,6 +2469,11 @@ class AppLocalizationsBg extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2469,6 +2469,11 @@ class AppLocalizationsCs extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2467,6 +2467,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2485,6 +2485,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'OpenChargeMap-API-Schlüssel nicht konfiguriert. Fügen Sie einen in den Einstellungen hinzu, um Ladestationen zu suchen.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'Der Datenanbieter ($host) verwendet ein abgelaufenes oder ungültiges TLS-Zertifikat. Die App kann von dieser Quelle keine Daten laden, bis der Anbieter das Problem behebt. Bitte wenden Sie sich an $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2471,6 +2471,11 @@ class AppLocalizationsEl extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2462,6 +2462,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2470,6 +2470,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2464,6 +2464,11 @@ class AppLocalizationsEt extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2467,6 +2467,11 @@ class AppLocalizationsFi extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2485,6 +2485,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Clé API OpenChargeMap non configurée. Ajoutez-en une dans Paramètres pour rechercher des bornes de recharge.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Hors ligne';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2466,6 +2466,11 @@ class AppLocalizationsHr extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2471,6 +2471,11 @@ class AppLocalizationsHu extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2470,6 +2470,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2468,6 +2468,11 @@ class AppLocalizationsLt extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2470,6 +2470,11 @@ class AppLocalizationsLv extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2466,6 +2466,11 @@ class AppLocalizationsNb extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2471,6 +2471,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2469,6 +2469,11 @@ class AppLocalizationsPl extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2470,6 +2470,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2469,6 +2469,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2470,6 +2470,11 @@ class AppLocalizationsSk extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2464,6 +2464,11 @@ class AppLocalizationsSl extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2468,6 +2468,11 @@ class AppLocalizationsSv extends AppLocalizations {
       'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
 
   @override
+  String errorUpstreamCertExpired(String host) {
+    return 'The data provider ($host) is serving an expired or invalid TLS certificate. The app cannot load data from this source until the provider fixes it. Please contact $host.';
+  }
+
+  @override
   String get offlineLabel => 'Offline';
 
   @override

--- a/test/core/error/error_localizer_test.dart
+++ b/test/core/error/error_localizer_test.dart
@@ -72,6 +72,35 @@ void main() {
       expect(msg, contains('load data'));
     });
 
+    test('UpstreamCertificateException names the provider host (#837)', () {
+      final msg = ErrorLocalizer.localize(
+        const UpstreamCertificateException(
+          host: 'datos.energia.gob.ar',
+          countryCode: 'ar',
+          detail: 'HandshakeException: certificate has expired',
+        ),
+        null,
+      );
+      // The user has to know WHO to contact — the host must appear in the
+      // message, and we must mention the cert problem so the blame is on
+      // the provider, not the app.
+      expect(msg, contains('datos.energia.gob.ar'));
+      expect(msg.toLowerCase(), contains('certificate'));
+    });
+
+    test('UpstreamCertificateException does not leak raw Dart error text', () {
+      final msg = ErrorLocalizer.localize(
+        const UpstreamCertificateException(
+          host: 'example.com',
+          detail: 'HandshakeException: bad cert',
+        ),
+        null,
+      );
+      // The low-level `HandshakeException` string is for logs, not for users.
+      expect(msg.contains('HandshakeException'), isFalse,
+          reason: 'Raw Dart exception class should not reach the UI');
+    });
+
     test('CacheException returns cache error', () {
       final msg = ErrorLocalizer.localize(
         const CacheException(message: 'corrupt'),
@@ -127,6 +156,7 @@ void main() {
         const LocationException(message: 'test'),
         const NoApiKeyException(),
         const ServiceChainExhaustedException(errors: []),
+        const UpstreamCertificateException(host: 'example.com'),
         const CacheException(message: 'test'),
         DioException(
           requestOptions: RequestOptions(),

--- a/test/core/error/exceptions_test.dart
+++ b/test/core/error/exceptions_test.dart
@@ -167,6 +167,7 @@ void main() {
         const NoApiKeyException(),
         const NoEvApiKeyException(),
         const ServiceChainExhaustedException(errors: []),
+        const UpstreamCertificateException(host: 'example.com'),
       ];
       for (final e in exceptions) {
         // This switch must compile - proves exhaustiveness of sealed class
@@ -177,6 +178,7 @@ void main() {
           NoApiKeyException() => 'nokey',
           NoEvApiKeyException() => 'noevkey',
           ServiceChainExhaustedException() => 'chain',
+          UpstreamCertificateException() => 'cert',
         };
         expect(result, isNotEmpty);
       }

--- a/test/core/services/impl/argentina_station_service_test.dart
+++ b/test/core/services/impl/argentina_station_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/services/impl/argentina_station_service.dart';
@@ -311,12 +312,18 @@ col0,col1,col2,TestCo,Dir,Loc,Prov,col7,col8,Nafta premium,col10,col11,100.5,202
       const params = SearchParams(
         lat: -34.6, lng: -58.4, radiusKm: 10.0,
       );
-      // The service will try to download the CSV and fail (no network in test)
+      // The service will try to download the CSV and fail. Either a generic
+      // network error (ApiException) or the specific cert-expired path
+      // (#837 — UpstreamCertificateException) is acceptable here, since the
+      // real upstream cert is currently expired and the test harness has no
+      // network.
       try {
         await service.searchStations(params);
         // If it somehow succeeds (cached data), just verify the result
       } on ApiException catch (e) {
         expect(e.message, isNotEmpty);
+      } on UpstreamCertificateException catch (e) {
+        expect(e.host, 'datos.energia.gob.ar');
       }
     });
 
@@ -330,6 +337,8 @@ col0,col1,col2,TestCo,Dir,Loc,Prov,col7,col8,Nafta premium,col10,col11,100.5,202
         expect(result.data, isA<List<Station>>());
       } on ApiException catch (_) {
         // Expected if no network
+      } on UpstreamCertificateException catch (_) {
+        // Expected if the live cert is expired (#837)
       }
     });
   });
@@ -554,6 +563,121 @@ col0,col1,col2,YPF,Dir,Loc,Prov,col7,col8,Nafta premium,col10,col11,800.0,2026-0
       expect(stationMap.values.first.naftaPremium, closeTo(750.0, 0.01));
     });
   });
+
+  // #837 — datos.energia.gob.ar started serving an expired TLS cert. Assert
+  // that the service classifies this as a specific UpstreamCertificateException
+  // (so the UI can show a precise message) rather than a generic ApiException.
+  group('#837 Argentina TLS certificate error classification', () {
+    const params = SearchParams(
+      lat: -34.6, lng: -58.4, radiusKm: 10.0,
+    );
+
+    test('DioExceptionType.badCertificate surfaces UpstreamCertificateException', () async {
+      final dio = Dio()
+        ..httpClientAdapter = _ThrowingAdapter(
+          (opts) => DioException(
+            type: DioExceptionType.badCertificate,
+            requestOptions: opts,
+            message: 'CERTIFICATE_VERIFY_FAILED: certificate has expired',
+          ),
+        );
+      final service = ArgentinaStationService.withDio(dio);
+
+      try {
+        await service.searchStations(params);
+        fail('Expected UpstreamCertificateException');
+      } on UpstreamCertificateException catch (e) {
+        expect(e.host, 'datos.energia.gob.ar');
+        expect(e.countryCode, 'ar');
+        expect(e.message, contains('datos.energia.gob.ar'));
+      }
+    });
+
+    test('DioExceptionType.unknown with CERT in message is classified as cert error', () async {
+      // Some platforms (older Android, Windows) surface cert failures as
+      // `DioExceptionType.unknown` with a `HandshakeException` in `error`.
+      final dio = Dio()
+        ..httpClientAdapter = _ThrowingAdapter(
+          (opts) => DioException(
+            type: DioExceptionType.unknown,
+            requestOptions: opts,
+            error: 'HandshakeException: Handshake error in client '
+                '(CERTIFICATE_VERIFY_FAILED: certificate has expired)',
+            message: 'HandshakeException',
+          ),
+        );
+      final service = ArgentinaStationService.withDio(dio);
+
+      expect(
+        () => service.searchStations(params),
+        throwsA(isA<UpstreamCertificateException>()),
+      );
+    });
+
+    test('DioExceptionType.unknown without cert hints falls back to ApiException', () async {
+      // Non-cert unknown errors should NOT be mis-classified as cert errors —
+      // the user gets the regular network-error path.
+      final dio = Dio()
+        ..httpClientAdapter = _ThrowingAdapter(
+          (opts) => DioException(
+            type: DioExceptionType.unknown,
+            requestOptions: opts,
+            message: 'something else went wrong',
+          ),
+        );
+      final service = ArgentinaStationService.withDio(dio);
+
+      expect(
+        () => service.searchStations(params),
+        throwsA(
+          allOf(
+            isA<ApiException>(),
+            isNot(isA<UpstreamCertificateException>()),
+          ),
+        ),
+      );
+    });
+
+    test('DioExceptionType.connectionTimeout is NOT treated as cert error', () async {
+      final dio = Dio()
+        ..httpClientAdapter = _ThrowingAdapter(
+          (opts) => DioException(
+            type: DioExceptionType.connectionTimeout,
+            requestOptions: opts,
+          ),
+        );
+      final service = ArgentinaStationService.withDio(dio);
+
+      expect(
+        () => service.searchStations(params),
+        throwsA(
+          allOf(
+            isA<ApiException>(),
+            isNot(isA<UpstreamCertificateException>()),
+          ),
+        ),
+      );
+    });
+  });
+}
+
+/// Tiny HTTP adapter that always throws whatever the supplied builder returns.
+class _ThrowingAdapter implements HttpClientAdapter {
+  _ThrowingAdapter(this._build);
+
+  final DioException Function(RequestOptions) _build;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    throw _build(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
 }
 
 /// Expected CSV header columns (mirrors the service's validation).


### PR DESCRIPTION
## Why

`datos.energia.gob.ar` (the Argentine Secretaría de Energía open-data CSV) is currently serving an expired TLS certificate. Every AR search was therefore failing silently behind a generic `ServiceChainExhaustedException`, leaving the user with a useless "Could not load data" message. We must **not** bypass cert validation (MITM risk), so the fix has to surface the real cause: an upstream-provider problem the user should report to `datos.energia.gob.ar`.

## What

- **New sealed subtype** `UpstreamCertificateException` in `lib/core/error/exceptions.dart` (host / countryCode / detail).
- **Classify the Dio error** in `ArgentinaStationService` before it hits the generic `throwApiException` path:
  - `DioExceptionType.badCertificate` — direct match.
  - `DioExceptionType.unknown` with `CERT` / `X509` / `SSL` / `TLS` / `HANDSHAKE` in the message/error — covers platforms where a cert failure arrives wrapped as `HandshakeException`.
- **Localize** the new exception in `ErrorLocalizer` via a new ARB key `errorUpstreamCertExpired(host)`; `app_en.arb` + `app_de.arb` updated and `flutter gen-l10n` re-run (other locales fall back to the English string until a dedicated translation pass).
- **Test-only constructor** `ArgentinaStationService.withDio(...)` (`@visibleForTesting`) so we can drive the cert-error path through a fake `HttpClientAdapter` without touching the real network.

## Testing

- `flutter gen-l10n` — clean, only the expected "untranslated message" warning for the new key in non-en/de locales.
- `flutter analyze` — **zero issues**.
- `flutter test` — passes, except the pre-existing flaky `api_connectivity_test.dart` "Argentina — Energía CSV is reachable and has coordinates" test, which is the very endpoint this issue is about (expired cert = 400/handshake failure) and is unrelated to the fix itself.
- New tests:
  - `test/core/services/impl/argentina_station_service_test.dart` — injects `DioException(type: badCertificate)` and asserts `UpstreamCertificateException` (host = `datos.energia.gob.ar`, countryCode = `ar`); also covers the `unknown + CERT` variant and verifies non-cert errors still produce `ApiException`.
  - `test/core/error/error_localizer_test.dart` — asserts the new exception renders a user-facing message that names the host and does not leak raw Dart exception text.
  - `test/core/error/exceptions_test.dart` — exhaustiveness switch extended to cover the new sealed subtype.

## Screenshots

N/A — backend/error-surface change only. The UI will now show a precise "The data provider (datos.energia.gob.ar) is serving an expired or invalid TLS certificate…" message instead of the generic chain-exhausted one.

Closes #837