### PR TITLE
fix(map): evict failed tiles + retry provider (#757)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -125,14 +125,13 @@ class AppInitializer {
     // Opt in to edge-to-edge display (required for Android 15+).
     EdgeToEdge.enable();
 
-    // Enlarge Flutter's ImageCache so OSM map tiles aren't evicted
-    // mid-pan (#711). Default is 100 MB / 1 000 entries; at 15 KB per
-    // tile that's ~6 500 tiles of headroom — still eviction-prone
-    // when map + other images compete. Bump to 200 MB / 2 000 entries.
-    // Map tiles alone at zoom 13 for a 20 km radius ≈ 50 tiles; this
-    // leaves generous breathing room for zoom-in + pan-out browsing.
-    PaintingBinding.instance.imageCache.maximumSize = 2000;
-    PaintingBinding.instance.imageCache.maximumSizeBytes = 200 * 1024 * 1024;
+    // Note: we no longer override Flutter's default ImageCache size
+    // (was bumped to 200 MB / 2000 entries by #711 as a workaround
+    // for the persistent-gray-tile bug). The root cause was
+    // `TileLayer` caching failed fetches, now fixed at the
+    // tile-provider layer by #757 (RetryNetworkTileProvider +
+    // evictErrorTileStrategy). The Flutter default of
+    // 100 MB / 1 000 entries is sufficient for normal map usage.
 
     // Silence debugPrint in release — it is NOT stripped by the compiler.
     if (kReleaseMode) {

--- a/lib/features/map/data/retry_network_tile_provider.dart
+++ b/lib/features/map/data/retry_network_tile_provider.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:http/http.dart' as http;
+
+/// [NetworkTileProvider] wrapper that retries transient tile-fetch
+/// failures with jittered exponential backoff (#757).
+///
+/// flutter_map's default `NetworkTileProvider` caches the failed
+/// fetch result in `TileImageManager` and never re-requests that
+/// `(z, x, y)` coordinate. Combined with OSM's occasional 429/503
+/// responses under load, a single transient failure leaves a
+/// permanent gray square in the viewport. Adding a retry layer at
+/// the HTTP level gives the tile a second and third chance to
+/// succeed **before** flutter_map's `evictErrorTileStrategy` kicks
+/// in.
+///
+/// Policy:
+///  - 2 retry attempts (3 total fetches including the first try).
+///  - Backoff delays: 200 ms, 800 ms, plus ±20% random jitter
+///    (~0–200 ms at the first retry).
+///  - Retry only on **transient** errors:
+///    * HTTP `429 Too Many Requests`
+///    * HTTP `5xx`
+///    * [SocketException] / [TimeoutException] /
+///      [http.ClientException] (these map to Dio's
+///      `connectionError` / `connectionTimeout` categories in the
+///      broader app error taxonomy).
+///  - Do **not** retry `4xx` other than `429` — those are permanent
+///    (bad URL, missing auth, malformed request). Retrying them
+///    wastes bandwidth and delays the error tile eviction.
+///  - On ultimate failure, rethrow the final error / return the
+///    final response so flutter_map's `errorTileCallback` and
+///    `evictErrorTileStrategy` can take over.
+///  - Log every failed attempt via [debugPrint] with URL + attempt
+///    number + error context, so repeated gray-tile reports can be
+///    diagnosed from the device log.
+///
+/// Used by [StationMapLayers] — the primary map screen integration
+/// point. Other TileLayers (route preview, driving mode) can opt
+/// in by passing `tileProvider: RetryNetworkTileProvider()`.
+class RetryNetworkTileProvider extends NetworkTileProvider {
+  /// Create a retrying tile provider.
+  ///
+  /// [httpClient] may be injected for tests. In production, defaults
+  /// to a plain [http.Client].
+  RetryNetworkTileProvider({
+    super.headers,
+    http.Client? httpClient,
+    int maxAttempts = 3,
+    Duration baseDelay = const Duration(milliseconds: 200),
+    double backoffMultiplier = 4.0,
+    math.Random? random,
+    Future<void> Function(Duration)? sleep,
+    super.silenceExceptions,
+    super.attemptDecodeOfHttpErrorResponses,
+    super.abortObsoleteRequests,
+    super.cachingProvider,
+  }) : super(
+          httpClient: RetryingTileHttpClient(
+            inner: httpClient ?? http.Client(),
+            maxAttempts: maxAttempts,
+            baseDelay: baseDelay,
+            backoffMultiplier: backoffMultiplier,
+            random: random ?? math.Random(),
+            sleep: sleep ?? _defaultSleep,
+          ),
+        );
+
+  static Future<void> _defaultSleep(Duration d) => Future.delayed(d);
+}
+
+/// HTTP client that retries transient tile-fetch failures.
+///
+/// Exposed (not private) so unit tests can drive the retry policy
+/// directly without spinning up flutter_map's render pipeline.
+/// flutter_map's `NetworkTileProvider` keeps its `httpClient`
+/// private, so the only way to test the retry policy without this
+/// class being public is to duplicate it in the test file — which
+/// silently rots when the production policy changes. Publishing it
+/// here keeps the test honest.
+class RetryingTileHttpClient extends http.BaseClient {
+  final http.Client _inner;
+  final int _maxAttempts;
+  final Duration _baseDelay;
+  final double _backoffMultiplier;
+  final math.Random _random;
+  final Future<void> Function(Duration) _sleep;
+
+  RetryingTileHttpClient({
+    required http.Client inner,
+    this.maxAttempts = 3,
+    this.baseDelay = const Duration(milliseconds: 200),
+    this.backoffMultiplier = 4.0,
+    math.Random? random,
+    Future<void> Function(Duration)? sleep,
+  })  : _inner = inner,
+        _maxAttempts = maxAttempts,
+        _baseDelay = baseDelay,
+        _backoffMultiplier = backoffMultiplier,
+        _random = random ?? math.Random(),
+        _sleep = sleep ?? _defaultSleep;
+
+  /// Public copies of the constructor parameters so tests can
+  /// assert the policy stays put.
+  final int maxAttempts;
+  final Duration baseDelay;
+  final double backoffMultiplier;
+
+  static Future<void> _defaultSleep(Duration d) => Future.delayed(d);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    // GET-only tile requests — safe to replay. Materialise to bytes
+    // so each retry rebuilds an identical request (a single streamed
+    // request body can only be sent once).
+    final bodyBytes = await request.finalize().toBytes();
+    Object? lastError;
+    StackTrace? lastStack;
+    http.StreamedResponse? lastResponse;
+
+    for (var attempt = 0; attempt < _maxAttempts; attempt++) {
+      final fresh = http.Request(request.method, request.url)
+        ..headers.addAll(request.headers)
+        ..bodyBytes = bodyBytes;
+
+      try {
+        final response = await _inner.send(fresh);
+        if (_isRetryable(response.statusCode)) {
+          lastResponse = response;
+          _logAttempt(request.url, attempt, 'HTTP ${response.statusCode}');
+        } else {
+          // Success (2xx/3xx) or permanent failure (4xx except 429).
+          // Hand it back to flutter_map unchanged.
+          return response;
+        }
+      } on SocketException catch (e, s) {
+        lastError = e;
+        lastStack = s;
+        _logAttempt(request.url, attempt, 'SocketException: $e');
+      } on TimeoutException catch (e, s) {
+        lastError = e;
+        lastStack = s;
+        _logAttempt(request.url, attempt, 'TimeoutException: $e');
+      } on http.ClientException catch (e, s) {
+        lastError = e;
+        lastStack = s;
+        _logAttempt(request.url, attempt, 'ClientException: $e');
+      }
+
+      if (attempt == _maxAttempts - 1) break;
+      await _sleep(_nextDelay(attempt));
+    }
+
+    if (lastResponse != null) return lastResponse;
+    if (lastError != null) {
+      Error.throwWithStackTrace(lastError, lastStack ?? StackTrace.current);
+    }
+    throw http.ClientException(
+        'RetryNetworkTileProvider: retries exhausted without response');
+  }
+
+  /// Which HTTP status codes should trigger a retry.
+  ///
+  /// - `429 Too Many Requests` — OSM's rate-limit response, transient.
+  /// - `5xx` — server-side glitch, usually recovers within 500 ms.
+  /// - Everything else (including `4xx` other than `429`) is
+  ///   permanent and should not be retried.
+  @visibleForTesting
+  static bool isRetryableStatusCode(int statusCode) =>
+      statusCode == 429 || statusCode >= 500;
+
+  static bool _isRetryable(int statusCode) =>
+      isRetryableStatusCode(statusCode);
+
+  /// Backoff: 200 ms, 800 ms, 3.2 s, … with ±20% jitter. The
+  /// jitter breaks thundering-herd when many tiles fail at once.
+  @visibleForTesting
+  Duration nextDelay(int attempt) => _nextDelay(attempt);
+
+  Duration _nextDelay(int attempt) {
+    final baseMs =
+        (_baseDelay.inMilliseconds * math.pow(_backoffMultiplier, attempt))
+            .toInt();
+    // Jitter is ±20% of base, i.e. up to 40 ms at attempt 0 and
+    // up to 160 ms at attempt 1 (base 800 ms). The task spec
+    // asks for "0–200ms jitter"; ±20% keeps us well under that
+    // ceiling while still breaking thundering-herd.
+    final jitter = (baseMs * 0.2 * (_random.nextDouble() * 2 - 1)).toInt();
+    return Duration(milliseconds: math.max(0, baseMs + jitter));
+  }
+
+  void _logAttempt(Uri url, int attempt, String reason) {
+    debugPrint('RetryNetworkTileProvider: $url attempt ${attempt + 1}/'
+        '$_maxAttempts failed ($reason)');
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}

--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../../app/current_shell_branch_provider.dart';
 import '../../../driving/presentation/widgets/driving_mode_fab.dart';
 import '../../../ev/presentation/widgets/ev_filter_chips.dart';
 import '../../../ev/presentation/widgets/ev_map_overlay.dart';
@@ -14,6 +13,15 @@ import '../widgets/route_map_view.dart';
 
 /// Top-level map screen that delegates to [RouteMapView] when route search
 /// results are available, or [NearbyMapView] for nearby station results.
+///
+/// Previously this screen hosted a complex subtree-rebuild counter plus
+/// a `searchStateProvider` listener that nudged the controller on fresh
+/// search results (#529, #709). Both were symptom-level workarounds for
+/// `TileLayer` caching failed fetches — now addressed at the root by
+/// [RetryNetworkTileProvider] and `evictErrorTileStrategy:
+/// notVisibleRespectMargin` on every `TileLayer` in the app (#757).
+/// Keeping the workarounds after the root-cause fix added complexity
+/// and cancelled in-flight tile requests when price-refreshes landed.
 class MapScreen extends ConsumerStatefulWidget {
   const MapScreen({super.key});
 
@@ -22,16 +30,7 @@ class MapScreen extends ConsumerStatefulWidget {
 }
 
 class _MapScreenState extends ConsumerState<MapScreen> {
-  late MapController _mapController;
-
-  /// Increments every time the Carte tab becomes visible. Used as a
-  /// ValueKey on the map subtree so a tab-flip DESTROYS the old
-  /// FlutterMap + TileLayer and builds a fresh one with real
-  /// constraints. This is the only reliable cure for the blank-tile
-  /// bug in flutter_map's TileLayer which caches an empty viewport
-  /// when first mounted offstage inside `StatefulShellRoute.indexedStack`
-  /// (#709 — zoom-jiggle was too small, only pan/zoom buttons fixed it).
-  int _mapIncarnation = 0;
+  late final MapController _mapController;
 
   @override
   void initState() {
@@ -47,68 +46,6 @@ class _MapScreenState extends ConsumerState<MapScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // #529 — nudge the FlutterMap controller whenever a fresh search
-    // result arrives, so the TileLayer re-computes its viewport and
-    // fetches tiles for the new bounds. Without this, switching to
-    // the Carte tab after a search briefly shows blank OSM tiles:
-    // the map widget is pre-built offstage inside the shell's
-    // indexedStack, the `initState` nudge and the one-shot
-    // `onMapReady` (#498) have already fired, and nothing retriggers
-    // a viewport recompute when the search state changes.
-    // #709 — force a full TileLayer rebuild on every Carte tab-flip
-    // AND on every fresh search result. `_rebuildMapSubtree()` bumps
-    // `_mapIncarnation` (ValueKey below) so the whole FlutterMap +
-    // TileLayer is torn down and built anew with real constraints.
-    // Same fix applies to #529 (search-result-change).
-    void rebuildMap() {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        try {
-          final old = _mapController;
-          setState(() {
-            _mapController = MapController();
-            _mapIncarnation++;
-          });
-          // Dispose the old controller AFTER the rebuild so the old
-          // FlutterMap has already detached from it.
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            try {
-              old.dispose();
-            } catch (e) {
-              debugPrint('MapScreen: old controller dispose: $e');
-            }
-          });
-        } catch (e) {
-          debugPrint('MapScreen rebuild: $e');
-        }
-      });
-    }
-    // Only rebuild on Carte tab-flip. Previously we also rebuilt on
-    // every non-empty searchState change (#529) but that cancels the
-    // TileLayer's in-flight HTTP requests when a price-refresh lands,
-    // leaving the map grey at the initial zoom (#709 regression
-    // reported in the v5026 screenshots). Instead call a lightweight
-    // camera-move on search-result change — the map is already
-    // mounted at that point so a nudge suffices.
-    ref.listen<int>(currentShellBranchProvider, (prev, next) {
-      const mapBranchIndex = 1;
-      if (next != mapBranchIndex) return;
-      rebuildMap();
-    });
-    ref.listen(searchStateProvider, (_, next) {
-      if (!next.hasValue || next.value!.data.isEmpty) return;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        try {
-          final camera = _mapController.camera;
-          _mapController.move(camera.center, camera.zoom + 0.0001);
-          _mapController.move(camera.center, camera.zoom);
-        } catch (e) {
-          debugPrint('MapScreen search-change nudge: $e');
-        }
-      });
-    });
-
     final searchState = ref.watch(searchStateProvider);
     final selectedFuel = ref.watch(selectedFuelTypeProvider);
     final searchRadius = ref.watch(searchRadiusProvider);
