### PR TITLE
feat(obd2): adaptive η_v learning (#815)

### DIFF
--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -26,6 +26,28 @@ class ConsumptionScreen extends ConsumerWidget {
     final activeVehicle = ref.watch(activeVehicleProfileProvider);
     final l = AppLocalizations.of(context);
 
+    // #815 — surface the η_v calibration outcome as a one-shot
+    // snackbar when the fill-up save path learns a new value for the
+    // active vehicle. Listening here (rather than in the fill-up
+    // screen) keeps the snackbar visible after the fill-up form
+    // pops, which is the screen the user actually sees.
+    ref.listen(lastVeLearnResultProvider, (previous, next) {
+      if (next == null) return;
+      final vehicles = ref.read(vehicleProfileListProvider);
+      final vehicle = vehicles
+          .where((v) => v.id == next.vehicleId)
+          .firstOrNull;
+      final name = vehicle?.name ?? '';
+      final percent = next.accuracyImprovementPct.round().toString();
+      final msg = l?.veCalibratedTitle(name, percent) ??
+          'Consumption calibration updated for $name — '
+              'accuracy improved by $percent%';
+      SnackBarHelper.showSuccess(context, msg);
+      // Clear so a rebuild doesn't re-fire the snackbar on the next
+      // unrelated rebuild (e.g. the user deleting a fill-up).
+      ref.read(lastVeLearnResultProvider.notifier).set(null);
+    });
+
     return Scaffold(
       appBar: AppBar(
         title: Text(l?.consumptionLogTitle ?? 'Fuel consumption'),

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -2,12 +2,15 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/storage/storage_providers.dart';
+import '../../vehicle/data/ve_learner.dart';
 import '../../vehicle/providers/service_reminder_providers.dart';
+import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/repositories/fill_up_repository.dart';
 import '../domain/entities/consumption_stats.dart';
 import '../domain/entities/eco_score.dart';
 import '../domain/entities/fill_up.dart';
 import '../domain/services/eco_score_calculator.dart';
+import 'trip_history_provider.dart';
 
 part 'consumption_providers.g.dart';
 
@@ -16,6 +19,43 @@ part 'consumption_providers.g.dart';
 FillUpRepository fillUpRepository(Ref ref) {
   final storage = ref.watch(settingsStorageProvider);
   return FillUpRepository(storage);
+}
+
+/// Learner for per-vehicle volumetric efficiency (#815).
+///
+/// Returns null when the trip-history Hive box isn't open (widget
+/// tests that don't bother initialising Hive) — callers guard by
+/// skipping the reconciliation entirely when the instance is null,
+/// which also lets the fill-up save path stay a single-line change.
+@Riverpod(keepAlive: true)
+VeLearner? veLearner(Ref ref) {
+  final history = ref.watch(tripHistoryRepositoryProvider);
+  if (history == null) return null;
+  final profileRepo = ref.watch(vehicleProfileRepositoryProvider);
+  return VeLearner.fromRepos(
+    profileRepository: profileRepo,
+    tripHistoryRepository: history,
+  );
+}
+
+/// Holds the most recent [VeLearnResult] (#815) so the UI can show a
+/// one-shot calibration snackbar after the fill-up save flow closes.
+///
+/// The fill-up screen reads-and-clears this on its way out; unread
+/// results persist across widget rebuilds so the snackbar still fires
+/// when the user lands on the consumption tab. Only the most recent
+/// result is retained — if two tankfuls calibrate back-to-back (rare,
+/// but possible during data imports) the second one wins.
+@Riverpod(keepAlive: true)
+class LastVeLearnResult extends _$LastVeLearnResult {
+  @override
+  VeLearnResult? build() => null;
+
+  /// Stash [result]. Pass `null` from the consumer to clear after
+  /// rendering the snackbar.
+  void set(VeLearnResult? result) {
+    state = result;
+  }
 }
 
 /// Mutable list of all fill-ups, newest first.
@@ -30,14 +70,33 @@ class FillUpList extends _$FillUpList {
   /// Insert a new fill-up entry and refresh the list.
   ///
   /// After saving, runs the odometer-based service-reminder check
-  /// (#584) for the fill-up's vehicle. Failures in the reminder
-  /// path are swallowed — logging a fill-up must never fail because
-  /// a downstream side-effect did.
+  /// (#584) for the fill-up's vehicle and — when the vehicle has an
+  /// OBD2 trip history since the previous fill-up — kicks off the
+  /// η_v reconciliation (#815). Failures in either side-effect path
+  /// are swallowed: logging a fill-up must never fail because a
+  /// downstream calibration did.
   Future<void> add(FillUp fillUp) async {
     final repo = ref.read(fillUpRepositoryProvider);
+    final previous = _previousFillUpFor(fillUp, repo.getAll());
     await repo.save(fillUp);
     state = repo.getAll();
     await _evaluateReminders(fillUp);
+    await _reconcileVolumetricEfficiency(fillUp, previous);
+  }
+
+  /// Pick the fill-up with the largest `date` that is strictly older
+  /// than [current] for the same vehicle. Ignores fill-ups without a
+  /// vehicle id — reconciliation only applies to vehicle-bound fills.
+  FillUp? _previousFillUpFor(FillUp current, List<FillUp> all) {
+    if (current.vehicleId == null) return null;
+    FillUp? best;
+    for (final f in all) {
+      if (f.id == current.id) continue;
+      if (f.vehicleId != current.vehicleId) continue;
+      if (!f.date.isBefore(current.date)) continue;
+      if (best == null || f.date.isAfter(best.date)) best = f;
+    }
+    return best;
   }
 
   Future<void> _evaluateReminders(FillUp fillUp) async {
@@ -54,6 +113,35 @@ class FillUpList extends _$FillUpList {
       ref.invalidate(serviceReminderListProvider);
     } catch (e) {
       debugPrint('FillUpList: reminder evaluation failed: $e');
+    }
+  }
+
+  Future<void> _reconcileVolumetricEfficiency(
+    FillUp fillUp,
+    FillUp? previous,
+  ) async {
+    final vehicleId = fillUp.vehicleId;
+    if (vehicleId == null) return;
+    if (fillUp.liters <= 0) return;
+    try {
+      final learner = ref.read(veLearnerProvider);
+      if (learner == null) return;
+      final result = await learner.reconcileAfterFillUp(
+        vehicleId: vehicleId,
+        pumpedLiters: fillUp.liters,
+        fillUpTimestamp: fillUp.date,
+        previousFillUpTimestamp: previous?.date,
+      );
+      if (result != null) {
+        ref
+            .read(lastVeLearnResultProvider.notifier)
+            .set(result);
+        // Refresh the vehicle list so the edit screen reflects the
+        // bumped η_v sample count immediately.
+        ref.invalidate(vehicleProfileListProvider);
+      }
+    } catch (e) {
+      debugPrint('FillUpList: VE reconciliation failed: $e');
     }
   }
 

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -59,6 +59,153 @@ final class FillUpRepositoryProvider
 
 String _$fillUpRepositoryHash() => r'cc5e51ddaa9f996875c6e5bace204386b25f55dd';
 
+/// Learner for per-vehicle volumetric efficiency (#815).
+///
+/// Returns null when the trip-history Hive box isn't open (widget
+/// tests that don't bother initialising Hive) — callers guard by
+/// skipping the reconciliation entirely when the instance is null,
+/// which also lets the fill-up save path stay a single-line change.
+
+@ProviderFor(veLearner)
+final veLearnerProvider = VeLearnerProvider._();
+
+/// Learner for per-vehicle volumetric efficiency (#815).
+///
+/// Returns null when the trip-history Hive box isn't open (widget
+/// tests that don't bother initialising Hive) — callers guard by
+/// skipping the reconciliation entirely when the instance is null,
+/// which also lets the fill-up save path stay a single-line change.
+
+final class VeLearnerProvider
+    extends $FunctionalProvider<VeLearner?, VeLearner?, VeLearner?>
+    with $Provider<VeLearner?> {
+  /// Learner for per-vehicle volumetric efficiency (#815).
+  ///
+  /// Returns null when the trip-history Hive box isn't open (widget
+  /// tests that don't bother initialising Hive) — callers guard by
+  /// skipping the reconciliation entirely when the instance is null,
+  /// which also lets the fill-up save path stay a single-line change.
+  VeLearnerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'veLearnerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$veLearnerHash();
+
+  @$internal
+  @override
+  $ProviderElement<VeLearner?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  VeLearner? create(Ref ref) {
+    return veLearner(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(VeLearner? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<VeLearner?>(value),
+    );
+  }
+}
+
+String _$veLearnerHash() => r'3ee7af1d1504ef129c160480ac732df0494e036f';
+
+/// Holds the most recent [VeLearnResult] (#815) so the UI can show a
+/// one-shot calibration snackbar after the fill-up save flow closes.
+///
+/// The fill-up screen reads-and-clears this on its way out; unread
+/// results persist across widget rebuilds so the snackbar still fires
+/// when the user lands on the consumption tab. Only the most recent
+/// result is retained — if two tankfuls calibrate back-to-back (rare,
+/// but possible during data imports) the second one wins.
+
+@ProviderFor(LastVeLearnResult)
+final lastVeLearnResultProvider = LastVeLearnResultProvider._();
+
+/// Holds the most recent [VeLearnResult] (#815) so the UI can show a
+/// one-shot calibration snackbar after the fill-up save flow closes.
+///
+/// The fill-up screen reads-and-clears this on its way out; unread
+/// results persist across widget rebuilds so the snackbar still fires
+/// when the user lands on the consumption tab. Only the most recent
+/// result is retained — if two tankfuls calibrate back-to-back (rare,
+/// but possible during data imports) the second one wins.
+final class LastVeLearnResultProvider
+    extends $NotifierProvider<LastVeLearnResult, VeLearnResult?> {
+  /// Holds the most recent [VeLearnResult] (#815) so the UI can show a
+  /// one-shot calibration snackbar after the fill-up save flow closes.
+  ///
+  /// The fill-up screen reads-and-clears this on its way out; unread
+  /// results persist across widget rebuilds so the snackbar still fires
+  /// when the user lands on the consumption tab. Only the most recent
+  /// result is retained — if two tankfuls calibrate back-to-back (rare,
+  /// but possible during data imports) the second one wins.
+  LastVeLearnResultProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'lastVeLearnResultProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$lastVeLearnResultHash();
+
+  @$internal
+  @override
+  LastVeLearnResult create() => LastVeLearnResult();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(VeLearnResult? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<VeLearnResult?>(value),
+    );
+  }
+}
+
+String _$lastVeLearnResultHash() => r'71c27ad112b34edc9636c7ccd0694d1758ecd4d0';
+
+/// Holds the most recent [VeLearnResult] (#815) so the UI can show a
+/// one-shot calibration snackbar after the fill-up save flow closes.
+///
+/// The fill-up screen reads-and-clears this on its way out; unread
+/// results persist across widget rebuilds so the snackbar still fires
+/// when the user lands on the consumption tab. Only the most recent
+/// result is retained — if two tankfuls calibrate back-to-back (rare,
+/// but possible during data imports) the second one wins.
+
+abstract class _$LastVeLearnResult extends $Notifier<VeLearnResult?> {
+  VeLearnResult? build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<VeLearnResult?, VeLearnResult?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<VeLearnResult?, VeLearnResult?>,
+              VeLearnResult?,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
 /// Mutable list of all fill-ups, newest first.
 
 @ProviderFor(FillUpList)
@@ -95,7 +242,7 @@ final class FillUpListProvider
   }
 }
 
-String _$fillUpListHash() => r'9a14d041513e659f3ec8ff20e1ce51f2593bc800';
+String _$fillUpListHash() => r'0262985944ee0598189037bb600934c219993f7e';
 
 /// Mutable list of all fill-ups, newest first.
 

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'3c616da118b0d19985eeb46622b3d2d2151e4a4d';
+String _$tripRecordingHash() => r'bafa70f4533d52b9aabfc319c85e816a95c25469';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/favorites/providers/favorites_provider.g.dart
+++ b/lib/features/favorites/providers/favorites_provider.g.dart
@@ -68,7 +68,7 @@ final class FavoritesProvider
   }
 }
 
-String _$favoritesHash() => r'fe40f2d936cd8e72587523c7faa88a30fe4446b1';
+String _$favoritesHash() => r'985b20d42867bb9905658bd0caf1e017bafebebd';
 
 /// Manages the user's list of favorite station IDs.
 ///

--- a/lib/features/vehicle/data/ve_learner.dart
+++ b/lib/features/vehicle/data/ve_learner.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/foundation.dart';
+
+import '../../consumption/data/trip_history_repository.dart';
+import '../domain/entities/vehicle_profile.dart';
+import 'repositories/vehicle_profile_repository.dart';
+
+/// Outcome of a single [VeLearner.reconcileAfterFillUp] update (#815).
+///
+/// Surfaced to the UI so a calibration snackbar can announce the
+/// before/after gap in user-visible terms (see [accuracyImprovementPct]).
+@immutable
+class VeLearnResult {
+  /// Id of the vehicle whose profile was updated.
+  final String vehicleId;
+
+  /// η_v held by the profile when the reconciliation started.
+  final double previousVe;
+
+  /// η_v written back to the profile by the EWMA blend.
+  final double newVe;
+
+  /// Sum of OBD2-integrated fuel across every trip that fell between
+  /// the previous fill-up and the current one.
+  final double integratedLiters;
+
+  /// Pump-receipt total that closed the tank (user-entered).
+  final double pumpedLiters;
+
+  /// Fractional improvement in absolute gap: `100 * (1 - |new_gap| /
+  /// |old_gap|)`. Clamped to [0, 100] — a worse new estimate (which
+  /// can happen if the true η is wildly different from the default)
+  /// still reports 0 rather than a misleading negative.
+  final double accuracyImprovementPct;
+
+  /// Post-update sample count for the vehicle's η_v field.
+  final int sampleCount;
+
+  const VeLearnResult({
+    required this.vehicleId,
+    required this.previousVe,
+    required this.newVe,
+    required this.integratedLiters,
+    required this.pumpedLiters,
+    required this.accuracyImprovementPct,
+    required this.sampleCount,
+  });
+}
+
+/// Signature for the history-loading hook [VeLearner] uses to find the
+/// trips between the previous fill-up and the current one. Pulled out
+/// so tests can seed trip data in-memory without touching Hive — the
+/// production wiring in [VeLearner.fromRepos] just reads
+/// [TripHistoryRepository.loadAll].
+typedef TripHistoryLoader = List<TripHistoryEntry> Function();
+
+/// Signature for the "how many OBD2 samples did this trip carry"
+/// hook. In production we proxy via the trip's `endedAt - startedAt`
+/// duration (OBD2 polling runs at ~1 Hz, so seconds ≈ samples); tests
+/// can inject a stub. See [_defaultSampleCount].
+typedef TripSampleCounter = int Function(TripHistoryEntry entry);
+
+/// Adaptive volumetric-efficiency learner (#815).
+///
+/// Every tankful, we already own two numbers:
+///   - `integrated`: sum of OBD2 fuel-rate integrations across trips
+///     since the previous fill-up.
+///   - `pumped`: the user-entered litres from the pump receipt.
+///
+/// The gap is mostly η_v — fuel-trim (#813) closes the ECU correction
+/// and the cold-start tables (#769) handle driving-mode variance, but
+/// the speed-density branch's η_v is a static 0.85 guess. Reconciling
+/// `pumped / integrated` gives us a first-order estimate of the true
+/// η_v for this engine; an EWMA blend keeps single-tank noise from
+/// whipsawing the value.
+///
+/// Same calibration pattern as #779's fuel-consumption baseline.
+///
+/// Safety rails ([reconcileAfterFillUp] returns null without updating):
+///   - combined trip distance < [minDistanceKm]
+///   - < [minObd2Samples] OBD2 samples
+///   - |integrated − pumped| / pumped > [maxGapFraction] — outlier
+///     that probably indicates bad input (missed fill-up, user typo)
+///   - no trip found between the previous and current fill-up
+///
+/// Clamp: η_v ∈ [[minVe], [maxVe]] after the EWMA step.
+/// EWMA: `new_stored = ewmaBlend * current + (1 - ewmaBlend) * raw`
+/// where `raw = current * (pumped / integrated)`.
+class VeLearner {
+  final VehicleProfileRepository profileRepository;
+  final TripHistoryLoader tripHistoryLoader;
+  final TripSampleCounter sampleCounter;
+
+  /// Minimum trip distance (summed across every trip between the two
+  /// fill-ups) required to learn anything. 50 km matches the issue
+  /// spec — below this the signal is dominated by stop-and-go noise.
+  final double minDistanceKm;
+
+  /// Minimum OBD2 sample count required. Production derives this
+  /// from trip duration (≈1 Hz polling); tests inject a fixed count.
+  final int minObd2Samples;
+
+  /// Maximum |gap| fraction tolerated. 0.40 (40 %) from the issue
+  /// spec — larger gaps almost always mean the user skipped logging
+  /// a fill-up or typed the wrong litres.
+  final double maxGapFraction;
+
+  /// EWMA weight on the existing stored value. 0.7 matches the issue
+  /// spec — gentle blending so one odd tankful can't tank the η.
+  final double ewmaBlend;
+
+  /// Lower / upper clamp on η_v. 0.50 and 1.00 match the issue spec
+  /// and the physically-plausible range for a road engine.
+  final double minVe;
+  final double maxVe;
+
+  VeLearner({
+    required this.profileRepository,
+    required this.tripHistoryLoader,
+    TripSampleCounter? sampleCounter,
+    this.minDistanceKm = 50.0,
+    this.minObd2Samples = 10,
+    this.maxGapFraction = 0.40,
+    this.ewmaBlend = 0.70,
+    this.minVe = 0.50,
+    this.maxVe = 1.00,
+  }) : sampleCounter = sampleCounter ?? _defaultSampleCount;
+
+  /// Convenience constructor that wires the repository-backed trip
+  /// history loader. Used by the production provider.
+  VeLearner.fromRepos({
+    required this.profileRepository,
+    required TripHistoryRepository tripHistoryRepository,
+    TripSampleCounter? sampleCounter,
+    this.minDistanceKm = 50.0,
+    this.minObd2Samples = 10,
+    this.maxGapFraction = 0.40,
+    this.ewmaBlend = 0.70,
+    this.minVe = 0.50,
+    this.maxVe = 1.00,
+  })  : tripHistoryLoader = tripHistoryRepository.loadAll,
+        sampleCounter = sampleCounter ?? _defaultSampleCount;
+
+  /// Reconcile the OBD2 integrated fuel estimate against [pumpedLiters]
+  /// and, if every guard passes, write the updated η_v back to the
+  /// stored [VehicleProfile]. Returns a [VeLearnResult] on success,
+  /// `null` when any guard rejects the tankful.
+  ///
+  /// The previous fill-up anchor is carried by the caller — i.e. the
+  /// fill-up save hook already has the full fill-up list in scope and
+  /// knows which entry lands just before the one that triggered this
+  /// reconciliation. Passing [previousFillUpTimestamp] explicitly
+  /// keeps the learner agnostic of the FillUp repo.
+  Future<VeLearnResult?> reconcileAfterFillUp({
+    required String vehicleId,
+    required double pumpedLiters,
+    required DateTime fillUpTimestamp,
+    required DateTime? previousFillUpTimestamp,
+  }) async {
+    if (pumpedLiters <= 0) return null;
+
+    final profile = profileRepository.getById(vehicleId);
+    if (profile == null) return null;
+
+    final trips = _tripsBetween(
+      vehicleId: vehicleId,
+      from: previousFillUpTimestamp,
+      to: fillUpTimestamp,
+    );
+    if (trips.isEmpty) return null;
+
+    double distance = 0;
+    double integrated = 0;
+    int samples = 0;
+    for (final t in trips) {
+      distance += t.summary.distanceKm;
+      final f = t.summary.fuelLitersConsumed;
+      if (f != null) integrated += f;
+      samples += sampleCounter(t);
+    }
+
+    if (distance < minDistanceKm) {
+      debugPrint('VeLearner: skip — distance $distance < $minDistanceKm km');
+      return null;
+    }
+    if (samples < minObd2Samples) {
+      debugPrint('VeLearner: skip — samples $samples < $minObd2Samples');
+      return null;
+    }
+    if (integrated <= 0) {
+      debugPrint('VeLearner: skip — no integrated fuel on trips');
+      return null;
+    }
+    final gap = (integrated - pumpedLiters).abs() / pumpedLiters;
+    if (gap > maxGapFraction) {
+      debugPrint('VeLearner: skip — gap ${(gap * 100).toStringAsFixed(1)}% '
+          '> ${(maxGapFraction * 100).toStringAsFixed(0)}%');
+      return null;
+    }
+
+    final currentVe = profile.volumetricEfficiency;
+    // Integrated fuel scales linearly with η_v (the speed-density
+    // fallback multiplies by η_v). If the integrator over-predicted
+    // the actual pump, the true η is lower than what's stored:
+    //   trueVe ≈ currentVe × (pumped / integrated)
+    final rawNewVe = currentVe * (pumpedLiters / integrated);
+    final blended = ewmaBlend * currentVe + (1.0 - ewmaBlend) * rawNewVe;
+    final clamped = blended.clamp(minVe, maxVe).toDouble();
+
+    final oldGap = (integrated - pumpedLiters).abs();
+    // Estimate the new integrated number under the updated η — again
+    // a linear scale — and derive the absolute improvement fraction.
+    final newIntegrated = integrated * (clamped / currentVe);
+    final newGap = (newIntegrated - pumpedLiters).abs();
+    double improvement;
+    if (oldGap <= 0) {
+      improvement = 0;
+    } else {
+      improvement = (1.0 - newGap / oldGap) * 100.0;
+      if (improvement.isNaN || improvement.isInfinite) improvement = 0;
+      if (improvement < 0) improvement = 0;
+      if (improvement > 100) improvement = 100;
+    }
+
+    final updated = profile.copyWith(
+      volumetricEfficiency: clamped,
+      volumetricEfficiencySamples: profile.volumetricEfficiencySamples + 1,
+    );
+    await profileRepository.save(updated);
+
+    return VeLearnResult(
+      vehicleId: vehicleId,
+      previousVe: currentVe,
+      newVe: clamped,
+      integratedLiters: integrated,
+      pumpedLiters: pumpedLiters,
+      accuracyImprovementPct: improvement,
+      sampleCount: updated.volumetricEfficiencySamples,
+    );
+  }
+
+  List<TripHistoryEntry> _tripsBetween({
+    required String vehicleId,
+    required DateTime? from,
+    required DateTime to,
+  }) {
+    final all = tripHistoryLoader();
+    return all.where((e) {
+      if (e.vehicleId != vehicleId) return false;
+      final started = e.summary.startedAt;
+      if (started == null) return false;
+      if (from != null && !started.isAfter(from)) return false;
+      if (!started.isBefore(to)) return false;
+      return true;
+    }).toList();
+  }
+}
+
+/// Default sample-count heuristic: trip duration in seconds ≈ sample
+/// count, because OBD2 polling hovers near 1 Hz. Falls back to a
+/// 50-sample floor when either timestamp is missing but the trip
+/// carried fuel integration (i.e. it *did* record samples — we just
+/// don't know how many). 50 is under the minObd2Samples gate by a
+/// wide enough margin that the heuristic stays protective: a
+/// sample-poor trip still rejects.
+int _defaultSampleCount(TripHistoryEntry entry) {
+  final started = entry.summary.startedAt;
+  final ended = entry.summary.endedAt;
+  if (started != null && ended != null) {
+    final secs = ended.difference(started).inSeconds;
+    if (secs > 0) return secs;
+  }
+  // Unknown duration but fuel integration present — treat as "some
+  // unknown non-zero count, probably enough" via a conservative 50.
+  if (entry.summary.fuelLitersConsumed != null) return 50;
+  return 0;
+}

--- a/lib/features/vehicle/domain/entities/vehicle_profile.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.dart
@@ -108,11 +108,19 @@ abstract class VehicleProfile with _$VehicleProfile {
     //     default — null is honest.
     //   volumetricEfficiency: 0.60–0.95 range. Default 0.85 is
     //     reasonable for a typical NA petrol engine at cruise.
-    //     Adaptive calibration (#815) will narrow this per vehicle
-    //     from tankful reconciliation.
+    //     Adaptive calibration (#815) narrows this per vehicle
+    //     from tankful reconciliation — see [VeLearner].
+    //   volumetricEfficiencySamples: EWMA sample counter for η_v
+    //     (#815). 0 at first fill-up; bumps by 1 every time the
+    //     reconciliation pipeline accepts a pumped/integrated pair.
+    //     Used for debugging and UX — e.g. "calibrated from 3
+    //     tankfuls" — and as a future ramp for the EWMA alpha if
+    //     the fixed 0.3 blend ever needs to soften during early
+    //     samples.
     int? engineDisplacementCc,
     int? engineCylinders,
     @Default(0.85) double volumetricEfficiency,
+    @Default(0) int volumetricEfficiencySamples,
 
     // Curb weight in kilograms (#812). Populated by the VIN decoder
     // phase 2 onboarding flow (GVWR-minus-payload on the NHTSA side,

--- a/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
@@ -307,9 +307,16 @@ mixin _$VehicleProfile {
 //     default — null is honest.
 //   volumetricEfficiency: 0.60–0.95 range. Default 0.85 is
 //     reasonable for a typical NA petrol engine at cruise.
-//     Adaptive calibration (#815) will narrow this per vehicle
-//     from tankful reconciliation.
- int? get engineDisplacementCc; int? get engineCylinders; double get volumetricEfficiency;// Curb weight in kilograms (#812). Populated by the VIN decoder
+//     Adaptive calibration (#815) narrows this per vehicle
+//     from tankful reconciliation — see [VeLearner].
+//   volumetricEfficiencySamples: EWMA sample counter for η_v
+//     (#815). 0 at first fill-up; bumps by 1 every time the
+//     reconciliation pipeline accepts a pumped/integrated pair.
+//     Used for debugging and UX — e.g. "calibrated from 3
+//     tankfuls" — and as a future ramp for the EWMA alpha if
+//     the fixed 0.3 blend ever needs to soften during early
+//     samples.
+ int? get engineDisplacementCc; int? get engineCylinders; double get volumetricEfficiency; int get volumetricEfficiencySamples;// Curb weight in kilograms (#812). Populated by the VIN decoder
 // phase 2 onboarding flow (GVWR-minus-payload on the NHTSA side,
 // or manufacturer spec sheets via a future secondary lookup).
 // Null means "unknown" — consumers like the rolling-resistance
@@ -339,16 +346,16 @@ $VehicleProfileCopyWith<VehicleProfile> get copyWith => _$VehicleProfileCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin);
+int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin)';
 }
 
 
@@ -359,7 +366,7 @@ abstract mixin class $VehicleProfileCopyWith<$Res>  {
   factory $VehicleProfileCopyWith(VehicleProfile value, $Res Function(VehicleProfile) _then) = _$VehicleProfileCopyWithImpl;
 @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin
 });
 
 
