### PR TITLE
feat(shell): Conso tab gated on vehicle (#893)

### DIFF
--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../core/utils/frame_callbacks.dart';
+import '../features/vehicle/providers/vehicle_providers.dart';
 import '../l10n/app_localizations.dart';
 import 'current_shell_branch_provider.dart';
 import 'responsive_search_layout.dart';
@@ -38,6 +39,12 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
 
   int _currentIndex = 0;
   bool _isTransitioning = false;
+
+  /// Router-branch indices for the currently visible nav slots. Refreshed
+  /// on every `build()` so the swipe handler can walk to the adjacent
+  /// visible tab rather than blindly `_currentIndex ± 1` (which would
+  /// otherwise stop on the hidden Conso branch, #893).
+  List<int> _branchForSlot = const [0, 1, 2, 3, 4];
 
   /// Upper bound on destination count — the router always registers 5
   /// branches (see StatefulShellRoute in router.dart), the UI decides
@@ -130,10 +137,15 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
     final velocity = details.primaryVelocity ?? 0;
     if (velocity.abs() < 300) return;
 
-    if (velocity < 0 && _currentIndex < _pageCount - 1) {
-      _goToPage(_currentIndex + 1);
-    } else if (velocity > 0 && _currentIndex > 0) {
-      _goToPage(_currentIndex - 1);
+    // Walk through the visible slots, not the branch indices — when
+    // Conso is hidden (#893) the branch list has a gap between 2 and
+    // 4 that the user shouldn't be able to swipe through.
+    final slot = _branchForSlot.indexOf(_currentIndex);
+    if (slot < 0) return;
+    if (velocity < 0 && slot < _branchForSlot.length - 1) {
+      _goToPage(_branchForSlot[slot + 1]);
+    } else if (velocity > 0 && slot > 0) {
+      _goToPage(_branchForSlot[slot - 1]);
     }
   }
 
@@ -154,10 +166,22 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
     final screenSize = screenSizeOf(context);
     final isLandscape = MediaQuery.of(context).orientation == Orientation.landscape;
 
-    // #778 — Consumption is a first-class destination now: always
-    // visible, sitting between Favorites and Settings. Order must
-    // match the StatefulShellRoute branches in router.dart.
-    final destinations = <_NavItem>[
+    // #893 — Conso tab is only visible once the user has configured at
+    // least one vehicle. A fresh install (no vehicles) shows the 4
+    // canonical destinations (Search, Map, Favorites, Settings); the
+    // Conso branch still exists in the router (deep links to
+    // `/consumption-tab` and `/consumption/...` remain functional),
+    // only the bottom-nav item is conditional. `ref.watch` makes this
+    // reactive — removing the last vehicle from Settings instantly
+    // collapses the tab to 4, and adding the first vehicle grows it
+    // back to 5.
+    final hasVehicle =
+        ref.watch(vehicleProfileListProvider).isNotEmpty;
+
+    // Kept in router-branch order so the index we hand to
+    // `navigationShell.goBranch()` still lines up: Search=0, Map=1,
+    // Favorites=2, Consumption=3, Settings=4.
+    final allDestinations = <_NavItem>[
       _NavItem(Icons.search_outlined, Icons.search, l10n?.search ?? 'Search'),
       _NavItem(Icons.map_outlined, Icons.map, l10n?.map ?? 'Map'),
       _NavItem(Icons.star_outline, Icons.star, l10n?.favorites ?? 'Favorites'),
@@ -172,6 +196,35 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
         l10n?.settings ?? 'Settings',
       ),
     ];
+
+    // Visible items + the router-branch index each one maps to. When
+    // Conso is hidden, Settings still routes to branch 4 even though
+    // it renders at display-slot 3.
+    final visibleDestinations = <_NavItem>[];
+    final branchForSlot = <int>[];
+    for (var i = 0; i < allDestinations.length; i++) {
+      if (i == _consumptionBranchIndex && !hasVehicle) continue;
+      visibleDestinations.add(allDestinations[i]);
+      branchForSlot.add(i);
+    }
+    _branchForSlot = branchForSlot;
+
+    // If the user was on the Conso tab and just deleted their last
+    // vehicle, snap the selection to Search (branch 0) — the Conso
+    // slot has disappeared from the nav bar and leaving
+    // `_currentIndex` pointing at it would leave no item highlighted.
+    if (!hasVehicle && _currentIndex == _consumptionBranchIndex) {
+      safePostFrame(() {
+        if (!mounted) return;
+        if (_currentIndex != _consumptionBranchIndex) return;
+        _goToPage(0);
+      });
+    }
+
+    // Display-slot the animated nav bar should highlight. `-1` when
+    // the active branch has no visible slot (transient, resolved by
+    // the snap above on the next frame).
+    final selectedSlot = branchForSlot.indexOf(_currentIndex);
 
     final body = GestureDetector(
       behavior: HitTestBehavior.translucent,
@@ -192,6 +245,15 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
       ),
     );
 
