### PR TITLE
feat(alerts): radius alert UI — section + create sheet (#578 phase 2)

### DIFF
--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -7,8 +7,11 @@ import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/price_alert.dart';
+import '../../domain/entities/radius_alert.dart';
 import '../../providers/alert_provider.dart';
+import '../../providers/radius_alerts_provider.dart';
 import '../widgets/alert_statistics_card.dart';
+import '../widgets/radius_alert_create_sheet.dart';
 
 class AlertsScreen extends ConsumerWidget {
   const AlertsScreen({super.key});
@@ -28,24 +31,7 @@ class AlertsScreen extends ConsumerWidget {
         ),
       ),
       body: alertsAsync.when(
-        data: (alerts) => alerts.isEmpty
-            ? EmptyState(
-                icon: Icons.notifications_off_outlined,
-                title: l10n?.noPriceAlerts ?? 'No price alerts',
-                subtitle: l10n?.noPriceAlertsHint ??
-                    'Create an alert from a station\'s detail page.',
-              )
-            : ListView.builder(
-                itemCount: alerts.length + 1,
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                itemBuilder: (context, index) {
-                  if (index == 0) {
-                    return const AlertStatisticsCard();
-                  }
-                  final alert = alerts[index - 1];
-                  return _AlertListTile(key: ValueKey(alert.id), alert: alert);
-                },
-              ),
+        data: (alerts) => _AlertsBody(alerts: alerts),
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stackTrace) => ServiceChainErrorWidget(
           error: error,
@@ -60,6 +46,69 @@ class AlertsScreen extends ConsumerWidget {
           },
         ),
       ),
+    );
+  }
+}
+
+/// Splits the data branch out so the radius section can hook into the
+/// same scroll view as the per-station list. Keeping it a separate
+/// `ConsumerWidget` lets each section drive its own provider watch
+/// without forcing a full rebuild when the other half changes.
+class _AlertsBody extends ConsumerWidget {
+  final List<PriceAlert> alerts;
+
+  const _AlertsBody({required this.alerts});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final radiusAsync = ref.watch(radiusAlertsProvider);
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        const AlertStatisticsCard(),
+        // ── Per-station alerts ──────────────────────────────────────
+        if (alerts.isEmpty)
+          EmptyState(
+            icon: Icons.notifications_off_outlined,
+            title: l10n?.noPriceAlerts ?? 'No price alerts',
+            subtitle: l10n?.noPriceAlertsHint ??
+                'Create an alert from a station\'s detail page.',
+          )
+        else
+          ...alerts.map((a) => _AlertListTile(key: ValueKey(a.id), alert: a)),
+        const Divider(height: 32),
+        // ── Radius alerts (#578 phase 2) ────────────────────────────
+        _RadiusSectionHeader(
+          count: radiusAsync.asData?.value.length ?? 0,
+        ),
+        radiusAsync.when(
+          data: (radiusAlerts) {
+            if (radiusAlerts.isEmpty) {
+              return _RadiusEmptyState();
+            }
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final a in radiusAlerts)
+                  _RadiusAlertListTile(key: ValueKey('radius-${a.id}'), alert: a),
+              ],
+            );
+          },
+          loading: () => const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+          error: (error, stackTrace) => ServiceChainErrorWidget(
+            error: error,
+            stackTrace: stackTrace,
+            searchContext:
+                l10n?.alertsLoadErrorTitle ?? "Couldn't load your alerts",
+            onRetry: () => ref.invalidate(radiusAlertsProvider),
+          ),
+        ),
+      ],
     );
   }
 }
