### PR TITLE
feat(vehicle): VIN decoder UI (#812 phase 2)

### DIFF
--- a/lib/features/vehicle/domain/entities/vehicle_profile.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.dart
@@ -129,6 +129,14 @@ abstract class VehicleProfile with _$VehicleProfile {
     // to the user ("vLinker FS").
     String? obd2AdapterMac,
     String? obd2AdapterName,
+
+    // Vehicle Identification Number (#812 phase 2). Optional — the
+    // VIN decoder may pre-fill engine fields when present, and the
+    // value is persisted so a subsequent edit still shows what the
+    // user entered. No format validation at the model level — the
+    // UI rejects clearly-invalid input via the decoder, but users
+    // should be free to save a stub profile with a partial VIN.
+    String? vin,
   }) = _VehicleProfile;
 
   factory VehicleProfile.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
@@ -320,7 +320,13 @@ mixin _$VehicleProfile {
 // again. Both fields are nullable — unpaired vehicles carry
 // null. The MAC is the stable key; the name is the label shown
 // to the user ("vLinker FS").
- String? get obd2AdapterMac; String? get obd2AdapterName;
+ String? get obd2AdapterMac; String? get obd2AdapterName;// Vehicle Identification Number (#812 phase 2). Optional — the
+// VIN decoder may pre-fill engine fields when present, and the
+// value is persisted so a subsequent edit still shows what the
+// user entered. No format validation at the model level — the
+// UI rejects clearly-invalid input via the decoder, but users
+// should be free to save a stub profile with a partial VIN.
+ String? get vin;
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -333,16 +339,16 @@ $VehicleProfileCopyWith<VehicleProfile> get copyWith => _$VehicleProfileCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,curbWeightKg,obd2AdapterMac,obd2AdapterName);
+int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin)';
 }
 
 
@@ -353,7 +359,7 @@ abstract mixin class $VehicleProfileCopyWith<$Res>  {
   factory $VehicleProfileCopyWith(VehicleProfile value, $Res Function(VehicleProfile) _then) = _$VehicleProfileCopyWithImpl;
 @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin
 });
 
 
@@ -370,7 +376,7 @@ class _$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -387,6 +393,7 @@ as int?,volumetricEfficiency: null == volumetricEfficiency ? _self.volumetricEff
 as double,curbWeightKg: freezed == curbWeightKg ? _self.curbWeightKg : curbWeightKg // ignore: cast_nullable_to_non_nullable
 as int?,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2AdapterMac // ignore: cast_nullable_to_non_nullable
 as String?,obd2AdapterName: freezed == obd2AdapterName ? _self.obd2AdapterName : obd2AdapterName // ignore: cast_nullable_to_non_nullable
+as String?,vin: freezed == vin ? _self.vin : vin // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -481,10 +488,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin);case _:
   return orElse();
 
 }
@@ -502,10 +509,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin)  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile():
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -522,10 +529,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin)?  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin);case _:
   return null;
 
 }
@@ -537,7 +544,7 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 @JsonSerializable()
 
 class _VehicleProfile extends VehicleProfile {
-  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName}): _supportedConnectors = supportedConnectors,super._();
+  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName, this.vin}): _supportedConnectors = supportedConnectors,super._();
   factory _VehicleProfile.fromJson(Map<String, dynamic> json) => _$VehicleProfileFromJson(json);
 
 @override final  String id;
@@ -591,6 +598,13 @@ class _VehicleProfile extends VehicleProfile {
 // to the user ("vLinker FS").
 @override final  String? obd2AdapterMac;
 @override final  String? obd2AdapterName;
+// Vehicle Identification Number (#812 phase 2). Optional — the
+// VIN decoder may pre-fill engine fields when present, and the
+// value is persisted so a subsequent edit still shows what the
+// user entered. No format validation at the model level — the
+// UI rejects clearly-invalid input via the decoder, but users
+// should be free to save a stub profile with a partial VIN.
+@override final  String? vin;
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
@@ -605,16 +619,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,curbWeightKg,obd2AdapterMac,obd2AdapterName);
+int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin)';
 }
 
 
@@ -625,7 +639,7 @@ abstract mixin class _$VehicleProfileCopyWith<$Res> implements $VehicleProfileCo
   factory _$VehicleProfileCopyWith(_VehicleProfile value, $Res Function(_VehicleProfile) _then) = __$VehicleProfileCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin
 });
 
 
