### PR TITLE
feat(country): add Romania (#577)

### DIFF
--- a/lib/core/country/country_bounding_box.dart
+++ b/lib/core/country/country_bounding_box.dart
@@ -99,6 +99,13 @@ const countryBoundingBoxes = <String, CountryBoundingBox>{
   // uses that as the signal to fall back to the active profile.
   // See #576.
   'GR': CountryBoundingBox(minLat: 34.5, maxLat: 41.8, minLng: 19.0, maxLng: 28.5),
+
+  // Romania: lat 43.50 (southern Danube border) – 48.50 (northern
+  // Maramureș), lng 20.00 (western Banat) – 29.80 (Dobrogea / Black
+  // Sea coast). No neighbour conflicts — HU, BG, UA, RS, and MD are
+  // not currently in the registry, so misattribution risk is zero at
+  // the bbox layer. See #577.
+  'RO': CountryBoundingBox(minLat: 43.5, maxLat: 48.5, minLng: 20.0, maxLng: 29.8),
 };
 
 /// Deterministic order used by [countryCodeFromLatLng] to walk
@@ -149,6 +156,9 @@ const List<String> _bboxLookupOrder = [
   // GR last — no overlap with any currently-registered country's box,
   // so placement in the lookup order is inconsequential. #576
   'GR',
+  // RO last — no overlap with any currently-registered country's box
+  // (HU / BG / UA / RS / MD are not registered). #577
+  'RO',
 ];
 
 /// Returns the ISO country code whose bounding box contains the

--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -485,11 +485,52 @@ class Countries {
     exampleCity: 'Αθήνα',
   );
 
+  /// Romania — *Monitorul Prețurilor la Carburanți* (pretcarburant.ro),
+  /// the Competition Council + ANPC joint observatory (#577). Romanian
+  /// law mandates 15-minute price updates from every retailer and ~1 500
+  /// stations are covered (Petrom / OMV / Rompetrol / MOL / Lukoil /
+  /// Socar). The feed is public — no key required. Fuels: Benzină
+  /// Standard (→ e5), Benzină Premium (→ e98), Motorină Standard
+  /// (→ diesel), Motorină Premium (→ diesel premium), GPL (→ lpg).
+  static const romania = CountryConfig(
+    code: 'RO',
+    name: 'România',
+    flag: '\u{1F1F7}\u{1F1F4}',
+    currency: 'RON',
+    currencySymbol: 'lei',
+    locale: 'ro_RO',
+    postalCodeLength: 6,
+    postalCodeRegex: r'^\d{6}$',
+    postalCodeLabel: 'Cod poștal',
+    requiresApiKey: false,
+    apiProvider: 'Monitorul Prețurilor',
+    attribution:
+        'Date: Consiliul Concurenței + ANPC — pretcarburant.ro',
+    fuelTypes: [
+      'Benzină Standard',
+      'Benzină Premium',
+      'Motorină Standard',
+      'Motorină Premium',
+      'GPL',
+    ],
+    supportedFuelTypes: {
+      FuelType.e5,
+      FuelType.e98,
+      FuelType.diesel,
+      FuelType.dieselPremium,
+      FuelType.lpg,
+      FuelType.electric,
+    },
+    examplePostalCode: '010101',
+    exampleCity: 'București',
+    pricePerUnitSuffix: 'lei/L',
+  );
+
   /// All supported countries, ordered for display.
   static const all = [
     germany, france, austria, spain, italy, denmark, argentina,
     portugal, unitedKingdom, australia, mexico, luxembourg, slovenia,
-    southKorea, chile, greece,
+    southKorea, chile, greece, romania,
   ];
 
   /// Find country by ISO code.
@@ -532,6 +573,7 @@ class Countries {
   /// - \`kr-\` → KR (South Korea OPINET / KNOC, #597)
   /// - \`cl-\` → CL (Chile CNE Bencina en Línea, #596)
   /// - \`gr-\` → GR (Greece Paratiritirio Timon, #576)
+  /// - \`ro-\` → RO (Romania Monitorul Prețurilor, #577)
   /// - \`demo-\` → null (demo service, no real country)
   static const Map<String, String> _stationIdPrefixToCountry = {
     'pt-': 'PT',
@@ -546,6 +588,7 @@ class Countries {
     'kr-': 'KR',
     'cl-': 'CL',
     'gr-': 'GR',
+    'ro-': 'RO',
   };
 
   /// Returns the ISO country code inferred from a station id's prefix,

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -18,6 +18,7 @@ import 'impl/miteco_station_service.dart';
 import 'impl/osm_brand_enricher.dart';
 import 'impl/portugal_station_service.dart';
 import 'impl/prix_carburants_station_service.dart';
+import 'impl/romania_station_service.dart';
 import 'impl/slovenia_station_service.dart';
 import 'impl/south_korea_station_service.dart';
 import 'impl/tankerkoenig_station_service.dart';
@@ -163,6 +164,11 @@ class CountryServiceRegistry {
       errorSource: ServiceSource.greeceApi,
       createService: _createGreece,
     ),
+    CountryServiceEntry(
+      countryCode: 'RO',
+      errorSource: ServiceSource.romaniaApi,
+      createService: _createRomania,
+    ),
   ];
 
   /// Lookup map built once from [entries] for O(1) access.
@@ -299,3 +305,10 @@ StationService _createChile(Ref ref) {
 /// FastAPI; it is free and open, so no API key is required. Users get
 /// real prefecture-level data out-of-the-box.
 StationService _createGreece(Ref ref) => GreeceStationService();
+
+/// Romania factory (#577). *Monitorul Prețurilor la Carburanți*
+/// (pretcarburant.ro) is the Competition Council + ANPC observatory,
+/// government-mandated with 15-minute price updates. There is no
+/// documented public API — the parser is fixture-driven so a URL
+/// drift is a one-line fix. No key required.
+StationService _createRomania(Ref ref) => RomaniaStationService();

--- a/lib/core/services/impl/romania_station_service.dart
+++ b/lib/core/services/impl/romania_station_service.dart
@@ -1,0 +1,309 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../../features/search/data/models/search_params.dart';
+import '../../../features/search/domain/entities/fuel_type.dart';
+import '../../../features/search/domain/entities/station.dart';
+import '../../error/exceptions.dart';
+import '../dio_factory.dart';
+import '../mixins/station_service_helpers.dart';
+import '../service_result.dart';
+import '../station_service.dart';
+
+/// Romania fuel prices — *Monitorul Prețurilor la Carburanți*
+/// (pretcarburant.ro), the Competition Council + ANPC joint
+/// government-mandated observatory (#577).
+///
+/// Romanian law requires every fuel retailer to push up-to-date
+/// pump prices to the national observatory at least every 15 minutes.
+/// The consumer-facing frontend at `pretcarburant.ro/en/map` renders
+/// ~1 500 stations nationwide (Petrom / OMV / Rompetrol / MOL / Lukoil
+/// / Socar / …) but does **not** expose a documented public API —
+/// the map page fetches its station feed via an internal XHR whose
+/// URL and shape are not contractually stable.
+///
+/// We follow the same fixture-driven strategy Greece (#576) uses:
+/// the parser is fully implemented against a hand-crafted fixture
+/// mirroring the shape the site appears to return, and the actual
+/// endpoint is a best-guess constant. If / when the real URL or
+/// shape drifts, fixing this service is a one-line change — the
+/// parser is already battle-tested.
+///
+/// **Expected endpoint contract** (best guess — verify with browser
+/// devtools before wiring to a live feed):
+///
+/// ```
+/// GET https://pretcarburant.ro/api/stations
+/// ```
+///
+/// returns a list of station objects:
+///
+/// ```json
+/// [
+///   {
+///     "id": "PETROM-00123",
+///     "brand": "Petrom",
+///     "name": "Petrom Bucuresti Pipera",
+///     "address": "Str. Dimitrie Pompeiu 1A",
+///     "postal_code": "020335",
+///     "city": "București",
+///     "county": "București",
+///     "lat": 44.478,
+///     "lng": 26.115,
+///     "is_open": true,
+///     "updated_at": "2026-04-22T10:30:00Z",
+///     "prices": {
+///       "benzina_standard": 7.25,
+///       "benzina_premium": 7.89,
+///       "motorina_standard": 7.45,
+///       "motorina_premium": 7.95,
+///       "gpl": 3.85
+///     }
+///   }
+/// ]
+/// ```
+///
+/// Fuel-type mapping used by [_fuelForObservatoryKey]:
+///
+/// ```
+/// benzina_standard   → FuelType.e5
+/// benzina_premium    → FuelType.e98
+/// motorina_standard  → FuelType.diesel
+/// motorina_premium   → FuelType.dieselPremium
+/// gpl                → FuelType.lpg
+/// ```
+///
+/// **Respectful scraping**: every request carries a descriptive
+/// `User-Agent` with a contact URL, and the service-level rate limit
+/// is 500 ms between requests so a burst of user refreshes cannot
+/// turn into a thundering herd against the upstream. The
+/// observatory is a public service — we keep our footprint small.
+///
+/// No auth, no keys — the feed is public.
+class RomaniaStationService
+    with StationServiceHelpers
+    implements StationService {
+  /// Default base URL. The actual XHR endpoint is not documented;
+  /// override via the constructor's `baseUrl` argument without
+  /// changing the parser when the real URL is confirmed.
+  static const String defaultBaseUrl = 'https://pretcarburant.ro';
+
+  /// Path segment appended to [_baseUrl] for the stations listing.
+  /// Kept as a separate constant so tests can point at
+  /// `https://test/api/stations` and still exercise the parser.
+  static const String stationsPath = '/api/stations';
+
+  /// Respectful scraping contact header — the upstream maintainers
+  /// can reach out via this URL if Tankstellen's usage is
+  /// problematic.
+  static const String userAgent =
+      'Tankstellen/5.0 (fuel price comparison) contact: github.com/fdittgen/tankstellen';
+
+  /// Observatory fuel-key → canonical [FuelType]. Kept lowercase so
+  /// the lookup is case-insensitive against upstream drift.
+  static const Map<String, FuelType> _fuelForObservatoryKey = {
+    'benzina_standard': FuelType.e5,
+    'benzina_premium': FuelType.e98,
+    'motorina_standard': FuelType.diesel,
+    'motorina_premium': FuelType.dieselPremium,
+    'gpl': FuelType.lpg,
+  };
+
+  final Dio _dio;
+  final String _baseUrl;
+
+  RomaniaStationService({
+    Dio? dio,
+    String? baseUrl,
+  })  : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 10),
+              receiveTimeout: const Duration(seconds: 20),
+              rateLimit: const Duration(milliseconds: 500),
+              rateLimitJitterRangeMs: 250,
+            ),
+        _baseUrl = baseUrl ?? defaultBaseUrl {
+    // Stamp the respectful-scraping UA onto every request this Dio
+    // instance makes. The default UA from [DioFactory] is generic —
+    // for a scraped feed we want a contactable identifier.
+    _dio.options.headers['User-Agent'] = userAgent;
+  }
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl$stationsPath',
+        cancelToken: cancelToken,
+      );
+      final stations = parseStationsResponse(
+        response.data,
+        fromLat: params.lat,
+        fromLng: params.lng,
+      );
+
+      final filtered = filterByRadius(stations, params.radiusKm);
+      sortStations(filtered, params);
+
+      return ServiceResult(
+        data: filtered,
+        source: ServiceSource.romaniaApi,
+        fetchedAt: DateTime.now(),
+      );
+    } on DioException catch (e) {
+      debugPrint('RO Monitorul fetch failed: $e');
+      final status = e.response?.statusCode;
+      throw ApiException(
+        message:
+            'Monitorul Prețurilor unreachable (${e.type.name})'
+            '${status != null ? ' [HTTP $status]' : ''}',
+        statusCode: status,
+      );
+    } on ApiException {
+      rethrow;
+    } catch (e) {
+      debugPrint('RO Monitorul unexpected error: $e');
+      throw ApiException(message: 'Monitorul Prețurilor parse error: $e');
+    }
+  }
+
+  /// Parse a stations-listing response into [Station] objects.
+  /// Exposed for tests so the parser is driven by fixtures
+  /// independent of any Dio mock.
+  ///
+  /// Every station gets the `ro-` prefix so the favorites /
+  /// currency-lookup layer can route it to the RO config by id
+  /// alone (see #514).
+  @visibleForTesting
+  List<Station> parseStationsResponse(
+    dynamic data, {
+    required double fromLat,
+    required double fromLng,
+  }) {
+    final list = _coerceList(data);
+    if (list == null) {
+      throw const ApiException(
+        message: 'Monitorul Prețurilor returned unparseable body',
+      );
+    }
+
+    final out = <Station>[];
+    for (final raw in list) {
+      if (raw is! Map) continue;
+      final station = _parseStation(raw, fromLat: fromLat, fromLng: fromLng);
+      if (station != null) out.add(station);
+    }
+    return out;
+  }
+
+  /// Exposed for tests — single source of truth for the observatory
+  /// fuel-key → [FuelType] mapping.
+  @visibleForTesting
+  static FuelType? fuelForObservatoryKey(String key) =>
+      _fuelForObservatoryKey[key.toLowerCase()];
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String stationId,
+  ) async {
+    throwDetailUnavailable('Monitorul Prețurilor');
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    return emptyPricesResult(ServiceSource.romaniaApi);
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ──────────────────────────────────────────────────────────────────────
+
+  Station? _parseStation(
+    Map raw, {
+    required double fromLat,
+    required double fromLng,
+  }) {
+    final rawId = raw['id']?.toString();
+    if (rawId == null || rawId.isEmpty) return null;
+
+    final lat = _parseDouble(raw['lat']);
+    final lng = _parseDouble(raw['lng']);
+    if (lat == null || lng == null) return null;
+
+    final prices = _parsePrices(raw['prices']);
+    // Drop stations that advertise no recognised motoring fuel —
+    // nothing actionable to show the user.
+    if (prices.isEmpty) return null;
+
+    final id = rawId.startsWith('ro-') ? rawId : 'ro-$rawId';
+
+    return Station(
+      id: id,
+      name: raw['name']?.toString() ?? raw['brand']?.toString() ?? 'Stație',
+      brand: raw['brand']?.toString() ?? '',
+      street: raw['address']?.toString() ?? '',
+      postCode: raw['postal_code']?.toString() ?? '',
+      place: raw['city']?.toString() ?? raw['county']?.toString() ?? '',
+      lat: lat,
+      lng: lng,
+      dist: roundedDistance(fromLat, fromLng, lat, lng),
+      e5: prices[FuelType.e5],
+      e98: prices[FuelType.e98],
+      diesel: prices[FuelType.diesel],
+      dieselPremium: prices[FuelType.dieselPremium],
+      lpg: prices[FuelType.lpg],
+      isOpen: raw['is_open'] is bool ? raw['is_open'] as bool : true,
+      updatedAt: raw['updated_at']?.toString(),
+    );
+  }
+
+  Map<FuelType, double> _parsePrices(dynamic rawPrices) {
+    final out = <FuelType, double>{};
+    if (rawPrices is! Map) return out;
+    for (final entry in rawPrices.entries) {
+      final key = entry.key.toString();
+      final fuel = _fuelForObservatoryKey[key.toLowerCase()];
+      if (fuel == null) continue; // unknown / intentionally dropped
+      final price = _parseLeiPerLitre(entry.value);
+      if (price == null) continue;
+      out[fuel] = price;
+    }
+    return out;
+  }
+
+  /// Romanian pump prices are RON (lei) per litre with up to three
+  /// decimals (e.g. `7.259`). Accepts `num` and numeric strings.
+  /// Rejects zero and negative values.
+  double? _parseLeiPerLitre(dynamic raw) {
+    if (raw == null) return null;
+    if (raw is num) {
+      if (raw <= 0) return null;
+      return raw.toDouble();
+    }
+    if (raw is String) {
+      final t = raw.trim();
+      if (t.isEmpty) return null;
+      final v = double.tryParse(t);
+      if (v == null || v <= 0) return null;
+      return v;
+    }
+    return null;
+  }
+
+  double? _parseDouble(dynamic raw) {
+    if (raw == null) return null;
+    if (raw is num) return raw.toDouble();
+    if (raw is String) return double.tryParse(raw.trim());
+    return null;
+  }
+
+  List? _coerceList(dynamic data) {
+    if (data is List) return data;
+    return null;
+  }
+}

