### PR TITLE
feat(vehicle): service reminders (#584)

### DIFF
--- a/lib/core/notifications/local_notification_service.dart
+++ b/lib/core/notifications/local_notification_service.dart
@@ -20,6 +20,16 @@ class LocalNotificationService implements NotificationService {
   static const _channelDescription =
       'Notifications when fuel prices drop below your target';
 
+  /// #584 — separate channel for service reminders so the user can
+  /// independently mute maintenance reminders without muting price
+  /// drops (and vice versa). Default importance is lower than price
+  /// alerts — a missed oil change is less time-sensitive than a
+  /// short-lived price dip.
+  static const _serviceChannelId = 'service_reminders';
+  static const _serviceChannelName = 'Service reminders';
+  static const _serviceChannelDescription =
+      'Reminders when your odometer crosses a scheduled service interval';
+
   @override
   Future<void> initialize() async {
     const androidSettings =
@@ -41,6 +51,25 @@ class LocalNotificationService implements NotificationService {
         channelDescription: _channelDescription,
         importance: Importance.high,
         priority: Priority.high,
+      ),
+    );
+    await plugin.show(
+        id: id, title: title, body: body, notificationDetails: details);
+  }
+
+  @override
+  Future<void> showServiceReminder({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    const details = NotificationDetails(
+      android: AndroidNotificationDetails(
+        _serviceChannelId,
+        _serviceChannelName,
+        channelDescription: _serviceChannelDescription,
+        importance: Importance.defaultImportance,
+        priority: Priority.defaultPriority,
       ),
     );
     await plugin.show(

--- a/lib/core/notifications/notification_service.dart
+++ b/lib/core/notifications/notification_service.dart
@@ -18,6 +18,19 @@ abstract class NotificationService {
     required String body,
   });
 
+  /// Display a service-reminder notification (#584). Uses a distinct
+  /// channel on Android so the user can mute price alerts without
+  /// silencing maintenance reminders.
+  ///
+  /// [id] should be stable per reminder so repeated triggers (e.g.
+  /// because the same fill-up is re-saved) update the existing
+  /// notification instead of stacking.
+  Future<void> showServiceReminder({
+    required int id,
+    required String title,
+    required String body,
+  });
+
   /// Cancel a specific notification by its [id].
   Future<void> cancelNotification(int id);
 

--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -40,6 +40,12 @@ class HiveBoxes {
   /// OBD2 boxes.
   static const String obd2SupportedPids = 'obd2_supported_pids';
 
+  /// Odometer-based service reminders (#584). One JSON payload per
+  /// reminder keyed by reminder id. Not PII (label + interval +
+  /// odometer) — unencrypted to keep startup cheap, same as
+  /// [obd2Baselines] and [achievements].
+  static const String serviceReminders = 'service_reminders';
+
   static const _encryptedBoxes = {
     settings,
     profiles,
@@ -125,6 +131,8 @@ class HiveBoxes {
     // mirroring the storage idiom used by the other OBD2 boxes so
     // we don't need a custom adapter.
     await Hive.openBox<String>(obd2SupportedPids);
+    // #584 — odometer-based service reminders: one entry per reminder.
+    await Hive.openBox<String>(serviceReminders);
   }
 
   /// Initialize Hive in a background isolate with proper encryption.
@@ -163,6 +171,10 @@ class HiveBoxes {
     await Hive.openBox(profiles);
     await Hive.openBox(priceHistory);
     await Hive.openBox(alerts);
+    // #584 — service reminders live in their own box so tests that
+    // exercise the vehicle feature can open it without pulling in the
+    // rest of the app. String-typed to match runtime.
+    await Hive.openBox<String>(serviceReminders);
   }
 
   /// Safely converts any Hive map to a typed map.

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/storage/storage_providers.dart';
+import '../../vehicle/providers/service_reminder_providers.dart';
 import '../data/repositories/fill_up_repository.dart';
 import '../domain/entities/consumption_stats.dart';
 import '../domain/entities/eco_score.dart';
@@ -26,10 +28,33 @@ class FillUpList extends _$FillUpList {
   }
 
   /// Insert a new fill-up entry and refresh the list.
+  ///
+  /// After saving, runs the odometer-based service-reminder check
+  /// (#584) for the fill-up's vehicle. Failures in the reminder
+  /// path are swallowed — logging a fill-up must never fail because
+  /// a downstream side-effect did.
   Future<void> add(FillUp fillUp) async {
     final repo = ref.read(fillUpRepositoryProvider);
     await repo.save(fillUp);
     state = repo.getAll();
+    await _evaluateReminders(fillUp);
+  }
+
+  Future<void> _evaluateReminders(FillUp fillUp) async {
+    final vehicleId = fillUp.vehicleId;
+    if (vehicleId == null || fillUp.odometerKm <= 0) return;
+    try {
+      final evaluator = ref.read(serviceReminderEvaluatorProvider);
+      await evaluator.evaluate(
+        vehicleId: vehicleId,
+        currentOdometerKm: fillUp.odometerKm,
+      );
+      // Invalidate the reminder list so the vehicle edit screen
+      // picks up the new `pendingAcknowledgment` flag immediately.
+      ref.invalidate(serviceReminderListProvider);
+    } catch (e) {
+      debugPrint('FillUpList: reminder evaluation failed: $e');
+    }
   }
 
   /// Persist edits to an existing fill-up (matched by id) and refresh.

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -95,7 +95,7 @@ final class FillUpListProvider
   }
 }
 
-String _$fillUpListHash() => r'fc45561bba1bd7a5cf79ec1a39430d8316a2ef80';
+String _$fillUpListHash() => r'9a14d041513e659f3ec8ff20e1ce51f2593bc800';
 
 /// Mutable list of all fill-ups, newest first.
 

--- a/lib/features/vehicle/data/repositories/service_reminder_repository.dart
+++ b/lib/features/vehicle/data/repositories/service_reminder_repository.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../../core/storage/hive_boxes.dart';
+import '../../domain/entities/service_reminder.dart';
+
+/// CRUD repository for [ServiceReminder] entries (#584).
+///
+/// Backed by the `service_reminders` Hive box. Each reminder is
+/// stored as a JSON-encoded string keyed by its id — the same
+/// pattern [HiveBoxes.achievements] and [HiveBoxes.obd2TripHistory]
+/// use. No custom TypeAdapter is needed; freezed/json_serializable
+/// handles (de)serialisation.
+class ServiceReminderRepository {
+  final Box<String> _box;
+
+  ServiceReminderRepository(this._box);
+
+  /// Factory that grabs the open box from Hive. Use this in app code;
+  /// tests can pass a specific [Box<String>] to the default ctor.
+  factory ServiceReminderRepository.fromHive() =>
+      ServiceReminderRepository(Hive.box<String>(HiveBoxes.serviceReminders));
+
+  /// Returns all stored reminders, unsorted.
+  List<ServiceReminder> getAll() {
+    final result = <ServiceReminder>[];
+    for (final key in _box.keys) {
+      final raw = _box.get(key);
+      if (raw == null) continue;
+      try {
+        final map = jsonDecode(raw) as Map<String, dynamic>;
+        result.add(ServiceReminder.fromJson(map));
+      } catch (e) {
+        debugPrint('ServiceReminderRepository: skipping "$key": $e');
+      }
+    }
+    return result;
+  }
+
+  /// Returns all reminders attached to [vehicleId].
+  List<ServiceReminder> getForVehicle(String vehicleId) =>
+      getAll().where((r) => r.vehicleId == vehicleId).toList();
+
+  /// Returns a single reminder by id or `null` when missing.
+  ServiceReminder? getById(String id) {
+    final raw = _box.get(id);
+    if (raw == null) return null;
+    try {
+      final map = jsonDecode(raw) as Map<String, dynamic>;
+      return ServiceReminder.fromJson(map);
+    } catch (e) {
+      debugPrint('ServiceReminderRepository: failed to decode "$id": $e');
+      return null;
+    }
+  }
+
+  /// Add or update a single reminder (matched by id).
+  Future<void> save(ServiceReminder reminder) async {
+    await _box.put(reminder.id, jsonEncode(reminder.toJson()));
+  }
+
+  /// Delete a reminder by id. No-op when it does not exist.
+  Future<void> delete(String id) async {
+    if (_box.containsKey(id)) {
+      await _box.delete(id);
+    }
+  }
+
+  /// Delete every reminder attached to [vehicleId]. Used when the
+  /// parent vehicle is removed.
+  Future<void> deleteForVehicle(String vehicleId) async {
+    final victimKeys = <dynamic>[];
+    for (final r in getAll()) {
+      if (r.vehicleId == vehicleId) victimKeys.add(r.id);
+    }
+    if (victimKeys.isNotEmpty) {
+      await _box.deleteAll(victimKeys);
+    }
+  }
+
+  /// Wipe the entire reminder box. Used by the privacy dashboard.
+  Future<void> clear() async {
+    await _box.clear();
+  }
+
+  /// Mark a reminder done at [currentOdometerKm] — rebases
+  /// `lastServiceOdometerKm` and clears the pending-ack flag. No-op
+  /// when [id] does not resolve.
+  Future<ServiceReminder?> markDone(String id, double currentOdometerKm) async {
+    final existing = getById(id);
+    if (existing == null) return null;
+    final updated = existing.markDone(currentOdometerKm);
+    await save(updated);
+    return updated;
+  }
+}

--- a/lib/features/vehicle/domain/entities/service_reminder.dart
+++ b/lib/features/vehicle/domain/entities/service_reminder.dart
@@ -6,26 +6,50 @@ part 'service_reminder.g.dart';
 /// Odometer-triggered maintenance reminder for a [VehicleProfile]
 /// (#584).
 ///
-/// Stored as a list field on VehicleProfile. Each reminder carries
-/// the last-service odometer value; the trigger fires when the
-/// current odometer crosses `lastServiceOdometerKm + intervalKm`.
-/// Marking the reminder done resets `lastServiceOdometerKm` to the
-/// current odometer so the next cycle starts from there.
+/// Stored in the `service_reminders` Hive box keyed by [id]. Each
+/// reminder carries the last-service odometer value; the trigger
+/// fires when the current odometer crosses
+/// `lastServiceOdometerKm + intervalKm`. Marking the reminder done
+/// sets [lastServiceOdometerKm] to the current odometer so the next
+/// cycle starts from there.
+///
+/// [pendingAcknowledgment] goes `true` when a fill-up crosses the
+/// threshold and the local notification has been fired; it clears
+/// back to `false` when the user hits "mark as done" so the UI badge
+/// disappears.
 @freezed
 abstract class ServiceReminder with _$ServiceReminder {
   const factory ServiceReminder({
     required String id,
+
+    /// The vehicle this reminder belongs to. Fills-ups are checked
+    /// only against reminders that match the fill-up's vehicleId.
+    required String vehicleId,
+
     /// Short label — "Oil change", "Tires", "Inspection". Stored
     /// verbatim; localisation happens in the UI if the label matches
     /// a known preset.
     required String label,
+
     /// Service interval in km between occurrences.
     required double intervalKm,
+
     /// Odometer reading at the last service. Null when the user
     /// added the reminder but hasn't yet recorded a completion — the
     /// first fill-up that brings the odometer above `intervalKm`
     /// will trip the alert.
     double? lastServiceOdometerKm,
+
+    /// Toggle for pausing a reminder without deleting it — the
+    /// trigger skips inactive reminders. Defaults to `true` so a new
+    /// reminder is armed immediately.
+    @Default(true) bool isActive,
+
+    /// Set to `true` after the trigger fires and the notification
+    /// has been shown; reset by `markDone`. The vehicle edit row
+    /// shows a badge when this is `true` so the user can confirm
+    /// completion.
+    @Default(false) bool pendingAcknowledgment,
   }) = _ServiceReminder;
 
   const ServiceReminder._();
@@ -40,4 +64,20 @@ abstract class ServiceReminder with _$ServiceReminder {
   /// True when [currentOdometerKm] has crossed the due threshold.
   bool isDue(double currentOdometerKm) =>
       currentOdometerKm >= nextDueOdometerKm;
+
+  /// Kilometres past the due threshold at [currentOdometerKm]. Returns
+  /// a non-negative value — 0 when the reminder is exactly at the
+  /// threshold, the positive overrun otherwise. Used for the "{kmOver}
+  /// km past due" line in the notification body.
+  double kmOverdue(double currentOdometerKm) {
+    final over = currentOdometerKm - nextDueOdometerKm;
+    return over < 0 ? 0 : over;
+  }
+
+  /// Returns a new reminder rebased to [currentOdometerKm] — the next
+  /// due cycle starts from here, and the pending-ack flag clears.
+  ServiceReminder markDone(double currentOdometerKm) => copyWith(
+        lastServiceOdometerKm: currentOdometerKm,
+        pendingAcknowledgment: false,
+      );
 }

--- a/lib/features/vehicle/domain/entities/service_reminder.freezed.dart
+++ b/lib/features/vehicle/domain/entities/service_reminder.freezed.dart
@@ -15,7 +15,9 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ServiceReminder {
 
- String get id;/// Short label — "Oil change", "Tires", "Inspection". Stored
+ String get id;/// The vehicle this reminder belongs to. Fills-ups are checked
+/// only against reminders that match the fill-up's vehicleId.
+ String get vehicleId;/// Short label — "Oil change", "Tires", "Inspection". Stored
 /// verbatim; localisation happens in the UI if the label matches
 /// a known preset.
  String get label;/// Service interval in km between occurrences.
@@ -23,7 +25,14 @@ mixin _$ServiceReminder {
 /// added the reminder but hasn't yet recorded a completion — the
 /// first fill-up that brings the odometer above `intervalKm`
 /// will trip the alert.
- double? get lastServiceOdometerKm;
+ double? get lastServiceOdometerKm;/// Toggle for pausing a reminder without deleting it — the
+/// trigger skips inactive reminders. Defaults to `true` so a new
+/// reminder is armed immediately.
+ bool get isActive;/// Set to `true` after the trigger fires and the notification
+/// has been shown; reset by `markDone`. The vehicle edit row
+/// shows a badge when this is `true` so the user can confirm
+/// completion.
+ bool get pendingAcknowledgment;
 /// Create a copy of ServiceReminder
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -36,16 +45,16 @@ $ServiceReminderCopyWith<ServiceReminder> get copyWith => _$ServiceReminderCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ServiceReminder&&(identical(other.id, id) || other.id == id)&&(identical(other.label, label) || other.label == label)&&(identical(other.intervalKm, intervalKm) || other.intervalKm == intervalKm)&&(identical(other.lastServiceOdometerKm, lastServiceOdometerKm) || other.lastServiceOdometerKm == lastServiceOdometerKm));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ServiceReminder&&(identical(other.id, id) || other.id == id)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&(identical(other.label, label) || other.label == label)&&(identical(other.intervalKm, intervalKm) || other.intervalKm == intervalKm)&&(identical(other.lastServiceOdometerKm, lastServiceOdometerKm) || other.lastServiceOdometerKm == lastServiceOdometerKm)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.pendingAcknowledgment, pendingAcknowledgment) || other.pendingAcknowledgment == pendingAcknowledgment));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,label,intervalKm,lastServiceOdometerKm);
+int get hashCode => Object.hash(runtimeType,id,vehicleId,label,intervalKm,lastServiceOdometerKm,isActive,pendingAcknowledgment);
 
 @override
 String toString() {
-  return 'ServiceReminder(id: $id, label: $label, intervalKm: $intervalKm, lastServiceOdometerKm: $lastServiceOdometerKm)';
+  return 'ServiceReminder(id: $id, vehicleId: $vehicleId, label: $label, intervalKm: $intervalKm, lastServiceOdometerKm: $lastServiceOdometerKm, isActive: $isActive, pendingAcknowledgment: $pendingAcknowledgment)';
 }
 
 
@@ -56,7 +65,7 @@ abstract mixin class $ServiceReminderCopyWith<$Res>  {
   factory $ServiceReminderCopyWith(ServiceReminder value, $Res Function(ServiceReminder) _then) = _$ServiceReminderCopyWithImpl;
 @useResult
 $Res call({
- String id, String label, double intervalKm, double? lastServiceOdometerKm
+ String id, String vehicleId, String label, double intervalKm, double? lastServiceOdometerKm, bool isActive, bool pendingAcknowledgment
 });
 
 
@@ -73,13 +82,16 @@ class _$ServiceReminderCopyWithImpl<$Res>
 
 /// Create a copy of ServiceReminder
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? label = null,Object? intervalKm = null,Object? lastServiceOdometerKm = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? vehicleId = null,Object? label = null,Object? intervalKm = null,Object? lastServiceOdometerKm = freezed,Object? isActive = null,Object? pendingAcknowledgment = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,vehicleId: null == vehicleId ? _self.vehicleId : vehicleId // ignore: cast_nullable_to_non_nullable
 as String,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
 as String,intervalKm: null == intervalKm ? _self.intervalKm : intervalKm // ignore: cast_nullable_to_non_nullable
 as double,lastServiceOdometerKm: freezed == lastServiceOdometerKm ? _self.lastServiceOdometerKm : lastServiceOdometerKm // ignore: cast_nullable_to_non_nullable
-as double?,
+as double?,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,pendingAcknowledgment: null == pendingAcknowledgment ? _self.pendingAcknowledgment : pendingAcknowledgment // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -164,10 +176,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String label,  double intervalKm,  double? lastServiceOdometerKm)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String vehicleId,  String label,  double intervalKm,  double? lastServiceOdometerKm,  bool isActive,  bool pendingAcknowledgment)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ServiceReminder() when $default != null:
-return $default(_that.id,_that.label,_that.intervalKm,_that.lastServiceOdometerKm);case _:
+return $default(_that.id,_that.vehicleId,_that.label,_that.intervalKm,_that.lastServiceOdometerKm,_that.isActive,_that.pendingAcknowledgment);case _:
   return orElse();
 
 }
@@ -185,10 +197,10 @@ return $default(_that.id,_that.label,_that.intervalKm,_that.lastServiceOdometerK
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String label,  double intervalKm,  double? lastServiceOdometerKm)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String vehicleId,  String label,  double intervalKm,  double? lastServiceOdometerKm,  bool isActive,  bool pendingAcknowledgment)  $default,) {final _that = this;
 switch (_that) {
 case _ServiceReminder():
-return $default(_that.id,_that.label,_that.intervalKm,_that.lastServiceOdometerKm);case _:
+return $default(_that.id,_that.vehicleId,_that.label,_that.intervalKm,_that.lastServiceOdometerKm,_that.isActive,_that.pendingAcknowledgment);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -205,10 +217,10 @@ return $default(_that.id,_that.label,_that.intervalKm,_that.lastServiceOdometerK
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String label,  double intervalKm,  double? lastServiceOdometerKm)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String vehicleId,  String label,  double intervalKm,  double? lastServiceOdometerKm,  bool isActive,  bool pendingAcknowledgment)?  $default,) {final _that = this;
 switch (_that) {
 case _ServiceReminder() when $default != null:
-return $default(_that.id,_that.label,_that.intervalKm,_that.lastServiceOdometerKm);case _:
+return $default(_that.id,_that.vehicleId,_that.label,_that.intervalKm,_that.lastServiceOdometerKm,_that.isActive,_that.pendingAcknowledgment);case _:
   return null;
 
 }
@@ -220,10 +232,13 @@ return $default(_that.id,_that.label,_that.intervalKm,_that.lastServiceOdometerK
 @JsonSerializable()
 
 class _ServiceReminder extends ServiceReminder {
-  const _ServiceReminder({required this.id, required this.label, required this.intervalKm, this.lastServiceOdometerKm}): super._();
+  const _ServiceReminder({required this.id, required this.vehicleId, required this.label, required this.intervalKm, this.lastServiceOdometerKm, this.isActive = true, this.pendingAcknowledgment = false}): super._();
   factory _ServiceReminder.fromJson(Map<String, dynamic> json) => _$ServiceReminderFromJson(json);
 
 @override final  String id;
+/// The vehicle this reminder belongs to. Fills-ups are checked
+/// only against reminders that match the fill-up's vehicleId.
+@override final  String vehicleId;
 /// Short label — "Oil change", "Tires", "Inspection". Stored
 /// verbatim; localisation happens in the UI if the label matches
 /// a known preset.
@@ -235,6 +250,15 @@ class _ServiceReminder extends ServiceReminder {
 /// first fill-up that brings the odometer above `intervalKm`
 /// will trip the alert.
 @override final  double? lastServiceOdometerKm;
+/// Toggle for pausing a reminder without deleting it — the
+/// trigger skips inactive reminders. Defaults to `true` so a new
+/// reminder is armed immediately.
+@override@JsonKey() final  bool isActive;
+/// Set to `true` after the trigger fires and the notification
+/// has been shown; reset by `markDone`. The vehicle edit row
+/// shows a badge when this is `true` so the user can confirm
+/// completion.
+@override@JsonKey() final  bool pendingAcknowledgment;
 
 /// Create a copy of ServiceReminder
 /// with the given fields replaced by the non-null parameter values.
@@ -249,16 +273,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ServiceReminder&&(identical(other.id, id) || other.id == id)&&(identical(other.label, label) || other.label == label)&&(identical(other.intervalKm, intervalKm) || other.intervalKm == intervalKm)&&(identical(other.lastServiceOdometerKm, lastServiceOdometerKm) || other.lastServiceOdometerKm == lastServiceOdometerKm));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ServiceReminder&&(identical(other.id, id) || other.id == id)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&(identical(other.label, label) || other.label == label)&&(identical(other.intervalKm, intervalKm) || other.intervalKm == intervalKm)&&(identical(other.lastServiceOdometerKm, lastServiceOdometerKm) || other.lastServiceOdometerKm == lastServiceOdometerKm)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.pendingAcknowledgment, pendingAcknowledgment) || other.pendingAcknowledgment == pendingAcknowledgment));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,label,intervalKm,lastServiceOdometerKm);
+int get hashCode => Object.hash(runtimeType,id,vehicleId,label,intervalKm,lastServiceOdometerKm,isActive,pendingAcknowledgment);
 
 @override
 String toString() {
-  return 'ServiceReminder(id: $id, label: $label, intervalKm: $intervalKm, lastServiceOdometerKm: $lastServiceOdometerKm)';
+  return 'ServiceReminder(id: $id, vehicleId: $vehicleId, label: $label, intervalKm: $intervalKm, lastServiceOdometerKm: $lastServiceOdometerKm, isActive: $isActive, pendingAcknowledgment: $pendingAcknowledgment)';
 }
 
 
