### PR TITLE
feat(country/gb): UK Fuel Finder OAuth2 scaffold — dormant (#573)

### DIFF
--- a/lib/core/services/impl/uk_fuel_finder_service.dart
+++ b/lib/core/services/impl/uk_fuel_finder_service.dart
@@ -1,0 +1,380 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../../../features/search/data/models/search_params.dart';
+import '../../../features/search/domain/entities/station.dart';
+import '../../error/exceptions.dart';
+import '../../utils/geo_utils.dart';
+import '../dio_factory.dart';
+import '../mixins/station_service_helpers.dart';
+import '../service_result.dart';
+import '../station_service.dart';
+
+/// GOV.UK Fuel Finder — new single-endpoint UK fuel price service (#573).
+///
+/// The UK Competition and Markets Authority's original Motor Fuel Price
+/// scheme required each retailer to publish a JSON file on its own
+/// domain. The Motor Fuel Price Open Data Regulations 2025 replaced
+/// that fan-out with a single aggregated government API served at
+/// `developer.fuel-finder.service.gov.uk`, reached via OAuth2 client
+/// credentials.
+///
+/// **This class is a scaffold only.** It is NOT wired into the country
+/// service registry — the legacy per-retailer [UkStationService] stays
+/// live until the user registers for OAuth2 credentials. Activation is
+/// a three-step flip once credentials exist:
+///
+///   1. Write `uk_fuel_finder_client_id` and `uk_fuel_finder_client_secret`
+///      into [FlutterSecureStorage] via the settings screen.
+///   2. Flip [_useFuelFinder] to `true` (single constant edit below).
+///   3. Register `UkFuelFinderService` in `country_service_registry.dart`
+///      for country code `gb` in place of `UkStationService`.
+///
+/// Keeping the gate inline (not in a central config) deliberately
+/// minimises the blast radius of this dormant code path.
+///
+/// ### OAuth2 flow
+///
+/// A `_TokenManager` fetches and caches an access token via the client
+/// credentials grant. The token is kept in memory with its `expires_in`
+/// and refreshed proactively one minute before expiry. A 401 from the
+/// token endpoint surfaces as an [ApiException] with "OAuth" in the
+/// message so the UI can differentiate credential problems from plain
+/// network errors.
+///
+/// ### Endpoints
+///
+/// The exact paths are hosted on
+/// `https://www.developer.fuel-finder.service.gov.uk` but the developer
+/// portal requires authentication to browse — the concrete token and
+/// data paths are therefore injectable via constructor so the user can
+/// confirm them against the GOV.UK spec once their application is
+/// approved and the docs become visible. Defaults match the published
+/// portal structure (`/oauth/token` for the OAuth2 step,
+/// `/api/v1/stations` for the data step).
+class UkFuelFinderService
+    with StationServiceHelpers
+    implements StationService {
+  // ── Activation flag ──────────────────────────────────────────────────────
+  //
+  // Hard-coded dormant. Flip to `true` only after:
+  //   - creds are written to secure storage under the two keys below, AND
+  //   - this service is registered in CountryServiceRegistry for 'gb'.
+  // ignore: unused_field
+  static const bool _useFuelFinder = false;
+
+  // ── Secure storage keys (secrets live here, nowhere else) ────────────────
+
+  /// Secure-storage key for the OAuth2 client id. Populated via settings.
+  static const String kClientIdStorageKey = 'uk_fuel_finder_client_id';
+
+  /// Secure-storage key for the OAuth2 client secret. Populated via settings.
+  static const String kClientSecretStorageKey = 'uk_fuel_finder_client_secret';
+
+  // ── Default endpoints (overridable for tests + future spec adjustments) ──
+
+  /// Default token endpoint — OAuth2 client-credentials grant.
+  static const String defaultTokenUrl =
+      'https://www.developer.fuel-finder.service.gov.uk/oauth/token';
+
+  /// Default data endpoint — list of stations with prices.
+  static const String defaultStationsUrl =
+      'https://www.developer.fuel-finder.service.gov.uk/api/v1/stations';
+
+  // ── Deps ─────────────────────────────────────────────────────────────────
+
+  final Dio _dio;
+  final FlutterSecureStorage _secureStorage;
+  final String _tokenUrl;
+  final String _stationsUrl;
+  final _TokenManager _tokenManager;
+
+  UkFuelFinderService({
+    Dio? dio,
+    FlutterSecureStorage? secureStorage,
+    String? tokenUrl,
+    String? stationsUrl,
+  })  : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 8),
+              receiveTimeout: const Duration(seconds: 12),
+            ),
+        _secureStorage = secureStorage ?? const FlutterSecureStorage(),
+        _tokenUrl = tokenUrl ?? defaultTokenUrl,
+        _stationsUrl = stationsUrl ?? defaultStationsUrl,
+        _tokenManager = _TokenManager();
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    final token = await _fetchAccessToken(cancelToken: cancelToken);
+
+    final Response<dynamic> response;
+    try {
+      response = await _dio.get<dynamic>(
+        _stationsUrl,
+        cancelToken: cancelToken,
+        options: Options(
+          headers: {'Authorization': 'Bearer $token'},
+          responseType: ResponseType.json,
+          // Non-2xx responses throw so we can surface them as ApiException.
+          validateStatus: (status) => status != null && status < 400,
+        ),
+      );
+    } on DioException catch (e) {
+      throwApiException(e, defaultMessage: 'Fuel Finder request failed');
+    }
+
+    final items = _extractStationList(response.data);
+    final stations = parseFuelFinderStations(
+      items,
+      lat: params.lat,
+      lng: params.lng,
+      radiusKm: params.radiusKm,
+    );
+
+    return ServiceResult(
+      data: stations,
+      source: ServiceSource.ukApi,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String stationId,
+  ) async {
+    throw const ApiException(
+      message: 'Station detail not supported for UK Fuel Finder',
+    );
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    // Fuel Finder returns the full price table with `searchStations`; the
+    // favorites-refresh path piggybacks on that rather than forcing a
+    // second round trip.
+    return emptyPricesResult(ServiceSource.ukApi);
+  }
+
+  // ── OAuth2 ───────────────────────────────────────────────────────────────
+
+  Future<String> _fetchAccessToken({CancelToken? cancelToken}) async {
+    final cached = _tokenManager.cachedToken;
+    if (cached != null) return cached;
+
+    final clientId = await _secureStorage.read(key: kClientIdStorageKey);
+    final clientSecret =
+        await _secureStorage.read(key: kClientSecretStorageKey);
+    if (clientId == null ||
+        clientId.isEmpty ||
+        clientSecret == null ||
+        clientSecret.isEmpty) {
+      throw const ApiException(
+        message:
+            'Fuel Finder OAuth credentials missing — set client id and '
+            'secret in secure storage before enabling.',
+      );
+    }
+
+    try {
+      final response = await _dio.post<Map<String, dynamic>>(
+        _tokenUrl,
+        data: {
+          'grant_type': 'client_credentials',
+          'client_id': clientId,
+          'client_secret': clientSecret,
+        },
+        cancelToken: cancelToken,
+        options: Options(
+          contentType: Headers.formUrlEncodedContentType,
+          responseType: ResponseType.json,
+          validateStatus: (status) => status != null && status < 400,
+        ),
+      );
+
+      final data = response.data;
+      if (data == null) {
+        throw const ApiException(
+          message: 'OAuth token response empty for Fuel Finder',
+        );
+      }
+      final accessToken = data['access_token']?.toString();
+      final expiresIn = (data['expires_in'] as num?)?.toInt() ?? 3600;
+      if (accessToken == null || accessToken.isEmpty) {
+        throw const ApiException(
+          message: 'OAuth token response missing access_token',
+        );
+      }
+
+      _tokenManager.store(accessToken, Duration(seconds: expiresIn));
+      return accessToken;
+    } on DioException catch (e) {
+      final status = e.response?.statusCode;
+      if (status == 401 || status == 403) {
+        throw ApiException(
+          message:
+              'OAuth authentication failed for Fuel Finder (HTTP $status) '
+              '— check client id and secret.',
+          statusCode: status,
+        );
+      }
+      throw ApiException(
+        message: 'OAuth token request failed: ${e.type.name}',
+        statusCode: status,
+      );
+    }
+  }
+
+  // ── Payload parsing ──────────────────────────────────────────────────────
+
+  List<dynamic> _extractStationList(dynamic data) {
+    if (data is List) return data;
+    if (data is Map<String, dynamic>) {
+      final list = data['stations'] as List<dynamic>? ??
+          data['data'] as List<dynamic>? ??
+          data['items'] as List<dynamic>? ??
+          const <dynamic>[];
+      return List<dynamic>.from(list);
+    }
+    return const <dynamic>[];
+  }
+
+  /// Parses Fuel Finder station records into [Station] entities, filters
+  /// by radius, dedupes by `site_id`, sorts by distance, caps at 50.
+  ///
+  /// Exposed for tests.
+  @visibleForTesting
+  static List<Station> parseFuelFinderStations(
+    List<dynamic> items, {
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) {
+    final seenIds = <String>{};
+    final stations = <Station>[];
+
+    for (final item in items) {
+      if (item is! Map) continue;
+      try {
+        final loc = item['location'];
+        final locMap = loc is Map ? loc : null;
+        final itemLat = (locMap?['latitude'] as num?)?.toDouble() ??
+            (item['latitude'] as num?)?.toDouble() ??
+            (item['lat'] as num?)?.toDouble();
+        final itemLng = (locMap?['longitude'] as num?)?.toDouble() ??
+            (item['longitude'] as num?)?.toDouble() ??
+            (item['lng'] as num?)?.toDouble();
+        if (itemLat == null || itemLng == null) continue;
+
+        final dist = distanceKm(lat, lng, itemLat, itemLng);
+        if (dist > radiusKm) continue;
+
+        final rawId = item['site_id']?.toString() ??
+            item['id']?.toString() ??
+            '${itemLat.toStringAsFixed(5)}_${itemLng.toStringAsFixed(5)}';
+        final stationId = 'uk-$rawId';
+        if (!seenIds.add(stationId)) continue;
+
+        final prices = item['prices'] is Map
+            ? Map<String, dynamic>.from(item['prices'] as Map)
+            : <String, dynamic>{};
+
+        stations.add(Station(
+          id: stationId,
+          name: item['site_name']?.toString() ??
+              item['name']?.toString() ??
+              item['brand']?.toString() ??
+              '',
+          brand: item['brand']?.toString() ?? '',
+          street: item['address']?.toString() ?? '',
+          postCode: item['postcode']?.toString() ?? '',
+          place:
+              item['town']?.toString() ?? item['locality']?.toString() ?? '',
+          lat: itemLat,
+          lng: itemLng,
+          dist: dist,
+          // E5 → FuelType.e5 (Super Unleaded 95 octane)
+          e5: _parsePence(prices['E5'] ?? prices['unleaded']),
+          // E10 → FuelType.e10 (95 octane, 10% ethanol)
+          e10: _parsePence(prices['E10']),
+          // E98 / Super Unleaded → FuelType.e98 (97/98 octane premium petrol)
+          e98: _parsePence(
+            prices['E98'] ?? prices['super_unleaded'] ?? prices['E5_97'],
+          ),
+          // B7 / Diesel → FuelType.diesel (7% biodiesel blend, standard UK spec)
+          diesel: _parsePence(prices['B7'] ?? prices['diesel']),
+          // SDV / Premium Diesel → FuelType.dieselPremium
+          dieselPremium: _parsePence(
+            prices['SDV'] ?? prices['premium_diesel'] ?? prices['B7_plus'],
+          ),
+          isOpen: true,
+        ));
+      } catch (e) {
+        debugPrint('UK Fuel Finder parse failed: $e');
+        continue;
+      }
+    }
+
+    stations.sort((a, b) => a.dist.compareTo(b.dist));
+    return stations.take(50).toList();
+  }
+
+  /// UK prices are published in pence per litre. Anything above 10
+  /// is treated as pence and divided by 100; anything at or below 10 is
+  /// assumed to already be in pounds.
+  ///
+  /// Exposed for tests.
+  @visibleForTesting
+  static double? parsePenceForTest(dynamic value) => _parsePence(value);
+
+  /// Force the cached OAuth token to appear expired so the next
+  /// [searchStations] call triggers a fresh `/oauth/token` request.
+  /// Exposed for tests only.
+  @visibleForTesting
+  void expireTokenForTest() => _tokenManager.forceExpire();
+
+  static double? _parsePence(dynamic value) {
+    if (value == null) return null;
+    final price = double.tryParse(value.toString());
+    if (price == null) return null;
+    return price > 10 ? price / 100 : price;
+  }
+}
+
+/// Private OAuth2 token cache. One instance per service — keeps blast
+/// radius local instead of pushing a Dio-wide interceptor that would
+/// touch unrelated requests.
+class _TokenManager {
+  String? _accessToken;
+  DateTime? _expiresAt;
+
+  /// Returns the cached token if it is still valid for at least 60s,
+  /// otherwise `null` (caller must fetch a fresh one).
+  String? get cachedToken {
+    final token = _accessToken;
+    final expiry = _expiresAt;
+    if (token == null || expiry == null) return null;
+    // Refresh one minute before expiry to avoid racing a request against
+    // a token that expires mid-flight.
+    if (DateTime.now().isAfter(expiry.subtract(const Duration(seconds: 60)))) {
+      return null;
+    }
+    return token;
+  }
+
+  void store(String token, Duration ttl) {
+    _accessToken = token;
+    _expiresAt = DateTime.now().add(ttl);
+  }
+
+  @visibleForTesting
+  void forceExpire() {
+    _expiresAt = DateTime.now().subtract(const Duration(minutes: 1));
+  }
+}