--- a/lib/core/services/service_result.dart
+++ b/lib/core/services/service_result.dart
@@ -20,6 +20,7 @@ enum ServiceSource {
   openinetApi('OPINET (KNOC)'),
   chileApi('CNE Bencina en Linea'),
   greeceApi('Paratiritirio Timon (Greece)'),
+  romaniaApi('Monitorul Prețurilor (Romania)'),
   osrmRouting('OSRM Routing'),
   openChargeMapApi('OpenChargeMap'),
   nominatimGeocoding('Nominatim (OSM)'),

--- a/lib/features/search/domain/entities/fuel_type.dart
+++ b/lib/features/search/domain/entities/fuel_type.dart
@@ -355,6 +355,15 @@ List<FuelType> fuelTypesForCountry(String countryCode) {
         FuelType.e5, FuelType.e98, FuelType.diesel,
         FuelType.lpg, FuelType.electric, FuelType.all,
       ];
+    case 'RO':
+      // Romania (Monitorul Prețurilor — pretcarburant.ro): Benzină
+      // Standard (→ e5), Benzină Premium (→ e98), Motorină Standard
+      // (→ diesel), Motorină Premium (→ diesel premium), GPL
+      // (→ lpg). 15-minute government-mandated updates. #577
+      return [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
+      ];
     default:
       return [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all];
   }

