### PR TITLE
fix(obd2): BT-drop banner (#797 phase 2)

### DIFF
--- a/lib/features/consumption/presentation/widgets/obd2_pause_banner.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_pause_banner.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../providers/trip_recording_provider.dart';
+
+/// Banner shown when the OBD2 Bluetooth link drops mid-recording
+/// (#797 phase 2).
+///
+/// Phase 1 (#864) persists the partial trip and flips the recording
+/// controller to [TripRecordingPhase.pausedDueToDrop]. This banner
+/// surfaces that state to the user, with two escape hatches:
+///
+///   * **Resume recording** — re-enters the recording phase. Intended
+///     for when the adapter reconnected on its own (phase 3 will add
+///     the auto-reconnect scanner; until then the user initiates).
+///   * **End recording** — stops the controller so the captured trip
+///     is finalised and saved via the normal fill-up flow.
+///
+/// The widget renders zero-height unless the phase is
+/// [TripRecordingPhase.pausedDueToDrop], so it's safe to drop into
+/// any layout that always-on renders the trip chrome.
+class Obd2PauseBanner extends ConsumerWidget {
+  const Obd2PauseBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Watching only the phase (via select) means unrelated state
+    // changes — live readings, band transitions — don't rebuild the
+    // banner. The wider TripRecordingBanner already rebuilds on those.
+    final phase = ref.watch(
+      tripRecordingProvider.select((s) => s.phase),
+    );
+    if (phase != TripRecordingPhase.pausedDueToDrop) {
+      return const SizedBox.shrink();
+    }
+
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return MaterialBanner(
+      key: const Key('obd2PauseBanner'),
+      backgroundColor: theme.colorScheme.errorContainer,
+      contentTextStyle: TextStyle(
+        color: theme.colorScheme.onErrorContainer,
+      ),
+      leading: Icon(
+        Icons.bluetooth_disabled,
+        color: theme.colorScheme.onErrorContainer,
+      ),
+      content: Text(
+        l?.obd2PauseBannerTitle ??
+            'OBD2 connection lost — recording paused',
+      ),
+      actions: [
+        TextButton(
+          key: const Key('obd2PauseBannerResume'),
+          onPressed: () =>
+              ref.read(tripRecordingProvider.notifier).resume(),
+          child: Text(l?.obd2PauseBannerResume ?? 'Resume recording'),
+        ),
+        TextButton(
+          key: const Key('obd2PauseBannerEnd'),
+          onPressed: () =>
+              ref.read(tripRecordingProvider.notifier).stop(),
+          child: Text(l?.obd2PauseBannerEnd ?? 'End recording'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -7,6 +7,7 @@ import '../../domain/cold_start_baselines.dart';
 import '../../domain/situation_classifier.dart';
 import '../../providers/obd2_connection_state_provider.dart';
 import '../../providers/trip_recording_provider.dart';
+import 'obd2_pause_banner.dart';
 import 'obd2_status_dot.dart';
 
 /// Persistent indicator of an active OBD2 trip (#726 + #768).
@@ -83,6 +84,11 @@ class TripRecordingBanner extends ConsumerWidget {
             ),
           ),
         ),
+        // #797 phase 2 — BT-drop pause banner. Zero-height unless the
+        // provider is in pausedDueToDrop; self-watches its slice of
+        // the state so the main banner above doesn't rebuild on
+        // drop/resume transitions.
+        const Obd2PauseBanner(),
         Expanded(child: child),
       ],
     );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1204,5 +1204,8 @@
   "vinModifyAction": "Manuell anpassen",
   "vinPartialInfoNote": "Teilinfo (offline). Sie können die Felder unten bearbeiten.",
   "vinDecodeError": "Diese FIN konnte nicht entschlüsselt werden",
-  "vinInvalidFormat": "Ungültiges FIN-Format"
+  "vinInvalidFormat": "Ungültiges FIN-Format",
+  "obd2PauseBannerTitle": "OBD2-Verbindung verloren — Aufzeichnung pausiert",
+  "obd2PauseBannerResume": "Weiter aufzeichnen",
+  "obd2PauseBannerEnd": "Aufzeichnung beenden"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1258,5 +1258,17 @@
   "vinModifyAction": "Modify manually",
   "vinPartialInfoNote": "Partial info (offline). You can edit below.",
   "vinDecodeError": "Couldn't decode this VIN",
-  "vinInvalidFormat": "Invalid VIN format"
+  "vinInvalidFormat": "Invalid VIN format",
+  "obd2PauseBannerTitle": "OBD2 connection lost — recording paused",
+  "@obd2PauseBannerTitle": {
+    "description": "Banner shown (#797 phase 2) when the OBD2 Bluetooth link drops mid-recording. The trip is auto-paused on the device and the partial data is preserved. User can resume (if the link comes back) or end the recording entirely."
+  },
+  "obd2PauseBannerResume": "Resume recording",
+  "@obd2PauseBannerResume": {
+    "description": "Action on the OBD2 pause banner that resumes the recording once the Bluetooth link is back."
+  },
+  "obd2PauseBannerEnd": "End recording",
+  "@obd2PauseBannerEnd": {
+    "description": "Action on the OBD2 pause banner that stops the recording and saves what was captured before the drop."
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5761,6 +5761,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Invalid VIN format'**
   String get vinInvalidFormat;
+
+  /// Banner shown (#797 phase 2) when the OBD2 Bluetooth link drops mid-recording. The trip is auto-paused on the device and the partial data is preserved. User can resume (if the link comes back) or end the recording entirely.
+  ///
+  /// In en, this message translates to:
+  /// **'OBD2 connection lost — recording paused'**
+  String get obd2PauseBannerTitle;
+
+  /// Action on the OBD2 pause banner that resumes the recording once the Bluetooth link is back.
+  ///
+  /// In en, this message translates to:
+  /// **'Resume recording'**
+  String get obd2PauseBannerResume;
+
+  /// Action on the OBD2 pause banner that stops the recording and saves what was captured before the drop.
+  ///
+  /// In en, this message translates to:
+  /// **'End recording'**
+  String get obd2PauseBannerEnd;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3061,4 +3061,13 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3061,4 +3061,13 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3059,4 +3059,13 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3083,4 +3083,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Ungültiges FIN-Format';
+
+  @override
+  String get obd2PauseBannerTitle =>
+      'OBD2-Verbindung verloren — Aufzeichnung pausiert';
+
+  @override
+  String get obd2PauseBannerResume => 'Weiter aufzeichnen';
+
+  @override
+  String get obd2PauseBannerEnd => 'Aufzeichnung beenden';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3063,4 +3063,13 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3054,4 +3054,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3062,4 +3062,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3056,4 +3056,13 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3059,4 +3059,13 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3083,4 +3083,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3058,4 +3058,13 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3063,4 +3063,13 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3062,4 +3062,13 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3060,4 +3060,13 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3062,4 +3062,13 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3058,4 +3058,13 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3063,4 +3063,13 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3061,4 +3061,13 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3062,4 +3062,13 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3061,4 +3061,13 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3062,4 +3062,13 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3056,4 +3056,13 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3060,4 +3060,13 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get vinInvalidFormat => 'Invalid VIN format';
+
+  @override
+  String get obd2PauseBannerTitle => 'OBD2 connection lost — recording paused';
+
+  @override
+  String get obd2PauseBannerResume => 'Resume recording';
+
+  @override
+  String get obd2PauseBannerEnd => 'End recording';
 }

--- a/test/features/consumption/presentation/widgets/obd2_pause_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_pause_banner_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/obd2_pause_banner.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Fake notifier lets tests flip the phase imperatively while
+/// counting how often the banner's Resume / End actions wire through
+/// to the provider. Overriding the whole TripRecording class is
+/// preferred over stubbing `resume()` / `stop()` since those methods
+/// touch Obd2Service + Hive in production and we want neither
+/// anywhere near a widget test.
+class _FakeTripRecording extends TripRecording {
+  _FakeTripRecording(this._initial);
+
+  TripRecordingState _initial;
+  int resumeCalls = 0;
+  int stopCalls = 0;
+
+  @override
+  TripRecordingState build() => _initial;
+
+  /// Flip the exposed state without touching the underlying
+  /// controller. Simulates the phase transition the real provider
+  /// would publish when the controller wakes from a BT drop.
+  void setPhase(TripRecordingPhase phase) {
+    _initial = _initial.copyWith(phase: phase);
+    state = _initial;
+  }
+
+  @override
+  void resume() {
+    resumeCalls++;
+  }
+
+  @override
+  Future<StoppedTripResult> stop() async {
+    stopCalls++;
+    return const StoppedTripResult.empty();
+  }
+}
+
+/// Wrapper so tests can grab the banner and a ScaffoldMessenger host
+/// in one pumpApp call — MaterialBanner doesn't render outside of
+/// one.
+class _Host extends StatelessWidget {
+  const _Host();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [Obd2PauseBanner()],
+    );
+  }
+}
+
+void main() {
+  group('Obd2PauseBanner (#797 phase 2)', () {
+    testWidgets('not visible when phase is recording', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.recording),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [
+          tripRecordingProvider.overrideWith(() => fake),
+        ],
+      );
+      expect(find.byKey(const Key('obd2PauseBanner')), findsNothing);
+    });
+
+    testWidgets('appears on transition to pausedDueToDrop', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.recording),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [
+          tripRecordingProvider.overrideWith(() => fake),
+        ],
+      );
+      expect(find.byKey(const Key('obd2PauseBanner')), findsNothing);
+
+      fake.setPhase(TripRecordingPhase.pausedDueToDrop);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('obd2PauseBanner')), findsOneWidget);
+      expect(
+        find.text('OBD2 connection lost — recording paused'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Resume action calls provider.resume()', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.pausedDueToDrop),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [
+          tripRecordingProvider.overrideWith(() => fake),
+        ],
+      );
+
+      expect(fake.resumeCalls, 0);
+      await tester.tap(find.byKey(const Key('obd2PauseBannerResume')));
+      await tester.pumpAndSettle();
+      expect(fake.resumeCalls, 1);
+      expect(fake.stopCalls, 0);
+    });
+
+    testWidgets('End action calls provider.stop()', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.pausedDueToDrop),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [
+          tripRecordingProvider.overrideWith(() => fake),
+        ],
+      );
+
+      expect(fake.stopCalls, 0);
+      await tester.tap(find.byKey(const Key('obd2PauseBannerEnd')));
+      await tester.pumpAndSettle();
+      expect(fake.stopCalls, 1);
+      expect(fake.resumeCalls, 0);
+    });
+
+    testWidgets('disappears when phase returns to recording', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.pausedDueToDrop),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [
+          tripRecordingProvider.overrideWith(() => fake),
+        ],
+      );
+      expect(find.byKey(const Key('obd2PauseBanner')), findsOneWidget);
+
+      fake.setPhase(TripRecordingPhase.recording);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('obd2PauseBanner')), findsNothing);
+    });
+
+    testWidgets('disappears when phase returns to idle after End',
+        (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.pausedDueToDrop),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [
+          tripRecordingProvider.overrideWith(() => fake),
+        ],
+      );
+      expect(find.byKey(const Key('obd2PauseBanner')), findsOneWidget);
+
+      // The real provider's stop() completes by setting state to
+      // finished. Simulate that here so the banner tears down.
+      fake.setPhase(TripRecordingPhase.finished);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('obd2PauseBanner')), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 of #797 — surfaces the BT-drop pause to the user.

