### PR TITLE
feat(alerts): velocity drop alerts (#579)

### DIFF
--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -1,8 +1,14 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:workmanager/workmanager.dart';
 
+import '../../features/alerts/data/price_snapshot_store.dart';
 import '../../features/alerts/data/repositories/alert_repository.dart';
+import '../../features/alerts/data/velocity_alert_cooldown.dart';
+import '../../features/alerts/data/velocity_alert_runner.dart';
+import '../../features/alerts/domain/velocity_alert_detector.dart';
 import '../../features/price_history/data/models/price_record.dart';
 import '../../features/search/domain/entities/fuel_type.dart';
 import '../../features/widget/data/home_widget_service.dart';
@@ -323,6 +329,25 @@ Future<void> _refreshPricesAndCheckAlerts() async {
       debugPrint('BackgroundService: ${activeAlerts.length} active alerts, ${prices.length} prices available');
     }
 
+    // 5b. #579 — Velocity detector: rapid drops across multiple nearby
+    //     stations. Runs even when no per-station alert exists so the
+    //     user gets notified about a wider price slide. Snapshots are
+    //     pruned by the store itself; cooldown is per fuel type.
+    if (prices.isNotEmpty) {
+      try {
+        final notifier = LocalNotificationService();
+        await notifier.initialize();
+        await _runVelocityDetector(
+          storage: storage,
+          prices: prices,
+          now: now,
+          notifier: notifier,
+        );
+      } catch (e) {
+        debugPrint('BackgroundService: velocity detector failed: $e');
+      }
+    }
+
     // 6. Update home screen widgets with latest favorite prices.
     //    Pass profile + settings storage so the widget can resolve the
     //    active profile's preferred fuel type and last-known GPS.
@@ -348,6 +373,112 @@ Future<void> _refreshPricesAndCheckAlerts() async {
     }
     lock?.release();
   }
+}
+
+/// #579 — orchestrate the velocity detector from the BG isolate.
+///
+/// Builds per-station [VelocityStationObservation]s by joining the
+/// freshly fetched prices with the `station:<id>` cache (for
+/// coordinates), then hands off to [VelocityAlertRunner] which owns
+/// snapshot recording, detection, cooldown, and notification firing.
+///
+/// Extracted so a future test can drive the same code path with a
+/// fake notifier + seeded snapshots.
+Future<void> _runVelocityDetector({
+  required HiveStorage storage,
+  required Map<String, Map<String, dynamic>> prices,
+  required DateTime now,
+  required LocalNotificationService notifier,
+}) async {
+  final runner = VelocityAlertRunner(
+    snapshotStore: PriceSnapshotStore(),
+    cooldown: VelocityAlertCooldown(),
+    notifier: notifier,
+    copyBuilder: _buildVelocityCopy,
+  );
+  final config = await runner.loadConfig();
+  final fuelKey = _tankerkoenigKeyFor(config.fuelType);
+  if (fuelKey == null) {
+    debugPrint('BackgroundService: velocity skipped — ${config.fuelType.apiValue} not in Tankerkoenig response');
+    return;
+  }
+
+  final observations = <VelocityStationObservation>[];
+  for (final entry in prices.entries) {
+    final stationId = entry.key;
+    final p = entry.value;
+    if (p[TankerkoenigFields.status] == TankerkoenigFields.statusNoPrices) {
+      continue;
+    }
+    final price = p.getDouble(fuelKey);
+    if (price == null) continue;
+    final cached = storage.getCachedData('station:$stationId');
+    final data = cached?.getMap('data');
+    final lat = data?.getDouble('lat');
+    final lng = data?.getDouble('lng');
+    if (lat == null || lng == null) continue;
+    observations.add(VelocityStationObservation(
+      stationId: stationId,
+      price: price,
+      lat: lat,
+      lng: lng,
+    ));
+  }
+  if (observations.isEmpty) {
+    debugPrint('BackgroundService: velocity detector has no usable observations');
+    return;
+  }
+
+  final userLat = storage.getSetting(StorageKeys.userPositionLat) as num?;
+  final userLng = storage.getSetting(StorageKeys.userPositionLng) as num?;
+
+  final event = await runner.run(
+    observations: observations,
+    now: now,
+    userLat: userLat?.toDouble(),
+    userLng: userLng?.toDouble(),
+  );
+  if (event != null) {
+    debugPrint(
+        'BackgroundService: velocity alert ${event.fuelType.apiValue}, '
+        'count=${event.stationCount}, max=${event.maxDropCents.toStringAsFixed(1)}ct');
+  }
+}
+
+/// Map [FuelType] → Tankerkoenig JSON key. The BG isolate only
+/// fetches E5/E10/diesel today (see [_refreshPricesAndCheckAlerts])
+/// so other fuels return `null` and skip velocity detection until
+/// we broaden the batch fetcher.
+String? _tankerkoenigKeyFor(FuelType fuelType) {
+  return switch (fuelType) {
+    FuelTypeE5() => TankerkoenigFields.e5,
+    FuelTypeE10() => TankerkoenigFields.e10,
+    FuelTypeDiesel() => TankerkoenigFields.diesel,
+    _ => null,
+  };
+}
+
+/// Build notification copy for a velocity event. The BG isolate
+/// can't resolve the full ARB bundle (no BuildContext) so we pick
+/// German vs English from [Platform.localeName] and format with
+/// the same placeholders the ARB keys use.
+VelocityAlertCopy _buildVelocityCopy(VelocityAlertEvent event) {
+  final fuelLabel = event.fuelType.displayName.toUpperCase();
+  final stationCount = event.stationCount;
+  final maxCents = event.maxDropCents.round();
+  final isGerman = Platform.localeName.toLowerCase().startsWith('de');
+  if (isGerman) {
+    return VelocityAlertCopy(
+      title: '$fuelLabel an Tankstellen in der Nähe gefallen',
+      body:
+          '$stationCount Tankstellen um bis zu $maxCents¢ in der letzten Stunde gefallen',
+    );
+  }
+  return VelocityAlertCopy(
+    title: '$fuelLabel dropped at nearby stations',
+    body:
+        '$stationCount stations dropped by up to $maxCents¢ in the last hour',
+  );
 }
 
 /// Run the new nearest-widget builder from the background isolate.