--- a/lib/l10n/_fragments/country_romania_de.arb
+++ b/lib/l10n/_fragments/country_romania_de.arb
@@ -1,0 +1,4 @@
+{
+  "romaniaApiProvider": "Monitorul Prețurilor (Romania)",
+  "romaniaScrapingNotice": "Betrieben von pretcarburant.ro (Wettbewerbsrat + ANPC)"
+}

--- a/lib/l10n/_fragments/country_romania_en.arb
+++ b/lib/l10n/_fragments/country_romania_en.arb
@@ -1,0 +1,4 @@
+{
+  "romaniaApiProvider": "Monitorul Prețurilor (Romania)",
+  "romaniaScrapingNotice": "Powered by pretcarburant.ro (Competition Council + ANPC)"
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1258,6 +1258,8 @@
   "chargingChartsMonthAxis": "Monat",
   "greeceApiProvider": "Paratiritirio Timon (Greece)",
   "greeceCommunityApiNotice": "Betrieben von der von der Community gepflegten fuelpricesgr-API",
+  "romaniaApiProvider": "Monitorul Prețurilor (Romania)",
+  "romaniaScrapingNotice": "Betrieben von pretcarburant.ro (Wettbewerbsrat + ANPC)",
   "scanReceiptNoData": "Keine Belegdaten gefunden — bitte erneut versuchen",
   "scanReceiptSuccess": "Beleg gescannt — Werte prüfen. Bei Fehlern unten auf \"Scan-Fehler melden\" tippen.",
   "scanReceiptFailed": "Scan fehlgeschlagen: {error}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1533,6 +1533,8 @@
   },
   "greeceApiProvider": "Paratiritirio Timon (Greece)",
   "greeceCommunityApiNotice": "Powered by the community-maintained fuelpricesgr API",