@@ -376,7 +383,7 @@ class _$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -390,7 +397,8 @@ as double?,preferredFuelType: freezed == preferredFuelType ? _self.preferredFuel
 as String?,engineDisplacementCc: freezed == engineDisplacementCc ? _self.engineDisplacementCc : engineDisplacementCc // ignore: cast_nullable_to_non_nullable
 as int?,engineCylinders: freezed == engineCylinders ? _self.engineCylinders : engineCylinders // ignore: cast_nullable_to_non_nullable
 as int?,volumetricEfficiency: null == volumetricEfficiency ? _self.volumetricEfficiency : volumetricEfficiency // ignore: cast_nullable_to_non_nullable
-as double,curbWeightKg: freezed == curbWeightKg ? _self.curbWeightKg : curbWeightKg // ignore: cast_nullable_to_non_nullable
+as double,volumetricEfficiencySamples: null == volumetricEfficiencySamples ? _self.volumetricEfficiencySamples : volumetricEfficiencySamples // ignore: cast_nullable_to_non_nullable
+as int,curbWeightKg: freezed == curbWeightKg ? _self.curbWeightKg : curbWeightKg // ignore: cast_nullable_to_non_nullable
 as int?,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2AdapterMac // ignore: cast_nullable_to_non_nullable
 as String?,obd2AdapterName: freezed == obd2AdapterName ? _self.obd2AdapterName : obd2AdapterName // ignore: cast_nullable_to_non_nullable
 as String?,vin: freezed == vin ? _self.vin : vin // ignore: cast_nullable_to_non_nullable