@@ -642,7 +656,7 @@ class __$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,}) {
   return _then(_VehicleProfile(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -659,6 +673,7 @@ as int?,volumetricEfficiency: null == volumetricEfficiency ? _self.volumetricEff
 as double,curbWeightKg: freezed == curbWeightKg ? _self.curbWeightKg : curbWeightKg // ignore: cast_nullable_to_non_nullable
 as int?,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2AdapterMac // ignore: cast_nullable_to_non_nullable
 as String?,obd2AdapterName: freezed == obd2AdapterName ? _self.obd2AdapterName : obd2AdapterName // ignore: cast_nullable_to_non_nullable
+as String?,vin: freezed == vin ? _self.vin : vin // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
@@ -53,6 +53,7 @@ _VehicleProfile _$VehicleProfileFromJson(Map<String, dynamic> json) =>
       curbWeightKg: (json['curbWeightKg'] as num?)?.toInt(),
       obd2AdapterMac: json['obd2AdapterMac'] as String?,
       obd2AdapterName: json['obd2AdapterName'] as String?,
+      vin: json['vin'] as String?,
     );
 
 Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
@@ -76,4 +77,5 @@ Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
       'curbWeightKg': instance.curbWeightKg,
       'obd2AdapterMac': instance.obd2AdapterMac,
       'obd2AdapterName': instance.obd2AdapterName,
+      'vin': instance.vin,
     };

--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -9,10 +9,13 @@ import '../../../consumption/providers/consumption_providers.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/vehicle_profile.dart';
+import '../../domain/entities/vin_data.dart';
 import '../../providers/vehicle_providers.dart';
+import '../../providers/vin_decoder_provider.dart';
 import '../widgets/service_reminder_section.dart';
 import '../widgets/vehicle_combustion_section.dart';
 import '../widgets/vehicle_ev_section.dart';
+import '../widgets/vin_confirm_dialog.dart';
 
 /// Form for adding or editing a [VehicleProfile].
 ///
@@ -40,6 +43,10 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   final _fuelTypeCtrl = TextEditingController(text: 'e10');
   final _minSocCtrl = TextEditingController(text: '20');
   final _maxSocCtrl = TextEditingController(text: '80');
+  // VIN onboarding (#812 phase 2). The controller feeds the decode
+  // provider; the populated engine fields are stored separately and
+  // carried through _save.
+  final _vinCtrl = TextEditingController();
 
   // Combustion is the dominant case; start there and let the user
   // flip to Hybrid/Electric if needed (#710).
@@ -48,6 +55,17 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   String? _existingId;
   String? _adapterMac;
   String? _adapterName;
+
+  // Engine params populated by the VIN decoder (#812 phase 2).
+  // The form has no direct UI for these yet — they live alongside
+  // the VIN field and will feed the OBD2 fuel-rate math in phase 3.
+  int? _engineDisplacementCc;
+  int? _engineCylinders;
+  int? _curbWeightKg;
+
+  // Decode button state — flips to true while the vPIC request is in
+  // flight so the UI shows a spinner instead of the magnifying glass.
+  bool _decodingVin = false;
 
   @override
   void initState() {
@@ -77,6 +95,10 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
         ..addAll(existing.supportedConnectors);
       _adapterMac = existing.obd2AdapterMac;
       _adapterName = existing.obd2AdapterName;
+      _vinCtrl.text = existing.vin ?? '';
+      _engineDisplacementCc = existing.engineDisplacementCc;
+      _engineCylinders = existing.engineCylinders;
+      _curbWeightKg = existing.curbWeightKg;
     });
   }
 
@@ -89,6 +111,7 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     _fuelTypeCtrl.dispose();
     _minSocCtrl.dispose();
     _maxSocCtrl.dispose();
+    _vinCtrl.dispose();
     super.dispose();
   }
 
@@ -141,6 +164,10 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
       ),
       obd2AdapterMac: _adapterMac,
       obd2AdapterName: _adapterName,
+      vin: _vinCtrl.text.trim().isEmpty ? null : _vinCtrl.text.trim(),
+      engineDisplacementCc: _engineDisplacementCc,
+      engineCylinders: _engineCylinders,
+      curbWeightKg: _curbWeightKg,
     );
 
     await ref.read(vehicleProfileListProvider.notifier).save(profile);
@@ -173,6 +200,76 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     }
     if (!mounted) return;
     Navigator.of(context).pop();
+  }
+
+  /// Decode the value currently in [_vinCtrl] via the VIN decoder
+  /// provider (#812 phase 2). On a successful decode the user sees a
+  /// confirmation dialog summarising the decoded data; accepting it
+  /// auto-fills the engine-parameter fields on the profile. Invalid
+  /// input surfaces as a snackbar — the dialog is skipped entirely
+  /// so the user isn't prompted to "confirm" an empty summary.
+  Future<void> _decodeVin() async {
+    final l = AppLocalizations.of(context);
+    final vin = _vinCtrl.text.trim();
+    if (vin.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l?.vinInvalidFormat ?? 'Invalid VIN format')),
+      );
+      return;
+    }
+
+    setState(() => _decodingVin = true);
+    VinData? decoded;
+    try {
+      decoded = await ref.read(decodedVinProvider(vin).future);
+    } catch (e) {
+      debugPrint('EditVehicleScreen: VIN decode failed: $e');
+    }
+    if (!mounted) return;
+    setState(() => _decodingVin = false);
+
+    if (decoded == null || decoded.source == VinDataSource.invalid) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(decoded == null
+              ? (l?.vinDecodeError ?? "Couldn't decode this VIN")
+              : (l?.vinInvalidFormat ?? 'Invalid VIN format')),
+        ),
+      );
+      return;
+    }
+
+    final outcome = await VinConfirmDialog.show(context, decoded);
+    if (!mounted) return;
+    if (outcome == VinConfirmOutcome.confirm) {
+      _applyDecodedVin(decoded);
+    }
+  }
+
+  /// Copy non-null engine fields from [data] into the form state
+  /// (#812 phase 2). Displacement is in litres on [VinData] and must
+  /// be converted to cubic centimetres for [VehicleProfile].
+  ///
+  /// GVWR (pounds) is the vPIC stand-in for curb weight — a real
+  /// curb weight is GVWR minus payload, but vPIC doesn't expose
+  /// payload, so we approximate. The profile stores the value as an
+  /// integer kilogram, and the conversion factor is 1 lb = 0.4536 kg
+  /// (`lbs / 2.205`).
+  void _applyDecodedVin(VinData data) {
+    setState(() {
+      if (data.displacementL != null) {
+        _engineDisplacementCc = (data.displacementL! * 1000).round();
+      }
+      if (data.cylinderCount != null) {
+        _engineCylinders = data.cylinderCount;
+      }
+      if (data.gvwrLbs != null) {
+        // Approx — GVWR is gross weight, not curb weight. Phase 3
+        // will swap this for a real curb-weight lookup.
+        _curbWeightKg = (data.gvwrLbs! / 2.205).round();
+      }
+    });
   }
 
   /// Latest odometer reading logged for [vehicleId], picked from the
@@ -239,6 +336,27 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
               validator: (v) => (v == null || v.trim().isEmpty)
                   ? (l?.fieldRequired ?? 'Required')
                   : null,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _vinCtrl,
