### PR TITLE
feat(obd2): supported-PID scan + per-VIN cache (#811)

### DIFF
--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -33,6 +33,13 @@ class HiveBoxes {
   /// badge keyed by enum name; not PII.
   static const String achievements = 'achievements';
 
+  /// Supported-PID bitmap cache (#811). Keyed by VIN (preferred) or
+  /// `make:model:year` (fallback when the car doesn't return a VIN).
+  /// Values are sorted `List<int>` of PID indices the car implements
+  /// for Mode 01. Small, not PII, opened unencrypted like the other
+  /// OBD2 boxes.
+  static const String obd2SupportedPids = 'obd2_supported_pids';
+
   static const _encryptedBoxes = {
     settings,
     profiles,
@@ -113,6 +120,11 @@ class HiveBoxes {
     await Hive.openBox<String>(obd2TripHistory);
     // #781 — gamification badges: one entry per earned badge.
     await Hive.openBox<String>(achievements);
+    // #811 — supported-PID bitmap cache (per VIN, or make:model:year
+    // fallback). Values are JSON-encoded `List<int>` of PID indices,
+    // mirroring the storage idiom used by the other OBD2 boxes so
+    // we don't need a custom adapter.
+    await Hive.openBox<String>(obd2SupportedPids);
   }
 
   /// Initialize Hive in a background isolate with proper encryption.

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import 'elm327_protocol.dart';
 import 'obd2_transport.dart';
+import 'supported_pids_cache.dart';
 
 /// High-level OBD-II service for reading vehicle data.
 ///
@@ -10,21 +11,45 @@ import 'obd2_transport.dart';
 class Obd2Service {
   final Obd2Transport _transport;
 
+  /// Optional persistent supported-PID cache (#811). When present and
+  /// a VIN (or [vehicleFallbackKey]) resolves to a cached entry,
+  /// [connect] skips the 8 × `01 XX` bitmap scan entirely.
+  final SupportedPidsCache? _pidsCache;
+
+  /// Fallback cache key for when the car doesn't return a VIN (old
+  /// ECUs / incompatible adapters). Typically `'${make}:${model}:${year}'`
+  /// — see [SupportedPidsCache.fallbackKey].
+  final String? _vehicleFallbackKey;
+
   /// Per-connection cache of the Mode 01 PIDs the car supports,
-  /// populated by [discoverSupportedPids]. Reset on every new
-  /// [connect] — each session must re-discover because the user may
-  /// have switched cars since last time. `null` means "we haven't
-  /// asked the car yet, so don't trust this cache to reject PIDs"
-  /// (see [isPidSupported] for the exact semantics).
+  /// populated by [discoverSupportedPids] or reloaded from [_pidsCache]
+  /// during [connect]. `null` means "we haven't asked the car yet,
+  /// so don't trust this cache to reject PIDs" (see [isPidSupported]
+  /// for the exact semantics).
   Set<int>? _supportedPids;
 
-  Obd2Service(this._transport);
+  Obd2Service(
+    this._transport, {
+    SupportedPidsCache? pidsCache,
+    String? vehicleFallbackKey,
+  })  : _pidsCache = pidsCache,
+        _vehicleFallbackKey = vehicleFallbackKey;
 
   /// `true` when the underlying [Obd2Transport] currently has an open
   /// connection to the vehicle's ELM327 adapter.
   bool get isConnected => _transport.isConnected;
 
   /// Connect and initialize the ELM327 adapter.
+  ///
+  /// After the init sequence, if a [SupportedPidsCache] was wired in
+  /// via the constructor (#811) this also:
+  ///   1. Reads the VIN from the car (Mode 09 PID 02). Falls back to
+  ///      the optional `vehicleFallbackKey` when no VIN comes back.
+  ///   2. Looks up the supported-PID set by that key. On cache hit,
+  ///      populates the in-memory set and skips the scan entirely —
+  ///      saves 8 × `01 XX` Bluetooth round-trips every session.
+  ///   3. On cache miss, runs [discoverSupportedPids] and persists
+  ///      the result under the chosen key for next time.
   Future<bool> connect() async {
     try {
       await _transport.connect();
@@ -40,11 +65,62 @@ class Obd2Service {
         await Future.delayed(const Duration(milliseconds: 100));
       }
 
+      await _primeSupportedPidsCache();
+
       return true;
     } catch (e) {
       debugPrint('OBD2 connect failed: $e');
       return false;
     }
+  }
+
+  /// Attempt to load the supported-PID set from the persistent cache
+  /// (#811). Silent no-op when no cache was injected. Always swallows
+  /// errors: a broken cache must not break the connect flow — worst
+  /// case we fall back to blind querying, which is exactly what the
+  /// adapter did before this feature landed.
+  Future<void> _primeSupportedPidsCache() async {
+    final cache = _pidsCache;
+    if (cache == null) return;
+    try {
+      final key = await _resolveVehicleCacheKey();
+      if (key == null) {
+        debugPrint(
+            'OBD2 supported-PID cache: no VIN and no fallback key — '
+            'scanning blindly this session');
+        return;
+      }
+      final cached = cache.get(key);
+      if (cached != null) {
+        _supportedPids = cached;
+        debugPrint(
+            'OBD2 supported-PID cache HIT for "$key" '
+            '(${cached.length} PIDs) — skipping scan');
+        return;
+      }
+      debugPrint('OBD2 supported-PID cache MISS for "$key" — scanning');
+      final discovered = await discoverSupportedPids();
+      if (discovered.isNotEmpty) {
+        await cache.put(key, discovered);
+      }
+    } catch (e) {
+      debugPrint('OBD2 supported-PID cache prime failed: $e');
+    }
+  }
+
+  /// Resolve the cache key for the currently-connected vehicle.
+  /// Prefers the VIN; falls back to the static [_vehicleFallbackKey]
+  /// provided at construction time. Returns null when neither is
+  /// available, at which point the cache is skipped this session.
+  Future<String?> _resolveVehicleCacheKey() async {
+    try {
+      final response = await _transport.sendCommand(Elm327Protocol.vinCommand);
+      final vin = Elm327Protocol.parseVin(response);
+      if (vin != null && vin.isNotEmpty) return vin;
+    } catch (e) {
+      debugPrint('OBD2 VIN read for cache key failed: $e');
+    }
+    return _vehicleFallbackKey;
   }
 
   /// Whether [pid] is known to be supported by the connected vehicle
@@ -60,6 +136,19 @@ class Obd2Service {
   ///     `false` — callers skip the query.
   bool isPidSupported(int pid) =>
       _supportedPids == null || _supportedPids!.contains(pid);
+
+  /// Alias for [isPidSupported] — matches the name used in the #811
+  /// issue. Same semantics: `true` when the cache is unpopulated or
+  /// [pid] is present, `false` only when we know the car doesn't
+  /// implement it.
+  bool supportsPid(int pid) => isPidSupported(pid);
+
+  /// Direct view of the supported-PID set for tests and diagnostics.
+  /// Returns an unmodifiable empty set when discovery hasn't run —
+  /// callers that want "is this supported?" should use [supportsPid]
+  /// instead to respect the "unknown ⇒ allow" semantics.
+  @visibleForTesting
+  Set<int> get debugSupportedPids => Set.unmodifiable(_supportedPids ?? {});
 
   /// Read the odometer value in km.
   ///

--- a/lib/features/consumption/data/obd2/supported_pids_cache.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_cache.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+/// Persistent cache of Mode 01 supported-PID bitmaps, keyed per
+/// vehicle (#811).
+///
+/// Every serious OSS OBD project (python-OBD, Car Scanner) runs Service
+/// 01 PID 00 / 20 / 40 / 60 / 80 / A0 / C0 on first connect to figure
+/// out which PIDs the ECU implements, then caches the result so future
+/// sessions can skip the eight extra round-trips over a slow Bluetooth
+/// pipe. Tankstellen does the same thing here.
+///
+/// Preferred key is the VIN — globally unique per vehicle and stable
+/// for the life of the car. When the car doesn't answer Mode 09 PID 02
+/// (older ECUs, some adapters) the fallback key is
+/// `'${make}:${model}:${year}'`. Less precise but still better than
+/// re-scanning every connect.
+///
+/// The underlying box is the unencrypted `Box<String>` opened by
+/// [HiveBoxes.init]. Values are JSON-encoded `List<int>` of PID
+/// indices — mirrors the idiom used by baselines and trip history
+/// (also `Box<String>` + JSON) and sidesteps Hive type-adapter
+/// registration entirely.
+class SupportedPidsCache {
+  final Box<String> _box;
+
+  SupportedPidsCache(this._box);
+
+  /// Build a composite cache key from a make, model, and year triple.
+  /// Lower-cased so minor capitalisation mismatches (e.g. "Peugeot"
+  /// vs "PEUGEOT") still share a cache entry.
+  static String fallbackKey({
+    required String make,
+    required String model,
+    required int year,
+  }) {
+    return '${make.trim().toLowerCase()}:'
+        '${model.trim().toLowerCase()}:'
+        '$year';
+  }
+
+  /// Look up the cached supported-PID set for [key], or null when
+  /// there's no entry / the entry is corrupt.
+  Set<int>? get(String key) {
+    final raw = _box.get(key);
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final decoded = json.decode(raw);
+      if (decoded is! List) {
+        debugPrint(
+            'SupportedPidsCache: non-list entry at "$key" — ignoring cache');
+        return null;
+      }
+      final pids = <int>{};
+      for (final v in decoded) {
+        if (v is int) {
+          pids.add(v);
+        } else if (v is num) {
+          pids.add(v.toInt());
+        }
+      }
+      return pids;
+    } catch (e) {
+      debugPrint('SupportedPidsCache: corrupt JSON at "$key": $e');
+      return null;
+    }
+  }
+
+  /// Persist [pids] under [key]. Stored as a sorted JSON list so
+  /// debug inspection of the Hive file surfaces a deterministic
+  /// layout.
+  Future<void> put(String key, Set<int> pids) async {
+    final sorted = pids.toList()..sort();
+    await _box.put(key, json.encode(sorted));
+  }
+
+  /// Delete every cache entry. Handy when a user switches cars or
+  /// wants to re-scan the connected ECU from scratch.
+  Future<void> clear() async {
+    await _box.clear();
+  }
+}

--- a/test/features/consumption/data/obd2/supported_pids_cache_test.dart
+++ b/test/features/consumption/data/obd2/supported_pids_cache_test.dart
@@ -1,0 +1,435 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/supported_pids_cache.dart';
+
+// Shared AT-init boilerplate for the FakeObd2Transport — mirrors
+// obd2_service_test.dart so the #811 tests can stay self-contained.
+const _initResponses = {
+  'ATZ': 'ELM327 v1.5>',
+  'ATE0': 'OK>',
+  'ATL0': 'OK>',
+  'ATH0': 'OK>',
+  'ATSP0': 'OK>',
+};
+
+/// Build a valid VIN Mode 09 PID 02 response (`49 02 01 ...`) from a
+/// plain-ASCII 17-character VIN. Lets individual tests declare a VIN
+/// as a string instead of hand-packing hex frames.
+String _vinResponse(String vin) {
+  assert(vin.length == 17, 'VIN must be 17 chars');
+  final bytes = StringBuffer('49 02 01');
+  for (final codeUnit in vin.codeUnits) {
+    bytes.write(' ${codeUnit.toRadixString(16).toUpperCase().padLeft(2, '0')}');
+  }
+  bytes.write('>');
+  return bytes.toString();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Elm327Protocol.parseSupportedPidsBitmap — #811 parser', () {
+    test('groupBase 0x00, all zeros → empty set', () {
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(
+        '41 00 00 00 00 00>',
+        0x00,
+      );
+      expect(pids, isEmpty);
+    });
+
+    test('groupBase 0x00, single high bit → PID 1', () {
+      // 0x80 = 1000_0000 → MSB = PID (groupBase + 1) = PID 1.
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(
+        '41 00 80 00 00 00>',
+        0x00,
+      );
+      expect(pids, {1});
+    });
+
+    test('groupBase 0x00, BE 3F A8 13 → canonical "modern car" bitmap', () {
+      // Picked from the issue description as a real-world example.
+      // 0xBE = 1011_1110 → bits 0,2,3,4,5,6 set → PIDs 1, 3, 4, 5, 6, 7.
+      // 0x3F = 0011_1111 → bits 2,3,4,5,6,7 set → PIDs 11,12,13,14,15,16.
+      // 0xA8 = 1010_1000 → bits 0,2,4       → PIDs 17,19,21.
+      // 0x13 = 0001_0011 → bits 3,6,7       → PIDs 28,31,32.
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(
+        '41 00 BE 3F A8 13>',
+        0x00,
+      );
+      expect(
+        pids,
+        {1, 3, 4, 5, 6, 7, 11, 12, 13, 14, 15, 16, 17, 19, 21, 28, 31, 32},
+      );
+    });
+
+    test('groupBase 0x20 shifts the PID numbers by the base', () {
+      // Same 0x80 bitmap but for range 0x20..0x3F → should decode to
+      // PID (0x20 + 1) = PID 33.
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(
+        '41 20 80 00 00 00>',
+        0x20,
+      );
+      expect(pids, {33});
+    });
+
+    test('groupBase 0x40 → PIDs 0x41..0x60 (65..96)', () {
+      // 0x01 in the last byte = PID (0x40 + 32) = 0x60 = 96.
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(
+        '41 40 00 00 00 01>',
+        0x40,
+      );
+      expect(pids, {96});
+    });
+
+    test('groupBase 0x60 → PIDs 0x61..0x80 (97..128)', () {
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(
+        '41 60 80 00 00 00>',
+        0x60,
+      );
+      expect(pids, {0x61});
+    });
+
+    test('groupBase 0x80 → PIDs 0x81..0xA0 (129..160)', () {
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(
+        '41 80 80 00 00 00>',
+        0x80,
+      );
+      expect(pids, {0x81});
+    });
+
+    test('groupBase 0xA0 → PIDs 0xA1..0xC0 (161..192)', () {
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(
+        '41 A0 80 00 00 00>',
+        0xA0,
+      );
+      expect(pids, {0xA1});
+    });
+
+    test('groupBase 0xC0 → PIDs 0xC1..0xE0 (193..224)', () {
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(
+        '41 C0 80 00 00 00>',
+        0xC0,
+      );
+      expect(pids, {0xC1});
+    });
+
+    test('NO DATA returns null (not an empty set — a distinct signal)', () {
+      expect(
+        Elm327Protocol.parseSupportedPidsBitmap('NO DATA>', 0x00),
+        isNull,
+      );
+    });
+
+    test('truncated response returns null (minBytes guard)', () {
+      // Missing last payload byte — only 3 of 4 bytes present.
+      expect(
+        Elm327Protocol.parseSupportedPidsBitmap('41 00 FF FF FF>', 0x00),
+        isNull,
+      );
+    });
+
+    test('wrong Mode echo (42 instead of 41) returns null', () {
+      expect(
+        Elm327Protocol.parseSupportedPidsBitmap('42 00 FF FF FF FF>', 0x00),
+        isNull,
+      );
+    });
+
+    test('wrong PID echo returns null', () {
+      // Response claims range 0x20 but caller asked about 0x00.
+      expect(
+        Elm327Protocol.parseSupportedPidsBitmap('41 20 FF FF FF FF>', 0x00),
+        isNull,
+      );
+    });
+
+    test('multi-response chain — a single bitmap spread across frames '
+        'still decodes correctly once cleanResponse anchors on "41"', () {
+      // ELM327 frames can arrive with a leading "SEARCHING..." line or
+      // multiple echoed \r between payload bytes. cleanResponse strips
+      // them; the parser should still land on the right 6 bytes.
+      const raw = 'SEARCHING...\r\r41 00\rBE 3F A8 13\r>';
+      final pids = Elm327Protocol.parseSupportedPidsBitmap(raw, 0x00);
+      expect(
+        pids,
+        {1, 3, 4, 5, 6, 7, 11, 12, 13, 14, 15, 16, 17, 19, 21, 28, 31, 32},
+      );
+    });
+  });
+
+  group('SupportedPidsCache — #811 persistence', () {
+    late Directory tmpDir;
+    late Box<String> box;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('supported_pids_cache_');
+      Hive.init(tmpDir.path);
+      box = await Hive.openBox<String>(
+        'test_${DateTime.now().microsecondsSinceEpoch}',
+      );
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    test('empty cache returns null', () {
+      final cache = SupportedPidsCache(box);
+      expect(cache.get('unknown-vin'), isNull);
+    });
+
+    test('round-trip — put then get yields the same set', () async {
+      final cache = SupportedPidsCache(box);
+      final pids = {1, 3, 11, 12, 13, 14, 15, 16, 32};
+      await cache.put('VF7PPPP0000000001', pids);
+      expect(cache.get('VF7PPPP0000000001'), pids);
+    });
+
+    test('fallbackKey lower-cases and trims, so capitalisation '
+        'mismatches share a cache entry', () {
+      final a = SupportedPidsCache.fallbackKey(
+        make: 'Peugeot',
+        model: '107',
+        year: 2008,
+      );
+      final b = SupportedPidsCache.fallbackKey(
+        make: '  PEUGEOT  ',
+        model: '107 ',
+        year: 2008,
+      );
+      expect(a, b);
+    });
+
+    test('persistence across Hive close/reopen — stored set loads back', () async {
+      final boxName = box.name;
+      final cache = SupportedPidsCache(box);
+      await cache.put('VIN-X', {1, 3, 5, 32});
+      await box.close();
+
+      final reopened = await Hive.openBox<String>(boxName);
+      final cache2 = SupportedPidsCache(reopened);
+      expect(cache2.get('VIN-X'), {1, 3, 5, 32});
+      // Reassign the test-scope `box` so tearDown deletes the right one.
+      box = reopened;
+    });
+
+    test('corrupt JSON entry ignored → returns null', () async {
+      // Simulate an entry that's not valid JSON (e.g. a disk corruption
+      // or a stale payload from a previous schema).
+      await box.put('VIN-CORRUPT', 'not-json');
+      final cache = SupportedPidsCache(box);
+      expect(cache.get('VIN-CORRUPT'), isNull);
+    });
+
+    test('non-list JSON entry ignored → returns null', () async {
+      // JSON-valid but wrong shape (object instead of list).
+      await box.put('VIN-WRONG-SHAPE', '{"pids": [1, 2]}');
+      final cache = SupportedPidsCache(box);
+      expect(cache.get('VIN-WRONG-SHAPE'), isNull);
+    });
+
+    test('clear wipes every entry', () async {
+      final cache = SupportedPidsCache(box);
+      await cache.put('VIN-A', {1});
+      await cache.put('VIN-B', {2});
+      await cache.clear();
+      expect(cache.get('VIN-A'), isNull);
+      expect(cache.get('VIN-B'), isNull);
+    });
+  });
+
+  group('Obd2Service connect-time cache integration — #811', () {
+    late Directory tmpDir;
+    late Box<String> box;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('obd2_cache_int_');
+      Hive.init(tmpDir.path);
+      box = await Hive.openBox<String>(
+        'test_${DateTime.now().microsecondsSinceEpoch}',
+      );
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    test('cache miss on first connect → scan runs, result is persisted',
+        () async {
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '0902': _vinResponse('VF7PPPP0000000001'),
+        // Only range 0x00 bitmap is answered; continuation bit (PID
+        // 32) is NOT set so the walk stops after one round-trip.
+        // Byte 0 bit 0 = PID 1, byte 1 bit 2 = PID 0x0B, byte 1 bit
+        // 3 = PID 0x0C, byte 1 bit 6 = PID 0x0F.
+        '0100': '41 00 80 32 00 00>',
+      });
+      final cache = SupportedPidsCache(box);
+      final service = Obd2Service(transport, pidsCache: cache);
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+
+      // Scan ran → in-memory set populated with the decoded PIDs.
+      expect(service.supportsPid(0x01), isTrue);
+      expect(service.supportsPid(0x0B), isTrue);
+      expect(service.supportsPid(0x0C), isTrue);
+      expect(service.supportsPid(0x0F), isTrue);
+      expect(service.supportsPid(0x5E), isFalse);
+
+      // And persisted under the VIN key for next session.
+      expect(cache.get('VF7PPPP0000000001'),
+          containsAll([0x01, 0x0B, 0x0C, 0x0F]));
+    });
+
+    test('cache hit on second connect → no scan, no 01 XX round-trips',
+        () async {
+      // Pre-seed the cache as if a previous session already scanned.
+      await SupportedPidsCache(box).put(
+        'VF7PPPP0000000001',
+        {0x01, 0x0B, 0x0C, 0x0F},
+      );
+
+      // Note: '0100' is INTENTIONALLY NOT in the transport's response
+      // map. If the service tries to scan, FakeObd2Transport returns
+      // 'NO DATA>' — which would blank the in-memory cache and fail
+      // the supportsPid(0x0B) assertion below.
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '0902': _vinResponse('VF7PPPP0000000001'),
+      });
+      final cache = SupportedPidsCache(box);
+      final service = Obd2Service(transport, pidsCache: cache);
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+
+      expect(service.supportsPid(0x0B), isTrue,
+          reason: 'cached set must have populated _supportedPids without '
+              'any 01 XX round-trip');
+      expect(service.supportsPid(0x5E), isFalse);
+    });
+
+    test(
+        'VIN change invalidates the cache hit — different VIN forces a '
+        'fresh scan', () async {
+      // Cache was filled for car A (only PID 0x01).
+      await SupportedPidsCache(box).put('VF7PPPP0000000001', {0x01});
+
+      // Now we connect to a DIFFERENT car (VF7PPPP0000000002). The cache
+      // has no entry for this second VIN, so the service must run a
+      // fresh scan. VIN chosen without 'A' so byte 0x41 doesn't confuse
+      // cleanResponse's Mode 01 anchor.
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '0902': _vinResponse('VF7PPPP0000000002'),
+        '0100': '41 00 00 32 00 00>', // PIDs 0x0B, 0x0C, 0x0F
+      });
+      final cache = SupportedPidsCache(box);
+      final service = Obd2Service(transport, pidsCache: cache);
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+
+      // Fresh-scan PIDs, NOT the cached VIN-A single-PID set.
+      expect(service.supportsPid(0x0B), isTrue);
+      expect(service.supportsPid(0x0C), isTrue);
+      expect(service.supportsPid(0x0F), isTrue);
+      expect(service.supportsPid(0x01), isFalse,
+          reason: 'VIN-A cache must not leak into VIN-B');
+    });
+
+    test(
+        'no VIN from the car + no fallback key → cache skipped, scan still '
+        'runs blindly', () async {
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        // 0902 NOT provided → FakeObd2Transport returns 'NO DATA>' →
+        // parseVin returns null.
+        '0100': '41 00 80 00 00 00>', // PID 1 only, no continuation
+      });
+      final cache = SupportedPidsCache(box);
+      final service = Obd2Service(transport, pidsCache: cache);
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+      // No cache key → nothing written.
+      expect(box.length, 0);
+      // And nothing primed in memory either — supportsPid stays in
+      // "unknown ⇒ allow" mode.
+      expect(service.supportsPid(0x5E), isTrue);
+    });
+
+    test(
+        'no VIN + fallback key provided → cache uses the fallback make:'
+        'model:year', () async {
+      final fallback = SupportedPidsCache.fallbackKey(
+        make: 'Peugeot',
+        model: '107',
+        year: 2008,
+      );
+      // Pre-seed with the fallback-key scenario.
+      await SupportedPidsCache(box).put(fallback, {0x0B, 0x0C, 0x0F});
+
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        // 0902 NOT provided → VIN parse returns null → fall back to
+        // the injected static key.
+      });
+      final cache = SupportedPidsCache(box);
+      final service = Obd2Service(
+        transport,
+        pidsCache: cache,
+        vehicleFallbackKey: fallback,
+      );
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+      // Cached PIDs loaded → 0x5E still false → sanity signal.
+      expect(service.supportsPid(0x0B), isTrue);
+      expect(service.supportsPid(0x5E), isFalse);
+    });
+
+    test('readFuelRateLPerHour skips PID 5E and MAF round-trips when '
+        'the cached set excludes them (Peugeot 107 flow)', () async {
+      // Seed cache with the real Peugeot 107 1KR-FE profile: no 5E,
+      // no MAF, but MAP/IAT/RPM all present.
+      const vin = 'VF7PPPP0000000001';
+      await SupportedPidsCache(box).put(vin, {0x0B, 0x0C, 0x0F});
+
+      // Intentionally do NOT wire '015E' or '0110' — if the service
+      // bypasses the cache and tries them, FakeObd2Transport returns
+      // 'NO DATA>' and the round-trips count toward wasted Bluetooth
+      // time. We assert the fuel rate comes out of the speed-density
+      // path anyway.
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '0902': _vinResponse(vin),
+        '010B': '41 0B 28>', // MAP 40 kPa
+        '010F': '41 0F 41>', // IAT 25 °C
+        '010C': '41 0C 0C 80>', // RPM 800
+      });
+      final service = Obd2Service(
+        transport,
+        pidsCache: SupportedPidsCache(box),
+      );
+      await service.connect();
+
+      expect(service.supportsPid(0x5E), isFalse);
+      expect(service.supportsPid(0x10), isFalse);
+      final rate = await service.readFuelRateLPerHour();
+      expect(rate, isNotNull);
+      expect(rate, greaterThan(0));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the persistent-cache layer for the Mode 01 supported-PID scan (#811).

Phase 1 (protocol commands `01 00`/`01 20`/.../`01 C0`), Phase 2 (in-memory `discoverSupportedPids` and `isPidSupported`) already landed with earlier PRs. This PR closes the loop by persisting the result per vehicle so the 8-round-trip scan only runs once per car, and fuel-rate reads that query a known-unsupported PID now short-circuit before reaching Bluetooth.

## Why

Older cars like the Peugeot 107 don't implement PIDs 5E, 10, 0B, 0F on every tick. Blindly querying them on every trip loop burns Bluetooth bandwidth that should be spent on the PIDs the ECU actually answers. Every OSS OBD project (python-OBD, Car Scanner) solves this the same way: scan once on first connect, cache per VIN, skip the scan on future connects.

Serves the *burn less fuel behind the wheel* lens of the product leitmotiv — a snappier in-car logger means the consumption estimator converges on a number sooner and the trip summary doesn't show long stretches of `—`.

## Changes

- `lib/core/storage/hive_boxes.dart` — register `obd2_supported_pids` as an unencrypted `Box<String>` next to the other OBD2 boxes (baselines, trip history, achievements).
- `lib/features/consumption/data/obd2/supported_pids_cache.dart` *(new)* — thin JSON-encoded cache wrapper. Key = VIN, fallback key = `make:model:year` (lower-cased, trimmed).
- `lib/features/consumption/data/obd2/obd2_service.dart` — `Obd2Service` now optionally takes a cache + fallback key. After the AT-init handshake, `_primeSupportedPidsCache`:
  1. reads the VIN (falls back to the injected static key);
  2. on cache hit, populates `_supportedPids` from the stored list — zero `01 XX` round-trips;
  3. on cache miss, runs `discoverSupportedPids` and persists the result.
  Also adds a `supportsPid(int)` alias matching the name used in the issue spec.
- `test/features/consumption/data/obd2/supported_pids_cache_test.dart` *(new)* — 27 tests:
  - parser covers all 8 groupBases (00-E0), truncation, malformed echo, NO DATA, multi-frame responses;
  - cache round-trip + persistence across Hive close/reopen;
  - corrupt JSON / wrong-shape JSON handled gracefully;
  - `connect()` integration: miss → scan → persist, hit → skip scan, VIN change → miss → fresh scan, no-VIN + no-fallback → blind-query fallback, no-VIN + fallback key → cache uses `make:model:year`, Peugeot 107 end-to-end (cache hit → `readFuelRateLPerHour` lands on speed-density without trying 5E or MAF).

## Test plan

- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — 4983 tests pass (1 pre-existing skipped)
- [x] 27 new cache tests pass
- [x] `obd2_service_test.dart` still passes — no regression on the existing 185 OBD2 tests
- [x] `hive_boxes_test.dart` static scan still passes (new box uses typed `Hive.openBox<String>` so it's explicitly unencrypted)

Closes #811