@@ -488,10 +496,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin);case _:
   return orElse();
 
 }
@@ -509,10 +517,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin)  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile():
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -529,10 +537,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin)?  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin);case _:
   return null;
 
 }
@@ -544,7 +552,7 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 @JsonSerializable()
 
 class _VehicleProfile extends VehicleProfile {
-  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName, this.vin}): _supportedConnectors = supportedConnectors,super._();
+  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.volumetricEfficiencySamples = 0, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName, this.vin}): _supportedConnectors = supportedConnectors,super._();
   factory _VehicleProfile.fromJson(Map<String, dynamic> json) => _$VehicleProfileFromJson(json);
 
 @override final  String id;
@@ -579,11 +587,19 @@ class _VehicleProfile extends VehicleProfile {
 //     default — null is honest.
 //   volumetricEfficiency: 0.60–0.95 range. Default 0.85 is
 //     reasonable for a typical NA petrol engine at cruise.
-//     Adaptive calibration (#815) will narrow this per vehicle
-//     from tankful reconciliation.
+//     Adaptive calibration (#815) narrows this per vehicle
+//     from tankful reconciliation — see [VeLearner].
+//   volumetricEfficiencySamples: EWMA sample counter for η_v
+//     (#815). 0 at first fill-up; bumps by 1 every time the
+//     reconciliation pipeline accepts a pumped/integrated pair.
+//     Used for debugging and UX — e.g. "calibrated from 3
+//     tankfuls" — and as a future ramp for the EWMA alpha if
+//     the fixed 0.3 blend ever needs to soften during early
+//     samples.
 @override final  int? engineDisplacementCc;
 @override final  int? engineCylinders;
 @override@JsonKey() final  double volumetricEfficiency;
+@override@JsonKey() final  int volumetricEfficiencySamples;
 // Curb weight in kilograms (#812). Populated by the VIN decoder
 // phase 2 onboarding flow (GVWR-minus-payload on the NHTSA side,
 // or manufacturer spec sheets via a future secondary lookup).
@@ -619,16 +635,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin);
+int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin)';
 }
 
 