--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -55,6 +55,15 @@ class HiveBoxes {
   /// startup.
   static const String obd2PausedTrips = 'obd2_paused_trips';
 
+  /// Rolling price snapshots used by the price-drop velocity detector
+  /// (#579). One JSON payload per (station, fuel, timestamp) with a
+  /// synthetic key. Coords are captured per-snapshot so the detector
+  /// can filter by radius without re-joining against station data.
+  /// Pruned to the last 6 h on every write to keep the box small.
+  /// Unencrypted like the other OBD2 boxes — contains no PII beyond
+  /// public station coordinates.
+  static const String priceSnapshots = 'price_snapshots';
+
   static const _encryptedBoxes = {
     settings,
     profiles,
@@ -145,6 +154,8 @@ class HiveBoxes {
     // #797 — partial OBD2 trips paused by a BT drop. Same string-typed
     // JSON pattern as [obd2TripHistory] so one box adapter covers both.
     await Hive.openBox<String>(obd2PausedTrips);
+    // #579 — rolling price snapshots for the velocity detector.
+    await Hive.openBox<String>(priceSnapshots);
   }
 
   /// Initialize Hive in a background isolate with proper encryption.
@@ -156,6 +167,9 @@ class HiveBoxes {
     await Hive.openBox(alerts, encryptionCipher: cipher);
     await Hive.openBox(cache, encryptionCipher: cipher);
     await Hive.openBox(priceHistory, encryptionCipher: cipher);
+    // #579 — velocity detector reads/writes snapshots from the BG
+    // isolate, mirroring the main-isolate open above.
+    await Hive.openBox<String>(priceSnapshots);
   }
 
   /// Close all Hive boxes opened by [initInIsolate].
@@ -163,7 +177,7 @@ class HiveBoxes {
   /// Must be called at the end of every background task to release file
   /// handles and prevent race conditions with the main isolate.
   static Future<void> closeIsolateBoxes() async {
-    final boxNames = [settings, favorites, alerts, cache, priceHistory];
+    final boxNames = [settings, favorites, alerts, cache, priceHistory, priceSnapshots];
     for (final name in boxNames) {
       try {
         if (Hive.isBoxOpen(name)) {
@@ -189,6 +203,9 @@ class HiveBoxes {
     await Hive.openBox<String>(serviceReminders);
     // #797 — paused trips box, string-typed JSON, matches runtime.
     await Hive.openBox<String>(obd2PausedTrips);
+    // #579 — velocity detector snapshots. String-typed JSON so the
+    // same one-adapter pattern covers unit tests + runtime.
+    await Hive.openBox<String>(priceSnapshots);
   }
 
   /// Safely converts any Hive map to a typed map.

--- a/lib/features/alerts/data/models/price_snapshot.dart
+++ b/lib/features/alerts/data/models/price_snapshot.dart
@@ -1,0 +1,52 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../search/domain/entities/fuel_type.dart';
+
+part 'price_snapshot.freezed.dart';
+part 'price_snapshot.g.dart';
+
+/// One observation of a fuel price at a single station (#579).
+///
+/// The background worker writes one snapshot per (station, fuel)
+/// every time it fetches fresh prices. The velocity detector then
+/// diffs the most-recent snapshot older than `lookback` against the
+/// current price to decide whether enough nearby stations have
+/// dropped to warrant a notification.
+///
+/// `fuelType` is stored as a string (FuelType.apiValue) so stored
+/// snapshots survive sealed-class changes without a migration. Coords
+/// are captured per-snapshot so the detector can filter by radius
+/// without re-joining against station data.
+@freezed
+abstract class PriceSnapshot with _$PriceSnapshot {
+  const factory PriceSnapshot({
+    required String stationId,
+    required String fuelType,
+    required double price,
+    required DateTime timestamp,
+    required double lat,
+    required double lng,
+  }) = _PriceSnapshot;
+
+  factory PriceSnapshot.fromJson(Map<String, dynamic> json) =>
+      _$PriceSnapshotFromJson(json);
+
+  /// Convenience for callers that already hold a [FuelType] instance.
+  static PriceSnapshot forFuel({
+    required String stationId,
+    required FuelType fuelType,
+    required double price,
+    required DateTime timestamp,
+    required double lat,
+    required double lng,
+  }) {
+    return PriceSnapshot(
+      stationId: stationId,
+      fuelType: fuelType.apiValue,
+      price: price,
+      timestamp: timestamp,
+      lat: lat,
+      lng: lng,
+    );
+  }
+}

--- a/lib/features/alerts/data/models/price_snapshot.freezed.dart
+++ b/lib/features/alerts/data/models/price_snapshot.freezed.dart
@@ -1,0 +1,292 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'price_snapshot.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PriceSnapshot {
+
+ String get stationId; String get fuelType; double get price; DateTime get timestamp; double get lat; double get lng;
+/// Create a copy of PriceSnapshot
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PriceSnapshotCopyWith<PriceSnapshot> get copyWith => _$PriceSnapshotCopyWithImpl<PriceSnapshot>(this as PriceSnapshot, _$identity);
+
+  /// Serializes this PriceSnapshot to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PriceSnapshot&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.price, price) || other.price == price)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.lat, lat) || other.lat == lat)&&(identical(other.lng, lng) || other.lng == lng));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,stationId,fuelType,price,timestamp,lat,lng);
+
+@override
+String toString() {
+  return 'PriceSnapshot(stationId: $stationId, fuelType: $fuelType, price: $price, timestamp: $timestamp, lat: $lat, lng: $lng)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PriceSnapshotCopyWith<$Res>  {
+  factory $PriceSnapshotCopyWith(PriceSnapshot value, $Res Function(PriceSnapshot) _then) = _$PriceSnapshotCopyWithImpl;
+@useResult
+$Res call({
+ String stationId, String fuelType, double price, DateTime timestamp, double lat, double lng
+});
+
+
+
+
+}
+/// @nodoc
+class _$PriceSnapshotCopyWithImpl<$Res>
+    implements $PriceSnapshotCopyWith<$Res> {
+  _$PriceSnapshotCopyWithImpl(this._self, this._then);
+
+  final PriceSnapshot _self;
+  final $Res Function(PriceSnapshot) _then;
+
+/// Create a copy of PriceSnapshot
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? stationId = null,Object? fuelType = null,Object? price = null,Object? timestamp = null,Object? lat = null,Object? lng = null,}) {
+  return _then(_self.copyWith(
+stationId: null == stationId ? _self.stationId : stationId // ignore: cast_nullable_to_non_nullable
+as String,fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nullable_to_non_nullable
+as String,price: null == price ? _self.price : price // ignore: cast_nullable_to_non_nullable
+as double,timestamp: null == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
+as DateTime,lat: null == lat ? _self.lat : lat // ignore: cast_nullable_to_non_nullable
+as double,lng: null == lng ? _self.lng : lng // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PriceSnapshot].
+extension PriceSnapshotPatterns on PriceSnapshot {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PriceSnapshot value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PriceSnapshot() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PriceSnapshot value)  $default,){
+final _that = this;
+switch (_that) {
+case _PriceSnapshot():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PriceSnapshot value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PriceSnapshot() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String stationId,  String fuelType,  double price,  DateTime timestamp,  double lat,  double lng)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PriceSnapshot() when $default != null:
+return $default(_that.stationId,_that.fuelType,_that.price,_that.timestamp,_that.lat,_that.lng);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String stationId,  String fuelType,  double price,  DateTime timestamp,  double lat,  double lng)  $default,) {final _that = this;
+switch (_that) {
+case _PriceSnapshot():
+return $default(_that.stationId,_that.fuelType,_that.price,_that.timestamp,_that.lat,_that.lng);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String stationId,  String fuelType,  double price,  DateTime timestamp,  double lat,  double lng)?  $default,) {final _that = this;
+switch (_that) {
+case _PriceSnapshot() when $default != null:
+return $default(_that.stationId,_that.fuelType,_that.price,_that.timestamp,_that.lat,_that.lng);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PriceSnapshot implements PriceSnapshot {
+  const _PriceSnapshot({required this.stationId, required this.fuelType, required this.price, required this.timestamp, required this.lat, required this.lng});
+  factory _PriceSnapshot.fromJson(Map<String, dynamic> json) => _$PriceSnapshotFromJson(json);
+
+@override final  String stationId;
+@override final  String fuelType;
+@override final  double price;
+@override final  DateTime timestamp;
+@override final  double lat;
+@override final  double lng;
+
+/// Create a copy of PriceSnapshot
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PriceSnapshotCopyWith<_PriceSnapshot> get copyWith => __$PriceSnapshotCopyWithImpl<_PriceSnapshot>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PriceSnapshotToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PriceSnapshot&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.price, price) || other.price == price)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.lat, lat) || other.lat == lat)&&(identical(other.lng, lng) || other.lng == lng));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,stationId,fuelType,price,timestamp,lat,lng);
+
+@override
+String toString() {
+  return 'PriceSnapshot(stationId: $stationId, fuelType: $fuelType, price: $price, timestamp: $timestamp, lat: $lat, lng: $lng)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PriceSnapshotCopyWith<$Res> implements $PriceSnapshotCopyWith<$Res> {
+  factory _$PriceSnapshotCopyWith(_PriceSnapshot value, $Res Function(_PriceSnapshot) _then) = __$PriceSnapshotCopyWithImpl;
+@override @useResult
+$Res call({
+ String stationId, String fuelType, double price, DateTime timestamp, double lat, double lng
+});
+
+
+
+
+}
+/// @nodoc
+class __$PriceSnapshotCopyWithImpl<$Res>
+    implements _$PriceSnapshotCopyWith<$Res> {
+  __$PriceSnapshotCopyWithImpl(this._self, this._then);
+
+  final _PriceSnapshot _self;
+  final $Res Function(_PriceSnapshot) _then;
+
+/// Create a copy of PriceSnapshot
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? stationId = null,Object? fuelType = null,Object? price = null,Object? timestamp = null,Object? lat = null,Object? lng = null,}) {
+  return _then(_PriceSnapshot(
+stationId: null == stationId ? _self.stationId : stationId // ignore: cast_nullable_to_non_nullable
+as String,fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nullable_to_non_nullable
+as String,price: null == price ? _self.price : price // ignore: cast_nullable_to_non_nullable
+as double,timestamp: null == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
+as DateTime,lat: null == lat ? _self.lat : lat // ignore: cast_nullable_to_non_nullable
+as double,lng: null == lng ? _self.lng : lng // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/alerts/data/models/price_snapshot.g.dart
+++ b/lib/features/alerts/data/models/price_snapshot.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'price_snapshot.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PriceSnapshot _$PriceSnapshotFromJson(Map<String, dynamic> json) =>
+    _PriceSnapshot(
+      stationId: json['stationId'] as String,
+      fuelType: json['fuelType'] as String,
+      price: (json['price'] as num).toDouble(),
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      lat: (json['lat'] as num).toDouble(),
+      lng: (json['lng'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$PriceSnapshotToJson(_PriceSnapshot instance) =>
+    <String, dynamic>{
+      'stationId': instance.stationId,
+      'fuelType': instance.fuelType,
+      'price': instance.price,
+      'timestamp': instance.timestamp.toIso8601String(),
+      'lat': instance.lat,
+      'lng': instance.lng,
+    };

--- a/lib/features/alerts/data/price_snapshot_store.dart
+++ b/lib/features/alerts/data/price_snapshot_store.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../core/storage/hive_boxes.dart';
+import 'models/price_snapshot.dart';
+
+/// Hive-backed rolling store of [PriceSnapshot] records (#579).
+///
+/// Feeds the velocity detector by keeping a short history (last 6 h
+/// by default) of observed fuel prices per station. Every
+/// [recordSnapshot] call auto-prunes anything older than
+/// [retention] so the box stays bounded regardless of how long the
+/// user runs the app.
+///
+/// Keys are synthetic composites of
+/// `station:fuel:epochMillis` — collisions are impossible at the
+/// millisecond resolution the background worker uses (one fetch
+/// per hour on battery, per 30 min on charger) and the prefix makes
+/// tests and ad-hoc inspection easier than raw hashes.
+class PriceSnapshotStore {
+  /// How long a snapshot stays in the box before being pruned on
+  /// write. The issue specifies 6 h to comfortably cover the default
+  /// 1 h lookback plus a few fetch cycles for the detector to compare.
+  static const Duration retention = Duration(hours: 6);
+
+  /// Key prefix for every snapshot. Public so background and tests
+  /// can iterate without re-importing private constants.
+  static const String keyPrefix = 'snapshot:';
+
+  /// Injectable clock — production callers leave the default
+  /// [DateTime.now]. Tests pass a fixed instant to assert pruning.
+  final DateTime Function() _now;
+
+  PriceSnapshotStore({DateTime Function()? now}) : _now = now ?? DateTime.now;
+
+  Box<String>? _boxOrNull() {
+    try {
+      if (!Hive.isBoxOpen(HiveBoxes.priceSnapshots)) return null;
+      return Hive.box<String>(HiveBoxes.priceSnapshots);
+    } catch (e) {
+      debugPrint('PriceSnapshotStore: box unavailable: $e');
+      return null;
+    }
+  }
+
+  /// Record a new snapshot and prune anything older than
+  /// [retention]. Missing box (e.g. tests that skipped
+  /// [HiveBoxes.initForTest]) is logged and ignored so the caller
+  /// never has to guard.
+  Future<void> recordSnapshot(PriceSnapshot snapshot) async {
+    final box = _boxOrNull();
+    if (box == null) {
+      debugPrint(
+          'PriceSnapshotStore.recordSnapshot: box closed, dropping ${snapshot.stationId}');
+      return;
+    }
+    final key =
+        '$keyPrefix${snapshot.stationId}:${snapshot.fuelType}:${snapshot.timestamp.millisecondsSinceEpoch}';
+    await box.put(key, jsonEncode(snapshot.toJson()));
+    await _prune(box);
+  }
+
+  /// Return every snapshot currently in the box, oldest-first.
+  /// Corrupt payloads are logged and skipped so one bad write can't
+  /// blind the detector.
+  Future<List<PriceSnapshot>> all() async {
+    final box = _boxOrNull();
+    if (box == null) return const [];
+    final out = <PriceSnapshot>[];
+    for (final key in box.keys) {
+      if (key is! String || !key.startsWith(keyPrefix)) continue;
+      final raw = box.get(key);
+      if (raw == null || raw.isEmpty) continue;
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is Map) {
+          final map = HiveBoxes.toStringDynamicMap(decoded);
+          if (map == null) continue;
+          out.add(PriceSnapshot.fromJson(map));
+        }
+      } catch (e) {
+        debugPrint('PriceSnapshotStore.all: skipping $key: $e');
+      }
+    }
+    out.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return out;
+  }
+
+  /// Return snapshots strictly older than [cutoff]. Used by the
+  /// detector to pick a "before" comparison point for each station.
+  Future<List<PriceSnapshot>> snapshotsOlderThan(Duration lookback) async {
+    final cutoff = _now().subtract(lookback);
+    final all = await this.all();
+    return all.where((s) => s.timestamp.isBefore(cutoff)).toList();
+  }
+
+  /// Drop every snapshot in the box. Used by tests.
+  @visibleForTesting
+  Future<void> clear() async {
+    final box = _boxOrNull();
+    if (box == null) return;
+    await box.clear();
+  }
+
+  /// Remove snapshots older than [retention]. Cheap: iterates the
+  /// keys once, deletes in a batch.
+  Future<void> _prune(Box<String> box) async {
+    final cutoff = _now().subtract(retention);
+    final toDelete = <String>[];
+    for (final key in box.keys) {
+      if (key is! String || !key.startsWith(keyPrefix)) continue;
+      final raw = box.get(key);
+      if (raw == null || raw.isEmpty) continue;
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is! Map) {
+          toDelete.add(key);
+          continue;
+        }
+        final ts = DateTime.tryParse(decoded['timestamp']?.toString() ?? '');
+        if (ts == null || ts.isBefore(cutoff)) {
+          toDelete.add(key);
+        }
+      } catch (e) {
+        debugPrint('PriceSnapshotStore._prune: removing corrupt $key: $e');
+        toDelete.add(key);
+      }
+    }
+    if (toDelete.isNotEmpty) {
+      await box.deleteAll(toDelete);
+    }
+  }
+}

--- a/lib/features/alerts/data/velocity_alert_cooldown.dart
+++ b/lib/features/alerts/data/velocity_alert_cooldown.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../core/storage/hive_boxes.dart';
+import '../../search/domain/entities/fuel_type.dart';
+
+/// Per-fuel cooldown tracker for the velocity alert detector (#579).
+///
+/// A single user-visible notification per fuel type per cooldown
+/// window is plenty — firing "E10 dropped" ten times in an hour
+/// would just train the user to swipe the channel away. This store
+/// simply remembers "last fired at" per fuel type and answers
+/// `canFire(fuelType, now)` against a caller-supplied window.
+///
+/// Persists under the already-encrypted `settings` box (one tiny
+/// string per fuel) rather than introducing yet another box —
+/// cooldown state is neither large nor independently useful.
+class VelocityAlertCooldown {
+  /// Key prefix in the settings box — one entry per fuel apiValue.
+  static const String keyPrefix = 'velocity_cooldown:';
+
+  Box? _boxOrNull() {
+    try {
+      if (!Hive.isBoxOpen(HiveBoxes.settings)) return null;
+      return Hive.box(HiveBoxes.settings);
+    } catch (e) {
+      debugPrint('VelocityAlertCooldown: settings box unavailable: $e');
+      return null;
+    }
+  }
+
+  String _key(FuelType fuelType) => '$keyPrefix${fuelType.apiValue}';
+
+  /// Return `true` when either no alert has ever fired for
+  /// [fuelType] or when `now - lastFired >= cooldown`.
+  Future<bool> canFire({
+    required FuelType fuelType,
+    required DateTime now,
+    required Duration cooldown,
+  }) async {
+    final last = await _lastFired(fuelType);
+    if (last == null) return true;
+    return now.difference(last) >= cooldown;
+  }
+
+  /// Stamp [fuelType] as having fired at [now]. Subsequent
+  /// [canFire] calls within the cooldown window return `false`.
+  Future<void> recordFired({
+    required FuelType fuelType,
+    required DateTime now,
+  }) async {
+    final box = _boxOrNull();
+    if (box == null) {
+      debugPrint(
+          'VelocityAlertCooldown.recordFired: settings box closed, dropping ${fuelType.apiValue}');
+      return;
+    }
+    await box.put(_key(fuelType), now.toIso8601String());
+  }
+
+  /// Read the last-fired stamp, if any. Corrupt values are logged
+  /// and treated as "never fired".
+  Future<DateTime?> _lastFired(FuelType fuelType) async {
+    final box = _boxOrNull();
+    if (box == null) return null;
+    final raw = box.get(_key(fuelType));
+    if (raw == null) return null;
+    try {
+      final parsed = DateTime.tryParse(raw.toString());
+      return parsed;
+    } catch (e) {
+      debugPrint('VelocityAlertCooldown: corrupt timestamp for ${fuelType.apiValue}: $e');
+      return null;
+    }
+  }
+
+  /// Drop every cooldown entry. Used by tests.
+  @visibleForTesting
+  Future<void> clear() async {
+    final box = _boxOrNull();
+    if (box == null) return;
+    final keys = box.keys
+        .whereType<String>()
+        .where((k) => k.startsWith(keyPrefix))
+        .toList();
+    await box.deleteAll(keys);
+  }
+}

--- a/lib/features/alerts/data/velocity_alert_runner.dart
+++ b/lib/features/alerts/data/velocity_alert_runner.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../core/notifications/notification_service.dart';
+import '../../../core/storage/hive_boxes.dart';
+import '../../search/domain/entities/fuel_type.dart';
+import '../domain/entities/velocity_alert_config.dart';
+import '../domain/velocity_alert_detector.dart';
+import 'models/price_snapshot.dart';
+import 'price_snapshot_store.dart';
+import 'velocity_alert_cooldown.dart';
+
+/// Glue between the background price refresh cycle and the
+/// velocity detector (#579).
+///
+/// The background isolate calls [run] once per cycle after it has
+/// fetched fresh prices. The runner:
+///   1. records a snapshot for every observation (auto-pruned by
+///      the store),
+///   2. loads the user's [VelocityAlertConfig] from the settings
+///      box (falling back to defaults),
+///   3. asks the detector whether an alert-worthy cluster of drops
+///      has happened,
+///   4. checks the cooldown and, if allowed, fires a single local
+///      notification with a localized title/body built by the
+///      injected [copyBuilder].
+///
+/// All collaborators are injected so the background-hook integration
+/// test can seed snapshots + assert that exactly one notification
+/// was sent when the threshold is crossed.
+class VelocityAlertRunner {
+  final PriceSnapshotStore snapshotStore;
+  final VelocityAlertCooldown cooldown;
+  final NotificationService notifier;
+
+  /// How far back the detector diffs current prices against.
+  /// Matches the issue's default of 1 h.
+  final Duration lookback;
+
+  /// Builder for the user-facing notification copy. The caller
+  /// passes in a function that reaches into the ARB bundle. When
+  /// the background isolate has no BuildContext (no MaterialApp),
+  /// a plain-German/English fallback is used.
+  final VelocityAlertCopy Function(VelocityAlertEvent event) copyBuilder;
+
+  VelocityAlertRunner({
+    required this.snapshotStore,
+    required this.cooldown,
+    required this.notifier,
+    required this.copyBuilder,
+    this.lookback = const Duration(hours: 1),
+  });
+
+  /// Executes the whole pipeline once. Safe to call even when
+  /// [observations] is empty — the snapshot step is skipped and no
+  /// detection runs.
+  ///
+  /// [userLat]/[userLng] come from the last-known position stored
+  /// under the `user_position_*` settings keys. Pass `null` to
+  /// disable the radius filter (detector will then accept every
+  /// observation, which matches the "better to fire" stance).
+  Future<VelocityAlertEvent?> run({
+    required List<VelocityStationObservation> observations,
+    required DateTime now,
+    double? userLat,
+    double? userLng,
+  }) async {
+    final config = await loadConfig();
+
+    // 1. Record current snapshots (auto-pruning inside the store).
+    for (final obs in observations) {
+      await snapshotStore.recordSnapshot(
+        PriceSnapshot(
+          stationId: obs.stationId,
+          fuelType: config.fuelType.apiValue,
+          price: obs.price,
+          timestamp: now,
+          lat: obs.lat,
+          lng: obs.lng,
+        ),
+      );
+    }
+
+    // 2. Fetch baseline snapshots older than `lookback` so the
+    //    detector has a "before" per station.
+    final previous = await snapshotStore.snapshotsOlderThan(lookback);
+
+    // 3. Run the detector.
+    final event = VelocityAlertDetector.detect(
+      config: config,
+      observations: observations,
+      previousSnapshots: previous,
+      now: now,
+      userLat: userLat,
+      userLng: userLng,
+      lookback: lookback,
+    );
+    if (event == null) return null;
+
+    // 4. Cooldown gate + fire.
+    final allowed = await cooldown.canFire(
+      fuelType: event.fuelType,
+      now: now,
+      cooldown: Duration(hours: config.cooldownHours),
+    );
+    if (!allowed) {
+      debugPrint(
+          'VelocityAlertRunner: cooldown active for ${event.fuelType.apiValue}, skipping notification');
+      return event;
+    }
+
+    final copy = copyBuilder(event);
+    // Deterministic id so re-fires update the existing
+    // notification in-place rather than stacking.
+    final id = _notificationId(event.fuelType);
+    await notifier.showPriceAlert(
+      id: id,
+      title: copy.title,
+      body: copy.body,
+    );
+    await cooldown.recordFired(fuelType: event.fuelType, now: now);
+    return event;
+  }
+
+  /// Load the persisted [VelocityAlertConfig] from the `settings`
+  /// Hive box or return defaults when missing/corrupt.
+  Future<VelocityAlertConfig> loadConfig() async {
+    try {
+      if (!Hive.isBoxOpen(HiveBoxes.settings)) {
+        return VelocityAlertConfig.defaults();
+      }
+      final raw = Hive.box(HiveBoxes.settings).get(configKey);
+      if (raw is String && raw.isNotEmpty) {
+        final decoded = jsonDecode(raw);
+        if (decoded is Map) {
+          final map = HiveBoxes.toStringDynamicMap(decoded);
+          if (map != null) {
+            return VelocityAlertConfig.fromJson(map);
+          }
+        }
+      }
+    } catch (e) {
+      debugPrint('VelocityAlertRunner.loadConfig: falling back to defaults: $e');
+    }
+    return VelocityAlertConfig.defaults();
+  }
+
+  /// Persist a fresh [VelocityAlertConfig]. Callers are the future
+  /// settings UI and tests.
+  Future<void> saveConfig(VelocityAlertConfig config) async {
+    if (!Hive.isBoxOpen(HiveBoxes.settings)) {
+      debugPrint('VelocityAlertRunner.saveConfig: settings box closed');
+      return;
+    }
+    await Hive.box(HiveBoxes.settings)
+        .put(configKey, jsonEncode(config.toJson()));
+  }
+
+  /// Settings-box key for the persisted config blob.
+  static const String configKey = 'velocity_alert_config';
+
+  /// Stable notification id per fuel so re-fires overwrite the
+  /// existing notification instead of stacking a new one per fire.
+  static int _notificationId(FuelType fuelType) =>
+      ('velocity:${fuelType.apiValue}').hashCode;
+}
+
+/// User-facing copy for a velocity alert notification. Kept as a
+/// plain value object so the background isolate and the eventual
+/// foreground preview both produce identical strings.
+class VelocityAlertCopy {
+  final String title;
+  final String body;
+  const VelocityAlertCopy({required this.title, required this.body});
+}

--- a/lib/features/alerts/domain/entities/velocity_alert_config.dart
+++ b/lib/features/alerts/domain/entities/velocity_alert_config.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../search/domain/entities/fuel_type.dart';
+
+part 'velocity_alert_config.freezed.dart';
+part 'velocity_alert_config.g.dart';
+
+/// Configuration for the price-drop velocity detector (#579).
+///
+/// Stored as a single JSON blob under the settings box; defaults are
+/// applied when no config has been persisted yet. The detector is a
+/// pure function that consumes this config plus the current nearby
+/// stations and recent snapshots, and emits a [VelocityAlertEvent]
+/// when enough nearby stations drop fast enough.
+///
+/// Defaults mirror the issue's "3 ct / 2 stations / 15 km / 1 h"
+/// spec with a 6 h cooldown between fires of the same fuel type.
+@freezed
+abstract class VelocityAlertConfig with _$VelocityAlertConfig {
+  const factory VelocityAlertConfig({
+    @FuelTypeJsonConverter() required FuelType fuelType,
+    @Default(3) double minDropCents,
+    @Default(2) int minStations,
+    @Default(15) double radiusKm,
+    @Default(6) int cooldownHours,
+  }) = _VelocityAlertConfig;
+
+  factory VelocityAlertConfig.fromJson(Map<String, dynamic> json) =>
+      _$VelocityAlertConfigFromJson(json);
+
+  /// Default config — E10 with the spec thresholds. Used when the
+  /// settings box has no persisted config yet.
+  factory VelocityAlertConfig.defaults() =>
+      const VelocityAlertConfig(fuelType: FuelType.e10);
+}

--- a/lib/features/alerts/domain/entities/velocity_alert_config.freezed.dart
+++ b/lib/features/alerts/domain/entities/velocity_alert_config.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'velocity_alert_config.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$VelocityAlertConfig {
+
+@FuelTypeJsonConverter() FuelType get fuelType; double get minDropCents; int get minStations; double get radiusKm; int get cooldownHours;
+/// Create a copy of VelocityAlertConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VelocityAlertConfigCopyWith<VelocityAlertConfig> get copyWith => _$VelocityAlertConfigCopyWithImpl<VelocityAlertConfig>(this as VelocityAlertConfig, _$identity);
+
+  /// Serializes this VelocityAlertConfig to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VelocityAlertConfig&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.minDropCents, minDropCents) || other.minDropCents == minDropCents)&&(identical(other.minStations, minStations) || other.minStations == minStations)&&(identical(other.radiusKm, radiusKm) || other.radiusKm == radiusKm)&&(identical(other.cooldownHours, cooldownHours) || other.cooldownHours == cooldownHours));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,fuelType,minDropCents,minStations,radiusKm,cooldownHours);
+
+@override
+String toString() {
+  return 'VelocityAlertConfig(fuelType: $fuelType, minDropCents: $minDropCents, minStations: $minStations, radiusKm: $radiusKm, cooldownHours: $cooldownHours)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VelocityAlertConfigCopyWith<$Res>  {
+  factory $VelocityAlertConfigCopyWith(VelocityAlertConfig value, $Res Function(VelocityAlertConfig) _then) = _$VelocityAlertConfigCopyWithImpl;
+@useResult
+$Res call({
+@FuelTypeJsonConverter() FuelType fuelType, double minDropCents, int minStations, double radiusKm, int cooldownHours
+});
+
+
+
+
+}
+/// @nodoc
+class _$VelocityAlertConfigCopyWithImpl<$Res>
+    implements $VelocityAlertConfigCopyWith<$Res> {
+  _$VelocityAlertConfigCopyWithImpl(this._self, this._then);
+
+  final VelocityAlertConfig _self;
+  final $Res Function(VelocityAlertConfig) _then;
+
+/// Create a copy of VelocityAlertConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? fuelType = null,Object? minDropCents = null,Object? minStations = null,Object? radiusKm = null,Object? cooldownHours = null,}) {
+  return _then(_self.copyWith(
+fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nullable_to_non_nullable
+as FuelType,minDropCents: null == minDropCents ? _self.minDropCents : minDropCents // ignore: cast_nullable_to_non_nullable
+as double,minStations: null == minStations ? _self.minStations : minStations // ignore: cast_nullable_to_non_nullable
+as int,radiusKm: null == radiusKm ? _self.radiusKm : radiusKm // ignore: cast_nullable_to_non_nullable
+as double,cooldownHours: null == cooldownHours ? _self.cooldownHours : cooldownHours // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [VelocityAlertConfig].
+extension VelocityAlertConfigPatterns on VelocityAlertConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _VelocityAlertConfig value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _VelocityAlertConfig() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _VelocityAlertConfig value)  $default,){
+final _that = this;
+switch (_that) {
+case _VelocityAlertConfig():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _VelocityAlertConfig value)?  $default,){
+final _that = this;
+switch (_that) {
+case _VelocityAlertConfig() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@FuelTypeJsonConverter()  FuelType fuelType,  double minDropCents,  int minStations,  double radiusKm,  int cooldownHours)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _VelocityAlertConfig() when $default != null:
+return $default(_that.fuelType,_that.minDropCents,_that.minStations,_that.radiusKm,_that.cooldownHours);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@FuelTypeJsonConverter()  FuelType fuelType,  double minDropCents,  int minStations,  double radiusKm,  int cooldownHours)  $default,) {final _that = this;
+switch (_that) {
+case _VelocityAlertConfig():
+return $default(_that.fuelType,_that.minDropCents,_that.minStations,_that.radiusKm,_that.cooldownHours);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@FuelTypeJsonConverter()  FuelType fuelType,  double minDropCents,  int minStations,  double radiusKm,  int cooldownHours)?  $default,) {final _that = this;
+switch (_that) {
+case _VelocityAlertConfig() when $default != null:
+return $default(_that.fuelType,_that.minDropCents,_that.minStations,_that.radiusKm,_that.cooldownHours);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _VelocityAlertConfig implements VelocityAlertConfig {
+  const _VelocityAlertConfig({@FuelTypeJsonConverter() required this.fuelType, this.minDropCents = 3, this.minStations = 2, this.radiusKm = 15, this.cooldownHours = 6});
+  factory _VelocityAlertConfig.fromJson(Map<String, dynamic> json) => _$VelocityAlertConfigFromJson(json);
+
+@override@FuelTypeJsonConverter() final  FuelType fuelType;
+@override@JsonKey() final  double minDropCents;
+@override@JsonKey() final  int minStations;
+@override@JsonKey() final  double radiusKm;
+@override@JsonKey() final  int cooldownHours;
+
+/// Create a copy of VelocityAlertConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VelocityAlertConfigCopyWith<_VelocityAlertConfig> get copyWith => __$VelocityAlertConfigCopyWithImpl<_VelocityAlertConfig>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$VelocityAlertConfigToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VelocityAlertConfig&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.minDropCents, minDropCents) || other.minDropCents == minDropCents)&&(identical(other.minStations, minStations) || other.minStations == minStations)&&(identical(other.radiusKm, radiusKm) || other.radiusKm == radiusKm)&&(identical(other.cooldownHours, cooldownHours) || other.cooldownHours == cooldownHours));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,fuelType,minDropCents,minStations,radiusKm,cooldownHours);
+
+@override
+String toString() {
+  return 'VelocityAlertConfig(fuelType: $fuelType, minDropCents: $minDropCents, minStations: $minStations, radiusKm: $radiusKm, cooldownHours: $cooldownHours)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$VelocityAlertConfigCopyWith<$Res> implements $VelocityAlertConfigCopyWith<$Res> {
+  factory _$VelocityAlertConfigCopyWith(_VelocityAlertConfig value, $Res Function(_VelocityAlertConfig) _then) = __$VelocityAlertConfigCopyWithImpl;
+@override @useResult
+$Res call({
+@FuelTypeJsonConverter() FuelType fuelType, double minDropCents, int minStations, double radiusKm, int cooldownHours
+});
+
+
+
+
+}
+/// @nodoc
+class __$VelocityAlertConfigCopyWithImpl<$Res>
+    implements _$VelocityAlertConfigCopyWith<$Res> {
+  __$VelocityAlertConfigCopyWithImpl(this._self, this._then);
+
+  final _VelocityAlertConfig _self;
+  final $Res Function(_VelocityAlertConfig) _then;
+
+/// Create a copy of VelocityAlertConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? fuelType = null,Object? minDropCents = null,Object? minStations = null,Object? radiusKm = null,Object? cooldownHours = null,}) {
+  return _then(_VelocityAlertConfig(
+fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nullable_to_non_nullable
+as FuelType,minDropCents: null == minDropCents ? _self.minDropCents : minDropCents // ignore: cast_nullable_to_non_nullable
+as double,minStations: null == minStations ? _self.minStations : minStations // ignore: cast_nullable_to_non_nullable
+as int,radiusKm: null == radiusKm ? _self.radiusKm : radiusKm // ignore: cast_nullable_to_non_nullable
+as double,cooldownHours: null == cooldownHours ? _self.cooldownHours : cooldownHours // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/alerts/domain/entities/velocity_alert_config.g.dart
+++ b/lib/features/alerts/domain/entities/velocity_alert_config.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'velocity_alert_config.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_VelocityAlertConfig _$VelocityAlertConfigFromJson(Map<String, dynamic> json) =>
+    _VelocityAlertConfig(
+      fuelType: const FuelTypeJsonConverter().fromJson(
+        json['fuelType'] as String,
+      ),
+      minDropCents: (json['minDropCents'] as num?)?.toDouble() ?? 3,
+      minStations: (json['minStations'] as num?)?.toInt() ?? 2,
+      radiusKm: (json['radiusKm'] as num?)?.toDouble() ?? 15,
+      cooldownHours: (json['cooldownHours'] as num?)?.toInt() ?? 6,
+    );
+
+Map<String, dynamic> _$VelocityAlertConfigToJson(
+  _VelocityAlertConfig instance,
+) => <String, dynamic>{
+  'fuelType': const FuelTypeJsonConverter().toJson(instance.fuelType),
+  'minDropCents': instance.minDropCents,
+  'minStations': instance.minStations,
+  'radiusKm': instance.radiusKm,
+  'cooldownHours': instance.cooldownHours,
+};

--- a/lib/features/alerts/domain/velocity_alert_detector.dart
+++ b/lib/features/alerts/domain/velocity_alert_detector.dart
@@ -1,0 +1,130 @@
+import '../../../core/utils/geo_utils.dart';
+import '../../search/domain/entities/fuel_type.dart';
+import '../data/models/price_snapshot.dart';
+import 'entities/velocity_alert_config.dart';
+
+/// Snapshot of a station's *current* price for a given fuel.
+///
+/// The detector accepts a minimal shape rather than the full
+/// [Station] model so it can be driven from the background isolate,
+/// tests, or a future different source without coupling to the
+/// search feature.
+class VelocityStationObservation {
+  final String stationId;
+  final double price;
+  final double lat;
+  final double lng;
+
+  const VelocityStationObservation({
+    required this.stationId,
+    required this.price,
+    required this.lat,
+    required this.lng,
+  });
+}
+
+/// Emitted when enough nearby stations have dropped fast enough on
+/// the watched fuel type (#579).
+class VelocityAlertEvent {
+  final FuelType fuelType;
+  final List<String> affectedStationIds;
+
+  /// Largest observed drop across the qualifying stations, in cents.
+  final double maxDropCents;
+
+  const VelocityAlertEvent({
+    required this.fuelType,
+    required this.affectedStationIds,
+    required this.maxDropCents,
+  });
+
+  /// Convenience: number of stations that contributed to the event.
+  int get stationCount => affectedStationIds.length;
+}
+
+/// Detects "price is falling fast" across multiple nearby stations
+/// by diffing current observations against the most-recent
+/// [PriceSnapshot] older than [VelocityAlertConfig] lookback.
+///
+/// Pure function — no storage, no notifications. The background
+/// hook is responsible for calling this, checking the cooldown, and
+/// firing the local notification.
+class VelocityAlertDetector {
+  VelocityAlertDetector._();
+
+  /// Run the detector once against the provided observations.
+  ///
+  /// [observations] — current per-station price readings for the
+  /// fuel in [config.fuelType].
+  /// [previousSnapshots] — snapshots older than [lookback]; the
+  /// detector picks the *most recent* one per (station, fuel) to
+  /// compare against.
+  /// [userLat]/[userLng] — radius filter origin. Pass `null` to
+  /// disable the radius check (e.g. when the user's location is
+  /// unknown at run time).
+  /// [now] — injected clock for deterministic tests.
+  ///
+  /// Returns `null` when nothing interesting happened, otherwise a
+  /// [VelocityAlertEvent] summarising the drops.
+  static VelocityAlertEvent? detect({
+    required VelocityAlertConfig config,
+    required List<VelocityStationObservation> observations,
+    required List<PriceSnapshot> previousSnapshots,
+    required DateTime now,
+    double? userLat,
+    double? userLng,
+    Duration lookback = const Duration(hours: 1),
+  }) {
+    if (observations.isEmpty) return null;
+
+    final fuelApiValue = config.fuelType.apiValue;
+    final cutoff = now.subtract(lookback);
+
+    // Index previous snapshots by station for O(1) lookup and pick
+    // the *most-recent-before-cutoff* per station for the fuel we
+    // care about. A station can legitimately have several snapshots
+    // in the box (multiple BG cycles) so we need the freshest one
+    // that still predates the lookback window.
+    final mostRecentBefore = <String, PriceSnapshot>{};
+    for (final s in previousSnapshots) {
+      if (s.fuelType != fuelApiValue) continue;
+      if (!s.timestamp.isBefore(cutoff)) continue;
+      final existing = mostRecentBefore[s.stationId];
+      if (existing == null || s.timestamp.isAfter(existing.timestamp)) {
+        mostRecentBefore[s.stationId] = s;
+      }
+    }
+
+    final drops = <_Drop>[];
+    for (final obs in observations) {
+      // Radius filter — skip stations outside the configured
+      // radius when we know where the user is. When we don't,
+      // accept every station (better to fire than be silent).
+      if (userLat != null && userLng != null) {
+        final d = distanceKm(userLat, userLng, obs.lat, obs.lng);
+        if (d > config.radiusKm) continue;
+      }
+      final prior = mostRecentBefore[obs.stationId];
+      if (prior == null) continue; // first time seen → can't compute drop
+      final dropCents = (prior.price - obs.price) * 100;
+      if (dropCents < config.minDropCents) continue;
+      drops.add(_Drop(obs.stationId, dropCents));
+    }
+
+    if (drops.length < config.minStations) return null;
+
+    drops.sort((a, b) => b.cents.compareTo(a.cents));
+    final max = drops.first.cents;
+    return VelocityAlertEvent(
+      fuelType: config.fuelType,
+      affectedStationIds: drops.map((d) => d.stationId).toList(),
+      maxDropCents: max,
+    );
+  }
+}
+
+class _Drop {
+  final String stationId;
+  final double cents;
+  const _Drop(this.stationId, this.cents);
+}

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'bafa70f4533d52b9aabfc319c85e816a95c25469';
+String _$tripRecordingHash() => r'a3296260018bed8b717cd2bdb9620c61d6bfa837';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1226,5 +1226,7 @@
   "alertsRadiusSave": "Speichern",
   "alertsRadiusCancel": "Abbrechen",
   "alertsRadiusDeleteConfirm": "Umkreis-Alarm löschen?",
-  "obd2ConnectedTooltip": "OBD2 verbunden: {adapterName}"
+  "obd2ConnectedTooltip": "OBD2 verbunden: {adapterName}",
+  "velocityAlertTitle": "{fuelLabel} an Tankstellen in der Nähe gefallen",
+  "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1353,5 +1353,20 @@
     "placeholders": {
       "adapterName": { "type": "String", "example": "vLinker FS" }
     }
+  },
+  "velocityAlertTitle": "{fuelLabel} dropped at nearby stations",
+  "@velocityAlertTitle": {
+    "description": "Title of the price-drop velocity notification (#579). Fired when multiple nearby stations drop within the lookback window.",
+    "placeholders": {
+      "fuelLabel": { "type": "String", "example": "E10" }
+    }
+  },
+  "velocityAlertBody": "{stationCount} stations dropped by up to {maxDropCents}¢ in the last hour",
+  "@velocityAlertBody": {
+    "description": "Body of the price-drop velocity notification (#579). Lists the number of affected stations and the largest observed drop in cents.",
+    "placeholders": {
+      "stationCount": { "type": "int", "example": "3" },
+      "maxDropCents": { "type": "int", "example": "5" }
+    }
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5893,6 +5893,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'OBD2 connected: {adapterName}'**
   String obd2ConnectedTooltip(String adapterName);
+
+  /// Title of the price-drop velocity notification (#579). Fired when multiple nearby stations drop within the lookback window.
+  ///
+  /// In en, this message translates to:
+  /// **'{fuelLabel} dropped at nearby stations'**
+  String velocityAlertTitle(String fuelLabel);
+
+  /// Body of the price-drop velocity notification (#579). Lists the number of affected stations and the largest observed drop in cents.
+  ///
+  /// In en, this message translates to:
+  /// **'{stationCount} stations dropped by up to {maxDropCents}¢ in the last hour'**
+  String velocityAlertBody(int stationCount, int maxDropCents);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3132,4 +3132,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3132,4 +3132,14 @@ class AppLocalizationsCs extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3130,4 +3130,14 @@ class AppLocalizationsDa extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3155,4 +3155,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 verbunden: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel an Tankstellen in der Nähe gefallen';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount Tankstellen um bis zu $maxDropCents¢ in der letzten Stunde gefallen';
+  }
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3134,4 +3134,14 @@ class AppLocalizationsEl extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3125,4 +3125,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3133,4 +3133,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3127,4 +3127,14 @@ class AppLocalizationsEt extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3130,4 +3130,14 @@ class AppLocalizationsFi extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3154,4 +3154,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3129,4 +3129,14 @@ class AppLocalizationsHr extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3134,4 +3134,14 @@ class AppLocalizationsHu extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3133,4 +3133,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3131,4 +3131,14 @@ class AppLocalizationsLt extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3133,4 +3133,14 @@ class AppLocalizationsLv extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3129,4 +3129,14 @@ class AppLocalizationsNb extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3134,4 +3134,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3132,4 +3132,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3133,4 +3133,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3132,4 +3132,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3133,4 +3133,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3127,4 +3127,14 @@ class AppLocalizationsSl extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3131,4 +3131,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String obd2ConnectedTooltip(String adapterName) {
     return 'OBD2 connected: $adapterName';
   }
+
+  @override
+  String velocityAlertTitle(String fuelLabel) {
+    return '$fuelLabel dropped at nearby stations';
+  }
+
+  @override
+  String velocityAlertBody(int stationCount, int maxDropCents) {
+    return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
+  }
 }

--- a/test/features/alerts/data/price_snapshot_store_test.dart
+++ b/test/features/alerts/data/price_snapshot_store_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/alerts/data/models/price_snapshot.dart';
+import 'package:tankstellen/features/alerts/data/price_snapshot_store.dart';
+
+void main() {
+  late Directory tempDir;
+
+  PriceSnapshot makeSnapshot({
+    String stationId = 's1',
+    String fuelType = 'e10',
+    double price = 1.899,
+    DateTime? at,
+    double lat = 43.5,
+    double lng = 3.5,
+  }) {
+    return PriceSnapshot(
+      stationId: stationId,
+      fuelType: fuelType,
+      price: price,
+      timestamp: at ?? DateTime.utc(2026, 4, 22, 12),
+      lat: lat,
+      lng: lng,
+    );
+  }
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_price_snapshots_');
+    Hive.init(tempDir.path);
+  });
+
+  setUp(() async {
+    if (Hive.isBoxOpen(HiveBoxes.priceSnapshots)) {
+      await Hive.box<String>(HiveBoxes.priceSnapshots).close();
+    }
+    await Hive.openBox<String>(HiveBoxes.priceSnapshots);
+    await Hive.box<String>(HiveBoxes.priceSnapshots).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('PriceSnapshotStore', () {
+    test('records a snapshot and reads it back', () async {
+      final now = DateTime.utc(2026, 4, 22, 12);
+      final store = PriceSnapshotStore(now: () => now);
+      final snap = makeSnapshot(at: now);
+
+      await store.recordSnapshot(snap);
+
+      final all = await store.all();
+      expect(all, hasLength(1));
+      final read = all.single;
+      expect(read.stationId, 's1');
+      expect(read.fuelType, 'e10');
+      expect(read.price, closeTo(1.899, 0.0001));
+      expect(read.timestamp, now);
+      expect(read.lat, closeTo(43.5, 0.0001));
+      expect(read.lng, closeTo(3.5, 0.0001));
+    });
+
+    test('auto-prunes snapshots older than the 6 h retention window',
+        () async {
+      final now = DateTime.utc(2026, 4, 22, 12);
+      final store = PriceSnapshotStore(now: () => now);
+
+      // Seed with a snapshot from 8 h ago — will be pruned on next
+      // write — and one from 2 h ago — will survive.
+      await store.recordSnapshot(makeSnapshot(
+          stationId: 's_old', at: now.subtract(const Duration(hours: 8))));
+      await store.recordSnapshot(makeSnapshot(
+          stationId: 's_recent',
+          at: now.subtract(const Duration(hours: 2))));
+
+      // Trigger pruning by adding a fresh snapshot.
+      await store.recordSnapshot(makeSnapshot(
+          stationId: 's_fresh', at: now));
+
+      final remaining = await store.all();
+      final ids = remaining.map((s) => s.stationId).toSet();
+      expect(ids, {'s_recent', 's_fresh'});
+      expect(ids, isNot(contains('s_old')));
+    });
+
+    test('snapshotsOlderThan returns only older entries', () async {
+      final now = DateTime.utc(2026, 4, 22, 12);
+      final store = PriceSnapshotStore(now: () => now);
+
+      await store.recordSnapshot(makeSnapshot(
+          stationId: 's_fresh', at: now.subtract(const Duration(minutes: 5))));
+      await store.recordSnapshot(makeSnapshot(
+          stationId: 's_hourAgo',
+          at: now.subtract(const Duration(hours: 1, minutes: 10))));
+
+      final older = await store.snapshotsOlderThan(const Duration(hours: 1));
+      expect(older.map((s) => s.stationId), ['s_hourAgo']);
+    });
+  });
+}

--- a/test/features/alerts/data/velocity_alert_cooldown_test.dart
+++ b/test/features/alerts/data/velocity_alert_cooldown_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/alerts/data/velocity_alert_cooldown.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_velocity_cd_');
+    Hive.init(tempDir.path);
+  });
+
+  setUp(() async {
+    if (Hive.isBoxOpen(HiveBoxes.settings)) {
+      await Hive.box(HiveBoxes.settings).close();
+    }
+    await Hive.openBox(HiveBoxes.settings);
+    await Hive.box(HiveBoxes.settings).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('VelocityAlertCooldown', () {
+    test('canFire returns true when no alert has ever fired', () async {
+      final cd = VelocityAlertCooldown();
+      expect(
+        await cd.canFire(
+          fuelType: FuelType.e10,
+          now: DateTime.utc(2026, 4, 22, 12),
+          cooldown: const Duration(hours: 6),
+        ),
+        isTrue,
+      );
+    });
+
+    test('cooldown is honored per fuel type independently', () async {
+      final cd = VelocityAlertCooldown();
+      final now = DateTime.utc(2026, 4, 22, 12);
+
+      // Fire for E10 → E10 blocked, diesel still eligible.
+      await cd.recordFired(fuelType: FuelType.e10, now: now);
+
+      expect(
+        await cd.canFire(
+          fuelType: FuelType.e10,
+          now: now.add(const Duration(hours: 1)),
+          cooldown: const Duration(hours: 6),
+        ),
+        isFalse,
+        reason: 'E10 within cooldown window should be blocked',
+      );
+
+      expect(
+        await cd.canFire(
+          fuelType: FuelType.diesel,
+          now: now.add(const Duration(hours: 1)),
+          cooldown: const Duration(hours: 6),
+        ),
+        isTrue,
+        reason: 'Diesel is a separate fuel and must not be blocked by E10',
+      );
+    });
+
+    test('canFire returns true once the cooldown has elapsed', () async {
+      final cd = VelocityAlertCooldown();
+      final now = DateTime.utc(2026, 4, 22, 12);
+      await cd.recordFired(fuelType: FuelType.e10, now: now);
+
+      expect(
+        await cd.canFire(
+          fuelType: FuelType.e10,
+          now: now.add(const Duration(hours: 5, minutes: 59)),
+          cooldown: const Duration(hours: 6),
+        ),
+        isFalse,
+      );
+
+      expect(
+        await cd.canFire(
+          fuelType: FuelType.e10,
+          now: now.add(const Duration(hours: 6)),
+          cooldown: const Duration(hours: 6),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/features/alerts/data/velocity_alert_runner_test.dart
+++ b/test/features/alerts/data/velocity_alert_runner_test.dart
@@ -1,0 +1,224 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/notifications/notification_service.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/alerts/data/models/price_snapshot.dart';
+import 'package:tankstellen/features/alerts/data/price_snapshot_store.dart';
+import 'package:tankstellen/features/alerts/data/velocity_alert_cooldown.dart';
+import 'package:tankstellen/features/alerts/data/velocity_alert_runner.dart';
+import 'package:tankstellen/features/alerts/domain/entities/velocity_alert_config.dart';
+import 'package:tankstellen/features/alerts/domain/velocity_alert_detector.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Captures every notification the runner fires. Stand-in for
+/// [LocalNotificationService] — the BG-isolate hook just needs
+/// `showPriceAlert` to reach it.
+class _FakeNotifier implements NotificationService {
+  final List<({int id, String title, String body})> priceAlerts = [];
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> showPriceAlert({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    priceAlerts.add((id: id, title: title, body: body));
+  }
+
+  @override
+  Future<void> showServiceReminder({
+    required int id,
+    required String title,
+    required String body,
+  }) async {}
+
+  @override
+  Future<void> cancelNotification(int id) async {}
+
+  @override
+  Future<void> cancelAll() async {}
+}
+
+VelocityAlertCopy _copy(VelocityAlertEvent event) => VelocityAlertCopy(
+      title: '${event.fuelType.displayName.toUpperCase()} dropped',
+      body:
+          '${event.stationCount} stations dropped by up to ${event.maxDropCents.round()}¢',
+    );
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_velocity_runner_');
+    Hive.init(tempDir.path);
+  });
+
+  setUp(() async {
+    for (final name in [HiveBoxes.priceSnapshots]) {
+      if (Hive.isBoxOpen(name)) {
+        await Hive.box<String>(name).close();
+      }
+      await Hive.openBox<String>(name);
+      await Hive.box<String>(name).clear();
+    }
+    if (Hive.isBoxOpen(HiveBoxes.settings)) {
+      await Hive.box(HiveBoxes.settings).close();
+    }
+    await Hive.openBox(HiveBoxes.settings);
+    await Hive.box(HiveBoxes.settings).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  // User sits at this point; stations are clustered within ~2 km.
+  const userLat = 43.5;
+  const userLng = 3.5;
+  final nearbyCoords = <String, List<double>>{
+    's1': [userLat, 3.51],
+    's2': [userLat, 3.49],
+    's3': [userLat, 3.52],
+  };
+  final now = DateTime.utc(2026, 4, 22, 12);
+  final hourPlus =
+      now.subtract(const Duration(hours: 1, minutes: 10));
+
+  VelocityStationObservation obs(String id, double price) {
+    final c = nearbyCoords[id]!;
+    return VelocityStationObservation(
+      stationId: id,
+      price: price,
+      lat: c[0],
+      lng: c[1],
+    );
+  }
+
+  PriceSnapshot priorSnap(String id, double price) {
+    final c = nearbyCoords[id]!;
+    return PriceSnapshot(
+      stationId: id,
+      fuelType: 'e10',
+      price: price,
+      timestamp: hourPlus,
+      lat: c[0],
+      lng: c[1],
+    );
+  }
+
+  group('VelocityAlertRunner (background hook)', () {
+    test(
+        'fires a single notification when threshold is met and cooldown is idle',
+        () async {
+      final snapshotStore = PriceSnapshotStore(now: () => now);
+      final cooldown = VelocityAlertCooldown();
+      final notifier = _FakeNotifier();
+      final runner = VelocityAlertRunner(
+        snapshotStore: snapshotStore,
+        cooldown: cooldown,
+        notifier: notifier,
+        copyBuilder: _copy,
+      );
+
+      // Seed yesterday's baseline snapshots.
+      await snapshotStore.recordSnapshot(priorSnap('s1', 1.900));
+      await snapshotStore.recordSnapshot(priorSnap('s2', 1.900));
+      await snapshotStore.recordSnapshot(priorSnap('s3', 1.900));
+
+      final event = await runner.run(
+        observations: [
+          obs('s1', 1.860), // -4 ct
+          obs('s2', 1.860), // -4 ct
+          obs('s3', 1.860), // -4 ct
+        ],
+        now: now,
+        userLat: userLat,
+        userLng: userLng,
+      );
+
+      expect(event, isNotNull);
+      expect(event!.stationCount, 3);
+      expect(notifier.priceAlerts, hasLength(1));
+      expect(notifier.priceAlerts.single.title, contains('E10'));
+      expect(notifier.priceAlerts.single.body, contains('3 stations'));
+    });
+
+    test('suppresses a second notification while cooldown is active', () async {
+      final snapshotStore = PriceSnapshotStore(now: () => now);
+      final cooldown = VelocityAlertCooldown();
+      final notifier = _FakeNotifier();
+      final runner = VelocityAlertRunner(
+        snapshotStore: snapshotStore,
+        cooldown: cooldown,
+        notifier: notifier,
+        copyBuilder: _copy,
+      );
+
+      // Prime the cooldown as if we'd just fired.
+      await cooldown.recordFired(fuelType: FuelType.e10, now: now);
+
+      await snapshotStore.recordSnapshot(priorSnap('s1', 1.900));
+      await snapshotStore.recordSnapshot(priorSnap('s2', 1.900));
+
+      final event = await runner.run(
+        observations: [
+          obs('s1', 1.860),
+          obs('s2', 1.860),
+        ],
+        now: now.add(const Duration(minutes: 5)),
+        userLat: userLat,
+        userLng: userLng,
+      );
+
+      // Detector still emits the event — the cooldown gate is the
+      // one that mutes the notification.
+      expect(event, isNotNull);
+      expect(notifier.priceAlerts, isEmpty);
+    });
+
+    test('persists config via saveConfig and loadConfig round-trips', () async {
+      final snapshotStore = PriceSnapshotStore(now: () => now);
+      final cooldown = VelocityAlertCooldown();
+      final notifier = _FakeNotifier();
+      final runner = VelocityAlertRunner(
+        snapshotStore: snapshotStore,
+        cooldown: cooldown,
+        notifier: notifier,
+        copyBuilder: _copy,
+      );
+
+      // Default config when nothing is persisted.
+      final initial = await runner.loadConfig();
+      expect(initial.fuelType, FuelType.e10);
+      expect(initial.minDropCents, 3);
+      expect(initial.minStations, 2);
+      expect(initial.radiusKm, 15);
+      expect(initial.cooldownHours, 6);
+
+      // Save a custom config (e.g. diesel / 5 ct / 3 stations).
+      const custom = VelocityAlertConfig(
+        fuelType: FuelType.diesel,
+        minDropCents: 5,
+        minStations: 3,
+        radiusKm: 20,
+        cooldownHours: 12,
+      );
+      await runner.saveConfig(custom);
+
+      final reloaded = await runner.loadConfig();
+      expect(reloaded.fuelType, FuelType.diesel);
+      expect(reloaded.minDropCents, 5);
+      expect(reloaded.minStations, 3);
+      expect(reloaded.radiusKm, 20);
+      expect(reloaded.cooldownHours, 12);
+    });
+  });
+}

--- a/test/features/alerts/domain/velocity_alert_detector_test.dart
+++ b/test/features/alerts/domain/velocity_alert_detector_test.dart
@@ -1,0 +1,248 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/alerts/data/models/price_snapshot.dart';
+import 'package:tankstellen/features/alerts/domain/entities/velocity_alert_config.dart';
+import 'package:tankstellen/features/alerts/domain/velocity_alert_detector.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Snapshot-based velocity detector (#579). Pure function. Input:
+/// current nearby station observations + previous [PriceSnapshot]s
+/// older than the lookback. Output: a [VelocityAlertEvent] when
+/// enough nearby stations dropped by ≥ [minDropCents] on the
+/// configured fuel type.
+void main() {
+  // User is in the middle of three stations roughly 2 km apart.
+  const userLat = 43.5;
+  const userLng = 3.5;
+  final now = DateTime.utc(2026, 4, 22, 12);
+  final hourPlusAgo =
+      now.subtract(const Duration(hours: 1, minutes: 5));
+
+  // Handy nearby coords — same lat as the user, varied lng so each
+  // station lies a few kilometres away (≈8 km per 0.1°).
+  const nearbyStations = <String, List<double>>{
+    's1': [userLat, 3.52],
+    's2': [userLat, 3.48],
+    's3': [userLat, 3.54],
+  };
+
+  PriceSnapshot previousSnap({
+    required String stationId,
+    required double price,
+    String fuel = 'e10',
+    DateTime? at,
+  }) {
+    final coords = nearbyStations[stationId] ?? [userLat, userLng];
+    return PriceSnapshot(
+      stationId: stationId,
+      fuelType: fuel,
+      price: price,
+      timestamp: at ?? hourPlusAgo,
+      lat: coords[0],
+      lng: coords[1],
+    );
+  }
+
+  VelocityStationObservation observation({
+    required String stationId,
+    required double price,
+    List<double>? coords,
+  }) {
+    final c = coords ?? nearbyStations[stationId] ?? [userLat, userLng];
+    return VelocityStationObservation(
+      stationId: stationId,
+      price: price,
+      lat: c[0],
+      lng: c[1],
+    );
+  }
+
+  group('VelocityAlertDetector (#579)', () {
+    test('fires when 3 stations drop 4 ct each within radius', () {
+      const config = VelocityAlertConfig(fuelType: FuelType.e10);
+      final previous = [
+        previousSnap(stationId: 's1', price: 1.900),
+        previousSnap(stationId: 's2', price: 1.900),
+        previousSnap(stationId: 's3', price: 1.900),
+      ];
+      final observations = [
+        observation(stationId: 's1', price: 1.860), // -4 ct
+        observation(stationId: 's2', price: 1.860), // -4 ct
+        observation(stationId: 's3', price: 1.860), // -4 ct
+      ];
+
+      final event = VelocityAlertDetector.detect(
+        config: config,
+        observations: observations,
+        previousSnapshots: previous,
+        now: now,
+        userLat: userLat,
+        userLng: userLng,
+      );
+
+      expect(event, isNotNull);
+      expect(event!.stationCount, 3);
+      expect(event.maxDropCents, closeTo(4, 0.01));
+      expect(event.fuelType, FuelType.e10);
+      expect(event.affectedStationIds, containsAll(['s1', 's2', 's3']));
+    });
+
+    test('returns null when fewer than minStations qualify', () {
+      // Default minStations is 2 → only 1 station drops → null.
+      const config = VelocityAlertConfig(fuelType: FuelType.e10);
+      final previous = [
+        previousSnap(stationId: 's1', price: 1.900),
+        previousSnap(stationId: 's2', price: 1.850),
+        previousSnap(stationId: 's3', price: 1.850),
+      ];
+      final observations = [
+        observation(stationId: 's1', price: 1.850), // -5 ct ✓
+        observation(stationId: 's2', price: 1.850), // 0 ✗
+        observation(stationId: 's3', price: 1.850), // 0 ✗
+      ];
+
+      final event = VelocityAlertDetector.detect(
+        config: config,
+        observations: observations,
+        previousSnapshots: previous,
+        now: now,
+        userLat: userLat,
+        userLng: userLng,
+      );
+
+      expect(event, isNull);
+    });
+
+    test('mixed drops count only those above the threshold', () {
+      const config = VelocityAlertConfig(fuelType: FuelType.e10);
+      final previous = [
+        previousSnap(stationId: 's1', price: 1.900),
+        previousSnap(stationId: 's2', price: 1.900),
+        previousSnap(stationId: 's3', price: 1.900),
+      ];
+      final observations = [
+        observation(stationId: 's1', price: 1.860), // -4 ct ✓
+        observation(stationId: 's2', price: 1.860), // -4 ct ✓
+        observation(stationId: 's3', price: 1.890), // -1 ct (below min=3)
+      ];
+
+      final event = VelocityAlertDetector.detect(
+        config: config,
+        observations: observations,
+        previousSnapshots: previous,
+        now: now,
+        userLat: userLat,
+        userLng: userLng,
+      );
+
+      expect(event, isNotNull);
+      expect(event!.stationCount, 2);
+      expect(event.maxDropCents, closeTo(4, 0.01));
+      expect(event.affectedStationIds, containsAll(['s1', 's2']));
+      expect(event.affectedStationIds, isNot(contains('s3')));
+    });
+
+    test('stations outside radiusKm are excluded', () {
+      // Tight 2 km radius — s1 is ≈1.6 km away, s_far ≈111 km away
+      // (+1° latitude). If the filter weren't applied both drops
+      // would qualify and an event would fire.
+      const config =
+          VelocityAlertConfig(fuelType: FuelType.e10, radiusKm: 2);
+      final farCoords = [userLat + 1, userLng];
+      final previous = [
+        previousSnap(stationId: 's1', price: 1.900),
+        PriceSnapshot(
+          stationId: 's_far',
+          fuelType: 'e10',
+          price: 1.900,
+          timestamp: hourPlusAgo,
+          lat: farCoords[0],
+          lng: farCoords[1],
+        ),
+      ];
+      final observations = [
+        observation(stationId: 's1', price: 1.860), // -4 ct ✓
+        observation(
+          stationId: 's_far',
+          price: 1.860,
+          coords: farCoords,
+        ), // -4 ct, but filtered out
+      ];
+
+      final event = VelocityAlertDetector.detect(
+        config: config,
+        observations: observations,
+        previousSnapshots: previous,
+        now: now,
+        userLat: userLat,
+        userLng: userLng,
+      );
+      // Only s1 qualifies after the radius filter → below
+      // minStations=2 → null.
+      expect(event, isNull);
+
+      // Sanity-check: widen the radius → both qualify → event fires.
+      final wide = VelocityAlertDetector.detect(
+        config: const VelocityAlertConfig(
+            fuelType: FuelType.e10, radiusKm: 200),
+        observations: observations,
+        previousSnapshots: previous,
+        now: now,
+        userLat: userLat,
+        userLng: userLng,
+      );
+      expect(wide, isNotNull);
+      expect(wide!.stationCount, 2);
+    });
+
+    test('stations with no previous snapshot are excluded', () {
+      const config = VelocityAlertConfig(fuelType: FuelType.e10);
+      final previous = [
+        previousSnap(stationId: 's1', price: 1.900),
+        // No previous snapshot for s2 — first time we see it.
+      ];
+      final observations = [
+        observation(stationId: 's1', price: 1.860), // -4 ct ✓
+        observation(stationId: 's2', price: 1.860), // no baseline → skip
+      ];
+
+      final event = VelocityAlertDetector.detect(
+        config: config,
+        observations: observations,
+        previousSnapshots: previous,
+        now: now,
+        userLat: userLat,
+        userLng: userLng,
+      );
+
+      // Only s1 qualifies → below minStations=2 → null.
+      expect(event, isNull);
+    });
+
+    test('only the configured fuelType participates in drops', () {
+      const config = VelocityAlertConfig(fuelType: FuelType.e10);
+      final previous = [
+        previousSnap(stationId: 's1', price: 1.900, fuel: 'e10'),
+        previousSnap(stationId: 's2', price: 1.900, fuel: 'diesel'),
+        previousSnap(stationId: 's3', price: 1.900, fuel: 'diesel'),
+      ];
+      final observations = [
+        observation(stationId: 's1', price: 1.860), // e10 -4 ct ✓
+        observation(stationId: 's2', price: 1.860),
+        observation(stationId: 's3', price: 1.860),
+        // Detector only compares against e10 baselines, so s2/s3 have
+        // no baseline and drop out. Result: only s1 qualifies.
+      ];
+
+      final event = VelocityAlertDetector.detect(
+        config: config,
+        observations: observations,
+        previousSnapshots: previous,
+        now: now,
+        userLat: userLat,
+        userLng: userLng,
+      );
+
+      expect(event, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Detect rapid fuel-price drops across multiple nearby stations and
fire a single local notification per fuel type per cooldown window
(#579). The background refresh cycle now snapshots every fetched
station, a pure detector diffs current prices against
snapshots older than 1 h, and a new runner owns snapshot +
cooldown + notification.

## Why

Per-station threshold alerts only fire when the user has
explicitly watchlisted a station. This ships a second lens — "E10
dropped 5 ¢ in the last hour at 3 stations near you" — that helps
the user pay less AT the pump even when they haven't pre-picked
which pump to watch.

## What's in this PR

- `PriceSnapshot` (freezed entity) + `PriceSnapshotStore` — Hive
  box `price_snapshots`, auto-prunes to a 6 h retention window on
  every write
- `VelocityAlertConfig` (freezed) — fuel / min drop / min stations
  / radius / cooldown hours; persisted as a JSON blob under
  settings with defaults (E10, 3 ct, 2 stations, 15 km, 6 h)
- `VelocityAlertDetector` — pure function, no storage, no side
  effects; filters by radius, diffs against the most-recent
  pre-lookback snapshot per station
- `VelocityAlertCooldown` — per-fuel last-fired timestamp under
  the existing `settings` box
- `VelocityAlertRunner` — glue that records snapshots, invokes
  the detector, checks the cooldown, builds copy, and fires the
  notification exactly once per fuel per cooldown
- Background hook — `_refreshPricesAndCheckAlerts` now calls the
  runner after the per-station alert loop, joining fresh prices
  with cached station coords and the user's last-known position
- ARB keys `velocityAlertTitle` + `velocityAlertBody` (en + de
  only; other locales inherit the English fallback)

## Test plan

- [x] `flutter analyze` — zero warnings/errors
- [x] `flutter test` — all 5331 tests pass
- [x] Detector unit tests (6 cases): happy, below-threshold,
  mixed, radius filter, no-prior-snapshot, fuel-type filter
- [x] Snapshot store tests: round-trip + 6 h auto-prune
- [x] Cooldown tests: per-fuel independence + elapsed window
- [x] Runner integration test: fires once when threshold met,
  suppresses when cooldown active, config round-trips

## Follow-ups (explicitly out of scope)

- User-facing settings screen to tweak min drop / stations /
  radius / cooldown — the data layer is ready, the screen lands
  in a separate PR.

Closes #579