### PR TITLE
feat(country): add Greece — Paratiritirio (#576)

### DIFF
--- a/lib/core/country/country_bounding_box.dart
+++ b/lib/core/country/country_bounding_box.dart
@@ -86,6 +86,19 @@ const countryBoundingBoxes = <String, CountryBoundingBox>{
   // the Atacama coast but kept narrow on the east so Chile's tight west-
   // coast strip does not shadow Argentina's much larger box. See #596.
   'CL': CountryBoundingBox(minLat: -56.5, maxLat: -17.0, minLng: -77.0, maxLng: -66.0),
+
+  // Greece: lat 34.50 (southern Crete) – 41.80 (north Macedonia border),
+  // lng 19.00 (Corfu / Ionian) – 28.50 (eastern Dodecanese / Rhodes).
+  // The eastern edge is deliberately pulled in from the geographic
+  // limit (~29.6 for Kastellorizo) so Istanbul (41.01, 28.98) is
+  // NOT falsely attributed to GR. Kastellorizo (~500 residents) is
+  // the only Greek territory lost; every populated island including
+  // Rhodes (36.43, 28.22) and Kos stays inside the box. Turkey is
+  // not currently in the registry, so a point that falls between the
+  // bbox and the Turkish border simply returns `null` — the caller
+  // uses that as the signal to fall back to the active profile.
+  // See #576.
+  'GR': CountryBoundingBox(minLat: 34.5, maxLat: 41.8, minLng: 19.0, maxLng: 28.5),
 };
 
 /// Deterministic order used by [countryCodeFromLatLng] to walk
@@ -133,6 +146,9 @@ const List<String> _bboxLookupOrder = [
   'AR',
   'AU',
   'KR',
+  // GR last — no overlap with any currently-registered country's box,
+  // so placement in the lookup order is inconsequential. #576
+  'GR',
 ];
 
 /// Returns the ISO country code whose bounding box contains the

--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -453,11 +453,43 @@ class Countries {
     pricePerUnitSuffix: '\$/L',
   );
 
+  /// Greece — Paratiritirio Timon (Fuel Price Observatory) via the
+  /// community [fuelpricesgr](https://github.com/mavroprovato/fuelpricesgr)
+  /// API (#576). The community feed is free and open — no key required.
+  /// Coverage is prefecture-level (not station-level): we synthesize one
+  /// virtual station per major prefecture, each showing that region's
+  /// daily mean price. Fuels: Αμόλυβδη 95 (→ e5), Αμόλυβδη 100 (→ e98),
+  /// Diesel (→ diesel), Υγραέριο / LPG (→ lpg). Diesel heating is
+  /// published but dropped — not a motoring fuel.
+  static const greece = CountryConfig(
+    code: 'GR',
+    name: 'Ελλάδα',
+    flag: '\u{1F1EC}\u{1F1F7}',
+    locale: 'el_GR',
+    postalCodeLength: 5,
+    postalCodeRegex: r'^\d{5}$',
+    postalCodeLabel: 'Ταχυδρομικός κώδικας',
+    requiresApiKey: false,
+    apiProvider: 'Paratiritirio Timon',
+    attribution:
+        'Data: fuelprices.gr (Paratiritirio Timon) via fuelpricesgr community API',
+    fuelTypes: ['Αμόλυβδη 95', 'Αμόλυβδη 100', 'Diesel', 'LPG'],
+    supportedFuelTypes: {
+      FuelType.e5,
+      FuelType.e98,
+      FuelType.diesel,
+      FuelType.lpg,
+      FuelType.electric,
+    },
+    examplePostalCode: '10431',
+    exampleCity: 'Αθήνα',
+  );
+
   /// All supported countries, ordered for display.
   static const all = [
     germany, france, austria, spain, italy, denmark, argentina,
     portugal, unitedKingdom, australia, mexico, luxembourg, slovenia,
-    southKorea, chile,
+    southKorea, chile, greece,
   ];
 
   /// Find country by ISO code.
@@ -499,6 +531,7 @@ class Countries {
   /// - \`si-\` → SI (Slovenia goriva.si, #575)
   /// - \`kr-\` → KR (South Korea OPINET / KNOC, #597)
   /// - \`cl-\` → CL (Chile CNE Bencina en Línea, #596)
+  /// - \`gr-\` → GR (Greece Paratiritirio Timon, #576)
   /// - \`demo-\` → null (demo service, no real country)
   static const Map<String, String> _stationIdPrefixToCountry = {
     'pt-': 'PT',
@@ -512,6 +545,7 @@ class Countries {
     'si-': 'SI',
     'kr-': 'KR',
     'cl-': 'CL',
+    'gr-': 'GR',
   };
 
   /// Returns the ISO country code inferred from a station id's prefix,

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -10,6 +10,7 @@ import 'impl/chile_station_service.dart';
 import 'impl/demo_station_service.dart';
 import 'impl/denmark_station_service.dart';
 import 'impl/econtrol_station_service.dart';
+import 'impl/greece_station_service.dart';
 import 'impl/luxembourg_station_service.dart';
 import 'impl/mexico_station_service.dart';
 import 'impl/mise_station_service.dart';
@@ -157,6 +158,11 @@ class CountryServiceRegistry {
       requiresApiKey: true,
       createService: _createChile,
     ),
+    CountryServiceEntry(
+      countryCode: 'GR',
+      errorSource: ServiceSource.greeceApi,
+      createService: _createGreece,
+    ),
   ];
 
   /// Lookup map built once from [entries] for O(1) access.
@@ -287,3 +293,9 @@ StationService _createChile(Ref ref) {
   }
   return ChileStationService(apiKey: apiKey);
 }
+
+/// Greece factory (#576). The Paratiritirio Timon feed is wrapped by
+/// the community [fuelpricesgr](https://github.com/mavroprovato/fuelpricesgr)
+/// FastAPI; it is free and open, so no API key is required. Users get
+/// real prefecture-level data out-of-the-box.
+StationService _createGreece(Ref ref) => GreeceStationService();

--- a/lib/core/services/impl/greece_station_service.dart
+++ b/lib/core/services/impl/greece_station_service.dart
@@ -1,0 +1,449 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../../features/search/data/models/search_params.dart';
+import '../../../features/search/domain/entities/fuel_type.dart';
+import '../../../features/search/domain/entities/station.dart';
+import '../../error/exceptions.dart';
+import '../dio_factory.dart';
+import '../mixins/station_service_helpers.dart';
+import '../service_result.dart';
+import '../station_service.dart';
+
+/// Greece fuel prices — Paratiritirio Timon (Fuel Price Observatory) via the
+/// community [fuelpricesgr](https://github.com/mavroprovato/fuelpricesgr)
+/// FastAPI wrapper (#576).
+///
+/// Greece's government-run *Paratiritirio Timon Υγρών Καυσίμων* publishes
+/// mandatory daily / weekly fuel price data, but only as brittle PDFs on
+/// `catalog.data.gov.gr`. The community wrapper parses those PDFs into a
+/// well-formed JSON API with no authentication.
+///
+/// **Crucial caveat**: unlike CNE (Chile) or OPINET (Korea), the Greek
+/// feed is **not station-level** — the finest granularity published by
+/// the Observatory (and therefore by the community API) is the
+/// *prefecture* (νομός). Greek law requires each station to print its
+/// prices on public-facing boards but there is no central per-station
+/// registry open to the public.
+///
+/// We model this the same way [LuxembourgStationService] models its
+/// uniform regulated prices: one synthetic "virtual station" per
+/// representative prefecture, stamped with that prefecture's latest
+/// daily mean price. The user sees a short list of `gr-attica`,
+/// `gr-thessaloniki`, ... entries around the Greek mainland / islands,
+/// each showing the prefecture-level average. For a pay-less-at-the-pump
+/// decision this is not as sharp as a station-level feed, but it at
+/// least surfaces regional variance (Attica vs. Thrace vs. Crete, which
+/// can differ by 10–15 cents/L) and keeps the app usable in Greece
+/// until — or unless — a station-level feed becomes available.
+///
+/// **Endpoint contract** (community API defaults to `https://fuelpricesgr.com/api/`):
+///
+/// ```
+/// GET /data/daily/prefecture/{prefecture}
+/// ```
+///
+/// returns the prefecture's most recent daily price points:
+///
+/// ```json
+/// [
+///   {
+///     "date": "2026-04-21",
+///     "data": [
+///       { "fuel_type": "UNLEADED_95",  "price": 1.721 },
+///       { "fuel_type": "UNLEADED_100", "price": 1.969 },
+///       { "fuel_type": "DIESEL",       "price": 1.528 },
+///       { "fuel_type": "DIESEL_HEATING", "price": 1.165 },
+///       { "fuel_type": "GAS",          "price": 0.978 }
+///     ]
+///   }
+/// ]
+/// ```
+///
+/// Fuel-type mapping used by [_fuelForObservatoryKey]:
+///
+/// ```
+/// UNLEADED_95      → FuelType.e5
+/// UNLEADED_100     → FuelType.e98
+/// DIESEL           → FuelType.diesel
+/// DIESEL_HEATING   → (skipped — not a motoring fuel)
+/// GAS              → FuelType.lpg    (Υγραέριο)
+/// SUPER            → (skipped — leaded; phased out)
+/// ```
+///
+/// No auth, no keys — the community API is free and open. The service
+/// still round-trips the user's `_baseUrl` so operators can point
+/// Tankstellen at a self-hosted mirror if the hosted endpoint goes
+/// down; and the parser is fully fixture-driven so a URL-path drift at
+/// upstream is a one-line fix.
+class GreeceStationService
+    with StationServiceHelpers
+    implements StationService {
+  /// Community API base URL. The upstream project documents that it
+  /// runs at `http://localhost:8000/api` locally; a hosted mirror is
+  /// commonly available at `https://fuelpricesgr.com/api/` (or a
+  /// user-operated mirror). The exact hosted URL is a moving target
+  /// between releases of the upstream project — if the hosted endpoint
+  /// drifts, override via the constructor's `baseUrl` argument without
+  /// changing the parser.
+  static const String defaultBaseUrl = 'https://fuelpricesgr.com/api';
+
+  /// Observatory fuel_type enum → canonical [FuelType].
+  ///
+  /// `DIESEL_HEATING` and `SUPER` are intentionally absent from the
+  /// map. [droppedObservatoryKeys] pins the policy for tests.
+  static const Map<String, FuelType> _fuelForObservatoryKey = {
+    'unleaded_95': FuelType.e5,
+    'unleaded_100': FuelType.e98,
+    'diesel': FuelType.diesel,
+    'gas': FuelType.lpg,
+  };
+
+  /// Keys the parser deliberately drops because no [FuelType] exists
+  /// (DIESEL_HEATING is not a motoring fuel; SUPER is phased-out
+  /// leaded).
+  static const Set<String> droppedObservatoryKeys = {
+    'diesel_heating',
+    'super',
+  };
+
+  /// Representative prefectures used as virtual stations. Coordinates
+  /// are each prefecture's capital (OpenStreetMap). The set is
+  /// deliberately small and geographically spread so a user searching
+  /// from anywhere in Greece hits at least one entry within a
+  /// sensible radius, without flooding the map with 50+ synthetic
+  /// pins.
+  static const List<_GreekPrefecture> _prefectures = [
+    _GreekPrefecture(
+      apiName: 'ATTICA',
+      id: 'gr-attica',
+      displayName: 'Αττική / Attica',
+      place: 'Αθήνα',
+      lat: 37.9838,
+      lng: 23.7275,
+    ),
+    _GreekPrefecture(
+      apiName: 'THESSALONIKI',
+      id: 'gr-thessaloniki',
+      displayName: 'Θεσσαλονίκη / Thessaloniki',
+      place: 'Θεσσαλονίκη',
+      lat: 40.6401,
+      lng: 22.9444,
+    ),
+    _GreekPrefecture(
+      apiName: 'ACHAEA',
+      id: 'gr-achaea',
+      displayName: 'Αχαΐα / Achaea',
+      place: 'Πάτρα',
+      lat: 38.2466,
+      lng: 21.7346,
+    ),
+    _GreekPrefecture(
+      apiName: 'LARISSA',
+      id: 'gr-larissa',
+      displayName: 'Λάρισα / Larissa',
+      place: 'Λάρισα',
+      lat: 39.6390,
+      lng: 22.4191,
+    ),
+    _GreekPrefecture(
+      apiName: 'HERAKLION',
+      id: 'gr-heraklion',
+      displayName: 'Ηράκλειο / Heraklion',
+      place: 'Ηράκλειο',
+      lat: 35.3387,
+      lng: 25.1442,
+    ),
+    _GreekPrefecture(
+      apiName: 'IOANNINA',
+      id: 'gr-ioannina',
+      displayName: 'Ιωάννινα / Ioannina',
+      place: 'Ιωάννινα',
+      lat: 39.6650,
+      lng: 20.8537,
+    ),
+    _GreekPrefecture(
+      apiName: 'DODECANESE',
+      id: 'gr-dodecanese',
+      displayName: 'Δωδεκάνησα / Dodecanese',
+      place: 'Ρόδος',
+      lat: 36.4349,
+      lng: 28.2176,
+    ),
+    _GreekPrefecture(
+      apiName: 'CHANIA',
+      id: 'gr-chania',
+      displayName: 'Χανιά / Chania',
+      place: 'Χανιά',
+      lat: 35.5138,
+      lng: 24.0180,
+    ),
+  ];
+
+  final Dio _dio;
+  final String _baseUrl;
+
+  GreeceStationService({
+    Dio? dio,
+    String? baseUrl,
+  })  : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 10),
+              receiveTimeout: const Duration(seconds: 20),
+            ),
+        _baseUrl = baseUrl ?? defaultBaseUrl;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    // Pull the user's nearest prefectures first — a radius-based
+    // pre-filter so we don't slam the upstream with 8 serial requests
+    // when the user is standing in Athens and the answer is `ATTICA`.
+    final candidates = _prefecturesForQuery(params);
+
+    final stations = <Station>[];
+    final errors = <ServiceError>[];
+
+    for (final pref in candidates) {
+      try {
+        final response = await _dio.get(
+          '$_baseUrl/data/daily/prefecture/${pref.apiName}',
+          cancelToken: cancelToken,
+        );
+        final s = parsePrefectureResponse(
+          response.data,
+          stationId: pref.id,
+          displayName: pref.displayName,
+          place: pref.place,
+          prefectureLat: pref.lat,
+          prefectureLng: pref.lng,
+          fromLat: params.lat,
+          fromLng: params.lng,
+        );
+        if (s != null) stations.add(s);
+      } on DioException catch (e) {
+        debugPrint('GR daily fetch failed for ${pref.apiName}: $e');
+        final status = e.response?.statusCode;
+        if (status == 401 || status == 403) {
+          // The community API is free and anonymous — a 401/403 means
+          // the operator has proxied it behind auth. Surface as a hard
+          // error so the fallback chain can log it.
+          throw ApiException(
+            message: 'Paratiritirio rejected request (HTTP $status)',
+            statusCode: status,
+          );
+        }
+        errors.add(ServiceError(
+          source: ServiceSource.greeceApi,
+          message: 'fetch ${pref.apiName}: ${e.type.name}',
+          statusCode: status,
+          occurredAt: DateTime.now(),
+        ));
+      } catch (e) {
+        debugPrint('GR daily fetch unexpected error for ${pref.apiName}: $e');
+        errors.add(ServiceError(
+          source: ServiceSource.greeceApi,
+          message: 'parse ${pref.apiName}: $e',
+          occurredAt: DateTime.now(),
+        ));
+      }
+    }
+
+    // If every prefecture request failed hard, surface an ApiException
+    // so the chain drops to stale cache.
+    if (stations.isEmpty && candidates.isNotEmpty && errors.isNotEmpty) {
+      throw ApiException(
+        message:
+            'Paratiritirio unreachable (${errors.length}/${candidates.length} '
+            'prefectures failed)',
+      );
+    }
+
+    final filtered = filterByRadius(stations, params.radiusKm);
+    sortStations(filtered, params);
+
+    return ServiceResult(
+      data: filtered,
+      source: ServiceSource.greeceApi,
+      fetchedAt: DateTime.now(),
+      errors: errors,
+    );
+  }
+
+  /// Parse a single prefecture's daily response into a synthetic
+  /// [Station]. Exposed for tests so the parser is driven by fixtures
+  /// independent of any Dio mock.
+  ///
+  /// The response is either:
+  /// - A list of `PriceResponse` objects (most recent first), or
+  /// - An empty list when the prefecture has no recent data.
+  ///
+  /// We pick the most recent entry (first in the list) and stamp its
+  /// fuel prices onto the virtual station.
+  ///
+  /// The prefecture is addressed by its stable `stationId` so tests do
+  /// not need access to the private `_GreekPrefecture` class.
+  @visibleForTesting
+  Station? parsePrefectureResponse(
+    dynamic data, {
+    required String stationId,
+    required String displayName,
+    required String place,
+    required double prefectureLat,
+    required double prefectureLng,
+    required double fromLat,
+    required double fromLng,
+  }) {
+    final list = _coerceList(data);
+    if (list == null) {
+      throw const ApiException(
+        message: 'Paratiritirio returned unparseable body',
+      );
+    }
+
+    // Empty list is valid — just means no recent data for this
+    // prefecture. Drop the station (a synthetic entry with no prices
+    // would clutter the list).
+    if (list.isEmpty) return null;
+
+    // Prefer the newest entry. The community API documents "most recent
+    // first" but we defend against order drift by picking the entry with
+    // the greatest `date` string (ISO-8601 lexicographic order works).
+    Map? newest;
+    String newestDate = '';
+    for (final item in list) {
+      if (item is! Map) continue;
+      final date = item['date']?.toString() ?? '';
+      if (date.compareTo(newestDate) > 0) {
+        newestDate = date;
+        newest = item;
+      }
+    }
+    if (newest == null) return null;
+
+    final prices = _parsePrices(newest['data']);
+    // A prefecture with zero recognised fuel rows is dropped — no
+    // synthetic pin for "nothing to show".
+    if (prices.isEmpty) return null;
+
+    return Station(
+      id: stationId,
+      name: displayName,
+      brand: 'Paratiritirio',
+      street: '',
+      postCode: '',
+      place: place,
+      lat: prefectureLat,
+      lng: prefectureLng,
+      dist: roundedDistance(fromLat, fromLng, prefectureLat, prefectureLng),
+      e5: prices[FuelType.e5],
+      e98: prices[FuelType.e98],
+      diesel: prices[FuelType.diesel],
+      lpg: prices[FuelType.lpg],
+      isOpen: true,
+      updatedAt: newestDate.isEmpty ? null : newestDate,
+    );
+  }
+
+  /// Exposed for tests — single source of truth for the observatory
+  /// fuel-key → [FuelType] mapping.
+  @visibleForTesting
+  static FuelType? fuelForObservatoryKey(String key) =>
+      _fuelForObservatoryKey[key.toLowerCase()];
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String stationId,
+  ) async {
+    throwDetailUnavailable('Paratiritirio Timon');
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    return emptyPricesResult(ServiceSource.greeceApi);
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ──────────────────────────────────────────────────────────────────────
+
+  /// Order the prefectures so the nearest ones come first. Keeps us
+  /// from fanning out to the entire country when the user is standing
+  /// in one prefecture.
+  List<_GreekPrefecture> _prefecturesForQuery(SearchParams params) {
+    final ordered = List<_GreekPrefecture>.from(_prefectures)
+      ..sort((a, b) {
+        final da = roundedDistance(params.lat, params.lng, a.lat, a.lng);
+        final db = roundedDistance(params.lat, params.lng, b.lat, b.lng);
+        return da.compareTo(db);
+      });
+    // Fetch the four closest prefectures. Covers the mainland /
+    // island cases without making 8 serial HTTP calls per search.
+    return ordered.take(4).toList();
+  }
+
+  Map<FuelType, double> _parsePrices(dynamic rawData) {
+    final out = <FuelType, double>{};
+    if (rawData is! List) return out;
+    for (final row in rawData) {
+      if (row is! Map) continue;
+      final key = row['fuel_type']?.toString() ?? '';
+      if (key.isEmpty) continue;
+      final fuel = _fuelForObservatoryKey[key.toLowerCase()];
+      if (fuel == null) continue; // unknown / intentionally dropped
+      final price = _parseEuroPerLitre(row['price']);
+      if (price == null) continue;
+      out[fuel] = price;
+    }
+    return out;
+  }
+
+  /// Observatory prices are EUR per litre with up to three decimals
+  /// (e.g. `1.721`). Accepts `num` and numeric strings. Rejects zero
+  /// and negative values.
+  double? _parseEuroPerLitre(dynamic raw) {
+    if (raw == null) return null;
+    if (raw is num) {
+      if (raw <= 0) return null;
+      return raw.toDouble();
+    }
+    if (raw is String) {
+      final t = raw.trim();
+      if (t.isEmpty) return null;
+      final v = double.tryParse(t);
+      if (v == null || v <= 0) return null;
+      return v;
+    }
+    return null;
+  }
+
+  List? _coerceList(dynamic data) {
+    if (data is List) return data;
+    return null;
+  }
+}
+
+/// Internal representation of a Greek prefecture used as a virtual
+/// station. Kept private — callers only ever see fully-built
+/// [Station] objects.
+class _GreekPrefecture {
+  final String apiName;
+  final String id;
+  final String displayName;
+  final String place;
+  final double lat;
+  final double lng;
+
+  const _GreekPrefecture({
+    required this.apiName,
+    required this.id,
+    required this.displayName,
+    required this.place,
+    required this.lat,
+    required this.lng,
+  });
+}

