### PR TITLE
feat(obd2): PidScheduler migration (#814 phase 2)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -54,6 +54,15 @@ class Obd2Service {
   /// connection to the vehicle's ELM327 adapter.
   bool get isConnected => _transport.isConnected;
 
+  /// Send a raw command to the ELM327 adapter and return the raw
+  /// response. Exposed for the [PidScheduler]-based trip recording
+  /// loop (#814) — the scheduler dispatches individual PID commands
+  /// directly and parses responses PID-by-PID, rather than going
+  /// through the typed `readRpm` / `readSpeed` helpers. Keeping the
+  /// escape hatch on the service lets the transport stay private.
+  Future<String> sendCommand(String command) =>
+      _transport.sendCommand(command);
+
   /// Connect and initialize the ELM327 adapter.
   ///
   /// After the init sequence, if a [SupportedPidsCache] was wired in

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -4,11 +4,13 @@ import 'package:flutter/foundation.dart';
 
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../domain/trip_recorder.dart';
+import 'elm327_protocol.dart';
 import 'obd2_service.dart';
+import 'pid_scheduler.dart';
 
 /// Live read-out from the currently-recording trip (#726).
 ///
-/// Emitted on every poll tick so the recording screen can show the
+/// Emitted on every debounced tick so the recording screen can show the
 /// user speed / RPM / distance / estimated fuel without having to
 /// ask the recorder for a full summary each time.
 @immutable
@@ -18,6 +20,12 @@ class TripLiveReading {
   final double? fuelRateLPerHour;
   final double? fuelLevelPercent;
   final double? engineLoadPercent;
+  /// Absolute throttle position, 0–100 %. Subscribed to the 5 Hz tier
+  /// of the [PidScheduler] (#814) so the eco-feedback UI and the
+  /// future coasting-detection logic have a direct signal instead of
+  /// the engine-load proxy. Null when the adapter hasn't surfaced PID
+  /// 11 or the first tick hasn't landed yet.
+  final double? throttlePercent;
   final double distanceKmSoFar;
   final double? fuelLitersSoFar;
   final Duration elapsed;
@@ -30,6 +38,7 @@ class TripLiveReading {
     this.fuelRateLPerHour,
     this.fuelLevelPercent,
     this.engineLoadPercent,
+    this.throttlePercent,
     required this.distanceKmSoFar,
     this.fuelLitersSoFar,
     required this.elapsed,
@@ -46,18 +55,44 @@ class TripLiveReading {
   }
 }
 
-/// Drives the polling loop that feeds an [Obd2Service]'s live PIDs
-/// into a [TripRecorder] (#726).
+/// Drives the priority-tiered PID polling loop that feeds an
+/// [Obd2Service]'s live PIDs into a [TripRecorder] (#726, #814).
 ///
 /// Not a Riverpod notifier — kept as a plain class so the recording
 /// screen owns the lifecycle (start on screen mount, stop on tap).
 /// The screen subscribes to [live] for UI updates and calls [stop]
 /// to finalise the trip.
 ///
-/// Polling cadence is 1 Hz — faster than that doesn't improve the
-/// derived metrics (RPM/speed integration is already smooth at 1 Hz
-/// for typical driving), and most cheap ELM327 clones can't answer
-/// 5 PIDs reliably inside a 500 ms window.
+/// ## #814 phase 2 — PidScheduler migration
+///
+/// Phase 1 (PR #860) shipped the standalone [PidScheduler]. Phase 2
+/// wires it here: instead of one monolithic `Timer.periodic(1s)` that
+/// reads every PID on every tick, we subscribe each PID at its own
+/// target frequency and let the scheduler's weighted round-robin pick
+/// the next command:
+///
+///   - **5 Hz (high priority):** RPM, speed, MAF/MAP, throttle, fuel-
+///     rate PID 5E. These drive the eco-feedback band classifier and
+///     the live L/100 km readout — users feel a 200 ms refresh.
+///   - **1 Hz (medium):** STFT, LTFT, IAT, engine load. Needed for
+///     the fuel-rate correction and the situation classifier, but
+///     they don't change fast enough to warrant a 200 ms slot.
+///   - **0.1 Hz (low):** fuel tank level. 10 s is plenty — the gauge
+///     barely moves per tick.
+///
+/// VIN (Mode 09) is a one-shot read at [start] and is intentionally
+/// NOT subscribed — it doesn't change mid-trip, and blasting the
+/// adapter with a 0x0902 every 10 s wastes bandwidth the 5 Hz tier
+/// needs.
+///
+/// Emissions are debounced. Every PID response updates an internal
+/// snapshot; a secondary timer (running at [_pollInterval]) emits a
+/// consolidated [TripLiveReading] off that snapshot. At 5 Hz on the
+/// fast tier we would otherwise fire ten+ events per second — more
+/// signal than the UI can consume and more state-change churn than
+/// the situation/band classifier needs. The debounced approach keeps
+/// the event rate bounded at whatever cadence the caller wants
+/// (production: 250–500 ms; tests: 1 minute to pin the loop quiet).
 class TripRecordingController {
   final Obd2Service _service;
   final TripRecorder _recorder;
@@ -72,67 +107,117 @@ class TripRecordingController {
   /// η_v 0.85 defaults — still honest, just less precise.
   final VehicleProfile? _vehicle;
 
+  /// Optional override — tests inject a hand-built scheduler (usually
+  /// with a tiny [PidScheduler.tickRate] + a fake transport) to
+  /// exercise the scheduler ↔ controller wiring without touching the
+  /// real [Obd2Service] chain. Production always passes null and
+  /// [start] constructs a scheduler against [service.sendCommand].
+  final PidScheduler? _schedulerOverride;
+
   final StreamController<TripLiveReading> _liveController =
       StreamController<TripLiveReading>.broadcast();
 
-  Timer? _timer;
+  PidScheduler? _scheduler;
+  Timer? _emitTimer;
   DateTime? _startedAt;
+  DateTime? _lastSampleAt;
   double? _odometerStartKm;
   double? _odometerLatestKm;
   double _fuelLitersSoFar = 0;
   bool _fuelRateSeen = false;
-  bool _polling = false;
   bool _paused = false;
+  bool _started = false;
+
+  /// Latest parsed values, keyed by PID command. Written by scheduler
+  /// callbacks, read by [_emit] when assembling [TripLiveReading]. Not
+  /// using a typed struct because most fields are optional doubles
+  /// and adding a freezed class for this scratch space buys nothing.
+  double? _latestSpeedKmh;
+  double? _latestRpm;
+  double? _latestMaf;
+  double? _latestMapKpa;
+  double? _latestIatCelsius;
+  double? _latestThrottlePercent;
+  double? _latestEngineLoadPercent;
+  double? _latestFuelLevelPercent;
+  double? _latestStft;
+  double? _latestLtft;
+  double? _latestDirectFuelRate;
+  String? _vin;
 
   TripRecordingController({
     required Obd2Service service,
     TripRecorder? recorder,
-    Duration pollInterval = const Duration(seconds: 1),
+    Duration pollInterval = const Duration(milliseconds: 250),
     DateTime Function()? now,
     VehicleProfile? vehicle,
+    PidScheduler? scheduler,
   })  : _service = service,
         _recorder = recorder ?? TripRecorder(),
         _pollInterval = pollInterval,
         _now = now ?? DateTime.now,
-        _vehicle = vehicle;
+        _vehicle = vehicle,
+        _schedulerOverride = scheduler;
 
   /// Live metrics stream — subscribe to update the recording UI.
   Stream<TripLiveReading> get live => _liveController.stream;
 
-  bool get isRecording => _timer != null && !_paused;
+  bool get isRecording => _started && !_paused;
   bool get isPaused => _paused;
-  bool get isActive => _timer != null;
+  bool get isActive => _started;
 
   /// Pause the polling loop without tearing down the recorder. The
-  /// controller keeps its timer alive internally and ignores ticks
-  /// while paused; [resume] flips the flag back without resetting
-  /// state. Safe to call when not recording — no-op.
+  /// scheduler is stopped (no wasted Bluetooth chatter while the user
+  /// is looking at another screen) but the emit timer keeps ticking so
+  /// a frozen `TripLiveReading` still flushes if UI subscribed late.
+  /// [resume] restarts the scheduler. Safe to call when not recording
+  /// — no-op.
   void pause() {
-    if (_timer == null) return;
+    if (!_started) return;
+    if (_paused) return;
     _paused = true;
+    _scheduler?.stop();
   }
 
   /// Resume a paused recording. Idempotent; no-op if not paused.
   void resume() {
+    if (!_paused) return;
     _paused = false;
+    _scheduler?.start();
   }
 
-  /// Start polling. Reads the odometer ONCE to pin the trip start;
-  /// subsequent ticks read speed/RPM/fuel-rate/etc. Safe to call
-  /// multiple times — no-op when already recording.
+  /// Start polling. Reads the odometer and VIN ONCE to pin trip
+  /// identity; subsequent ticks are scheduled per-PID by
+  /// [PidScheduler]. Safe to call multiple times — no-op when already
+  /// recording.
   Future<void> start() async {
-    if (_timer != null) return;
+    if (_started) return;
+    _started = true;
     _startedAt = _now();
     _odometerStartKm = await _service.readOdometerKm();
     _odometerLatestKm = _odometerStartKm;
-    _timer = Timer.periodic(_pollInterval, (_) => _pollOnce());
+
+    // One-shot VIN read (#814). VIN is Mode 09 PID 02 — it never
+    // changes mid-trip, so subscribing it to the 0.1 Hz tier would
+    // just waste one Bluetooth round-trip per 10 s on a value we
+    // already have. Best-effort: a car that can't answer 0902 simply
+    // leaves [_vin] null.
+    _vin = await _readVinOnce();
+
+    _scheduler = _schedulerOverride ?? _buildScheduler();
+    _subscribeAllTiers(_scheduler!);
+    _scheduler!.start();
+
+    _emitTimer = Timer.periodic(_pollInterval, (_) => _emit());
   }
 
   /// Stop the polling loop and return the accumulated summary.
   /// Idempotent — calling twice returns the same summary.
   Future<TripSummary> stop() async {
-    _timer?.cancel();
-    _timer = null;
+    _scheduler?.stop();
+    _emitTimer?.cancel();
+    _emitTimer = null;
+    _started = false;
     await _liveController.close();
     return _recorder.buildSummary();
   }
@@ -151,6 +236,12 @@ class TripRecordingController {
   /// end via [refreshOdometer].
   double? get odometerLatestKm => _odometerLatestKm;
 
+  /// VIN read once at [start]. Null on older ECUs / adapters that
+  /// can't answer Mode 09 PID 02. Exposed so the fill-up screen can
+  /// stamp the trip with a vehicle identity independent of the
+  /// user's selected profile.
+  String? get vin => _vin;
+
   /// Refresh the odometer reading. Call this just before [stop] so
   /// the save-as-fill-up gets a ground-truth end km rather than a
   /// derived value.
@@ -159,48 +250,243 @@ class TripRecordingController {
     if (km != null) _odometerLatestKm = km;
   }
 
-  Future<void> _pollOnce() async {
-    if (_paused) return; // paused — skip this tick but keep the timer
-    if (_polling) return; // previous tick still in flight — skip
-    _polling = true;
+  // ---------------------------------------------------------------------------
+  // Scheduler wiring
+  // ---------------------------------------------------------------------------
+
+  PidScheduler _buildScheduler() {
+    return PidScheduler(
+      transport: _service.sendCommand,
+      clock: _now,
+    );
+  }
+
+  void _subscribeAllTiers(PidScheduler scheduler) {
+    // ---- 5 Hz tier (high priority) --------------------------------
+    // RPM and speed are consumed directly by TripSample → TripRecorder
+    // for distance/idle/harsh-accel accumulation, so they need the
+    // highest refresh we can squeeze out of the adapter.
+    scheduler.subscribe(
+      Elm327Protocol.engineRpmCommand,
+      ScheduledPid(hz: 5.0, priority: PidPriority.high),
+      (r) {
+        final v = Elm327Protocol.parseEngineRpm(r);
+        if (v != null) _latestRpm = v;
+      },
+    );
+    scheduler.subscribe(
+      Elm327Protocol.vehicleSpeedCommand,
+      ScheduledPid(hz: 5.0, priority: PidPriority.high),
+      (r) {
+        final v = Elm327Protocol.parseVehicleSpeed(r);
+        if (v != null) _latestSpeedKmh = v.toDouble();
+      },
+    );
+    // MAF and MAP are the two alternate air-mass inputs to the fuel-
+    // rate derivation. Cheap cars (Peugeot 107) only have MAP+IAT;
+    // modern cars expose MAF. We subscribe both and let the snapshot-
+    // based derivation pick whichever landed most recently.
+    if (_service.supportsPid(0x10)) {
+      scheduler.subscribe(
+        Elm327Protocol.mafCommand,
+        ScheduledPid(hz: 5.0, priority: PidPriority.high),
+        (r) {
+          final v = Elm327Protocol.parseMafGramsPerSecond(r);
+          if (v != null) _latestMaf = v;
+        },
+      );
+    }
+    if (_service.supportsPid(0x0B)) {
+      scheduler.subscribe(
+        Elm327Protocol.intakeManifoldPressureCommand,
+        ScheduledPid(hz: 5.0, priority: PidPriority.high),
+        (r) {
+          final v = Elm327Protocol.parseManifoldPressureKpa(r);
+          if (v != null) _latestMapKpa = v;
+        },
+      );
+    }
+    scheduler.subscribe(
+      Elm327Protocol.throttlePositionCommand,
+      ScheduledPid(hz: 5.0, priority: PidPriority.high),
+      (r) {
+        final v = Elm327Protocol.parseThrottlePercent(r);
+        if (v != null) _latestThrottlePercent = v;
+      },
+    );
+    // PID 5E is only present on ~2014+ ECUs. Skip when #811 discovery
+    // already proved the car rejects it, to save the 200 ms round-
+    // trip of a guaranteed NO DATA.
+    if (_service.supportsPid(0x5E)) {
+      scheduler.subscribe(
+        Elm327Protocol.engineFuelRateCommand,
+        ScheduledPid(hz: 5.0, priority: PidPriority.high),
+        (r) {
+          final v = Elm327Protocol.parseFuelRateLPerHour(r);
+          if (v != null) _latestDirectFuelRate = v;
+        },
+      );
+    }
+
+    // ---- 1 Hz tier (medium priority) ------------------------------
+    scheduler.subscribe(
+      Elm327Protocol.engineLoadCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseEngineLoad(r);
+        if (v != null) _latestEngineLoadPercent = v;
+      },
+    );
+    scheduler.subscribe(
+      Elm327Protocol.intakeAirTempCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseIntakeAirTempCelsius(r);
+        if (v != null) _latestIatCelsius = v;
+      },
+    );
+    scheduler.subscribe(
+      Elm327Protocol.shortTermFuelTrimCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseShortTermFuelTrim(r);
+        if (v != null) _latestStft = v;
+      },
+    );
+    scheduler.subscribe(
+      Elm327Protocol.longTermFuelTrimCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseLongTermFuelTrim(r);
+        if (v != null) _latestLtft = v;
+      },
+    );
+
+    // ---- 0.1 Hz tier (low priority) -------------------------------
+    scheduler.subscribe(
+      Elm327Protocol.fuelTankLevelCommand,
+      ScheduledPid(hz: 0.1, priority: PidPriority.low),
+      (r) {
+        final v = Elm327Protocol.parseFuelLevelPercent(r);
+        if (v != null) _latestFuelLevelPercent = v;
+      },
+    );
+  }
+
+  /// Read the VIN exactly once at [start]. Wrapped so the one-shot
+  /// decision is visible to readers of [start] — if we ever need to
+  /// re-read mid-trip (e.g. user hot-swaps cars) this is the place
+  /// to add the timer. Returns null on NO DATA / malformed response.
+  Future<String?> _readVinOnce() async {
     try {
-      final speed = await _service.readSpeedKmh();
-      final rpm = await _service.readRpm();
-      final fuelRate = await _service.readFuelRateLPerHour(vehicle: _vehicle);
-      final engineLoad = await _service.readEngineLoad();
-      final fuelLevel = await _service.readFuelLevelPercent();
-      final sample = TripSample(
-        timestamp: _now(),
-        speedKmh: (speed ?? 0).toDouble(),
-        rpm: rpm ?? 0,
-        fuelRateLPerHour: fuelRate,
-      );
-      _recorder.onSample(sample);
-      if (fuelRate != null) {
-        _fuelRateSeen = true;
-        // The recorder integrates fuel rate internally (private), but
-        // we also track a copy here for the live UI readout. Uses the
-        // same Δt as the recorder — a single-tick lag is invisible.
-        _fuelLitersSoFar =
-            (_recorder.buildSummary().fuelLitersConsumed) ?? _fuelLitersSoFar;
-      }
-      final reading = TripLiveReading(
-        speedKmh: sample.speedKmh,
-        rpm: sample.rpm,
-        fuelRateLPerHour: fuelRate,
-        fuelLevelPercent: fuelLevel,
-        engineLoadPercent: engineLoad,
-        distanceKmSoFar: _recorder.buildSummary().distanceKm,
-        fuelLitersSoFar: _fuelRateSeen ? _fuelLitersSoFar : null,
-        elapsed: _now().difference(_startedAt ?? _now()),
-        odometerStartKm: _odometerStartKm,
-        odometerNowKm: _odometerLatestKm,
-      );
-      if (!_liveController.isClosed) _liveController.add(reading);
+      final raw = await _service.sendCommand(Elm327Protocol.vinCommand);
+      return Elm327Protocol.parseVin(raw);
     } catch (e) {
-      debugPrint('TripRecordingController poll error: $e');
-    } finally {
-      _polling = false;
+      debugPrint('TripRecordingController VIN read failed: $e');
+      return null;
     }
   }
+
+  /// Called by the debounced emit timer. Snapshots current state into
+  /// a [TripLiveReading], integrates any new fuel/distance since the
+  /// last emit, and pushes to [live].
+  void _emit() {
+    if (_paused) return; // frozen: don't flood the stream while paused
+    if (_liveController.isClosed) return;
+
+    final nowTs = _now();
+    final fuelRate = _deriveFuelRateLPerHour();
+    // The recorder integrates fuel rate and Δt itself, so we only
+    // hand it one TripSample per emit — not per PID callback. At a
+    // 250 ms emit cadence that's 4 Hz into the recorder, matching
+    // the pre-#814 1 Hz loop's behavior closely enough that the
+    // distance/fuelLitersConsumed integration is unchanged.
+    if (_latestSpeedKmh != null || _latestRpm != null) {
+      _recorder.onSample(TripSample(
+        timestamp: nowTs,
+        speedKmh: _latestSpeedKmh ?? 0,
+        rpm: _latestRpm ?? 0,
+        fuelRateLPerHour: fuelRate,
+      ));
+      _lastSampleAt = nowTs;
+    }
+    if (fuelRate != null) {
+      _fuelRateSeen = true;
+      _fuelLitersSoFar =
+          (_recorder.buildSummary().fuelLitersConsumed) ?? _fuelLitersSoFar;
+    }
+    final reading = TripLiveReading(
+      speedKmh: _latestSpeedKmh,
+      rpm: _latestRpm,
+      fuelRateLPerHour: fuelRate,
+      fuelLevelPercent: _latestFuelLevelPercent,
+      engineLoadPercent: _latestEngineLoadPercent,
+      throttlePercent: _latestThrottlePercent,
+      distanceKmSoFar: _recorder.buildSummary().distanceKm,
+      fuelLitersSoFar: _fuelRateSeen ? _fuelLitersSoFar : null,
+      elapsed: nowTs.difference(_startedAt ?? nowTs),
+      odometerStartKm: _odometerStartKm,
+      odometerNowKm: _odometerLatestKm,
+    );
+    _liveController.add(reading);
+  }
+
+  /// Derive the current fuel rate (L/h) from whatever snapshot
+  /// values have landed so far. Mirrors the tier-1/2/3 fallback in
+  /// [Obd2Service.readFuelRateLPerHour], but over snapshot values
+  /// instead of live I/O — the scheduler has already done the
+  /// reads. Returns null when not enough inputs have arrived yet
+  /// (e.g. first 200 ms of a trip before MAP/IAT both land).
+  double? _deriveFuelRateLPerHour() {
+    // Step 1: direct PID 5E. Already post-trim, no correction.
+    final direct = _latestDirectFuelRate;
+    if (direct != null) return direct;
+
+    // Step 2: MAF-based. Stoich petrol: AFR 14.7, density 740 g/L.
+    final maf = _latestMaf;
+    if (maf != null) {
+      final raw = maf * 3600.0 / (14.7 * 740.0);
+      return _applyTrim(raw);
+    }
+
+    // Step 3: speed-density from MAP+IAT+RPM. Feeds the pre-#810
+    // estimator with the active vehicle's displacement + VE (#812).
+    final mapKpa = _latestMapKpa;
+    final iat = _latestIatCelsius;
+    final rpm = _latestRpm;
+    if (mapKpa == null || iat == null || rpm == null) return null;
+    final raw = Obd2Service.estimateFuelRateLPerHourFromMap(
+      mapKpa: mapKpa,
+      iatCelsius: iat,
+      rpm: rpm,
+      engineDisplacementCc: _vehicle?.engineDisplacementCc ?? 1000,
+      volumetricEfficiency: _vehicle?.volumetricEfficiency ?? 0.85,
+    );
+    if (raw == null) return null;
+    return _applyTrim(raw);
+  }
+
+  /// Apply the STFT + LTFT correction used on the MAF / speed-density
+  /// branches (#813). Returns [raw] unchanged when either trim hasn't
+  /// landed yet — better an uncorrected estimate than one shifted by
+  /// half the real signal.
+  double _applyTrim(double raw) {
+    final stft = _latestStft;
+    final ltft = _latestLtft;
+    if (stft == null || ltft == null) return raw;
+    return Obd2Service.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
+  }
+
+  /// Exposed for tests: force an emit immediately instead of waiting
+  /// for the debounced timer. Useful when a test injects a tiny
+  /// scheduler tickRate but wants deterministic TripLiveReading
+  /// emission on demand.
+  @visibleForTesting
+  void debugEmitNow() => _emit();
+
+  /// Exposed for tests: the last sample timestamp pushed to
+  /// [TripRecorder]. Null until the first emit with non-null speed
+  /// or RPM.
+  @visibleForTesting
+  DateTime? get debugLastSampleAt => _lastSampleAt;
 }

--- a/test/features/consumption/data/obd2/trip_recording_controller_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/pid_scheduler.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 
@@ -221,7 +222,254 @@ void main() {
         await ctl.stop();
       });
     });
