### PR TITLE
chore(l10n): ARB-fragment pattern for parallel workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ docs/guides/*
 !docs/guides/NEW_COUNTRY.md
 !docs/guides/DEV-GIT-WORKTREES.md
 !docs/guides/AUTONOMOUS-LOOP-PROTOCOL.md
+!docs/guides/ARB_FRAGMENTS.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/ARB_FRAGMENTS.md
+++ b/docs/guides/ARB_FRAGMENTS.md
@@ -1,0 +1,112 @@
+# ARB-Fragment Build Pattern
+
+## One-line summary
+
+New localization keys go into **per-feature fragment files** under
+`lib/l10n/_fragments/`, not directly into `lib/l10n/app_en.arb` /
+`lib/l10n/app_de.arb`. A tiny build script merges the fragments back
+into the canonical ARB files that Flutter's `gen-l10n` consumes.
+
+## Why
+
+Every parallel-worker session ends in ARB merge conflicts: two workers
+each append five keys at the end of `app_en.arb`, and the rebase is
+unavoidable. In the 2026-04-22 `/tankstellenfix` run this cost about
+six rebase cycles (roughly an hour of wall-clock).
+
+Fragment files are per-feature — two workers touching different features
+cannot collide. The merged `app_en.arb` / `app_de.arb` are regenerated
+mechanically, so the "conflict" is shifted to a deterministic script
+that never produces an ambiguous diff.
+
+## Files
+
+Under `lib/l10n/_fragments/`:
+
+- `_base_en.arb` / `_base_de.arb` — the ARB header (`@@locale`, etc.)
+  plus every key that has not yet been extracted into a feature fragment.
+  All existing keys start their life here and migrate out opportunistically.
+- `<feature>_en.arb` / `<feature>_de.arb` — one pair per feature
+  (e.g. `vehicle_en.arb`, `vehicle_de.arb`). Each fragment contains only
+  that feature's keys.
+
+Under `lib/l10n/`:
+
+- `app_en.arb` / `app_de.arb` — **GENERATED**. The merged output of the
+  fragments. Flutter's `gen-l10n` reads these. **Humans must not edit
+  them directly** — edit the fragments.
+
+## How to add a new localization key (as a worker)
+
+1. Pick (or create) a fragment for the feature you're working on.
+
+   - Existing fragment: `lib/l10n/_fragments/vehicle_en.arb` +
+     `lib/l10n/_fragments/vehicle_de.arb`.
+   - New feature: create both files at once. Start with a minimal
+     two-line JSON object:
+
+     ```json
+     {
+       "myNewKey": "English value"
+     }
+     ```
+
+     Both the `_en` and the `_de` file MUST define the same set of keys.
+     The consistency test fails if one locale is missing a key that
+     exists in the other.
+
+2. Add your key + German translation to both fragments.
+
+3. Regenerate the merged ARBs:
+
+   ```bash
+   dart run tool/build_arb.dart
+   flutter gen-l10n
+   ```
+
+4. Use the new key in code via `AppLocalizations.of(context)!.myNewKey`,
+   exactly as before.
+
+5. Commit the two fragment files **and** the regenerated `app_en.arb` /
+   `app_de.arb` (they must stay in sync with the fragments — the test
+   in `test/lint/arb_fragments_consistency_test.dart` enforces this).
+
+## The duplicate-key error
+
+If the same key appears in two fragments, the build script aborts:
+
+```
+ERROR: duplicate ARB key `priceWin` in both `achievements_en.arb`
+and `alerts_en.arb` — rename one.
+```
+
+Rename the newer key (e.g. `alertsPriceWin`) to disambiguate. Features
+that genuinely share a string should move the key into `_base_<locale>.arb`.
+
+## Migrating existing keys to a fragment
+
+The big bang migration (moving all ~1000 keys out of `_base_*.arb` into
+per-feature fragments) is deliberately NOT part of the initial rollout —
+too large to review, too disruptive. Existing keys migrate opportunistically:
+
+- When a PR already touches a key, move it (and its `@<key>` metadata
+  block if any) from `_base_<locale>.arb` to `<feature>_<locale>.arb`.
+- Do this for BOTH `en` and `de` in the same PR.
+- Re-run `dart run tool/build_arb.dart` — the regenerated `app_en.arb` /
+  `app_de.arb` should change only in the relative position of the moved
+  keys (the JSON ordering follows fragment merge order).
+
+## Validation
+
+`test/lint/arb_fragments_consistency_test.dart` enforces three rules:
+
+1. Every `<feature>_en.arb` has a matching `<feature>_de.arb` with the
+   same key set.
+2. Running `build_arb.dart` produces output byte-identical to the
+   committed `app_en.arb` / `app_de.arb` (catches hand-edits to the
+   generated files).
+3. No two fragments share a key name (redundant with the build-script
+   check, but catches fragments that were added without the script
+   being rerun).
+
+CI runs this test like any other unit test.

--- a/docs/guides/AUTONOMOUS-LOOP-PROTOCOL.md
+++ b/docs/guides/AUTONOMOUS-LOOP-PROTOCOL.md
@@ -70,9 +70,9 @@ Non-negotiable, inlined here so workers don't need to chase down `feedback_agent
 
 - `flutter analyze` (STRICT — NO `--no-fatal-infos`; CI fails on `prefer_const_constructors` per `feedback_analyze_stricter_in_ci.md`).
 - `dart run build_runner build --delete-conflicting-outputs` if any freezed/riverpod model changed.
-- `flutter gen-l10n` if any ARB file changed.
+- **New ARB keys → feature fragments**: add your keys to `lib/l10n/_fragments/<feature>_en.arb` + `lib/l10n/_fragments/<feature>_de.arb` (NOT directly to `app_en.arb` / `app_de.arb` — those are generated). Then `dart run tool/build_arb.dart` and `flutter gen-l10n`. See `docs/guides/ARB_FRAGMENTS.md`.
 - `flutter test` — full suite, not just the new test file.
-- Every new ARB key: present in `app_en.arb` AND `app_de.arb` (the `test/l10n/localization_completeness_test.dart` gate fails CI on a missing German translation).
+- Every new ARB key: present in BOTH the `_en` and the `_de` fragment (the `test/lint/arb_fragments_consistency_test.dart` + `test/l10n/localization_completeness_test.dart` gates fail CI on a missing German translation).
 - `flutter analyze` again after generation — generated code occasionally reintroduces lints.
 
 ## Coordinator-workers model
@@ -124,7 +124,7 @@ Issues that touch shared state and MUST be serialized (only one at a time, no co
 - **#575** Slovenia country API (new file under `lib/core/services/impl/`)
 - **#573** UK upgrade to GOV.UK (modifies existing `uk_station_service.dart` only)
 
-All three touch country-service files plus ARB keys. Coordinator handles ARB merge centrally: each worker appends its keys to a dedicated block in `app_en.arb` + `app_de.arb`, coordinator resolves on merge.
+All three touch country-service files plus ARB keys. Since the ARB-fragment pattern landed, each worker writes keys to its own `lib/l10n/_fragments/<feature>_<locale>.arb` pair — no coordinator-side merge conflict on the ARB files. See `docs/guides/ARB_FRAGMENTS.md`.
 
 ## When to stop
 

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -1237,10 +1237,5 @@
   "alertsRadiusDeleteConfirm": "Umkreis-Alarm löschen?",
   "obd2ConnectedTooltip": "OBD2 verbunden: {adapterName}",
   "velocityAlertTitle": "{fuelLabel} an Tankstellen in der Nähe gefallen",
-  "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen",
-  "vinLabel": "FIN (optional)",
-  "vinDecodeTooltip": "FIN entschlüsseln",
-  "vinConfirmAction": "Ja, automatisch ausfüllen",
-  "vinModifyAction": "Manuell anpassen",
-  "veResetAction": "Kalibrierung zurücksetzen"
+  "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen"
 }

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -1448,13 +1448,5 @@
         "example": "5"
       }
     }
-  },
-  "vinLabel": "VIN (optional)",
-  "vinDecodeTooltip": "Decode VIN",
-  "vinConfirmAction": "Yes, auto-fill",
-  "vinModifyAction": "Modify manually",
-  "veResetAction": "Reset calibration",
-  "@veResetAction": {
-    "description": "Action on the vehicle edit screen that discards the learned volumetric-efficiency calibration (#815)."
   }
 }

--- a/lib/l10n/_fragments/vehicle_de.arb
+++ b/lib/l10n/_fragments/vehicle_de.arb
@@ -1,0 +1,7 @@
+{
+  "vinLabel": "FIN (optional)",
+  "vinDecodeTooltip": "FIN entschlüsseln",
+  "vinConfirmAction": "Ja, automatisch ausfüllen",
+  "vinModifyAction": "Manuell anpassen",
+  "veResetAction": "Kalibrierung zurücksetzen"
+}

--- a/lib/l10n/_fragments/vehicle_en.arb
+++ b/lib/l10n/_fragments/vehicle_en.arb
@@ -1,0 +1,10 @@
+{
+  "vinLabel": "VIN (optional)",
+  "vinDecodeTooltip": "Decode VIN",
+  "vinConfirmAction": "Yes, auto-fill",
+  "vinModifyAction": "Modify manually",
+  "veResetAction": "Reset calibration",
+  "@veResetAction": {
+    "description": "Action on the vehicle edit screen that discards the learned volumetric-efficiency calibration (#815)."
+  }
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5701,18 +5701,6 @@ abstract class AppLocalizations {
   /// **'CNE Bencina en Linea'**
   String get chileApiProvider;
 
-  /// No description provided for @vinLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'VIN (optional)'**
-  String get vinLabel;
-
-  /// No description provided for @vinDecodeTooltip.
-  ///
-  /// In en, this message translates to:
-  /// **'Decode VIN'**
-  String get vinDecodeTooltip;
-
   /// No description provided for @vinConfirmTitle.
   ///
   /// In en, this message translates to:
@@ -5731,18 +5719,6 @@ abstract class AppLocalizations {
     String cylinders,
     String fuel,
   );
-
-  /// No description provided for @vinConfirmAction.
-  ///
-  /// In en, this message translates to:
-  /// **'Yes, auto-fill'**
-  String get vinConfirmAction;
-
-  /// No description provided for @vinModifyAction.
-  ///
-  /// In en, this message translates to:
-  /// **'Modify manually'**
-  String get vinModifyAction;
 
   /// No description provided for @vinPartialInfoNote.
   ///
@@ -5785,12 +5761,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Consumption calibration updated for {vehicleName} — accuracy improved by {percent}%'**
   String veCalibratedTitle(String vehicleName, String percent);
-
-  /// Action on the vehicle edit screen that discards the learned volumetric-efficiency calibration (#815).
-  ///
-  /// In en, this message translates to:
-  /// **'Reset calibration'**
-  String get veResetAction;
 
   /// Title of the confirm dialog shown before discarding the learned volumetric efficiency (#815).
   ///
@@ -5905,6 +5875,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{stationCount} stations dropped by up to {maxDropCents}¢ in the last hour'**
   String velocityAlertBody(int stationCount, int maxDropCents);
+
+  /// No description provided for @vinLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'VIN (optional)'**
+  String get vinLabel;
+
+  /// No description provided for @vinDecodeTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Decode VIN'**
+  String get vinDecodeTooltip;
+
+  /// No description provided for @vinConfirmAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Yes, auto-fill'**
+  String get vinConfirmAction;
+
+  /// No description provided for @vinModifyAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Modify manually'**
+  String get vinModifyAction;
+
+  /// Action on the vehicle edit screen that discards the learned volumetric-efficiency calibration (#815).
+  ///
+  /// In en, this message translates to:
+  /// **'Reset calibration'**
+  String get veResetAction;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3026,12 +3026,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3045,12 +3039,6 @@ class AppLocalizationsBg extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3075,9 +3063,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3142,4 +3127,19 @@ class AppLocalizationsBg extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3026,12 +3026,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3045,12 +3039,6 @@ class AppLocalizationsCs extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3075,9 +3063,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3142,4 +3127,19 @@ class AppLocalizationsCs extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3024,12 +3024,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3043,12 +3037,6 @@ class AppLocalizationsDa extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3073,9 +3061,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3140,4 +3125,19 @@ class AppLocalizationsDa extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3048,12 +3048,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'FIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'FIN entschlüsseln';
-
-  @override
   String get vinConfirmTitle => 'Ist das Ihr Auto?';
 
   @override
@@ -3067,12 +3061,6 @@ class AppLocalizationsDe extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-Zyl., $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Ja, automatisch ausfüllen';
-
-  @override
-  String get vinModifyAction => 'Manuell anpassen';
 
   @override
   String get vinPartialInfoNote =>
@@ -3098,9 +3086,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Verbrauchsberechnung für $vehicleName kalibriert — Genauigkeit verbessert um $percent%';
   }
-
-  @override
-  String get veResetAction => 'Kalibrierung zurücksetzen';
 
   @override
   String get veResetConfirmTitle => 'Kalibrierung zurücksetzen?';
@@ -3165,4 +3150,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount Tankstellen um bis zu $maxDropCents¢ in der letzten Stunde gefallen';
   }
+
+  @override
+  String get vinLabel => 'FIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'FIN entschlüsseln';
+
+  @override
+  String get vinConfirmAction => 'Ja, automatisch ausfüllen';
+
+  @override
+  String get vinModifyAction => 'Manuell anpassen';
+
+  @override
+  String get veResetAction => 'Kalibrierung zurücksetzen';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3028,12 +3028,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3047,12 +3041,6 @@ class AppLocalizationsEl extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3077,9 +3065,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3144,4 +3129,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3019,12 +3019,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3038,12 +3032,6 @@ class AppLocalizationsEn extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3068,9 +3056,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3135,4 +3120,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3027,12 +3027,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3046,12 +3040,6 @@ class AppLocalizationsEs extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3076,9 +3064,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3143,4 +3128,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3021,12 +3021,6 @@ class AppLocalizationsEt extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3040,12 +3034,6 @@ class AppLocalizationsEt extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3070,9 +3058,6 @@ class AppLocalizationsEt extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3137,4 +3122,19 @@ class AppLocalizationsEt extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3024,12 +3024,6 @@ class AppLocalizationsFi extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3043,12 +3037,6 @@ class AppLocalizationsFi extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3073,9 +3061,6 @@ class AppLocalizationsFi extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3140,4 +3125,19 @@ class AppLocalizationsFi extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3048,12 +3048,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3067,12 +3061,6 @@ class AppLocalizationsFr extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3097,9 +3085,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3164,4 +3149,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3023,12 +3023,6 @@ class AppLocalizationsHr extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3042,12 +3036,6 @@ class AppLocalizationsHr extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3072,9 +3060,6 @@ class AppLocalizationsHr extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3139,4 +3124,19 @@ class AppLocalizationsHr extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3028,12 +3028,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3047,12 +3041,6 @@ class AppLocalizationsHu extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3077,9 +3065,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3144,4 +3129,19 @@ class AppLocalizationsHu extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3027,12 +3027,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3046,12 +3040,6 @@ class AppLocalizationsIt extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3076,9 +3064,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3143,4 +3128,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3025,12 +3025,6 @@ class AppLocalizationsLt extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3044,12 +3038,6 @@ class AppLocalizationsLt extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3074,9 +3062,6 @@ class AppLocalizationsLt extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3141,4 +3126,19 @@ class AppLocalizationsLt extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3027,12 +3027,6 @@ class AppLocalizationsLv extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3046,12 +3040,6 @@ class AppLocalizationsLv extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3076,9 +3064,6 @@ class AppLocalizationsLv extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3143,4 +3128,19 @@ class AppLocalizationsLv extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3023,12 +3023,6 @@ class AppLocalizationsNb extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3042,12 +3036,6 @@ class AppLocalizationsNb extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3072,9 +3060,6 @@ class AppLocalizationsNb extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3139,4 +3124,19 @@ class AppLocalizationsNb extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3028,12 +3028,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3047,12 +3041,6 @@ class AppLocalizationsNl extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3077,9 +3065,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3144,4 +3129,19 @@ class AppLocalizationsNl extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3026,12 +3026,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3045,12 +3039,6 @@ class AppLocalizationsPl extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3075,9 +3063,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3142,4 +3127,19 @@ class AppLocalizationsPl extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3027,12 +3027,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3046,12 +3040,6 @@ class AppLocalizationsPt extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3076,9 +3064,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3143,4 +3128,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3026,12 +3026,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3045,12 +3039,6 @@ class AppLocalizationsRo extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3075,9 +3063,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3142,4 +3127,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3027,12 +3027,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3046,12 +3040,6 @@ class AppLocalizationsSk extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3076,9 +3064,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3143,4 +3128,19 @@ class AppLocalizationsSk extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3021,12 +3021,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3040,12 +3034,6 @@ class AppLocalizationsSl extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3070,9 +3058,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3137,4 +3122,19 @@ class AppLocalizationsSl extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3025,12 +3025,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get chileApiProvider => 'CNE Bencina en Linea';
 
   @override
-  String get vinLabel => 'VIN (optional)';
-
-  @override
-  String get vinDecodeTooltip => 'Decode VIN';
-
-  @override
   String get vinConfirmTitle => 'Is this your car?';
 
   @override
@@ -3044,12 +3038,6 @@ class AppLocalizationsSv extends AppLocalizations {
   ) {
     return '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
   }
-
-  @override
-  String get vinConfirmAction => 'Yes, auto-fill';
-
-  @override
-  String get vinModifyAction => 'Modify manually';
 
   @override
   String get vinPartialInfoNote =>
@@ -3074,9 +3062,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String veCalibratedTitle(String vehicleName, String percent) {
     return 'Consumption calibration updated for $vehicleName — accuracy improved by $percent%';
   }
-
-  @override
-  String get veResetAction => 'Reset calibration';
 
   @override
   String get veResetConfirmTitle => 'Reset calibration?';
@@ -3141,4 +3126,19 @@ class AppLocalizationsSv extends AppLocalizations {
   String velocityAlertBody(int stationCount, int maxDropCents) {
     return '$stationCount stations dropped by up to $maxDropCents¢ in the last hour';
   }
+
+  @override
+  String get vinLabel => 'VIN (optional)';
+
+  @override
+  String get vinDecodeTooltip => 'Decode VIN';
+
+  @override
+  String get vinConfirmAction => 'Yes, auto-fill';
+
+  @override
+  String get vinModifyAction => 'Modify manually';
+
+  @override
+  String get veResetAction => 'Reset calibration';
 }

--- a/test/lint/arb_fragments_consistency_test.dart
+++ b/test/lint/arb_fragments_consistency_test.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Enforces the ARB-fragment build pattern (see `docs/guides/ARB_FRAGMENTS.md`).
+///
+/// Three invariants:
+///   1. Every `<feature>_en.arb` has a matching `<feature>_de.arb` with the
+///      same set of keys. Catches "worker added an English key and forgot
+///      the German translation" early.
+///   2. No two fragments for the same locale share a key name. This is the
+///      whole point of the pattern — if fragments collide, `build_arb.dart`
+///      produces undefined output.
+///   3. Running `dart run tool/build_arb.dart` would produce output
+///      byte-identical to the committed `lib/l10n/app_en.arb` /
+///      `lib/l10n/app_de.arb`. Catches "someone hand-edited the generated
+///      file and forgot to rerun the script".
+void main() {
+  const fragmentsDir = 'lib/l10n/_fragments';
+  const l10nDir = 'lib/l10n';
+  const locales = <String>['en', 'de'];
+
+  group('ARB fragments consistency', () {
+    test('each feature fragment has matching en/de files with same keys', () {
+      final dir = Directory(fragmentsDir);
+      expect(
+        dir.existsSync(),
+        isTrue,
+        reason: 'Fragments directory missing: $fragmentsDir',
+      );
+
+      final byFeature = <String, Map<String, File>>{};
+      for (final entity in dir.listSync()) {
+        if (entity is! File || !entity.path.endsWith('.arb')) continue;
+        final name = entity.uri.pathSegments.last;
+        // `_base_en.arb` / `_base_de.arb` — skip (legacy keys, not a feature).
+        if (name.startsWith('_base_')) continue;
+        final match = RegExp(r'^(.+)_([a-z]{2})\.arb$').firstMatch(name);
+        if (match == null) {
+          fail(
+            'Fragment file `$name` does not follow `<feature>_<locale>.arb` naming.',
+          );
+        }
+        final feature = match.group(1)!;
+        final locale = match.group(2)!;
+        byFeature.putIfAbsent(feature, () => <String, File>{})[locale] =
+            entity;
+      }
+
+      for (final entry in byFeature.entries) {
+        final feature = entry.key;
+        final files = entry.value;
+        for (final locale in locales) {
+          expect(
+            files.containsKey(locale),
+            isTrue,
+            reason:
+                'Feature `$feature` is missing `${feature}_$locale.arb` — '
+                'every fragment must have both en and de variants.',
+          );
+        }
+        // Metadata entries (`@key`, `@@locale`) are structural and
+        // English-only — German/other locales do not redeclare them.
+        // Parity is checked on real user-facing keys only.
+        final enKeys = _realKeys(_loadKeys(files['en']!));
+        final deKeys = _realKeys(_loadKeys(files['de']!));
+        expect(
+          deKeys.toSet(),
+          equals(enKeys.toSet()),
+          reason:
+              'Fragment `$feature` has diverging keys between en and de. '
+              'Add the missing translation or remove the stray key.',
+        );
+      }
+    });
+
+    test('no two fragments share a key name (same locale)', () {
+      for (final locale in locales) {
+        final seen = <String, String>{};
+        for (final entity in Directory(fragmentsDir).listSync()) {
+          if (entity is! File) continue;
+          final name = entity.uri.pathSegments.last;
+          if (!name.endsWith('_$locale.arb')) continue;
+          // The base fragment is intentionally the fallback bucket for
+          // not-yet-migrated keys; it always appears first and its keys are
+          // allowed to be "owned" by it. We still need to detect duplicates
+          // BETWEEN non-base fragments (and between a non-base and base).
+          final keys = _loadKeys(entity);
+          // Strip ARB metadata entries — only real keys and @key blocks
+          // can collide; @@locale-style are allowed to repeat trivially.
+          final real = keys.where((k) => !k.startsWith('@@'));
+          for (final key in real) {
+            final prior = seen[key];
+            if (prior != null) {
+              fail(
+                'Duplicate ARB key `$key` in both `$prior` and `$name` '
+                '(locale `$locale`). Rename one.',
+              );
+            }
+            seen[key] = name;
+          }
+        }
+      }
+    });
+
+    test('committed app_<locale>.arb matches a fresh fragment rebuild', () {
+      // We reimplement the merge here (rather than shelling out to the Dart
+      // build script) so the test runs under `flutter test` without needing
+      // a separate `dart` invocation. The logic MUST mirror
+      // `tool/build_arb.dart` — if you change the build script, update here.
+      for (final locale in locales) {
+        final committed = File('$l10nDir/app_$locale.arb').readAsStringSync();
+        final rebuilt = _rebuild(locale, fragmentsDir);
+        expect(
+          rebuilt,
+          equals(committed),
+          reason:
+              'app_$locale.arb is out of sync with the fragments. '
+              'Run `dart run tool/build_arb.dart` and commit the result.',
+        );
+      }
+    });
+  });
+}
+
+Iterable<String> _loadKeys(File file) {
+  final raw = file.readAsStringSync();
+  final parsed = jsonDecode(raw) as Map<String, dynamic>;
+  return parsed.keys;
+}
+
+/// Filters out ARB metadata entries (`@key`, `@@locale`). Only real
+/// user-facing keys are compared across locales — metadata is allowed
+/// to exist only in the English template.
+Iterable<String> _realKeys(Iterable<String> keys) =>
+    keys.where((k) => !k.startsWith('@'));
+
+String _rebuild(String locale, String fragmentsDir) {
+  final merged = <String, dynamic>{};
+  final keySource = <String, String>{};
+
+  void mergeFile(File file) {
+    final raw = file.readAsStringSync();
+    final parsed = jsonDecode(raw) as Map<String, dynamic>;
+    for (final entry in parsed.entries) {
+      if (merged.containsKey(entry.key)) {
+        final prior = keySource[entry.key] ?? '(unknown)';
+        fail(
+          'Duplicate ARB key `${entry.key}` in both `$prior` and '
+          '`${file.uri.pathSegments.last}` during rebuild.',
+        );
+      }
+      merged[entry.key] = entry.value;
+      keySource[entry.key] = file.uri.pathSegments.last;
+    }
+  }
+
+  final base = File('$fragmentsDir/_base_$locale.arb');
+  if (!base.existsSync()) {
+    fail('Missing base fragment: ${base.path}');
+  }
+  mergeFile(base);
+
+  final featureFragments = Directory(fragmentsDir)
+      .listSync()
+      .whereType<File>()
+      .where((f) {
+        final n = f.uri.pathSegments.last;
+        if (n.startsWith('_base_')) return false;
+        return n.endsWith('_$locale.arb');
+      })
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  for (final f in featureFragments) {
+    mergeFile(f);
+  }
+
+  const encoder = JsonEncoder.withIndent('  ');
+  return '${encoder.convert(merged)}\n';
+}

--- a/tool/build_arb.dart
+++ b/tool/build_arb.dart
@@ -1,0 +1,118 @@
+// Merges ARB fragment files into the canonical `app_<locale>.arb` templates.
+//
+// Rationale: during parallel-worker sessions, every worker appending new
+// localization keys to `lib/l10n/app_en.arb` + `lib/l10n/app_de.arb`
+// produces trivial-but-unavoidable merge conflicts at the end of the file.
+// This script lets each feature keep its keys in its own fragment file
+// (`lib/l10n/_fragments/<feature>_<locale>.arb`) — fragments never collide.
+// A short post-merge step rebuilds the canonical ARB files that Flutter's
+// gen-l10n consumes.
+//
+// Usage:
+//   dart run tool/build_arb.dart
+//   flutter gen-l10n   # consumes the merged files as before
+//
+// Rules:
+//   * `_base_<locale>.arb` provides the `@@locale`/`@@author`/`@@last_modified`
+//     header plus the canonical key ordering for everything that has not yet
+//     been extracted into a feature fragment.
+//   * `<feature>_<locale>.arb` fragments contain ONLY that feature's keys.
+//     Fragments are merged in alphabetical order by feature filename,
+//     producing a deterministic output.
+//   * If the same key appears in two fragments for the same locale, the
+//     script aborts with a clear error — rename one of the fragments'
+//     keys to resolve.
+//   * The generated `app_<locale>.arb` files are regular JSON with 2-space
+//     indentation and a trailing newline. Humans MUST NOT edit them
+//     directly — edit the fragments instead and rerun this script.
+
+import 'dart:convert';
+import 'dart:io';
+
+const List<String> _locales = <String>['en', 'de'];
+const String _l10nDir = 'lib/l10n';
+const String _fragmentsDir = 'lib/l10n/_fragments';
+
+void main(List<String> args) {
+  for (final locale in _locales) {
+    _buildLocale(locale);
+  }
+  stdout.writeln('ARB fragments merged for locales: ${_locales.join(', ')}');
+}
+
+void _buildLocale(String locale) {
+  final baseFile = File('$_fragmentsDir/_base_$locale.arb');
+  if (!baseFile.existsSync()) {
+    stderr.writeln('ERROR: missing base fragment: ${baseFile.path}');
+    exit(1);
+  }
+
+  final merged = <String, dynamic>{};
+  final keySource = <String, String>{};
+
+  // 1. Base fragment — preserves canonical header + legacy key ordering.
+  _mergeFragment(baseFile, merged, keySource);
+
+  // 2. Feature fragments — deterministic (alphabetical) order.
+  final featureFragments = _findFeatureFragments(locale);
+  for (final fragment in featureFragments) {
+    _mergeFragment(fragment, merged, keySource);
+  }
+
+  // 3. Write the merged output.
+  final outFile = File('$_l10nDir/app_$locale.arb');
+  const encoder = JsonEncoder.withIndent('  ');
+  final body = encoder.convert(merged);
+  outFile.writeAsStringSync('$body\n');
+  stdout.writeln(
+    '  wrote ${outFile.path} '
+    '(${merged.length} entries, '
+    '${featureFragments.length} feature fragment${featureFragments.length == 1 ? '' : 's'})',
+  );
+}
+
+List<File> _findFeatureFragments(String locale) {
+  final dir = Directory(_fragmentsDir);
+  final suffix = '_$locale.arb';
+  final files = dir
+      .listSync()
+      .whereType<File>()
+      .where((f) {
+        final name = f.uri.pathSegments.last;
+        // Skip the base fragment — already merged first.
+        if (name.startsWith('_base_')) return false;
+        return name.endsWith(suffix);
+      })
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  return files;
+}
+
+void _mergeFragment(
+  File file,
+  Map<String, dynamic> merged,
+  Map<String, String> keySource,
+) {
+  final raw = file.readAsStringSync();
+  final Map<String, dynamic> parsed;
+  try {
+    parsed = jsonDecode(raw) as Map<String, dynamic>;
+  } catch (e) {
+    stderr.writeln('ERROR: ${file.path} is not valid JSON: $e');
+    exit(1);
+  }
+
+  final fragmentName = file.uri.pathSegments.last;
+  for (final entry in parsed.entries) {
+    if (merged.containsKey(entry.key)) {
+      final prior = keySource[entry.key] ?? '(unknown)';
+      stderr.writeln(
+        'ERROR: duplicate ARB key `${entry.key}` in both '
+        '`$prior` and `$fragmentName` — rename one.',
+      );
+      exit(1);
+    }
+    merged[entry.key] = entry.value;
+    keySource[entry.key] = fragmentName;
+  }
+}


### PR DESCRIPTION
## Summary

- Introduces a per-feature ARB-fragment build pattern so parallel workers can add localization keys without colliding in `lib/l10n/app_en.arb` / `lib/l10n/app_de.arb`.
- Moves 5 vehicle keys (`vinLabel`, `vinDecodeTooltip`, `vinConfirmAction`, `vinModifyAction`, `veResetAction`) into `lib/l10n/_fragments/vehicle_<locale>.arb` as a working example — the remaining ~1000 keys stay in `_base_<locale>.arb` and migrate opportunistically.
- Adds `tool/build_arb.dart` (merges fragments, aborts on duplicate keys) and `test/lint/arb_fragments_consistency_test.dart` (enforces en/de parity, cross-fragment uniqueness, and byte-identical regeneration).

## Why

The 2026-04-22 `/tankstellenfix` run burned ~6 rebase cycles (roughly an hour of wall-clock) on trivial-but-unavoidable ARB conflicts — every parallel worker appended keys at the end of `app_en.arb` and the rebase was mechanical but unavoidable. With this pattern, each feature owns its fragment file and two workers touching different features cannot collide. The merged `app_<locale>.arb` is regenerated mechanically.

**This does not close any issue** — it is a coordinator-ergonomics PR. Motivated by parallel-worker ARB conflicts, no issue #.

## Scope

- `lib/l10n/_fragments/` (new): `_base_en.arb`, `_base_de.arb`, `vehicle_en.arb`, `vehicle_de.arb`.
- `lib/l10n/app_en.arb` / `app_de.arb` regenerated — sorted-key diff against master shows ZERO semantic changes. Formatting of compact placeholders is normalized by `JsonEncoder.withIndent('  ')`, which accounts for the diff bulk in those two files.
- `lib/l10n/app_localizations*.dart` auto-regenerated by `flutter gen-l10n` — the only change is the 5 vehicle getters moving from their in-place positions to the end of each file.
- `tool/build_arb.dart` (new) — merge script.
- `test/lint/arb_fragments_consistency_test.dart` (new) — validation.
- `docs/guides/ARB_FRAGMENTS.md` (new) — worker onboarding, duplicate-key resolution.
- `docs/guides/AUTONOMOUS-LOOP-PROTOCOL.md` (updated) — pre-push checklist and parallel-batch notes now point at fragments.
- `.gitignore` (updated) — exception for the new tracked guide.

## Migration scope-limit

Only 5 vehicle keys are migrated in this PR. Moving all ~1000 existing keys would be a ~1000-LOC diff impossible to review by eyeball. The value of the pattern is 100% delivered on day one: every **new** key a future worker adds goes into a fragment, not the shared file.

## Test plan

- [x] `dart run tool/build_arb.dart` is idempotent (no-op on second run).
- [x] `dart run tool/build_arb.dart` aborts on duplicate key (manually verified with a temporary collision).
- [x] `flutter gen-l10n` produces `app_localizations*.dart` without errors.
- [x] `flutter analyze` — 0 issues.
- [x] `flutter test` — all 5363 tests pass, including 3 new checks in `arb_fragments_consistency_test.dart`.
- [x] `app_en.arb` / `app_de.arb` sorted-key diff vs master: zero divergence.

## Verification: byte-identical check

The committed `app_en.arb` / `app_de.arb` differ from master in exactly two ways — both expected:

1. **The 5 vehicle keys moved to end-of-file** (they were at lines 1243, 1244, 1257, 1258, 1282 in master; now at the end since `vehicle_*.arb` is merged after `_base_*.arb`).
2. **JSON formatting is normalized** — `JsonEncoder.withIndent('  ')` expands compact `{ "type": "String" }` objects to multi-line form. No keys gained, lost, or changed value.

Semantic equivalence verified: `sorted(keys(master_en)) == sorted(keys(pr_en))`, same for `de`, every value identical.