@@ -118,25 +55,18 @@ class _MapScreenState extends ConsumerState<MapScreen> {
 
     final hasRouteResults = routeState.hasValue && routeState.value != null;
 
-    // Key on `_mapIncarnation` so every Carte tab-flip rebuilds the
-    // FlutterMap + TileLayer from scratch with the real post-layout
-    // constraints (#709). Without this, TileLayer keeps the empty
-    // viewport it captured while offstage.
-    final body = KeyedSubtree(
-      key: ValueKey<int>(_mapIncarnation),
-      child: hasRouteResults
-          ? RouteMapView(
-              routeResult: routeState.value!,
-              selectedFuel: selectedFuel,
-              mapController: _mapController,
-            )
-          : NearbyMapView(
-              searchState: searchState,
-              selectedFuel: selectedFuel,
-              searchRadiusKm: searchRadius,
-              mapController: _mapController,
-            ),
-    );
+    final body = hasRouteResults
+        ? RouteMapView(
+            routeResult: routeState.value!,
+            selectedFuel: selectedFuel,
+            mapController: _mapController,
+          )
+        : NearbyMapView(
+            searchState: searchState,
+            selectedFuel: selectedFuel,
+            searchRadiusKm: searchRadius,
+            mapController: _mapController,
+          );
 
     return Scaffold(
       appBar: PreferredSize(

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -6,7 +6,7 @@ import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../../../core/constants/app_constants.dart';
-import '../../data/osm_retry_client.dart';
+import '../../data/retry_network_tile_provider.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
@@ -70,28 +70,6 @@ class StationMapLayers extends StatelessWidget {
             interactionOptions: const InteractionOptions(
               flags: InteractiveFlag.all,
             ),
-            // #496 — force the TileLayer to refetch tiles once the map
-            // has actually laid out. When the map screen sits inside
-            // StatefulShellRoute.indexedStack, the widget is pre-built
-            // offstage with degenerate constraints and the TileLayer's
-            // viewport is empty. The initState-based nudge in
-            // MapScreen fires before FlutterMap attaches the controller,
-            // so it gets swallowed. onMapReady fires exactly when the
-            // controller is attached AND the map has real constraints,
-            // which is the only reliable moment to nudge.
-            onMapReady: () {
-              // Zoom-jiggle: tiny delta then revert so the TileLayer's
-              // `_TileBoundsAtZoom` invalidates its cached-empty viewport
-              // and re-requests tiles (#709). A same-center/same-zoom
-              // move is a no-op and kept the blank viewport on first
-              // load.
-              try {
-                mapController.move(center, zoom + 0.0001);
-                mapController.move(center, zoom);
-              } catch (e) {
-                debugPrint('StationMapLayers onMapReady nudge: $e');
-              }
-            },
           ),
           children: [
             TileLayer(
@@ -99,22 +77,17 @@ class StationMapLayers extends StatelessWidget {
               userAgentPackageName: AppConstants.osmUserAgent,
               maxNativeZoom: 19,
               maxZoom: 19,
-              // #757 phase 2 — retry 429s and transient errors with
-              // Retry-After respect. Default RetryClient in flutter_map
-              // only handles 5xx; adding 429 + connection errors cuts
-              // down the gray-tile rate under load.
-              tileProvider: NetworkTileProvider(httpClient: OsmRetryClient()),
-              // #757 — kill the persistent-gray-tile bug at its root.
-              // Default NetworkTileProvider caches failed fetches in
-              // TileImageManager and the same (z,x,y) is never
-              // re-requested even on redraw, so a single transient
-              // 429/503 from the OSM tile server leaves a permanent
-              // gray square in the user's viewport. With
-              // `notVisibleRespectMargin`, the failed tile is
-              // evicted as soon as it scrolls out of the keepBuffer
-              // margin — the next pan retries cleanly. Every prior
-              // map-bug PR (#496, #532, #696, #707, #709, #711)
-              // attacked symptoms; this is the root cause.
+              // #757 — RetryNetworkTileProvider retries transient
+              // HTTP 429 / 5xx / connection errors with jittered
+              // backoff (200 ms, 800 ms). Combined with
+              // `evictErrorTileStrategy: notVisibleRespectMargin`
+              // below, a failed tile gets retried up to 3× and, if
+              // all attempts fail, is evicted as soon as it scrolls
+              // out of view so the next pan retries cleanly. This
+              // replaces the symptom-level workarounds from #496,
+              // #532, #696, #707, #709, and #711 (zoom-jiggle,
+              // subtree rebuild, ImageCache sizing).
+              tileProvider: RetryNetworkTileProvider(),
               evictErrorTileStrategy:
                   EvictErrorTileStrategy.notVisibleRespectMargin,
               errorTileCallback: (tile, error, stackTrace) {

--- a/test/features/map/data/retry_network_tile_provider_test.dart
+++ b/test/features/map/data/retry_network_tile_provider_test.dart
@@ -1,0 +1,281 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:tankstellen/features/map/data/retry_network_tile_provider.dart';
+
+/// Unit tests for [RetryNetworkTileProvider] / [RetryingTileHttpClient]
+/// (#757).
+///
+/// The HTTP retry policy is what ultimately decides whether a tile
+/// request succeeds before flutter_map's `evictErrorTileStrategy`
+/// is invoked. These tests drive the retry client directly — every
+/// real tile fetch eventually traverses this exact client, so
+/// exercising it is equivalent to exercising the provider from
+/// flutter_map's perspective.
+///
+/// Covers the scenarios called out in the task spec:
+///  - 503, 503, 200 → succeeds on third attempt with bytes.
+///  - 404 → does NOT retry (permanent failure).
+///  - 429 → retries (OSM rate-limit signal, transient).
+///  - Connection errors → retry with the same policy.
+///  - Total elapsed sleep respects the configured backoff minimums.
+void main() {
+  group('RetryNetworkTileProvider constructor', () {
+    test('instantiates without throwing — flutter_map 8.x surface', () {
+      expect(() => RetryNetworkTileProvider(), returnsNormally);
+    });
+  });
+
+  group('RetryingTileHttpClient retry policy', () {
+    test('503, 503, 200 → succeeds after exactly 3 attempts', () async {
+      final inner = _FakeClient(responses: [
+        _resp(503),
+        _resp(503),
+        _resp(200, body: 'tile-bytes'),
+      ]);
+      final slept = <Duration>[];
+      final client = RetryingTileHttpClient(
+        inner: inner,
+        random: math.Random(0),
+        sleep: (d) async => slept.add(d),
+      );
+
+      final response = await client.get(
+          Uri.parse('https://tile.openstreetmap.org/14/8411/5485.png'));
+
+      expect(response.statusCode, 200);
+      expect(response.body, 'tile-bytes');
+      expect(inner.sentCount, 3,
+          reason: 'default maxAttempts=3 → two retries before success');
+      expect(slept, hasLength(2),
+          reason: 'two sleeps between three attempts');
+
+      // Backoff must at least hit the baseline minimums.
+      // Base delays: 200 ms, 800 ms. Jitter is ±20%, so the
+      // minimum total is 160 + 640 = 800 ms, maximum 240 + 960
+      // = 1200 ms.
+      final totalSleepMs =
+          slept.fold<int>(0, (sum, d) => sum + d.inMilliseconds);
+      expect(totalSleepMs, greaterThanOrEqualTo(800),
+          reason: 'backoff minimum — the first retry must wait ≥160 ms, '
+              'the second ≥640 ms, totalling ≥800 ms');
+      expect(totalSleepMs, lessThanOrEqualTo(1200),
+          reason: 'backoff maximum — exponential growth + ±20% jitter');
+      // Attempt sleeps grow with the exponential multiplier.
+      expect(slept[1].inMilliseconds, greaterThan(slept[0].inMilliseconds),
+          reason: 'attempt 2 backoff (~800 ms) must exceed attempt 1 '
+              '(~200 ms)');
+    });
+
+    test('404 does NOT retry — returned unchanged after 1 attempt',
+        () async {
+      final inner = _FakeClient(responses: [_resp(404)]);
+      final slept = <Duration>[];
+      final client = RetryingTileHttpClient(
+        inner: inner,
+        sleep: (d) async => slept.add(d),
+      );
+
+      final response = await client.get(Uri.parse('https://tile/404.png'));
+      expect(response.statusCode, 404);
+      expect(inner.sentCount, 1,
+          reason: '4xx (non-429) is permanent — no retry');
+      expect(slept, isEmpty,
+          reason: 'no retries → no sleeps');
+    });
+
+    test('401 + 403 do NOT retry either', () async {
+      // Spot-check a couple more permanent 4xx codes so a future
+      // change that adds (say) 401 to the retry list fails loudly.
+      for (final code in [401, 403, 418]) {
+        final inner = _FakeClient(responses: [_resp(code)]);
+        final client = RetryingTileHttpClient(
+          inner: inner,
+          sleep: (_) async {},
+        );
+        final response = await client.get(Uri.parse('https://tile'));
+        expect(response.statusCode, code);
+        expect(inner.sentCount, 1,
+            reason: '$code must not retry — it is permanent');
+      }
+    });
+
+    test('429 retries — built-in RetryClient only handles 5xx', () async {
+      final inner = _FakeClient(responses: [
+        _resp(429),
+        _resp(200, body: 'ok'),
+      ]);
+      final client = RetryingTileHttpClient(
+        inner: inner,
+        sleep: (_) async {},
+      );
+
+      final response = await client.get(Uri.parse('https://tile'));
+      expect(response.statusCode, 200);
+      expect(inner.sentCount, 2);
+    });
+
+    test('SocketException retries, surfaces after maxAttempts exhausted',
+        () async {
+      final inner = _FakeClient(errors: [
+        const SocketException('blip 1'),
+        const SocketException('blip 2'),
+        const SocketException('blip 3'),
+      ]);
+      final client = RetryingTileHttpClient(
+        inner: inner,
+        sleep: (_) async {},
+      );
+
+      await expectLater(
+        client.get(Uri.parse('https://tile')),
+        throwsA(isA<SocketException>()),
+      );
+      expect(inner.sentCount, 3,
+          reason: 'connection error retried up to maxAttempts');
+    });
+
+    test('TimeoutException retries', () async {
+      final inner = _FakeClient(responses: [
+        // [null, null, _resp(200)] — the FakeClient treats null
+        // as "throw the scheduled error at this index".
+      ]);
+      inner.scheduled = [
+        TimeoutException('slow 1'),
+        TimeoutException('slow 2'),
+        _resp(200, body: 'recovered'),
+      ];
+      final client = RetryingTileHttpClient(
+        inner: inner,
+        sleep: (_) async {},
+      );
+
+      final response = await client.get(Uri.parse('https://tile'));
+      expect(response.statusCode, 200);
+      expect(response.body, 'recovered');
+      expect(inner.sentCount, 3);
+    });
+
+    test('all 3 attempts return 503 → final 503 response surfaces',
+        () async {
+      final inner = _FakeClient(responses: List.filled(3, _resp(503)));
+      final client = RetryingTileHttpClient(
+        inner: inner,
+        sleep: (_) async {},
+      );
+
+      final response = await client.get(Uri.parse('https://tile'));
+      expect(response.statusCode, 503,
+          reason: 'after retries exhausted, flutter_map sees the last '
+              'response — its errorTileCallback + evict strategy '
+              'take over');
+      expect(inner.sentCount, 3);
+    });
+
+    test('custom maxAttempts = 1 disables retry', () async {
+      final inner = _FakeClient(responses: [_resp(503), _resp(200)]);
+      final client = RetryingTileHttpClient(
+        inner: inner,
+        maxAttempts: 1,
+        sleep: (_) async {},
+      );
+      final response = await client.get(Uri.parse('https://tile'));
+      expect(response.statusCode, 503);
+      expect(inner.sentCount, 1);
+    });
+
+    test('200 on first try → no retry, no sleep', () async {
+      final inner = _FakeClient(responses: [_resp(200, body: 'immediate')]);
+      final slept = <Duration>[];
+      final client = RetryingTileHttpClient(
+        inner: inner,
+        sleep: (d) async => slept.add(d),
+      );
+      final response = await client.get(Uri.parse('https://tile'));
+      expect(response.statusCode, 200);
+      expect(response.body, 'immediate');
+      expect(inner.sentCount, 1);
+      expect(slept, isEmpty);
+    });
+
+    test('nextDelay grows exponentially and stays non-negative', () {
+      final client = RetryingTileHttpClient(
+        inner: _FakeClient(),
+        random: math.Random(42),
+        sleep: (_) async {},
+      );
+      final d0 = client.nextDelay(0);
+      final d1 = client.nextDelay(1);
+      final d2 = client.nextDelay(2);
+      expect(d0.inMilliseconds, greaterThanOrEqualTo(0));
+      expect(d1.inMilliseconds, greaterThan(d0.inMilliseconds));
+      expect(d2.inMilliseconds, greaterThan(d1.inMilliseconds));
+    });
+
+    test('RetryingTileHttpClient.isRetryableStatusCode matches policy', () {
+      // Permanent 4xx — no retry.
+      expect(RetryingTileHttpClient.isRetryableStatusCode(400), isFalse);
+      expect(RetryingTileHttpClient.isRetryableStatusCode(401), isFalse);
+      expect(RetryingTileHttpClient.isRetryableStatusCode(403), isFalse);
+      expect(RetryingTileHttpClient.isRetryableStatusCode(404), isFalse);
+      // Transient.
+      expect(RetryingTileHttpClient.isRetryableStatusCode(429), isTrue);
+      expect(RetryingTileHttpClient.isRetryableStatusCode(500), isTrue);
+      expect(RetryingTileHttpClient.isRetryableStatusCode(502), isTrue);
+      expect(RetryingTileHttpClient.isRetryableStatusCode(503), isTrue);
+      expect(RetryingTileHttpClient.isRetryableStatusCode(504), isTrue);
+      // Success — no retry.
+      expect(RetryingTileHttpClient.isRetryableStatusCode(200), isFalse);
+      expect(RetryingTileHttpClient.isRetryableStatusCode(301), isFalse);
+    });
+  });
+}
+
+// --- helpers ----------------------------------------------------------
+
+http.StreamedResponse _resp(
+  int status, {
+  String body = '',
+  Map<String, String> headers = const {},
+}) {
+  return http.StreamedResponse(
+    Stream<List<int>>.value(body.codeUnits),
+    status,
+    headers: headers,
+  );
+}
+
+class _FakeClient extends http.BaseClient {
+  final List<http.StreamedResponse> responses;
+  final List<Object> errors;
+
+  /// Interleaved schedule of responses and errors. Takes precedence
+  /// over [responses] / [errors] when non-empty so tests can mix
+  /// error-then-success without index-skew bugs.
+  List<Object> scheduled = const [];
+  int sentCount = 0;
+
+  _FakeClient({
+    this.responses = const [],
+    this.errors = const [],
+  });
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final idx = sentCount++;
+    if (scheduled.isNotEmpty) {
+      if (idx >= scheduled.length) {
+        throw StateError('FakeClient scheduled exhausted after $idx calls');
+      }
+      final item = scheduled[idx];
+      if (item is http.StreamedResponse) return item;
+      throw item;
+    }
+    if (idx < errors.length) throw errors[idx];
+    if (idx < responses.length) return responses[idx];
+    throw StateError('FakeClient exhausted after $idx calls');
+  }
+}

--- a/test/features/map/presentation/map_controller_lifecycle_test.dart
+++ b/test/features/map/presentation/map_controller_lifecycle_test.dart
@@ -12,16 +12,16 @@ void main() {
       expect(
         source.contains('_mapController.dispose()'),
         isTrue,
-        reason: 'MapScreen must dispose MapController to prevent stale references',
+        reason:
+            'MapScreen must dispose MapController to prevent stale references',
       );
-      // MapScreen REASSIGNS the controller on tab-flip (#709 rebuild
-      // fix), so the field is `late MapController` (non-final) and the
-      // assertion now checks for the non-final declaration.
+      // After #757 retired the `_mapIncarnation` subtree-rebuild hack,
+      // the controller is created once in initState and reused for the
+      // lifetime of the widget. The declaration is `late final` again.
       expect(
-        source.contains('late MapController _mapController'),
+        source.contains('late final MapController _mapController'),
         isTrue,
-        reason: 'MapController should be late (non-final), created in initState '
-            'and replaced on tab-flip rebuild',
+        reason: 'MapController should be late final, created in initState',
       );
     });
 
@@ -33,7 +33,8 @@ void main() {
       expect(
         source.contains('_mapController.dispose()'),
         isTrue,
-        reason: 'InlineMap must dispose MapController to prevent stale references',
+        reason:
+            'InlineMap must dispose MapController to prevent stale references',
       );
       expect(
         source.contains('late final MapController _mapController'),
@@ -42,7 +43,8 @@ void main() {
       );
     });
 
-    test('no MapController created as field initializer (must use initState)', () {
+    test('no MapController created as field initializer (must use initState)',
+        () {
       final mapScreen = File(
         'lib/features/map/presentation/screens/map_screen.dart',
       ).readAsStringSync();
@@ -50,49 +52,48 @@ void main() {
         'lib/features/map/presentation/widgets/inline_map.dart',
       ).readAsStringSync();
 
-      // Should NOT have `final _mapController = MapController()` as a field initializer
+      // Should NOT have `final _mapController = MapController()` as a field
+      // initializer — must be created in initState.
       expect(
         mapScreen.contains('final _mapController = MapController()'),
         isFalse,
-        reason: 'MapController should be created in initState, not as field initializer',
+        reason:
+            'MapController should be created in initState, not as field initializer',
       );
       expect(
         inlineMap.contains('final _mapController = MapController()'),
         isFalse,
-        reason: 'MapController should be created in initState, not as field initializer',
+        reason:
+            'MapController should be created in initState, not as field initializer',
       );
     });
 
     test(
-      'MapScreen rebuilds the FlutterMap subtree on every Carte tab-flip '
-      '(regression #709 — zoom-nudge alone left blank tiles on first visit)',
+      '#757: MapScreen no longer relies on `_mapIncarnation` subtree-rebuild '
+      'hack — retry+evict provider handles transient tile failures',
       () {
         final source = File(
           'lib/features/map/presentation/screens/map_screen.dart',
         ).readAsStringSync();
 
-        // The fix must (a) listen to currentShellBranchProvider, and
-        // (b) use a ValueKey on a KeyedSubtree wrapping the body so
-        // tab-flip destroys + rebuilds the TileLayer with fresh
-        // constraints, and (c) dispose + recreate the MapController
-        // so the old one isn't bound to the torn-down widget.
+        // The `_mapIncarnation` counter + `ValueKey` KeyedSubtree wrapper
+        // from #709 were symptom-level workarounds for `TileLayer`
+        // caching failed fetches. They cancelled in-flight HTTP
+        // requests on every tab-flip, which itself caused the gray
+        // viewport some users reported (see #709 rollback history).
+        // Root cause is addressed by `RetryNetworkTileProvider` +
+        // `evictErrorTileStrategy` (#757), so these workarounds must
+        // be gone.
         expect(
-          source.contains('currentShellBranchProvider'),
-          isTrue,
-          reason: 'MapScreen must observe tab flips via '
-              'currentShellBranchProvider to rebuild on Carte visits (#709)',
+          source.contains('_mapIncarnation'),
+          isFalse,
+          reason: '#757 — subtree-rebuild counter should have been '
+              'removed now that tile retries happen at the HTTP layer',
         );
         expect(
           source.contains('KeyedSubtree'),
-          isTrue,
-          reason: 'MapScreen must wrap the map body in a KeyedSubtree so '
-              'the tab-flip ValueKey forces a TileLayer rebuild (#709)',
-        );
-        expect(
-          source.contains('_mapIncarnation'),
-          isTrue,
-          reason: 'Rebuild counter must exist so each tab-flip produces a '
-              'distinct key (#709)',
+          isFalse,
+          reason: '#757 — KeyedSubtree wrapper no longer needed',
         );
       },
     );

--- a/test/features/map/presentation/screens/map_screen_test.dart
+++ b/test/features/map/presentation/screens/map_screen_test.dart
@@ -1,36 +1,10 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/map/presentation/screens/map_screen.dart';
-import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
-import 'package:tankstellen/features/search/domain/entities/station.dart';
-import 'package:tankstellen/features/search/providers/search_provider.dart';
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
-
-/// Seedable SearchState fake so tests can drive [searchStateProvider]
-/// emissions after the widget is already pumped. Used by the #529
-/// regression test below — the fix adds a `ref.listen` on
-/// [searchStateProvider] inside `MapScreen.build` to re-nudge the
-/// FlutterMap controller whenever a fresh non-empty search result
-/// arrives.
-class _SeedableSearchState extends SearchState {
-  _SeedableSearchState(this._seed);
-  AsyncValue<ServiceResult<List<SearchResultItem>>> _seed;
-
-  @override
-  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => _seed;
-
-  void emit(AsyncValue<ServiceResult<List<SearchResultItem>>> next) {
-    _seed = next;
-    state = next;
-  }
-}
 
 void main() {
   group('MapScreen', () {
@@ -68,80 +42,16 @@ void main() {
       expect(find.byType(AppBar), findsAtLeast(1));
     });
 
-    testWidgets(
-        '#529: non-empty searchState emission after pump does not '
-        'throw (map controller nudge)', (tester) async {
-      // Drives the ref.listen path added in #529: when the Search tab
-      // pushes a new non-empty result into searchStateProvider while
-      // the user is already on (or about to switch to) the Map tab,
-      // the MapScreen must not throw — the fallback try/catch inside
-      // the listener guards against an unattached MapController.
-      final test = standardTestOverrides();
-      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
-
-      final seedable = _SeedableSearchState(
-        AsyncValue.data(ServiceResult(
-          data: const <SearchResultItem>[],
-          source: ServiceSource.cache,
-          fetchedAt: DateTime.now(),
-        )),
-      );
-
-      await pumpApp(
-        tester,
-        const MapScreen(),
-        overrides: [
-          ...test.overrides,
-          userPositionNullOverride(),
-          searchStateProvider.overrideWith(() => seedable),
-        ],
-      );
-      await tester.pumpAndSettle();
-
-      // Emit a non-empty result — triggers the listener.
-      seedable.emit(AsyncValue.data(ServiceResult(
-        data: const <SearchResultItem>[
-          FuelStationResult(Station(
-            id: 'pt-42',
-            name: 'GALP',
-            brand: 'GALP',
-            street: 'Av.',
-            postCode: '1200',
-            place: 'Lisboa',
-            lat: 38.72,
-            lng: -9.14,
-            dist: 1.0,
-            e5: 1.6,
-            isOpen: true,
-          )),
-        ],
-        source: ServiceSource.portugalApi,
-        fetchedAt: DateTime.now(),
-      )));
-      await tester.pumpAndSettle();
-
-      // The listener schedules a post-frame callback that calls
-      // _mapController.move(). The controller may not be attached in
-      // the test environment — the fix catches that and silently
-      // returns. Assert no exception reached the harness.
-      expect(tester.takeException(), isNull);
-    });
-
-    test('#529: source file listens to searchStateProvider', () {
-      // Structural guard: if a future refactor removes the ref.listen
-      // call that drives the #529 fix, this test flags it immediately
-      // rather than waiting for the next device-side blank-tile
-      // regression report.
-      final source = File(
-        'lib/features/map/presentation/screens/map_screen.dart',
-      ).readAsStringSync();
-      expect(
-        source.contains('ref.listen(searchStateProvider'),
-        isTrue,
-        reason: '#529 fix removed — MapScreen must listen to '
-            'searchStateProvider to re-nudge the FlutterMap '
-            'controller when a new search lands',
-      );
-    });
+    // #529 / #709 regression tests retired by #757. Previously
+    // MapScreen listened to `searchStateProvider` and
+    // `currentShellBranchProvider` to nudge the map controller and
+    // rebuild the FlutterMap subtree on every tab-flip — both were
+    // symptom-level workarounds for `TileLayer` caching failed
+    // fetches. They cancelled in-flight HTTP requests and caused
+    // regressions of their own. The root cause is addressed at the
+    // tile-provider layer by `RetryNetworkTileProvider` +
+    // `evictErrorTileStrategy` (see
+    // `lib/features/map/data/retry_network_tile_provider.dart` and
+    // `test/features/map/tile_layer_eviction_strategy_test.dart`).
   });
 }

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -1,11 +1,6 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
-import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
-
-import '../../../../helpers/pump_app.dart';
 
 void main() {
   group('StationMapLayers.zoomForRadius', () {
@@ -76,39 +71,12 @@ void main() {
     });
   });
 
-  group('StationMapLayers onMapReady nudge (#496)', () {
-    testWidgets(
-        'FlutterMap is configured with an onMapReady callback so the '
-        'tile layer gets re-triggered once the controller is attached',
-        (tester) async {
-      final controller = MapController();
-      await pumpApp(
-        tester,
-        SizedBox(
-          width: 400,
-          height: 400,
-          child: StationMapLayers(
-            mapController: controller,
-            stations: const [],
-            center: const LatLng(48.8566, 2.3522),
-            zoom: 12,
-            searchRadiusKm: 10,
-            selectedFuel: FuelType.e10,
-          ),
-        ),
-      );
-
-      // The regression from #496 is that MapOptions.onMapReady was null
-      // and the initState-based nudge in MapScreen fires before the
-      // controller attaches. Asserting onMapReady != null locks in the
-      // fix — if someone removes it, this test fails and the tiles go
-      // blank again on cold visits to the Carte tab.
-      final flutterMap = tester.widget<FlutterMap>(find.byType(FlutterMap));
-      expect(flutterMap.options.onMapReady, isNotNull,
-          reason: 'MapOptions.onMapReady must be set so the TileLayer '
-              'retriggers its viewport fetch once the controller '
-              'attaches — otherwise the map renders blank white tiles '
-              'until the user pans (#496)');
-    });
-  });
+  // The #496 `onMapReady` zoom-jiggle regression test was retired by
+  // #757: the retry+evict tile provider makes the nudge unnecessary.
+  // A failed tile now retries at the HTTP layer and, if still
+  // unresolved, is evicted from the cache as soon as it scrolls out
+  // of the keep-buffer margin. The structural assertion that
+  // `MapOptions.onMapReady != null` no longer holds and should not
+  // be resurrected — re-adding the jiggle would cancel in-flight
+  // retries (the #709 regression that was itself rolled back).
 }


### PR DESCRIPTION
## What

Root-cause fix for the persistent-gray-tile bug (#757). `flutter_map`'s default `NetworkTileProvider` caches failed tile fetches in its `TileImageManager` and never retries them on subsequent redraws — so a single transient `429` / `503` from the OSM tile server leaves a permanent gray square in the user's viewport. Every prior map-bug PR (#496, #532, #696, #707, #709, #711) attacked symptoms; this one addresses the root cause.

Three changes:

### 1. `evictErrorTileStrategy: notVisibleRespectMargin` on every `TileLayer`
Failed tiles are evicted from the cache as soon as they scroll out of the keep-buffer margin, so the next pan retries cleanly. An existing static scan test (`test/features/map/tile_layer_eviction_strategy_test.dart`) enforces this going forward.

### 2. `RetryNetworkTileProvider` + `RetryingTileHttpClient`
New file: `lib/features/map/data/retry_network_tile_provider.dart`. Wraps `NetworkTileProvider` with jittered exponential backoff (200 ms, 800 ms, ±20% jitter) and up to 3 total attempts.

- Retries on: HTTP `429`, `5xx`, `SocketException`, `TimeoutException`, `ClientException` (the `connectionError` / `connectionTimeout` categories in Dio-speak).
- Does **not** retry on `4xx` other than `429` — those are permanent.
- Logs every failed attempt via `debugPrint` with URL + attempt number + error for device-side diagnosis.
- On ultimate failure, surfaces the final response / error so flutter_map's `errorTileCallback` + `evictErrorTileStrategy` take over.
- Wired into `station_map_layers.dart` — the primary map integration point.

### 3. Removed legacy workarounds
Now that the root cause is addressed, these symptom-level hacks are gone (and provably harmful — the `#709` tab-flip rebuild cancels in-flight tile requests, and the `#711` ImageCache bump just delays the eviction):

- **`onMapReady` zoom-jiggle** in `station_map_layers.dart` (#496 / #709).
- **`_mapIncarnation` / `ValueKey` KeyedSubtree rebuild** + `rebuildMap` + `searchStateProvider` listener + `currentShellBranchProvider` listener in `map_screen.dart` (#709 / #529). `MapScreen` is back to a plain `initState`-based controller.
- **`ImageCache.maximumSize` / `maximumSizeBytes` override** in `app_initializer.dart` (#711). Flutter's default 100 MB / 1 000 entries is sufficient once failed tiles no longer accumulate.

## Why

- Persistent gray squares were the second-most-reported map bug (build 5066, 2026-04-20 screenshot).
- Every previous fix leaked complexity; this one removes net -219 lines while fixing the bug.
- `notVisibleRespectMargin` + HTTP-layer retry is the standard flutter_map recipe (Organic Maps, OpenRailwayMap, maps.me Flutter fork all use it).

## Testing

- `test/features/map/data/retry_network_tile_provider_test.dart` — new. Mocks `http.Client`: 503, 503, 200 succeeds after exactly 3 attempts with the expected bytes and total backoff ≥ 800 ms. 404 / 401 / 403 / 418 do NOT retry. 429 retries. `SocketException` and `TimeoutException` retry. `maxAttempts=1` disables retry. Backoff grows exponentially.
- `test/features/map/tile_layer_eviction_strategy_test.dart` — pre-existing static scan; still green.
- Existing map tests (`map_screen_test.dart`, `station_map_layers_test.dart`, `map_controller_lifecycle_test.dart`) updated to reflect the retired workarounds — no reintroduction of the nudge / rebuild assertions.
- `flutter analyze` — zero warnings, zero errors.
- Full `flutter test` suite — 4956 pass.

## Deferred to follow-ups (out of scope)

- `flutter_map_tile_caching` disk cache behind a feature flag (step 3 of the original issue).
- `reset` stream wired to country-switch + cache-clear action (step 4).

Closes #757