+
+    group('PidScheduler integration — #814 phase 2', () {
+      test(
+          'high tier (5 Hz RPM) fires at least 3 callbacks within ~1 s '
+          'of simulated polling', () async {
+        final transport = _CountingTransport(responses: {
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+          // Valid RPM: 41 0C 0E A6 → 939.5 rpm
+          '010C': '41 0C 0E A6>',
+          // Valid speed: 41 0D 32 → 50 km/h
+          '010D': '41 0D 32>',
+          '0111': '41 11 40>',
+          '0104': '41 04 40>',
+          '010F': '41 0F 41>',
+          '0106': '41 06 80>',
+          '0107': '41 07 80>',
+          '012F': '41 2F 80>',
+          '01A6': '41 A6 00 01 6A 2C>',
+          '0902': 'NO DATA>',
+        });
+        final service = Obd2Service(transport);
+        await service.connect();
+
+        final ctl = TripRecordingController(
+          service: service,
+          // Keep emit debounce out of the way — we only care about
+          // the scheduler's per-PID callback rate for this assertion.
+          pollInterval: const Duration(minutes: 1),
+          // Inject a fast-tick scheduler so we can assert refresh
+          // behaviour within a test-friendly window. Production uses
+          // the 100 ms tickRate default (see _buildScheduler).
+          scheduler: PidScheduler(
+            transport: service.sendCommand,
+            tickRate: const Duration(milliseconds: 20),
+          ),
+        );
+        await ctl.start();
+        // Let the scheduler run for ~1 s of wall-clock time. With
+        // a 20 ms tickRate the 5 Hz RPM PID (010C) gets well above
+        // 3 callbacks even with ~12 subscribed PIDs in the round-
+        // robin.
+        await Future<void>.delayed(const Duration(seconds: 1));
+        await ctl.stop();
+
+        expect(
+          transport.callCount('010C'),
+          greaterThanOrEqualTo(3),
+          reason: '5 Hz RPM should land ≥ 3 reads per second under an '
+              'instant transport',
+        );
+      });
+
+      test(
+          'low tier (0.1 Hz fuel level) receives at least one read when '
+          'the scheduler runs long enough for the initial-read rule to '
+          'fire', () async {
+        // New subscriptions win unconditionally on their first tick
+        // (infinity weight), so even in a 1 s window crowded with fast
+        // PIDs the 0.1 Hz fuel-level PID gets its initial read.
+        final transport = _CountingTransport(responses: {
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+          '010C': '41 0C 0E A6>',
+          '010D': '41 0D 32>',
+          '0111': '41 11 40>',
+          '0104': '41 04 40>',
+          '010F': '41 0F 41>',
+          '0106': '41 06 80>',
+          '0107': '41 07 80>',
+          '012F': '41 2F 80>',
+          '01A6': '41 A6 00 01 6A 2C>',
+          '0902': 'NO DATA>',
+        });
+        final service = Obd2Service(transport);
+        await service.connect();
+
+        final ctl = TripRecordingController(
+          service: service,
+          pollInterval: const Duration(minutes: 1),
+          scheduler: PidScheduler(
+            transport: service.sendCommand,
+            tickRate: const Duration(milliseconds: 20),
+          ),
+        );
+        await ctl.start();
+        // 2 s of wall-clock is enough time for every subscribed PID
+        // to win its initial (infinity-weight) tick — the low-tier
+        // PID must be among them.
+        await Future<void>.delayed(const Duration(seconds: 2));
+        await ctl.stop();
+
+        expect(
+          transport.callCount('012F'),
+          greaterThanOrEqualTo(1),
+          reason: 'low-tier fuel level starved — the initial-read rule '
+              'should guarantee at least one read',
+        );
+      });
+
+      test(
+          'VIN is read exactly once at start() and exposed via the vin '
+          'getter — subsequent ticks never re-issue 0902', () async {
+        final transport = _CountingTransport(responses: {
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+          '010C': '41 0C 0E A6>',
+          '010D': '41 0D 32>',
+          '0111': '41 11 40>',
+          '0104': '41 04 40>',
+          '010F': '41 0F 41>',
+          '0106': '41 06 80>',
+          '0107': '41 07 80>',
+          '012F': '41 2F 80>',
+          '01A6': '41 A6 00 01 6A 2C>',
+          // VIN response for "WVWZZZ3BZYP123456" — Elm327Protocol
+          // just needs a valid 49 XX prefix + 17 ASCII-hex chars.
+          '0902': '49 02 01 57 56 57 5A 5A 5A 33 42 5A 59 50 31 32 33 '
+              '34 35 36>',
+        });
+        final service = Obd2Service(transport);
+        await service.connect();
+        final baseline0902Calls = transport.callCount('0902');
+
+        final ctl = TripRecordingController(
+          service: service,
+          pollInterval: const Duration(minutes: 1),
+          scheduler: PidScheduler(
+            transport: service.sendCommand,
+            tickRate: const Duration(milliseconds: 20),
+          ),
+        );
+        await ctl.start();
+        await Future<void>.delayed(const Duration(milliseconds: 600));
+        await ctl.stop();
+
+        // VIN was read at start() — exactly once since connect() ran
+        // (connect() consumes 0902 for the supported-PID cache key
+        // when a cache is wired in; here no cache, so connect doesn't
+        // call it). The scheduler must not re-issue 0902 mid-trip.
+        final delta = transport.callCount('0902') - baseline0902Calls;
+        expect(
+          delta,
+          1,
+          reason: 'VIN should be a single one-shot read at start(); '
+              'found $delta 0902 commands during the trip',
+        );
+        expect(ctl.vin, isNotNull);
+      });
+
+      test(
+          'TripLiveReading captures snapshot values from independent '
+          'PID callbacks — characterization against the old one-shot '
+          'poll', () async {
+        // Under the pre-#814 model _pollOnce() read speed/RPM/fuel-
+        // rate/engine-load/fuel-level on every tick and fired one
+        // TripLiveReading. Under the new model each PID arrives
+        // independently; a debounced emit assembles the same fields.
+        // This test injects a hand-controlled scheduler with a tiny
+        // tickRate and asserts that after running the scheduler for a
+        // bit the TripLiveReading carries the expected values.
+        final transport = _CountingTransport(responses: {
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+          '010C': '41 0C 0E A6>', // 939.5 rpm
+          '010D': '41 0D 32>', // 50 km/h
+          '0111': '41 11 40>',
+          '0104': '41 04 33>', // 0x33 = 51 → ~20 %
+          '010F': '41 0F 41>',
+          '0106': '41 06 80>',
+          '0107': '41 07 80>',
+          '012F': '41 2F 80>', // 50 %
+          '01A6': '41 A6 00 01 6A 2C>',
+          '0902': 'NO DATA>',
+        });
+        final service = Obd2Service(transport);
+        await service.connect();
+
+        // 50 ms emit cadence so we get a burst of debounced events
+        // within a ~1 s test window.
+        final ctl = TripRecordingController(
+          service: service,
+          pollInterval: const Duration(milliseconds: 50),
+          scheduler: PidScheduler(
+            transport: service.sendCommand,
+            tickRate: const Duration(milliseconds: 20),
+          ),
+        );
+        final readings = <TripLiveReading>[];
+        final sub = ctl.live.listen(readings.add);
+        await ctl.start();
+        await Future<void>.delayed(const Duration(milliseconds: 800));
+        await sub.cancel();
+        await ctl.stop();
+
+        expect(readings, isNotEmpty,
+            reason: 'debounced emit timer must produce at least one '
+                'TripLiveReading within the test window');
+        final latest = readings.last;
+        // Speed landed via 010D → 50 km/h.
+        expect(latest.speedKmh, closeTo(50, 0.001));
+        // RPM landed via 010C (0x0E 0xA6): ((14×256)+166)/4 = 937.5.
+        expect(latest.rpm, closeTo(937.5, 0.5));
+        // Engine load landed via 0104 → ~20 %.
+        expect(latest.engineLoadPercent, closeTo(20, 1));
+        // Fuel level landed via 012F → ~50 %.
+        expect(latest.fuelLevelPercent, closeTo(50, 1));
+      });
+    });
   });