--- a/test/core/services/impl/uk_fuel_finder_service_test.dart
+++ b/test/core/services/impl/uk_fuel_finder_service_test.dart
@@ -1,0 +1,487 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/impl/uk_fuel_finder_service.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+
+/// Canned reply for a single URL (token or data endpoint).
+class _Reply {
+  final int status;
+  final String body;
+  const _Reply(this.status, this.body);
+}
+
+/// Fake HTTP adapter — matches by endpoint substring so tests can key on
+/// the OAuth path vs the data path without having to match the full URL
+/// including query strings.
+class _FakeAdapter implements HttpClientAdapter {
+  final List<_Matcher> matchers;
+  int tokenRequests = 0;
+  int stationsRequests = 0;
+  final List<String> requestedUrls = [];
+
+  _FakeAdapter(this.matchers);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final url = options.uri.toString();
+    requestedUrls.add(url);
+    if (url.contains('/oauth/token')) tokenRequests++;
+    if (url.contains('/stations')) stationsRequests++;
+
+    for (final m in matchers) {
+      if (m.matches(url)) {
+        final reply = m.reply();
+        return ResponseBody.fromString(
+          reply.body,
+          reply.status,
+          headers: {
+            Headers.contentTypeHeader: ['application/json'],
+          },
+        );
+      }
+    }
+    return ResponseBody.fromString('', 404);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// A matcher picks a reply based on the request URL. `reply` is a
+/// function so tests can vary the response across retries.
+class _Matcher {
+  final bool Function(String url) matches;
+  final _Reply Function() reply;
+  _Matcher(this.matches, this.reply);
+}
+
+/// Mock the platform method channel used by `flutter_secure_storage` so
+/// tests don't need to touch the real keychain. Pattern mirrors
+/// `test/core/storage/stores/settings_hive_store_test.dart`.
+void _mockSecureStorage(Map<String, String?> seed) {
+  final store = Map<String, String?>.from(seed);
+  const channel =
+      MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async {
+    final args = (call.arguments as Map?) ?? {};
+    final key = args['key'] as String? ?? '';
+    switch (call.method) {
+      case 'read':
+        return store[key];
+      case 'write':
+        store[key] = args['value'] as String?;
+        return null;
+      case 'delete':
+        store.remove(key);
+        return null;
+      case 'readAll':
+        return Map<String, String?>.from(store);
+      case 'deleteAll':
+        store.clear();
+        return null;
+      case 'containsKey':
+        return store.containsKey(key);
+    }
+    return null;
+  });
+}
+
+const _tokenUrl = 'https://fake.example/oauth/token';
+const _stationsUrl = 'https://fake.example/api/v1/stations';
+
+const _validSearch = SearchParams(lat: 51.5, lng: -0.12, radiusKm: 50);
+
+String _tokenBody({String token = 'TEST-TOKEN', int expiresIn = 3600}) {
+  return jsonEncode({
+    'access_token': token,
+    'token_type': 'Bearer',
+    'expires_in': expiresIn,
+  });
+}
+
+String _stationsBody(List<Map<String, dynamic>> stations) {
+  return jsonEncode({'stations': stations});
+}
+
+({Dio dio, _FakeAdapter adapter}) _buildDio(List<_Matcher> matchers) {
+  final dio = Dio();
+  final adapter = _FakeAdapter(matchers);
+  dio.httpClientAdapter = adapter;
+  return (dio: dio, adapter: adapter);
+}
+
+FlutterSecureStorage _storageWithCreds({
+  String clientId = 'CID',
+  String clientSecret = 'SECRET',
+}) {
+  _mockSecureStorage({
+    UkFuelFinderService.kClientIdStorageKey: clientId,
+    UkFuelFinderService.kClientSecretStorageKey: clientSecret,
+  });
+  return const FlutterSecureStorage();
+}
+
+FlutterSecureStorage _storageEmpty() {
+  _mockSecureStorage(const {});
+  return const FlutterSecureStorage();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('UkFuelFinderService — contract', () {
+    test('implements StationService', () {
+      final svc = UkFuelFinderService(
+        dio: Dio(),
+        secureStorage: _storageEmpty(),
+      );
+      expect(svc, isA<StationService>());
+    });
+
+    test('getStationDetail throws ApiException', () async {
+      final svc = UkFuelFinderService(
+        dio: Dio(),
+        secureStorage: _storageEmpty(),
+      );
+      expect(
+        () => svc.getStationDetail('uk-1'),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('getPrices returns empty map tagged as ukApi', () async {
+      final svc = UkFuelFinderService(
+        dio: Dio(),
+        secureStorage: _storageEmpty(),
+      );
+      final result = await svc.getPrices(['uk-1']);
+      expect(result.data, isEmpty);
+      expect(result.source, ServiceSource.ukApi);
+    });
+
+    test('secure-storage key constants are stable', () {
+      // Guard against accidental rename — settings screen will use
+      // exactly these keys to write user-provided credentials.
+      expect(UkFuelFinderService.kClientIdStorageKey,
+          'uk_fuel_finder_client_id');
+      expect(UkFuelFinderService.kClientSecretStorageKey,
+          'uk_fuel_finder_client_secret');
+    });
+  });
+
+  group('OAuth2 token flow', () {
+    test('fetches a token with valid creds and caches it across calls',
+        () async {
+      final built = _buildDio([
+        _Matcher(
+          (url) => url.contains('/oauth/token'),
+          () => _Reply(200, _tokenBody()),
+        ),
+        _Matcher(
+          (url) => url.contains('/stations'),
+          () => _Reply(200, _stationsBody(const [])),
+        ),
+      ]);
+
+      final svc = UkFuelFinderService(
+        dio: built.dio,
+        secureStorage: _storageWithCreds(),
+        tokenUrl: _tokenUrl,
+        stationsUrl: _stationsUrl,
+      );
+
+      await svc.searchStations(_validSearch);
+      await svc.searchStations(_validSearch);
+
+      // Two data requests, but only one token fetch — second call
+      // must hit the in-memory cache.
+      expect(built.adapter.tokenRequests, 1);
+      expect(built.adapter.stationsRequests, 2);
+    });
+
+    test('refreshes the token after expiry', () async {
+      final built = _buildDio([
+        _Matcher(
+          (url) => url.contains('/oauth/token'),
+          () => _Reply(200, _tokenBody()),
+        ),
+        _Matcher(
+          (url) => url.contains('/stations'),
+          () => _Reply(200, _stationsBody(const [])),
+        ),
+      ]);
+
+      final svc = UkFuelFinderService(
+        dio: built.dio,
+        secureStorage: _storageWithCreds(),
+        tokenUrl: _tokenUrl,
+        stationsUrl: _stationsUrl,
+      );
+
+      await svc.searchStations(_validSearch);
+      expect(built.adapter.tokenRequests, 1);
+
+      // Simulate clock-forward past expiry.
+      svc.expireTokenForTest();
+
+      await svc.searchStations(_validSearch);
+      expect(built.adapter.tokenRequests, 2,
+          reason: 'Expired token must trigger a refresh');
+    });
+
+    test('401 on the token endpoint surfaces as an OAuth ApiException',
+        () async {
+      final built = _buildDio([
+        _Matcher(
+          (url) => url.contains('/oauth/token'),
+          () => const _Reply(401, '{"error":"invalid_client"}'),
+        ),
+      ]);
+
+      final svc = UkFuelFinderService(
+        dio: built.dio,
+        secureStorage: _storageWithCreds(),
+        tokenUrl: _tokenUrl,
+        stationsUrl: _stationsUrl,
+      );
+
+      await expectLater(
+        svc.searchStations(_validSearch),
+        throwsA(
+          isA<ApiException>().having(
+            (e) => e.message,
+            'message',
+            contains('OAuth'),
+          ),
+        ),
+      );
+    });
+
+    test('missing credentials throw before any HTTP call', () async {
+      final built = _buildDio(const []);
+      final svc = UkFuelFinderService(
+        dio: built.dio,
+        secureStorage: _storageEmpty(),
+        tokenUrl: _tokenUrl,
+        stationsUrl: _stationsUrl,
+      );
+
+      await expectLater(
+        svc.searchStations(_validSearch),
+        throwsA(isA<ApiException>()),
+      );
+      // No HTTP traffic — we short-circuit on missing creds.
+      expect(built.adapter.tokenRequests, 0);
+      expect(built.adapter.stationsRequests, 0);
+    });
+  });
+
+  group('station list parsing', () {
+    test('parses a well-formed station with prices in pence', () async {
+      final built = _buildDio([
+        _Matcher(
+          (url) => url.contains('/oauth/token'),
+          () => _Reply(200, _tokenBody()),
+        ),
+        _Matcher(
+          (url) => url.contains('/stations'),
+          () => _Reply(
+            200,
+            _stationsBody([
+              {
+                'site_id': 'GB1',
+                'brand': 'BP',
+                'site_name': 'BP Victoria',
+                'address': '1 Victoria St',
+                'postcode': 'SW1E 6DE',
+                'town': 'London',
+                'location': {'latitude': 51.4975, 'longitude': -0.1357},
+                'prices': {
+                  'E5': 155.9,
+                  'E10': 145.9,
+                  'B7': 152.9,
+                  'E98': 158.9,
+                  'SDV': 165.9,
+                },
+              }
+            ]),
+          ),
+        ),
+      ]);
+
+      final svc = UkFuelFinderService(
+        dio: built.dio,
+        secureStorage: _storageWithCreds(),
+        tokenUrl: _tokenUrl,
+        stationsUrl: _stationsUrl,
+      );
+
+      final result = await svc.searchStations(_validSearch);
+      expect(result.source, ServiceSource.ukApi);
+      expect(result.data, hasLength(1));
+      final s = result.data.first;
+      expect(s.id, 'uk-GB1');
+      expect(s.brand, 'BP');
+      expect(s.name, 'BP Victoria');
+      expect(s.lat, closeTo(51.4975, 0.0001));
+      expect(s.lng, closeTo(-0.1357, 0.0001));
+      expect(s.e5, closeTo(1.559, 0.0001));
+      expect(s.e10, closeTo(1.459, 0.0001));
+      expect(s.diesel, closeTo(1.529, 0.0001));
+      expect(s.e98, closeTo(1.589, 0.0001));
+      expect(s.dieselPremium, closeTo(1.659, 0.0001));
+      expect(s.isOpen, isTrue);
+    });
+
+    test('HTTP 500 on the data endpoint throws ApiException', () async {
+      final built = _buildDio([
+        _Matcher(
+          (url) => url.contains('/oauth/token'),
+          () => _Reply(200, _tokenBody()),
+        ),
+        _Matcher(
+          (url) => url.contains('/stations'),
+          () => const _Reply(500, 'upstream boom'),
+        ),
+      ]);
+
+      final svc = UkFuelFinderService(
+        dio: built.dio,
+        secureStorage: _storageWithCreds(),
+        tokenUrl: _tokenUrl,
+        stationsUrl: _stationsUrl,
+      );
+
+      await expectLater(
+        svc.searchStations(_validSearch),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('empty stations list yields empty Station list (does not throw)',
+        () async {
+      final built = _buildDio([
+        _Matcher(
+          (url) => url.contains('/oauth/token'),
+          () => _Reply(200, _tokenBody()),
+        ),
+        _Matcher(
+          (url) => url.contains('/stations'),
+          () => _Reply(200, _stationsBody(const [])),
+        ),
+      ]);
+
+      final svc = UkFuelFinderService(
+        dio: built.dio,
+        secureStorage: _storageWithCreds(),
+        tokenUrl: _tokenUrl,
+        stationsUrl: _stationsUrl,
+      );
+
+      final result = await svc.searchStations(_validSearch);
+      expect(result.data, isEmpty);
+      expect(result.source, ServiceSource.ukApi);
+    });
+
+    test('stations outside the search radius are filtered out', () async {
+      final built = _buildDio([
+        _Matcher(
+          (url) => url.contains('/oauth/token'),
+          () => _Reply(200, _tokenBody()),
+        ),
+        _Matcher(
+          (url) => url.contains('/stations'),
+          () => _Reply(
+            200,
+            _stationsBody([
+              {
+                'site_id': 'LON',
+                'brand': 'BP',
+                'location': {'latitude': 51.5, 'longitude': -0.12},
+                'prices': <String, dynamic>{},
+              },
+              {
+                'site_id': 'EDI',
+                'brand': 'Shell',
+                'location': {'latitude': 55.9533, 'longitude': -3.1883},
+                'prices': <String, dynamic>{},
+              },
+            ]),
+          ),
+        ),
+      ]);
+
+      final svc = UkFuelFinderService(
+        dio: built.dio,
+        secureStorage: _storageWithCreds(),
+        tokenUrl: _tokenUrl,
+        stationsUrl: _stationsUrl,
+      );
+
+      final result = await svc.searchStations(
+        const SearchParams(lat: 51.5, lng: -0.12, radiusKm: 20),
+      );
+      expect(result.data, hasLength(1));
+      expect(result.data.first.id, 'uk-LON');
+    });
+  });
+
+  group('parseFuelFinderStations (static)', () {
+    test('parsePenceForTest handles pence, pounds, and garbage', () {
+      expect(UkFuelFinderService.parsePenceForTest(null), isNull);
+      expect(UkFuelFinderService.parsePenceForTest('abc'), isNull);
+      expect(
+        UkFuelFinderService.parsePenceForTest(145.9),
+        closeTo(1.459, 0.0001),
+      );
+      expect(UkFuelFinderService.parsePenceForTest(1.459), 1.459);
+      expect(UkFuelFinderService.parsePenceForTest('155'), closeTo(1.55, 0.0001));
+    });
+
+    test('dedupes by site_id and caps at 50 results', () {
+      final items = <Map<String, dynamic>>[
+        for (var i = 0; i < 120; i++)
+          {
+            'site_id': 'S$i',
+            'brand': 'Brand',
+            'location': {
+              'latitude': 51.5 + i * 0.0001,
+              'longitude': -0.12,
+            },
+            'prices': <String, dynamic>{},
+          },
+        // Duplicate of S0 — must be skipped.
+        {
+          'site_id': 'S0',
+          'brand': 'Dup',
+          'location': {'latitude': 51.5, 'longitude': -0.12},
+          'prices': <String, dynamic>{},
+        },
+      ];
+
+      final stations = UkFuelFinderService.parseFuelFinderStations(
+        items,
+        lat: 51.5,
+        lng: -0.12,
+        radiusKm: 500,
+      );
+
+      expect(stations.length, 50);
+      // First station is the closest (S0) and its duplicate was rejected.
+      expect(stations.first.id, 'uk-S0');
+      expect(stations.first.brand, 'Brand');
+    });
+  });
+}


### PR DESCRIPTION
## What

New `UkFuelFinderService` at `lib/core/services/impl/uk_fuel_finder_service.dart` implementing the GOV.UK Fuel Finder public API with an OAuth2 client-credentials flow and a single data endpoint. Ships alongside the legacy per-retailer `UkStationService` — the new service is **dormant**, gated by `static const bool _useFuelFinder = false` and intentionally **not** registered in `CountryServiceRegistry`.

14 new tests covering contract surface, OAuth happy path + caching + refresh + 401, station parsing (pence→pounds), 500 error, empty list, radius filter, and dedupe/50-cap.

## Why

The Motor Fuel Price Open Data Regulations 2025 replaced the CMA's per-retailer JSON fan-out (one HTTP call per brand, currently 14 of them in `UkStationService.defaultCmaFeedUrls`) with a single aggregated government endpoint at `developer.fuel-finder.service.gov.uk` reached via OAuth2. The new model is faster, more complete, and officially blessed — but it requires the developer to register for client credentials first. Until those credentials exist, we keep the old fan-out live so search keeps working, and ship the scaffold so activation is a one-line config flip instead of a new feature branch.

## Activation (future PR, when creds exist)

1. Write `uk_fuel_finder_client_id` and `uk_fuel_finder_client_secret` into `FlutterSecureStorage` via the settings screen.
2. Flip `_useFuelFinder` to `true` in `uk_fuel_finder_service.dart`.
3. Register `UkFuelFinderService` in `country_service_registry.dart` for country code `gb` in place of `UkStationService`.

## Testing

- `flutter analyze` — **No issues found!**
- `flutter test test/core/services/impl/uk_fuel_finder_service_test.dart` — **14 / 14 passing**
- `flutter test test/core/services/impl/uk_station_service_test.dart` (legacy, untouched) — **18 / 18 passing**

## Endpoints used (to verify against GOV.UK spec once the developer portal is accessible)

- Token: `POST https://www.developer.fuel-finder.service.gov.uk/oauth/token` — `application/x-www-form-urlencoded` body `grant_type=client_credentials&client_id=…&client_secret=…`; response `{access_token, token_type, expires_in}`.
- Data: `GET https://www.developer.fuel-finder.service.gov.uk/api/v1/stations` with `Authorization: Bearer <token>`.

Both paths are injectable via the constructor so they can be corrected in a follow-up patch once the authenticated portal confirms the published contract.

## Files touched

- `lib/core/services/impl/uk_fuel_finder_service.dart` (new, 350 lines)
- `test/core/services/impl/uk_fuel_finder_service_test.dart` (new, 400 lines)

## Anomalies

- The GOV.UK developer portal pages (`/public-api`, `/apicontent`, `/apis-ifr/access-token`) return HTTP 403 to unauthenticated fetchers — the public-facing spec is gated behind the same credentials we are gating activation on. Endpoint paths in this PR follow standard OAuth2 conventions and the portal URL structure; they are injectable so the user can verify and adjust in a one-line follow-up once they're logged into the developer portal.