@@ -98,12 +147,114 @@ class _AlertListTile extends ConsumerWidget {
           overflow: TextOverflow.ellipsis,
         ),
         subtitle: Text(
-          '${alert.fuelType.displayName} \u2264 ${PriceFormatter.formatPrice(alert.targetPrice)}',
+          '${alert.fuelType.displayName} ≤ ${PriceFormatter.formatPrice(alert.targetPrice)}',
         ),
         trailing: Switch(
           value: alert.isActive,
           onChanged: (_) {
             ref.read(alertProvider.notifier).toggleAlert(alert.id);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// Header row for the radius-alerts section: title + count + add
+/// button. Separated out so its tap target is trivially testable and
+/// so the parent body stays short enough to read at a glance.
+class _RadiusSectionHeader extends StatelessWidget {
+  final int count;
+
+  const _RadiusSectionHeader({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              '${l10n?.alertsRadiusSectionTitle ?? 'Radius alerts'} ($count)',
+              style: theme.textTheme.titleMedium,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.add_location_alt_outlined),
+            tooltip: l10n?.alertsRadiusAdd ?? 'Add radius alert',
+            onPressed: () => RadiusAlertCreateSheet.show(context),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RadiusEmptyState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: EmptyState(
+        icon: Icons.location_searching,
+        title: l10n?.alertsRadiusEmptyTitle ?? 'No radius alerts yet',
+        actionLabel: l10n?.alertsRadiusEmptyCta ?? 'Create a radius alert',
+        onAction: () => RadiusAlertCreateSheet.show(context),
+      ),
+    );
+  }
+}
+
+class _RadiusAlertListTile extends ConsumerWidget {
+  final RadiusAlert alert;
+
+  const _RadiusAlertListTile({super.key, required this.alert});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Dismissible(
+      key: ValueKey('radius-${alert.id}'),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 24),
+        color: Colors.red,
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      onDismissed: (_) {
+        ref.read(radiusAlertsProvider.notifier).remove(alert.id);
+        SnackBarHelper.show(
+          context,
+          l10n?.alertsRadiusDeleteConfirm ?? 'Delete radius alert?',
+        );
+      },
+      child: ListTile(
+        leading: Icon(
+          Icons.location_searching,
+          color: alert.enabled ? theme.colorScheme.primary : Colors.grey,
+        ),
+        title: Text(
+          alert.label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(
+          '${alert.fuelType} ≤ '
+          '${PriceFormatter.formatPrice(alert.threshold)} '
+          '· ${alert.radiusKm.round()} km',
+        ),
+        trailing: Switch(
+          value: alert.enabled,
+          onChanged: (_) {
+            ref.read(radiusAlertsProvider.notifier).toggle(alert.id);
           },
         ),
       ),

--- a/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../core/location/user_position_provider.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+import '../../domain/entities/radius_alert.dart';
+import '../../providers/radius_alerts_provider.dart';
+
+/// Bottom sheet that creates a new [RadiusAlert] (#578 phase 2).
+///
+/// Phase 2 intentionally keeps the center picker minimal: the user can
+/// tap "Use my location" to bind the alert to the cached GPS position
+/// or type a postal code as a textual fallback. A proper map-picker UI
+/// will land in a follow-up (no existing in-app widget could be reused
+/// without pulling the heavy map stack into the alerts feature — see
+/// PR body for the follow-up pointer).
+class RadiusAlertCreateSheet extends ConsumerStatefulWidget {
+  /// Injection hook so widget tests can swap the id generator for a
+  /// deterministic string. Production callers leave this unset.
+  final String Function()? idGenerator;
+
+  const RadiusAlertCreateSheet({super.key, this.idGenerator});
+
+  /// Convenience opener used by both the alerts-screen CTA and the
+  /// radius-section header button so the same entry point shows up
+  /// everywhere the user expects it.
+  static Future<void> show(
+    BuildContext context, {
+    String Function()? idGenerator,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (ctx) => Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(ctx).viewInsets.bottom,
+        ),
+        child: RadiusAlertCreateSheet(idGenerator: idGenerator),
+      ),
+    );
+  }
+
+  @override
+  ConsumerState<RadiusAlertCreateSheet> createState() =>
+      _RadiusAlertCreateSheetState();
+}
+
+class _RadiusAlertCreateSheetState
+    extends ConsumerState<RadiusAlertCreateSheet> {
+  final _labelController = TextEditingController();
+  final _thresholdController = TextEditingController(text: '1.500');
+  final _postalCodeController = TextEditingController();
+
+  FuelType _fuelType = FuelType.diesel;
+  double _radiusKm = 10;
+
+  double? _centerLat;
+  double? _centerLng;
+  String? _centerSource;
+
+  @override
+  void dispose() {
+    _labelController.dispose();
+    _thresholdController.dispose();
+    _postalCodeController.dispose();
+    super.dispose();
+  }
+
+  void _useMyLocation() {
+    final pos = ref.read(userPositionProvider);
+    if (pos == null) {
+      SnackBarHelper.showError(
+        context,
+        AppLocalizations.of(context)?.errorTitleLocation ??
+            'Location unavailable',
+      );
+      return;
+    }
+    setState(() {
+      _centerLat = pos.lat;
+      _centerLng = pos.lng;
+      _centerSource = pos.source;
+    });
+  }
+
+  bool get _canSave {
+    if (_labelController.text.trim().isEmpty) return false;
+    final threshold = _parseThreshold();
+    if (threshold == null || threshold <= 0) return false;
+    // A center is required. GPS wins; otherwise postal code must be
+    // non-empty so the phase-3 worker has something to geocode.
+    final hasGps = _centerLat != null && _centerLng != null;
+    final hasPostal = _postalCodeController.text.trim().isNotEmpty;
+    return hasGps || hasPostal;
+  }
+
+  double? _parseThreshold() {
+    final raw = _thresholdController.text.trim().replaceAll(',', '.');
+    if (raw.isEmpty) return null;
+    return double.tryParse(raw);
+  }
+
+  Future<void> _save() async {
+    final threshold = _parseThreshold();
+    if (threshold == null) return;
+
+    // Postal-code-only entries are parked at (0,0) until the phase-3
+    // worker geocodes them. The stored postal code lives in the
+    // label so the user can see what they asked for; the coordinates
+    // are filled in once the geocoding lands.
+    final lat = _centerLat ?? 0.0;
+    final lng = _centerLng ?? 0.0;
+
+    final alert = RadiusAlert(
+      id: (widget.idGenerator ?? _defaultId)(),
+      fuelType: _fuelType.apiValue,
+      threshold: threshold,
+      centerLat: lat,
+      centerLng: lng,
+      radiusKm: _radiusKm,
+      label: _labelController.text.trim(),
+      createdAt: DateTime.now(),
+    );
+
+    await ref.read(radiusAlertsProvider.notifier).add(alert);
+    if (!mounted) return;
+    Navigator.of(context).pop();
+  }
+
+  static String _defaultId() => const Uuid().v4();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            l10n?.alertsRadiusCreateTitle ?? 'Create radius alert',
+            style: theme.textTheme.titleLarge,
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _labelController,
+            decoration: InputDecoration(
+              hintText: l10n?.alertsRadiusLabelHint ?? 'Label',
+              border: const OutlineInputBorder(),
+            ),
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<FuelType>(
+            initialValue: _fuelType,
+            decoration: InputDecoration(
+              labelText: l10n?.alertsRadiusFuelType ?? 'Fuel type',
+              border: const OutlineInputBorder(),
+            ),
+            items: FuelType.values
+                .where((t) => t != FuelType.all)
+                .map((t) => DropdownMenuItem(
+                      value: t,
+                      child: Text(t.displayName),
+                    ))
+                .toList(),
+            onChanged: (v) {
+              if (v != null) setState(() => _fuelType = v);
+            },
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _thresholdController,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: InputDecoration(
+              labelText: l10n?.alertsRadiusThreshold ?? 'Threshold (€/L)',
+              border: const OutlineInputBorder(),
+            ),
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Text(
+                l10n?.alertsRadiusKm ?? 'Radius (km)',
+                style: theme.textTheme.titleSmall,
+              ),
+              const Spacer(),
+              Text(
+                '${_radiusKm.round()} km',
+                style: theme.textTheme.titleSmall,
+              ),
+            ],
+          ),
+          Slider(
+            value: _radiusKm.clamp(1, 50),
+            min: 1,
+            max: 50,
+            divisions: 49,
+            label: '${_radiusKm.round()} km',
+            onChanged: (v) => setState(() => _radiusKm = v),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  icon: const Icon(Icons.my_location),
+                  onPressed: _useMyLocation,
+                  label: Text(
+                    l10n?.alertsRadiusCenterGps ?? 'Use my location',
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (_centerSource != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _centerSource!,
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+          const SizedBox(height: 16),
+          TextField(
+            controller: _postalCodeController,
+            decoration: InputDecoration(
+              labelText:
+                  l10n?.alertsRadiusCenterPostalCode ?? 'Postal code',
+              border: const OutlineInputBorder(),
+            ),
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text(l10n?.alertsRadiusCancel ?? 'Cancel'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: FilledButton(
+                  onPressed: _canSave ? _save : null,
+                  child: Text(l10n?.alertsRadiusSave ?? 'Save'),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1211,5 +1211,19 @@
   "veCalibratedTitle": "Verbrauchsberechnung für {vehicleName} kalibriert — Genauigkeit verbessert um {percent}%",
   "veResetAction": "Kalibrierung zurücksetzen",
   "veResetConfirmTitle": "Kalibrierung zurücksetzen?",
-  "veResetConfirmBody": "Dies verwirft die gelernte fahrzeugspezifische Kalibrierung und stellt den Standardwert (0,85) wieder her."
+  "veResetConfirmBody": "Dies verwirft die gelernte fahrzeugspezifische Kalibrierung und stellt den Standardwert (0,85) wieder her.",
+  "alertsRadiusSectionTitle": "Umkreis-Alarme",
+  "alertsRadiusAdd": "Umkreis-Alarm hinzufügen",
+  "alertsRadiusEmptyTitle": "Noch keine Umkreis-Alarme",
+  "alertsRadiusEmptyCta": "Umkreis-Alarm anlegen",
+  "alertsRadiusCreateTitle": "Umkreis-Alarm anlegen",
+  "alertsRadiusLabelHint": "Bezeichnung (z. B. Zuhause Diesel)",
+  "alertsRadiusFuelType": "Kraftstoffart",
+  "alertsRadiusThreshold": "Schwelle (€/L)",
+  "alertsRadiusKm": "Radius (km)",
+  "alertsRadiusCenterGps": "Meinen Standort verwenden",
+  "alertsRadiusCenterPostalCode": "Postleitzahl",
+  "alertsRadiusSave": "Speichern",
+  "alertsRadiusCancel": "Abbrechen",
+  "alertsRadiusDeleteConfirm": "Umkreis-Alarm löschen?"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1290,5 +1290,61 @@
   "veResetConfirmBody": "This will discard the learned per-vehicle calibration and restore the default value (0.85).",
   "@veResetConfirmBody": {
     "description": "Body of the confirm dialog shown before discarding the learned volumetric efficiency (#815)."
+  },
+  "alertsRadiusSectionTitle": "Radius alerts",
+  "@alertsRadiusSectionTitle": {
+    "description": "Header of the radius-based watchlist section on the alerts screen (#578)."
+  },
+  "alertsRadiusAdd": "Add radius alert",
+  "@alertsRadiusAdd": {
+    "description": "Tooltip/label of the button that opens the radius-alert create sheet (#578)."
+  },
+  "alertsRadiusEmptyTitle": "No radius alerts yet",
+  "@alertsRadiusEmptyTitle": {
+    "description": "Empty state title shown when no radius alerts are configured (#578)."
+  },
+  "alertsRadiusEmptyCta": "Create a radius alert",
+  "@alertsRadiusEmptyCta": {
+    "description": "Call-to-action button that opens the create sheet from the empty state (#578)."
+  },
+  "alertsRadiusCreateTitle": "Create radius alert",
+  "@alertsRadiusCreateTitle": {
+    "description": "Title of the bottom sheet used to create a new radius alert (#578)."
+  },
+  "alertsRadiusLabelHint": "Label (e.g. Home diesel)",
+  "@alertsRadiusLabelHint": {
+    "description": "Hint text for the label field in the radius-alert create sheet (#578)."
+  },
+  "alertsRadiusFuelType": "Fuel type",
+  "@alertsRadiusFuelType": {
+    "description": "Fuel-type picker label in the radius-alert create sheet (#578)."
+  },
+  "alertsRadiusThreshold": "Threshold (€/L)",
+  "@alertsRadiusThreshold": {
+    "description": "Price-threshold field label in the radius-alert create sheet (#578)."
+  },
+  "alertsRadiusKm": "Radius (km)",
+  "@alertsRadiusKm": {
+    "description": "Radius slider label in the radius-alert create sheet (#578)."
+  },
+  "alertsRadiusCenterGps": "Use my location",
+  "@alertsRadiusCenterGps": {
+    "description": "Button that sets the alert center to the user's current GPS position (#578)."
+  },
+  "alertsRadiusCenterPostalCode": "Postal code",
+  "@alertsRadiusCenterPostalCode": {
+    "description": "Fallback input for entering a postal code as the alert center when no map picker is available (#578)."
+  },
+  "alertsRadiusSave": "Save",
+  "@alertsRadiusSave": {
+    "description": "Save button label in the radius-alert create sheet (#578)."
+  },
+  "alertsRadiusCancel": "Cancel",
+  "@alertsRadiusCancel": {
+    "description": "Cancel button label in the radius-alert create sheet (#578)."
+  },
+  "alertsRadiusDeleteConfirm": "Delete radius alert?",
+  "@alertsRadiusDeleteConfirm": {
+    "description": "Snackbar/confirm text shown when a radius alert is dismissed for deletion (#578)."
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5803,6 +5803,90 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'This will discard the learned per-vehicle calibration and restore the default value (0.85).'**
   String get veResetConfirmBody;
+
+  /// Header of the radius-based watchlist section on the alerts screen (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Radius alerts'**
+  String get alertsRadiusSectionTitle;
+
+  /// Tooltip/label of the button that opens the radius-alert create sheet (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Add radius alert'**
+  String get alertsRadiusAdd;
+
+  /// Empty state title shown when no radius alerts are configured (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'No radius alerts yet'**
+  String get alertsRadiusEmptyTitle;
+
+  /// Call-to-action button that opens the create sheet from the empty state (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Create a radius alert'**
+  String get alertsRadiusEmptyCta;
+
+  /// Title of the bottom sheet used to create a new radius alert (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Create radius alert'**
+  String get alertsRadiusCreateTitle;
+
+  /// Hint text for the label field in the radius-alert create sheet (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Label (e.g. Home diesel)'**
+  String get alertsRadiusLabelHint;
+
+  /// Fuel-type picker label in the radius-alert create sheet (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Fuel type'**
+  String get alertsRadiusFuelType;
+
+  /// Price-threshold field label in the radius-alert create sheet (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Threshold (€/L)'**
+  String get alertsRadiusThreshold;
+
+  /// Radius slider label in the radius-alert create sheet (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Radius (km)'**
+  String get alertsRadiusKm;
+
+  /// Button that sets the alert center to the user's current GPS position (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Use my location'**
+  String get alertsRadiusCenterGps;
+
+  /// Fallback input for entering a postal code as the alert center when no map picker is available (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Postal code'**
+  String get alertsRadiusCenterPostalCode;
+
+  /// Save button label in the radius-alert create sheet (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get alertsRadiusSave;
+
+  /// Cancel button label in the radius-alert create sheet (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get alertsRadiusCancel;
+
+  /// Snackbar/confirm text shown when a radius alert is dismissed for deletion (#578).
+  ///
+  /// In en, this message translates to:
+  /// **'Delete radius alert?'**
+  String get alertsRadiusDeleteConfirm;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3085,4 +3085,46 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3085,4 +3085,46 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3083,4 +3083,46 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3108,4 +3108,46 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'Dies verwirft die gelernte fahrzeugspezifische Kalibrierung und stellt den Standardwert (0,85) wieder her.';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Umkreis-Alarme';
+
+  @override
+  String get alertsRadiusAdd => 'Umkreis-Alarm hinzufügen';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'Noch keine Umkreis-Alarme';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Umkreis-Alarm anlegen';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Umkreis-Alarm anlegen';
+
+  @override
+  String get alertsRadiusLabelHint => 'Bezeichnung (z. B. Zuhause Diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Kraftstoffart';
+
+  @override
+  String get alertsRadiusThreshold => 'Schwelle (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Meinen Standort verwenden';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postleitzahl';
+
+  @override
+  String get alertsRadiusSave => 'Speichern';
+
+  @override
+  String get alertsRadiusCancel => 'Abbrechen';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Umkreis-Alarm löschen?';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3087,4 +3087,46 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3078,4 +3078,46 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3086,4 +3086,46 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3080,4 +3080,46 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3083,4 +3083,46 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3107,4 +3107,46 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3082,4 +3082,46 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3087,4 +3087,46 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3086,4 +3086,46 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3084,4 +3084,46 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3086,4 +3086,46 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3082,4 +3082,46 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3087,4 +3087,46 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3085,4 +3085,46 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3086,4 +3086,46 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3085,4 +3085,46 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3086,4 +3086,46 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3080,4 +3080,46 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3084,4 +3084,46 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get veResetConfirmBody =>
       'This will discard the learned per-vehicle calibration and restore the default value (0.85).';
+
+  @override
+  String get alertsRadiusSectionTitle => 'Radius alerts';
+
+  @override
+  String get alertsRadiusAdd => 'Add radius alert';
+
+  @override
+  String get alertsRadiusEmptyTitle => 'No radius alerts yet';
+
+  @override
+  String get alertsRadiusEmptyCta => 'Create a radius alert';
+
+  @override
+  String get alertsRadiusCreateTitle => 'Create radius alert';
+
+  @override
+  String get alertsRadiusLabelHint => 'Label (e.g. Home diesel)';
+
+  @override
+  String get alertsRadiusFuelType => 'Fuel type';
+
+  @override
+  String get alertsRadiusThreshold => 'Threshold (€/L)';
+
+  @override
+  String get alertsRadiusKm => 'Radius (km)';
+
+  @override
+  String get alertsRadiusCenterGps => 'Use my location';
+
+  @override
+  String get alertsRadiusCenterPostalCode => 'Postal code';
+
+  @override
+  String get alertsRadiusSave => 'Save';
+
+  @override
+  String get alertsRadiusCancel => 'Cancel';
+
+  @override
+  String get alertsRadiusDeleteConfirm => 'Delete radius alert?';
 }

--- a/test/features/alerts/presentation/screens/alerts_screen_radius_empty_test.dart
+++ b/test/features/alerts/presentation/screens/alerts_screen_radius_empty_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/features/alerts/data/models/price_alert.dart';

--- a/test/features/alerts/presentation/screens/alerts_screen_radius_empty_test.dart
+++ b/test/features/alerts/presentation/screens/alerts_screen_radius_empty_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/features/alerts/data/models/price_alert.dart';
+import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
+import 'package:tankstellen/features/alerts/presentation/screens/alerts_screen.dart';
+import 'package:tankstellen/features/alerts/presentation/widgets/radius_alert_create_sheet.dart';
+import 'package:tankstellen/features/alerts/providers/alert_provider.dart';
+import 'package:tankstellen/features/alerts/providers/radius_alerts_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('AlertsScreen radius empty state (#578 phase 2)', () {
+    testWidgets(
+        'shows empty state CTA when no radius alerts are configured',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertProvider.overrideWith(() => _EmptyAlerts()),
+          radiusAlertsProvider.overrideWith(() => _EmptyRadiusAlerts()),
+        ],
+      );
+
+      expect(find.text('Radius alerts (0)'), findsOneWidget);
+      expect(find.text('No radius alerts yet'), findsOneWidget);
+      expect(find.text('Create a radius alert'), findsOneWidget);
+    });
+
+    testWidgets('tapping empty-state CTA opens the create sheet',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertProvider.overrideWith(() => _EmptyAlerts()),
+          radiusAlertsProvider.overrideWith(() => _EmptyRadiusAlerts()),
+          userPositionNullOverride(),
+        ],
+      );
+
+      // The ListView may push the CTA below the fold on the 800x600
+      // test viewport; scroll it into view before tapping.
+      await tester.ensureVisible(find.text('Create a radius alert'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Create a radius alert'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RadiusAlertCreateSheet), findsOneWidget);
+      expect(find.text('Create radius alert'), findsOneWidget);
+    });
+  });
+}
+
+class _EmptyAlerts extends AlertNotifier {
+  @override
+  List<PriceAlert> build() => const [];
+}
+
+class _EmptyRadiusAlerts extends RadiusAlerts {
+  @override
+  Future<List<RadiusAlert>> build() async => const [];
+}

--- a/test/features/alerts/presentation/screens/alerts_screen_radius_section_test.dart
+++ b/test/features/alerts/presentation/screens/alerts_screen_radius_section_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/features/alerts/data/models/price_alert.dart';
+import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
+import 'package:tankstellen/features/alerts/presentation/screens/alerts_screen.dart';
+import 'package:tankstellen/features/alerts/providers/alert_provider.dart';
+import 'package:tankstellen/features/alerts/providers/radius_alerts_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('AlertsScreen radius section (#578 phase 2)', () {
+    testWidgets('renders section header with count and add button',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+
+      final fake = _FakeRadiusAlerts([
+        _sampleAlert(id: 'r1', label: 'Home diesel'),
+        _sampleAlert(id: 'r2', label: 'Work e10', fuelType: 'e10'),
+      ]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertProvider.overrideWith(() => _EmptyAlerts()),
+          radiusAlertsProvider.overrideWith(() => fake),
+        ],
+      );
+
+      expect(find.text('Radius alerts (2)'), findsOneWidget);
+      expect(find.byTooltip('Add radius alert'), findsOneWidget);
+      expect(find.text('Home diesel'), findsOneWidget);
+      expect(find.text('Work e10'), findsOneWidget);
+    });
+
+    testWidgets('toggle switch calls RadiusAlerts.toggle(id)',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+
+      final fake = _FakeRadiusAlerts([
+        _sampleAlert(id: 'r1', label: 'Home diesel', enabled: true),
+      ]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertProvider.overrideWith(() => _EmptyAlerts()),
+          radiusAlertsProvider.overrideWith(() => fake),
+        ],
+      );
+
+      // Two switches may be present (stats + list). Filter by position
+      // near the radius label.
+      final switches = find.byType(Switch);
+      expect(switches, findsAtLeast(1));
+      await tester.tap(switches.last);
+      await tester.pumpAndSettle();
+
+      expect(fake.toggledIds, ['r1']);
+    });
+
+    testWidgets('swipe-dismiss calls RadiusAlerts.remove(id)',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+
+      final fake = _FakeRadiusAlerts([
+        _sampleAlert(id: 'r1', label: 'Home diesel'),
+      ]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertProvider.overrideWith(() => _EmptyAlerts()),
+          radiusAlertsProvider.overrideWith(() => fake),
+        ],
+      );
+
+      await tester.drag(
+        find.text('Home diesel'),
+        const Offset(-600, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(fake.removedIds, ['r1']);
+    });
+  });
+}
+
+RadiusAlert _sampleAlert({
+  required String id,
+  required String label,
+  String fuelType = 'diesel',
+  double threshold = 1.50,
+  double centerLat = 48.8566,
+  double centerLng = 2.3522,
+  double radiusKm = 10,
+  bool enabled = true,
+}) {
+  return RadiusAlert(
+    id: id,
+    fuelType: fuelType,
+    threshold: threshold,
+    centerLat: centerLat,
+    centerLng: centerLng,
+    radiusKm: radiusKm,
+    label: label,
+    createdAt: DateTime(2026, 1, 1),
+    enabled: enabled,
+  );
+}
+
+class _EmptyAlerts extends AlertNotifier {
+  @override
+  List<PriceAlert> build() => const [];
+}
+
+class _FakeRadiusAlerts extends RadiusAlerts {
+  final List<RadiusAlert> _initial;
+  final List<String> toggledIds = [];
+  final List<String> removedIds = [];
+  final List<RadiusAlert> addedAlerts = [];
+
+  _FakeRadiusAlerts(this._initial);
+
+  @override
+  Future<List<RadiusAlert>> build() async => _initial;
+
+  @override
+  Future<void> add(RadiusAlert alert) async {
+    addedAlerts.add(alert);
+    state = AsyncValue.data([..._initial, alert]);
+  }
+
+  @override
+  Future<void> remove(String id) async {
+    removedIds.add(id);
+    state = AsyncValue.data(
+      _initial.where((a) => a.id != id).toList(),
+    );
+  }
+
+  @override
+  Future<void> toggle(String id) async {
+    toggledIds.add(id);
+    state = AsyncValue.data(
+      _initial
+          .map((a) => a.id == id ? a.copyWith(enabled: !a.enabled) : a)
+          .toList(),
+    );
+  }
+}