+}
+
+/// Counts how many times each command is sent. Used to assert
+/// per-tier refresh rates and one-shot semantics under the new
+/// scheduler-driven polling loop (#814 phase 2).
+class _CountingTransport implements Obd2Transport {
+  final Map<String, String> responses;
+  final Map<String, int> _counts = <String, int>{};
+  bool _connected = false;
+
+  _CountingTransport({required this.responses});
+
+  int callCount(String command) => _counts[command] ?? 0;
+
+  @override
+  Future<void> connect() async => _connected = true;
+  @override
+  Future<void> disconnect() async => _connected = false;
+  @override
+  bool get isConnected => _connected;
+  @override
+  Future<String> sendCommand(String command) async {
+    final key = command.trim();
+    _counts[key] = (_counts[key] ?? 0) + 1;
+    return responses[key] ?? 'NO DATA>';
+  }
 }
 
 /// Transport that serves canned responses for the init + a custom


### PR DESCRIPTION
## Summary

Phase 2 of #814 — migrate `trip_recording_controller.dart` from the
monolithic `Timer.periodic(1s, _pollOnce)` loop to the weighted
round-robin `PidScheduler` that landed in phase 1 (PR #860).

Each PID is now subscribed independently at its own target frequency:

| Tier | Hz | PIDs |
|------|-----|------|
| High | 5 Hz | RPM (010C), speed (010D), MAF (0110), MAP (010B), throttle (0111), fuel rate (015E) |
| Medium | 1 Hz | STFT (0106), LTFT (0107), IAT (010F), engine load (0104) |
| Low | 0.1 Hz | fuel tank level (012F) |

**VIN (Mode 09 PID 02) is a one-shot read at `start()`**, not a
subscription — it doesn't change mid-trip, and re-issuing `0902` every
10 s would waste bandwidth the fast tier needs. The parsed VIN is
exposed via `TripRecordingController.vin`.

## Why

Before phase 2, every PID fired once per second regardless of how
fast the signal actually changes. Under the new model:

- Fast signals (RPM, speed, throttle) refresh at ~200 ms so the eco-
  feedback band classifier and live L/100 km readout feel responsive.
- Slow signals (fuel level, fuel trims) don't waste Bluetooth
  bandwidth on values that barely move between ticks.
- The scheduler's backpressure + initial-read rules guarantee no tier
  starves the others.

Every feature must help the user pay less at the pump or burn less
fuel behind the wheel. This one serves the wheel: a faster eco-
feedback loop detects heavy-foot episodes sooner, so the haptic nudge
lands while the user can still back off the throttle.

## Changes

- `trip_recording_controller.dart`: replaced `Timer.periodic` + inline
  `_pollOnce` with a `PidScheduler` subscription graph + a debounced
  emit timer (default 250 ms, tests use 1 minute).
- `obd2_service.dart`: added a thin `sendCommand` pass-through so the
  scheduler can dispatch raw PID commands without exposing the
  private `_transport`.
- `TripLiveReading.throttlePercent`: new 5 Hz throttle signal exposed
  to the UI layer.

## Test plan

- [x] `flutter analyze` — zero warnings/errors
- [x] `flutter test` — 5252 pass (1 skipped, unrelated Argentina CSV
  network flake)
- [x] Existing `trip_recording_controller_test.dart` suite still
  passes (6 tests) — odometer read, empty-trip stop, pause/resume,
  refreshOdometer, #812 vehicle-profile plumbing.
- [x] New tests (`group('PidScheduler integration — #814 phase 2')`):
  - High-tier refresh: 5 Hz RPM fires ≥ 3 callbacks in ~1 s
  - Low-tier no starvation: 0.1 Hz fuel level gets its initial read
    within 2 s
  - VIN one-shot: exactly one `0902` call per trip (none after start)
  - Characterization: `TripLiveReading` carries the snapshot values
    assembled from independent per-PID callbacks, matching the old
    one-shot poll model's observable fields.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)