+    // Translate a tap on a visible slot into the underlying branch
+    // index before calling `_goToPage`. Keeps the animation + router
+    // state machine unchanged when Conso is hidden (Settings at
+    // display-slot 3 still targets branch 4).
+    void onSlotTap(int slot) {
+      if (slot < 0 || slot >= branchForSlot.length) return;
+      _goToPage(branchForSlot[slot]);
+    }
+
     // Wide screens: use NavigationRail instead of bottom nav
     if (screenSize != ScreenSize.compact) {
       return Scaffold(
@@ -207,11 +269,12 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
         body: Row(
           children: [
             _AdaptiveNavigationRail(
-              items: destinations,
-              currentIndex: _currentIndex,
+              items: visibleDestinations,
+              branchForSlot: branchForSlot,
+              currentIndex: selectedSlot < 0 ? 0 : selectedSlot,
               iconControllers: _iconControllers,
               extended: screenSize == ScreenSize.expanded,
-              onTap: _goToPage,
+              onTap: onSlotTap,
             ),
             const VerticalDivider(width: 1, thickness: 1),
             Expanded(child: body),
@@ -227,14 +290,20 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
       primary: false,
       body: body,
       bottomNavigationBar: _AnimatedNavBar(
-        items: destinations,
-        currentIndex: _currentIndex,
+        items: visibleDestinations,
+        branchForSlot: branchForSlot,
+        currentIndex: selectedSlot < 0 ? 0 : selectedSlot,
         iconControllers: _iconControllers,
         isLandscape: isLandscape,
-        onTap: _goToPage,
+        onTap: onSlotTap,
       ),
     );
   }
+
+  /// Index of the Consumption branch in the StatefulShellRoute (see
+  /// `router.dart`). Exposed as a constant so hiding/showing logic can
+  /// refer to it by name rather than a naked `3`.
+  static const int _consumptionBranchIndex = 3;
 }
 
 class _NavItem {
@@ -250,6 +319,9 @@ class _NavItem {
 /// Shows icons-only rail on medium screens (600-840dp).
 class _AdaptiveNavigationRail extends StatelessWidget {
   final List<_NavItem> items;
+  /// Router-branch index for each visible slot. Used to index into the
+  /// 5-wide `iconControllers` list when Conso is hidden (#893).
+  final List<int> branchForSlot;
   final int currentIndex;
   final List<AnimationController> iconControllers;
   final bool extended;
@@ -257,6 +329,7 @@ class _AdaptiveNavigationRail extends StatelessWidget {
 
   const _AdaptiveNavigationRail({
     required this.items,
+    required this.branchForSlot,
     required this.currentIndex,
     required this.iconControllers,
     required this.extended,
@@ -283,16 +356,17 @@ class _AdaptiveNavigationRail extends StatelessWidget {
       destinations: List.generate(items.length, (i) {
         final item = items[i];
         final selected = i == currentIndex;
+        final controller = iconControllers[branchForSlot[i]];
         return NavigationRailDestination(
           icon: _BounceIcon(
-            controller: iconControllers[i],
+            controller: controller,
             selected: false,
             icon: item.outlinedIcon,
             iconSize: 24,
             color: theme.colorScheme.onSurfaceVariant,
           ),
           selectedIcon: _BounceIcon(
-            controller: iconControllers[i],
+            controller: controller,
             selected: true,
             icon: item.filledIcon,
             iconSize: 24,
@@ -308,6 +382,8 @@ class _AdaptiveNavigationRail extends StatelessWidget {
 
 class _AnimatedNavBar extends StatelessWidget {
   final List<_NavItem> items;
+  /// Router-branch index for each visible slot (see rail comment, #893).
+  final List<int> branchForSlot;
   final int currentIndex;
   final List<AnimationController> iconControllers;
   final bool isLandscape;
@@ -315,6 +391,7 @@ class _AnimatedNavBar extends StatelessWidget {
 
   const _AnimatedNavBar({
     required this.items,
+    required this.branchForSlot,
     required this.currentIndex,
     required this.iconControllers,
     required this.isLandscape,
@@ -353,6 +430,7 @@ class _AnimatedNavBar extends StatelessWidget {
         children: List.generate(items.length, (i) {
           final selected = i == currentIndex;
           final item = items[i];
+          final controller = iconControllers[branchForSlot[i]];
 
           return Expanded(
             child: Semantics(
@@ -368,7 +446,7 @@ class _AnimatedNavBar extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   _BounceIcon(
-                    controller: iconControllers[i],
+                    controller: controller,
                     selected: selected,
                     icon: selected ? item.filledIcon : item.outlinedIcon,
                     iconSize: iconSize,

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -11,6 +11,8 @@ import 'package:tankstellen/features/favorites/providers/favorites_provider.dart
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
 import '../helpers/mock_providers.dart';
@@ -35,6 +37,19 @@ class _EmptySearchState extends SearchState {
       fetchedAt: DateTime.now(),
     ));
   }
+}
+
+/// Stubs one configured vehicle so the #893 Conso-tab gating keeps
+/// the 5-tab shell visible in tests that assert all five icons.
+class _OneVehicleList extends VehicleProfileList {
+  @override
+  List<VehicleProfile> build() => const [
+        VehicleProfile(
+          id: 'car-1',
+          name: 'Daily Driver',
+          type: VehicleType.combustion,
+        ),
+      ];
 }
 
 /// Fixed FavoriteStations returning empty data.
@@ -80,6 +95,10 @@ void main() {
         userPositionNullOverride(),
         searchStateProvider.overrideWith(() => _EmptySearchState()),
         favoriteStationsProvider.overrideWith(() => _EmptyFavoriteStations()),
+        // #893 — the Conso tab is hidden when no vehicle is configured,
+        // so tests that assert the 5-tab layout must seed at least one
+        // vehicle.
+        vehicleProfileListProvider.overrideWith(() => _OneVehicleList()),
       ].cast();
     });
 

--- a/test/app/shell_consumption_tab_test.dart
+++ b/test/app/shell_consumption_tab_test.dart
@@ -3,7 +3,23 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tankstellen/app/shell_screen.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// #893 — seeds one vehicle so the Conso tab is visible in the
+/// existing #778 layout tests (Conso is otherwise hidden on fresh
+/// installs).
+class _OneVehicleList extends VehicleProfileList {
+  @override
+  List<VehicleProfile> build() => const [
+        VehicleProfile(
+          id: 'car-1',
+          name: 'Daily Driver',
+          type: VehicleType.combustion,
+        ),
+      ];
+}
 
 /// #778: Consumption is a first-class destination — always visible,
 /// sitting between Favorites and Settings. Supersedes the #701
@@ -57,6 +73,9 @@ Future<List<IconData>> _pumpShellIcons(WidgetTester tester) async {
 
   await tester.pumpWidget(
     ProviderScope(
+      overrides: [
+        vehicleProfileListProvider.overrideWith(() => _OneVehicleList()),
+      ],
       child: MaterialApp.router(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,

--- a/test/app/shell_nav_vehicle_gating_test.dart
+++ b/test/app/shell_nav_vehicle_gating_test.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tankstellen/app/shell_screen.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// #893 — the Conso bottom-nav tab is only visible once the user has
+/// configured at least one vehicle. Fresh installs see 4 tabs; adding
+/// a vehicle grows the nav to 5; deleting the last vehicle collapses
+/// it back to 4 (and if Conso was the active tab, selection snaps
+/// to Search).
+
+class _EmptyVehicleList extends VehicleProfileList {
+  @override
+  List<VehicleProfile> build() => const [];
+}
+
+class _MutableVehicleList extends VehicleProfileList {
+  final List<VehicleProfile> initial;
+  _MutableVehicleList(this.initial);
+
+  @override
+  List<VehicleProfile> build() => List<VehicleProfile>.from(initial);
+
+  void setAll(List<VehicleProfile> next) {
+    state = List<VehicleProfile>.from(next);
+  }
+}
+
+class _OneVehicleList extends VehicleProfileList {
+  @override
+  List<VehicleProfile> build() => const [
+        VehicleProfile(
+          id: 'car-1',
+          name: 'Daily Driver',
+          type: VehicleType.combustion,
+        ),
+      ];
+}
+
+Future<void> _pumpShell(
+  WidgetTester tester, {
+  required List<Object> overrides,
+  String initialLocation = '/',
+}) async {
+  // Force phone-size canvas so the compact bottom nav renders (not
+  // NavigationRail — the rail swap triggers at >=600dp).
+  tester.view.physicalSize = const Size(400, 800);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final router = GoRouter(
+    initialLocation: initialLocation,
+    routes: [
+      StatefulShellRoute.indexedStack(
+        builder: (_, _, shell) => ShellScreen(navigationShell: shell),
+        branches: [
+          StatefulShellBranch(routes: [
+            GoRoute(path: '/', builder: (_, _) => const Text('SearchBody')),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(path: '/map', builder: (_, _) => const Text('MapBody')),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(
+              path: '/favorites',
+              builder: (_, _) => const Text('FavoritesBody'),
+            ),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(
+              path: '/consumption-tab',
+              builder: (_, _) => const Text('ConsumptionBody'),
+            ),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(
+              path: '/profile',
+              builder: (_, _) => const Text('SettingsBody'),
+            ),
+          ]),
+        ],
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: overrides.cast(),
+      child: MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pump(const Duration(seconds: 1));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ShellScreen bottom-nav vehicle gating (#893)', () {
+    testWidgets(
+        'fresh install with zero vehicles renders exactly 4 tabs, no '
+        'Consumption label or icon', (tester) async {
+      await _pumpShell(
+        tester,
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _EmptyVehicleList()),
+        ],
+      );
+
+      // The four canonical destinations remain; Consumption is gone.
+      expect(find.text('Search'), findsOneWidget);
+      expect(find.text('Map'), findsOneWidget);
+      expect(find.text('Favorites'), findsOneWidget);
+      expect(find.text('Settings'), findsOneWidget);
+      expect(find.text('Consumption'), findsNothing);
+
+      // The fuel-station icons (outlined / filled) only belong to the
+      // Consumption nav item — neither should be in the tree.
+      expect(find.byIcon(Icons.local_gas_station), findsNothing);
+      expect(find.byIcon(Icons.local_gas_station_outlined), findsNothing);
+
+      // Double-check by counting Semantics buttons the nav exposes.
+      expect(find.bySemanticsLabel('Search'), findsOneWidget);
+      expect(find.bySemanticsLabel('Map'), findsOneWidget);
+      expect(find.bySemanticsLabel('Favorites'), findsOneWidget);
+      expect(find.bySemanticsLabel('Settings'), findsOneWidget);
+      expect(find.bySemanticsLabel('Consumption'), findsNothing);
+    });
+
+    testWidgets('one vehicle configured renders 5 tabs including Consumption',
+        (tester) async {
+      await _pumpShell(
+        tester,
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _OneVehicleList()),
+        ],
+      );
+
+      expect(find.text('Search'), findsOneWidget);
+      expect(find.text('Map'), findsOneWidget);
+      expect(find.text('Favorites'), findsOneWidget);
+      expect(find.text('Consumption'), findsOneWidget);
+      expect(find.text('Settings'), findsOneWidget);
+      // The Consumption icon should now be visible in the nav bar.
+      expect(
+        find.byIcon(Icons.local_gas_station_outlined),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'Settings still routes to its branch when Conso is hidden — '
+        'tapping it on a 4-tab nav shows SettingsBody, not the '
+        'ConsumptionBody that sits at the same display slot',
+        (tester) async {
+      await _pumpShell(
+        tester,
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _EmptyVehicleList()),
+        ],
+      );
+
+      await tester.tap(find.text('Settings'));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('SettingsBody'), findsOneWidget);
+      expect(find.text('ConsumptionBody'), findsNothing);
+    });
+
+    testWidgets(
+        'deleting the last vehicle while Conso is selected snaps the '
+        'nav back to 4 tabs and selection to Search', (tester) async {
+      final vehicles = _MutableVehicleList(const [
+        VehicleProfile(
+          id: 'car-1',
+          name: 'Daily Driver',
+          type: VehicleType.combustion,
+        ),
+      ]);
+
+      await _pumpShell(
+        tester,
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => vehicles),
+        ],
+        initialLocation: '/consumption-tab',
+      );
+
+      // Start with 5 tabs and Conso showing.
+      expect(find.text('Consumption'), findsOneWidget);
+      expect(find.text('ConsumptionBody'), findsOneWidget);
+
+      // User deletes their last vehicle in Settings.
+      vehicles.setAll(const []);
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // Conso tab is gone from the bottom nav.
+      expect(find.text('Consumption'), findsNothing);
+      expect(find.byIcon(Icons.local_gas_station), findsNothing);
+      expect(find.byIcon(Icons.local_gas_station_outlined), findsNothing);
+
+      // Remaining tabs are still 4.
+      expect(find.text('Search'), findsOneWidget);
+      expect(find.text('Map'), findsOneWidget);
+      expect(find.text('Favorites'), findsOneWidget);
+      expect(find.text('Settings'), findsOneWidget);
+
+      // Selection snapped to Search — SearchBody is what the user now
+      // sees. The Conso branch is hidden; we don't want a stranded
+      // "nothing highlighted" state.
+      expect(find.text('SearchBody'), findsOneWidget);
+      expect(find.text('ConsumptionBody'), findsNothing);
+    });
+  });
+}

--- a/test/app/shell_screen_responsive_test.dart
+++ b/test/app/shell_screen_responsive_test.dart
@@ -10,6 +10,8 @@ import 'package:tankstellen/features/favorites/providers/favorites_provider.dart
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
 import '../helpers/mock_providers.dart';
@@ -33,6 +35,19 @@ class _EmptySearchState extends SearchState {
       fetchedAt: DateTime.now(),
     ));
   }
+}
+
+/// Stubs one configured vehicle so the shell renders all 5 tabs —
+/// #893 hides the Conso tab when no vehicle is configured.
+class _OneVehicleList extends VehicleProfileList {
+  @override
+  List<VehicleProfile> build() => const [
+        VehicleProfile(
+          id: 'car-1',
+          name: 'Daily Driver',
+          type: VehicleType.combustion,
+        ),
+      ];
 }
 
 /// Fixed FavoriteStations returning empty data.
@@ -67,6 +82,9 @@ void main() {
         userPositionNullOverride(),
         searchStateProvider.overrideWith(() => _EmptySearchState()),
         favoriteStationsProvider.overrideWith(() => _EmptyFavoriteStations()),
+        // #893 — seed a vehicle so the Conso tab is visible for the
+        // existing 5-tab assertions below.
+        vehicleProfileListProvider.overrideWith(() => _OneVehicleList()),
       ];
     });
 

--- a/test/app/shell_screen_test.dart
+++ b/test/app/shell_screen_test.dart
@@ -10,6 +10,8 @@ import 'package:tankstellen/features/favorites/providers/favorites_provider.dart
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
 import '../helpers/mock_providers.dart';
@@ -33,6 +35,19 @@ class _EmptySearchState extends SearchState {
       fetchedAt: DateTime.now(),
     ));
   }
+}
+
+/// Stubs one configured vehicle so the shell renders all 5 tabs —
+/// #893 hides the Conso tab when the vehicle list is empty.
+class _OneVehicleList extends VehicleProfileList {
+  @override
+  List<VehicleProfile> build() => const [
+        VehicleProfile(
+          id: 'car-1',
+          name: 'Daily Driver',
+          type: VehicleType.combustion,
+        ),
+      ];
 }
 
 /// Fixed FavoriteStations returning empty data.
@@ -67,6 +82,9 @@ void main() {
         userPositionNullOverride(),
         searchStateProvider.overrideWith(() => _EmptySearchState()),
         favoriteStationsProvider.overrideWith(() => _EmptyFavoriteStations()),
+        // #893 — seed a vehicle so the Conso tab shows up and the
+        // existing 5-tab / 5-label assertions below still hold.
+        vehicleProfileListProvider.overrideWith(() => _OneVehicleList()),
       ];
     });
 


### PR DESCRIPTION
Closes #893

## What

Gate the Consumption (Conso) bottom-nav tab on the presence of at least one configured vehicle.

- **0 vehicles** → nav renders 4 tabs: Search, Map, Favorites, Settings.
- **1+ vehicles** → nav renders 5 tabs with Conso sitting between Favorites and Settings (preserves #778 muscle-memory).
- **Delete the last vehicle while Conso is selected** → nav collapses to 4 tabs, selection snaps to Search.

Reactive via \`ref.watch(vehicleProfileListProvider)\` — a delete in Settings or Vehicle List instantly updates the shell without manual refresh.

## Why

Conso is irrelevant until the user has a vehicle to log fill-ups for. Surfacing an empty tab on fresh installs creates a dead-end: tapping it forces the user through a "add a vehicle first" empty state for every attempt. Hiding the entry reclaims a nav slot for the 4 savings-lens destinations that work without any setup, and keeps the onboarding path focused.

## Scope

- Router branches remain unchanged — \`/consumption-tab\` and \`/consumption/...\` deep links still resolve. Only the bottom-nav and navigation-rail items are conditional.
- Slot-to-branch mapping keeps \`Settings\` routing to branch 4 even when it renders at display-slot 3 (i.e. after Conso is hidden).
- Swipe-to-navigate walks the visible-slot list, so the user can't swipe through a hidden Conso slot.

## Testing

- New: \`test/app/shell_nav_vehicle_gating_test.dart\` — 4 cases covering fresh install (4 tabs), with-vehicle (5 tabs), Settings-still-routes-correctly when Conso is hidden, and delete-last-vehicle snaps to Search.
- Updated: \`test/app/shell_consumption_tab_test.dart\`, \`test/app/shell_screen_test.dart\`, \`test/app/shell_screen_responsive_test.dart\`, \`test/app/router_test.dart\` — seed one vehicle in overrides so the 5-tab assertions from #778 still hold.
- \`flutter analyze\` — 0 issues.
- \`flutter test\` — 5598 tests pass.

## Screenshots

N/A — behaviour is covered by widget tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)