### PR TITLE
feat(alerts): radius alert model + evaluator — phase 1 (#578)

### DIFF
--- a/lib/features/alerts/data/radius_alert_store.dart
+++ b/lib/features/alerts/data/radius_alert_store.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../core/storage/hive_boxes.dart';
+import '../domain/entities/radius_alert.dart';
+
+/// Hive-backed store for [RadiusAlert] records (#578 phase 1).
+///
+/// Reuses the existing [HiveBoxes.alerts] box — deliberately *no*
+/// new box — and namespaces its keys under `radius_alert:<id>` so
+/// the legacy per-station [PriceAlert] list stored under the
+/// `'alerts'` key is left untouched. That also means deleting a
+/// RadiusAlert by id is a cheap single-key drop rather than a list
+/// rewrite.
+///
+/// Every method degrades gracefully when the alerts box isn't open
+/// yet (e.g. widget tests that never call `HiveBoxes.initForTest()`)
+/// so the provider can `ref.watch` us from the tree without
+/// worrying about startup order.
+class RadiusAlertStore {
+  /// Shared key prefix. Public so the phase-2 background worker can
+  /// iterate alerts from an isolate without re-importing this class.
+  static const String keyPrefix = 'radius_alert:';
+
+  Box? _boxOrNull() {
+    try {
+      if (!Hive.isBoxOpen(HiveBoxes.alerts)) return null;
+      return Hive.box(HiveBoxes.alerts);
+    } catch (e) {
+      debugPrint('RadiusAlertStore: alerts box unavailable: $e');
+      return null;
+    }
+  }
+
+  /// Load every persisted radius alert. Corrupt payloads are logged
+  /// and skipped — one bad write mustn't wipe the whole watchlist.
+  Future<List<RadiusAlert>> list() async {
+    final box = _boxOrNull();
+    if (box == null) return const [];
+    final out = <RadiusAlert>[];
+    for (final key in box.keys) {
+      if (key is! String || !key.startsWith(keyPrefix)) continue;
+      final raw = box.get(key);
+      if (raw == null) continue;
+      try {
+        final json = _decode(raw);
+        if (json == null) continue;
+        out.add(RadiusAlert.fromJson(json));
+      } catch (e) {
+        debugPrint('RadiusAlertStore.list: skipping $key: $e');
+      }
+    }
+    // Stable order — oldest-first keeps the UI deterministic across
+    // reloads.
+    out.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return out;
+  }
+
+  /// Insert or overwrite [alert] by id. The JSON payload is stored
+  /// as a plain map (not a JSON string) to mirror the way the legacy
+  /// per-station alerts already sit in this box.
+  Future<void> upsert(RadiusAlert alert) async {
+    final box = _boxOrNull();
+    if (box == null) {
+      debugPrint('RadiusAlertStore.upsert: alerts box closed, dropping ${alert.id}');
+      return;
+    }
+    await box.put('$keyPrefix${alert.id}', alert.toJson());
+  }
+
+  /// Remove a radius alert by id. No-op when the key isn't present.
+  Future<void> remove(String id) async {
+    final box = _boxOrNull();
+    if (box == null) return;
+    await box.delete('$keyPrefix$id');
+  }
+
+  /// Accept either a `Map` (the default Hive round-trip for our
+  /// payloads) or a `String` (belt-and-braces for older entries that
+  /// may have been written as JSON text elsewhere). Returns null when
+  /// neither shape applies.
+  Map<String, dynamic>? _decode(dynamic raw) {
+    if (raw is Map) {
+      return HiveBoxes.toStringDynamicMap(raw);
+    }
+    if (raw is String) {
+      if (raw.isEmpty) return null;
+      final decoded = jsonDecode(raw);
+      if (decoded is Map) return HiveBoxes.toStringDynamicMap(decoded);
+    }
+    return null;
+  }
+}

--- a/lib/features/alerts/domain/entities/radius_alert.dart
+++ b/lib/features/alerts/domain/entities/radius_alert.dart
@@ -1,0 +1,36 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'radius_alert.freezed.dart';
+part 'radius_alert.g.dart';
+
+/// Watch-a-whole-area price alert (#578 phase 1).
+///
+/// Unlike [PriceAlert], which pins a single station by id, a
+/// [RadiusAlert] triggers whenever ANY station within [radiusKm] of
+/// ([centerLat], [centerLng]) offers [fuelType] at or below
+/// [threshold]. This lets the user say "tell me if diesel drops
+/// below 1.50€/L anywhere within 10 km of home" without pre-picking
+/// stations.
+///
+/// [fuelType] is intentionally stored as a string (the `apiValue` of
+/// the corresponding `FuelType` — e.g. `'diesel'`, `'e10'`) so this
+/// domain entity has zero cross-package coupling with the search
+/// feature's sealed class hierarchy. Callers that already hold a
+/// `FuelType` instance should pass `fuelType.apiValue`.
+@freezed
+abstract class RadiusAlert with _$RadiusAlert {
+  const factory RadiusAlert({
+    required String id,
+    required String fuelType,
+    required double threshold,
+    required double centerLat,
+    required double centerLng,
+    required double radiusKm,
+    required String label,
+    required DateTime createdAt,
+    @Default(true) bool enabled,
+  }) = _RadiusAlert;
+
+  factory RadiusAlert.fromJson(Map<String, dynamic> json) =>
+      _$RadiusAlertFromJson(json);
+}

--- a/lib/features/alerts/domain/entities/radius_alert.freezed.dart
+++ b/lib/features/alerts/domain/entities/radius_alert.freezed.dart
@@ -1,0 +1,301 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'radius_alert.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RadiusAlert {
+
+ String get id; String get fuelType; double get threshold; double get centerLat; double get centerLng; double get radiusKm; String get label; DateTime get createdAt; bool get enabled;
+/// Create a copy of RadiusAlert
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RadiusAlertCopyWith<RadiusAlert> get copyWith => _$RadiusAlertCopyWithImpl<RadiusAlert>(this as RadiusAlert, _$identity);
+
+  /// Serializes this RadiusAlert to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RadiusAlert&&(identical(other.id, id) || other.id == id)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.threshold, threshold) || other.threshold == threshold)&&(identical(other.centerLat, centerLat) || other.centerLat == centerLat)&&(identical(other.centerLng, centerLng) || other.centerLng == centerLng)&&(identical(other.radiusKm, radiusKm) || other.radiusKm == radiusKm)&&(identical(other.label, label) || other.label == label)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.enabled, enabled) || other.enabled == enabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,fuelType,threshold,centerLat,centerLng,radiusKm,label,createdAt,enabled);
+
+@override
+String toString() {
+  return 'RadiusAlert(id: $id, fuelType: $fuelType, threshold: $threshold, centerLat: $centerLat, centerLng: $centerLng, radiusKm: $radiusKm, label: $label, createdAt: $createdAt, enabled: $enabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RadiusAlertCopyWith<$Res>  {
+  factory $RadiusAlertCopyWith(RadiusAlert value, $Res Function(RadiusAlert) _then) = _$RadiusAlertCopyWithImpl;
+@useResult
+$Res call({
+ String id, String fuelType, double threshold, double centerLat, double centerLng, double radiusKm, String label, DateTime createdAt, bool enabled
+});
+
+
+
+
+}
+/// @nodoc
+class _$RadiusAlertCopyWithImpl<$Res>
+    implements $RadiusAlertCopyWith<$Res> {
+  _$RadiusAlertCopyWithImpl(this._self, this._then);
+
+  final RadiusAlert _self;
+  final $Res Function(RadiusAlert) _then;
+
+/// Create a copy of RadiusAlert
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? fuelType = null,Object? threshold = null,Object? centerLat = null,Object? centerLng = null,Object? radiusKm = null,Object? label = null,Object? createdAt = null,Object? enabled = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nullable_to_non_nullable
+as String,threshold: null == threshold ? _self.threshold : threshold // ignore: cast_nullable_to_non_nullable
+as double,centerLat: null == centerLat ? _self.centerLat : centerLat // ignore: cast_nullable_to_non_nullable
+as double,centerLng: null == centerLng ? _self.centerLng : centerLng // ignore: cast_nullable_to_non_nullable
+as double,radiusKm: null == radiusKm ? _self.radiusKm : radiusKm // ignore: cast_nullable_to_non_nullable
+as double,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RadiusAlert].
+extension RadiusAlertPatterns on RadiusAlert {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RadiusAlert value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RadiusAlert() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RadiusAlert value)  $default,){
+final _that = this;
+switch (_that) {
+case _RadiusAlert():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RadiusAlert value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RadiusAlert() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String fuelType,  double threshold,  double centerLat,  double centerLng,  double radiusKm,  String label,  DateTime createdAt,  bool enabled)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RadiusAlert() when $default != null:
+return $default(_that.id,_that.fuelType,_that.threshold,_that.centerLat,_that.centerLng,_that.radiusKm,_that.label,_that.createdAt,_that.enabled);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String fuelType,  double threshold,  double centerLat,  double centerLng,  double radiusKm,  String label,  DateTime createdAt,  bool enabled)  $default,) {final _that = this;
+switch (_that) {
+case _RadiusAlert():
+return $default(_that.id,_that.fuelType,_that.threshold,_that.centerLat,_that.centerLng,_that.radiusKm,_that.label,_that.createdAt,_that.enabled);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String fuelType,  double threshold,  double centerLat,  double centerLng,  double radiusKm,  String label,  DateTime createdAt,  bool enabled)?  $default,) {final _that = this;
+switch (_that) {
+case _RadiusAlert() when $default != null:
+return $default(_that.id,_that.fuelType,_that.threshold,_that.centerLat,_that.centerLng,_that.radiusKm,_that.label,_that.createdAt,_that.enabled);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _RadiusAlert implements RadiusAlert {
+  const _RadiusAlert({required this.id, required this.fuelType, required this.threshold, required this.centerLat, required this.centerLng, required this.radiusKm, required this.label, required this.createdAt, this.enabled = true});
+  factory _RadiusAlert.fromJson(Map<String, dynamic> json) => _$RadiusAlertFromJson(json);
+
+@override final  String id;
+@override final  String fuelType;
+@override final  double threshold;
+@override final  double centerLat;
+@override final  double centerLng;
+@override final  double radiusKm;
+@override final  String label;
+@override final  DateTime createdAt;
+@override@JsonKey() final  bool enabled;
+
+/// Create a copy of RadiusAlert
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RadiusAlertCopyWith<_RadiusAlert> get copyWith => __$RadiusAlertCopyWithImpl<_RadiusAlert>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RadiusAlertToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RadiusAlert&&(identical(other.id, id) || other.id == id)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.threshold, threshold) || other.threshold == threshold)&&(identical(other.centerLat, centerLat) || other.centerLat == centerLat)&&(identical(other.centerLng, centerLng) || other.centerLng == centerLng)&&(identical(other.radiusKm, radiusKm) || other.radiusKm == radiusKm)&&(identical(other.label, label) || other.label == label)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.enabled, enabled) || other.enabled == enabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,fuelType,threshold,centerLat,centerLng,radiusKm,label,createdAt,enabled);
+
+@override
+String toString() {
+  return 'RadiusAlert(id: $id, fuelType: $fuelType, threshold: $threshold, centerLat: $centerLat, centerLng: $centerLng, radiusKm: $radiusKm, label: $label, createdAt: $createdAt, enabled: $enabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RadiusAlertCopyWith<$Res> implements $RadiusAlertCopyWith<$Res> {
+  factory _$RadiusAlertCopyWith(_RadiusAlert value, $Res Function(_RadiusAlert) _then) = __$RadiusAlertCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String fuelType, double threshold, double centerLat, double centerLng, double radiusKm, String label, DateTime createdAt, bool enabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$RadiusAlertCopyWithImpl<$Res>
+    implements _$RadiusAlertCopyWith<$Res> {
+  __$RadiusAlertCopyWithImpl(this._self, this._then);
+
+  final _RadiusAlert _self;
+  final $Res Function(_RadiusAlert) _then;
+
+/// Create a copy of RadiusAlert
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? fuelType = null,Object? threshold = null,Object? centerLat = null,Object? centerLng = null,Object? radiusKm = null,Object? label = null,Object? createdAt = null,Object? enabled = null,}) {
+  return _then(_RadiusAlert(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nullable_to_non_nullable
+as String,threshold: null == threshold ? _self.threshold : threshold // ignore: cast_nullable_to_non_nullable
+as double,centerLat: null == centerLat ? _self.centerLat : centerLat // ignore: cast_nullable_to_non_nullable
+as double,centerLng: null == centerLng ? _self.centerLng : centerLng // ignore: cast_nullable_to_non_nullable
+as double,radiusKm: null == radiusKm ? _self.radiusKm : radiusKm // ignore: cast_nullable_to_non_nullable
+as double,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/alerts/domain/entities/radius_alert.g.dart
+++ b/lib/features/alerts/domain/entities/radius_alert.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'radius_alert.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RadiusAlert _$RadiusAlertFromJson(Map<String, dynamic> json) => _RadiusAlert(
+  id: json['id'] as String,
+  fuelType: json['fuelType'] as String,
+  threshold: (json['threshold'] as num).toDouble(),
+  centerLat: (json['centerLat'] as num).toDouble(),
+  centerLng: (json['centerLng'] as num).toDouble(),
+  radiusKm: (json['radiusKm'] as num).toDouble(),
+  label: json['label'] as String,
+  createdAt: DateTime.parse(json['createdAt'] as String),
+  enabled: json['enabled'] as bool? ?? true,
+);
+
+Map<String, dynamic> _$RadiusAlertToJson(_RadiusAlert instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'fuelType': instance.fuelType,
+      'threshold': instance.threshold,
+      'centerLat': instance.centerLat,
+      'centerLng': instance.centerLng,
+      'radiusKm': instance.radiusKm,
+      'label': instance.label,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'enabled': instance.enabled,
+    };

--- a/lib/features/alerts/domain/radius_alert_evaluator.dart
+++ b/lib/features/alerts/domain/radius_alert_evaluator.dart
@@ -1,0 +1,116 @@
+import '../../../core/utils/geo_utils.dart';
+import '../../search/domain/entities/fuel_type.dart';
+import '../../search/domain/entities/station.dart';
+import '../../../core/utils/station_extensions.dart';
+import 'entities/radius_alert.dart';
+
+/// A minimal value-type describing one station's current price for
+/// one fuel, used by [RadiusAlertEvaluator] (#578 phase 1).
+///
+/// Kept deliberately small and serialization-free so the evaluator can
+/// run inside a WorkManager isolate in phase 2 without pulling the
+/// full [Station] graph through the channel. Build one per (station,
+/// fuelType) combination you care about.
+class StationPriceSample {
+  final String stationId;
+  final double lat;
+  final double lng;
+
+  /// The `apiValue` of the fuel — matches
+  /// [RadiusAlert.fuelType]'s string storage convention.
+  final String fuelType;
+
+  /// Current observed price in whatever unit matches [fuelType]
+  /// (EUR/L for petrol/diesel, EUR/kg for CNG/H2, EUR/kWh for EV).
+  /// Callers must make sure the unit lines up with the alert
+  /// threshold — the evaluator doesn't convert units.
+  final double pricePerLiter;
+
+  const StationPriceSample({
+    required this.stationId,
+    required this.lat,
+    required this.lng,
+    required this.fuelType,
+    required this.pricePerLiter,
+  });
+
+  /// Build one sample per fuel that [station] has a price for.
+  ///
+  /// Stations typically report several fuels at once, so a single
+  /// sweep of the current search result produces a list like
+  /// `[diesel@1.67, e10@1.78, e5@1.83, …]` — exactly what the
+  /// evaluator needs to cross-check against every user-configured
+  /// radius alert in one pass.
+  static List<StationPriceSample> fromStation(Station station) {
+    final out = <StationPriceSample>[];
+    for (final fuel in FuelType.values) {
+      // Skip the "all" wildcard — it isn't a real fuel and its price
+      // comes from priceFor() falling back to another column, which
+      // would double-count samples.
+      if (fuel == FuelType.all) continue;
+      final price = station.priceFor(fuel);
+      if (price == null) continue;
+      out.add(StationPriceSample(
+        stationId: station.id,
+        lat: station.lat,
+        lng: station.lng,
+        fuelType: fuel.apiValue,
+        pricePerLiter: price,
+      ));
+    }
+    return out;
+  }
+}
+
+/// Pure-Dart threshold evaluator for [RadiusAlert] (#578 phase 1).
+///
+/// Zero Riverpod / Hive imports so this can be reused inside the
+/// phase-2 background worker without hauling the whole app
+/// dependency graph into a WorkManager isolate.
+class RadiusAlertEvaluator {
+  const RadiusAlertEvaluator();
+
+  /// True iff at least one [StationPriceSample] satisfies all three
+  /// of: (a) same fuel as [alert], (b) price at or below
+  /// [RadiusAlert.threshold], and (c) located within
+  /// [RadiusAlert.radiusKm] of the alert's centre.
+  ///
+  /// Disabled alerts ([RadiusAlert.enabled] false) never trigger —
+  /// the caller can filter on `enabled` themselves, but short-
+  /// circuiting here keeps the common "toggled off" path cheap.
+  bool triggered(RadiusAlert alert, List<StationPriceSample> samples) {
+    if (!alert.enabled) return false;
+    for (final s in samples) {
+      if (_matches(alert, s)) return true;
+    }
+    return false;
+  }
+
+  /// Iterable of every sample that would trigger [alert]. Used by
+  /// the phase-2 notification payload so the user sees a list like
+  /// "Shell, Aldi, Total" instead of a bare "someone is cheap
+  /// somewhere".
+  ///
+  /// Returns an empty iterable when [alert] is disabled.
+  Iterable<StationPriceSample> matches(
+    RadiusAlert alert,
+    List<StationPriceSample> samples,
+  ) sync* {
+    if (!alert.enabled) return;
+    for (final s in samples) {
+      if (_matches(alert, s)) yield s;
+    }
+  }
+
+  bool _matches(RadiusAlert alert, StationPriceSample s) {
+    if (s.fuelType != alert.fuelType) return false;
+    if (s.pricePerLiter > alert.threshold) return false;
+    final d = distanceKm(
+      alert.centerLat,
+      alert.centerLng,
+      s.lat,
+      s.lng,
+    );
+    return d <= alert.radiusKm;
+  }
+}

--- a/lib/features/alerts/providers/radius_alerts_provider.dart
+++ b/lib/features/alerts/providers/radius_alerts_provider.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../data/radius_alert_store.dart';
+import '../domain/entities/radius_alert.dart';
+
+part 'radius_alerts_provider.g.dart';
+
+/// Shared [RadiusAlertStore] instance. Kept alive for the app's
+/// lifetime so the async notifier below can re-read it without
+/// re-instantiating a store per operation.
+@Riverpod(keepAlive: true)
+RadiusAlertStore radiusAlertStore(Ref ref) => RadiusAlertStore();
+
+/// Radius-watchlist state (#578 phase 1).
+///
+/// Loads the persisted list from the store on first read and exposes
+/// [add] / [remove] / [toggle] for the phase-2 UI layer. Mirrors the
+/// per-station [AlertNotifier] shape so users of either can swap
+/// between the two in follow-up PRs without relearning the surface.
+@Riverpod(keepAlive: true)
+class RadiusAlerts extends _$RadiusAlerts {
+  @override
+  Future<List<RadiusAlert>> build() async {
+    final store = ref.read(radiusAlertStoreProvider);
+    return store.list();
+  }
+
+  /// Persist [alert] and refresh state. If an alert with the same id
+  /// already exists it's overwritten (the store's upsert semantics).
+  Future<void> add(RadiusAlert alert) async {
+    final store = ref.read(radiusAlertStoreProvider);
+    try {
+      await store.upsert(alert);
+    } catch (e) {
+      debugPrint('RadiusAlerts.add: $e');
+    }
+    state = AsyncValue.data(await store.list());
+  }
+
+  /// Remove the alert with [id] and refresh state. No-op if unknown.
+  Future<void> remove(String id) async {
+    final store = ref.read(radiusAlertStoreProvider);
+    try {
+      await store.remove(id);
+    } catch (e) {
+      debugPrint('RadiusAlerts.remove: $e');
+    }
+    state = AsyncValue.data(await store.list());
+  }
+
+  /// Flip [RadiusAlert.enabled] on the alert with [id]. No-op when
+  /// the id isn't in the current list — mirrors the legacy alert
+  /// provider's quiet-no-op behaviour so the UI can blindly call
+  /// toggle on whatever id the user tapped.
+  Future<void> toggle(String id) async {
+    final store = ref.read(radiusAlertStoreProvider);
+    final current = await store.list();
+    final match = current.where((a) => a.id == id).toList();
+    if (match.isEmpty) {
+      // Keep state fresh in case the list changed under us.
+      state = AsyncValue.data(current);
+      return;
+    }
+    final updated = match.first.copyWith(enabled: !match.first.enabled);
+    try {
+      await store.upsert(updated);
+    } catch (e) {
+      debugPrint('RadiusAlerts.toggle: $e');
+    }
+    state = AsyncValue.data(await store.list());
+  }
+}

--- a/lib/features/alerts/providers/radius_alerts_provider.g.dart
+++ b/lib/features/alerts/providers/radius_alerts_provider.g.dart
@@ -1,0 +1,137 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'radius_alerts_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Shared [RadiusAlertStore] instance. Kept alive for the app's
+/// lifetime so the async notifier below can re-read it without
+/// re-instantiating a store per operation.
+
+@ProviderFor(radiusAlertStore)
+final radiusAlertStoreProvider = RadiusAlertStoreProvider._();
+
+/// Shared [RadiusAlertStore] instance. Kept alive for the app's
+/// lifetime so the async notifier below can re-read it without
+/// re-instantiating a store per operation.
+
+final class RadiusAlertStoreProvider
+    extends
+        $FunctionalProvider<
+          RadiusAlertStore,
+          RadiusAlertStore,
+          RadiusAlertStore
+        >
+    with $Provider<RadiusAlertStore> {
+  /// Shared [RadiusAlertStore] instance. Kept alive for the app's
+  /// lifetime so the async notifier below can re-read it without
+  /// re-instantiating a store per operation.
+  RadiusAlertStoreProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'radiusAlertStoreProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$radiusAlertStoreHash();
+
+  @$internal
+  @override
+  $ProviderElement<RadiusAlertStore> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  RadiusAlertStore create(Ref ref) {
+    return radiusAlertStore(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RadiusAlertStore value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RadiusAlertStore>(value),
+    );
+  }
+}
+
+String _$radiusAlertStoreHash() => r'379932ffed7a9f10c6a9a32f77e0195d9f167316';
+
+/// Radius-watchlist state (#578 phase 1).
+///
+/// Loads the persisted list from the store on first read and exposes
+/// [add] / [remove] / [toggle] for the phase-2 UI layer. Mirrors the
+/// per-station [AlertNotifier] shape so users of either can swap
+/// between the two in follow-up PRs without relearning the surface.
+
+@ProviderFor(RadiusAlerts)
+final radiusAlertsProvider = RadiusAlertsProvider._();
+
+/// Radius-watchlist state (#578 phase 1).
+///
+/// Loads the persisted list from the store on first read and exposes
+/// [add] / [remove] / [toggle] for the phase-2 UI layer. Mirrors the
+/// per-station [AlertNotifier] shape so users of either can swap
+/// between the two in follow-up PRs without relearning the surface.
+final class RadiusAlertsProvider
+    extends $AsyncNotifierProvider<RadiusAlerts, List<RadiusAlert>> {
+  /// Radius-watchlist state (#578 phase 1).
+  ///
+  /// Loads the persisted list from the store on first read and exposes
+  /// [add] / [remove] / [toggle] for the phase-2 UI layer. Mirrors the
+  /// per-station [AlertNotifier] shape so users of either can swap
+  /// between the two in follow-up PRs without relearning the surface.
+  RadiusAlertsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'radiusAlertsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$radiusAlertsHash();
+
+  @$internal
+  @override
+  RadiusAlerts create() => RadiusAlerts();
+}
+
+String _$radiusAlertsHash() => r'635ffc03242162c975914d077f27c16748c32564';
+
+/// Radius-watchlist state (#578 phase 1).
+///
+/// Loads the persisted list from the store on first read and exposes
+/// [add] / [remove] / [toggle] for the phase-2 UI layer. Mirrors the
+/// per-station [AlertNotifier] shape so users of either can swap
+/// between the two in follow-up PRs without relearning the surface.
+
+abstract class _$RadiusAlerts extends $AsyncNotifier<List<RadiusAlert>> {
+  FutureOr<List<RadiusAlert>> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref as $Ref<AsyncValue<List<RadiusAlert>>, List<RadiusAlert>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<List<RadiusAlert>>, List<RadiusAlert>>,
+              AsyncValue<List<RadiusAlert>>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/alerts/data/radius_alert_store_test.dart
+++ b/test/features/alerts/data/radius_alert_store_test.dart
@@ -1,0 +1,156 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/alerts/data/radius_alert_store.dart';
+import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
+
+void main() {
+  late Directory tempDir;
+
+  RadiusAlert makeAlert({
+    String id = 'r1',
+    String fuelType = 'diesel',
+    double threshold = 1.55,
+    double centerLat = 48.1,
+    double centerLng = 2.2,
+    double radiusKm = 10,
+    String label = 'Home',
+    DateTime? createdAt,
+    bool enabled = true,
+  }) {
+    return RadiusAlert(
+      id: id,
+      fuelType: fuelType,
+      threshold: threshold,
+      centerLat: centerLat,
+      centerLng: centerLng,
+      radiusKm: radiusKm,
+      label: label,
+      createdAt: createdAt ?? DateTime(2026, 1, 1, 10, 0),
+      enabled: enabled,
+    );
+  }
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_radius_alerts_');
+    Hive.init(tempDir.path);
+  });
+
+  setUp(() async {
+    // Reopen a clean alerts box for every test. Mirrors the pattern
+    // used by the legacy alerts repository test.
+    if (Hive.isBoxOpen(HiveBoxes.alerts)) {
+      await Hive.box(HiveBoxes.alerts).close();
+    }
+    await Hive.openBox(HiveBoxes.alerts);
+    await Hive.box(HiveBoxes.alerts).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('RadiusAlertStore', () {
+    test('list returns an empty list when the box is empty', () async {
+      final store = RadiusAlertStore();
+      expect(await store.list(), isEmpty);
+    });
+
+    test('upsert persists an alert retrievable via list', () async {
+      final store = RadiusAlertStore();
+      final alert = makeAlert(id: 'a1');
+
+      await store.upsert(alert);
+
+      final all = await store.list();
+      expect(all, hasLength(1));
+      expect(all.single.id, 'a1');
+      expect(all.single.threshold, alert.threshold);
+      expect(all.single.centerLat, alert.centerLat);
+    });
+
+    test('upsert overwrites an existing alert with the same id', () async {
+      final store = RadiusAlertStore();
+      await store.upsert(makeAlert(id: 'a1', threshold: 1.50));
+      await store.upsert(makeAlert(id: 'a1', threshold: 1.30));
+
+      final all = await store.list();
+      expect(all, hasLength(1));
+      expect(all.single.threshold, 1.30);
+    });
+
+    test('remove deletes only the targeted alert', () async {
+      final store = RadiusAlertStore();
+      await store.upsert(makeAlert(id: 'a1'));
+      await store.upsert(makeAlert(
+        id: 'a2',
+        createdAt: DateTime(2026, 1, 2),
+      ));
+
+      await store.remove('a1');
+
+      final all = await store.list();
+      expect(all, hasLength(1));
+      expect(all.single.id, 'a2');
+    });
+
+    test('remove is a no-op when the id is unknown', () async {
+      final store = RadiusAlertStore();
+      await store.upsert(makeAlert(id: 'a1'));
+
+      await store.remove('does-not-exist');
+
+      final all = await store.list();
+      expect(all, hasLength(1));
+      expect(all.single.id, 'a1');
+    });
+
+    test('list ignores non-radius-alert keys in the shared box', () async {
+      // Legacy per-station alerts live under the 'alerts' key (a
+      // list of maps). list() must filter those out so we don't
+      // crash on unrelated payloads.
+      final box = Hive.box(HiveBoxes.alerts);
+      await box.put('alerts', [
+        {'id': 'legacy', 'stationId': 's', 'targetPrice': 1.5},
+      ]);
+
+      final store = RadiusAlertStore();
+      await store.upsert(makeAlert(id: 'radius-only'));
+
+      final all = await store.list();
+      expect(all, hasLength(1));
+      expect(all.single.id, 'radius-only');
+    });
+
+    test('list returns alerts oldest-first by createdAt', () async {
+      final store = RadiusAlertStore();
+      await store.upsert(
+        makeAlert(id: 'newer', createdAt: DateTime(2026, 3, 1)),
+      );
+      await store.upsert(
+        makeAlert(id: 'oldest', createdAt: DateTime(2025, 12, 1)),
+      );
+      await store.upsert(
+        makeAlert(id: 'middle', createdAt: DateTime(2026, 1, 15)),
+      );
+
+      final all = await store.list();
+      expect(all.map((a) => a.id).toList(), ['oldest', 'middle', 'newer']);
+    });
+
+    test('list returns empty list when the alerts box is closed', () async {
+      final box = Hive.box(HiveBoxes.alerts);
+      await box.close();
+
+      final store = RadiusAlertStore();
+      expect(await store.list(), isEmpty);
+      // Restore for teardown
+      await Hive.openBox(HiveBoxes.alerts);
+    });
+  });
+}

--- a/test/features/alerts/domain/entities/radius_alert_test.dart
+++ b/test/features/alerts/domain/entities/radius_alert_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
+
+void main() {
+  RadiusAlert makeAlert({
+    String id = 'r1',
+    String fuelType = 'diesel',
+    double threshold = 1.55,
+    double centerLat = 48.1,
+    double centerLng = 2.2,
+    double radiusKm = 10,
+    String label = 'Home',
+    DateTime? createdAt,
+    bool enabled = true,
+  }) {
+    return RadiusAlert(
+      id: id,
+      fuelType: fuelType,
+      threshold: threshold,
+      centerLat: centerLat,
+      centerLng: centerLng,
+      radiusKm: radiusKm,
+      label: label,
+      createdAt: createdAt ?? DateTime(2026, 1, 1, 10, 0),
+      enabled: enabled,
+    );
+  }
+
+  group('RadiusAlert', () {
+    test('toJson / fromJson round-trip preserves every field', () {
+      final original = makeAlert(
+        id: 'round-trip',
+        fuelType: 'e10',
+        threshold: 1.639,
+        centerLat: 43.4527,
+        centerLng: 3.4892,
+        radiusKm: 12.5,
+        label: 'Castelnau',
+        createdAt: DateTime(2026, 4, 22, 8, 30),
+        enabled: false,
+      );
+
+      final restored = RadiusAlert.fromJson(original.toJson());
+
+      expect(restored.id, original.id);
+      expect(restored.fuelType, original.fuelType);
+      expect(restored.threshold, original.threshold);
+      expect(restored.centerLat, original.centerLat);
+      expect(restored.centerLng, original.centerLng);
+      expect(restored.radiusKm, original.radiusKm);
+      expect(restored.label, original.label);
+      expect(restored.createdAt, original.createdAt);
+      expect(restored.enabled, original.enabled);
+    });
+
+    test('enabled defaults to true when omitted from JSON', () {
+      final json = <String, dynamic>{
+        'id': 'default-enabled',
+        'fuelType': 'diesel',
+        'threshold': 1.60,
+        'centerLat': 48.0,
+        'centerLng': 2.0,
+        'radiusKm': 5.0,
+        'label': 'Work',
+        'createdAt': DateTime(2026, 1, 1).toIso8601String(),
+      };
+
+      final alert = RadiusAlert.fromJson(json);
+      expect(alert.enabled, isTrue);
+    });
+
+    test('copyWith updates only the targeted field', () {
+      final base = makeAlert();
+
+      final toggled = base.copyWith(enabled: false);
+      expect(toggled.enabled, isFalse);
+      expect(toggled.id, base.id);
+      expect(toggled.threshold, base.threshold);
+
+      final raised = base.copyWith(threshold: 1.80);
+      expect(raised.threshold, 1.80);
+      expect(raised.enabled, isTrue);
+      expect(raised.fuelType, base.fuelType);
+    });
+
+    test('equality compares by value, not identity', () {
+      final a = makeAlert();
+      final b = makeAlert();
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+
+      final c = a.copyWith(threshold: 1.99);
+      expect(a, isNot(equals(c)));
+    });
+  });
+}

--- a/test/features/alerts/domain/radius_alert_evaluator_test.dart
+++ b/test/features/alerts/domain/radius_alert_evaluator_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
+import 'package:tankstellen/features/alerts/domain/radius_alert_evaluator.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+void main() {
+  const evaluator = RadiusAlertEvaluator();
+
+  // Center of Castelnau-de-Guers (~home coordinates for the dev).
+  // Distances below are calibrated against haversine from here.
+  const double centerLat = 43.4527;
+  const double centerLng = 3.4892;
+
+  RadiusAlert makeAlert({
+    String id = 'r1',
+    String fuelType = 'diesel',
+    double threshold = 1.60,
+    double lat = centerLat,
+    double lng = centerLng,
+    double radiusKm = 10,
+    bool enabled = true,
+  }) {
+    return RadiusAlert(
+      id: id,
+      fuelType: fuelType,
+      threshold: threshold,
+      centerLat: lat,
+      centerLng: lng,
+      radiusKm: radiusKm,
+      label: 'Test',
+      createdAt: DateTime(2026, 1, 1),
+      enabled: enabled,
+    );
+  }
+
+  StationPriceSample sample({
+    String stationId = 's1',
+    double lat = centerLat,
+    double lng = centerLng,
+    String fuelType = 'diesel',
+    double price = 1.50,
+  }) {
+    return StationPriceSample(
+      stationId: stationId,
+      lat: lat,
+      lng: lng,
+      fuelType: fuelType,
+      pricePerLiter: price,
+    );
+  }
+
+  group('RadiusAlertEvaluator.triggered — single-condition tests', () {
+    test('triggers when price is strictly below threshold and inside radius',
+        () {
+      final alert = makeAlert(threshold: 1.60);
+      final samples = [sample(price: 1.45)];
+      expect(evaluator.triggered(alert, samples), isTrue);
+    });
+
+    test('triggers when price equals threshold exactly (<= boundary)', () {
+      final alert = makeAlert(threshold: 1.50);
+      final samples = [sample(price: 1.50)];
+      expect(evaluator.triggered(alert, samples), isTrue);
+    });
+
+    test('does NOT trigger when the only sample is above threshold', () {
+      final alert = makeAlert(threshold: 1.40);
+      final samples = [sample(price: 1.55)];
+      expect(evaluator.triggered(alert, samples), isFalse);
+    });
+
+    test('does NOT trigger when the only sample is outside the radius', () {
+      // ~18 km north of the centre (~0.16 deg lat)
+      final alert = makeAlert(radiusKm: 5);
+      final samples = [sample(lat: centerLat + 0.16, price: 1.40)];
+      expect(evaluator.triggered(alert, samples), isFalse);
+    });
+
+    test('does NOT trigger when the fuel type of the sample differs', () {
+      final alert = makeAlert(fuelType: 'diesel', threshold: 1.60);
+      final samples = [sample(fuelType: 'e10', price: 1.40)];
+      expect(evaluator.triggered(alert, samples), isFalse);
+    });
+
+    test('does NOT trigger when the alert is disabled, even with a match',
+        () {
+      final alert = makeAlert(enabled: false);
+      final samples = [sample(price: 1.30)];
+      expect(evaluator.triggered(alert, samples), isFalse);
+    });
+  });
+
+  group('RadiusAlertEvaluator.triggered — combined conditions', () {
+    test(
+        'triggers when one mixed-fuel sample matches, others differ in fuel or distance',
+        () {
+      final alert = makeAlert(fuelType: 'diesel', threshold: 1.60, radiusKm: 5);
+      final samples = [
+        sample(fuelType: 'e10', price: 1.30), // wrong fuel
+        sample(lat: centerLat + 0.16, price: 1.20), // right fuel, out of range
+        sample(price: 1.55), // perfect match
+      ];
+      expect(evaluator.triggered(alert, samples), isTrue);
+    });
+
+    test('does NOT trigger when every sample fails at least one condition',
+        () {
+      final alert = makeAlert(fuelType: 'diesel', threshold: 1.50, radiusKm: 5);
+      final samples = [
+        sample(fuelType: 'e10', price: 1.30), // wrong fuel
+        sample(price: 1.80), // too expensive
+        sample(lat: centerLat + 0.5, price: 1.30), // out of range
+      ];
+      expect(evaluator.triggered(alert, samples), isFalse);
+    });
+
+    test('empty sample list never triggers, even for an enabled alert', () {
+      final alert = makeAlert();
+      expect(evaluator.triggered(alert, const []), isFalse);
+    });
+  });
+
+  group('RadiusAlertEvaluator.matches', () {
+    test('returns only the samples that satisfy every condition', () {
+      final alert = makeAlert(fuelType: 'diesel', threshold: 1.60, radiusKm: 5);
+      final samples = [
+        sample(stationId: 'wrong-fuel', fuelType: 'e10', price: 1.30),
+        sample(stationId: 'too-expensive', price: 1.75),
+        sample(stationId: 'out-of-range', lat: centerLat + 0.5, price: 1.40),
+        sample(stationId: 'match-1', price: 1.55),
+        sample(stationId: 'match-2', price: 1.60),
+      ];
+
+      final matches = evaluator.matches(alert, samples).toList();
+      expect(matches.map((s) => s.stationId), ['match-1', 'match-2']);
+    });
+
+    test('returns empty when the alert is disabled', () {
+      final alert = makeAlert(enabled: false);
+      final samples = [sample(price: 1.00), sample(stationId: 's2', price: 0.99)];
+      expect(evaluator.matches(alert, samples), isEmpty);
+    });
+  });
+
+  group('StationPriceSample.fromStation', () {
+    test('emits one sample per priced fuel on a Station', () {
+      const station = Station(
+        id: 'multi',
+        name: 'Multi',
+        brand: 'Brand',
+        street: 'Street',
+        postCode: '34120',
+        place: 'Castelnau',
+        lat: centerLat,
+        lng: centerLng,
+        isOpen: true,
+        diesel: 1.55,
+        e10: 1.72,
+        e5: 1.80,
+      );
+
+      final samples = StationPriceSample.fromStation(station);
+
+      final fuels = samples.map((s) => s.fuelType).toSet();
+      expect(fuels, containsAll(<String>['diesel', 'e10', 'e5']));
+      expect(samples.length, 3);
+      // Every sample inherits the station's coordinates and id.
+      expect(samples.every((s) => s.stationId == 'multi'), isTrue);
+      expect(samples.every((s) => s.lat == centerLat), isTrue);
+    });
+
+    test('skips fuels that have no price on the station', () {
+      const station = Station(
+        id: 'diesel-only',
+        name: '',
+        brand: '',
+        street: '',
+        postCode: '34120',
+        place: '',
+        lat: centerLat,
+        lng: centerLng,
+        isOpen: true,
+        diesel: 1.48,
+      );
+
+      final samples = StationPriceSample.fromStation(station);
+      expect(samples, hasLength(1));
+      expect(samples.single.fuelType, FuelType.diesel.apiValue);
+      expect(samples.single.pricePerLiter, 1.48);
+    });
+  });
+}

--- a/test/features/alerts/providers/radius_alerts_provider_test.dart
+++ b/test/features/alerts/providers/radius_alerts_provider_test.dart
@@ -1,0 +1,157 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/alerts/data/radius_alert_store.dart';
+import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
+import 'package:tankstellen/features/alerts/providers/radius_alerts_provider.dart';
+
+void main() {
+  late Directory tempDir;
+
+  RadiusAlert makeAlert({
+    String id = 'r1',
+    String fuelType = 'diesel',
+    double threshold = 1.55,
+    bool enabled = true,
+    DateTime? createdAt,
+  }) {
+    return RadiusAlert(
+      id: id,
+      fuelType: fuelType,
+      threshold: threshold,
+      centerLat: 48.0,
+      centerLng: 2.0,
+      radiusKm: 10,
+      label: 'Home',
+      createdAt: createdAt ?? DateTime(2026, 1, 1, 10, 0),
+      enabled: enabled,
+    );
+  }
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_radius_prov_');
+    Hive.init(tempDir.path);
+  });
+
+  setUp(() async {
+    if (Hive.isBoxOpen(HiveBoxes.alerts)) {
+      await Hive.box(HiveBoxes.alerts).close();
+    }
+    await Hive.openBox(HiveBoxes.alerts);
+    await Hive.box(HiveBoxes.alerts).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('radiusAlertsProvider', () {
+    test('build() returns the empty list when no alerts are persisted',
+        () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(radiusAlertsProvider.future);
+      expect(result, isEmpty);
+    });
+
+    test('add() persists the alert and pushes it to state', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // Prime the provider so state transitions from loading → data.
+      await container.read(radiusAlertsProvider.future);
+
+      final alert = makeAlert(id: 'added');
+      await container.read(radiusAlertsProvider.notifier).add(alert);
+
+      final state = container.read(radiusAlertsProvider).value;
+      expect(state, isNotNull);
+      expect(state!, hasLength(1));
+      expect(state.first.id, 'added');
+    });
+
+    test('build() loads previously persisted alerts', () async {
+      // Write directly via the store, then spin up the provider.
+      final store = RadiusAlertStore();
+      await store.upsert(makeAlert(id: 'preloaded'));
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(radiusAlertsProvider.future);
+      expect(result, hasLength(1));
+      expect(result.first.id, 'preloaded');
+    });
+
+    test('remove() drops the alert and keeps the rest', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(radiusAlertsProvider.future);
+
+      final notifier = container.read(radiusAlertsProvider.notifier);
+      await notifier.add(makeAlert(id: 'keep', createdAt: DateTime(2026, 1, 1)));
+      await notifier.add(makeAlert(id: 'drop', createdAt: DateTime(2026, 1, 2)));
+
+      await notifier.remove('drop');
+
+      final state = container.read(radiusAlertsProvider).value!;
+      expect(state.map((a) => a.id), ['keep']);
+    });
+
+    test('remove() with an unknown id is a silent no-op', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(radiusAlertsProvider.future);
+
+      final notifier = container.read(radiusAlertsProvider.notifier);
+      await notifier.add(makeAlert(id: 'a1'));
+
+      await notifier.remove('not-there');
+
+      final state = container.read(radiusAlertsProvider).value!;
+      expect(state, hasLength(1));
+      expect(state.first.id, 'a1');
+    });
+
+    test('toggle() flips enabled and persists the change', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(radiusAlertsProvider.future);
+
+      final notifier = container.read(radiusAlertsProvider.notifier);
+      await notifier.add(makeAlert(id: 't1', enabled: true));
+
+      await notifier.toggle('t1');
+
+      var state = container.read(radiusAlertsProvider).value!;
+      expect(state.single.enabled, isFalse);
+
+      await notifier.toggle('t1');
+      state = container.read(radiusAlertsProvider).value!;
+      expect(state.single.enabled, isTrue);
+    });
+
+    test('toggle() with an unknown id leaves state untouched', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(radiusAlertsProvider.future);
+
+      final notifier = container.read(radiusAlertsProvider.notifier);
+      await notifier.add(makeAlert(id: 'real', enabled: true));
+
+      await notifier.toggle('ghost');
+
+      final state = container.read(radiusAlertsProvider).value!;
+      expect(state, hasLength(1));
+      expect(state.single.id, 'real');
+      expect(state.single.enabled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What

Phase 1 scaffolding for the radius-based watchlist feature (#578). Ships the data + domain + provider layers with unit + Hive tests. **No UI screen, no WorkManager job, no local notifications** — those are deliberately deferred to a phase-2 PR.

New files:

- `lib/features/alerts/domain/entities/radius_alert.dart` — freezed entity (`id`, `fuelType` as apiValue string, `threshold`, `centerLat/Lng`, `radiusKm`, `label`, `createdAt`, `enabled`).
- `lib/features/alerts/data/radius_alert_store.dart` — Hive-backed CRUD. Reuses the existing `HiveBoxes.alerts` box (no new box was added); keys namespaced under `radius_alert:<id>` so the legacy per-station alert list under the `'alerts'` key is untouched.
- `lib/features/alerts/domain/radius_alert_evaluator.dart` — pure-Dart evaluator. `triggered()` / `matches()` check fuel + threshold + radius AND-conditions; disabled alerts short-circuit. Distance comes from the existing `core/utils/geo_utils.distanceKm`.
- `StationPriceSample` value-type inside the evaluator file; `fromStation()` emits one sample per priced fuel so the phase-2 background worker can pass a flat list to the evaluator.
- `lib/features/alerts/providers/radius_alerts_provider.dart` — `@Riverpod(keepAlive: true)` `AsyncNotifier<List<RadiusAlert>>` with `add` / `remove` / `toggle`, mirroring the shape of the legacy `AlertNotifier`.

## Why

Splitting this feature into two PRs keeps the surface reviewable: this one is model/storage/logic only (data-layer + tests), the follow-up is UI + periodic check + notification payload wiring. The evaluator is deliberately free of Riverpod / Hive imports so phase 2 can reuse it inside a WorkManager isolate without dragging the whole app graph through the channel.

Serves the **pump** lens: the user saves at the pump by knowing when ANY station in their catchment area drops below a target price, not just the one they hand-picked today.

## Testing

- `flutter analyze` — No issues found
- `flutter test test/features/alerts/` — 117 pass (new + existing alerts tests)
- `flutter test` (full suite) — 5061 pass, 1 skipped (pre-existing)
- 24 new tests across 4 files:
  - `radius_alert_test.dart` — JSON round-trip, default-enabled, `copyWith`, equality.
  - `radius_alert_store_test.dart` — upsert/remove/list, overwrite semantics, key-prefix isolation from legacy per-station alerts, closed-box graceful no-op, deterministic oldest-first ordering.
  - `radius_alert_evaluator_test.dart` — each AND-condition (fuel / threshold / radius / enabled) individually, combined, empty list, `matches()` payload, `StationPriceSample.fromStation` sweep.
  - `radius_alerts_provider_test.dart` — build / add / remove (incl. unknown id) / toggle (incl. unknown id) via `ProviderContainer`.

## Phase 2 hand-off

Follow-up PR will add:

1. `AlertsScreen` section for radius watchlist (create/edit/list/toggle dialogs, map picker for centre + radius).
2. Extension of the existing WorkManager periodic alert check (`BackgroundService`) to iterate radius alerts and call `RadiusAlertEvaluator.matches()` against the current search area's station snapshot.
3. `flutter_local_notifications` payload using the matches returned by the evaluator (Shell / Aldi / Total style list).
4. ARB strings for the new UI and notification bodies (none touched in this PR — phase 1 exposes no user-facing text).

Phase 2 will link `Closes #578`. This PR deliberately does not.