--- a/lib/core/services/service_result.dart
+++ b/lib/core/services/service_result.dart
@@ -19,6 +19,7 @@ enum ServiceSource {
   sloveniaApi('goriva.si'),
   openinetApi('OPINET (KNOC)'),
   chileApi('CNE Bencina en Linea'),
+  greeceApi('Paratiritirio Timon (Greece)'),
   osrmRouting('OSRM Routing'),
   openChargeMapApi('OpenChargeMap'),
   nominatimGeocoding('Nominatim (OSM)'),

--- a/lib/features/search/domain/entities/fuel_type.dart
+++ b/lib/features/search/domain/entities/fuel_type.dart
@@ -346,6 +346,15 @@ List<FuelType> fuelTypesForCountry(String countryCode) {
         FuelType.e5, FuelType.e98, FuelType.diesel,
         FuelType.lpg, FuelType.electric, FuelType.all,
       ];
+    case 'GR':
+      // Greece (Paratiritirio Timon via fuelpricesgr community API):
+      // Αμόλυβδη 95 (→ e5), Αμόλυβδη 100 (→ e98), Diesel, Υγραέριο /
+      // LPG. Diesel heating is published but intentionally dropped
+      // (not a motoring fuel). #576
+      return [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.lpg, FuelType.electric, FuelType.all,
+      ];
     default:
       return [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all];
   }