--- a/test/features/alerts/presentation/widgets/radius_alert_create_sheet_test.dart
+++ b/test/features/alerts/presentation/widgets/radius_alert_create_sheet_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
+import 'package:tankstellen/features/alerts/presentation/widgets/radius_alert_create_sheet.dart';
+import 'package:tankstellen/features/alerts/providers/radius_alerts_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('RadiusAlertCreateSheet (#578 phase 2)', () {
+    testWidgets('save button builds a RadiusAlert and calls add()',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      final fake = _CapturingRadiusAlerts();
+
+      // Seed a cached GPS position so the "Use my location" branch
+      // produces a usable center without reaching the geolocator.
+      await pumpApp(
+        tester,
+        RadiusAlertCreateSheet(idGenerator: () => 'fixed-id-123'),
+        overrides: [
+          ...test.overrides,
+          radiusAlertsProvider.overrideWith(() => fake),
+          userPositionOverride(lat: 48.85, lng: 2.35, source: 'GPS'),
+        ],
+      );
+
+      // Fill the label field.
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Label (e.g. Home diesel)'),
+        'Home diesel',
+      );
+      await tester.pump();
+
+      // Threshold field — overwrite the seed value.
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Threshold (€/L)'),
+        '1.499',
+      );
+      await tester.pump();
+
+      // Bind the center to the cached GPS position.
+      await tester.tap(find.text('Use my location'));
+      await tester.pumpAndSettle();
+
+      // Save.
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(fake.addedAlerts, hasLength(1));
+      final a = fake.addedAlerts.single;
+      expect(a.id, 'fixed-id-123');
+      expect(a.label, 'Home diesel');
+      expect(a.threshold, closeTo(1.499, 1e-9));
+      expect(a.centerLat, closeTo(48.85, 1e-9));
+      expect(a.centerLng, closeTo(2.35, 1e-9));
+      // Default fuel type (diesel) and default radius (10 km).
+      expect(a.fuelType, 'diesel');
+      expect(a.radiusKm, 10);
+    });
+
+    testWidgets('save is disabled until label + center are set',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      final fake = _CapturingRadiusAlerts();
+
+      await pumpApp(
+        tester,
+        const RadiusAlertCreateSheet(),
+        overrides: [
+          ...test.overrides,
+          radiusAlertsProvider.overrideWith(() => fake),
+          userPositionNullOverride(),
+        ],
+      );
+
+      // No label, no center → save must be disabled.
+      final saveButton =
+          tester.widget<FilledButton>(find.widgetWithText(FilledButton, 'Save'));
+      expect(saveButton.onPressed, isNull);
+    });
+
+    testWidgets('cancel button dismisses without calling add()',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      final fake = _CapturingRadiusAlerts();
+
+      // Wrap in a Builder so we can push the sheet via showModalBottomSheet
+      // and verify the route pops.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...test.overrides,
+            radiusAlertsProvider.overrideWith(() => fake),
+            userPositionOverride(lat: 48.85, lng: 2.35),
+          ].cast(),
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () => RadiusAlertCreateSheet.show(context),
+                    child: const Text('open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RadiusAlertCreateSheet), findsOneWidget);
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RadiusAlertCreateSheet), findsNothing);
+      expect(fake.addedAlerts, isEmpty);
+    });
+  });
+}
+
+class _CapturingRadiusAlerts extends RadiusAlerts {
+  final List<RadiusAlert> addedAlerts = [];
+
+  @override
+  Future<List<RadiusAlert>> build() async => const [];
+
+  @override
+  Future<void> add(RadiusAlert alert) async {
+    addedAlerts.add(alert);
+    state = AsyncValue.data([alert]);
+  }
+}