@@ -269,7 +293,7 @@ abstract mixin class _$ServiceReminderCopyWith<$Res> implements $ServiceReminder
   factory _$ServiceReminderCopyWith(_ServiceReminder value, $Res Function(_ServiceReminder) _then) = __$ServiceReminderCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String label, double intervalKm, double? lastServiceOdometerKm
+ String id, String vehicleId, String label, double intervalKm, double? lastServiceOdometerKm, bool isActive, bool pendingAcknowledgment
 });
 
 
@@ -286,13 +310,16 @@ class __$ServiceReminderCopyWithImpl<$Res>
 
 /// Create a copy of ServiceReminder
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? label = null,Object? intervalKm = null,Object? lastServiceOdometerKm = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? vehicleId = null,Object? label = null,Object? intervalKm = null,Object? lastServiceOdometerKm = freezed,Object? isActive = null,Object? pendingAcknowledgment = null,}) {
   return _then(_ServiceReminder(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,vehicleId: null == vehicleId ? _self.vehicleId : vehicleId // ignore: cast_nullable_to_non_nullable
 as String,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
 as String,intervalKm: null == intervalKm ? _self.intervalKm : intervalKm // ignore: cast_nullable_to_non_nullable
 as double,lastServiceOdometerKm: freezed == lastServiceOdometerKm ? _self.lastServiceOdometerKm : lastServiceOdometerKm // ignore: cast_nullable_to_non_nullable
-as double?,
+as double?,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,pendingAcknowledgment: null == pendingAcknowledgment ? _self.pendingAcknowledgment : pendingAcknowledgment // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/lib/features/vehicle/domain/entities/service_reminder.g.dart
+++ b/lib/features/vehicle/domain/entities/service_reminder.g.dart
@@ -9,16 +9,22 @@ part of 'service_reminder.dart';
 _ServiceReminder _$ServiceReminderFromJson(Map<String, dynamic> json) =>
     _ServiceReminder(
       id: json['id'] as String,
+      vehicleId: json['vehicleId'] as String,
       label: json['label'] as String,
       intervalKm: (json['intervalKm'] as num).toDouble(),
       lastServiceOdometerKm: (json['lastServiceOdometerKm'] as num?)
           ?.toDouble(),
+      isActive: json['isActive'] as bool? ?? true,
+      pendingAcknowledgment: json['pendingAcknowledgment'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$ServiceReminderToJson(_ServiceReminder instance) =>
     <String, dynamic>{
       'id': instance.id,
+      'vehicleId': instance.vehicleId,
       'label': instance.label,
       'intervalKm': instance.intervalKm,
       'lastServiceOdometerKm': instance.lastServiceOdometerKm,
+      'isActive': instance.isActive,
+      'pendingAcknowledgment': instance.pendingAcknowledgment,
     };

--- a/lib/features/vehicle/domain/services/service_reminder_evaluator.dart
+++ b/lib/features/vehicle/domain/services/service_reminder_evaluator.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../../core/notifications/notification_service.dart';
+import '../../data/repositories/service_reminder_repository.dart';
+import '../entities/service_reminder.dart';
+import 'service_reminder_trigger.dart';
+
+/// Copy of the strings the notification renders. Dart doesn't have
+/// test-time locale resolution for background isolates, so the
+/// evaluator accepts the already-localised title/body pair from the
+/// caller (the provider reads from the active [AppLocalizations]
+/// before invoking `evaluate`).
+class ServiceReminderMessages {
+  final String title;
+  final String Function({required String label, required int kmOver}) bodyFor;
+
+  const ServiceReminderMessages({
+    required this.title,
+    required this.bodyFor,
+  });
+
+  /// English fallback used when the UI has no [AppLocalizations]
+  /// handy (background isolates, unit tests).
+  static const fallback = ServiceReminderMessages(
+    title: 'Service due',
+    bodyFor: _fallbackBody,
+  );
+
+  static String _fallbackBody({required String label, required int kmOver}) {
+    if (kmOver <= 0) return '$label is due now.';
+    return '$label is due — $kmOver km past the interval.';
+  }
+}
+
+/// Coordinates the three layers of the #584 reminder flow:
+///   1. Pure trigger logic ([ServiceReminderTrigger]).
+///   2. Persistence of the `pendingAcknowledgment` flag via
+///      [ServiceReminderRepository].
+///   3. A local notification per triggered reminder via
+///      [NotificationService].
+///
+/// Keeping the evaluator separate from the provider makes it testable
+/// without Riverpod and keeps the fill-up save path's hook trivial.
+class ServiceReminderEvaluator {
+  final ServiceReminderRepository repository;
+  final NotificationService notifications;
+  final ServiceReminderTrigger trigger;
+
+  const ServiceReminderEvaluator({
+    required this.repository,
+    required this.notifications,
+    this.trigger = const ServiceReminderTrigger(),
+  });
+
+  /// Stable 32-bit id derived from the reminder id. Local
+  /// notifications are keyed by int; hashing the reminder's id gives
+  /// us a deterministic mapping so repeated triggers for the same
+  /// reminder replace rather than stack.
+  static int notificationIdFor(String reminderId) {
+    // Use the absolute value to stay positive and clamp to int32 so
+    // platform channels do not choke on 64-bit values.
+    return reminderId.hashCode.abs() & 0x7fffffff;
+  }
+
+  /// Evaluate every reminder attached to [vehicleId] against
+  /// [currentOdometerKm]. For each triggered reminder, persists the
+  /// `pendingAcknowledgment = true` flag and fires a local
+  /// notification. Returns the list of reminders that fired (useful
+  /// for callers that want to show a snackbar).
+  Future<List<ServiceReminder>> evaluate({
+    required String vehicleId,
+    required double currentOdometerKm,
+    ServiceReminderMessages messages = ServiceReminderMessages.fallback,
+  }) async {
+    final all = repository.getForVehicle(vehicleId);
+    final triggered = trigger.findTriggered(
+      vehicleId: vehicleId,
+      currentOdometerKm: currentOdometerKm,
+      reminders: all,
+    );
+    if (triggered.isEmpty) return const [];
+
+    final fired = <ServiceReminder>[];
+    for (final reminder in triggered) {
+      // Flip the pending flag first so a race (second fill-up while
+      // the notification is still showing) doesn't re-notify.
+      final updated = reminder.copyWith(pendingAcknowledgment: true);
+      try {
+        await repository.save(updated);
+      } catch (e) {
+        debugPrint('ServiceReminderEvaluator: failed to persist flag: $e');
+        continue;
+      }
+      try {
+        await notifications.showServiceReminder(
+          id: notificationIdFor(reminder.id),
+          title: messages.title,
+          body: messages.bodyFor(
+            label: reminder.label,
+            kmOver: reminder.kmOverdue(currentOdometerKm).round(),
+          ),
+        );
+      } catch (e) {
+        debugPrint('ServiceReminderEvaluator: notification failed: $e');
+      }
+      fired.add(updated);
+    }
+    return fired;
+  }
+}

--- a/lib/features/vehicle/domain/services/service_reminder_trigger.dart
+++ b/lib/features/vehicle/domain/services/service_reminder_trigger.dart
@@ -1,0 +1,37 @@
+import '../entities/service_reminder.dart';
+
+/// Pure domain helper that decides which reminders an odometer
+/// reading trips (#584).
+///
+/// Kept free of repositories and platform channels so the unit tests
+/// can drive it with plain data. The notification layer composes it
+/// with [ServiceReminderRepository] and [NotificationService].
+class ServiceReminderTrigger {
+  const ServiceReminderTrigger();
+
+  /// Returns the subset of [reminders] that fire when the vehicle's
+  /// odometer reads [currentOdometerKm].
+  ///
+  /// Rules:
+  /// - Only reminders attached to [vehicleId] are considered.
+  /// - Inactive reminders (`isActive == false`) are skipped.
+  /// - Reminders already flagged `pendingAcknowledgment` are skipped —
+  ///   the notification has already been shown and the user has not
+  ///   acknowledged it yet. We do not re-notify until they mark it
+  ///   done.
+  /// - A reminder fires when `currentOdometerKm` is at or past the
+  ///   reminder's `nextDueOdometerKm`.
+  List<ServiceReminder> findTriggered({
+    required String vehicleId,
+    required double currentOdometerKm,
+    required List<ServiceReminder> reminders,
+  }) {
+    return reminders
+        .where((r) =>
+            r.vehicleId == vehicleId &&
+            r.isActive &&
+            !r.pendingAcknowledgment &&
+            r.isDue(currentOdometerKm))
+        .toList();
+  }
+}

--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -5,10 +5,12 @@ import 'package:uuid/uuid.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../consumption/presentation/widgets/vehicle_adapter_section.dart';
 import '../../../consumption/presentation/widgets/vehicle_baseline_section.dart';
+import '../../../consumption/providers/consumption_providers.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/vehicle_profile.dart';
 import '../../providers/vehicle_providers.dart';
+import '../widgets/service_reminder_section.dart';
 import '../widgets/vehicle_combustion_section.dart';
 import '../widgets/vehicle_ev_section.dart';
 
@@ -173,6 +175,24 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     Navigator.of(context).pop();
   }
 
+  /// Latest odometer reading logged for [vehicleId], picked from the
+  /// fill-up history (#584). Falls back to null so the reminder
+  /// section can prompt the user for a manual entry.
+  double? _latestOdometerKm(String vehicleId) {
+    try {
+      final fillUps = ref.watch(fillUpListProvider);
+      final forVehicle = fillUps.where((f) => f.vehicleId == vehicleId);
+      if (forVehicle.isEmpty) return null;
+      final latest = forVehicle.reduce(
+        (a, b) => a.odometerKm > b.odometerKm ? a : b,
+      );
+      return latest.odometerKm;
+    } catch (e) {
+      debugPrint('EditVehicleScreen: odometer lookup failed: $e');
+      return null;
+    }
+  }
+
   /// Translates a vehicle's type + stored `preferredFuelType` into the
   /// canonical [FuelType] the rest of the app uses (#710). EV always
   /// maps to electric; combustion parses via [FuelType.fromString].
@@ -282,6 +302,18 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
             if (_existingId != null) ...[
               const SizedBox(height: 24),
               VehicleBaselineSection(vehicleId: _existingId!),
+            ],
+            // Service reminders (#584). Needs a stable vehicle id —
+            // the id is the foreign key stored on each reminder — so
+            // the section only renders for saved vehicles. Users
+            // adding a new vehicle hit Save first, then return to
+            // edit and see this section.
+            if (_existingId != null) ...[
+              const SizedBox(height: 24),
+              ServiceReminderSection(
+                vehicleId: _existingId!,
+                currentOdometerKm: _latestOdometerKm(_existingId!),
+              ),
             ],
             const SizedBox(height: 32),
             FilledButton.icon(

--- a/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
+++ b/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
@@ -1,0 +1,309 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/service_reminder.dart';
+import '../../providers/service_reminder_providers.dart';
+
+/// Service-reminders section of the vehicle edit screen (#584).
+///
+/// Renders a preset chip row ("Oil 15000 km", "Tires 20000 km",
+/// "Inspection 30000 km"), the list of currently configured
+/// reminders, and a free-form "Add reminder" action for custom
+/// intervals. The parent screen provides [vehicleId] and the current
+/// odometer (used when the user marks a reminder done).
+///
+/// The section hides itself when [vehicleId] is null — reminders
+/// need a stable id so they can be attached. The edit screen lets
+/// the user save a new vehicle first to unlock this section.
+class ServiceReminderSection extends ConsumerWidget {
+  final String vehicleId;
+
+  /// Best-known odometer reading for this vehicle — used for the
+  /// "mark as done" action. May be null when no fill-up has been
+  /// logged yet, in which case the mark-done action prompts the
+  /// user for the value.
+  final double? currentOdometerKm;
+
+  const ServiceReminderSection({
+    super.key,
+    required this.vehicleId,
+    this.currentOdometerKm,
+  });
+
+  static const _uuid = Uuid();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context);
+    final reminders = ref.watch(serviceRemindersForVehicleProvider(vehicleId));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          l?.serviceRemindersSection ?? 'Service reminders',
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        const SizedBox(height: 8),
+        _PresetChipRow(
+          onAdd: (label, interval) => _addPreset(ref, label, interval),
+        ),
+        const SizedBox(height: 8),
+        if (reminders.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Text(
+              l?.serviceRemindersEmpty ??
+                  'No reminders yet — pick a preset above.',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          )
+        else
+          ...reminders.map(
+            (r) => _ReminderRow(
+              reminder: r,
+              currentOdometerKm: currentOdometerKm,
+              onMarkDone: () => _markDone(context, ref, r),
+              onDelete: () => _delete(ref, r.id),
+            ),
+          ),
+        const SizedBox(height: 8),
+        OutlinedButton.icon(
+          icon: const Icon(Icons.add),
+          label: Text(l?.addServiceReminder ?? 'Add reminder'),
+          onPressed: () => _promptCustom(context, ref),
+        ),
+      ],
+    );
+  }
+
+  void _addPreset(WidgetRef ref, String label, double intervalKm) {
+    final reminder = ServiceReminder(
+      id: _uuid.v4(),
+      vehicleId: vehicleId,
+      label: label,
+      intervalKm: intervalKm,
+      lastServiceOdometerKm: currentOdometerKm,
+    );
+    ref.read(serviceReminderListProvider.notifier).save(reminder);
+  }
+
+  void _delete(WidgetRef ref, String id) {
+    ref.read(serviceReminderListProvider.notifier).remove(id);
+  }
+
+  Future<void> _markDone(
+    BuildContext context,
+    WidgetRef ref,
+    ServiceReminder reminder,
+  ) async {
+    double? odo = currentOdometerKm;
+    if (odo == null) {
+      odo = await _promptForOdometer(context);
+      if (odo == null) return;
+    }
+    await ref
+        .read(serviceReminderListProvider.notifier)
+        .markDone(reminder.id, odo);
+  }
+
+  Future<double?> _promptForOdometer(BuildContext context) async {
+    final l = AppLocalizations.of(context);
+    final controller = TextEditingController();
+    try {
+      return await showDialog<double>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: Text(l?.serviceReminderMarkDone ?? 'Mark as done'),
+          content: TextField(
+            controller: controller,
+            autofocus: true,
+            keyboardType:
+                const TextInputType.numberWithOptions(decimal: true),
+            decoration: InputDecoration(
+              labelText: l?.odometerKm ?? 'Odometer (km)',
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: Text(l?.cancel ?? 'Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final value = double.tryParse(
+                    controller.text.trim().replaceAll(',', '.'));
+                Navigator.of(ctx).pop(value);
+              },
+              child: Text(l?.save ?? 'Save'),
+            ),
+          ],
+        ),
+      );
+    } finally {
+      controller.dispose();
+    }
+  }
+
+  Future<void> _promptCustom(BuildContext context, WidgetRef ref) async {
+    final l = AppLocalizations.of(context);
+    final labelCtrl = TextEditingController();
+    final intervalCtrl = TextEditingController();
+    try {
+      final added = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: Text(l?.addServiceReminder ?? 'Add reminder'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: labelCtrl,
+                autofocus: true,
+                decoration: InputDecoration(
+                  labelText: l?.serviceReminderLabel ?? 'Label',
+                ),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: intervalCtrl,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: false),
+                decoration: InputDecoration(
+                  labelText: l?.serviceReminderInterval ?? 'Interval (km)',
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: Text(l?.cancel ?? 'Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: Text(l?.save ?? 'Save'),
+            ),
+          ],
+        ),
+      );
+      if (added != true) return;
+      final label = labelCtrl.text.trim();
+      final interval = double.tryParse(
+        intervalCtrl.text.trim().replaceAll(',', '.'),
+      );
+      if (label.isEmpty || interval == null || interval <= 0) return;
+      final reminder = ServiceReminder(
+        id: _uuid.v4(),
+        vehicleId: vehicleId,
+        label: label,
+        intervalKm: interval,
+        lastServiceOdometerKm: currentOdometerKm,
+      );
+      await ref.read(serviceReminderListProvider.notifier).save(reminder);
+    } finally {
+      labelCtrl.dispose();
+      intervalCtrl.dispose();
+    }
+  }
+}
+
+class _PresetChipRow extends StatelessWidget {
+  final void Function(String label, double intervalKm) onAdd;
+
+  const _PresetChipRow({required this.onAdd});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        ActionChip(
+          avatar: const Icon(Icons.oil_barrel_outlined, size: 18),
+          label:
+              Text(l?.serviceReminderPresetOil ?? 'Oil (15,000 km)'),
+          onPressed: () =>
+              onAdd(l?.serviceReminderPresetOilLabel ?? 'Oil change', 15000),
+        ),
+        ActionChip(
+          avatar: const Icon(Icons.tire_repair_outlined, size: 18),
+          label:
+              Text(l?.serviceReminderPresetTires ?? 'Tires (20,000 km)'),
+          onPressed: () =>
+              onAdd(l?.serviceReminderPresetTiresLabel ?? 'Tires', 20000),
+        ),
+        ActionChip(
+          avatar: const Icon(Icons.build_outlined, size: 18),
+          label: Text(
+              l?.serviceReminderPresetInspection ?? 'Inspection (30,000 km)'),
+          onPressed: () => onAdd(
+              l?.serviceReminderPresetInspectionLabel ?? 'Inspection', 30000),
+        ),
+      ],
+    );
+  }
+}
+
+class _ReminderRow extends StatelessWidget {
+  final ServiceReminder reminder;
+  final double? currentOdometerKm;
+  final VoidCallback onMarkDone;
+  final VoidCallback onDelete;
+
+  const _ReminderRow({
+    required this.reminder,
+    required this.currentOdometerKm,
+    required this.onMarkDone,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final intervalText = '${reminder.intervalKm.round()} km';
+    final lastService = reminder.lastServiceOdometerKm;
+    final subtitle = lastService == null
+        ? intervalText
+        : '$intervalText • '
+            '${l?.serviceReminderLastService ?? 'Last service'}: '
+            '${lastService.round()} km';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        children: [
+          Icon(
+            reminder.pendingAcknowledgment
+                ? Icons.notification_important
+                : Icons.build_circle_outlined,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(reminder.label),
+                Text(subtitle,
+                    style: Theme.of(context).textTheme.bodySmall),
+              ],
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.check_circle_outline),
+            tooltip: l?.serviceReminderMarkDone ?? 'Mark as done',
+            onPressed: onMarkDone,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: l?.delete ?? 'Delete',
+            onPressed: onDelete,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/vehicle/providers/service_reminder_providers.dart
+++ b/lib/features/vehicle/providers/service_reminder_providers.dart
@@ -1,0 +1,83 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/notifications/notification_providers.dart';
+import '../data/repositories/service_reminder_repository.dart';
+import '../domain/entities/service_reminder.dart';
+import '../domain/services/service_reminder_evaluator.dart';
+
+part 'service_reminder_providers.g.dart';
+
+/// Repository for CRUD on [ServiceReminder] entries (#584).
+///
+/// Opens against the already-registered `service_reminders` Hive box
+/// (see [HiveBoxes.serviceReminders]).
+@Riverpod(keepAlive: true)
+ServiceReminderRepository serviceReminderRepository(Ref ref) {
+  return ServiceReminderRepository.fromHive();
+}
+
+/// Evaluator that combines [ServiceReminderRepository] with the
+/// app's [NotificationService]. Exposed as a provider so the fill-up
+/// save path can fire it after a new fill-up is persisted.
+@Riverpod(keepAlive: true)
+ServiceReminderEvaluator serviceReminderEvaluator(Ref ref) {
+  return ServiceReminderEvaluator(
+    repository: ref.watch(serviceReminderRepositoryProvider),
+    notifications: ref.watch(notificationServiceProvider),
+  );
+}
+
+/// Mutable list of every stored reminder. Individual screens watch
+/// [serviceRemindersForVehicle] — this provider is the source of
+/// truth for the mutations.
+@Riverpod(keepAlive: true)
+class ServiceReminderList extends _$ServiceReminderList {
+  @override
+  List<ServiceReminder> build() {
+    return ref.watch(serviceReminderRepositoryProvider).getAll();
+  }
+
+  Future<void> save(ServiceReminder reminder) async {
+    await ref.read(serviceReminderRepositoryProvider).save(reminder);
+    state = ref.read(serviceReminderRepositoryProvider).getAll();
+  }
+
+  Future<void> remove(String id) async {
+    await ref.read(serviceReminderRepositoryProvider).delete(id);
+    state = ref.read(serviceReminderRepositoryProvider).getAll();
+  }
+
+  /// Mark the reminder done at [currentOdometerKm] — rebases the
+  /// threshold and clears the pending flag.
+  Future<void> markDone(String id, double currentOdometerKm) async {
+    await ref
+        .read(serviceReminderRepositoryProvider)
+        .markDone(id, currentOdometerKm);
+    state = ref.read(serviceReminderRepositoryProvider).getAll();
+  }
+
+  /// Used when a vehicle is deleted — cascades the reminders so the
+  /// box does not accumulate orphans.
+  Future<void> removeAllForVehicle(String vehicleId) async {
+    await ref
+        .read(serviceReminderRepositoryProvider)
+        .deleteForVehicle(vehicleId);
+    state = ref.read(serviceReminderRepositoryProvider).getAll();
+  }
+}
+
+/// Derived list of reminders attached to a specific vehicle.
+///
+/// Vehicle-edit UI watches this instead of the global list so a
+/// reminder change on one vehicle doesn't invalidate the edit screen
+/// of another.
+@riverpod
+List<ServiceReminder> serviceRemindersForVehicle(
+  Ref ref,
+  String vehicleId,
+) {
+  return ref
+      .watch(serviceReminderListProvider)
+      .where((r) => r.vehicleId == vehicleId)
+      .toList();
+}

--- a/lib/features/vehicle/providers/service_reminder_providers.g.dart
+++ b/lib/features/vehicle/providers/service_reminder_providers.g.dart
@@ -1,0 +1,311 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'service_reminder_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Repository for CRUD on [ServiceReminder] entries (#584).
+///
+/// Opens against the already-registered `service_reminders` Hive box
+/// (see [HiveBoxes.serviceReminders]).
+
+@ProviderFor(serviceReminderRepository)
+final serviceReminderRepositoryProvider = ServiceReminderRepositoryProvider._();
+
+/// Repository for CRUD on [ServiceReminder] entries (#584).
+///
+/// Opens against the already-registered `service_reminders` Hive box
+/// (see [HiveBoxes.serviceReminders]).
+
+final class ServiceReminderRepositoryProvider
+    extends
+        $FunctionalProvider<
+          ServiceReminderRepository,
+          ServiceReminderRepository,
+          ServiceReminderRepository
+        >
+    with $Provider<ServiceReminderRepository> {
+  /// Repository for CRUD on [ServiceReminder] entries (#584).
+  ///
+  /// Opens against the already-registered `service_reminders` Hive box
+  /// (see [HiveBoxes.serviceReminders]).
+  ServiceReminderRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'serviceReminderRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$serviceReminderRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<ServiceReminderRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ServiceReminderRepository create(Ref ref) {
+    return serviceReminderRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ServiceReminderRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ServiceReminderRepository>(value),
+    );
+  }
+}
+
+String _$serviceReminderRepositoryHash() =>
+    r'b62354f1ce62244f630cbb67a12035c0b9f35cbd';
+
+/// Evaluator that combines [ServiceReminderRepository] with the
+/// app's [NotificationService]. Exposed as a provider so the fill-up
+/// save path can fire it after a new fill-up is persisted.
+
+@ProviderFor(serviceReminderEvaluator)
+final serviceReminderEvaluatorProvider = ServiceReminderEvaluatorProvider._();
+
+/// Evaluator that combines [ServiceReminderRepository] with the
+/// app's [NotificationService]. Exposed as a provider so the fill-up
+/// save path can fire it after a new fill-up is persisted.
+
+final class ServiceReminderEvaluatorProvider
+    extends
+        $FunctionalProvider<
+          ServiceReminderEvaluator,
+          ServiceReminderEvaluator,
+          ServiceReminderEvaluator
+        >
+    with $Provider<ServiceReminderEvaluator> {
+  /// Evaluator that combines [ServiceReminderRepository] with the
+  /// app's [NotificationService]. Exposed as a provider so the fill-up
+  /// save path can fire it after a new fill-up is persisted.
+  ServiceReminderEvaluatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'serviceReminderEvaluatorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$serviceReminderEvaluatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<ServiceReminderEvaluator> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ServiceReminderEvaluator create(Ref ref) {
+    return serviceReminderEvaluator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ServiceReminderEvaluator value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ServiceReminderEvaluator>(value),
+    );
+  }
+}
+
+String _$serviceReminderEvaluatorHash() =>
+    r'b46da525c9cea889a8a7c0c6f9ee484cc0c88835';
+
+/// Mutable list of every stored reminder. Individual screens watch
+/// [serviceRemindersForVehicle] — this provider is the source of
+/// truth for the mutations.
+
+@ProviderFor(ServiceReminderList)
+final serviceReminderListProvider = ServiceReminderListProvider._();
+
+/// Mutable list of every stored reminder. Individual screens watch
+/// [serviceRemindersForVehicle] — this provider is the source of
+/// truth for the mutations.
+final class ServiceReminderListProvider
+    extends $NotifierProvider<ServiceReminderList, List<ServiceReminder>> {
+  /// Mutable list of every stored reminder. Individual screens watch
+  /// [serviceRemindersForVehicle] — this provider is the source of
+  /// truth for the mutations.
+  ServiceReminderListProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'serviceReminderListProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$serviceReminderListHash();
+
+  @$internal
+  @override
+  ServiceReminderList create() => ServiceReminderList();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<ServiceReminder> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<ServiceReminder>>(value),
+    );
+  }
+}
+
+String _$serviceReminderListHash() =>
+    r'70cfd31b0c39b078716e14f1857bdc18b68d13d4';
+
+/// Mutable list of every stored reminder. Individual screens watch
+/// [serviceRemindersForVehicle] — this provider is the source of
+/// truth for the mutations.
+
+abstract class _$ServiceReminderList extends $Notifier<List<ServiceReminder>> {
+  List<ServiceReminder> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<List<ServiceReminder>, List<ServiceReminder>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<List<ServiceReminder>, List<ServiceReminder>>,
+              List<ServiceReminder>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+/// Derived list of reminders attached to a specific vehicle.
+///
+/// Vehicle-edit UI watches this instead of the global list so a
+/// reminder change on one vehicle doesn't invalidate the edit screen
+/// of another.
+
+@ProviderFor(serviceRemindersForVehicle)
+final serviceRemindersForVehicleProvider = ServiceRemindersForVehicleFamily._();
+
+/// Derived list of reminders attached to a specific vehicle.
+///
+/// Vehicle-edit UI watches this instead of the global list so a
+/// reminder change on one vehicle doesn't invalidate the edit screen
+/// of another.
+
+final class ServiceRemindersForVehicleProvider
+    extends
+        $FunctionalProvider<
+          List<ServiceReminder>,
+          List<ServiceReminder>,
+          List<ServiceReminder>
+        >
+    with $Provider<List<ServiceReminder>> {
+  /// Derived list of reminders attached to a specific vehicle.
+  ///
+  /// Vehicle-edit UI watches this instead of the global list so a
+  /// reminder change on one vehicle doesn't invalidate the edit screen
+  /// of another.
+  ServiceRemindersForVehicleProvider._({
+    required ServiceRemindersForVehicleFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'serviceRemindersForVehicleProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$serviceRemindersForVehicleHash();
+
+  @override
+  String toString() {
+    return r'serviceRemindersForVehicleProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<List<ServiceReminder>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  List<ServiceReminder> create(Ref ref) {
+    final argument = this.argument as String;
+    return serviceRemindersForVehicle(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<ServiceReminder> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<ServiceReminder>>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ServiceRemindersForVehicleProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$serviceRemindersForVehicleHash() =>
+    r'ae77757632a19115643230f6b8d5abfe87cf4ff7';
+
+/// Derived list of reminders attached to a specific vehicle.
+///
+/// Vehicle-edit UI watches this instead of the global list so a
+/// reminder change on one vehicle doesn't invalidate the edit screen
+/// of another.
+
+final class ServiceRemindersForVehicleFamily extends $Family
+    with $FunctionalFamilyOverride<List<ServiceReminder>, String> {
+  ServiceRemindersForVehicleFamily._()
+    : super(
+        retry: null,
+        name: r'serviceRemindersForVehicleProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Derived list of reminders attached to a specific vehicle.
+  ///
+  /// Vehicle-edit UI watches this instead of the global list so a
+  /// reminder change on one vehicle doesn't invalidate the edit screen
+  /// of another.
+
+  ServiceRemindersForVehicleProvider call(String vehicleId) =>
+      ServiceRemindersForVehicleProvider._(argument: vehicleId, from: this);
+
+  @override
+  String toString() => r'serviceRemindersForVehicleProvider';
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1174,5 +1174,20 @@
   "wrongLpgPrice": "Falscher LPG Preis",
   "wrongStationName": "Falscher Tankstellenname",
   "wrongStationAddress": "Falsche Adresse",
-  "independentStation": "Unabhängige Tankstelle"
+  "independentStation": "Unabhängige Tankstelle",
+  "serviceRemindersSection": "Wartungserinnerungen",
+  "serviceRemindersEmpty": "Noch keine Erinnerungen — wähle oben eine Vorlage.",
+  "addServiceReminder": "Erinnerung hinzufügen",
+  "serviceReminderPresetOil": "Öl (15.000 km)",
+  "serviceReminderPresetOilLabel": "Ölwechsel",
+  "serviceReminderPresetTires": "Reifen (20.000 km)",
+  "serviceReminderPresetTiresLabel": "Reifen",
+  "serviceReminderPresetInspection": "Inspektion (30.000 km)",
+  "serviceReminderPresetInspectionLabel": "Inspektion",
+  "serviceReminderLabel": "Bezeichnung",
+  "serviceReminderInterval": "Intervall (km)",
+  "serviceReminderLastService": "Letzter Service",
+  "serviceReminderMarkDone": "Als erledigt markieren",
+  "serviceReminderDueTitle": "Wartung fällig",
+  "serviceReminderDueBody": "{label} ist fällig — {kmOver} km über dem Intervall."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1212,5 +1212,26 @@
   "wrongLpgPrice": "Wrong LPG price",
   "wrongStationName": "Wrong station name",
   "wrongStationAddress": "Wrong address",
-  "independentStation": "Independent station"
+  "independentStation": "Independent station",
+  "serviceRemindersSection": "Service reminders",
+  "serviceRemindersEmpty": "No reminders yet — pick a preset above.",
+  "addServiceReminder": "Add reminder",
+  "serviceReminderPresetOil": "Oil (15,000 km)",
+  "serviceReminderPresetOilLabel": "Oil change",
+  "serviceReminderPresetTires": "Tires (20,000 km)",
+  "serviceReminderPresetTiresLabel": "Tires",
+  "serviceReminderPresetInspection": "Inspection (30,000 km)",
+  "serviceReminderPresetInspectionLabel": "Inspection",
+  "serviceReminderLabel": "Label",
+  "serviceReminderInterval": "Interval (km)",
+  "serviceReminderLastService": "Last service",
+  "serviceReminderMarkDone": "Mark as done",
+  "serviceReminderDueTitle": "Service due",
+  "serviceReminderDueBody": "{label} is due — {kmOver} km past the interval.",
+  "@serviceReminderDueBody": {
+    "placeholders": {
+      "label": { "type": "String", "example": "Oil change" },
+      "kmOver": { "type": "int", "example": "250" }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5574,6 +5574,96 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Independent station'**
   String get independentStation;
+
+  /// No description provided for @serviceRemindersSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Service reminders'**
+  String get serviceRemindersSection;
+
+  /// No description provided for @serviceRemindersEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No reminders yet — pick a preset above.'**
+  String get serviceRemindersEmpty;
+
+  /// No description provided for @addServiceReminder.
+  ///
+  /// In en, this message translates to:
+  /// **'Add reminder'**
+  String get addServiceReminder;
+
+  /// No description provided for @serviceReminderPresetOil.
+  ///
+  /// In en, this message translates to:
+  /// **'Oil (15,000 km)'**
+  String get serviceReminderPresetOil;
+
+  /// No description provided for @serviceReminderPresetOilLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Oil change'**
+  String get serviceReminderPresetOilLabel;
+
+  /// No description provided for @serviceReminderPresetTires.
+  ///
+  /// In en, this message translates to:
+  /// **'Tires (20,000 km)'**
+  String get serviceReminderPresetTires;
+
+  /// No description provided for @serviceReminderPresetTiresLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Tires'**
+  String get serviceReminderPresetTiresLabel;
+
+  /// No description provided for @serviceReminderPresetInspection.
+  ///
+  /// In en, this message translates to:
+  /// **'Inspection (30,000 km)'**
+  String get serviceReminderPresetInspection;
+
+  /// No description provided for @serviceReminderPresetInspectionLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Inspection'**
+  String get serviceReminderPresetInspectionLabel;
+
+  /// No description provided for @serviceReminderLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Label'**
+  String get serviceReminderLabel;
+
+  /// No description provided for @serviceReminderInterval.
+  ///
+  /// In en, this message translates to:
+  /// **'Interval (km)'**
+  String get serviceReminderInterval;
+
+  /// No description provided for @serviceReminderLastService.
+  ///
+  /// In en, this message translates to:
+  /// **'Last service'**
+  String get serviceReminderLastService;
+
+  /// No description provided for @serviceReminderMarkDone.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark as done'**
+  String get serviceReminderMarkDone;
+
+  /// No description provided for @serviceReminderDueTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Service due'**
+  String get serviceReminderDueTitle;
+
+  /// No description provided for @serviceReminderDueBody.
+  ///
+  /// In en, this message translates to:
+  /// **'{label} is due — {kmOver} km past the interval.'**
+  String serviceReminderDueBody(String label, int kmOver);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2958,4 +2958,51 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2958,4 +2958,51 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2956,4 +2956,51 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2977,4 +2977,52 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get independentStation => 'Unabhängige Tankstelle';
+
+  @override
+  String get serviceRemindersSection => 'Wartungserinnerungen';
+
+  @override
+  String get serviceRemindersEmpty =>
+      'Noch keine Erinnerungen — wähle oben eine Vorlage.';
+
+  @override
+  String get addServiceReminder => 'Erinnerung hinzufügen';
+
+  @override
+  String get serviceReminderPresetOil => 'Öl (15.000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Ölwechsel';
+
+  @override
+  String get serviceReminderPresetTires => 'Reifen (20.000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Reifen';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspektion (30.000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspektion';
+
+  @override
+  String get serviceReminderLabel => 'Bezeichnung';
+
+  @override
+  String get serviceReminderInterval => 'Intervall (km)';
+
+  @override
+  String get serviceReminderLastService => 'Letzter Service';
+
+  @override
+  String get serviceReminderMarkDone => 'Als erledigt markieren';
+
+  @override
+  String get serviceReminderDueTitle => 'Wartung fällig';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label ist fällig — $kmOver km über dem Intervall.';
+  }
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2960,4 +2960,51 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2951,4 +2951,51 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2959,4 +2959,51 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2953,4 +2953,51 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2956,4 +2956,51 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2980,4 +2980,51 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2955,4 +2955,51 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2960,4 +2960,51 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2959,4 +2959,51 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2957,4 +2957,51 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2959,4 +2959,51 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2955,4 +2955,51 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2960,4 +2960,51 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2958,4 +2958,51 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2959,4 +2959,51 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2958,4 +2958,51 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2959,4 +2959,51 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2953,4 +2953,51 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2957,4 +2957,51 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get independentStation => 'Independent station';
+
+  @override
+  String get serviceRemindersSection => 'Service reminders';
+
+  @override
+  String get serviceRemindersEmpty => 'No reminders yet — pick a preset above.';
+
+  @override
+  String get addServiceReminder => 'Add reminder';
+
+  @override
+  String get serviceReminderPresetOil => 'Oil (15,000 km)';
+
+  @override
+  String get serviceReminderPresetOilLabel => 'Oil change';
+
+  @override
+  String get serviceReminderPresetTires => 'Tires (20,000 km)';
+
+  @override
+  String get serviceReminderPresetTiresLabel => 'Tires';
+
+  @override
+  String get serviceReminderPresetInspection => 'Inspection (30,000 km)';
+
+  @override
+  String get serviceReminderPresetInspectionLabel => 'Inspection';
+
+  @override
+  String get serviceReminderLabel => 'Label';
+
+  @override
+  String get serviceReminderInterval => 'Interval (km)';
+
+  @override
+  String get serviceReminderLastService => 'Last service';
+
+  @override
+  String get serviceReminderMarkDone => 'Mark as done';
+
+  @override
+  String get serviceReminderDueTitle => 'Service due';
+
+  @override
+  String serviceReminderDueBody(String label, int kmOver) {
+    return '$label is due — $kmOver km past the interval.';
+  }
 }

--- a/test/core/notifications/notification_service_test.dart
+++ b/test/core/notifications/notification_service_test.dart
@@ -7,6 +7,7 @@ import 'package:tankstellen/core/notifications/notification_service.dart';
 class FakeNotificationService implements NotificationService {
   bool initialized = false;
   final List<({int id, String title, String body})> shownAlerts = [];
+  final List<({int id, String title, String body})> shownServiceReminders = [];
   final List<int> cancelledIds = [];
   bool allCancelled = false;
 
@@ -22,6 +23,15 @@ class FakeNotificationService implements NotificationService {
     required String body,
   }) async {
     shownAlerts.add((id: id, title: title, body: body));
+  }
+
+  @override
+  Future<void> showServiceReminder({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    shownServiceReminders.add((id: id, title: title, body: body));
   }
 
   @override

--- a/test/features/vehicle/data/service_reminder_repository_test.dart
+++ b/test/features/vehicle/data/service_reminder_repository_test.dart
@@ -1,0 +1,159 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/service_reminder_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/service_reminder.dart';
+
+void main() {
+  late Directory tempDir;
+  late Box<String> box;
+  late ServiceReminderRepository repo;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('service_reminder_test_');
+    Hive.init(tempDir.path);
+    box = await Hive.openBox<String>(HiveBoxes.serviceReminders);
+    await box.clear();
+    repo = ServiceReminderRepository(box);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  const oilChange = ServiceReminder(
+    id: 'r-oil',
+    vehicleId: 'v-1',
+    label: 'Oil change',
+    intervalKm: 15000,
+    lastServiceOdometerKm: 0,
+  );
+
+  const tiresV1 = ServiceReminder(
+    id: 'r-tires-v1',
+    vehicleId: 'v-1',
+    label: 'Tires',
+    intervalKm: 40000,
+  );
+
+  const oilV2 = ServiceReminder(
+    id: 'r-oil-v2',
+    vehicleId: 'v-2',
+    label: 'Oil change',
+    intervalKm: 20000,
+  );
+
+  group('ServiceReminderRepository', () {
+    test('getAll returns empty on a fresh box', () {
+      expect(repo.getAll(), isEmpty);
+    });
+
+    test('save then getAll returns the reminder', () async {
+      await repo.save(oilChange);
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.id, 'r-oil');
+      expect(all.first.intervalKm, 15000);
+      expect(all.first.isActive, isTrue);
+      expect(all.first.pendingAcknowledgment, isFalse);
+    });
+
+    test('save updates an existing entry matched by id', () async {
+      await repo.save(oilChange);
+      await repo.save(oilChange.copyWith(intervalKm: 12000));
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.intervalKm, 12000);
+    });
+
+    test('getForVehicle filters by vehicleId', () async {
+      await repo.save(oilChange);
+      await repo.save(tiresV1);
+      await repo.save(oilV2);
+
+      final v1 = repo.getForVehicle('v-1');
+      expect(v1.map((r) => r.id).toSet(), {'r-oil', 'r-tires-v1'});
+
+      final v2 = repo.getForVehicle('v-2');
+      expect(v2, hasLength(1));
+      expect(v2.first.id, 'r-oil-v2');
+    });
+
+    test('getById returns the stored reminder', () async {
+      await repo.save(oilChange);
+      final r = repo.getById('r-oil');
+      expect(r, isNotNull);
+      expect(r!.label, 'Oil change');
+    });
+
+    test('getById returns null for missing id', () {
+      expect(repo.getById('missing'), isNull);
+    });
+
+    test('delete removes the reminder', () async {
+      await repo.save(oilChange);
+      await repo.save(tiresV1);
+      await repo.delete('r-oil');
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.id, 'r-tires-v1');
+    });
+
+    test('delete is a no-op for unknown ids', () async {
+      await repo.save(oilChange);
+      await repo.delete('missing');
+      expect(repo.getAll(), hasLength(1));
+    });
+
+    test('deleteForVehicle cascades reminders of a given vehicle', () async {
+      await repo.save(oilChange);
+      await repo.save(tiresV1);
+      await repo.save(oilV2);
+
+      await repo.deleteForVehicle('v-1');
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.vehicleId, 'v-2');
+    });
+
+    test('markDone rebases lastService and clears pending flag', () async {
+      await repo.save(oilChange.copyWith(pendingAcknowledgment: true));
+      final updated = await repo.markDone('r-oil', 15200);
+      expect(updated, isNotNull);
+      expect(updated!.lastServiceOdometerKm, 15200);
+      expect(updated.pendingAcknowledgment, isFalse);
+
+      final reloaded = repo.getById('r-oil');
+      expect(reloaded!.lastServiceOdometerKm, 15200);
+      expect(reloaded.pendingAcknowledgment, isFalse);
+    });
+
+    test('markDone returns null for unknown id', () async {
+      final updated = await repo.markDone('missing', 123);
+      expect(updated, isNull);
+    });
+
+    test('clear empties the box', () async {
+      await repo.save(oilChange);
+      await repo.save(tiresV1);
+      await repo.clear();
+      expect(repo.getAll(), isEmpty);
+    });
+
+    test('malformed entries are skipped without crashing', () async {
+      await repo.save(oilChange);
+      await box.put('garbage', 'not valid json');
+      // A syntactically valid JSON that is missing required fields.
+      await box.put('half-valid', '{"id":"x"}');
+
+      final all = repo.getAll();
+      expect(all, hasLength(1));
+      expect(all.first.id, 'r-oil');
+    });
+  });
+}

--- a/test/features/vehicle/domain/entities/service_reminder_test.dart
+++ b/test/features/vehicle/domain/entities/service_reminder_test.dart
@@ -6,6 +6,7 @@ void main() {
     test('nextDueOdometerKm = lastServiceOdometerKm + intervalKm', () {
       const r = ServiceReminder(
         id: '1',
+        vehicleId: 'v1',
         label: 'Oil change',
         intervalKm: 15000,
         lastServiceOdometerKm: 42000,
@@ -16,6 +17,7 @@ void main() {
     test('nextDueOdometerKm = intervalKm when lastService is null', () {
       const r = ServiceReminder(
         id: '1',
+        vehicleId: 'v1',
         label: 'Oil change',
         intervalKm: 15000,
       );
@@ -25,6 +27,7 @@ void main() {
     test('isDue fires at the exact threshold', () {
       const r = ServiceReminder(
         id: '1',
+        vehicleId: 'v1',
         label: 'Oil change',
         intervalKm: 15000,
         lastServiceOdometerKm: 42000,
@@ -36,6 +39,7 @@ void main() {
     test('isDue stays true past the threshold', () {
       const r = ServiceReminder(
         id: '1',
+        vehicleId: 'v1',
         label: 'Oil change',
         intervalKm: 15000,
         lastServiceOdometerKm: 42000,
@@ -43,12 +47,55 @@ void main() {
       expect(r.isDue(60000), isTrue);
     });
 
+    test('kmOverdue returns positive overrun past the threshold', () {
+      const r = ServiceReminder(
+        id: '1',
+        vehicleId: 'v1',
+        label: 'Oil change',
+        intervalKm: 15000,
+        lastServiceOdometerKm: 0,
+      );
+      expect(r.kmOverdue(15000), 0);
+      expect(r.kmOverdue(15500), 500);
+      expect(r.kmOverdue(30500), 15500);
+    });
+
+    test('kmOverdue clamps to 0 before the threshold', () {
+      const r = ServiceReminder(
+        id: '1',
+        vehicleId: 'v1',
+        label: 'Oil change',
+        intervalKm: 15000,
+      );
+      expect(r.kmOverdue(14000), 0);
+    });
+
+    test('markDone resets lastService to the current odometer', () {
+      const r = ServiceReminder(
+        id: '1',
+        vehicleId: 'v1',
+        label: 'Oil change',
+        intervalKm: 15000,
+        lastServiceOdometerKm: 0,
+        pendingAcknowledgment: true,
+      );
+      final done = r.markDone(15200);
+      expect(done.lastServiceOdometerKm, 15200);
+      expect(done.pendingAcknowledgment, isFalse);
+      // After mark-done the threshold shifts 15000 km further out.
+      expect(done.isDue(20000), isFalse);
+      expect(done.isDue(30200), isTrue);
+    });
+
     test('JSON round-trip preserves every field', () {
       const r = ServiceReminder(
         id: 'r-1',
+        vehicleId: 'v-7',
         label: 'Tires',
         intervalKm: 40000,
         lastServiceOdometerKm: 18500,
+        isActive: false,
+        pendingAcknowledgment: true,
       );
       final json = r.toJson();
       final restored = ServiceReminder.fromJson(json);
@@ -58,12 +105,16 @@ void main() {
     test('JSON round-trip with null lastService preserves null', () {
       const r = ServiceReminder(
         id: 'r-1',
+        vehicleId: 'v-2',
         label: 'Inspection',
         intervalKm: 30000,
       );
       final json = r.toJson();
       final restored = ServiceReminder.fromJson(json);
       expect(restored.lastServiceOdometerKm, isNull);
+      // Defaults survive the round-trip.
+      expect(restored.isActive, isTrue);
+      expect(restored.pendingAcknowledgment, isFalse);
       expect(restored, r);
     });
   });

--- a/test/features/vehicle/domain/services/service_reminder_evaluator_test.dart
+++ b/test/features/vehicle/domain/services/service_reminder_evaluator_test.dart
@@ -1,0 +1,220 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/notifications/notification_service.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/service_reminder_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/service_reminder.dart';
+import 'package:tankstellen/features/vehicle/domain/services/service_reminder_evaluator.dart';
+
+/// Local fake that mirrors `test/core/notifications/notification_service_test.dart`.
+/// Duplicated on purpose so this test file stays self-contained and
+/// doesn't reach into another test file at import time.
+class _FakeNotificationService implements NotificationService {
+  final List<({int id, String title, String body})> serviceReminders = [];
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> showPriceAlert({
+    required int id,
+    required String title,
+    required String body,
+  }) async {}
+
+  @override
+  Future<void> showServiceReminder({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    serviceReminders.add((id: id, title: title, body: body));
+  }
+
+  @override
+  Future<void> cancelNotification(int id) async {}
+
+  @override
+  Future<void> cancelAll() async {}
+}
+
+void main() {
+  late Directory tempDir;
+  late Box<String> box;
+  late ServiceReminderRepository repo;
+  late _FakeNotificationService notifications;
+  late ServiceReminderEvaluator evaluator;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('reminder_eval_');
+    Hive.init(tempDir.path);
+    box = await Hive.openBox<String>(HiveBoxes.serviceReminders);
+    await box.clear();
+    repo = ServiceReminderRepository(box);
+    notifications = _FakeNotificationService();
+    evaluator = ServiceReminderEvaluator(
+      repository: repo,
+      notifications: notifications,
+    );
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('ServiceReminderEvaluator (#584)', () {
+    test('fires a notification when a reminder is due', () async {
+      await repo.save(
+        const ServiceReminder(
+          id: 'r-1',
+          vehicleId: 'v-1',
+          label: 'Oil change',
+          intervalKm: 15000,
+        ),
+      );
+
+      final fired = await evaluator.evaluate(
+        vehicleId: 'v-1',
+        currentOdometerKm: 15200,
+      );
+
+      expect(fired, hasLength(1));
+      expect(notifications.serviceReminders, hasLength(1));
+      expect(notifications.serviceReminders.first.title, 'Service due');
+      // Default-English fallback: "{label} is due — {kmOver} km past the interval."
+      expect(
+        notifications.serviceReminders.first.body,
+        contains('Oil change'),
+      );
+      expect(
+        notifications.serviceReminders.first.body,
+        contains('200'),
+      );
+    });
+
+    test('does not fire before the threshold', () async {
+      await repo.save(
+        const ServiceReminder(
+          id: 'r-1',
+          vehicleId: 'v-1',
+          label: 'Oil change',
+          intervalKm: 15000,
+        ),
+      );
+
+      final fired = await evaluator.evaluate(
+        vehicleId: 'v-1',
+        currentOdometerKm: 14000,
+      );
+
+      expect(fired, isEmpty);
+      expect(notifications.serviceReminders, isEmpty);
+    });
+
+    test('persists the pending flag once triggered', () async {
+      await repo.save(
+        const ServiceReminder(
+          id: 'r-1',
+          vehicleId: 'v-1',
+          label: 'Oil change',
+          intervalKm: 15000,
+        ),
+      );
+
+      await evaluator.evaluate(
+        vehicleId: 'v-1',
+        currentOdometerKm: 15001,
+      );
+
+      expect(repo.getById('r-1')!.pendingAcknowledgment, isTrue);
+    });
+
+    test('does not re-notify while pending', () async {
+      await repo.save(
+        const ServiceReminder(
+          id: 'r-1',
+          vehicleId: 'v-1',
+          label: 'Oil change',
+          intervalKm: 15000,
+        ),
+      );
+
+      await evaluator.evaluate(
+        vehicleId: 'v-1',
+        currentOdometerKm: 15200,
+      );
+      // Second fill-up further past the threshold — the reminder is
+      // still pending, so no new notification fires.
+      await evaluator.evaluate(
+        vehicleId: 'v-1',
+        currentOdometerKm: 15500,
+      );
+
+      expect(notifications.serviceReminders, hasLength(1));
+    });
+
+    test('after mark-done at 15000, odometer 20000 does not fire', () async {
+      const reminder = ServiceReminder(
+        id: 'r-1',
+        vehicleId: 'v-1',
+        label: 'Oil change',
+        intervalKm: 15000,
+      );
+      await repo.save(reminder);
+      await repo.markDone('r-1', 15000);
+
+      await evaluator.evaluate(
+        vehicleId: 'v-1',
+        currentOdometerKm: 20000,
+      );
+
+      expect(notifications.serviceReminders, isEmpty);
+    });
+
+    test('notification id is stable for the same reminder id', () {
+      const id = 'reminder-12345';
+      expect(
+        ServiceReminderEvaluator.notificationIdFor(id),
+        ServiceReminderEvaluator.notificationIdFor(id),
+      );
+      // Different reminders should generally map to different ids.
+      expect(
+        ServiceReminderEvaluator.notificationIdFor('reminder-a'),
+        isNot(ServiceReminderEvaluator.notificationIdFor('reminder-b')),
+      );
+    });
+
+    test('respects a localised messages bundle', () async {
+      await repo.save(
+        const ServiceReminder(
+          id: 'r-1',
+          vehicleId: 'v-1',
+          label: 'Reifen',
+          intervalKm: 20000,
+        ),
+      );
+
+      await evaluator.evaluate(
+        vehicleId: 'v-1',
+        currentOdometerKm: 21000,
+        messages: ServiceReminderMessages(
+          title: 'Wartung fällig',
+          bodyFor: ({required String label, required int kmOver}) =>
+              '$label ist fällig — $kmOver km über dem Intervall.',
+        ),
+      );
+
+      expect(notifications.serviceReminders, hasLength(1));
+      expect(notifications.serviceReminders.first.title, 'Wartung fällig');
+      expect(
+        notifications.serviceReminders.first.body,
+        'Reifen ist fällig — 1000 km über dem Intervall.',
+      );
+    });
+  });
+}

--- a/test/features/vehicle/domain/services/service_reminder_trigger_test.dart
+++ b/test/features/vehicle/domain/services/service_reminder_trigger_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/service_reminder.dart';
+import 'package:tankstellen/features/vehicle/domain/services/service_reminder_trigger.dart';
+
+void main() {
+  const trigger = ServiceReminderTrigger();
+
+  group('ServiceReminderTrigger (#584)', () {
+    // Baseline scenario straight out of the issue:
+    //   lastServiceOdometerKm = 0, intervalKm = 15000
+    const active = ServiceReminder(
+      id: 'r-oil',
+      vehicleId: 'v-1',
+      label: 'Oil change',
+      intervalKm: 15000,
+      lastServiceOdometerKm: 0,
+    );
+
+    test('odometer 14999 does not trigger', () {
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 14999,
+        reminders: const [active],
+      );
+      expect(result, isEmpty);
+    });
+
+    test('odometer 15000 triggers exactly at the threshold', () {
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 15000,
+        reminders: const [active],
+      );
+      expect(result, hasLength(1));
+      expect(result.first.id, 'r-oil');
+    });
+
+    test('odometer 15001 triggers one km past the threshold', () {
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 15001,
+        reminders: const [active],
+      );
+      expect(result, hasLength(1));
+    });
+
+    test('odometer 30500 still triggers — the reminder has not been reset',
+        () {
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 30500,
+        reminders: const [active],
+      );
+      expect(result, hasLength(1));
+    });
+
+    test('after markDone at 15000, odometer 20000 does not trigger', () {
+      final afterDone = active.markDone(15000);
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 20000,
+        reminders: [afterDone],
+      );
+      expect(result, isEmpty);
+    });
+
+    test('after markDone at 15000, odometer 30000 triggers again', () {
+      final afterDone = active.markDone(15000);
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 30000,
+        reminders: [afterDone],
+      );
+      expect(result, hasLength(1));
+    });
+
+    test('isActive=false reminders are skipped even when past threshold', () {
+      final paused = active.copyWith(isActive: false);
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 20000,
+        reminders: [paused],
+      );
+      expect(result, isEmpty);
+    });
+
+    test('reminders already pending are not re-triggered', () {
+      final pending = active.copyWith(pendingAcknowledgment: true);
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 30000,
+        reminders: [pending],
+      );
+      expect(result, isEmpty);
+    });
+
+    test('only reminders for the fill-up vehicle are considered', () {
+      const otherVehicleReminder = ServiceReminder(
+        id: 'r-oil-v2',
+        vehicleId: 'v-2',
+        label: 'Oil change',
+        intervalKm: 15000,
+      );
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 30000,
+        reminders: const [otherVehicleReminder, active],
+      );
+      expect(result.map((r) => r.id), ['r-oil']);
+    });
+
+    test('returns every matching reminder when several are due', () {
+      const tires = ServiceReminder(
+        id: 'r-tires',
+        vehicleId: 'v-1',
+        label: 'Tires',
+        intervalKm: 20000,
+      );
+      const inspection = ServiceReminder(
+        id: 'r-inspection',
+        vehicleId: 'v-1',
+        label: 'Inspection',
+        intervalKm: 30000,
+      );
+      final result = trigger.findTriggered(
+        vehicleId: 'v-1',
+        currentOdometerKm: 40000,
+        reminders: const [active, tires, inspection],
+      );
+      expect(result.map((r) => r.id).toSet(),
+          {'r-oil', 'r-tires', 'r-inspection'});
+    });
+  });
+}

--- a/test/features/vehicle/presentation/widgets/service_reminder_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/service_reminder_section_test.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/service_reminder_repository.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/service_reminder_section.dart';
+import 'package:tankstellen/features/vehicle/providers/service_reminder_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Render tests for [ServiceReminderSection] (#584). Focuses on the
+/// empty-state UI because the preset chips are the only UI the user
+/// interacts with on a fresh vehicle. Tap behaviour (preset → stored
+/// reminder) is covered in
+/// `service_reminder_providers_test.dart`, and the rendering of
+/// existing reminder rows is covered by `service_reminder_row_test.dart`
+/// — keeping this file narrow avoids the Material ripple stall that
+/// hits widget tests when a chip's `onPressed` mutates a
+/// `Riverpod` notifier mid-frame on Windows.
+void main() {
+  late Directory tempDir;
+  late Box<String> box;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('reminder_widget_');
+    Hive.init(tempDir.path);
+    box = await Hive.openBox<String>(HiveBoxes.serviceReminders);
+    await box.clear();
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  Future<void> pump(
+    WidgetTester tester,
+    String vehicleId, {
+    double? currentOdometerKm,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          serviceReminderRepositoryProvider
+              .overrideWithValue(ServiceReminderRepository(box)),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: ServiceReminderSection(
+                vehicleId: vehicleId,
+                currentOdometerKm: currentOdometerKm,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('renders the three preset chips with their interval labels',
+      (tester) async {
+    await pump(tester, 'v-1');
+
+    expect(find.text('Oil (15,000 km)'), findsOneWidget);
+    expect(find.text('Tires (20,000 km)'), findsOneWidget);
+    expect(find.text('Inspection (30,000 km)'), findsOneWidget);
+  });
+
+  testWidgets('shows the empty-state message when no reminders exist',
+      (tester) async {
+    await pump(tester, 'v-1');
+    expect(
+      find.textContaining('No reminders yet'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shows the add-reminder button', (tester) async {
+    await pump(tester, 'v-1');
+    expect(find.text('Add reminder'), findsOneWidget);
+  });
+
+  testWidgets('renders section title', (tester) async {
+    await pump(tester, 'v-1');
+    expect(find.text('Service reminders'), findsOneWidget);
+  });
+
+  testWidgets('preset chips are ActionChips with an onPressed callback',
+      (tester) async {
+    await pump(tester, 'v-1');
+
+    // Asserting the chip is interactive guarantees the preset picker
+    // is actually wired up without triggering a full tap gesture.
+    final oil = tester.widget<ActionChip>(
+      find.widgetWithText(ActionChip, 'Oil (15,000 km)'),
+    );
+    final tires = tester.widget<ActionChip>(
+      find.widgetWithText(ActionChip, 'Tires (20,000 km)'),
+    );
+    final inspection = tester.widget<ActionChip>(
+      find.widgetWithText(ActionChip, 'Inspection (30,000 km)'),
+    );
+    expect(oil.onPressed, isNotNull);
+    expect(tires.onPressed, isNotNull);
+    expect(inspection.onPressed, isNotNull);
+  });
+}

--- a/test/features/vehicle/providers/service_reminder_providers_test.dart
+++ b/test/features/vehicle/providers/service_reminder_providers_test.dart
@@ -1,0 +1,137 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/service_reminder_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/service_reminder.dart';
+import 'package:tankstellen/features/vehicle/providers/service_reminder_providers.dart';
+
+void main() {
+  late Directory tempDir;
+  late Box<String> box;
+  late ProviderContainer container;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('reminder_provider_');
+    Hive.init(tempDir.path);
+    box = await Hive.openBox<String>(HiveBoxes.serviceReminders);
+    await box.clear();
+    container = ProviderContainer(
+      overrides: [
+        serviceReminderRepositoryProvider
+            .overrideWithValue(ServiceReminderRepository(box)),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('ServiceReminderList provider (#584)', () {
+    test('starts empty', () {
+      expect(container.read(serviceReminderListProvider), isEmpty);
+    });
+
+    test('save then read returns the reminder', () async {
+      const reminder = ServiceReminder(
+        id: 'r-1',
+        vehicleId: 'v-1',
+        label: 'Oil change',
+        intervalKm: 15000,
+      );
+      await container
+          .read(serviceReminderListProvider.notifier)
+          .save(reminder);
+      final list = container.read(serviceReminderListProvider);
+      expect(list, hasLength(1));
+      expect(list.first.id, 'r-1');
+    });
+
+    test('remove deletes and updates state', () async {
+      const reminder = ServiceReminder(
+        id: 'r-1',
+        vehicleId: 'v-1',
+        label: 'Oil change',
+        intervalKm: 15000,
+      );
+      final notifier = container.read(serviceReminderListProvider.notifier);
+      await notifier.save(reminder);
+      await notifier.remove('r-1');
+      expect(container.read(serviceReminderListProvider), isEmpty);
+    });
+
+    test('markDone rebases lastService and clears the pending flag', () async {
+      const reminder = ServiceReminder(
+        id: 'r-1',
+        vehicleId: 'v-1',
+        label: 'Oil change',
+        intervalKm: 15000,
+        pendingAcknowledgment: true,
+      );
+      final notifier = container.read(serviceReminderListProvider.notifier);
+      await notifier.save(reminder);
+      await notifier.markDone('r-1', 15200);
+
+      final list = container.read(serviceReminderListProvider);
+      expect(list.first.lastServiceOdometerKm, 15200);
+      expect(list.first.pendingAcknowledgment, isFalse);
+    });
+
+    test('serviceRemindersForVehicle filters by vehicleId', () async {
+      final notifier = container.read(serviceReminderListProvider.notifier);
+      await notifier.save(const ServiceReminder(
+        id: 'r-1',
+        vehicleId: 'v-1',
+        label: 'Oil',
+        intervalKm: 15000,
+      ));
+      await notifier.save(const ServiceReminder(
+        id: 'r-2',
+        vehicleId: 'v-2',
+        label: 'Oil',
+        intervalKm: 15000,
+      ));
+
+      final v1 =
+          container.read(serviceRemindersForVehicleProvider('v-1'));
+      expect(v1, hasLength(1));
+      expect(v1.first.id, 'r-1');
+    });
+
+    test('removeAllForVehicle cascades reminders for a deleted vehicle',
+        () async {
+      final notifier = container.read(serviceReminderListProvider.notifier);
+      await notifier.save(const ServiceReminder(
+        id: 'r-1',
+        vehicleId: 'v-1',
+        label: 'Oil',
+        intervalKm: 15000,
+      ));
+      await notifier.save(const ServiceReminder(
+        id: 'r-2',
+        vehicleId: 'v-1',
+        label: 'Tires',
+        intervalKm: 20000,
+      ));
+      await notifier.save(const ServiceReminder(
+        id: 'r-3',
+        vehicleId: 'v-2',
+        label: 'Oil',
+        intervalKm: 15000,
+      ));
+
+      await notifier.removeAllForVehicle('v-1');
+
+      final remaining = container.read(serviceReminderListProvider);
+      expect(remaining, hasLength(1));
+      expect(remaining.first.vehicleId, 'v-2');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds odometer-based service reminders so drivers can stay on top of oil, tires, and inspection without piping it through the calendar.
- Stores reminders in a new `service_reminders` Hive box (JSON payload per id, mirrors the achievements / trip history stores — no custom TypeAdapter).
- Wires the fill-up save path to a new `ServiceReminderEvaluator` that triggers a local notification on a distinct Android channel when `currentOdometerKm >= lastServiceOdometerKm + intervalKm`.
- Vehicle-edit screen grows a "Service reminders" section with preset chips (Oil 15k / Tires 20k / Inspection 30k), a free-form "Add reminder" dialog, and mark-as-done per row.

## Why

Matches the leitmotiv's "wheel" lens — timely maintenance keeps consumption in the band the vehicle was designed for. Low-effort UX gain: the odometer is already captured on every fill-up, so the feature costs the user nothing beyond picking a preset.

## Testing

- `flutter analyze` — zero warnings / errors.
- `flutter test` — 5006 tests passing (pre-existing Argentina CSV network flake unrelated).
- TDD protocol followed:
  - Model round-trip and edge-threshold (14999 / 15000 / 15001 / 30500 / post-markDone 20000) unit tests.
  - Repository CRUD + cascade-on-vehicle-delete against a real Hive box.
  - Pure `ServiceReminderTrigger` covers isActive / pendingAcknowledgment / vehicle-scoping.
  - `ServiceReminderEvaluator` asserts notification is scheduled on a fake `NotificationService`, persists the pending flag, and does not re-notify.
  - Widget tests render the presets, empty state, and add button.

## UX notes

- ARB keys added to `app_en.arb` + `app_de.arb` only (the other 21 locales fall back to English as usual — translations arrive on demand per CLAUDE.md).
- Mark-as-done prompts for an odometer value when none is known, otherwise uses the latest fill-up odometer for the vehicle.
- `pendingAcknowledgment` flag prevents re-notifying on every subsequent fill-up while the reminder is still waiting to be acknowledged.

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)