@@ -639,7 +655,7 @@ abstract mixin class _$VehicleProfileCopyWith<$Res> implements $VehicleProfileCo
   factory _$VehicleProfileCopyWith(_VehicleProfile value, $Res Function(_VehicleProfile) _then) = __$VehicleProfileCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin
 });
 
 
@@ -656,7 +672,7 @@ class __$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,}) {
   return _then(_VehicleProfile(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -670,7 +686,8 @@ as double?,preferredFuelType: freezed == preferredFuelType ? _self.preferredFuel
 as String?,engineDisplacementCc: freezed == engineDisplacementCc ? _self.engineDisplacementCc : engineDisplacementCc // ignore: cast_nullable_to_non_nullable
 as int?,engineCylinders: freezed == engineCylinders ? _self.engineCylinders : engineCylinders // ignore: cast_nullable_to_non_nullable
 as int?,volumetricEfficiency: null == volumetricEfficiency ? _self.volumetricEfficiency : volumetricEfficiency // ignore: cast_nullable_to_non_nullable
-as double,curbWeightKg: freezed == curbWeightKg ? _self.curbWeightKg : curbWeightKg // ignore: cast_nullable_to_non_nullable
+as double,volumetricEfficiencySamples: null == volumetricEfficiencySamples ? _self.volumetricEfficiencySamples : volumetricEfficiencySamples // ignore: cast_nullable_to_non_nullable
+as int,curbWeightKg: freezed == curbWeightKg ? _self.curbWeightKg : curbWeightKg // ignore: cast_nullable_to_non_nullable
 as int?,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2AdapterMac // ignore: cast_nullable_to_non_nullable
 as String?,obd2AdapterName: freezed == obd2AdapterName ? _self.obd2AdapterName : obd2AdapterName // ignore: cast_nullable_to_non_nullable
 as String?,vin: freezed == vin ? _self.vin : vin // ignore: cast_nullable_to_non_nullable

--- a/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
@@ -50,6 +50,8 @@ _VehicleProfile _$VehicleProfileFromJson(Map<String, dynamic> json) =>
       engineCylinders: (json['engineCylinders'] as num?)?.toInt(),
       volumetricEfficiency:
           (json['volumetricEfficiency'] as num?)?.toDouble() ?? 0.85,
+      volumetricEfficiencySamples:
+          (json['volumetricEfficiencySamples'] as num?)?.toInt() ?? 0,
       curbWeightKg: (json['curbWeightKg'] as num?)?.toInt(),
       obd2AdapterMac: json['obd2AdapterMac'] as String?,
       obd2AdapterName: json['obd2AdapterName'] as String?,
@@ -74,6 +76,7 @@ Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
       'engineDisplacementCc': instance.engineDisplacementCc,
       'engineCylinders': instance.engineCylinders,
       'volumetricEfficiency': instance.volumetricEfficiency,
+      'volumetricEfficiencySamples': instance.volumetricEfficiencySamples,
       'curbWeightKg': instance.curbWeightKg,
       'obd2AdapterMac': instance.obd2AdapterMac,
       'obd2AdapterName': instance.obd2AdapterName,

--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -272,6 +272,53 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     });
   }
 
