### PR TITLE
feat(vehicle): VIN -> fuel rate (#812 phase 3)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -1,8 +1,23 @@
 import 'package:flutter/foundation.dart';
 
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import 'elm327_protocol.dart';
 import 'obd2_transport.dart';
 import 'supported_pids_cache.dart';
+
+/// Fallback engine displacement used by the speed-density fuel-rate
+/// estimator when the active vehicle profile doesn't expose one
+/// (#810, #812). 1000 cc = 1.0 L NA petrol — matches the Peugeot 107
+/// / Aygo / C1 class that originally motivated the fallback. Kept as
+/// a named constant so the no-profile case is obvious at a glance
+/// and easy to update if the default assumption ever changes.
+const int _defaultEngineDisplacementCc = 1000;
+
+/// Fallback volumetric efficiency for the speed-density estimator
+/// (#810, #812). 0.85 is a sensible midpoint for a NA petrol engine
+/// at cruise; adaptive calibration (#815) will later narrow this per
+/// vehicle from tankful reconciliation.
+const double _defaultVolumetricEfficiency = 0.85;
 
 /// High-level OBD-II service for reading vehicle data.
 ///
@@ -324,11 +339,15 @@ class Obd2Service {
   ///      error — still infinitely better than the `—` placeholder the
   ///      trip summary would otherwise show.
   ///
-  /// [engineDisplacementCc] and [volumetricEfficiency] are per-vehicle
-  /// constants for the step-3 fallback. Defaults are tuned for a 1.0 L
-  /// NA petrol engine (matches the Peugeot 107 / Aygo / C1 class and
-  /// covers many other sub-1.2 L city cars). A follow-up PR will plumb
-  /// per-vehicle overrides from the vehicle profile.
+  /// Pass the active [VehicleProfile] via [vehicle] to feed the
+  /// step-3 speed-density fallback the car's real engine displacement
+  /// and volumetric efficiency (#812 phase 3). When [vehicle] is null
+  /// or its engine fields are null, the method falls back to
+  /// [_defaultEngineDisplacementCc] / [_defaultVolumetricEfficiency]
+  /// — still honest, just tuned for the 1.0 L NA petrol class (Peugeot
+  /// 107 / Aygo / C1) that originally motivated the fallback.
+  /// Partial profiles (e.g. displacement known, VE unknown) use the
+  /// known field and fall back for the missing one.
   ///
   /// Fuel-trim correction (#813) is applied on the MAF and
   /// speed-density branches — both compute air-mass at stoichiometric
@@ -336,10 +355,14 @@ class Obd2Service {
   /// `(1 + (STFT + LTFT) / 100)` factor closes most of the gap with
   /// pump-measured consumption. Skipped on the direct-5E path because
   /// the ECU already returns a post-trim number there.
-  Future<double?> readFuelRateLPerHour({
-    int engineDisplacementCc = 1000,
-    double volumetricEfficiency = 0.85,
-  }) async {
+  Future<double?> readFuelRateLPerHour({VehicleProfile? vehicle}) async {
+    final engineDisplacementCc =
+        vehicle?.engineDisplacementCc ?? _defaultEngineDisplacementCc;
+    // VE on VehicleProfile is a non-nullable double with its own
+    // default (0.85). Using it directly here is equivalent to the
+    // service-level fallback for that field.
+    final volumetricEfficiency =
+        vehicle?.volumetricEfficiency ?? _defaultVolumetricEfficiency;
     // Step 1: direct fuel-rate PID (already post-trim — no correction).
     // Skipped when #811 discovery proved the car doesn't implement PID 5E.
     if (isPidSupported(0x5E)) {

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../domain/trip_recorder.dart';
 import 'obd2_service.dart';
 
@@ -63,14 +64,13 @@ class TripRecordingController {
   final Duration _pollInterval;
   final DateTime Function() _now;
 
-  /// Engine constants for the speed-density fuel-rate fallback
-  /// (#810, #812). Captured once at construction — the user's
-  /// vehicle doesn't change mid-trip, and recomputing these per
-  /// tick would just burn CPU. When null, `readFuelRateLPerHour`
-  /// uses its generic 1.0 L / η_v 0.85 defaults — still honest,
-  /// just less precise.
-  final int? _engineDisplacementCc;
-  final double? _volumetricEfficiency;
+  /// Active [VehicleProfile] snapshot for the speed-density
+  /// fuel-rate fallback (#810, #812 phase 3). Captured once at
+  /// construction — the user's vehicle doesn't change mid-trip, and
+  /// re-reading the profile every tick would just burn CPU. When
+  /// null, `readFuelRateLPerHour` falls back to its generic 1.0 L /
+  /// η_v 0.85 defaults — still honest, just less precise.
+  final VehicleProfile? _vehicle;
 
   final StreamController<TripLiveReading> _liveController =
       StreamController<TripLiveReading>.broadcast();
@@ -89,14 +89,12 @@ class TripRecordingController {
     TripRecorder? recorder,
     Duration pollInterval = const Duration(seconds: 1),
     DateTime Function()? now,
-    int? engineDisplacementCc,
-    double? volumetricEfficiency,
+    VehicleProfile? vehicle,
   })  : _service = service,
         _recorder = recorder ?? TripRecorder(),
         _pollInterval = pollInterval,
         _now = now ?? DateTime.now,
-        _engineDisplacementCc = engineDisplacementCc,
-        _volumetricEfficiency = volumetricEfficiency;
+        _vehicle = vehicle;
 
   /// Live metrics stream — subscribe to update the recording UI.
   Stream<TripLiveReading> get live => _liveController.stream;
@@ -168,10 +166,7 @@ class TripRecordingController {
     try {
       final speed = await _service.readSpeedKmh();
       final rpm = await _service.readRpm();
-      final fuelRate = await _service.readFuelRateLPerHour(
-        engineDisplacementCc: _engineDisplacementCc ?? 1000,
-        volumetricEfficiency: _volumetricEfficiency ?? 0.85,
-      );
+      final fuelRate = await _service.readFuelRateLPerHour(vehicle: _vehicle);
       final engineLoad = await _service.readEngineLoad();
       final fuelLevel = await _service.readFuelLevelPercent();
       final sample = TripSample(

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -137,16 +137,17 @@ class TripRecording extends _$TripRecording {
   Future<void> start(Obd2Service service) async {
     if (state.isActive) return;
     _service = service;
-    // #812 phase 2 — read the active vehicle's engine params once
-    // here so the controller can pass them to `readFuelRateLPerHour`
-    // on every tick (speed-density fallback uses them per car). We
-    // read the vehicle a second time below for the baseline-store
+    // #812 phase 3 — snapshot the active vehicle so the controller
+    // can hand it to `readFuelRateLPerHour` on every tick. The
+    // speed-density fallback reads engineDisplacementCc +
+    // volumetricEfficiency off the profile; a null vehicle or null
+    // fields fall back to the service-level defaults. We read the
+    // vehicle a second time below for the baseline-store
     // bookkeeping; both reads are cheap Riverpod cache hits.
     final activeVehicle = _tryReadActiveVehicle();
     final ctl = TripRecordingController(
       service: service,
-      engineDisplacementCc: activeVehicle?.engineDisplacementCc,
-      volumetricEfficiency: activeVehicle?.volumetricEfficiency,
+      vehicle: activeVehicle,
     );
     _controller = ctl;
     _classifier = SituationClassifier();

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 
 // Shared AT-init boilerplate for the FakeObd2Transport.
 const _initResponses = {
@@ -245,6 +246,149 @@ void main() {
         // MAF path (10.24 × 3600 / (14.7 × 740)) ≈ 3.389 L/h,
         // no trim correction because trims are NO DATA.
         expect(rate, closeTo(3.389, 0.01));
+      });
+    });
+
+    group('readFuelRateLPerHour + VehicleProfile plumbing — #812 phase 3',
+        () {
+      // Shared Peugeot 107-style speed-density fixture: no 5E, no
+      // MAF; only MAP+IAT+RPM. Same operating point across all the
+      // tests below so expected values are comparable.
+      const mapKpa = 65.0;
+      const iatCelsius = 30.0;
+      const rpm = 2500.0;
+      Future<Obd2Service> speedDensityOnly() async {
+        return _connected({
+          '015E': 'NO DATA>',
+          '0110': 'NO DATA>',
+          '010B': '41 0B 41>', // MAP raw 0x41 = 65 kPa
+          '010F': '41 0F 46>', // IAT raw 0x46 = 70; 70 − 40 = 30 °C
+          '010C': '41 0C 27 10>', // RPM ((0x27×256)+0x10)/4 = 2500
+          '0106': 'NO DATA>', // no fuel-trim correction in these tests
+          '0107': 'NO DATA>',
+        });
+      }
+
+      test(
+          'null vehicle falls back to the same 1000 cc / 0.85 VE output '
+          'as pre-phase-3 — characterization test', () async {
+        final service = await speedDensityOnly();
+        final rate = await service.readFuelRateLPerHour();
+        final expected = Obd2Service.estimateFuelRateLPerHourFromMap(
+          mapKpa: mapKpa,
+          iatCelsius: iatCelsius,
+          rpm: rpm,
+          engineDisplacementCc: 1000,
+          volumetricEfficiency: 0.85,
+        );
+        expect(rate, isNotNull);
+        expect(expected, isNotNull);
+        expect(rate, closeTo(expected!, 1e-3));
+      });
+
+      test(
+          'VehicleProfile overrides both displacement and VE in the '
+          'speed-density branch', () async {
+        final service = await speedDensityOnly();
+        const profile = VehicleProfile(
+          id: 'v1',
+          name: '1.6L override',
+          engineDisplacementCc: 1600,
+          volumetricEfficiency: 0.88,
+        );
+        final rate =
+            await service.readFuelRateLPerHour(vehicle: profile);
+        final expected = Obd2Service.estimateFuelRateLPerHourFromMap(
+          mapKpa: mapKpa,
+          iatCelsius: iatCelsius,
+          rpm: rpm,
+          engineDisplacementCc: 1600,
+          volumetricEfficiency: 0.88,
+        );
+        expect(rate, isNotNull);
+        expect(expected, isNotNull);
+        expect(rate, closeTo(expected!, 1e-3));
+
+        // And the override must actually change the answer vs. the
+        // defaults — otherwise the plumbing could be silently
+        // dropping the profile and the test would still pass.
+        final defaultRate = await (await speedDensityOnly())
+            .readFuelRateLPerHour();
+        expect(
+          (rate! - defaultRate!).abs(),
+          greaterThan(1e-2),
+          reason: '1600 cc × 0.88 VE should yield a clearly different '
+              'rate from 1000 cc × 0.85 VE',
+        );
+      });
+
+      test(
+          'partial profile (displacement known, VE left at model default) '
+          'uses the profile displacement and the VehicleProfile default VE',
+          () async {
+        final service = await speedDensityOnly();
+        // VehicleProfile's volumetricEfficiency field defaults to
+        // 0.85 at the model level — NOT null — so "unknown" here
+        // means "user hasn't overridden the VehicleProfile default".
+        // The behaviour should match passing a profile with
+        // displacement 1600 + VE 0.85 explicitly.
+        const profile = VehicleProfile(
+          id: 'v2',
+          name: '1.6L, default VE',
+          engineDisplacementCc: 1600,
+        );
+        final rate =
+            await service.readFuelRateLPerHour(vehicle: profile);
+        final expected = Obd2Service.estimateFuelRateLPerHourFromMap(
+          mapKpa: mapKpa,
+          iatCelsius: iatCelsius,
+          rpm: rpm,
+          engineDisplacementCc: 1600,
+          volumetricEfficiency: 0.85,
+        );
+        expect(rate, isNotNull);
+        expect(expected, isNotNull);
+        expect(rate, closeTo(expected!, 1e-3));
+      });
+
+      test(
+          'profile with null engineDisplacementCc falls back to the '
+          '1000 cc default — VE from profile still wins', () async {
+        final service = await speedDensityOnly();
+        const profile = VehicleProfile(
+          id: 'v3',
+          name: 'no displacement, custom VE',
+          volumetricEfficiency: 0.72,
+        );
+        final rate =
+            await service.readFuelRateLPerHour(vehicle: profile);
+        final expected = Obd2Service.estimateFuelRateLPerHourFromMap(
+          mapKpa: mapKpa,
+          iatCelsius: iatCelsius,
+          rpm: rpm,
+          engineDisplacementCc: 1000,
+          volumetricEfficiency: 0.72,
+        );
+        expect(rate, isNotNull);
+        expect(expected, isNotNull);
+        expect(rate, closeTo(expected!, 1e-3));
+      });
+
+      test(
+          'profile is not used on the direct PID 5E path — that value '
+          'is already per-vehicle from the ECU', () async {
+        final service = await _connected({'015E': '41 5E 08 00>'});
+        const profile = VehicleProfile(
+          id: 'v4',
+          name: 'irrelevant',
+          engineDisplacementCc: 9999,
+          volumetricEfficiency: 0.50,
+        );
+        final rate =
+            await service.readFuelRateLPerHour(vehicle: profile);
+        // Same 102.4 L/h as the no-profile 5E test above — the
+        // profile is just ignored when PID 5E wins.
+        expect(rate, closeTo(102.4, 0.1));
       });
     });
 

--- a/test/features/consumption/data/obd2/trip_recording_controller_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 
 void main() {
   group('TripRecordingController (#726)', () {
@@ -124,10 +125,10 @@ void main() {
       await ctl.stop();
     });
 
-    group('engine-param plumbing — #812 phase 2', () {
+    group('engine-param plumbing — #812 phase 3', () {
       test(
-          'accepts engineDisplacementCc + volumetricEfficiency and passes '
-          'them to readFuelRateLPerHour on every poll', () async {
+          'accepts a VehicleProfile and feeds its engine fields into '
+          'readFuelRateLPerHour on every poll', () async {
         // On a Peugeot 107-class setup (no PID 5E, no MAF; only
         // MAP+IAT+RPM), the resulting fuel rate is directly
         // proportional to displacement × η_v. Doubling displacement
@@ -153,30 +154,41 @@ void main() {
         }
 
         // Service-level sanity: 2.0 L yields twice the fuel rate of
-        // 1.0 L at the same VE and operating point.
+        // 1.0 L at the same VE and operating point — passing two
+        // profiles that differ only in displacement.
         final svc1 = await peugeot107();
         final rate1L = await svc1.readFuelRateLPerHour(
-          engineDisplacementCc: 1000,
-          volumetricEfficiency: 0.85,
+          vehicle: const VehicleProfile(
+            id: 'a',
+            name: '1.0L',
+            engineDisplacementCc: 1000,
+          ),
         );
         final svc2 = await peugeot107();
         final rate2L = await svc2.readFuelRateLPerHour(
-          engineDisplacementCc: 2000,
-          volumetricEfficiency: 0.85,
+          vehicle: const VehicleProfile(
+            id: 'b',
+            name: '2.0L',
+            engineDisplacementCc: 2000,
+          ),
         );
         expect(rate1L, isNotNull);
         expect(rate2L, isNotNull);
         expect(rate2L! / rate1L!, closeTo(2.0, 0.01));
 
-        // Controller wire-up: the constructor params are plumbed
+        // Controller wire-up: the constructor param is plumbed
         // through. Not validated by running the poll loop (that
-        // requires a timer + streaming), but the parameters are
+        // requires a timer + streaming), but the parameter is
         // captured and non-null when supplied.
         final ctl = TripRecordingController(
           service: svc1,
           pollInterval: const Duration(minutes: 1),
-          engineDisplacementCc: 998, // Peugeot 107
-          volumetricEfficiency: 0.80,
+          vehicle: const VehicleProfile(
+            id: 'peugeot107',
+            name: 'Peugeot 107',
+            engineDisplacementCc: 998,
+            volumetricEfficiency: 0.80,
+          ),
         );
         await ctl.start();
         await ctl.stop();
@@ -186,7 +198,7 @@ void main() {
       });
 
       test(
-          'null engine params fall back to generic 1.0 L / 0.85 defaults — '
+          'null vehicle falls back to the generic 1.0 L / 0.85 defaults — '
           'matches the pre-#812 hardcoded behavior', () async {
         final transport = FakeObd2Transport({
           'ATZ': 'ELM327 v1.5>',
@@ -199,7 +211,7 @@ void main() {
         final service = Obd2Service(transport);
         await service.connect();
 
-        // Omitting the engine params should not throw and should
+        // Omitting the vehicle param should not throw and should
         // behave identically to the pre-#812 constructor.
         final ctl = TripRecordingController(
           service: service,


### PR DESCRIPTION
## Summary

- Replace hardcoded `1000 cc` / `0.85 VE` defaults in `Obd2Service.readFuelRateLPerHour` with values read from the active `VehicleProfile`.
- Named private constants (`_defaultEngineDisplacementCc`, `_defaultVolumetricEfficiency`) hold the no-profile fallback so the intent is visible at the top of the file.
- `TripRecordingController` now takes a `VehicleProfile? vehicle` instead of two raw engine fields; the trip recording provider forwards the active profile verbatim.
- Partial profiles (displacement known but VE unknown, or vice-versa) gracefully degrade field-by-field.

## Why

Phase 1 (#856) shipped the `VehicleProfile.engineDisplacementCc` / `volumetricEfficiency` fields. Phase 2 (#861) shipped the VIN-decoder UI that populates them. Without this phase, those fields were cosmetic: the fuel-rate estimator still ran with the 1.0 L NA petrol defaults for every user. This PR closes the loop so a user who enters a 1.6 L vehicle actually gets a 1.6 L-correct fuel-rate estimate.

Closes #812

Phases 1 (PR #856) and 2 (PR #861) have landed; this PR completes the issue.

## Testing

- Added `readFuelRateLPerHour + VehicleProfile plumbing - #812 phase 3` group in `obd2_service_test.dart`:
  - **Characterization test**: null vehicle produces the exact same output as `estimateFuelRateLPerHourFromMap(1000, 0.85)` (within `1e-3`).
  - **Full override**: `VehicleProfile(engineDisplacementCc: 1600, volumetricEfficiency: 0.88)` matches `estimateFuelRateLPerHourFromMap(1600, 0.88)` and is clearly distinct from the default.
  - **Partial profile**: displacement set but VE left at the model default (`0.85`) uses the profile displacement with the VE default.
  - **Partial profile (other half)**: `engineDisplacementCc: null` + custom VE uses the 1000 cc fallback + profile VE.
  - **PID 5E bypass**: the profile is ignored when PID 5E wins (the ECU value is already per-vehicle).
- Updated `trip_recording_controller_test.dart` to cover the new `vehicle:` ctor param (ratio-of-rates test + null-profile fallback test).
- Full suite: `flutter analyze` zero issues, `flutter test` 5247 passing + 1 pre-existing skip.

## Files touched

- `lib/features/consumption/data/obd2/obd2_service.dart`
- `lib/features/consumption/data/obd2/trip_recording_controller.dart`
- `lib/features/consumption/providers/trip_recording_provider.dart`
- `test/features/consumption/data/obd2/obd2_service_test.dart`
- `test/features/consumption/data/obd2/trip_recording_controller_test.dart`

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` green
- [ ] Device smoke: record a short trip on a Peugeot 107 profile (998 cc) and confirm the live L/h readout is lower than it was on master's generic 1000 cc × 0.85 config.

---

Generated with [Claude Code](https://claude.com/claude-code)