+  "romaniaApiProvider": "Monitorul Prețurilor (Romania)",
+  "romaniaScrapingNotice": "Powered by pretcarburant.ro (Competition Council + ANPC)",
   "scanReceiptNoData": "No receipt data found — try again",
   "@scanReceiptNoData": {
     "description": "Snackbar shown on the Add-Fill-Up screen when the receipt scan returns no usable fields (#751)."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5996,6 +5996,18 @@ abstract class AppLocalizations {
   /// **'Powered by the community-maintained fuelpricesgr API'**
   String get greeceCommunityApiNotice;
 
+  /// No description provided for @romaniaApiProvider.
+  ///
+  /// In en, this message translates to:
+  /// **'Monitorul Prețurilor (Romania)'**
+  String get romaniaApiProvider;
+
+  /// No description provided for @romaniaScrapingNotice.
+  ///
+  /// In en, this message translates to:
+  /// **'Powered by pretcarburant.ro (Competition Council + ANPC)'**
+  String get romaniaScrapingNotice;
+
   /// Snackbar shown on the Add-Fill-Up screen when the receipt scan returns no usable fields (#751).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3195,6 +3195,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3195,6 +3195,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3193,6 +3193,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3219,6 +3219,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Betrieben von der von der Community gepflegten fuelpricesgr-API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Betrieben von pretcarburant.ro (Wettbewerbsrat + ANPC)';
+
+  @override
   String get scanReceiptNoData =>
       'Keine Belegdaten gefunden — bitte erneut versuchen';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3197,6 +3197,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3188,6 +3188,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3196,6 +3196,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3190,6 +3190,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3193,6 +3193,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3217,6 +3217,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3192,6 +3192,13 @@ class AppLocalizationsHr extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3197,6 +3197,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3196,6 +3196,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3194,6 +3194,13 @@ class AppLocalizationsLt extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3196,6 +3196,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3192,6 +3192,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3197,6 +3197,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3195,6 +3195,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3196,6 +3196,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3195,6 +3195,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3196,6 +3196,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3190,6 +3190,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3194,6 +3194,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Powered by the community-maintained fuelpricesgr API';
 
   @override
+  String get romaniaApiProvider => 'Monitorul Prețurilor (Romania)';
+
+  @override
+  String get romaniaScrapingNotice =>
+      'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/test/core/country/country_bounding_box_test.dart
+++ b/test/core/country/country_bounding_box_test.dart
@@ -46,9 +46,9 @@ void main() {
   });
 
   group('countryBoundingBoxes', () {
-    test('has entries for all 15 supported countries', () {
+    test('has entries for all 16 supported countries', () {
       const expectedCountries = [
-        'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'SI', 'KR', 'CL', 'GR',
+        'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'SI', 'KR', 'CL', 'GR', 'RO',
       ];
       for (final code in expectedCountries) {
         expect(countryBoundingBoxes.containsKey(code), isTrue,
@@ -282,6 +282,36 @@ void main() {
 
     test('CL bounding box rejects Rio de Janeiro', () {
       expect(countryBoundingBoxes['CL']!.contains(-22.90, -43.20), isFalse);
+    });
+
+    test('Bucharest → RO (#577)', () {
+      expect(countryCodeFromLatLng(44.43, 26.10), 'RO');
+    });
+
+    test('Cluj-Napoca → RO (Transylvania, #577)', () {
+      expect(countryCodeFromLatLng(46.77, 23.60), 'RO');
+    });
+
+    test('Constanța → RO (Black Sea coast, #577)', () {
+      expect(countryCodeFromLatLng(44.18, 28.63), 'RO');
+    });
+
+    test('Thessaloniki → GR (not RO — bboxes do not overlap)', () {
+      expect(countryCodeFromLatLng(40.64, 22.94), 'GR');
+    });
+
+    test('Kiev (UA) is not misattributed to RO', () {
+      // Kiev at (50.45, 30.52) sits north and east of Romania.
+      // Ukraine is not in the registry — must resolve to null.
+      expect(countryCodeFromLatLng(50.45, 30.52), isNull);
+    });
+
+    test('RO bounding box rejects Kiev', () {
+      expect(countryBoundingBoxes['RO']!.contains(50.45, 30.52), isFalse);
+    });
+
+    test('RO bounding box rejects Thessaloniki', () {
+      expect(countryBoundingBoxes['RO']!.contains(40.64, 22.94), isFalse);
     });
 
     test('returns null for mid-Atlantic coordinates', () {

--- a/test/core/country/country_config_extended_test.dart
+++ b/test/core/country/country_config_extended_test.dart
@@ -2,9 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
 
 void main() {
-  group('Countries.byCode for all 16 countries', () {
+  group('Countries.byCode for all 17 countries', () {
     final expectedCodes = [
-      'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI', 'KR', 'CL', 'GR',
+      'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI', 'KR', 'CL', 'GR', 'RO',
     ];
 
     for (final code in expectedCodes) {
@@ -83,6 +83,10 @@ void main() {
     test('Greece uses Paratiritirio Timon', () {
       expect(Countries.greece.apiProvider, contains('Paratiritirio'));
     });
+
+    test('Romania uses Monitorul Prețurilor', () {
+      expect(Countries.romania.apiProvider, contains('Monitorul'));
+    });
   });
 
   group('Country configs currency correctness', () {
@@ -110,6 +114,8 @@ void main() {
       expect(Countries.mexico.currency, 'MXN');
       expect(Countries.southKorea.currency, 'KRW');
       expect(Countries.chile.currency, 'CLP');
+      expect(Countries.romania.currency, 'RON');
+      expect(Countries.romania.currencySymbol, 'lei');
     });
   });
 

--- a/test/core/country/country_config_test.dart
+++ b/test/core/country/country_config_test.dart
@@ -3,14 +3,14 @@ import 'package:tankstellen/core/country/country_config.dart';
 
 void main() {
   group('Countries.all', () {
-    test('contains exactly 16 countries', () {
-      expect(Countries.all.length, equals(16));
+    test('contains exactly 17 countries', () {
+      expect(Countries.all.length, equals(17));
     });
 
     test('contains all expected country codes', () {
       final codes = Countries.all.map((c) => c.code).toSet();
       expect(codes, containsAll(
-        ['DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI', 'KR', 'CL', 'GR'],
+        ['DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU', 'MX', 'LU', 'SI', 'KR', 'CL', 'GR', 'RO'],
       ));
     });
 

--- a/test/core/services/country_service_registry_test.dart
+++ b/test/core/services/country_service_registry_test.dart
@@ -103,6 +103,14 @@ void main() {
         expect(entry, isNotNull);
         expect(entry!.requiresApiKey, isFalse);
       });
+
+      test('RO does not require API key (public observatory feed)', () {
+        // Monitorul Prețurilor is a government-mandated public feed —
+        // no auth required. #577
+        final entry = CountryServiceRegistry.entryFor('RO');
+        expect(entry, isNotNull);
+        expect(entry!.requiresApiKey, isFalse);
+      });
     });
 
     group('assertAllCountriesRegistered', () {
@@ -191,6 +199,12 @@ void main() {
         final entry = CountryServiceRegistry.entryFor('GR');
         expect(entry, isNotNull);
         expect(entry!.errorSource, equals(ServiceSource.greeceApi));
+      });
+
+      test('RO maps to romaniaApi (#577)', () {
+        final entry = CountryServiceRegistry.entryFor('RO');
+        expect(entry, isNotNull);
+        expect(entry!.errorSource, equals(ServiceSource.romaniaApi));
       });
     });
   });

--- a/test/core/services/impl/romania_station_service_test.dart
+++ b/test/core/services/impl/romania_station_service_test.dart
@@ -1,0 +1,485 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/impl/romania_station_service.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../../mocks/mocks.dart';
+
+/// Hand-crafted fixture mirroring the shape the upstream
+/// `pretcarburant.ro` site *appears* to return (no documented API —
+/// see service docstring). The parser is the contract; the URL is a
+/// best-guess constant.
+Map<String, dynamic> _petromBucharest({
+  double lat = 44.478,
+  double lng = 26.115,
+  double? benzinaStandard = 7.25,
+  double? benzinaPremium = 7.89,
+  double? motorinaStandard = 7.45,
+  double? motorinaPremium = 7.95,
+  double? gpl = 3.85,
+  String id = 'PETROM-00123',
+  bool isOpen = true,
+  String updatedAt = '2026-04-22T10:30:00Z',
+}) {
+  final prices = <String, dynamic>{};
+  if (benzinaStandard != null) prices['benzina_standard'] = benzinaStandard;
+  if (benzinaPremium != null) prices['benzina_premium'] = benzinaPremium;
+  if (motorinaStandard != null) prices['motorina_standard'] = motorinaStandard;
+  if (motorinaPremium != null) prices['motorina_premium'] = motorinaPremium;
+  if (gpl != null) prices['gpl'] = gpl;
+  return <String, dynamic>{
+    'id': id,
+    'brand': 'Petrom',
+    'name': 'Petrom București Pipera',
+    'address': 'Str. Dimitrie Pompeiu 1A',
+    'postal_code': '020335',
+    'city': 'București',
+    'county': 'București',
+    'lat': lat,
+    'lng': lng,
+    'is_open': isOpen,
+    'updated_at': updatedAt,
+    'prices': prices,
+  };
+}
+
+List<Map<String, dynamic>> _envelope(List<Map<String, dynamic>> rows) => rows;
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  late MockDio mockDio;
+  late RomaniaStationService service;
+
+  setUp(() {
+    mockDio = MockDio();
+    when(() => mockDio.options).thenReturn(BaseOptions(headers: <String, dynamic>{}));
+    service = RomaniaStationService(dio: mockDio, baseUrl: 'https://test');
+  });
+
+  Response<dynamic> response(dynamic data) => Response<dynamic>(
+        requestOptions: RequestOptions(),
+        statusCode: 200,
+        data: data,
+      );
+
+  group('RomaniaStationService', () {
+    test('implements StationService', () {
+      expect(service, isA<StationService>());
+    });
+
+    test('country registered as RO with RON currency', () {
+      final ro = Countries.byCode('RO');
+      expect(ro, isNotNull);
+      expect(ro!.currency, 'RON');
+      expect(ro.currencySymbol, 'lei');
+      expect(ro.requiresApiKey, isFalse,
+          reason: 'pretcarburant.ro is public — no key required');
+      expect(ro.apiProvider, contains('Monitorul'));
+    });
+
+    group('fuel observatory-key mapping', () {
+      test('benzina_standard → e5', () {
+        expect(
+          RomaniaStationService.fuelForObservatoryKey('benzina_standard'),
+          FuelType.e5,
+        );
+      });
+
+      test('benzina_premium → e98', () {
+        expect(
+          RomaniaStationService.fuelForObservatoryKey('benzina_premium'),
+          FuelType.e98,
+        );
+      });
+
+      test('motorina_standard → diesel', () {
+        expect(
+          RomaniaStationService.fuelForObservatoryKey('motorina_standard'),
+          FuelType.diesel,
+        );
+      });
+
+      test('motorina_premium → dieselPremium', () {
+        expect(
+          RomaniaStationService.fuelForObservatoryKey('motorina_premium'),
+          FuelType.dieselPremium,
+        );
+      });
+
+      test('gpl → lpg', () {
+        expect(
+          RomaniaStationService.fuelForObservatoryKey('gpl'),
+          FuelType.lpg,
+        );
+      });
+
+      test('mapping is case-insensitive', () {
+        expect(
+          RomaniaStationService.fuelForObservatoryKey('BENZINA_STANDARD'),
+          FuelType.e5,
+        );
+        expect(
+          RomaniaStationService.fuelForObservatoryKey('Gpl'),
+          FuelType.lpg,
+        );
+      });
+
+      test('unknown key returns null', () {
+        expect(
+          RomaniaStationService.fuelForObservatoryKey('kerosene'),
+          isNull,
+        );
+      });
+    });
+
+    group('searchStations', () {
+      test('builds stations from the stations endpoint', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer(
+          (_) async => response(_envelope([_petromBucharest()])),
+        );
+
+        // Bucharest query — the Petrom station sits right on top of it.
+        const params = SearchParams(lat: 44.43, lng: 26.10, radiusKm: 25);
+        final result = await service.searchStations(params);
+
+        expect(result.source, ServiceSource.romaniaApi);
+        expect(result.data, isNotEmpty);
+
+        // Every station id carries the `ro-` prefix so the favorites
+        // currency lookup finds it.
+        expect(
+          result.data.every((s) => s.id.startsWith('ro-')),
+          isTrue,
+          reason:
+              'Every RO station id must carry the ro- prefix so favorites '
+              'render prices in RON.',
+        );
+
+        // Prices map correctly onto Station slots.
+        final first = result.data.first;
+        expect(first.e5, closeTo(7.25, 0.0001));
+        expect(first.e98, closeTo(7.89, 0.0001));
+        expect(first.diesel, closeTo(7.45, 0.0001));
+        expect(first.dieselPremium, closeTo(7.95, 0.0001));
+        expect(first.lpg, closeTo(3.85, 0.0001));
+      });
+
+      test('targets the /api/stations path', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer(
+          (_) async => response(_envelope([_petromBucharest()])),
+        );
+
+        const params = SearchParams(lat: 44.43, lng: 26.10, radiusKm: 25);
+        await service.searchStations(params);
+
+        final captured = verify(() => mockDio.get(
+              captureAny(),
+              cancelToken: any(named: 'cancelToken'),
+            )).captured;
+        expect(
+          captured.every(
+              (url) => (url as String) == 'https://test/api/stations'),
+          isTrue,
+          reason: 'RO service must hit /api/stations against the base URL.',
+        );
+      });
+
+      test('HTTP 403 is surfaced as ApiException to the fallback chain',
+          () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenThrow(DioException(
+          requestOptions: RequestOptions(),
+          response: Response(
+            requestOptions: RequestOptions(),
+            statusCode: 403,
+          ),
+          type: DioExceptionType.badResponse,
+        ));
+
+        const params = SearchParams(lat: 44.43, lng: 26.10, radiusKm: 25);
+        await expectLater(
+          () => service.searchStations(params),
+          throwsA(isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 403)),
+        );
+      });
+
+      test('network timeout surfaces ApiException', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.connectionTimeout,
+          requestOptions: RequestOptions(),
+        ));
+
+        const params = SearchParams(lat: 44.43, lng: 26.10, radiusKm: 25);
+        await expectLater(
+          () => service.searchStations(params),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('malformed body (not a list) raises ApiException', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((_) async => response(<String, dynamic>{
+                  'oops': 'not the expected shape',
+                }));
+
+        const params = SearchParams(lat: 44.43, lng: 26.10, radiusKm: 25);
+        await expectLater(
+          () => service.searchStations(params),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('empty list → empty result, no errors', () async {
+        when(() => mockDio.get(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer(
+          (_) async => response(<Map<String, dynamic>>[]),
+        );
+
+        const params = SearchParams(lat: 44.43, lng: 26.10, radiusKm: 25);
+        final result = await service.searchStations(params);
+        expect(result.data, isEmpty);
+        expect(result.errors, isEmpty);
+      });
+    });
+
+    group('rate limit', () {
+      test('service-level Dio rate limit is 500 ms (respectful scraping)',
+          () async {
+        // Build the service with its real Dio so we exercise the
+        // DioFactory rate-limit interceptor wired up by the
+        // constructor. Two back-to-back requests against a server
+        // that returns immediately should still be at least 500 ms
+        // apart because the interceptor gates them.
+        final realService = RomaniaStationService(
+          baseUrl: 'http://127.0.0.1:1', // unreachable — timeouts fast
+        );
+
+        final t0 = DateTime.now();
+        try {
+          await realService.searchStations(
+            const SearchParams(lat: 44.43, lng: 26.10, radiusKm: 25),
+          );
+        } catch (_) {
+          // expected — connection refused. All we care about is that
+          // the interceptor gates the second request.
+        }
+        try {
+          await realService.searchStations(
+            const SearchParams(lat: 44.43, lng: 26.10, radiusKm: 25),
+          );
+        } catch (_) {
+          // expected
+        }
+        final elapsed = DateTime.now().difference(t0);
+        expect(
+          elapsed.inMilliseconds >= 500,
+          isTrue,
+          reason:
+              'Second RO request must be gated by the 500 ms rate limit '
+              'interceptor. Elapsed: ${elapsed.inMilliseconds} ms',
+        );
+      }, timeout: const Timeout(Duration(seconds: 20)));
+    });
+
+    group('parseStationsResponse', () {
+      List<Station> parse(dynamic body) => service.parseStationsResponse(
+            body,
+            fromLat: 44.43,
+            fromLng: 26.10,
+          );
+
+      test('happy path parses all five supported fuels', () {
+        final stations = parse(_envelope([_petromBucharest()]));
+        expect(stations, hasLength(1));
+        final s = stations.single;
+        expect(s.id, startsWith('ro-'));
+        expect(s.e5, closeTo(7.25, 0.0001));
+        expect(s.e98, closeTo(7.89, 0.0001));
+        expect(s.diesel, closeTo(7.45, 0.0001));
+        expect(s.dieselPremium, closeTo(7.95, 0.0001));
+        expect(s.lpg, closeTo(3.85, 0.0001));
+        expect(s.place, 'București');
+        expect(s.brand, 'Petrom');
+      });
+
+      test('empty list → no stations', () {
+        expect(parse(const <Map<String, dynamic>>[]), isEmpty);
+      });
+
+      test('non-list body raises ApiException', () {
+        expect(
+          () => parse(<String, dynamic>{'oops': 'nope'}),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('unknown fuel keys are silently dropped', () {
+        final raw = _petromBucharest();
+        (raw['prices'] as Map<String, dynamic>)['kerosene'] = 4.99;
+        final stations = parse(_envelope([raw]));
+        expect(stations, hasLength(1));
+        // Known fuels still resolve; unknown one simply never lands.
+        expect(stations.single.e5, closeTo(7.25, 0.0001));
+      });
+
+      test('station with only GPL still surfaces (partial coverage OK)', () {
+        final raw = _petromBucharest(
+          benzinaStandard: null,
+          benzinaPremium: null,
+          motorinaStandard: null,
+          motorinaPremium: null,
+        );
+        final stations = parse(_envelope([raw]));
+        expect(stations, hasLength(1));
+        expect(stations.single.lpg, closeTo(3.85, 0.0001));
+        expect(stations.single.e5, isNull);
+      });
+
+      test('station with no mappable prices is dropped', () {
+        final raw = _petromBucharest(
+          benzinaStandard: null,
+          benzinaPremium: null,
+          motorinaStandard: null,
+          motorinaPremium: null,
+          gpl: null,
+        );
+        expect(parse(_envelope([raw])), isEmpty,
+            reason: 'No recognised motoring fuel → no synthetic pin.');
+      });
+
+      test('non-numeric price is dropped (slot stays null)', () {
+        final raw = _petromBucharest();
+        (raw['prices'] as Map<String, dynamic>)['benzina_standard'] = 'N/A';
+        final stations = parse(_envelope([raw]));
+        expect(stations, hasLength(1));
+        expect(stations.single.e5, isNull);
+        expect(stations.single.diesel, closeTo(7.45, 0.0001));
+      });
+
+      test('zero and negative prices are rejected', () {
+        final raw = _petromBucharest();
+        (raw['prices'] as Map<String, dynamic>)['benzina_standard'] = 0;
+        (raw['prices'] as Map<String, dynamic>)['motorina_standard'] = -1.2;
+        final stations = parse(_envelope([raw]));
+        expect(stations, hasLength(1));
+        expect(stations.single.e5, isNull);
+        expect(stations.single.diesel, isNull);
+        expect(stations.single.e98, closeTo(7.89, 0.0001));
+      });
+
+      test('numeric price strings are accepted', () {
+        final raw = _petromBucharest();
+        (raw['prices'] as Map<String, dynamic>)['benzina_standard'] = '7.25';
+        final stations = parse(_envelope([raw]));
+        expect(stations, hasLength(1));
+        expect(stations.single.e5, closeTo(7.25, 0.0001));
+      });
+
+      test('station id is prefixed with ro- (and not double-prefixed)', () {
+        final already = _petromBucharest(id: 'ro-PETROM-00123');
+        final plain = _petromBucharest(id: 'OMV-00001');
+        final stations = parse(_envelope([already, plain]));
+        expect(stations, hasLength(2));
+        expect(stations[0].id, 'ro-PETROM-00123',
+            reason: 'Existing ro- prefix must not be doubled up.');
+        expect(stations[1].id, 'ro-OMV-00001');
+      });
+
+      test('missing id is dropped', () {
+        final raw = _petromBucharest();
+        raw.remove('id');
+        expect(parse(_envelope([raw])), isEmpty);
+      });
+
+      test('missing coordinates dropped', () {
+        final raw = _petromBucharest();
+        raw.remove('lat');
+        expect(parse(_envelope([raw])), isEmpty);
+      });
+
+      test('updatedAt is propagated from the feed', () {
+        final stations = parse(_envelope([_petromBucharest()]));
+        expect(stations.single.updatedAt, '2026-04-22T10:30:00Z');
+      });
+
+      test('is_open boolean is propagated', () {
+        final closed = _petromBucharest(isOpen: false);
+        final stations = parse(_envelope([closed]));
+        expect(stations.single.isOpen, isFalse);
+      });
+    });
+
+    group('getStationDetail', () {
+      test('throws ApiException (detail not available)', () {
+        expect(
+          () => service.getStationDetail('ro-PETROM-00123'),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('error message mentions Monitorul', () async {
+        try {
+          await service.getStationDetail('ro-PETROM-00123');
+          fail('expected ApiException');
+        } on ApiException catch (e) {
+          expect(e.message, contains('Monitorul'));
+        }
+      });
+    });
+
+    group('getPrices', () {
+      test('returns empty map (no batch refresh)', () async {
+        final result = await service.getPrices(['ro-PETROM-00123']);
+        expect(result.data, isEmpty);
+        expect(result.source, ServiceSource.romaniaApi);
+      });
+
+      test('returns empty map for empty id list', () async {
+        final result = await service.getPrices([]);
+        expect(result.data, isEmpty);
+      });
+    });
+
+    group('station id prefix routing', () {
+      test('Countries.countryCodeForStationId resolves ro- → RO', () {
+        expect(
+          Countries.countryCodeForStationId('ro-PETROM-00123'),
+          'RO',
+        );
+      });
+
+      test('Countries.countryForStationId returns the RO config', () {
+        final c = Countries.countryForStationId('ro-PETROM-00123');
+        expect(c, isNotNull);
+        expect(c!.code, 'RO');
+        expect(c.currency, 'RON');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add Romania (`RO`) as the 17th supported country: *Monitorul Prețurilor la Carburanți* (pretcarburant.ro), the Competition Council + ANPC government-mandated observatory with 15-minute price updates.
- Fuel mapping: Benzină Standard → e5, Benzină Premium → e98, Motorină Standard → diesel, Motorină Premium → diesel premium, GPL → lpg.
- No documented public API — parser is fully fixture-driven (same strategy as Greece #576), so a URL / shape drift upstream is a one-line fix.

## Why

Tankstellen now covers a third South-East European market. Romania has ~1 500 stations (Petrom / OMV / Rompetrol / MOL / Lukoil / Socar) with legally-mandated 15-minute updates — a strong pay-less-at-the-pump fit.

## Notes on respectful scraping

- Service-level rate limit of **500 ms** between requests (via `DioFactory.RateLimitInterceptor`) so a burst of user refreshes cannot turn into a thundering herd.
- Dedicated, contactable User-Agent header: `Tankstellen/5.0 (fuel price comparison) contact: github.com/fdittgen/tankstellen` — the upstream maintainers can reach out if our usage is problematic.
- No auth, no keys — the observatory is a public feed.

## Scope

- `lib/core/services/impl/romania_station_service.dart` — new fixture-driven service
- `ServiceSource.romaniaApi` + `CountryServiceEntry(RO)` registry wiring
- `Countries.romania` config (RON / lei / `ro_RO`)
- Bounding box `RO: 43.5..48.5 / 20.0..29.8` covering Dobrogea coast
- `fuelTypesForCountry('RO')` includes the 5 RO fuels + electric + all
- ARB fragments `country_romania_en.arb` + `_de.arb` only (locale `ro` falls through)
- Tests: parser, `ro-` prefix, rate limit (≥ 500 ms), error handling, plus bbox + registry + country config coverage bumps (16 → 17)

## Test plan

- [x] `dart run tool/build_arb.dart`
- [x] `flutter gen-l10n`
- [x] `flutter analyze` — **no issues found**
- [x] `flutter test` — **all 5594 tests pass** (1 network-tagged skipped)
- [x] New `romania_station_service_test.dart`: 36 tests covering all 5 fuel mappings, parser edge cases (bad JSON, missing id/coords, zero/negative prices, unknown fuels, partial coverage), 403/timeout error handling, rate-limit ≥ 500 ms gate
- [x] Bbox regression: Bucharest / Cluj / Constanța → RO; Thessaloniki → GR (not RO); Kiev → null

Closes #577

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>