+  /// Reset the learned η_v for this vehicle (#815). Shows a confirm
+  /// dialog first — destructive actions should always be explicit —
+  /// then writes the default (0.85) back through the repository and
+  /// clears the sample counter. Safe to call before _save because
+  /// the user hasn't necessarily pressed Save on their other
+  /// changes; the reset targets the stored profile independently.
+  Future<void> _resetVolumetricEfficiency() async {
+    final id = _existingId;
+    if (id == null) return;
+    final l = AppLocalizations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(l?.veResetConfirmTitle ?? 'Reset calibration?'),
+        content: Text(
+          l?.veResetConfirmBody ??
+              'This will discard the learned per-vehicle calibration '
+                  'and restore the default value (0.85).',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(l?.cancel ?? 'Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(l?.veResetAction ?? 'Reset calibration'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    if (!mounted) return;
+    try {
+      final list = ref.read(vehicleProfileListProvider);
+      final existing = list.where((v) => v.id == id).firstOrNull;
+      if (existing == null) return;
+      final cleared = existing.copyWith(
+        volumetricEfficiency: 0.85,
+        volumetricEfficiencySamples: 0,
+      );
+      await ref.read(vehicleProfileListProvider.notifier).save(cleared);
+    } catch (e) {
+      debugPrint('EditVehicleScreen: VE reset failed: $e');
+    }
+  }
+
   /// Latest odometer reading logged for [vehicleId], picked from the
   /// fill-up history (#584). Falls back to null so the reminder
   /// section can prompt the user for a manual entry.
@@ -420,6 +467,18 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
             if (_existingId != null) ...[
               const SizedBox(height: 24),
               VehicleBaselineSection(vehicleId: _existingId!),
+            ],
+            // η_v calibration reset (#815). Lives in the same
+            // "learned calibration" band as the baseline section
+            // above — a user who wants to wipe one will often want
+            // to wipe the other.
+            if (_existingId != null) ...[
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                onPressed: _resetVolumetricEfficiency,
+                icon: const Icon(Icons.restart_alt_outlined),
+                label: Text(l?.veResetAction ?? 'Reset calibration'),
+              ),
             ],
             // Service reminders (#584). Needs a stable vehicle id —
             // the id is the foreign key stored on each reminder — so

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1207,5 +1207,9 @@
   "vinInvalidFormat": "Ungültiges FIN-Format",
   "obd2PauseBannerTitle": "OBD2-Verbindung verloren — Aufzeichnung pausiert",
   "obd2PauseBannerResume": "Weiter aufzeichnen",
-  "obd2PauseBannerEnd": "Aufzeichnung beenden"
+  "obd2PauseBannerEnd": "Aufzeichnung beenden",
+  "veCalibratedTitle": "Verbrauchsberechnung für {vehicleName} kalibriert — Genauigkeit verbessert um {percent}%",
+  "veResetAction": "Kalibrierung zurücksetzen",
+  "veResetConfirmTitle": "Kalibrierung zurücksetzen?",
+  "veResetConfirmBody": "Dies verwirft die gelernte fahrzeugspezifische Kalibrierung und stellt den Standardwert (0,85) wieder her."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1270,5 +1270,25 @@
   "obd2PauseBannerEnd": "End recording",
   "@obd2PauseBannerEnd": {
     "description": "Action on the OBD2 pause banner that stops the recording and saves what was captured before the drop."
+  },
+  "veCalibratedTitle": "Consumption calibration updated for {vehicleName} — accuracy improved by {percent}%",
+  "@veCalibratedTitle": {
+    "description": "Snackbar shown after #815 reconciles OBD2 integrated fuel against the pump receipt and learns a new volumetric-efficiency scalar for the vehicle.",
+    "placeholders": {
+      "vehicleName": { "type": "String", "example": "Peugeot 107" },
+      "percent": { "type": "String", "example": "42" }
+    }
+  },
+  "veResetAction": "Reset calibration",
+  "@veResetAction": {
+    "description": "Action on the vehicle edit screen that discards the learned volumetric-efficiency calibration (#815)."
+  },
+  "veResetConfirmTitle": "Reset calibration?",
+  "@veResetConfirmTitle": {
+    "description": "Title of the confirm dialog shown before discarding the learned volumetric efficiency (#815)."
+  },
+  "veResetConfirmBody": "This will discard the learned per-vehicle calibration and restore the default value (0.85).",
+  "@veResetConfirmBody": {
+    "description": "Body of the confirm dialog shown before discarding the learned volumetric efficiency (#815)."
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5779,6 +5779,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'End recording'**
   String get obd2PauseBannerEnd;
+
+  /// Snackbar shown after #815 reconciles OBD2 integrated fuel against the pump receipt and learns a new volumetric-efficiency scalar for the vehicle.
+  ///
+  /// In en, this message translates to:
+  /// **'Consumption calibration updated for {vehicleName} — accuracy improved by {percent}%'**
+  String veCalibratedTitle(String vehicleName, String percent);
+
+  /// Action on the vehicle edit screen that discards the learned volumetric-efficiency calibration (#815).
+  ///
+  /// In en, this message translates to:
+  /// **'Reset calibration'**
+  String get veResetAction;
+
+  /// Title of the confirm dialog shown before discarding the learned volumetric efficiency (#815).
+  ///
+  /// In en, this message translates to:
+  /// **'Reset calibration?'**
+  String get veResetConfirmTitle;
+
+  /// Body of the confirm dialog shown before discarding the learned volumetric efficiency (#815).
+  ///
+  /// In en, this message translates to:
+  /// **'This will discard the learned per-vehicle calibration and restore the default value (0.85).'**
+  String get veResetConfirmBody;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3070,4 +3070,19 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3070,4 +3070,19 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3068,4 +3068,19 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3093,4 +3093,19 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'Aufzeichnung beenden';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Verbrauchsberechnung für $vehicleName kalibriert — Genauigkeit verbessert um $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Kalibrierung zurücksetzen';
+
+  @override
+  String get veResetConfirmTitle => 'Kalibrierung zurücksetzen?';
+
+  @override
+  String get veResetConfirmBody =>
+      'Dies verwirft die gelernte fahrzeugspezifische Kalibrierung und stellt den Standardwert (0,85) wieder her.';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3072,4 +3072,19 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3063,4 +3063,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3071,4 +3071,19 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3065,4 +3065,19 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3068,4 +3068,19 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3092,4 +3092,19 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3067,4 +3067,19 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3072,4 +3072,19 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3071,4 +3071,19 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3069,4 +3069,19 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3071,4 +3071,19 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3067,4 +3067,19 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3072,4 +3072,19 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3070,4 +3070,19 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3071,4 +3071,19 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3070,4 +3070,19 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3071,4 +3071,19 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3065,4 +3065,19 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3069,4 +3069,19 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get obd2PauseBannerEnd => 'End recording';
+
+  @override
+  String veCalibratedTitle(String vehicleName, String percent) {
+    return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
+  }
+
+  @override
+  String get veResetAction => 'Reset calibration';
+
+  @override
+  String get veResetConfirmTitle => 'Reset calibration?';
+
+  @override
+  String get veResetConfirmBody =>
+      'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
 }

--- a/test/features/consumption/providers/fill_up_ve_calibration_test.dart
+++ b/test/features/consumption/providers/fill_up_ve_calibration_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/data/ve_learner.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+
+/// Integration-level tests for the fill-up save → η_v reconciliation
+/// path (#815). These tests drive the real provider graph (no Riverpod
+/// doubles) so the FillUpList.add hook is exercised end-to-end.
+void main() {
+  late ProviderContainer container;
+  late _FakeTripHistory history;
+  late VehicleProfileRepository profileRepo;
+
+  setUp(() {
+    history = _FakeTripHistory();
+    final storage = _FakeSettingsStorage();
+    profileRepo = VehicleProfileRepository(storage);
+    container = ProviderContainer(
+      overrides: [
+        settingsStorageProvider.overrideWithValue(storage),
+        vehicleProfileRepositoryProvider.overrideWithValue(profileRepo),
+        // Inject a deterministic learner whose sample counter doesn't
+        // depend on wall-clock trip duration — unit-test trips use
+        // fabricated timestamps — and whose trip loader reads from an
+        // in-memory list instead of Hive.
+        veLearnerProvider.overrideWith(
+          (ref) => VeLearner(
+            profileRepository:
+                ref.watch(vehicleProfileRepositoryProvider),
+            tripHistoryLoader: history.entries.toList,
+            sampleCounter: (_) => 600,
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  test(
+    'adding a second fill-up for a vehicle with trips since the '
+    'previous fill-up produces a VeLearnResult that surfaces via '
+    'lastVeLearnResultProvider, updates the vehicle η_v, and bumps '
+    'the sample count',
+    () async {
+      await profileRepo.save(const VehicleProfile(
+        id: 'veh-a',
+        name: 'Peugeot 107',
+      ));
+
+      final previousFillDate = DateTime(2026, 4, 1, 8);
+      final currentFillDate = DateTime(2026, 4, 15, 18);
+
+      history.entries.add(TripHistoryEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        summary: TripSummary(
+          distanceKm: 200,
+          maxRpm: 0,
+          highRpmSeconds: 0,
+          idleSeconds: 0,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+          fuelLitersConsumed: 55,
+          startedAt: previousFillDate.add(const Duration(hours: 2)),
+          endedAt: previousFillDate.add(const Duration(hours: 5)),
+        ),
+      ));
+
+      final notifier = container.read(fillUpListProvider.notifier);
+      // Seed the previous fill-up so the learner anchors against it.
+      await notifier.add(FillUp(
+        id: 'prev',
+        date: previousFillDate,
+        liters: 40,
+        totalCost: 60,
+        odometerKm: 10000,
+        fuelType: FuelType.e10,
+        vehicleId: 'veh-a',
+      ));
+      // No snackbar fired — the first fill-up has no prior anchor.
+      expect(container.read(lastVeLearnResultProvider), isNull);
+
+      // Current fill-up — 50 L pumped vs 55 L integrated.
+      await notifier.add(FillUp(
+        id: 'cur',
+        date: currentFillDate,
+        liters: 50,
+        totalCost: 75,
+        odometerKm: 10200,
+        fuelType: FuelType.e10,
+        vehicleId: 'veh-a',
+      ));
+
+      final result = container.read(lastVeLearnResultProvider);
+      expect(result, isNotNull);
+      expect(result!.vehicleId, 'veh-a');
+      expect(result.newVe, lessThan(0.85));
+      expect(result.newVe, greaterThan(0.50));
+      expect(result.sampleCount, 1);
+
+      final updatedProfile = profileRepo.getById('veh-a')!;
+      expect(updatedProfile.volumetricEfficiencySamples, 1);
+      expect(updatedProfile.volumetricEfficiency, lessThan(0.85));
+    },
+  );
+
+  test('snackbar text contains vehicle name and improvement percent',
+      () async {
+    await profileRepo.save(const VehicleProfile(
+      id: 'veh-a',
+      name: 'Peugeot 107',
+    ));
+
+    final previousFillDate = DateTime(2026, 4, 1, 8);
+    final currentFillDate = DateTime(2026, 4, 15, 18);
+
+    history.entries.add(TripHistoryEntry(
+      id: 't1',
+      vehicleId: 'veh-a',
+      summary: TripSummary(
+        distanceKm: 200,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: 55,
+        startedAt: previousFillDate.add(const Duration(hours: 2)),
+        endedAt: previousFillDate.add(const Duration(hours: 5)),
+      ),
+    ));
+
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(FillUp(
+      id: 'prev',
+      date: previousFillDate,
+      liters: 40,
+      totalCost: 60,
+      odometerKm: 10000,
+      fuelType: FuelType.e10,
+      vehicleId: 'veh-a',
+    ));
+    await notifier.add(FillUp(
+      id: 'cur',
+      date: currentFillDate,
+      liters: 50,
+      totalCost: 75,
+      odometerKm: 10200,
+      fuelType: FuelType.e10,
+      vehicleId: 'veh-a',
+    ));
+
+    final result = container.read(lastVeLearnResultProvider);
+    expect(result, isNotNull);
+
+    // Template-equivalent snackbar text (the real consumption screen
+    // uses AppLocalizations — we format the fallback string here to
+    // prove the data carried by the result is enough to render it).
+    final vehicle = profileRepo.getById(result!.vehicleId)!;
+    final snackbar =
+        'Consumption calibration updated for ${vehicle.name} — '
+        'accuracy improved by '
+        '${result.accuracyImprovementPct.round()}%';
+    expect(snackbar, contains('Peugeot 107'));
+    expect(
+      RegExp(r'improved by \d+%').hasMatch(snackbar),
+      isTrue,
+      reason: 'Snackbar must carry a numeric improvement percent',
+    );
+  });
+}
+
+class _FakeTripHistory {
+  final List<TripHistoryEntry> entries = [];
+}
+
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+

--- a/test/features/vehicle/data/ve_learner_test.dart
+++ b/test/features/vehicle/data/ve_learner_test.dart
@@ -1,0 +1,403 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/data/ve_learner.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+/// Seed helper — builds a [TripHistoryEntry] with the handful of
+/// fields the learner actually reads (distance, integrated fuel,
+/// startedAt/endedAt window). Everything else gets zero defaults.
+TripHistoryEntry _tripEntry({
+  required String id,
+  required String vehicleId,
+  required DateTime startedAt,
+  required DateTime endedAt,
+  required double distanceKm,
+  double? fuelLitersConsumed,
+}) {
+  return TripHistoryEntry(
+    id: id,
+    vehicleId: vehicleId,
+    summary: TripSummary(
+      distanceKm: distanceKm,
+      maxRpm: 0,
+      highRpmSeconds: 0,
+      idleSeconds: 0,
+      harshBrakes: 0,
+      harshAccelerations: 0,
+      fuelLitersConsumed: fuelLitersConsumed,
+      startedAt: startedAt,
+      endedAt: endedAt,
+    ),
+  );
+}
+
+void main() {
+  group('VeLearner.reconcileAfterFillUp', () {
+    late _FakeSettings settings;
+    late VehicleProfileRepository profileRepo;
+    late _InMemoryTrips trips;
+    late VeLearner learner;
+
+    final previousFill = DateTime(2026, 4, 1, 8);
+    final currentFill = DateTime(2026, 4, 15, 18);
+
+    setUp(() async {
+      settings = _FakeSettings();
+      profileRepo = VehicleProfileRepository(settings);
+      trips = _InMemoryTrips();
+      learner = VeLearner(
+        profileRepository: profileRepo,
+        tripHistoryLoader: trips.loadAll,
+        // Static sample counter so guards aren't accidentally
+        // tripped by wall-clock duration — test trips don't have
+        // realistic startedAt/endedAt ranges.
+        sampleCounter: (_) => 600,
+      );
+      // Seed vehicle A with the default η_v.
+      await profileRepo.save(const VehicleProfile(
+        id: 'veh-a',
+        name: 'Peugeot 107',
+      ));
+    });
+
+    test('10% overestimate adjusts η_v and bumps sample counter',
+        () async {
+      // integrated=55, pumped=50 → new_estimate = 0.85 × (50/55) =
+      // 0.77272727…; EWMA blend = 0.7 × 0.85 + 0.3 × 0.77272727 =
+      // 0.82681818. The issue spec rounds this to ~0.82 which is the
+      // value the UI surfaces.
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: previousFill.add(const Duration(hours: 2)),
+        endedAt: previousFill.add(const Duration(hours: 5)),
+        distanceKm: 200,
+        fuelLitersConsumed: 55,
+      ));
+
+      final result = await learner.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.previousVe, closeTo(0.85, 1e-9));
+      expect(result.newVe, closeTo(0.82681818, 1e-4));
+      expect(result.sampleCount, 1);
+
+      final updated = profileRepo.getById('veh-a')!;
+      expect(updated.volumetricEfficiency, closeTo(0.82681818, 1e-4));
+      expect(updated.volumetricEfficiencySamples, 1);
+    });
+
+    test('short trip (< 50 km) is ignored — profile untouched',
+        () async {
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: previousFill.add(const Duration(hours: 2)),
+        endedAt: previousFill.add(const Duration(hours: 3)),
+        distanceKm: 30,
+        fuelLitersConsumed: 3,
+      ));
+
+      final result = await learner.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 3,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+
+      expect(result, isNull);
+      final unchanged = profileRepo.getById('veh-a')!;
+      expect(unchanged.volumetricEfficiency, 0.85);
+      expect(unchanged.volumetricEfficiencySamples, 0);
+    });
+
+    test('too-few OBD2 samples is ignored', () async {
+      // Thin-samples learner — same trip distance & fuel, but the
+      // sample counter reports 3 samples. Under the 10-sample floor.
+      final thinLearner = VeLearner(
+        profileRepository: profileRepo,
+        tripHistoryLoader: trips.loadAll,
+        sampleCounter: (_) => 3,
+      );
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: previousFill.add(const Duration(hours: 2)),
+        endedAt: previousFill.add(const Duration(hours: 5)),
+        distanceKm: 200,
+        fuelLitersConsumed: 55,
+      ));
+
+      final result = await thinLearner.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+
+      expect(result, isNull);
+      expect(profileRepo.getById('veh-a')!.volumetricEfficiency, 0.85);
+    });
+
+    test('outlier (|gap|/pumped > 40%) is ignored', () async {
+      // integrated=80, pumped=50 — 60 % gap, way over the 40 % outlier
+      // cutoff. The user probably missed logging an earlier fill-up.
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: previousFill.add(const Duration(hours: 2)),
+        endedAt: previousFill.add(const Duration(hours: 10)),
+        distanceKm: 400,
+        fuelLitersConsumed: 80,
+      ));
+
+      final result = await learner.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+
+      expect(result, isNull);
+      expect(profileRepo.getById('veh-a')!.volumetricEfficiency, 0.85);
+    });
+
+    test('clamps above 1.0 — extreme under-integration', () async {
+      // Seed η near 1.0, pump way more than integrated — the raw new
+      // estimate would exceed 1.0 and the clamp must engage.
+      await profileRepo.save(const VehicleProfile(
+        id: 'veh-a',
+        name: 'Peugeot 107',
+        volumetricEfficiency: 0.98,
+      ));
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: previousFill.add(const Duration(hours: 2)),
+        endedAt: previousFill.add(const Duration(hours: 5)),
+        distanceKm: 200,
+        // Only 5 % gap so we stay inside the 40 % outlier cutoff.
+        fuelLitersConsumed: 48,
+      ));
+
+      final result = await learner.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.newVe, lessThanOrEqualTo(1.0));
+      expect(result.newVe, greaterThanOrEqualTo(0.98));
+      // Custom learner with a lower ewmaBlend → raw value dominates
+      // and the clamp kicks in.
+      final aggressive = VeLearner(
+        profileRepository: profileRepo,
+        tripHistoryLoader: trips.loadAll,
+        sampleCounter: (_) => 600,
+        ewmaBlend: 0.0,
+      );
+      await profileRepo.save(const VehicleProfile(
+        id: 'veh-a',
+        name: 'Peugeot 107',
+        volumetricEfficiency: 0.98,
+      ));
+      final r2 = await aggressive.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+      // raw = 0.98 × 50/48 ≈ 1.0208 — must be clamped to 1.0.
+      expect(r2!.newVe, 1.0);
+    });
+
+    test('clamps below 0.5 — extreme over-integration', () async {
+      // Learner with ewmaBlend = 0 (no smoothing) + a huge gap within
+      // the 40 % outlier window. 0.85 × (36/60) = 0.51 — set η
+      // artificially low so the raw estimate undershoots 0.5.
+      await profileRepo.save(const VehicleProfile(
+        id: 'veh-a',
+        name: 'Peugeot 107',
+        volumetricEfficiency: 0.70,
+      ));
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: previousFill.add(const Duration(hours: 2)),
+        endedAt: previousFill.add(const Duration(hours: 10)),
+        distanceKm: 400,
+        // 35 % over pumped, inside the 40 % outlier cutoff, but the
+        // η_v that would explain it is 0.70 × 50/67.5 ≈ 0.518 — still
+        // above 0.5. To force the clamp we drop ewmaBlend to 0 and
+        // shave η to 0.60 so raw = 0.60 × 50/67.5 ≈ 0.444 < 0.5.
+        fuelLitersConsumed: 67.5,
+      ));
+
+      final raw = VeLearner(
+        profileRepository: profileRepo,
+        tripHistoryLoader: trips.loadAll,
+        sampleCounter: (_) => 600,
+        ewmaBlend: 0.0,
+      );
+      await profileRepo.save(const VehicleProfile(
+        id: 'veh-a',
+        name: 'Peugeot 107',
+        volumetricEfficiency: 0.60,
+      ));
+      final r = await raw.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+      expect(r, isNotNull);
+      expect(r!.newVe, 0.5);
+    });
+
+    test('no trip between fill-ups is ignored', () async {
+      // Trip logged BEFORE the previous fill-up — the learner must
+      // filter it out by timestamp and return null rather than
+      // silently calibrating off stale data.
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: previousFill.subtract(const Duration(days: 5)),
+        endedAt: previousFill.subtract(const Duration(days: 5, hours: -3)),
+        distanceKm: 200,
+        fuelLitersConsumed: 55,
+      ));
+
+      final result = await learner.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+
+      expect(result, isNull);
+      expect(profileRepo.getById('veh-a')!.volumetricEfficiency, 0.85);
+    });
+
+    test('multi-vehicle isolation — B unaffected when A calibrates',
+        () async {
+      await profileRepo.save(const VehicleProfile(
+        id: 'veh-b',
+        name: 'Renault Zoe',
+      ));
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: previousFill.add(const Duration(hours: 2)),
+        endedAt: previousFill.add(const Duration(hours: 5)),
+        distanceKm: 200,
+        fuelLitersConsumed: 55,
+      ));
+
+      final result = await learner.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+      expect(result, isNotNull);
+
+      final a = profileRepo.getById('veh-a')!;
+      final b = profileRepo.getById('veh-b')!;
+      expect(a.volumetricEfficiency, isNot(0.85));
+      expect(a.volumetricEfficiencySamples, 1);
+      // Vehicle B kept its cold-start default and its zero counter —
+      // A's calibration did not bleed through.
+      expect(b.volumetricEfficiency, 0.85);
+      expect(b.volumetricEfficiencySamples, 0);
+    });
+
+    test('missing previous fill-up means first-ever calibration '
+        'over the full history', () async {
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: currentFill.subtract(const Duration(days: 3)),
+        endedAt: currentFill.subtract(const Duration(days: 3, hours: -3)),
+        distanceKm: 200,
+        fuelLitersConsumed: 55,
+      ));
+
+      final result = await learner.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: null,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.sampleCount, 1);
+    });
+
+    test('accuracy improvement is a positive percentage', () async {
+      trips.entries.add(_tripEntry(
+        id: 't1',
+        vehicleId: 'veh-a',
+        startedAt: previousFill.add(const Duration(hours: 2)),
+        endedAt: previousFill.add(const Duration(hours: 5)),
+        distanceKm: 200,
+        fuelLitersConsumed: 55,
+      ));
+
+      final result = await learner.reconcileAfterFillUp(
+        vehicleId: 'veh-a',
+        pumpedLiters: 50,
+        fillUpTimestamp: currentFill,
+        previousFillUpTimestamp: previousFill,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.accuracyImprovementPct, greaterThan(0));
+      expect(result.accuracyImprovementPct, lessThanOrEqualTo(100));
+    });
+  });
+}
+
+/// In-memory trip history so the learner can exercise the time
+/// window filter without touching Hive.
+class _InMemoryTrips {
+  final List<TripHistoryEntry> entries = [];
+  List<TripHistoryEntry> loadAll() => List.unmodifiable(entries);
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_ve_reset_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_ve_reset_test.dart
@@ -1,0 +1,176 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for the η_v calibration reset action added to
+/// [EditVehicleScreen] (#815).
+///
+/// Covers the confirm-then-reset flow: tapping the button opens a
+/// destructive-action dialog, and only the explicit confirm commits
+/// the change back to the profile repository.
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('ve_reset_widget_');
+    Hive.init(tempDir.path);
+    // The service-reminder section and baseline section both open
+    // Hive boxes during their first build. Open them empty so the
+    // sections render without throwing.
+    await Hive.openBox<String>(HiveBoxes.serviceReminders);
+    await Hive.openBox<String>(HiveBoxes.obd2Baselines);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('EditVehicleScreen — η_v reset (#815)', () {
+    testWidgets('renders the reset action on an existing vehicle',
+        (tester) async {
+      final repo = VehicleProfileRepository(_FakeSettings());
+      await repo.save(const VehicleProfile(
+        id: 'v1',
+        name: 'Peugeot 107',
+        volumetricEfficiency: 0.72,
+        volumetricEfficiencySamples: 5,
+      ));
+
+      await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+
+      // Scroll until the reset action is visible — it lives below
+      // the service-reminder and baseline sections.
+      await tester.dragUntilVisible(
+        find.text('Reset calibration'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      expect(find.text('Reset calibration'), findsOneWidget);
+    });
+
+    testWidgets('Cancel leaves the profile untouched', (tester) async {
+      final repo = VehicleProfileRepository(_FakeSettings());
+      await repo.save(const VehicleProfile(
+        id: 'v1',
+        name: 'Peugeot 107',
+        volumetricEfficiency: 0.72,
+        volumetricEfficiencySamples: 5,
+      ));
+
+      await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+      await tester.dragUntilVisible(
+        find.text('Reset calibration'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.tap(find.text('Reset calibration'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Reset calibration?'), findsOneWidget);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      final stored = repo.getById('v1')!;
+      expect(stored.volumetricEfficiency, 0.72);
+      expect(stored.volumetricEfficiencySamples, 5);
+    });
+
+    testWidgets(
+      'confirming the reset writes η_v=0.85 and samples=0 back to '
+      'the profile',
+      (tester) async {
+        final repo = VehicleProfileRepository(_FakeSettings());
+        await repo.save(const VehicleProfile(
+          id: 'v1',
+          name: 'Peugeot 107',
+          volumetricEfficiency: 0.72,
+          volumetricEfficiencySamples: 5,
+        ));
+
+        await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+        await tester.dragUntilVisible(
+          find.text('Reset calibration'),
+          find.byType(ListView),
+          const Offset(0, -200),
+        );
+        await tester.tap(find.text('Reset calibration'));
+        await tester.pumpAndSettle();
+
+        // The dialog's confirm action and the outer page button share
+        // the same label — find the one inside the AlertDialog.
+        final confirm = find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('Reset calibration'),
+        );
+        expect(confirm, findsOneWidget);
+        await tester.tap(confirm);
+        await tester.pumpAndSettle();
+
+        final stored = repo.getById('v1')!;
+        expect(stored.volumetricEfficiency, 0.85);
+        expect(stored.volumetricEfficiencySamples, 0);
+      },
+    );
+  });
+}
+
+Future<void> _pumpEditScreen(
+  WidgetTester tester, {
+  required VehicleProfileRepository repo,
+  required String vehicleId,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        vehicleProfileRepositoryProvider.overrideWithValue(repo),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: EditVehicleScreen(vehicleId: vehicleId),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}


### PR DESCRIPTION
## Summary
- Add `VeLearner` service that reconciles OBD2-integrated fuel vs pump-receipt litres on every tankful and EWMA-blends a per-vehicle η_v scalar.
- Hook the learner into the existing fill-up save flow in `FillUpList.add` next to the `#584` service-reminder evaluation.
- Surface a one-shot calibration snackbar on the consumption screen and a confirm-gated Reset action on the vehicle edit screen.

## Why
η_v is the biggest remaining source of error in the speed-density fuel-rate fallback (#810). The MAF and fuel-trim (#813) corrections already close most of the per-trip gap; adapting η_v per vehicle from tankful reconciliation closes the rest without ever needing the user to type a number. Same calibration pattern as #779.

## Scope / Files
- `lib/features/vehicle/data/ve_learner.dart` — the learner + `VeLearnResult`.
- `lib/features/vehicle/domain/entities/vehicle_profile.dart` — add `volumetricEfficiencySamples` counter (regenerated `.freezed.dart` / `.g.dart`).
- `lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart` — Reset-calibration action + confirm dialog.
- `lib/features/consumption/providers/consumption_providers.dart` — `veLearnerProvider`, `lastVeLearnResultProvider`, fill-up `add` hook.
- `lib/features/consumption/presentation/screens/consumption_screen.dart` — snackbar listener.
- `lib/l10n/app_en.arb` + `lib/l10n/app_de.arb` — 4 new keys: `veCalibratedTitle`, `veResetAction`, `veResetConfirmTitle`, `veResetConfirmBody`.

## Guards (learner skips with return null)
- trip distance (summed since previous fill-up) < 50 km
- OBD2 sample count < 10 (proxied from trip duration, 1 Hz polling)
- outlier: |integrated − pumped| / pumped > 40 %
- no trip between previous and current fill-up
- η_v clamp: [0.50, 1.00] after the EWMA step

## Test plan
- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — 5290 tests pass
- [x] `ve_learner_test.dart` covers 10 scenarios: 10 % adjust, short trip, few samples, outlier, clamp upper, clamp lower, no-trip, multi-vehicle isolation, first-ever calibration, accuracy improvement sign
- [x] `edit_vehicle_screen_ve_reset_test.dart` covers render / cancel / confirm of the reset dialog
- [x] `fill_up_ve_calibration_test.dart` drives the full fill-up save → reconciliation → snackbar state flow
- [ ] Verify on-device after merge + APK rebuild

Closes #815