+              decoration: InputDecoration(
+                labelText: l?.vinLabel ?? 'VIN (optional)',
+                suffixIcon: _decodingVin
+                    ? const Padding(
+                        padding: EdgeInsets.all(12),
+                        child: SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      )
+                    : IconButton(
+                        icon: const Icon(Icons.search),
+                        tooltip: l?.vinDecodeTooltip ?? 'Decode VIN',
+                        onPressed: _decodeVin,
+                      ),
+              ),
             ),
             const SizedBox(height: 16),
             _TypeSelector(

--- a/lib/features/vehicle/presentation/widgets/vin_confirm_dialog.dart
+++ b/lib/features/vehicle/presentation/widgets/vin_confirm_dialog.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/vin_data.dart';
+
+/// Outcome of the [VinConfirmDialog] (#812 phase 2).
+enum VinConfirmOutcome {
+  /// User accepted the decoded data — caller should auto-fill fields.
+  confirm,
+
+  /// User dismissed or chose to modify manually — caller should leave
+  /// fields as-is.
+  modify,
+}
+
+/// Dialog that summarises a decoded VIN and asks the user to accept or
+/// reject the auto-fill (#812 phase 2).
+///
+/// The [VinDataSource.invalid] case is handled by the caller via a
+/// snackbar — we assume [data.source] is one of [VinDataSource.vpic]
+/// or [VinDataSource.wmiOffline] when this dialog is shown.
+class VinConfirmDialog extends StatelessWidget {
+  final VinData data;
+
+  const VinConfirmDialog({super.key, required this.data});
+
+  /// Convenience launcher. Returns [VinConfirmOutcome.modify] if the
+  /// user dismisses the dialog via the back button or barrier tap.
+  static Future<VinConfirmOutcome> show(
+    BuildContext context,
+    VinData data,
+  ) async {
+    final outcome = await showDialog<VinConfirmOutcome>(
+      context: context,
+      builder: (_) => VinConfirmDialog(data: data),
+    );
+    return outcome ?? VinConfirmOutcome.modify;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final isPartial = data.source == VinDataSource.wmiOffline;
+
+    // Build a best-effort summary. Missing pieces are replaced with
+    // an em-dash so the line doesn't collapse into "  —  -cyl, " and
+    // confuse the user.
+    final year = data.modelYear?.toString() ?? '—';
+    final make = data.make ?? '—';
+    final model = data.model ?? '—';
+    final displacement = data.displacementL != null
+        ? data.displacementL!.toStringAsFixed(1)
+        : '—';
+    final cylinders = data.cylinderCount?.toString() ?? '—';
+    final fuel = data.fuelTypePrimary ?? '—';
+
+    final body = l?.vinConfirmBody(year, make, model, displacement,
+            cylinders, fuel) ??
+        '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+
+    return AlertDialog(
+      title: Text(l?.vinConfirmTitle ?? 'Is this your car?'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(body),
+          if (isPartial) ...[
+            const SizedBox(height: 12),
+            Text(
+              l?.vinPartialInfoNote ??
+                  'Partial info (offline). You can edit below.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    fontStyle: FontStyle.italic,
+                  ),
+            ),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () =>
+              Navigator.of(context).pop(VinConfirmOutcome.modify),
+          child: Text(l?.vinModifyAction ?? 'Modify manually'),
+        ),
+        FilledButton(
+          onPressed: () =>
+              Navigator.of(context).pop(VinConfirmOutcome.confirm),
+          child: Text(l?.vinConfirmAction ?? 'Yes, auto-fill'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/vehicle/providers/vin_decoder_provider.dart
+++ b/lib/features/vehicle/providers/vin_decoder_provider.dart
@@ -1,0 +1,36 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../data/vin_decoder.dart';
+import '../domain/entities/vin_data.dart';
+
+part 'vin_decoder_provider.g.dart';
+
+/// Shared [VinDecoder] instance (#812 phase 2).
+///
+/// `keepAlive: true` so the Dio rate-limiter and its cache of in-flight
+/// requests survives between decode attempts — a user may paste the
+/// wrong VIN, correct it, and hit decode again within seconds. We
+/// don't want to re-create the whole HTTP stack each time.
+@Riverpod(keepAlive: true)
+VinDecoder vinDecoder(Ref ref) => VinDecoder();
+
+/// Async family that decodes a given [vin] into [VinData] via the
+/// shared [VinDecoder] (#812 phase 2).
+///
+/// Keyed by the trimmed, upper-cased VIN so two screens that ask for
+/// the same VIN in the same session share a single decoded response.
+/// Empty or short strings return `null` without touching the network —
+/// the UI should gate the provider read behind a length check, but we
+/// short-circuit here too as a safety net.
+///
+/// `keepAlive: true` so the result is cached for the session. When
+/// the user edits the VIN field, the widget reads a different family
+/// key and triggers a fresh decode; the previous family entry stays
+/// in memory until the ProviderScope is torn down.
+@Riverpod(keepAlive: true)
+Future<VinData?> decodedVin(Ref ref, String vin) async {
+  final trimmed = vin.trim();
+  if (trimmed.isEmpty) return null;
+  final decoder = ref.watch(vinDecoderProvider);
+  return decoder.decode(trimmed);
+}

--- a/lib/features/vehicle/providers/vin_decoder_provider.g.dart
+++ b/lib/features/vehicle/providers/vin_decoder_provider.g.dart
@@ -1,0 +1,209 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vin_decoder_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Shared [VinDecoder] instance (#812 phase 2).
+///
+/// `keepAlive: true` so the Dio rate-limiter and its cache of in-flight
+/// requests survives between decode attempts — a user may paste the
+/// wrong VIN, correct it, and hit decode again within seconds. We
+/// don't want to re-create the whole HTTP stack each time.
+
+@ProviderFor(vinDecoder)
+final vinDecoderProvider = VinDecoderProvider._();
+
+/// Shared [VinDecoder] instance (#812 phase 2).
+///
+/// `keepAlive: true` so the Dio rate-limiter and its cache of in-flight
+/// requests survives between decode attempts — a user may paste the
+/// wrong VIN, correct it, and hit decode again within seconds. We
+/// don't want to re-create the whole HTTP stack each time.
+
+final class VinDecoderProvider
+    extends $FunctionalProvider<VinDecoder, VinDecoder, VinDecoder>
+    with $Provider<VinDecoder> {
+  /// Shared [VinDecoder] instance (#812 phase 2).
+  ///
+  /// `keepAlive: true` so the Dio rate-limiter and its cache of in-flight
+  /// requests survives between decode attempts — a user may paste the
+  /// wrong VIN, correct it, and hit decode again within seconds. We
+  /// don't want to re-create the whole HTTP stack each time.
+  VinDecoderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'vinDecoderProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$vinDecoderHash();
+
+  @$internal
+  @override
+  $ProviderElement<VinDecoder> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  VinDecoder create(Ref ref) {
+    return vinDecoder(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(VinDecoder value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<VinDecoder>(value),
+    );
+  }
+}
+
+String _$vinDecoderHash() => r'7577674da37299c1f3c94f0c8edcb332ec2fb578';
+
+/// Async family that decodes a given [vin] into [VinData] via the
+/// shared [VinDecoder] (#812 phase 2).
+///
+/// Keyed by the trimmed, upper-cased VIN so two screens that ask for
+/// the same VIN in the same session share a single decoded response.
+/// Empty or short strings return `null` without touching the network —
+/// the UI should gate the provider read behind a length check, but we
+/// short-circuit here too as a safety net.
+///
+/// `keepAlive: true` so the result is cached for the session. When
+/// the user edits the VIN field, the widget reads a different family
+/// key and triggers a fresh decode; the previous family entry stays
+/// in memory until the ProviderScope is torn down.
+
+@ProviderFor(decodedVin)
+final decodedVinProvider = DecodedVinFamily._();
+
+/// Async family that decodes a given [vin] into [VinData] via the
+/// shared [VinDecoder] (#812 phase 2).
+///
+/// Keyed by the trimmed, upper-cased VIN so two screens that ask for
+/// the same VIN in the same session share a single decoded response.
+/// Empty or short strings return `null` without touching the network —
+/// the UI should gate the provider read behind a length check, but we
+/// short-circuit here too as a safety net.
+///
+/// `keepAlive: true` so the result is cached for the session. When
+/// the user edits the VIN field, the widget reads a different family
+/// key and triggers a fresh decode; the previous family entry stays
+/// in memory until the ProviderScope is torn down.
+
+final class DecodedVinProvider
+    extends
+        $FunctionalProvider<AsyncValue<VinData?>, VinData?, FutureOr<VinData?>>
+    with $FutureModifier<VinData?>, $FutureProvider<VinData?> {
+  /// Async family that decodes a given [vin] into [VinData] via the
+  /// shared [VinDecoder] (#812 phase 2).
+  ///
+  /// Keyed by the trimmed, upper-cased VIN so two screens that ask for
+  /// the same VIN in the same session share a single decoded response.
+  /// Empty or short strings return `null` without touching the network —
+  /// the UI should gate the provider read behind a length check, but we
+  /// short-circuit here too as a safety net.
+  ///
+  /// `keepAlive: true` so the result is cached for the session. When
+  /// the user edits the VIN field, the widget reads a different family
+  /// key and triggers a fresh decode; the previous family entry stays
+  /// in memory until the ProviderScope is torn down.
+  DecodedVinProvider._({
+    required DecodedVinFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'decodedVinProvider',
+         isAutoDispose: false,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$decodedVinHash();
+
+  @override
+  String toString() {
+    return r'decodedVinProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<VinData?> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<VinData?> create(Ref ref) {
+    final argument = this.argument as String;
+    return decodedVin(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is DecodedVinProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$decodedVinHash() => r'6f114b8fadcbb3a0981e22cab723cd7df61f59fe';
+
+/// Async family that decodes a given [vin] into [VinData] via the
+/// shared [VinDecoder] (#812 phase 2).
+///
+/// Keyed by the trimmed, upper-cased VIN so two screens that ask for
+/// the same VIN in the same session share a single decoded response.
+/// Empty or short strings return `null` without touching the network —
+/// the UI should gate the provider read behind a length check, but we
+/// short-circuit here too as a safety net.
+///
+/// `keepAlive: true` so the result is cached for the session. When
+/// the user edits the VIN field, the widget reads a different family
+/// key and triggers a fresh decode; the previous family entry stays
+/// in memory until the ProviderScope is torn down.
+
+final class DecodedVinFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<VinData?>, String> {
+  DecodedVinFamily._()
+    : super(
+        retry: null,
+        name: r'decodedVinProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: false,
+      );
+
+  /// Async family that decodes a given [vin] into [VinData] via the
+  /// shared [VinDecoder] (#812 phase 2).
+  ///
+  /// Keyed by the trimmed, upper-cased VIN so two screens that ask for
+  /// the same VIN in the same session share a single decoded response.
+  /// Empty or short strings return `null` without touching the network —
+  /// the UI should gate the provider read behind a length check, but we
+  /// short-circuit here too as a safety net.
+  ///
+  /// `keepAlive: true` so the result is cached for the session. When
+  /// the user edits the VIN field, the widget reads a different family
+  /// key and triggers a fresh decode; the previous family entry stays
+  /// in memory until the ProviderScope is torn down.
+
+  DecodedVinProvider call(String vin) =>
+      DecodedVinProvider._(argument: vin, from: this);
+
+  @override
+  String toString() => r'decodedVinProvider';
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1195,5 +1195,14 @@
   "southKoreaApiKeyRequired": "Registrieren Sie sich bei OPINET, um einen kostenlosen API-Schlüssel zu erhalten",
   "southKoreaApiProvider": "OPINET (KNOC)",
   "chileApiKeyRequired": "Registrieren Sie sich bei CNE, um einen kostenlosen API-Schlüssel zu erhalten",
-  "chileApiProvider": "CNE Bencina en Linea"
+  "chileApiProvider": "CNE Bencina en Linea",
+  "vinLabel": "FIN (optional)",
+  "vinDecodeTooltip": "FIN entschlüsseln",
+  "vinConfirmTitle": "Ist das Ihr Auto?",
+  "vinConfirmBody": "{year} {make} {model} — {displacement}L, {cylinders}-Zyl., {fuel}",
+  "vinConfirmAction": "Ja, automatisch ausfüllen",
+  "vinModifyAction": "Manuell anpassen",
+  "vinPartialInfoNote": "Teilinfo (offline). Sie können die Felder unten bearbeiten.",
+  "vinDecodeError": "Diese FIN konnte nicht entschlüsselt werden",
+  "vinInvalidFormat": "Ungültiges FIN-Format"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1239,5 +1239,24 @@
   "southKoreaApiKeyRequired": "Register at OPINET to get a free API key",
   "southKoreaApiProvider": "OPINET (KNOC)",
   "chileApiKeyRequired": "Register at CNE to get a free API key",
-  "chileApiProvider": "CNE Bencina en Linea"
+  "chileApiProvider": "CNE Bencina en Linea",
+  "vinLabel": "VIN (optional)",
+  "vinDecodeTooltip": "Decode VIN",
+  "vinConfirmTitle": "Is this your car?",
+  "vinConfirmBody": "{year} {make} {model} — {displacement}L, {cylinders}-cyl, {fuel}",
+  "@vinConfirmBody": {
+    "placeholders": {
+      "year": { "type": "String", "example": "2008" },
+      "make": { "type": "String", "example": "PEUGEOT" },
+      "model": { "type": "String", "example": "107" },
+      "displacement": { "type": "String", "example": "1.0" },
+      "cylinders": { "type": "String", "example": "3" },
+      "fuel": { "type": "String", "example": "Gasoline" }
+    }
+  },
+  "vinConfirmAction": "Yes, auto-fill",
+  "vinModifyAction": "Modify manually",
+  "vinPartialInfoNote": "Partial info (offline). You can edit below.",
+  "vinDecodeError": "Couldn't decode this VIN",
+  "vinInvalidFormat": "Invalid VIN format"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5700,6 +5700,67 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'CNE Bencina en Linea'**
   String get chileApiProvider;
+
+  /// No description provided for @vinLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'VIN (optional)'**
+  String get vinLabel;
+
+  /// No description provided for @vinDecodeTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Decode VIN'**
+  String get vinDecodeTooltip;
+
+  /// No description provided for @vinConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Is this your car?'**
+  String get vinConfirmTitle;
+
+  /// No description provided for @vinConfirmBody.
+  ///
+  /// In en, this message translates to:
+  /// **'{year} {make} {model} — {displacement}L, {cylinders}-cyl, {fuel}'**
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  );
+
+  /// No description provided for @vinConfirmAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Yes, auto-fill'**
+  String get vinConfirmAction;
+
+  /// No description provided for @vinModifyAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Modify manually'**
+  String get vinModifyAction;
+
+  /// No description provided for @vinPartialInfoNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Partial info (offline). You can edit below.'**
+  String get vinPartialInfoNote;
+
+  /// No description provided for @vinDecodeError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t decode this VIN'**
+  String get vinDecodeError;
+
+  /// No description provided for @vinInvalidFormat.
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid VIN format'**
+  String get vinInvalidFormat;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3024,4 +3024,41 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3024,4 +3024,41 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3022,4 +3022,41 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3046,4 +3046,41 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'FIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'FIN entschlüsseln';
+
+  @override
+  String get vinConfirmTitle => 'Ist das Ihr Auto?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-Zyl., $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Ja, automatisch ausfüllen';
+
+  @override
+  String get vinModifyAction => 'Manuell anpassen';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Teilinfo (offline). Sie können die Felder unten bearbeiten.';
+
+  @override
+  String get vinDecodeError => 'Diese FIN konnte nicht entschlüsselt werden';
+
+  @override
+  String get vinInvalidFormat => 'Ungültiges FIN-Format';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3026,4 +3026,41 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3017,4 +3017,41 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3025,4 +3025,41 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3019,4 +3019,41 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3022,4 +3022,41 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3046,4 +3046,41 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3021,4 +3021,41 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3026,4 +3026,41 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3025,4 +3025,41 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3023,4 +3023,41 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3025,4 +3025,41 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3021,4 +3021,41 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3026,4 +3026,41 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3024,4 +3024,41 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3025,4 +3025,41 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3024,4 +3024,41 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3025,4 +3025,41 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3019,4 +3019,41 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3023,4 +3023,41 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get chileApiProvider => 'CNE Bencina en Linea';
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmTitle => 'Is this your car?';
+
+  @override
+  String vinConfirmBody(
+    String year,
+    String make,
+    String model,
+    String displacement,
+    String cylinders,
+    String fuel,
+  ) {
+    return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+  }
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get vinPartialInfoNote =>
+      'Partial info (offline). You can edit below.';
+
+  @override
+  String get vinDecodeError => 'Couldn\'t decode this VIN';
+
+  @override
+  String get vinInvalidFormat => 'Invalid VIN format';
 }

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_vin_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_vin_test.dart
@@ -1,0 +1,374 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vin_data.dart';
+import 'package:tankstellen/features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/features/vehicle/providers/vin_decoder_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for the VIN decoder UI added to [EditVehicleScreen]
+/// (#812 phase 2).
+///
+/// These tests drive the real screen; the VIN decoder is overridden
+/// per test so no network call happens. The vehicle repository is a
+/// fake backed by an in-memory settings map so Save doesn't touch
+/// Hive.
+void main() {
+  group('EditVehicleScreen — VIN decoder UI (#812)', () {
+    testWidgets('renders the VIN field and decode button with tooltip',
+        (tester) async {
+      await _pumpEditScreen(tester);
+
+      expect(find.text('VIN (optional)'), findsOneWidget);
+      // The decode button is an IconButton with the search icon and
+      // the localized tooltip. Tooltip lookup also proves the
+      // accessibility requirement (#566) is satisfied.
+      expect(find.byIcon(Icons.search), findsOneWidget);
+      expect(find.byTooltip('Decode VIN'), findsOneWidget);
+    });
+
+    testWidgets(
+      'decoding an empty VIN shows "Invalid VIN format" snackbar '
+      'and never opens the confirm dialog',
+      (tester) async {
+        await _pumpEditScreen(tester);
+
+        await tester.tap(find.byTooltip('Decode VIN'));
+        await tester.pump(); // start snackbar animation
+        await tester.pump(const Duration(milliseconds: 500));
+
+        expect(find.text('Invalid VIN format'), findsOneWidget);
+        expect(find.text('Is this your car?'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'decoding a VIN that returns VinDataSource.invalid shows the '
+      '"Couldn\'t decode" snackbar and skips the dialog',
+      (tester) async {
+        await _pumpEditScreen(
+          tester,
+          decoderResult: (vin) => VinData(
+            vin: vin,
+            source: VinDataSource.invalid,
+          ),
+        );
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'VIN (optional)'),
+          'BADBADBADBADBADBA',
+        );
+        await tester.tap(find.byTooltip('Decode VIN'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Is this your car?'), findsNothing);
+        // Either the generic decode error or the invalid-format label;
+        // we short-circuit on invalid with the invalid-format string.
+        expect(
+          find.text('Invalid VIN format'),
+          findsOneWidget,
+          reason: 'Invalid VIN decoder results show the invalid-format '
+              'snackbar; the dialog must stay dismissed.',
+        );
+      },
+    );
+
+    testWidgets(
+      'decoding a valid VIN opens the confirm dialog with a full '
+      'vPIC summary (year, make, model, displacement, cylinders, fuel)',
+      (tester) async {
+        await _pumpEditScreen(
+          tester,
+          decoderResult: (vin) => VinData(
+            vin: vin,
+            make: 'Peugeot',
+            model: '107',
+            modelYear: 2008,
+            displacementL: 1.0,
+            cylinderCount: 3,
+            fuelTypePrimary: 'Gasoline',
+            source: VinDataSource.vpic,
+          ),
+        );
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'VIN (optional)'),
+          'VF36B8HZL8R123456',
+        );
+        await tester.tap(find.byTooltip('Decode VIN'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Is this your car?'), findsOneWidget);
+        // The body is assembled by the l10n ICU template. We don't
+        // assert the exact formatting character-for-character — just
+        // that every dynamic piece made it through.
+        expect(
+          find.textContaining('Peugeot'),
+          findsOneWidget,
+        );
+        expect(find.textContaining('107'), findsOneWidget);
+        expect(find.textContaining('2008'), findsOneWidget);
+        expect(find.textContaining('1.0'), findsOneWidget);
+        expect(find.textContaining('3'), findsWidgets);
+        expect(find.textContaining('Gasoline'), findsOneWidget);
+
+        // Both dialog actions must be present.
+        expect(find.text('Yes, auto-fill'), findsOneWidget);
+        expect(find.text('Modify manually'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping "Yes, auto-fill" closes the dialog and leaves the VIN '
+      'in the field (the profile auto-fill is exercised by the save '
+      'round-trip below)',
+      (tester) async {
+        await _pumpEditScreen(
+          tester,
+          decoderResult: (vin) => VinData(
+            vin: vin,
+            make: 'Peugeot',
+            model: '107',
+            modelYear: 2008,
+            displacementL: 1.0,
+            cylinderCount: 3,
+            fuelTypePrimary: 'Gasoline',
+            source: VinDataSource.vpic,
+          ),
+        );
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'VIN (optional)'),
+          'VF36B8HZL8R123456',
+        );
+        await tester.tap(find.byTooltip('Decode VIN'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Yes, auto-fill'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Is this your car?'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'tapping "Yes, auto-fill" then Save persists the decoded '
+      'engineDisplacementCc (L→cc), cylinderCount, and VIN on the '
+      'new vehicle profile',
+      (tester) async {
+        final repo = VehicleProfileRepository(_FakeSettings());
+
+        await _pumpEditScreen(
+          tester,
+          repoOverride: repo,
+          decoderResult: (vin) => VinData(
+            vin: vin,
+            make: 'Peugeot',
+            model: '107',
+            modelYear: 2008,
+            displacementL: 1.0,
+            cylinderCount: 3,
+            fuelTypePrimary: 'Gasoline',
+            source: VinDataSource.vpic,
+          ),
+        );
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Name'),
+          'My Peugeot',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'VIN (optional)'),
+          'VF36B8HZL8R123456',
+        );
+        await tester.tap(find.byTooltip('Decode VIN'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Yes, auto-fill'));
+        await tester.pumpAndSettle();
+
+        // Tap the "Save" FilledButton.icon at the bottom (not the
+        // AppBar check — scrolling is simpler this way).
+        await tester.ensureVisible(
+          find.widgetWithText(FilledButton, 'Save'),
+        );
+        await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+        await tester.pumpAndSettle();
+
+        final saved = repo.getAll();
+        expect(saved, hasLength(1));
+        expect(saved.first.name, 'My Peugeot');
+        expect(saved.first.vin, 'VF36B8HZL8R123456');
+        expect(saved.first.engineDisplacementCc, 1000,
+            reason: '1.0 L displacement must be persisted as 1000 cc');
+        expect(saved.first.engineCylinders, 3);
+      },
+    );
+
+    testWidgets(
+      'tapping "Modify manually" closes the dialog and leaves the '
+      'engine fields unset — saving produces a profile with null '
+      'engineDisplacementCc / cylinderCount',
+      (tester) async {
+        final repo = VehicleProfileRepository(_FakeSettings());
+
+        await _pumpEditScreen(
+          tester,
+          repoOverride: repo,
+          decoderResult: (vin) => VinData(
+            vin: vin,
+            make: 'Peugeot',
+            model: '107',
+            modelYear: 2008,
+            displacementL: 1.0,
+            cylinderCount: 3,
+            fuelTypePrimary: 'Gasoline',
+            source: VinDataSource.vpic,
+          ),
+        );
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Name'),
+          'My Peugeot',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'VIN (optional)'),
+          'VF36B8HZL8R123456',
+        );
+        await tester.tap(find.byTooltip('Decode VIN'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Modify manually'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Is this your car?'), findsNothing);
+
+        await tester.ensureVisible(
+          find.widgetWithText(FilledButton, 'Save'),
+        );
+        await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+        await tester.pumpAndSettle();
+
+        final saved = repo.getAll();
+        expect(saved, hasLength(1));
+        // VIN is still persisted (the user typed it) but the engine
+        // fields stay null — that's the whole point of "modify
+        // manually".
+        expect(saved.first.vin, 'VF36B8HZL8R123456');
+        expect(saved.first.engineDisplacementCc, isNull);
+        expect(saved.first.engineCylinders, isNull);
+      },
+    );
+
+    testWidgets(
+      'a WMI-only (offline) decode opens the dialog with the '
+      'partial-info note so the user knows only some fields will '
+      'be pre-filled',
+      (tester) async {
+        await _pumpEditScreen(
+          tester,
+          decoderResult: (vin) => VinData(
+            vin: vin,
+            make: 'Peugeot',
+            country: 'France',
+            source: VinDataSource.wmiOffline,
+          ),
+        );
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'VIN (optional)'),
+          'VF38HKFVZ6R123456',
+        );
+        await tester.tap(find.byTooltip('Decode VIN'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Is this your car?'), findsOneWidget);
+        expect(
+          find.text('Partial info (offline). You can edit below.'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'every interactive element on the edit screen meets the Android '
+      'tap-target guideline (48dp minimum, #566)',
+      (tester) async {
+        await _pumpEditScreen(tester);
+
+        final handle = tester.ensureSemantics();
+        await expectLater(
+          tester,
+          meetsGuideline(androidTapTargetGuideline),
+        );
+        handle.dispose();
+      },
+    );
+  });
+}
+
+/// Pumps [EditVehicleScreen] inside a ProviderScope with the minimum
+/// overrides needed to run the VIN flow offline.
+///
+/// [decoderResult] controls what [decodedVinProvider] returns for a
+/// given VIN. Returning `null` mimics the "no result" path.
+/// [repoOverride] injects a real [VehicleProfileRepository] (backed by
+/// the fake settings map) so callers can assert on the saved profile.
+Future<void> _pumpEditScreen(
+  WidgetTester tester, {
+  VinData? Function(String vin)? decoderResult,
+  VehicleProfileRepository? repoOverride,
+}) async {
+  final repo = repoOverride ?? VehicleProfileRepository(_FakeSettings());
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        vehicleProfileRepositoryProvider.overrideWithValue(repo),
+        if (decoderResult != null)
+          decodedVinProvider.overrideWith((ref, vin) async {
+            return decoderResult(vin);
+          }),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: EditVehicleScreen(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Minimal in-memory [SettingsStorage] so the repository can run
+/// without a Hive box.
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/vehicle/presentation/widgets/vin_confirm_dialog_test.dart
+++ b/test/features/vehicle/presentation/widgets/vin_confirm_dialog_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vin_data.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vin_confirm_dialog.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Widget tests for [VinConfirmDialog] (#812 phase 2).
+///
+/// Focused on the rendering branches: full vPIC summary, partial
+/// offline summary with the "partial info" note, and the two action
+/// outcomes.
+void main() {
+  group('VinConfirmDialog', () {
+    const fullVpic = VinData(
+      vin: 'VF36B8HZL8R123456',
+      make: 'Peugeot',
+      model: '107',
+      modelYear: 2008,
+      displacementL: 1.0,
+      cylinderCount: 3,
+      fuelTypePrimary: 'Gasoline',
+      source: VinDataSource.vpic,
+    );
+
+    const partialWmi = VinData(
+      vin: 'VF38HKFVZ6R123456',
+      make: 'Peugeot',
+      country: 'France',
+      source: VinDataSource.wmiOffline,
+    );
+
+    testWidgets('renders the full vPIC summary with every field',
+        (tester) async {
+      await pumpApp(tester, const VinConfirmDialog(data: fullVpic));
+
+      expect(find.text('Is this your car?'), findsOneWidget);
+      expect(find.textContaining('Peugeot'), findsOneWidget);
+      expect(find.textContaining('107'), findsOneWidget);
+      expect(find.textContaining('2008'), findsOneWidget);
+      expect(find.textContaining('1.0'), findsOneWidget);
+      expect(find.textContaining('Gasoline'), findsOneWidget);
+      // No partial-info note on a full vPIC result.
+      expect(
+        find.text('Partial info (offline). You can edit below.'),
+        findsNothing,
+      );
+    });
+
+    testWidgets(
+      'renders the partial-info note when source is wmiOffline',
+      (tester) async {
+        await pumpApp(tester, const VinConfirmDialog(data: partialWmi));
+
+        expect(find.text('Is this your car?'), findsOneWidget);
+        expect(
+          find.text('Partial info (offline). You can edit below.'),
+          findsOneWidget,
+        );
+        // Missing fields render as em-dashes so the template keeps
+        // its shape.
+        expect(find.textContaining('—'), findsWidgets);
+      },
+    );
+
+    testWidgets('offers both Confirm and Modify actions', (tester) async {
+      await pumpApp(tester, const VinConfirmDialog(data: fullVpic));
+
+      expect(find.text('Yes, auto-fill'), findsOneWidget);
+      expect(find.text('Modify manually'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/vehicle/providers/vin_decoder_provider_test.dart
+++ b/test/features/vehicle/providers/vin_decoder_provider_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/data/vin_decoder.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vin_data.dart';
+import 'package:tankstellen/features/vehicle/providers/vin_decoder_provider.dart';
+
+/// Unit tests for [decodedVinProvider] (#812 phase 2).
+void main() {
+  group('decodedVinProvider', () {
+    test('returns null for an empty VIN without calling the decoder', () async {
+      final container = ProviderContainer(
+        overrides: [
+          vinDecoderProvider.overrideWithValue(_ThrowingDecoder()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(decodedVinProvider('').future);
+      expect(result, isNull);
+    });
+
+    test('delegates to VinDecoder.decode for a non-empty VIN', () async {
+      final decoder = _StubDecoder(
+        (vin) => VinData(
+          vin: vin,
+          make: 'Peugeot',
+          source: VinDataSource.wmiOffline,
+        ),
+      );
+      final container = ProviderContainer(
+        overrides: [vinDecoderProvider.overrideWithValue(decoder)],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(decodedVinProvider('VF38HKFVZ6R123456').future);
+
+      expect(result, isNotNull);
+      expect(result!.make, 'Peugeot');
+      expect(result.source, VinDataSource.wmiOffline);
+      expect(decoder.calls, ['VF38HKFVZ6R123456']);
+    });
+
+    test('reads from cache on the second call with the same VIN', () async {
+      final decoder = _StubDecoder(
+        (vin) => VinData(vin: vin, source: VinDataSource.wmiOffline),
+      );
+      final container = ProviderContainer(
+        overrides: [vinDecoderProvider.overrideWithValue(decoder)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(decodedVinProvider('VF36B8HZL8R123456').future);
+      await container.read(decodedVinProvider('VF36B8HZL8R123456').future);
+
+      expect(
+        decoder.calls,
+        ['VF36B8HZL8R123456'],
+        reason: 'The second read should hit the keep-alive family cache',
+      );
+    });
+  });
+}
+
+class _StubDecoder implements VinDecoder {
+  final VinData Function(String) _fn;
+  final List<String> calls = [];
+
+  _StubDecoder(this._fn);
+
+  @override
+  Future<VinData?> decode(String vin) async {
+    calls.add(vin);
+    return _fn(vin);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+class _ThrowingDecoder implements VinDecoder {
+  @override
+  Future<VinData?> decode(String vin) =>
+      throw StateError('decoder should not be called');
+
+  @override
+  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}


### PR DESCRIPTION
## Summary

Phase 2 of #812 — wires the phase-1 `VinDecoder` (merged in #856) into the Edit Vehicle screen. Users can now paste or type a VIN, tap Decode, confirm a summary dialog, and auto-fill their vehicle profile's engine parameters.

This is the *burn less fuel* half of the product leitmotiv — correct displacement + cylinder count + curb weight is what the phase-3 OBD2 fuel-rate math needs to stop emitting NO DATA blanks for small engines.

## Phased plan

- **Phase 1** (#856, shipped) — `VinDecoder`, `WmiTable`, `VinData` entity, extended `VehicleProfile` fields (`engineDisplacementCc`, `cylinderCount`, `volumetricEfficiency`, `curbWeightKg`).
- **Phase 2** (this PR) — UI. VIN field, Riverpod decoder provider, confirm dialog, form integration, `vin` field on the profile, en/de ARB.
- **Phase 3** (future) — plumb the populated engine parameters into `Obd2Service.readFuelRateLPerHour` (speed-density fallback for vehicles without MAF / PID `0x5E`).

## What changed

- `decodedVinProvider` — `@Riverpod(keepAlive: true)` family keyed by VIN so repeated decodes in a session hit the cache.
- `VinConfirmDialog` — renders the decoded `{year} {make} {model} — {displacement}L, {cylinders}-cyl, {fuel}` summary. Surfaces a "partial info (offline)" note when the source is `wmiOffline`. Invalid decodes skip the dialog and fall through to a snackbar.
- `EditVehicleScreen` — new "VIN (optional)" `TextFormField` with a search-icon decode button (+ tooltip). On confirm, displacement is converted L→cc, GVWR is approximated to curb weight (lbs / 2.205), and the values flow into the saved `VehicleProfile`. The VIN itself is also persisted so re-editing shows what the user typed.
- `VehicleProfile` — new optional `vin` field; freezed + json_serializable regenerated.
- `en` / `de` ARB only. Other locales fall back to English via gen-l10n autogeneration — matches the phased-rollout pattern used by #856 and earlier phases.

## Test plan

- [x] `flutter analyze` — zero warnings/errors
- [x] `flutter test` — 5243 pass, 1 skipped
- [x] `decodedVinProvider` — unit tests for empty-VIN short-circuit, delegation to `VinDecoder.decode`, and keep-alive cache behaviour
- [x] `VinConfirmDialog` — full vPIC summary, partial WMI note, both actions present
- [x] `EditVehicleScreen` — widget tests for VIN field + tooltip, empty-VIN snackbar (no dialog), invalid-decode snackbar (no dialog), vPIC happy path opens dialog, partial WMI opens dialog with note, confirm + save round-trips `engineDisplacementCc=1000` / `cylinderCount=3` / `vin` onto the persisted profile, modify-manually keeps engine fields null
- [x] `androidTapTargetGuideline` passes on the edit screen
- [x] Phase 3 plumbing (`lib/core/obd2/**`, `lib/features/consumption/**`) left untouched

Refs #812