--- a/lib/l10n/_fragments/country_greece_de.arb
+++ b/lib/l10n/_fragments/country_greece_de.arb
@@ -1,0 +1,4 @@
+{
+  "greeceApiProvider": "Paratiritirio Timon (Greece)",
+  "greeceCommunityApiNotice": "Betrieben von der von der Community gepflegten fuelpricesgr-API"
+}

--- a/lib/l10n/_fragments/country_greece_en.arb
+++ b/lib/l10n/_fragments/country_greece_en.arb
@@ -1,0 +1,4 @@
+{
+  "greeceApiProvider": "Paratiritirio Timon (Greece)",
+  "greeceCommunityApiNotice": "Powered by the community-maintained fuelpricesgr API"
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1256,6 +1256,8 @@
   "chargingEfficiencyTitle": "Effizienz (kWh/100 km)",
   "chargingChartsEmpty": "Noch nicht genügend Daten",
   "chargingChartsMonthAxis": "Monat",
+  "greeceApiProvider": "Paratiritirio Timon (Greece)",
+  "greeceCommunityApiNotice": "Betrieben von der von der Community gepflegten fuelpricesgr-API",
   "scanReceiptNoData": "Keine Belegdaten gefunden — bitte erneut versuchen",
   "scanReceiptSuccess": "Beleg gescannt — Werte prüfen. Bei Fehlern unten auf \"Scan-Fehler melden\" tippen.",
   "scanReceiptFailed": "Scan fehlgeschlagen: {error}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1531,6 +1531,8 @@
   "@chargingChartsMonthAxis": {
     "description": "Axis label for the X axis (month) on the charging charts (#582 phase 3)."
   },
+  "greeceApiProvider": "Paratiritirio Timon (Greece)",
+  "greeceCommunityApiNotice": "Powered by the community-maintained fuelpricesgr API",
   "scanReceiptNoData": "No receipt data found — try again",
   "@scanReceiptNoData": {
     "description": "Snackbar shown on the Add-Fill-Up screen when the receipt scan returns no usable fields (#751)."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5984,6 +5984,18 @@ abstract class AppLocalizations {
   /// **'Month'**
   String get chargingChartsMonthAxis;
 
+  /// No description provided for @greeceApiProvider.
+  ///
+  /// In en, this message translates to:
+  /// **'Paratiritirio Timon (Greece)'**
+  String get greeceApiProvider;
+
+  /// No description provided for @greeceCommunityApiNotice.
+  ///
+  /// In en, this message translates to:
+  /// **'Powered by the community-maintained fuelpricesgr API'**
+  String get greeceCommunityApiNotice;
+
   /// Snackbar shown on the Add-Fill-Up screen when the receipt scan returns no usable fields (#751).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3188,6 +3188,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3188,6 +3188,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3186,6 +3186,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3212,6 +3212,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Monat';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Betrieben von der von der Community gepflegten fuelpricesgr-API';
+
+  @override
   String get scanReceiptNoData =>
       'Keine Belegdaten gefunden — bitte erneut versuchen';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3190,6 +3190,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3181,6 +3181,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3189,6 +3189,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3183,6 +3183,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3186,6 +3186,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3210,6 +3210,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3185,6 +3185,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3190,6 +3190,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3189,6 +3189,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3187,6 +3187,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3189,6 +3189,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3185,6 +3185,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3190,6 +3190,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3188,6 +3188,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3189,6 +3189,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3188,6 +3188,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3189,6 +3189,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3183,6 +3183,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3187,6 +3187,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get greeceApiProvider => 'Paratiritirio Timon (Greece)';
+
+  @override
+  String get greeceCommunityApiNotice =>
+      'Powered by the community-maintained fuelpricesgr API';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/test/core/country/country_bounding_box_test.dart
+++ b/test/core/country/country_bounding_box_test.dart
@@ -46,9 +46,9 @@ void main() {
   });
 
   group('countryBoundingBoxes', () {
-    test('has entries for all 14 supported countries', () {
+    test('has entries for all 15 supported countries', () {
       const expectedCountries = [
-        'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'SI', 'KR', 'CL',
+        'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'SI', 'KR', 'CL', 'GR',
       ];
       for (final code in expectedCountries) {
         expect(countryBoundingBoxes.containsKey(code), isTrue,
@@ -220,6 +220,41 @@ void main() {
     test('KR bounding box rejects German coordinates', () {
       // Berlin sits at (52.52, 13.41) — must not be misattributed to KR.
       expect(countryBoundingBoxes['KR']!.contains(52.52, 13.41), isFalse);
+    });
+
+    test('Athens → GR (#576)', () {
+      expect(countryCodeFromLatLng(37.98, 23.72), 'GR');
+    });
+
+    test('Thessaloniki → GR (#576)', () {
+      expect(countryCodeFromLatLng(40.64, 22.94), 'GR');
+    });
+
+    test('Heraklion (Crete) → GR (#576)', () {
+      expect(countryCodeFromLatLng(35.34, 25.14), 'GR');
+    });
+
+    test('Rhodes → GR (eastern Aegean, #576)', () {
+      expect(countryCodeFromLatLng(36.43, 28.22), 'GR');
+    });
+
+    test('Rome → IT (not GR — Italy does not overlap the Greek box)', () {
+      expect(countryCodeFromLatLng(41.90, 12.50), 'IT');
+    });
+
+    test('Istanbul (TR) is not misattributed to GR', () {
+      // Istanbul at (41.01, 28.98) sits just east of the Greek box.
+      // Turkey is not in the registry — the point must resolve to null,
+      // not to GR.
+      expect(countryCodeFromLatLng(41.01, 28.98), isNull);
+    });
+
+    test('GR bounding box rejects Berlin', () {
+      expect(countryBoundingBoxes['GR']!.contains(52.52, 13.41), isFalse);
+    });
+
+    test('GR bounding box rejects Rome', () {
+      expect(countryBoundingBoxes['GR']!.contains(41.90, 12.50), isFalse);
     });
 
     test('Santiago → CL (#596 — CL lookup order wins over AR)', () {

--- a/test/core/country/country_config_extended_test.dart
+++ b/test/core/country/country_config_extended_test.dart
@@ -2,9 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
 
 void main() {
-  group('Countries.byCode for all 15 countries', () {
+  group('Countries.byCode for all 16 countries', () {
     final expectedCodes = [
-      'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI', 'KR', 'CL',
+      'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI', 'KR', 'CL', 'GR',
     ];
 
     for (final code in expectedCodes) {
@@ -78,6 +78,10 @@ void main() {
 
     test('Slovenia uses goriva.si', () {
       expect(Countries.slovenia.apiProvider, contains('goriva.si'));
+    });
+
+    test('Greece uses Paratiritirio Timon', () {
+      expect(Countries.greece.apiProvider, contains('Paratiritirio'));
     });
   });
 

--- a/test/core/country/country_config_test.dart
+++ b/test/core/country/country_config_test.dart
@@ -3,14 +3,14 @@ import 'package:tankstellen/core/country/country_config.dart';
 
 void main() {
   group('Countries.all', () {
-    test('contains exactly 15 countries', () {
-      expect(Countries.all.length, equals(15));
+    test('contains exactly 16 countries', () {
+      expect(Countries.all.length, equals(16));
     });
 
     test('contains all expected country codes', () {
       final codes = Countries.all.map((c) => c.code).toSet();
       expect(codes, containsAll(
-        ['DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI', 'KR', 'CL'],
+        ['DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI', 'KR', 'CL', 'GR'],
       ));
     });
 

--- a/test/core/services/country_service_registry_test.dart
+++ b/test/core/services/country_service_registry_test.dart
@@ -95,6 +95,14 @@ void main() {
         final entry = CountryServiceRegistry.entryFor('FR');
         expect(entry!.requiresApiKey, isFalse);
       });
+
+      test('GR does not require API key (community API is free)', () {
+        // Unlike KR / CL, the Greek Paratiritirio Timon feed is
+        // exposed via a community FastAPI wrapper with no auth. #576
+        final entry = CountryServiceRegistry.entryFor('GR');
+        expect(entry, isNotNull);
+        expect(entry!.requiresApiKey, isFalse);
+      });
     });
 
     group('assertAllCountriesRegistered', () {
@@ -177,6 +185,12 @@ void main() {
       test('CL maps to chileApi', () {
         final entry = CountryServiceRegistry.entryFor('CL');
         expect(entry!.errorSource, equals(ServiceSource.chileApi));
+      });
+
+      test('GR maps to greeceApi (#576)', () {
+        final entry = CountryServiceRegistry.entryFor('GR');
+        expect(entry, isNotNull);
+        expect(entry!.errorSource, equals(ServiceSource.greeceApi));
       });
     });
   });

--- a/test/core/services/impl/greece_station_service_test.dart
+++ b/test/core/services/impl/greece_station_service_test.dart
@@ -1,0 +1,503 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/impl/greece_station_service.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../../mocks/mocks.dart';
+
+/// Build a synthetic daily-price row in the shape `fuelpricesgr`
+/// returns. Mirrors the Pydantic `PriceData` model:
+/// `{ "fuel_type": "UNLEADED_95", "price": 1.721 }`.
+Map<String, dynamic> _priceRow(String fuelType, double price) =>
+    <String, dynamic>{'fuel_type': fuelType, 'price': price};
+
+/// Build a `PriceResponse`-shaped envelope for a given date.
+Map<String, dynamic> _priceResponse({
+  String date = '2026-04-21',
+  List<Map<String, dynamic>>? rows,
+}) {
+  return <String, dynamic>{
+    'date': date,
+    'data': rows ??
+        <Map<String, dynamic>>[
+          _priceRow('UNLEADED_95', 1.721),
+          _priceRow('UNLEADED_100', 1.969),
+          _priceRow('DIESEL', 1.528),
+          _priceRow('DIESEL_HEATING', 1.165),
+          _priceRow('GAS', 0.978),
+        ],
+  };
+}
+
+/// The community API returns `list[PriceResponse]`. Wrap a single
+/// response (or several) in a list for the happy path.
+List<Map<String, dynamic>> _envelope(List<Map<String, dynamic>> responses) =>
+    responses;
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  late MockDio mockDio;
+  late GreeceStationService service;
+
+  setUp(() {
+    mockDio = MockDio();
+    service = GreeceStationService(dio: mockDio, baseUrl: 'https://test/api');
+  });
+
+  Response<dynamic> response(dynamic data) => Response<dynamic>(
+        requestOptions: RequestOptions(),
+        statusCode: 200,
+        data: data,
+      );
+
+  group('GreeceStationService', () {
+    test('implements StationService', () {
+      expect(service, isA<StationService>());
+    });
+
+    test('country registered as GR with EUR currency', () {
+      final gr = Countries.byCode('GR');
+      expect(gr, isNotNull);
+      expect(gr!.currency, 'EUR');
+      expect(gr.requiresApiKey, isFalse,
+          reason: 'Greek community API is free / open — no key required');
+      expect(gr.apiProvider, contains('Paratiritirio'));
+    });
+
+    group('fuel observatory-key mapping', () {
+      test('UNLEADED_95 → e5', () {
+        expect(
+          GreeceStationService.fuelForObservatoryKey('UNLEADED_95'),
+          FuelType.e5,
+        );
+      });
+
+      test('UNLEADED_100 → e98', () {
+        expect(
+          GreeceStationService.fuelForObservatoryKey('UNLEADED_100'),
+          FuelType.e98,
+        );
+      });
+
+      test('DIESEL → diesel', () {
+        expect(
+          GreeceStationService.fuelForObservatoryKey('DIESEL'),
+          FuelType.diesel,
+        );
+      });
+
+      test('GAS (Υγραέριο) → lpg', () {
+        expect(
+          GreeceStationService.fuelForObservatoryKey('GAS'),
+          FuelType.lpg,
+        );
+      });
+
+      test('DIESEL_HEATING is intentionally unmapped (not motoring fuel)', () {
+        expect(
+          GreeceStationService.fuelForObservatoryKey('DIESEL_HEATING'),
+          isNull,
+        );
+        expect(
+          GreeceStationService.droppedObservatoryKeys,
+          contains('diesel_heating'),
+        );
+      });
+
+      test('SUPER is intentionally unmapped (leaded, phased out)', () {
+        expect(
+          GreeceStationService.fuelForObservatoryKey('SUPER'),
+          isNull,
+        );
+        expect(
+          GreeceStationService.droppedObservatoryKeys,
+          contains('super'),
+        );
+      });
+
+      test('mapping is case-insensitive', () {
+        expect(
+          GreeceStationService.fuelForObservatoryKey('unleaded_95'),
+          FuelType.e5,
+        );
+        expect(
+          GreeceStationService.fuelForObservatoryKey('Unleaded_95'),
+          FuelType.e5,
+        );
+      });
+    });
+
+    group('searchStations', () {
+      test('builds stations for the nearest prefectures from Athens',
+          () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(_envelope([_priceResponse()])));
+
+        // Athens → should hit ATTICA first; we fetch the 4 nearest.
+        const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
+        final result = await service.searchStations(params);
+
+        expect(result.source, ServiceSource.greeceApi);
+        expect(result.data, isNotEmpty);
+
+        // Every station id carries the `gr-` prefix.
+        expect(
+          result.data.every((s) => s.id.startsWith('gr-')),
+          isTrue,
+          reason: 'Every GR station id must carry the gr- prefix so the '
+              'favorites currency lookup finds it.',
+        );
+
+        // Prices must map correctly onto the Station slots.
+        final attica =
+            result.data.firstWhere((s) => s.id == 'gr-attica');
+        expect(attica.e5, closeTo(1.721, 0.0001));
+        expect(attica.e98, closeTo(1.969, 0.0001));
+        expect(attica.diesel, closeTo(1.528, 0.0001));
+        expect(attica.lpg, closeTo(0.978, 0.0001));
+      });
+
+      test('fetches exactly 4 closest prefectures (not all 8)', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(_envelope([_priceResponse()])));
+
+        const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
+        await service.searchStations(params);
+
+        verify(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).called(4);
+      });
+
+      test('targets the /data/daily/prefecture/{name} path', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(_envelope([_priceResponse()])));
+
+        const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
+        await service.searchStations(params);
+
+        final captured = verify(() => mockDio.get(
+              captureAny(),
+              cancelToken: any(named: 'cancelToken'),
+            )).captured;
+        expect(
+          captured.every((url) =>
+              (url as String).startsWith('https://test/api/data/daily/prefecture/')),
+          isTrue,
+          reason:
+              'Every GR call must hit /data/daily/prefecture/<PREFECTURE>.',
+        );
+      });
+
+      test('HTTP 401 is re-raised as ApiException', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenThrow(DioException(
+          requestOptions: RequestOptions(),
+          response: Response(
+            requestOptions: RequestOptions(),
+            statusCode: 401,
+          ),
+          type: DioExceptionType.badResponse,
+        ));
+
+        const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
+        await expectLater(
+          () => service.searchStations(params),
+          throwsA(isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 401)),
+        );
+      });
+
+      test('HTTP 403 is re-raised as ApiException', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenThrow(DioException(
+          requestOptions: RequestOptions(),
+          response: Response(
+            requestOptions: RequestOptions(),
+            statusCode: 403,
+          ),
+          type: DioExceptionType.badResponse,
+        ));
+
+        const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
+        await expectLater(
+          () => service.searchStations(params),
+          throwsA(isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 403)),
+        );
+      });
+
+      test(
+          'network timeout on every prefecture surfaces ApiException to '
+          'the fallback chain', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.connectionTimeout,
+          requestOptions: RequestOptions(),
+        ));
+
+        const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
+        await expectLater(
+          () => service.searchStations(params),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test(
+          'partial failures (some prefectures up, some down) still return '
+          'data with accumulated errors', () async {
+        var callCount = 0;
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async {
+          callCount += 1;
+          if (callCount.isEven) {
+            throw DioException(
+              type: DioExceptionType.connectionTimeout,
+              requestOptions: RequestOptions(),
+            );
+          }
+          return response(_envelope([_priceResponse()]));
+        });
+
+        const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
+        final result = await service.searchStations(params);
+
+        expect(result.data, isNotEmpty);
+        expect(result.errors, isNotEmpty,
+            reason: 'Errors from the failed fetches should accumulate.');
+      });
+
+      test('empty list for a prefecture drops that entry silently', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(<Map<String, dynamic>>[]));
+
+        const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
+        final result = await service.searchStations(params);
+
+        // All four prefectures returned empty → no stations, but no
+        // errors either (empty list is a valid response).
+        expect(result.data, isEmpty);
+        expect(result.errors, isEmpty);
+      });
+    });
+
+    group('parsePrefectureResponse', () {
+      const attica = {
+        'stationId': 'gr-attica',
+        'displayName': 'Αττική / Attica',
+        'place': 'Αθήνα',
+        'lat': 37.9838,
+        'lng': 23.7275,
+      };
+
+      Station? parse(dynamic body) => service.parsePrefectureResponse(
+            body,
+            stationId: attica['stationId']! as String,
+            displayName: attica['displayName']! as String,
+            place: attica['place']! as String,
+            prefectureLat: attica['lat']! as double,
+            prefectureLng: attica['lng']! as double,
+            fromLat: 37.98,
+            fromLng: 23.73,
+          );
+
+      test('happy path parses all four supported fuels', () {
+        final s = parse(_envelope([_priceResponse()]));
+        expect(s, isNotNull);
+        expect(s!.id, 'gr-attica');
+        expect(s.e5, closeTo(1.721, 0.0001));
+        expect(s.e98, closeTo(1.969, 0.0001));
+        expect(s.diesel, closeTo(1.528, 0.0001));
+        expect(s.lpg, closeTo(0.978, 0.0001));
+        // Diesel heating is dropped — no dedicated slot on Station,
+        // but confirm no fuel slot accidentally absorbed it.
+        expect(s.dieselPremium, isNull);
+      });
+
+      test('picks the newest entry when multiple dates are returned', () {
+        final s = parse(_envelope([
+          _priceResponse(date: '2026-04-20', rows: [
+            _priceRow('UNLEADED_95', 1.700),
+          ]),
+          _priceResponse(date: '2026-04-21', rows: [
+            _priceRow('UNLEADED_95', 1.721),
+          ]),
+        ]));
+        expect(s, isNotNull);
+        expect(s!.e5, closeTo(1.721, 0.0001));
+      });
+
+      test('empty list → null station', () {
+        expect(parse(const <Map<String, dynamic>>[]), isNull);
+      });
+
+      test('non-list body raises ApiException', () {
+        expect(
+          () => parse(<String, dynamic>{'oops': 'not a list'}),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('DIESEL_HEATING is silently dropped', () {
+        final s = parse(_envelope([
+          _priceResponse(rows: [
+            _priceRow('DIESEL', 1.528),
+            _priceRow('DIESEL_HEATING', 1.165), // dropped
+          ]),
+        ]));
+        expect(s, isNotNull);
+        expect(s!.diesel, closeTo(1.528, 0.0001));
+        // No dieselPremium on Station for GR.
+      });
+
+      test('SUPER (leaded) is silently dropped', () {
+        final s = parse(_envelope([
+          _priceResponse(rows: [
+            _priceRow('DIESEL', 1.528),
+            _priceRow('SUPER', 1.950),
+          ]),
+        ]));
+        expect(s, isNotNull);
+        expect(s!.diesel, closeTo(1.528, 0.0001));
+        expect(s.e5, isNull);
+        expect(s.e98, isNull);
+      });
+
+      test('stationId is threaded through unchanged (gr- prefix preserved)',
+          () {
+        final s = parse(_envelope([_priceResponse()]));
+        expect(s, isNotNull);
+        expect(s!.id, startsWith('gr-'));
+      });
+
+      test('prefecture with zero mappable rows returns null', () {
+        final s = parse(_envelope([
+          _priceResponse(rows: [
+            _priceRow('DIESEL_HEATING', 1.165),
+            _priceRow('SUPER', 1.950),
+          ]),
+        ]));
+        expect(s, isNull,
+            reason: 'No recognised motoring fuels → no synthetic pin.');
+      });
+
+      test('non-numeric price is dropped (price slot stays null)', () {
+        final s = parse(_envelope([
+          _priceResponse(rows: [
+            _priceRow('UNLEADED_95', 1.721),
+            <String, dynamic>{'fuel_type': 'DIESEL', 'price': 'N/A'},
+          ]),
+        ]));
+        expect(s, isNotNull);
+        expect(s!.e5, closeTo(1.721, 0.0001));
+        expect(s.diesel, isNull);
+      });
+
+      test('zero or negative prices are rejected', () {
+        final s = parse(_envelope([
+          _priceResponse(rows: [
+            _priceRow('UNLEADED_95', 0),
+            _priceRow('DIESEL', -1.0),
+            _priceRow('GAS', 0.978),
+          ]),
+        ]));
+        expect(s, isNotNull);
+        expect(s!.e5, isNull);
+        expect(s.diesel, isNull);
+        expect(s.lpg, closeTo(0.978, 0.0001));
+      });
+
+      test('numeric price strings are accepted', () {
+        final s = parse(_envelope([
+          _priceResponse(rows: [
+            <String, dynamic>{'fuel_type': 'UNLEADED_95', 'price': '1.721'},
+          ]),
+        ]));
+        expect(s, isNotNull);
+        expect(s!.e5, closeTo(1.721, 0.0001));
+      });
+
+      test('updatedAt reflects the newest response date', () {
+        final s = parse(_envelope([
+          _priceResponse(date: '2026-04-21'),
+        ]));
+        expect(s, isNotNull);
+        expect(s!.updatedAt, '2026-04-21');
+      });
+    });
+
+    group('getStationDetail', () {
+      test('throws ApiException (detail not available)', () {
+        expect(
+          () => service.getStationDetail('gr-attica'),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('error message mentions Paratiritirio', () async {
+        try {
+          await service.getStationDetail('gr-attica');
+          fail('expected ApiException');
+        } on ApiException catch (e) {
+          expect(e.message, contains('Paratiritirio'));
+        }
+      });
+    });
+
+    group('getPrices', () {
+      test('returns empty map (no batch refresh)', () async {
+        final result = await service.getPrices(['gr-attica', 'gr-chania']);
+        expect(result.data, isEmpty);
+        expect(result.source, ServiceSource.greeceApi);
+      });
+
+      test('returns empty map for empty id list', () async {
+        final result = await service.getPrices([]);
+        expect(result.data, isEmpty);
+      });
+    });
+
+    group('station id prefix routing', () {
+      test('Countries.countryCodeForStationId resolves gr- → GR', () {
+        expect(
+          Countries.countryCodeForStationId('gr-attica'),
+          'GR',
+        );
+      });
+
+      test('Countries.countryForStationId returns the GR config', () {
+        final c = Countries.countryForStationId('gr-attica');
+        expect(c, isNotNull);
+        expect(c!.code, 'GR');
+        expect(c.currency, 'EUR');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds Greece as the 16th supported country (#576) via the community
[`fuelpricesgr`](https://github.com/mavroprovato/fuelpricesgr) FastAPI
wrapper of the government-mandated Paratiritirio Timon (Fuel Price
Observatory) feed.

- No API key needed — the community API is free/open, unlike KR (#597)
  and CL (#596)
- Prefecture-level coverage only — upstream does not expose station-level
  data. We surface one synthetic virtual station per major prefecture
  (Attica / Thessaloniki / Achaea / Larissa / Heraklion / Ioannina /
  Dodecanese / Chania), same pattern as Luxembourg (#574) uniform prices
- `el` locale falls through to English as per the no-Greek-translations
  policy

### Fuel mapping

| Observatory key  | FuelType      |
|------------------|---------------|
| `UNLEADED_95`    | `e5`          |
| `UNLEADED_100`   | `e98`         |
| `DIESEL`         | `diesel`      |
| `GAS` (Υγραέριο) | `lpg`         |
| `DIESEL_HEATING` | dropped       |
| `SUPER`          | dropped       |

### Bounding box decision

`GR` bbox is deliberately trimmed east to `lng 28.5` so Istanbul
(`41.01, 28.98`) does NOT misattribute to GR. Kastellorizo (~500
residents, easternmost Greek island at lng 29.58) is the only Greek
territory excluded; every populated island including Rhodes (28.22)
stays inside the box. Turkey is not yet in the registry, so a point
between the box and the Turkish border returns `null`.

## Files touched

- **New:** `lib/core/services/impl/greece_station_service.dart`
- **New:** `lib/l10n/_fragments/country_greece_{en,de}.arb`
- **New:** `test/core/services/impl/greece_station_service_test.dart`
- Registry: `country_service_registry.dart`, `service_result.dart`
  (new `greeceApi` ServiceSource)
- Country config: `country_config.dart` (new `greece` + `gr-` prefix),
  `country_bounding_box.dart` (new `GR` box)
- Fuel types: `fuel_type.dart` (new `GR` case in `fuelTypesForCountry`)
- Tests bumped from 15 → 16 countries: `country_config_test.dart`,
  `country_config_extended_test.dart`,
  `country_bounding_box_test.dart`,
  `country_service_registry_test.dart`
- Regenerated `app_en.arb`, `app_de.arb`, 23 `app_localizations_*.dart`

## Test plan

- [x] `dart run tool/build_arb.dart` — fragments merged
- [x] `flutter gen-l10n` — regenerated 23 locale files
- [x] `flutter analyze` — 0 warnings / errors
- [x] `flutter test` — all 5547 tests pass (1 skipped, pre-existing)
- [x] New test file: 35 tests covering parser, fuel mapping, error paths,
      partial-failure behaviour, prefix routing
- [x] Istanbul correctly rejected from GR bbox (regression guard in
      `country_bounding_box_test.dart`)

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)