### PR TITLE
feat(widget): nearest widget queries real search (#609)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
@@ -80,6 +80,12 @@ object StationWidgetRenderer {
         val updatedAt: String?
         val emptyText: Int
         val nameRes: Int
+        // #609 — nearest-widget flags the data source: 'no_gps' when the
+        // app has never obtained a fix, 'no_network' when the search API
+        // is unreachable and no prior payload exists, 'isStale' when we
+        // are showing a previous successful payload as a fallback.
+        var emptyReason = ""
+        var isStale = false
         if (mode == MODE_FAVORITES) {
             stationsJson = prefs.getString("stations_json", "[]") ?: "[]"
             updatedAt = prefs.getString("updated_at", null)
@@ -90,6 +96,8 @@ object StationWidgetRenderer {
             updatedAt = prefs.getString("nearest_updated_at", null)
             emptyText = R.string.nearest_widget_empty
             nameRes = R.string.nearest_widget_name
+            emptyReason = prefs.getString("nearest_empty_reason", "") ?: ""
+            isStale = prefs.getBoolean("nearest_is_stale", false)
         }
 
         val views = RemoteViews(context.packageName, R.layout.station_widget_layout)
@@ -142,7 +150,15 @@ object StationWidgetRenderer {
         }
 
         if (stations.length() == 0) {
-            views.setTextViewText(R.id.widget_empty, context.getString(emptyText))
+            // #609 — surface a concrete hint when the list is empty because
+            // we don't know the user's location yet (no GPS fix). Falls
+            // back to the generic localised empty string otherwise.
+            val emptyString = when (emptyReason) {
+                "no_gps" -> "Turn on location in the app to see nearby stations"
+                "no_network" -> context.getString(emptyText)
+                else -> context.getString(emptyText)
+            }
+            views.setTextViewText(R.id.widget_empty, emptyString)
             views.setViewVisibility(R.id.widget_empty, View.VISIBLE)
             views.setViewVisibility(R.id.station_list, View.GONE)
         } else {
@@ -161,7 +177,14 @@ object StationWidgetRenderer {
         if (updatedAt != null) {
             try {
                 val fmt = SimpleDateFormat("HH:mm", Locale.getDefault())
-                views.setTextViewText(R.id.widget_updated_at, fmt.format(Date()))
+                // #609 — prefix a stale dot when we're showing a prior
+                // payload (network outage fallback). Mirrors the "cache"
+                // freshness hint the app shows in the search list.
+                val stamp = fmt.format(Date())
+                views.setTextViewText(
+                    R.id.widget_updated_at,
+                    if (isStale) "• $stamp" else stamp,
+                )
             } catch (e: Exception) {
                 views.setTextViewText(R.id.widget_updated_at, "")
             }
@@ -185,7 +208,13 @@ object StationWidgetRenderer {
             station.optString("brand", station.optString("name", "Station")),
         )
 
-        val distanceKm = station.optDouble("distance_km", Double.NaN)
+        // #609 — the real-search payload writes `distanceKm`; the legacy
+        // favorites payload still uses `distance_km`. Support both so the
+        // Kotlin widget survives either data producer.
+        val distanceKm = station.optDouble(
+            "distanceKm",
+            station.optDouble("distance_km", Double.NaN),
+        )
         if (!distanceKm.isNaN()) {
             row.setTextViewText(
                 R.id.station_distance,
@@ -211,19 +240,23 @@ object StationWidgetRenderer {
         val prefCode = station.optString("preferred_fuel_code", "")
         val prefPrice = station.optDouble("preferred_fuel_price", Double.NaN)
         val fallbackE10 = station.optDouble("e10", Double.NaN)
-        val (label, price) = when {
+        // #609 — when the Flutter builder sent a pre-formatted price
+        // (nearest real-search payload), prefer that over the raw double
+        // so decimals + currency match the search-results list exactly.
+        val formattedPrice = station.optString("priceFormatted", "")
+        val (label, priceText) = when {
+            prefCode.isNotBlank() && formattedPrice.isNotBlank() ->
+                prefCode.uppercase(Locale.getDefault()) to
+                    "$formattedPrice $currency".trim()
             prefCode.isNotBlank() && !prefPrice.isNaN() ->
-                prefCode.uppercase(Locale.getDefault()) to prefPrice
-            !fallbackE10.isNaN() -> "E10" to fallbackE10
-            else -> "" to Double.NaN
+                prefCode.uppercase(Locale.getDefault()) to
+                    String.format(Locale.getDefault(), "%.3f %s", prefPrice, currency).trim()
+            !fallbackE10.isNaN() -> "E10" to
+                String.format(Locale.getDefault(), "%.3f %s", fallbackE10, currency).trim()
+            else -> "" to "--"
         }
         row.setTextViewText(R.id.station_main_label, label)
-        row.setTextViewText(
-            R.id.station_main_price,
-            if (!price.isNaN())
-                String.format(Locale.getDefault(), "%.3f %s", price, currency).trim()
-            else "--",
-        )
+        row.setTextViewText(R.id.station_main_price, priceText)
 
         val isOpen = station.optBoolean("isOpen", false)
         row.setTextViewText(

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -20,6 +20,7 @@ import '../core/sync/supabase_client.dart';
 import '../core/utils/edge_to_edge.dart';
 import '../features/profile/data/repositories/profile_repository.dart';
 import '../features/widget/data/home_widget_service.dart';
+import '../features/widget/providers/nearest_widget_refresh_provider.dart';
 
 /// Drives the cold-start sequence in well-defined phases instead of one
 /// monolithic `main()` body. Splitting the work makes failures observable
@@ -281,6 +282,15 @@ class AppInitializer {
       container.read(traceRecorderProvider).record(error, stack);
       return true;
     };
+
+    // #609 — kick the 2-minute nearest-widget heartbeat so the home-screen
+    // widget stays fresh while the app is running. The provider is
+    // keepAlive and owns its own Timer; disposal cancels it cleanly.
+    try {
+      container.read(nearestWidgetRefreshProvider);
+    } catch (e) {
+      debugPrint('AppInitializer: nearestWidgetRefresh start failed: $e');
+    }
 
     StartupTimer.instance.mark('first_frame');
     StartupTimer.instance.finish();

--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -9,6 +9,7 @@ import '../../features/widget/data/home_widget_service.dart';
 import '../constants/field_names.dart';
 import '../notifications/local_notification_service.dart';
 import '../services/impl/tankerkoenig_batch_price_fetcher.dart';
+import '../services/impl/tankerkoenig_station_service.dart';
 import '../storage/hive_storage.dart';
 import '../storage/storage_keys.dart';
 import '../sync/ntfy_service.dart';
@@ -154,7 +155,12 @@ Future<void> _refreshPricesAndCheckAlerts() async {
     final allStationIds = {...favoriteIds, ...alertStationIds}.toList();
     debugPrint('BackgroundService: ${favoriteIds.length} favorites, ${alertStationIds.length} alert stations, ${allStationIds.length} total');
 
-    if (allStationIds.isEmpty) return;
+    if (allStationIds.isEmpty) {
+      // #609 — users without favorites still need a populated nearest
+      // widget. Run the real-search builder before bailing.
+      await _refreshNearestWidgetFromSearch(storage);
+      return;
+    }
 
     // 2. Fetch prices for all stations via the shared Tankerkoenig batch
     //    fetcher. The fetcher handles chunking + parsing + retry — see
@@ -325,11 +331,11 @@ Future<void> _refreshPricesAndCheckAlerts() async {
       profileStorage: storage,
       settingsStorage: storage,
     );
-    await HomeWidgetService.updateNearestWidget(
-      storage,
-      storage,
-      profileStorage: storage,
-    );
+    // #609 — nearest widget now queries a real search against the active
+    // country's API (when supported in the BG isolate) instead of just
+    // sorting favorites by distance. Shared helper so the early-return
+    // path above also runs it.
+    await _refreshNearestWidgetFromSearch(storage);
   } catch (e) {
     debugPrint('BackgroundService: task failed: $e');
   } finally {
@@ -341,5 +347,47 @@ Future<void> _refreshPricesAndCheckAlerts() async {
       debugPrint('BackgroundService: failed to close Hive boxes: $e');
     }
     lock?.release();
+  }
+}
+
+/// Run the new nearest-widget builder from the background isolate.
+///
+/// Instantiates a minimal [TankerkoenigStationService] because that's the
+/// only API for which we can assemble a working Dio here without pulling
+/// in the full Riverpod graph. Countries without a DE-style key-based API
+/// fall back to the legacy favorites-distance widget path by passing
+/// `stationService: null` to [HomeWidgetService.updateNearestWidget].
+///
+/// The key gate mirrors the existing background price refresh — which
+/// is also Tankerkoenig-only in the BG isolate today. Expanding this to
+/// other countries is tracked separately.
+Future<void> _refreshNearestWidgetFromSearch(HiveStorage storage) async {
+  try {
+    final apiKey = storage.getApiKey();
+    final hasKey = apiKey != null && apiKey.isNotEmpty;
+    if (hasKey) {
+      final dio = Dio(BaseOptions(
+        baseUrl: 'https://creativecommons.tankerkoenig.de/json',
+        connectTimeout: BackgroundService.bgConnectTimeout,
+        receiveTimeout: BackgroundService.bgReceiveTimeout,
+        queryParameters: {'apikey': apiKey},
+      ));
+      final service = TankerkoenigStationService(dio);
+      await HomeWidgetService.updateNearestWidget(
+        storage,
+        storage,
+        profileStorage: storage,
+        stationService: service,
+      );
+    } else {
+      // No API key → degrade to legacy favorites-distance path.
+      await HomeWidgetService.updateNearestWidget(
+        storage,
+        storage,
+        profileStorage: storage,
+      );
+    }
+  } catch (e) {
+    debugPrint('BackgroundService: nearest widget refresh failed: $e');
   }
 }

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'8a9fa9c61361135d9fee2f95ed54ef508e43c2db';
+String _$tripRecordingHash() => r'3c616da118b0d19985eeb46622b3d2d2151e4a4d';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/favorites/providers/favorites_provider.dart
+++ b/lib/features/favorites/providers/favorites_provider.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/data/storage_repository.dart';
+import '../../../core/services/service_providers.dart';
+import '../../../core/services/station_service.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/sync_helper.dart';
 import '../../../core/sync/favorites_sync.dart';
@@ -54,6 +56,12 @@ class Favorites extends _$Favorites {
 
   /// Fire-and-forget: tells [HomeWidgetService] to rebuild both the
   /// favorites and nearest widgets from the current Hive state.
+  ///
+  /// The nearest widget now queries the real station search (#609) —
+  /// reading the active country's [StationService] from Riverpod so it
+  /// works for users with zero favorites. When the station service
+  /// isn't configured yet (unit tests, pre-API-key cold start) the
+  /// nearest update degrades to the legacy favorites-distance path.
   void _refreshWidget(StorageRepository storage) {
     unawaited(() async {
       try {
@@ -62,10 +70,23 @@ class Favorites extends _$Favorites {
           profileStorage: storage,
           settingsStorage: storage,
         );
+        // Resolve the station service lazily + defensively — some test
+        // harnesses don't wire stationServiceProvider, and the nearest
+        // widget should still render (degraded) in that case.
+        StationService? stationService;
+        try {
+          stationService = ref.read(stationServiceProvider);
+        } catch (e) {
+          debugPrint(
+            'Favorites._refreshWidget: stationService unavailable, '
+            'falling back to legacy nearest update: $e',
+          );
+        }
         await HomeWidgetService.updateNearestWidget(
           storage,
           storage,
           profileStorage: storage,
+          stationService: stationService,
         );
       } catch (e) {
         debugPrint('Favorites._refreshWidget: $e');

--- a/lib/features/favorites/providers/favorites_provider.g.dart
+++ b/lib/features/favorites/providers/favorites_provider.g.dart
@@ -68,7 +68,7 @@ final class FavoritesProvider
   }
 }
 
-String _$favoritesHash() => r'6c85fc766234ed476d7f503a32c1b4c3e5c82325';
+String _$favoritesHash() => r'fe40f2d936cd8e72587523c7faa88a30fe4446b1';
 
 /// Manages the user's list of favorite station IDs.
 ///

--- a/lib/features/widget/data/home_widget_service.dart
+++ b/lib/features/widget/data/home_widget_service.dart
@@ -6,8 +6,10 @@ import 'package:home_widget/home_widget.dart';
 
 import '../../../core/country/country_config.dart';
 import '../../../core/data/storage_repository.dart';
+import '../../../core/services/station_service.dart';
 import '../../../core/storage/storage_keys.dart';
 import '../../search/domain/entities/fuel_type.dart';
+import 'nearest_widget_data_builder.dart';
 
 /// Manages data for the Android home screen widgets.
 ///
@@ -77,9 +79,12 @@ class HomeWidgetService {
 
   /// Update the nearest stations home screen widget.
   ///
-  /// Reads the user's last known GPS position from settings storage,
-  /// computes distances to all favorite stations, and writes the closest
-  /// ones to SharedPreferences for the native widget to display.
+  /// When [stationService] is provided, the widget is populated from a
+  /// real nearby-station search against the active country's API (#609) —
+  /// so the widget works for users with no favorites. When [stationService]
+  /// is null (e.g. background isolate where a fully wired service chain
+  /// is not available), falls back to the legacy favorites-distance mode
+  /// so existing users still see something.
   ///
   /// When [profileStorage] is non-null, the rendered price uses the active
   /// profile's preferred fuel type (falls back to e10 when profile absent).
@@ -87,11 +92,34 @@ class HomeWidgetService {
     FavoriteStorage favoriteStorage,
     SettingsStorage settingsStorage, {
     ProfileStorage? profileStorage,
+    StationService? stationService,
   }) async {
     try {
+      if (stationService != null && profileStorage != null) {
+        final builder = NearestWidgetDataBuilder(
+          stationService: stationService,
+          settingsStorage: settingsStorage,
+          profileStorage: profileStorage,
+        );
+        final payload = await builder.build();
+        await HomeWidget.updateWidget(androidName: _widgetAndroidName);
+        debugPrint(
+          'HomeWidget: nearest (real search) updated — '
+          'count=${payload.stations.length} '
+          'stale=${payload.isStale} reason=${payload.emptyReason}',
+        );
+        return;
+      }
+
+      // Legacy fallback: derive the list from favorites sorted by distance.
+      // Kept for the background isolate and any caller that can't construct
+      // a StationService. Will be removed once the background isolate is
+      // rewired (#609 follow-up).
       final favoriteIds = favoriteStorage.getFavoriteIds();
-      final lat = settingsStorage.getSetting(StorageKeys.userPositionLat) as double?;
-      final lng = settingsStorage.getSetting(StorageKeys.userPositionLng) as double?;
+      final lat = settingsStorage.getSetting(StorageKeys.userPositionLat)
+          as double?;
+      final lng = settingsStorage.getSetting(StorageKeys.userPositionLng)
+          as double?;
 
       if (favoriteIds.isEmpty || lat == null || lng == null) {
         await HomeWidget.saveWidgetData('nearest_count', 0);
@@ -100,6 +128,7 @@ class HomeWidgetService {
           'nearest_empty_reason',
           lat == null || lng == null ? 'no_gps' : 'no_favorites',
         );
+        await HomeWidget.saveWidgetData('nearest_is_stale', false);
         await HomeWidget.updateWidget(
           androidName: _widgetAndroidName,
         );
@@ -122,6 +151,8 @@ class HomeWidgetService {
         'nearest_updated_at',
         DateTime.now().toIso8601String(),
       );
+      await HomeWidget.saveWidgetData('nearest_empty_reason', '');
+      await HomeWidget.saveWidgetData('nearest_is_stale', false);
       await HomeWidget.saveWidgetData('nearest_lat', lat);
       await HomeWidget.saveWidgetData('nearest_lng', lng);
 

--- a/lib/features/widget/data/nearest_widget_data_builder.dart
+++ b/lib/features/widget/data/nearest_widget_data_builder.dart
@@ -1,0 +1,338 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:home_widget/home_widget.dart';
+
+import '../../../core/country/country_config.dart';
+import '../../../core/data/storage_repository.dart';
+import '../../../core/services/station_service.dart';
+import '../../../core/storage/storage_keys.dart';
+import '../../search/data/models/search_params.dart';
+import '../../search/domain/entities/fuel_type.dart';
+import '../../search/domain/entities/station.dart';
+
+/// Storage boundary for the nearest-widget JSON payload.
+///
+/// The builder writes the current rendering payload (and reads back the
+/// previous one on stale fallback). In production this is backed by the
+/// `home_widget` plugin's SharedPreferences bridge; in tests it's a
+/// plain in-memory map so unit tests don't need platform channels.
+abstract class NearestWidgetPayloadStore {
+  /// Read the `nearest_json` from the previous successful build, or null
+  /// when no prior payload exists.
+  Future<String?> readLastJson();
+
+  /// Read the ISO-8601 timestamp of the previous successful build, or null.
+  Future<DateTime?> readLastFetchedAt();
+
+  /// Persist a fresh payload (successful OR empty). The widget always
+  /// reads this; a stale flag + empty_reason tell the renderer what to
+  /// show on top of the data.
+  Future<void> writePayload({
+    required int count,
+    required String stationsJson,
+    required String updatedAtIso,
+    required String emptyReason,
+    required bool isStale,
+    double? userLat,
+    double? userLng,
+  });
+}
+
+/// Production [NearestWidgetPayloadStore] backed by the `home_widget`
+/// plugin. Uses the same keys the `StationWidgetRenderer` on the Kotlin
+/// side reads.
+class HomeWidgetPayloadStore implements NearestWidgetPayloadStore {
+  const HomeWidgetPayloadStore();
+
+  @override
+  Future<String?> readLastJson() async {
+    try {
+      final value = await HomeWidget.getWidgetData<String>('nearest_json');
+      return (value != null && value.isNotEmpty && value != '[]') ? value : null;
+    } catch (e) {
+      debugPrint('HomeWidgetPayloadStore.readLastJson failed: $e');
+      return null;
+    }
+  }
+
+  @override
+  Future<DateTime?> readLastFetchedAt() async {
+    try {
+      final iso =
+          await HomeWidget.getWidgetData<String>('nearest_updated_at');
+      return iso == null ? null : DateTime.tryParse(iso);
+    } catch (e) {
+      debugPrint('HomeWidgetPayloadStore.readLastFetchedAt failed: $e');
+      return null;
+    }
+  }
+
+  @override
+  Future<void> writePayload({
+    required int count,
+    required String stationsJson,
+    required String updatedAtIso,
+    required String emptyReason,
+    required bool isStale,
+    double? userLat,
+    double? userLng,
+  }) async {
+    await HomeWidget.saveWidgetData('nearest_count', count);
+    await HomeWidget.saveWidgetData('nearest_json', stationsJson);
+    await HomeWidget.saveWidgetData('nearest_updated_at', updatedAtIso);
+    await HomeWidget.saveWidgetData('nearest_empty_reason', emptyReason);
+    await HomeWidget.saveWidgetData('nearest_is_stale', isStale);
+    if (userLat != null) {
+      await HomeWidget.saveWidgetData('nearest_lat', userLat);
+    }
+    if (userLng != null) {
+      await HomeWidget.saveWidgetData('nearest_lng', userLng);
+    }
+  }
+}
+
+/// The JSON-ready result the builder returns in-process (also what it
+/// writes through the [NearestWidgetPayloadStore]).
+@immutable
+class NearestWidgetPayload {
+  final List<Map<String, dynamic>> stations;
+
+  /// Populated only when [stations] is empty. One of: `no_gps`, `no_network`,
+  /// or null on success.
+  final String? emptyReason;
+
+  /// True when the returned payload is a reuse of the previous successful
+  /// render because the current fetch failed. Widget greys out rows.
+  final bool isStale;
+
+  final DateTime updatedAt;
+
+  const NearestWidgetPayload({
+    required this.stations,
+    required this.updatedAt,
+    this.emptyReason,
+    this.isStale = false,
+  });
+}
+
+/// Builds the JSON payload the "nearest" home screen widget renders.
+///
+/// Rewritten for #609: previously the list came from favorites sorted by
+/// distance (empty for users with no favorites). Now it queries the active
+/// country's [StationService] with the user's last-known GPS fix so the
+/// widget reflects the real surroundings.
+///
+/// ## Failure modes
+/// - No GPS known → empty payload + `empty_reason='no_gps'`
+/// - Search fails, no prior payload → empty payload + `empty_reason='no_network'`
+/// - Search fails, prior payload exists → reuse last payload + `isStale=true`
+///
+/// All three paths write to the same SharedPreferences keys the Kotlin
+/// widget renderer reads; the empty_reason / isStale flags drive the UI.
+class NearestWidgetDataBuilder {
+  NearestWidgetDataBuilder({
+    required this.stationService,
+    required this.settingsStorage,
+    required this.profileStorage,
+    NearestWidgetPayloadStore? payloadStore,
+  }) : payloadStore = payloadStore ?? const HomeWidgetPayloadStore();
+
+  final StationService stationService;
+  final SettingsStorage settingsStorage;
+  final ProfileStorage profileStorage;
+  final NearestWidgetPayloadStore payloadStore;
+
+  /// Maximum rows the widget renders.
+  static const int maxStations = 5;
+
+  /// Build the payload and persist it via [payloadStore].
+  Future<NearestWidgetPayload> build() async {
+    final lat = (settingsStorage.getSetting(StorageKeys.userPositionLat)
+            as num?)
+        ?.toDouble();
+    final lng = (settingsStorage.getSetting(StorageKeys.userPositionLng)
+            as num?)
+        ?.toDouble();
+
+    if (lat == null || lng == null) {
+      final payload = NearestWidgetPayload(
+        stations: const [],
+        updatedAt: DateTime.now(),
+        emptyReason: 'no_gps',
+      );
+      await _persist(payload, userLat: null, userLng: null);
+      return payload;
+    }
+
+    final profile = _activeProfile();
+    final radiusKm = profile.radiusKm;
+    final fuelType = profile.fuelType;
+
+    try {
+      final result = await stationService.searchStations(
+        SearchParams(
+          lat: lat,
+          lng: lng,
+          radiusKm: radiusKm,
+          fuelType: fuelType,
+          sortBy: SortBy.distance,
+        ),
+      );
+
+      // Sort locally too — some country services honour sortBy at the
+      // server side, others don't. Cheap enough to always do.
+      final sorted = [...result.data]..sort((a, b) => a.dist.compareTo(b.dist));
+      final top = sorted.take(maxStations).toList(growable: false);
+
+      final rows = top
+          .map((s) => _stationToRow(s, userLat: lat, userLng: lng, fuel: fuelType))
+          .toList(growable: false);
+
+      final payload = NearestWidgetPayload(
+        stations: rows,
+        updatedAt: DateTime.now(),
+      );
+      await _persist(payload, userLat: lat, userLng: lng);
+      return payload;
+    } catch (e) {
+      debugPrint('NearestWidgetDataBuilder.build search failed: $e');
+      // Attempt stale-fallback: reuse the previous successful payload.
+      final previousJson = await payloadStore.readLastJson();
+      if (previousJson != null) {
+        try {
+          final decoded = (jsonDecode(previousJson) as List)
+              .cast<Map<String, dynamic>>();
+          if (decoded.isNotEmpty) {
+            final payload = NearestWidgetPayload(
+              stations: decoded,
+              updatedAt: await payloadStore.readLastFetchedAt() ??
+                  DateTime.now(),
+              isStale: true,
+            );
+            await _persist(payload, userLat: lat, userLng: lng);
+            return payload;
+          }
+        } catch (decodeErr) {
+          debugPrint(
+            'NearestWidgetDataBuilder: previous JSON decode failed: '
+            '$decodeErr',
+          );
+        }
+      }
+      // No usable prior payload — surface the network failure.
+      final payload = NearestWidgetPayload(
+        stations: const [],
+        updatedAt: DateTime.now(),
+        emptyReason: 'no_network',
+      );
+      await _persist(payload, userLat: lat, userLng: lng);
+      return payload;
+    }
+  }
+
+  // --- private helpers ------------------------------------------------------
+
+  _ProfileDefaults _activeProfile() {
+    final id = profileStorage.getActiveProfileId();
+    if (id == null) return const _ProfileDefaults();
+    final raw = profileStorage.getProfile(id);
+    if (raw == null) return const _ProfileDefaults();
+    final radius =
+        (raw['defaultSearchRadius'] as num?)?.toDouble() ?? 10.0;
+    FuelType fuel = FuelType.e10;
+    final key = raw['preferredFuelType']?.toString();
+    if (key != null) {
+      try {
+        fuel = FuelType.fromString(key);
+      } catch (e) {
+        debugPrint(
+          'NearestWidgetDataBuilder: unknown preferred fuel "$key": $e',
+        );
+      }
+    }
+    return _ProfileDefaults(radiusKm: radius, fuelType: fuel);
+  }
+
+  Map<String, dynamic> _stationToRow(
+    Station station, {
+    required double userLat,
+    required double userLng,
+    required FuelType fuel,
+  }) {
+    final brand = station.brand.trim().isNotEmpty
+        ? station.brand
+        : (station.name.trim().isNotEmpty ? station.name : 'Station');
+
+    final currency = Countries.countryForStation(
+          id: station.id,
+          lat: station.lat,
+          lng: station.lng,
+        )?.currencySymbol ??
+        '';
+
+    final price = _priceForFuel(station, fuel);
+    final priceFormatted =
+        price != null ? price.toStringAsFixed(3) : '';
+
+    return <String, dynamic>{
+      'id': station.id,
+      'brand': brand,
+      'name': station.name,
+      'street': station.street,
+      'postCode': station.postCode,
+      'place': station.place,
+      'distanceKm': double.parse(station.dist.toStringAsFixed(1)),
+      'priceFormatted': priceFormatted,
+      'currency': currency,
+      'isOpen': station.isOpen,
+      // Parity fields with the favorites widget so the Kotlin renderer
+      // can switch modes without a second JSON shape.
+      'preferred_fuel_code': fuel.apiValue,
+      'preferred_fuel_price': price,
+      'e5': station.e5,
+      'e10': station.e10,
+      'diesel': station.diesel,
+    };
+  }
+
+  static double? _priceForFuel(Station s, FuelType fuel) {
+    return switch (fuel) {
+      FuelTypeE5() => s.e5,
+      FuelTypeE10() => s.e10,
+      FuelTypeE98() => s.e98,
+      FuelTypeDiesel() => s.diesel,
+      FuelTypeDieselPremium() => s.dieselPremium,
+      FuelTypeE85() => s.e85,
+      FuelTypeLpg() => s.lpg,
+      FuelTypeCng() => s.cng,
+      _ => s.e10 ?? s.e5 ?? s.diesel,
+    };
+  }
+
+  Future<void> _persist(
+    NearestWidgetPayload payload, {
+    required double? userLat,
+    required double? userLng,
+  }) async {
+    await payloadStore.writePayload(
+      count: payload.stations.length,
+      stationsJson: jsonEncode(payload.stations),
+      updatedAtIso: payload.updatedAt.toIso8601String(),
+      emptyReason: payload.emptyReason ?? '',
+      isStale: payload.isStale,
+      userLat: userLat,
+      userLng: userLng,
+    );
+  }
+}
+
+/// Active-profile snapshot for one build pass.
+class _ProfileDefaults {
+  final double radiusKm;
+  final FuelType fuelType;
+  const _ProfileDefaults({
+    this.radiusKm = 10.0,
+    this.fuelType = FuelType.e10,
+  });
+}

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/services/service_providers.dart';
+import '../../../core/storage/storage_providers.dart';
+import '../data/home_widget_service.dart';
+
+part 'nearest_widget_refresh_provider.g.dart';
+
+/// Foreground heartbeat that rebuilds the nearest home-screen widget every
+/// [kNearestWidgetForegroundInterval].
+///
+/// WorkManager enforces a 15-minute floor on periodic tasks, so background
+/// refresh alone can't meet the #609 target of "widget feels fresh". This
+/// provider adds a foreground 2-minute tick that kicks the builder while
+/// the app is running. When the app is backgrounded, the provider is
+/// disposed by the framework; the background task takes over.
+///
+/// Reading the provider once (e.g. from the app's root widget) starts
+/// the tick; the provider owns its own Timer and releases it in onDispose.
+@Riverpod(keepAlive: true)
+class NearestWidgetRefresh extends _$NearestWidgetRefresh {
+  Timer? _timer;
+
+  @override
+  void build() {
+    ref.onDispose(() {
+      _timer?.cancel();
+      _timer = null;
+    });
+    _timer ??= Timer.periodic(
+      kNearestWidgetForegroundInterval,
+      (_) => _tick(),
+    );
+    // Fire one immediate refresh so the widget reflects the current
+    // session as soon as the user opens the app (don't wait two minutes).
+    unawaited(_tick());
+  }
+
+  Future<void> _tick() async {
+    try {
+      final storage = ref.read(storageRepositoryProvider);
+      final stationService = ref.read(stationServiceProvider);
+      await HomeWidgetService.updateNearestWidget(
+        storage,
+        storage,
+        profileStorage: storage,
+        stationService: stationService,
+      );
+    } catch (e) {
+      debugPrint('NearestWidgetRefresh: tick failed: $e');
+    }
+  }
+}
+
+/// Foreground refresh interval. Kept short so the nearest widget stays
+/// responsive while the app is open; the background WorkManager task
+/// handles longer-term refreshes under Android's 15-minute floor.
+const Duration kNearestWidgetForegroundInterval = Duration(minutes: 2);

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
@@ -1,0 +1,108 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nearest_widget_refresh_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Foreground heartbeat that rebuilds the nearest home-screen widget every
+/// [kNearestWidgetForegroundInterval].
+///
+/// WorkManager enforces a 15-minute floor on periodic tasks, so background
+/// refresh alone can't meet the #609 target of "widget feels fresh". This
+/// provider adds a foreground 2-minute tick that kicks the builder while
+/// the app is running. When the app is backgrounded, the provider is
+/// disposed by the framework; the background task takes over.
+///
+/// Reading the provider once (e.g. from the app's root widget) starts
+/// the tick; the provider owns its own Timer and releases it in onDispose.
+
+@ProviderFor(NearestWidgetRefresh)
+final nearestWidgetRefreshProvider = NearestWidgetRefreshProvider._();
+
+/// Foreground heartbeat that rebuilds the nearest home-screen widget every
+/// [kNearestWidgetForegroundInterval].
+///
+/// WorkManager enforces a 15-minute floor on periodic tasks, so background
+/// refresh alone can't meet the #609 target of "widget feels fresh". This
+/// provider adds a foreground 2-minute tick that kicks the builder while
+/// the app is running. When the app is backgrounded, the provider is
+/// disposed by the framework; the background task takes over.
+///
+/// Reading the provider once (e.g. from the app's root widget) starts
+/// the tick; the provider owns its own Timer and releases it in onDispose.
+final class NearestWidgetRefreshProvider
+    extends $NotifierProvider<NearestWidgetRefresh, void> {
+  /// Foreground heartbeat that rebuilds the nearest home-screen widget every
+  /// [kNearestWidgetForegroundInterval].
+  ///
+  /// WorkManager enforces a 15-minute floor on periodic tasks, so background
+  /// refresh alone can't meet the #609 target of "widget feels fresh". This
+  /// provider adds a foreground 2-minute tick that kicks the builder while
+  /// the app is running. When the app is backgrounded, the provider is
+  /// disposed by the framework; the background task takes over.
+  ///
+  /// Reading the provider once (e.g. from the app's root widget) starts
+  /// the tick; the provider owns its own Timer and releases it in onDispose.
+  NearestWidgetRefreshProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'nearestWidgetRefreshProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$nearestWidgetRefreshHash();
+
+  @$internal
+  @override
+  NearestWidgetRefresh create() => NearestWidgetRefresh();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$nearestWidgetRefreshHash() =>
+    r'4d4209e966c92c0919d9ff081c49fe34fb7c8f5c';
+
+/// Foreground heartbeat that rebuilds the nearest home-screen widget every
+/// [kNearestWidgetForegroundInterval].
+///
+/// WorkManager enforces a 15-minute floor on periodic tasks, so background
+/// refresh alone can't meet the #609 target of "widget feels fresh". This
+/// provider adds a foreground 2-minute tick that kicks the builder while
+/// the app is running. When the app is backgrounded, the provider is
+/// disposed by the framework; the background task takes over.
+///
+/// Reading the provider once (e.g. from the app's root widget) starts
+/// the tick; the provider owns its own Timer and releases it in onDispose.
+
+abstract class _$NearestWidgetRefresh extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<void, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<void, void>,
+              void,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/widget/data/nearest_widget_data_builder_test.dart
+++ b/test/features/widget/data/nearest_widget_data_builder_test.dart
@@ -1,0 +1,398 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/widget/data/nearest_widget_data_builder.dart';
+
+import 'package:dio/dio.dart';
+
+/// Fake [StationService] that returns a fixed list (or throws) on
+/// searchStations. getPrices / getStationDetail are unused by the builder.
+class _FakeStationService implements StationService {
+  _FakeStationService();
+
+  List<Station> stationsToReturn = const [];
+  bool throwOnSearch = false;
+  SearchParams? lastParams;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    lastParams = params;
+    if (throwOnSearch) {
+      throw Exception('network down');
+    }
+    return ServiceResult(
+      data: stationsToReturn,
+      source: ServiceSource.tankerkoenigApi,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
+}
+
+/// Fake [SettingsStorage] that stores values in a plain map.
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> _store = {};
+
+  @override
+  dynamic getSetting(String key) => _store[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    _store[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+
+/// Fake [ProfileStorage] returning a single active profile.
+class _FakeProfileStorage implements ProfileStorage {
+  _FakeProfileStorage({this.activeProfileJson});
+
+  Map<String, dynamic>? activeProfileJson;
+
+  @override
+  String? getActiveProfileId() =>
+      activeProfileJson == null ? null : 'p1';
+
+  @override
+  Map<String, dynamic>? getProfile(String id) =>
+      id == 'p1' ? activeProfileJson : null;
+
+  @override
+  List<Map<String, dynamic>> getAllProfiles() =>
+      activeProfileJson == null ? const [] : [activeProfileJson!];
+
+  @override
+  Future<void> saveProfile(String id, Map<String, dynamic> profile) async {
+    activeProfileJson = profile;
+  }
+
+  @override
+  Future<void> setActiveProfileId(String id) async {}
+
+  @override
+  Future<void> deleteProfile(String id) async {
+    activeProfileJson = null;
+  }
+
+  @override
+  int get profileCount => activeProfileJson == null ? 0 : 1;
+}
+
+/// In-memory implementation of the widget payload persistence boundary,
+/// so tests can simulate the previous run's payload without touching the
+/// real home_widget plugin (which requires platform channels).
+class _InMemoryStore implements NearestWidgetPayloadStore {
+  final Map<String, Object?> _data = {};
+
+  @override
+  Future<String?> readLastJson() async =>
+      _data['nearest_json'] as String?;
+
+  @override
+  Future<DateTime?> readLastFetchedAt() async {
+    final iso = _data['nearest_updated_at'] as String?;
+    return iso == null ? null : DateTime.tryParse(iso);
+  }
+
+  @override
+  Future<void> writePayload({
+    required int count,
+    required String stationsJson,
+    required String updatedAtIso,
+    required String emptyReason,
+    required bool isStale,
+    double? userLat,
+    double? userLng,
+  }) async {
+    _data['nearest_count'] = count;
+    _data['nearest_json'] = stationsJson;
+    _data['nearest_updated_at'] = updatedAtIso;
+    _data['nearest_empty_reason'] = emptyReason;
+    _data['nearest_is_stale'] = isStale;
+    _data['nearest_lat'] = userLat;
+    _data['nearest_lng'] = userLng;
+  }
+
+  T? read<T>(String key) => _data[key] as T?;
+}
+
+Station _stationFixture({
+  required String id,
+  required String brand,
+  required String street,
+  required String place,
+  required double lat,
+  required double lng,
+  double? e10,
+  double? e5,
+  double? diesel,
+  double dist = 0.0,
+  bool isOpen = true,
+}) =>
+    Station(
+      id: id,
+      name: brand,
+      brand: brand,
+      street: street,
+      postCode: '00000',
+      place: place,
+      lat: lat,
+      lng: lng,
+      dist: dist,
+      e5: e5,
+      e10: e10,
+      diesel: diesel,
+      isOpen: isOpen,
+    );
+
+void main() {
+  group('NearestWidgetDataBuilder.build', () {
+    late _FakeStationService stationService;
+    late _FakeSettingsStorage settings;
+    late _FakeProfileStorage profiles;
+    late _InMemoryStore store;
+    late NearestWidgetDataBuilder builder;
+
+    setUp(() {
+      stationService = _FakeStationService();
+      settings = _FakeSettingsStorage();
+      profiles = _FakeProfileStorage(activeProfileJson: {
+        'id': 'p1',
+        'name': 'Default',
+        'preferredFuelType': 'e10',
+        'defaultSearchRadius': 10.0,
+      });
+      store = _InMemoryStore();
+      builder = NearestWidgetDataBuilder(
+        stationService: stationService,
+        settingsStorage: settings,
+        profileStorage: profiles,
+        payloadStore: store,
+      );
+    });
+
+    test('empty payload with empty_reason=no_gps when settings have no GPS',
+        () async {
+      // No userPositionLat / userPositionLng set.
+      final result = await builder.build();
+
+      expect(result.stations, isEmpty);
+      expect(result.emptyReason, 'no_gps');
+      expect(result.isStale, isFalse);
+      expect(store.read<int>('nearest_count'), 0);
+      expect(store.read<String>('nearest_empty_reason'), 'no_gps');
+    });
+
+    test('empty payload with empty_reason=no_network when search throws '
+        '(and no prior payload)', () async {
+      await settings.putSetting(StorageKeys.userPositionLat, 52.52);
+      await settings.putSetting(StorageKeys.userPositionLng, 13.40);
+      stationService.throwOnSearch = true;
+
+      final result = await builder.build();
+
+      expect(result.stations, isEmpty);
+      expect(result.emptyReason, 'no_network');
+      expect(result.isStale, isFalse);
+      expect(store.read<String>('nearest_empty_reason'), 'no_network');
+    });
+
+    test('returns up to 5 nearest stations sorted by distance ascending '
+        'with all required fields populated', () async {
+      await settings.putSetting(StorageKeys.userPositionLat, 52.5200);
+      await settings.putSetting(StorageKeys.userPositionLng, 13.4050);
+
+      // 7 stations at increasing distances. The API returns them unsorted
+      // on purpose so we can prove the builder sorts locally.
+      stationService.stationsToReturn = [
+        _stationFixture(
+          id: 'de-0',
+          brand: 'Shell',
+          street: 'Str0',
+          place: 'Berlin',
+          lat: 52.5201,
+          lng: 13.4051,
+          e10: 1.799,
+          dist: 0.1,
+        ),
+        _stationFixture(
+          id: 'de-5',
+          brand: 'JET',
+          street: 'Str5',
+          place: 'Berlin',
+          lat: 52.57,
+          lng: 13.45,
+          e10: 1.859,
+          dist: 5.5,
+        ),
+        _stationFixture(
+          id: 'de-2',
+          brand: 'ARAL',
+          street: 'Str2',
+          place: 'Berlin',
+          lat: 52.53,
+          lng: 13.41,
+          e10: 1.829,
+          dist: 1.2,
+        ),
+        _stationFixture(
+          id: 'de-6',
+          brand: 'Total',
+          street: 'Str6',
+          place: 'Berlin',
+          lat: 52.60,
+          lng: 13.50,
+          e10: 1.869,
+          dist: 9.1,
+        ),
+        _stationFixture(
+          id: 'de-1',
+          brand: 'BP',
+          street: 'Str1',
+          place: 'Berlin',
+          lat: 52.525,
+          lng: 13.405,
+          e10: 1.819,
+          dist: 0.5,
+        ),
+        _stationFixture(
+          id: 'de-4',
+          brand: 'Esso',
+          street: 'Str4',
+          place: 'Berlin',
+          lat: 52.55,
+          lng: 13.43,
+          e10: 1.849,
+          dist: 3.2,
+        ),
+        _stationFixture(
+          id: 'de-3',
+          brand: 'OIL!',
+          street: 'Str3',
+          place: 'Berlin',
+          lat: 52.54,
+          lng: 13.42,
+          e10: 1.839,
+          dist: 2.1,
+        ),
+      ];
+
+      final result = await builder.build();
+
+      expect(result.emptyReason, isNull);
+      expect(result.isStale, isFalse);
+      expect(result.stations, hasLength(5));
+
+      // Exactly the 5 closest IDs (0..4) in ascending-distance order.
+      expect(
+        result.stations.map((s) => s['id']).toList(),
+        ['de-0', 'de-1', 'de-2', 'de-3', 'de-4'],
+      );
+
+      // Each row must carry every field the Kotlin renderer expects for
+      // parity with the search-results list.
+      for (final s in result.stations) {
+        expect(s['brand'], isA<String>());
+        expect(s['street'], isA<String>());
+        expect(s['place'], isA<String>());
+        expect(s['distanceKm'], isA<num>());
+        expect(s['priceFormatted'], isA<String>());
+        expect(s['currency'], isA<String>());
+        expect(s['isOpen'], isA<bool>());
+      }
+      // First station has the shortest distance.
+      final d0 = result.stations.first['distanceKm'] as num;
+      final d1 = result.stations[1]['distanceKm'] as num;
+      expect(d0, lessThanOrEqualTo(d1));
+    });
+
+    test('uses the active profile radius and fuel type (not hardcoded)',
+        () async {
+      await settings.putSetting(StorageKeys.userPositionLat, 52.5200);
+      await settings.putSetting(StorageKeys.userPositionLng, 13.4050);
+      profiles.activeProfileJson = {
+        'id': 'p1',
+        'name': 'Truck',
+        'preferredFuelType': 'diesel',
+        'defaultSearchRadius': 25.0,
+      };
+
+      stationService.stationsToReturn = const [];
+
+      await builder.build();
+
+      expect(stationService.lastParams, isNotNull);
+      expect(stationService.lastParams!.lat, 52.5200);
+      expect(stationService.lastParams!.lng, 13.4050);
+      expect(stationService.lastParams!.radiusKm, 25.0);
+      expect(stationService.lastParams!.fuelType, FuelType.diesel);
+    });
+
+    test('on second call after network failure, returns last successful '
+        'payload flagged isStale=true', () async {
+      await settings.putSetting(StorageKeys.userPositionLat, 52.5200);
+      await settings.putSetting(StorageKeys.userPositionLng, 13.4050);
+
+      // 1. First call succeeds → payload stored.
+      stationService.stationsToReturn = [
+        _stationFixture(
+          id: 'de-0',
+          brand: 'Shell',
+          street: 'Str0',
+          place: 'Berlin',
+          lat: 52.5201,
+          lng: 13.4051,
+          e10: 1.799,
+        ),
+      ];
+      final first = await builder.build();
+      expect(first.emptyReason, isNull);
+      expect(first.stations, hasLength(1));
+
+      // Capture the JSON that was persisted on the first successful run.
+      final storedJson = store.read<String>('nearest_json');
+      expect(storedJson, isNotNull);
+
+      // 2. Second call: API throws. We expect the last successful payload
+      //    to be returned with isStale=true (widget doesn't blank).
+      stationService.throwOnSearch = true;
+      final second = await builder.build();
+
+      expect(second.isStale, isTrue);
+      expect(second.emptyReason, isNull);
+      expect(second.stations, hasLength(1));
+      expect(second.stations.first['id'], 'de-0');
+      expect(store.read<bool>('nearest_is_stale'), isTrue);
+      // The prior JSON is kept / re-written unchanged.
+      expect(store.read<String>('nearest_json'), storedJson);
+    });
+  });
+}


### PR DESCRIPTION
## What

Closes #609.

Rewrites the "nearest" home-screen widget so it shows the stations actually closest to the user's last-known GPS — not just a favorites subset sorted by distance.

## Why

Before this change, `updateNearestWidget` built the payload from `FavoriteStorage` only. Users who installed the app and pinned the widget without adding favorites saw an empty widget even when dozens of stations surrounded them. The point of the nearest widget is the *surroundings*, so the input had to change from "favorites" to "a real search".

## Summary

- **`NearestWidgetDataBuilder`** (`lib/features/widget/data/nearest_widget_data_builder.dart`)
  - Reads `userPositionLat`/`userPositionLng` from `SettingsStorage`
  - Calls `StationService.searchStations(SearchParams(...))` with the active profile's `defaultSearchRadius` + `preferredFuelType`
  - Takes the 5 nearest (sorted client-side too, because not every country service honours `sortBy`)
  - Writes a JSON row for each with exactly the fields #609 spec calls out: `brand`, `street`, `place`, `distanceKm`, `priceFormatted`, `currency`, `isOpen` (plus legacy parity fields for the favorites widget mode)

- **Three explicit failure modes**, each flagged in the payload so Kotlin can switch UI:
  - `empty_reason='no_gps'` — no GPS fix yet → "Turn on location in the app"
  - `empty_reason='no_network'` — search failed AND no prior payload → generic empty
  - `isStale=true` — search failed but last successful payload is reused so the widget doesn't blank; rendered with a subtle stale dot on the timestamp

- **Foreground heartbeat** — a `NearestWidgetRefresh` provider (`keepAlive`) kicks the builder every 2 minutes while the app is open, launched from `AppInitializer._launch`. Timer is owned by the provider and cancelled in `onDispose`.

- **Background WorkManager** — the existing task now runs the same builder. Still Tankerkoenig-only in the BG isolate (matches the existing price-refresh scope); other countries continue with the legacy favorites-distance path as a graceful degrade.

- **Kotlin `StationWidgetRenderer`** — reads `nearest_empty_reason` + `nearest_is_stale` from SharedPreferences, swaps in a concrete hint for `no_gps`, stale-dots the timestamp when flagged. Accepts both new (`distanceKm`, `priceFormatted`) and legacy (`distance_km`, `preferred_fuel_price`) field names so pinned widgets survive rollout.

## Scope note

The per-instance widget-configuration activity referenced in the issue (`#NNN` placeholder) is **out of scope** for this PR — app-level profile defaults drive every widget instance for now. A follow-up issue can add a configuration activity that reads per-appWidgetId preferences.

## Test plan

- [x] `flutter analyze` → zero issues
- [x] `flutter test` → 4994 passed, 0 failed (1 skipped pre-existing)
- [x] TDD: 5 unit tests in `test/features/widget/data/nearest_widget_data_builder_test.dart` cover:
  1. `build` returns empty + `empty_reason='no_gps'` when settings have no position
  2. `build` returns empty + `empty_reason='no_network'` when `searchStations` throws and no prior payload exists
  3. `build` returns the 5 nearest stations sorted by distance ascending with every required field
  4. `build` uses the **active profile's** radius + fuel type (not hardcoded defaults)
  5. `build` returns the last successful payload flagged `isStale=true` after a network failure
- [ ] Manual device check: widget updates within 2 min while app is open; widget still shows last data when airplane mode is toggled on; widget shows "Turn on location" hint when `user_position_lat` is null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)