- New `Obd2PauseBanner` (`ConsumerWidget`): renders a `MaterialBanner` (`errorContainer` palette) when `TripRecordingPhase.pausedDueToDrop` fires, with two actions:
  - **Resume recording** → `tripRecordingProvider.resume()`
  - **End recording** → `tripRecordingProvider.stop()` (saves the captured trip via the regular flow)
- Mounted inside `TripRecordingBanner` (already wraps every screen via `MaterialApp.builder`), so the banner is visible regardless of which tab the user is on when the drop happens.
- Watches only the `phase` slice (`select`) so live-reading / band updates don't rebuild it.
- ARB keys `obd2PauseBannerTitle` / `obd2PauseBannerResume` / `obd2PauseBannerEnd` added to `app_en.arb` + `app_de.arb` only (the other 21 locales pick up the English fallback).

Phase 1 (#864) landed the state machine + data persistence. **Phase 3** (auto-reconnect scanner + title-bar indicator) is still pending — this PR is `Refs #797`, not `Closes`.

## Why

Right now a Bluetooth drop mid-recording silently pauses and persists the trip but gives the user no affordance to act on it. Without the banner they'd see a stale "Recording trip" label and no way to either resume (once the link recovers) or end and save what was captured. This PR fixes that before we ship the auto-reconnect scanner.

## Testing

New widget suite `test/features/consumption/presentation/widgets/obd2_pause_banner_test.dart`:

- [x] Banner hidden while phase is `recording`.
- [x] Banner appears on transition to `pausedDueToDrop` (English title visible).
- [x] Resume action invokes `provider.resume()`.
- [x] End action invokes `provider.stop()`.
- [x] Banner disappears when phase flips back to `recording`.
- [x] Banner disappears when phase advances to `finished` after End.

- [x] `flutter gen-l10n` — all 23 locale files regenerated.
- [x] `flutter analyze` — no issues.
- [x] `flutter test` — all 5275 tests pass.

## Screenshots

N/A (widget-level change; follow-up phase 3 PR will include a UX walkthrough once the auto-reconnect scanner lands).

Refs #797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)