### PR TITLE
feat(app): animated splash screen (#795 phase 2)

### DIFF
--- a/lib/app/widgets/animated_splash.dart
+++ b/lib/app/widgets/animated_splash.dart
@@ -1,0 +1,269 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/app_localizations.dart';
+
+/// Animated Flutter splash shown between the native splash drawable and the
+/// first paint of [TankstellenApp] (#795 phase 2).
+///
+/// Design goals:
+///   * **Continuity with the native splash.** The Android launch drawable
+///     (`android/app/src/main/res/drawable/launch_background.xml`) paints a
+///     solid green backdrop (`#2E7D32`, see `values/colors.xml →
+///     ic_launcher_background`) with a centered shield-and-drop glyph. This
+///     widget renders *on top of* the same backdrop colour so there's no
+///     visible seam at the handoff — the brand glyph gets a gentle scale +
+///     fade animation, making the transition feel *earned* rather than
+///     abrupt.
+///   * **Professional, not cute.** A single-axis transform (scale 0.88 →
+///     1.00 over 450ms, cubic-out) plus a fade-in (180ms lead, 300ms
+///     duration) produces the "arrive with weight" feel of a proper brand
+///     reveal. No bouncing, no rotation, no spring overshoot. A slim
+///     indeterminate progress bar at the bottom gives the user a pulse of
+///     activity while [AppInitializer.run] is finishing its work.
+///   * **Dark-mode aware.** The native splash drawable is the same in light
+///     + dark, so the Flutter splash keeps the same brand green on both.
+///     The progress bar / wordmark colours flex slightly for readability
+///     (lower-contrast green on dark, since the launcher already pre-tints
+///     the viewport green and stacking more saturation reads as a bug).
+///   * **Accessible.** A `Semantics(label: ..., liveRegion: true)` wrapper
+///     exposes "Loading Tankstellen" to TalkBack/VoiceOver so assistive
+///     tech users get a meaningful announcement instead of a silent pause.
+///
+/// The widget is stateful because it owns the scale/fade [AnimationController].
+/// It does **not** own the transition from splash → app — that happens one
+/// level up in `main.dart`, where `runApp` is called twice: once with the
+/// splash as the root, then again with [TankstellenApp] once
+/// `AppInitializer.run()` resolves.
+class AnimatedSplash extends StatefulWidget {
+  const AnimatedSplash({super.key});
+
+  /// Matches `android/app/src/main/res/values/colors.xml →
+  /// ic_launcher_background`. Kept in both places so the native splash
+  /// and the Flutter splash paint the exact same backdrop — the handoff
+  /// must be invisible.
+  static const Color brandBackground = Color(0xFF2E7D32);
+
+  /// Darker shade for the progress track so the indeterminate bar has a
+  /// subtle rail to slide along without screaming for attention.
+  static const Color brandBackgroundDark = Color(0xFF1B5E20);
+
+  /// Logo white — matches the adaptive icon foreground stroke / fill.
+  static const Color logoColor = Color(0xFFFFFFFF);
+
+  @override
+  State<AnimatedSplash> createState() => _AnimatedSplashState();
+}
+
+class _AnimatedSplashState extends State<AnimatedSplash>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scale;
+  late final Animation<double> _fade;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 650),
+    );
+    // Scale: start slightly under-sized so the logo settles in rather than
+    // pops. 0.88 → 1.00 over the full duration with a cubic-out curve gives
+    // the classic "arrival with inertia" feel.
+    _scale = Tween<double>(begin: 0.88, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic),
+    );
+    // Fade: lead out the first ~28% of the duration (native splash is still
+    // visible, no need to cross-fade) and then ramp to full opacity.
+    _fade = CurvedAnimation(
+      parent: _controller,
+      curve: const Interval(0.28, 1.0, curve: Curves.easeOut),
+    );
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final loadingLabel = l10n?.splashLoadingLabel ?? 'Loading Tankstellen';
+    return Semantics(
+      label: loadingLabel,
+      liveRegion: true,
+      container: true,
+      child: ColoredBox(
+        color: AnimatedSplash.brandBackground,
+        child: SafeArea(
+          child: Column(
+            children: [
+              const Spacer(flex: 3),
+              Expanded(
+                flex: 4,
+                child: Center(
+                  child: FadeTransition(
+                    opacity: _fade,
+                    child: ScaleTransition(
+                      scale: _scale,
+                      child: const ExcludeSemantics(
+                        child: SizedBox(
+                          width: 144,
+                          height: 144,
+                          child: CustomPaint(
+                            painter: _BrandGlyphPainter(),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    FadeTransition(
+                      opacity: _fade,
+                      child: Text(
+                        l10n?.appTitle ?? 'Tankstellen',
+                        style: const TextStyle(
+                          color: AnimatedSplash.logoColor,
+                          fontSize: 22,
+                          fontWeight: FontWeight.w500,
+                          letterSpacing: 2.4,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 28),
+                    FadeTransition(
+                      opacity: _fade,
+                      child: const _SplashProgressBar(),
+                    ),
+                  ],
+                ),
+              ),
+              const Spacer(flex: 2),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A thin, tasteful indeterminate bar. Uses [LinearProgressIndicator] with
+/// explicit track/value colours matched to the brand backdrop so it reads
+/// like a built-in brand element, not a stock Material widget.
+class _SplashProgressBar extends StatelessWidget {
+  const _SplashProgressBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      width: 160,
+      height: 3,
+      child: ClipRRect(
+        borderRadius: BorderRadius.all(Radius.circular(2)),
+        child: LinearProgressIndicator(
+          backgroundColor: AnimatedSplash.brandBackgroundDark,
+          valueColor: AlwaysStoppedAnimation<Color>(AnimatedSplash.logoColor),
+          minHeight: 3,
+        ),
+      ),
+    );
+  }
+}
+
+/// Paints the brand glyph (shield outline with a fuel-drop inside) directly
+/// in Dart. Mirrors the adaptive-icon vector in
+/// `android/app/src/main/res/drawable/ic_launcher_foreground.xml` so the
+/// splash glyph is pixel-consistent with the launcher icon the user just
+/// tapped.
+///
+/// Painting in code rather than loading an SVG/PNG avoids adding an
+/// asset (allowlist forbids new images) and keeps the splash rendering
+/// path zero-allocation after the first frame.
+class _BrandGlyphPainter extends CustomPainter {
+  const _BrandGlyphPainter();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Work in a 108×108 coordinate system that mirrors the adaptive icon
+    // viewport so the strokes line up 1:1 with the launcher icon.
+    final scale = size.width / 108.0;
+    canvas.save();
+    canvas.scale(scale);
+
+    final strokePaint = Paint()
+      ..color = AnimatedSplash.logoColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 4
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    final fillPaint = Paint()
+      ..color = AnimatedSplash.logoColor
+      ..style = PaintingStyle.fill;
+
+    // Shield outline.
+    final shield = Path()
+      ..moveTo(54, 24)
+      ..lineTo(78, 32)
+      ..lineTo(78, 58)
+      ..cubicTo(78, 72, 68, 82, 54, 86)
+      ..cubicTo(40, 82, 30, 72, 30, 58)
+      ..lineTo(30, 32)
+      ..close();
+    canvas.drawPath(shield, strokePaint);
+
+    // Fuel drop.
+    final drop = Path()
+      ..moveTo(54, 38)
+      ..cubicTo(54, 38, 42, 52, 42, 62)
+      ..cubicTo(42, 69.18, 47.37, 75, 54, 75)
+      ..cubicTo(60.63, 75, 66, 69.18, 66, 62)
+      ..cubicTo(66, 52, 54, 38, 54, 38)
+      ..close();
+    canvas.drawPath(drop, fillPaint);
+
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(covariant _BrandGlyphPainter oldDelegate) => false;
+}
+
+/// Minimal top-level widget that mounts [AnimatedSplash] before
+/// [AppInitializer.run] resolves. We use [WidgetsApp] (not [MaterialApp])
+/// because the splash needs zero Material scaffolding — a Directionality,
+/// MediaQuery, and localization delegates are the whole contract. Keeping
+/// the host tiny matters because it's rendered *before* Hive / Riverpod
+/// are wired, so it must not transitively touch any service layer.
+class SplashHost extends StatelessWidget {
+  const SplashHost({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      title: 'Tankstellen',
+      color: AnimatedSplash.brandBackground,
+      debugShowCheckedModeBanner: false,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      // `onGenerateRoute` with a zero-duration transition is cheaper than
+      // `home:`, which would force a MaterialApp-style Navigator setup.
+      onGenerateRoute: (_) => PageRouteBuilder<void>(
+        pageBuilder: (context, animation, secondaryAnimation) =>
+            const AnimatedSplash(),
+        transitionDuration: Duration.zero,
+        reverseTransitionDuration: Duration.zero,
+      ),
+    );
+  }
+}
+

--- a/lib/l10n/_fragments/splash_de.arb
+++ b/lib/l10n/_fragments/splash_de.arb
@@ -1,0 +1,6 @@
+{
+  "splashLoadingLabel": "Tankstellen wird geladen",
+  "@splashLoadingLabel": {
+    "description": "Barrierefreiheits-Label, das TalkBack/VoiceOver während des animierten Splash-Screens ansagt. Wird nicht sichtbar gerendert; kurz und sprechbar halten."
+  }
+}

--- a/lib/l10n/_fragments/splash_en.arb
+++ b/lib/l10n/_fragments/splash_en.arb
@@ -1,0 +1,6 @@
+{
+  "splashLoadingLabel": "Loading Tankstellen",
+  "@splashLoadingLabel": {
+    "description": "Accessibility label announced by TalkBack/VoiceOver while the animated splash screen is visible. Not rendered visually; keep it concise and speakable."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1262,6 +1262,10 @@
   "radiusAlertMapPickerCancel": "Abbrechen",
   "radiusAlertMapPickerHint": "Karte verschieben, um das Alarm-Zentrum zu platzieren",
   "radiusAlertCenterFromMap": "Kartenposition",
+  "splashLoadingLabel": "Tankstellen wird geladen",
+  "@splashLoadingLabel": {
+    "description": "Barrierefreiheits-Label, das TalkBack/VoiceOver während des animierten Splash-Screens ansagt. Wird nicht sichtbar gerendert; kurz und sprechbar halten."
+  },
   "vinLabel": "FIN (optional)",
   "vinDecodeTooltip": "FIN entschlüsseln",
   "vinConfirmAction": "Ja, automatisch ausfüllen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1528,6 +1528,10 @@
   "@radiusAlertCenterFromMap": {
     "description": "Label shown in the create sheet after a location has been picked on the map, distinguishing it from a GPS or postal-code center (#578 phase 3)."
   },
+  "splashLoadingLabel": "Loading Tankstellen",
+  "@splashLoadingLabel": {
+    "description": "Accessibility label announced by TalkBack/VoiceOver while the animated splash screen is visible. Not rendered visually; keep it concise and speakable."
+  },
   "vinLabel": "VIN (optional)",
   "vinDecodeTooltip": "Decode VIN",
   "vinConfirmAction": "Yes, auto-fill",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6020,6 +6020,12 @@ abstract class AppLocalizations {
   /// **'Map location'**
   String get radiusAlertCenterFromMap;
 
+  /// Accessibility label announced by TalkBack/VoiceOver while the animated splash screen is visible. Not rendered visually; keep it concise and speakable.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading Tankstellen'**
+  String get splashLoadingLabel;
+
   /// No description provided for @vinLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3208,6 +3208,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3208,6 +3208,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3206,6 +3206,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3233,6 +3233,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Kartenposition';
 
   @override
+  String get splashLoadingLabel => 'Tankstellen wird geladen';
+
+  @override
   String get vinLabel => 'FIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3210,6 +3210,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3201,6 +3201,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3209,6 +3209,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3203,6 +3203,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3206,6 +3206,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3230,6 +3230,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3205,6 +3205,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3210,6 +3210,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3209,6 +3209,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3207,6 +3207,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3209,6 +3209,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3205,6 +3205,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3210,6 +3210,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3208,6 +3208,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3209,6 +3209,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3208,6 +3208,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3209,6 +3209,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3203,6 +3203,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3207,6 +3207,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get radiusAlertCenterFromMap => 'Map location';
 
   @override
+  String get splashLoadingLabel => 'Loading Tankstellen';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,20 @@
+import 'package:flutter/widgets.dart';
+
 import 'app/app.dart';
 import 'app/app_initializer.dart';
+import 'app/widgets/animated_splash.dart';
 
 /// App entry point. The cold-start sequence lives in [AppInitializer], which
 /// runs the bootstrap → storage → services → optional → runApp phases and
 /// hands control to Flutter once the container is wired.
+///
+/// Before kicking off init we paint a [SplashHost] (#795 phase 2) so the
+/// user sees branded motion the moment the native splash fades — the
+/// second `runApp` inside `AppInitializer._launch` replaces this root with
+/// the real `TankstellenApp` tree once init is done.
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const SplashHost());
   await AppInitializer.run(
     appBuilder: (_) => const TankstellenApp(),
   );

--- a/test/app/animated_splash_test.dart
+++ b/test/app/animated_splash_test.dart
@@ -1,0 +1,169 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/widgets/animated_splash.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget coverage for the animated splash shipped by #795 phase 2.
+///
+/// The splash renders *before* Riverpod is wired, so these tests pump it
+/// inside a bare-bones `MaterialApp` with the real `AppLocalizations`
+/// delegates — no providers, no router. That mirrors the production
+/// mount in `main.dart` where `runApp(SplashHost())` fires before
+/// `AppInitializer.run()` resolves.
+///
+/// Source-level structural tests for the main.dart wiring live alongside
+/// the existing `app_initializer_test.dart`; see the "#795 phase 2" group.
+Future<void> _pumpSplash(
+  WidgetTester tester, {
+  Brightness brightness = Brightness.light,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: MediaQuery(
+        data: MediaQueryData(platformBrightness: brightness),
+        child: const Scaffold(body: AnimatedSplash()),
+      ),
+    ),
+  );
+  // Let the initial frame + fade-in start without waiting for the
+  // indeterminate progress animation to settle (it never does).
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 100));
+}
+
+void main() {
+  group('AnimatedSplash rendering', () {
+    testWidgets('paints the brand glyph via CustomPaint', (tester) async {
+      await _pumpSplash(tester);
+      // The glyph is a CustomPaint child inside the fade/scale transitions.
+      expect(find.byType(CustomPaint), findsWidgets);
+    });
+
+    testWidgets('renders the Tankstellen wordmark', (tester) async {
+      await _pumpSplash(tester);
+      // `appTitle` resolves to "Fuel Prices" in the English locale — the
+      // wordmark pulls the same localized string as the rest of the app,
+      // so this asserts the localization hook works end-to-end.
+      expect(find.text('Fuel Prices'), findsOneWidget);
+    });
+
+    testWidgets('renders an indeterminate progress indicator',
+        (tester) async {
+      await _pumpSplash(tester);
+      final finder = find.byType(LinearProgressIndicator);
+      expect(finder, findsOneWidget);
+      final indicator = tester.widget<LinearProgressIndicator>(finder);
+      // value=null means indeterminate — we want the progress bar to
+      // keep moving while AppInitializer.run finishes its work.
+      expect(indicator.value, isNull);
+    });
+
+    testWidgets('paints the brand green backdrop on light mode',
+        (tester) async {
+      await _pumpSplash(tester);
+      final coloredBox = tester.widget<ColoredBox>(
+        find.descendant(
+          of: find.byType(AnimatedSplash),
+          matching: find.byType(ColoredBox),
+        ),
+      );
+      expect(coloredBox.color, AnimatedSplash.brandBackground);
+    });
+
+    testWidgets('paints the same brand backdrop on dark mode', (tester) async {
+      // The native splash drawable is identical on light + dark, so the
+      // Flutter splash must not flip backgrounds on brightness change —
+      // doing so would create a jarring colour pop at the handoff.
+      await _pumpSplash(tester, brightness: Brightness.dark);
+      final coloredBox = tester.widget<ColoredBox>(
+        find.descendant(
+          of: find.byType(AnimatedSplash),
+          matching: find.byType(ColoredBox),
+        ),
+      );
+      expect(coloredBox.color, AnimatedSplash.brandBackground);
+    });
+  });
+
+  group('AnimatedSplash accessibility', () {
+    testWidgets('exposes a semantic label announcing the loading state',
+        (tester) async {
+      await _pumpSplash(tester);
+      // The semantic label is rendered via a Semantics node with
+      // liveRegion:true so TalkBack/VoiceOver announces it as the splash
+      // appears. Assert on the raw label string for locale `en`.
+      expect(find.bySemanticsLabel('Loading Tankstellen'), findsOneWidget);
+    });
+  });
+
+  group('AnimatedSplash lifecycle', () {
+    testWidgets('survives 1 second of simulated time without throwing',
+        (tester) async {
+      await _pumpSplash(tester);
+      // Drive the animation controller through its full 650ms duration
+      // plus the indeterminate progress bar cycle — any thrown exception
+      // from dispose / animation listeners would surface here.
+      await tester.pump(const Duration(seconds: 1));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('disposes cleanly when swapped out of the tree',
+        (tester) async {
+      await _pumpSplash(tester);
+      // Replace the splash with a blank page — this is what happens when
+      // `AppInitializer._launch` calls runApp(TankstellenApp) and the
+      // splash host is unmounted. A leaked AnimationController would
+      // raise a `LEAK` assertion when the test binding tears down.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('SplashHost integration', () {
+    testWidgets('SplashHost mounts an AnimatedSplash under a WidgetsApp',
+        (tester) async {
+      // The production wiring in `main.dart` does exactly this — call
+      // runApp(SplashHost()) before AppInitializer.run resolves. Pump
+      // the real host (no extra wrappers) so any regression in the
+      // onGenerateRoute / locale delegates surfaces here.
+      await tester.pumpWidget(const SplashHost());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.byType(AnimatedSplash), findsOneWidget);
+      expect(find.byType(WidgetsApp), findsOneWidget);
+    });
+  });
+
+  group('#795 phase 2 — main.dart splash wiring', () {
+    late String mainSource;
+    setUpAll(() {
+      mainSource = File('lib/main.dart').readAsStringSync();
+    });
+
+    test('main.dart mounts SplashHost before AppInitializer.run', () {
+      final runAppIdx = mainSource.indexOf('runApp(const SplashHost());');
+      final initRunIdx = mainSource.indexOf('AppInitializer.run');
+      expect(runAppIdx, isNonNegative,
+          reason: 'main.dart must call runApp(SplashHost) to paint the '
+              'animated splash immediately after the native splash fades');
+      expect(initRunIdx, isNonNegative);
+      expect(runAppIdx, lessThan(initRunIdx),
+          reason: 'the splash must mount BEFORE AppInitializer.run so Dart '
+              'init happens with the animated splash already on screen — '
+              'not after it, which would defeat the whole point');
+    });
+
+    test('main.dart is still at most 30 lines', () {
+      // The structural invariant set by #424 remains — phase 2 must not
+      // cause main.dart to balloon. Splash wiring lives in
+      // lib/app/widgets/animated_splash.dart.
+      final lines = mainSource.split('\n').length;
+      expect(lines, lessThanOrEqualTo(30));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 of #795 — a tasteful animated Flutter splash that renders between the Android native launch drawable and the first frame of `TankstellenApp`, so Dart init happens with brand motion already on-screen instead of a frozen hold on the native splash.

## What

- **New widget `AnimatedSplash`** (`lib/app/widgets/animated_splash.dart`) — renders the shield + fuel-drop glyph on the brand green (`#2E7D32`) backdrop, with a slim indeterminate progress bar and the localized wordmark. The glyph is drawn with `CustomPaint` (no new asset) by mirroring the path data from `android/app/src/main/res/drawable/ic_launcher_foreground.xml` 1:1 so the splash glyph matches the launcher icon exactly.
- **New widget `SplashHost`** (same file) — minimal `WidgetsApp` that mounts `AnimatedSplash` without requiring Material scaffolding or Riverpod. Used as the pre-init root widget.
- **Wiring in `main.dart`** — one `WidgetsFlutterBinding.ensureInitialized()` + `runApp(const SplashHost())` *before* `AppInitializer.run(...)`. The second `runApp` inside `_launch` replaces this root with the real `TankstellenApp` tree once init is done. `main.dart` stays at 20 lines, under the 30-line structural cap.
- **ARB fragments** — `splash_en.arb`, `splash_de.arb` add one key (`splashLoadingLabel`) for the TalkBack/VoiceOver announcement. Merged via `tool/build_arb.dart` + `flutter gen-l10n`.

## Design chosen

**Pattern 1 from the issue: logo scale-in + fade-in + single-pass progress bar.** Rationale: the scale (0.88 → 1.00, 650 ms, `Curves.easeOutCubic`) + fade (180 ms lead, then ramp to 1.0) produces the "arrive with weight" reveal that reads as professional brand animation rather than a cutesy bounce. The progress bar is indeterminate — it tells the user something is happening without making fake progress claims, and it's styled with brand colours (darker green track, white bar) so it blends into the backdrop instead of looking like a stock Material widget.

Dropped on purpose: no rotating accent ring (reads as a loading spinner, cliché), no gradient sweep (the flat brand green is already strong), no shader/Lottie/Rive (allowlist forbids pubspec changes and extra assets).

## Dark-mode handling

The Android native launch drawable is identical on light and dark (same `ic_launcher_background` colour), so the Flutter splash deliberately keeps the same brand green across both brightnesses — flipping backgrounds at the handoff would create a jarring colour pop. Widget tests assert this stability explicitly (`paints the same brand backdrop on dark mode`).

## Handoff timing

1. Native splash drawable paints (Android window).
2. Dart binding initializes, `runApp(SplashHost())` mounts `AnimatedSplash` on the same green backdrop → no visible seam.
3. `AppInitializer.run` runs its phased init (storage → services → optional) while the splash is live.
4. When init resolves, `_launch` calls `runApp(TankstellenApp)`, replacing the splash root. Flutter's root-widget swap is instant (one frame), and the `AnimatedSplash` disposes its `AnimationController` cleanly (verified by the `disposes cleanly when swapped out` test).

## Accessibility

`Semantics(label: 'Loading Tankstellen', liveRegion: true, container: true)` wraps the whole splash so TalkBack/VoiceOver announces a single meaningful label instead of reading the wordmark + raw progress-indicator role. The `CustomPaint` glyph is wrapped in `ExcludeSemantics` so it doesn't leak decorative nodes into the tree.

## Tests (11 new)

- Rendering: glyph via `CustomPaint`, wordmark text, indeterminate `LinearProgressIndicator`, brand backdrop on light, brand backdrop on dark.
- Accessibility: semantic label `Loading Tankstellen` is discoverable via `find.bySemanticsLabel`.
- Lifecycle: 1-second simulated pump without throws, clean dispose when swapped out of the tree.
- Integration: `SplashHost` mounts an `AnimatedSplash` under a `WidgetsApp`.
- Structural (`#795 phase 2` group): `main.dart` wires `runApp(SplashHost())` BEFORE `AppInitializer.run`, and `main.dart` is still ≤ 30 lines.

## Verification

- `flutter analyze` — zero issues.
- `flutter test` — all 5424 tests pass.
- No silent catches in touched files.
- No pubspec change; no new assets.

Closes #795