### PR DESCRIPTION
## What

Phase 2 of #578 — wires the radius-based watchlist into the alerts
screen so users can actually manage them from the UI. Builds on the
Phase 1 data layer (entity + store + provider) shipped in PR #850.

- `AlertsScreen` now renders a **Radius alerts** section alongside
  the per-station list: header with count + add button, swipeable
  tile per alert with label / fuelType / €-threshold / km-radius and
  an enable/disable toggle, delete via `Dismissible` (mirrors the
  favorites-tile pattern).
- **Empty state** shows a friendly message with a CTA button that
  opens the create sheet — matches the rest of the app's empty-state
  convention.
- **Error state** reuses `ServiceChainErrorWidget` so a future store
  read failure surfaces like the rest of the app.
- New `RadiusAlertCreateSheet` (modal bottom sheet): label, fuel-type
  dropdown (uses the sealed `FuelType` hierarchy, `FuelType.all`
  filtered out), threshold numeric input (`€/L`, accepts `,` and
  `.`), radius slider (1–50 km, 1-km divisions), GPS "Use my
  location" button wired to `userPositionProvider`, plus a
  postal-code text field as a center fallback. Save builds a fresh
  `RadiusAlert` with a UUID and hands it to
  `radiusAlertsProvider.add(...)`.

