### PR TITLE
fix(alerts): ServiceChainErrorWidget on load failures (#858)

### DIFF
--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -14,7 +15,7 @@ class AlertsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final alerts = ref.watch(alertProvider);
+    final alertsAsync = ref.watch(alertsAsyncProvider);
     final l10n = AppLocalizations.of(context);
 
     return Scaffold(
@@ -26,24 +27,39 @@ class AlertsScreen extends ConsumerWidget {
           onPressed: () => context.pop(),
         ),
       ),
-      body: alerts.isEmpty
-          ? EmptyState(
-              icon: Icons.notifications_off_outlined,
-              title: l10n?.noPriceAlerts ?? 'No price alerts',
-              subtitle: l10n?.noPriceAlertsHint ??
-                  'Create an alert from a station\'s detail page.',
-            )
-          : ListView.builder(
-              itemCount: alerts.length + 1,
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              itemBuilder: (context, index) {
-                if (index == 0) {
-                  return const AlertStatisticsCard();
-                }
-                final alert = alerts[index - 1];
-                return _AlertListTile(key: ValueKey(alert.id), alert: alert);
-              },
-            ),
+      body: alertsAsync.when(
+        data: (alerts) => alerts.isEmpty
+            ? EmptyState(
+                icon: Icons.notifications_off_outlined,
+                title: l10n?.noPriceAlerts ?? 'No price alerts',
+                subtitle: l10n?.noPriceAlertsHint ??
+                    'Create an alert from a station\'s detail page.',
+              )
+            : ListView.builder(
+                itemCount: alerts.length + 1,
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                itemBuilder: (context, index) {
+                  if (index == 0) {
+                    return const AlertStatisticsCard();
+                  }
+                  final alert = alerts[index - 1];
+                  return _AlertListTile(key: ValueKey(alert.id), alert: alert);
+                },
+              ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stackTrace) => ServiceChainErrorWidget(
+          error: error,
+          stackTrace: stackTrace,
+          searchContext:
+              l10n?.alertsLoadErrorTitle ?? "Couldn't load your alerts",
+          onRetry: () {
+            // Invalidate both the underlying notifier and the async
+            // wrapper so the read is retried from scratch.
+            ref.invalidate(alertProvider);
+            ref.invalidate(alertsAsyncProvider);
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/features/alerts/providers/alert_provider.dart
+++ b/lib/features/alerts/providers/alert_provider.dart
@@ -97,3 +97,22 @@ class AlertNotifier extends _$AlertNotifier {
         .toList();
   }
 }
+
+/// AsyncValue wrapper around [alertProvider] (#858).
+///
+/// The legacy [alertProvider] is a synchronous NotifierProvider, so if the
+/// underlying storage throws on read the error propagates to
+/// [ErrorWidget] with no retry affordance. This derived provider re-exposes
+/// the same list as an [AsyncValue] so screens can render a proper
+/// `ServiceChainErrorWidget` via `.when(..., error: ...)`.
+///
+/// Existing consumers of [alertProvider] keep working untouched; only
+/// screens that want a user-visible error branch need to switch.
+@riverpod
+AsyncValue<List<PriceAlert>> alertsAsync(Ref ref) {
+  try {
+    return AsyncValue.data(ref.watch(alertProvider));
+  } catch (e, st) {
+    return AsyncValue.error(e, st);
+  }
+}

--- a/lib/features/alerts/providers/alert_provider.g.dart
+++ b/lib/features/alerts/providers/alert_provider.g.dart
@@ -102,3 +102,82 @@ abstract class _$AlertNotifier extends $Notifier<List<PriceAlert>> {
     element.handleCreate(ref, build);
   }
 }
+
+/// AsyncValue wrapper around [alertProvider] (#858).
+///
+/// The legacy [alertProvider] is a synchronous NotifierProvider, so if the
+/// underlying storage throws on read the error propagates to
+/// [ErrorWidget] with no retry affordance. This derived provider re-exposes
+/// the same list as an [AsyncValue] so screens can render a proper
+/// `ServiceChainErrorWidget` via `.when(..., error: ...)`.
+///
+/// Existing consumers of [alertProvider] keep working untouched; only
+/// screens that want a user-visible error branch need to switch.
+
+@ProviderFor(alertsAsync)
+final alertsAsyncProvider = AlertsAsyncProvider._();
+
+/// AsyncValue wrapper around [alertProvider] (#858).
+///
+/// The legacy [alertProvider] is a synchronous NotifierProvider, so if the
+/// underlying storage throws on read the error propagates to
+/// [ErrorWidget] with no retry affordance. This derived provider re-exposes
+/// the same list as an [AsyncValue] so screens can render a proper
+/// `ServiceChainErrorWidget` via `.when(..., error: ...)`.
+///
+/// Existing consumers of [alertProvider] keep working untouched; only
+/// screens that want a user-visible error branch need to switch.
+
+final class AlertsAsyncProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<PriceAlert>>,
+          AsyncValue<List<PriceAlert>>,
+          AsyncValue<List<PriceAlert>>
+        >
+    with $Provider<AsyncValue<List<PriceAlert>>> {
+  /// AsyncValue wrapper around [alertProvider] (#858).
+  ///
+  /// The legacy [alertProvider] is a synchronous NotifierProvider, so if the
+  /// underlying storage throws on read the error propagates to
+  /// [ErrorWidget] with no retry affordance. This derived provider re-exposes
+  /// the same list as an [AsyncValue] so screens can render a proper
+  /// `ServiceChainErrorWidget` via `.when(..., error: ...)`.
+  ///
+  /// Existing consumers of [alertProvider] keep working untouched; only
+  /// screens that want a user-visible error branch need to switch.
+  AlertsAsyncProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'alertsAsyncProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$alertsAsyncHash();
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<List<PriceAlert>>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AsyncValue<List<PriceAlert>> create(Ref ref) {
+    return alertsAsync(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<PriceAlert>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<List<PriceAlert>>>(value),
+    );
+  }
+}
+
+String _$alertsAsyncHash() => r'23ee8094c9602cfc97a335904ee5a97b617d351e';

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1029,6 +1029,8 @@
   "errorHintConnection": "Prüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.",
   "errorHintRouting": "Routenberechnung fehlgeschlagen. Prüfen Sie Ihre Internetverbindung.",
   "errorHintFallback": "Versuchen Sie es erneut oder suchen Sie nach Postleitzahl / Stadt.",
+  "alertsLoadErrorTitle": "Alarme konnten nicht geladen werden",
+  "alertsBackgroundCheckErrorTitle": "Hintergrundprüfung der Alarme fehlgeschlagen",
   "detailsLabel": "Details",
   "remove": "Entfernen",
   "showKey": "Schlüssel anzeigen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1062,6 +1062,8 @@
   "errorHintConnection": "Check your internet connection and try again.",
   "errorHintRouting": "Route calculation failed. Check your internet connection and try again.",
   "errorHintFallback": "Try again or search by postal code / city name.",
+  "alertsLoadErrorTitle": "Couldn't load your alerts",
+  "alertsBackgroundCheckErrorTitle": "Alert background check failed",
   "detailsLabel": "Details",
   "remove": "Remove",
   "showKey": "Show key",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4735,6 +4735,18 @@ abstract class AppLocalizations {
   /// **'Try again or search by postal code / city name.'**
   String get errorHintFallback;
 
+  /// No description provided for @alertsLoadErrorTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load your alerts'**
+  String get alertsLoadErrorTitle;
+
+  /// No description provided for @alertsBackgroundCheckErrorTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Alert background check failed'**
+  String get alertsBackgroundCheckErrorTitle;
+
   /// No description provided for @detailsLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2507,6 +2507,12 @@ class AppLocalizationsBg extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2507,6 +2507,12 @@ class AppLocalizationsCs extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2505,6 +2505,12 @@ class AppLocalizationsDa extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2524,6 +2524,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Versuchen Sie es erneut oder suchen Sie nach Postleitzahl / Stadt.';
 
   @override
+  String get alertsLoadErrorTitle => 'Alarme konnten nicht geladen werden';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle =>
+      'Hintergrundprüfung der Alarme fehlgeschlagen';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2509,6 +2509,12 @@ class AppLocalizationsEl extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2500,6 +2500,12 @@ class AppLocalizationsEn extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2508,6 +2508,12 @@ class AppLocalizationsEs extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2502,6 +2502,12 @@ class AppLocalizationsEt extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2505,6 +2505,12 @@ class AppLocalizationsFi extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2523,6 +2523,12 @@ class AppLocalizationsFr extends AppLocalizations {
       'Réessayez ou cherchez par code postal / ville.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Détails';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2504,6 +2504,12 @@ class AppLocalizationsHr extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2509,6 +2509,12 @@ class AppLocalizationsHu extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2508,6 +2508,12 @@ class AppLocalizationsIt extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2506,6 +2506,12 @@ class AppLocalizationsLt extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2508,6 +2508,12 @@ class AppLocalizationsLv extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2504,6 +2504,12 @@ class AppLocalizationsNb extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2509,6 +2509,12 @@ class AppLocalizationsNl extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2507,6 +2507,12 @@ class AppLocalizationsPl extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2508,6 +2508,12 @@ class AppLocalizationsPt extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2507,6 +2507,12 @@ class AppLocalizationsRo extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2508,6 +2508,12 @@ class AppLocalizationsSk extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2502,6 +2502,12 @@ class AppLocalizationsSl extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2506,6 +2506,12 @@ class AppLocalizationsSv extends AppLocalizations {
       'Try again or search by postal code / city name.';
 
   @override
+  String get alertsLoadErrorTitle => 'Couldn\'t load your alerts';
+
+  @override
+  String get alertsBackgroundCheckErrorTitle => 'Alert background check failed';
+
+  @override
   String get detailsLabel => 'Details';
 
   @override

--- a/test/features/alerts/presentation/screens/alerts_screen_test.dart
+++ b/test/features/alerts/presentation/screens/alerts_screen_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/widgets/service_status_banner.dart';
 import 'package:tankstellen/features/alerts/data/models/price_alert.dart';
 import 'package:tankstellen/features/alerts/presentation/screens/alerts_screen.dart';
 import 'package:tankstellen/features/alerts/providers/alert_provider.dart';
@@ -73,6 +76,59 @@ void main() {
 
       expect(find.text('Shell Berlin'), findsOneWidget);
       expect(find.byType(Switch), findsOneWidget);
+    });
+
+    // #858: the alerts screen now surfaces load failures via
+    // ServiceChainErrorWidget instead of letting the exception propagate
+    // to a blank ErrorWidget.
+    testWidgets('renders ServiceChainErrorWidget when provider throws',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertsAsyncProvider.overrideWithValue(
+            AsyncValue<List<PriceAlert>>.error(
+              const ServiceChainExhaustedException(errors: []),
+              StackTrace.current,
+            ),
+          ),
+        ],
+      );
+
+      expect(find.byType(ServiceChainErrorWidget), findsOneWidget);
+      // The widget renders its standard "cloud off" icon + retry button.
+      expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+      expect(find.text('Try again'), findsOneWidget);
+    });
+
+    testWidgets(
+        'renders ServiceChainErrorWidget on arbitrary alert load exception',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertsAsyncProvider.overrideWithValue(
+            AsyncValue<List<PriceAlert>>.error(
+              Exception('alerts box corrupted'),
+              StackTrace.current,
+            ),
+          ),
+        ],
+      );
+
+      expect(find.byType(ServiceChainErrorWidget), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes #858.

The alerts screen had no user-visible error state: any exception from the `alertProvider` build propagated all the way to `ErrorWidget`, leaving the user with a blank/stale screen and no retry. Search and Favorites both use `ServiceChainErrorWidget` for this — now Alerts does too.

## What changed

- **New `alertsAsyncProvider`** (`lib/features/alerts/providers/alert_provider.dart`): thin `AsyncValue<List<PriceAlert>>` wrapper around the existing synchronous `alertProvider`. Catches build exceptions and re-exposes them via `AsyncValue.error` so UI can `.when(..., error: ...)`. Existing callers of `alertProvider` (favorites tab, statistics card, background service) are untouched.
- **`AlertsScreen`** now reads `alertsAsyncProvider` and renders `ServiceChainErrorWidget` on error, with `onRetry` invalidating both the underlying `alertProvider` and its async wrapper so the next build re-reads from storage.
- **ARB keys** `alertsLoadErrorTitle` and `alertsBackgroundCheckErrorTitle` (en + de only per coordinator policy). The load-error title is passed to `ServiceChainErrorWidget.searchContext` so bug reports name the failing operation. The background-check key is staged for future UI use when background failures surface beyond notifications.

## Out of scope / notes

- `radiusAlertsProvider` (phase-1 from #850) has no UI yet, so there is nothing to wrap today. When the phase-2 UI lands it should use the same `.when(..., error: ServiceChainErrorWidget(...))` pattern.
- `lib/features/favorites/presentation/widgets/alerts_tab.dart` also consumes `alertProvider`, but that file is owned by the favorites feature and is out of scope for this worker per the parallel-safety protocol.

## Test plan

- [x] New widget tests in `test/features/alerts/presentation/screens/alerts_screen_test.dart`:
  - overriding `alertsAsyncProvider` with `ServiceChainExhaustedException` renders `ServiceChainErrorWidget` + "cloud_off" icon + "Try again" button
  - a plain `Exception` also renders the error widget
- [x] Existing alerts tests still pass (119 / 119 in `test/features/alerts/`)
- [x] Full suite: 5172 / 5172 pass
- [x] `flutter analyze` — 0 issues
- [x] `grep ServiceChainErrorWidget lib/features/alerts/` — hits `alerts_screen.dart:50`
- [x] `flutter gen-l10n` regenerated; en + de touched only

🤖 Generated with [Claude Code](https://claude.com/claude-code)