## Why

Phase 1 persisted radius alerts and exposed a provider surface but
never showed them to the user. This PR closes that gap so testers can
exercise the data model and we can validate the UX before Phase 3
attaches the background worker.

## Testing

- 3 new widget tests:
  - `alerts_screen_radius_section_test.dart` — header renders the
    count, toggle calls `RadiusAlerts.toggle(id)`, swipe-dismiss
    calls `RadiusAlerts.remove(id)`.
  - `alerts_screen_radius_empty_test.dart` — empty provider shows
    CTA, tapping CTA opens the create sheet.
  - `radius_alert_create_sheet_test.dart` — save builds a
    `RadiusAlert` with the form values and the injected id generator;
    save disabled until label + center are set; cancel dismisses
    without calling `add()`.
- `flutter test test/features/alerts/` → 127 passed.
- `flutter test test/l10n/localization_completeness_test.dart` → all
  passed (German has every new key).
- `flutter test` full suite → **5298 passed, 1 skipped**, zero
  failures.
- `flutter analyze` → **No issues found**.

## Phase 3 deferred

Background-check + notification dispatch (WorkManager periodic task
that reads the persisted radius alerts, checks stations in the
center+radius, and posts a local push when a price drops below the
threshold) are **not** in this PR. A separate issue will cover that
work.

## ARB scope note

`en` + `de` only (14 new keys). Other 21 locales fall back to
English at runtime and get translated in a follow-up — the
`localization_completeness_test` only fails when German is missing
keys, so we're green without over-committing translator time for a
phase-2 surface.

## Anomalies

Did **not** reuse the existing `SearchRadiusSlider` — its max is 25 km
and its localization label is `searchRadius`, which would have leaked
"Search radius" copy into the alerts screen. A small inline slider
was simpler than adding a generic variant this PR doesn't need. No
in-app map-picker widget is lightweight enough to pull into the
alerts feature, so the center picker ships with a postal-code
textfield fallback; a proper map-picker UX is explicitly listed as a
phase-3 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)