### PR TITLE
fix(ui): VIN explanation (#895)

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -18,6 +18,7 @@ import '../widgets/service_reminder_section.dart';
 import '../widgets/vehicle_combustion_section.dart';
 import '../widgets/vehicle_ev_section.dart';
 import '../widgets/vin_confirm_dialog.dart';
+import '../widgets/vin_info_sheet.dart';
 
 /// Form for adding or editing a [VehicleProfile].
 ///
@@ -49,6 +50,10 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   // provider; the populated engine fields are stored separately and
   // carried through _save.
   final _vinCtrl = TextEditingController();
+  // Focus node for the VIN field — we grab focus back after the
+  // in-place explanation sheet (#895) dismisses, so TalkBack users
+  // don't lose their place on the form.
+  final _vinFocus = FocusNode();
 
   // Combustion is the dominant case; start there and let the user
   // flip to Hybrid/Electric if needed (#710).
@@ -123,7 +128,17 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     _minSocCtrl.dispose();
     _maxSocCtrl.dispose();
     _vinCtrl.dispose();
+    _vinFocus.dispose();
     super.dispose();
+  }
+
+  /// Open the in-place VIN explanation (#895). After the sheet is
+  /// dismissed focus returns to the VIN text field so the user can
+  /// resume typing without hunting for the input.
+  Future<void> _showVinInfo() async {
+    await VinInfoSheet.show(context);
+    if (!mounted) return;
+    _vinFocus.requestFocus();
   }
 
   double? _parseDouble(String text) {
@@ -420,31 +435,54 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
                         : null,
                   ),
                 ),
-                FormFieldTile(
-                  icon: Icons.qr_code_2_outlined,
-                  color: accent,
-                  content: TextFormField(
-                    controller: _vinCtrl,
-                    decoration: InputDecoration(
-                      labelText: l?.vinLabel ?? 'VIN (optional)',
-                      border: const OutlineInputBorder(),
-                      suffixIcon: _decodingVin
-                          ? const Padding(
-                              padding: EdgeInsets.all(12),
-                              child: SizedBox(
-                                width: 20,
-                                height: 20,
-                                child: CircularProgressIndicator(
-                                    strokeWidth: 2),
-                              ),
-                            )
-                          : IconButton(
-                              icon: const Icon(Icons.search),
-                              tooltip: l?.vinDecodeTooltip ?? 'Decode VIN',
-                              onPressed: _decodeVin,
-                            ),
+                // VIN row — the FormFieldTile keeps the existing
+                // input layout, and a trailing info icon button
+                // (#895) opens the in-place explanation sheet.
+                // Tooltip + Semantics satisfy
+                // androidTapTargetGuideline and TalkBack
+                // announcement requirements.
+                Row(
+                  children: [
+                    Expanded(
+                      child: FormFieldTile(
+                        icon: Icons.qr_code_2_outlined,
+                        color: accent,
+                        content: TextFormField(
+                          controller: _vinCtrl,
+                          focusNode: _vinFocus,
+                          decoration: InputDecoration(
+                            labelText: l?.vinLabel ?? 'VIN (optional)',
+                            border: const OutlineInputBorder(),
+                            suffixIcon: _decodingVin
+                                ? const Padding(
+                                    padding: EdgeInsets.all(12),
+                                    child: SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                          strokeWidth: 2),
+                                    ),
+                                  )
+                                : IconButton(
+                                    icon: const Icon(Icons.search),
+                                    tooltip:
+                                        l?.vinDecodeTooltip ?? 'Decode VIN',
+                                    onPressed: _decodeVin,
+                                  ),
+                          ),
+                        ),
+                      ),
                     ),
-                  ),
+                    Semantics(
+                      label: l?.vinInfoTooltip ?? 'What is a VIN?',
+                      button: true,
+                      child: IconButton(
+                        icon: const Icon(Icons.info_outline),
+                        tooltip: l?.vinInfoTooltip ?? 'What is a VIN?',
+                        onPressed: _showVinInfo,
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/features/vehicle/presentation/widgets/vin_confirm_dialog.dart
+++ b/lib/features/vehicle/presentation/widgets/vin_confirm_dialog.dart
@@ -64,6 +64,19 @@ class VinConfirmDialog extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // Privacy reassurance (#895). Shown at the top so the user
+          // sees it before committing to the auto-fill — NHTSA is a
+          // free, public database, the VIN never leaves their device
+          // for Tankstellen purposes.
+          Text(
+            l?.vinConfirmPrivacyNote ??
+                "We looked up your VIN on NHTSA's free vehicle "
+                    'database — nothing sent to Tankstellen servers.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+          ),
+          const SizedBox(height: 12),
           Text(body),
           if (isPartial) ...[
             const SizedBox(height: 12),

--- a/lib/features/vehicle/presentation/widgets/vin_info_sheet.dart
+++ b/lib/features/vehicle/presentation/widgets/vin_info_sheet.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Modal bottom sheet that explains what a VIN is, why the app asks
+/// for it, the privacy guarantees, and where to find it on the car
+/// (#895).
+///
+/// Designed around the product principle "the app must be
+/// self-explaining": the VIN field label alone does not convey
+/// enough context, so an `Icons.info_outline` tap-target next to the
+/// label opens this sheet with four labeled sections.
+class VinInfoSheet extends StatelessWidget {
+  const VinInfoSheet({super.key});
+
+  /// Launch the info sheet. Returns once the user dismisses it.
+  static Future<void> show(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (_) => const VinInfoSheet(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    // Cap the sheet height so the long body scrolls instead of
+    // spilling past the top of the screen on compact phones.
+    final maxHeight = MediaQuery.of(context).size.height * 0.85;
+
+    return SafeArea(
+      top: false,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxHeight),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Icons.info_outline,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      l?.vinInfoTooltip ?? 'What is a VIN?',
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              _Section(
+                title: l?.vinInfoSectionWhatTitle ?? 'What is a VIN?',
+                body: l?.vinInfoSectionWhatBody ??
+                    'The Vehicle Identification Number is a 17-character '
+                        'code unique to your car. It\'s stamped on the '
+                        'chassis and printed on your vehicle registration '
+                        'document.',
+              ),
+              _Section(
+                title: l?.vinInfoSectionWhyTitle ?? 'Why we ask',
+                body: l?.vinInfoSectionWhyBody ??
+                    'Decoding the VIN auto-fills engine displacement, '
+                        'cylinder count, model year, primary fuel type, '
+                        'and gross weight — saving you from looking up '
+                        'technical specs manually. The OBD2 fuel-rate '
+                        'calculation uses these values to give you '
+                        'accurate consumption numbers.',
+              ),
+              _Section(
+                title: l?.vinInfoSectionPrivacyTitle ?? 'Privacy',
+                body: l?.vinInfoSectionPrivacyBody ??
+                    'Your VIN is stored only locally in the app\'s '
+                        'encrypted storage — it\'s never uploaded to '
+                        'Tankstellen servers. The NHTSA vPIC database '
+                        'is queried with the VIN but returns only '
+                        'anonymous technical specs; NHTSA does not '
+                        'link the VIN to any personal data. Without '
+                        'network, an offline lookup returns '
+                        'manufacturer and country only.',
+              ),
+              _Section(
+                title: l?.vinInfoSectionWhereTitle ?? 'Where to find it',
+                body: l?.vinInfoSectionWhereBody ??
+                    'Look through the windshield at the lower-left '
+                        'corner on the driver\'s side, check the '
+                        'driver-side door-frame sticker when the door is '
+                        'open, or read it off your vehicle registration '
+                        'document (card / Carte Grise).',
+              ),
+              const SizedBox(height: 4),
+              Align(
+                alignment: Alignment.centerRight,
+                child: FilledButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text(l?.vinInfoDismiss ?? 'Got it'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// One labeled section inside the VIN info sheet.
+class _Section extends StatelessWidget {
+  final String title;
+  final String body;
+
+  const _Section({required this.title, required this.body});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            body,
+            style: theme.textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/l10n/_fragments/vin_info_de.arb
+++ b/lib/l10n/_fragments/vin_info_de.arb
@@ -1,0 +1,13 @@
+{
+  "vinInfoTooltip": "Was ist eine FIN?",
+  "vinInfoSectionWhatTitle": "Was ist eine FIN?",
+  "vinInfoSectionWhatBody": "Die Fahrzeug-Identifizierungsnummer ist ein 17-stelliger Code, der Ihr Fahrzeug eindeutig kennzeichnet. Sie ist im Chassis eingeprägt und steht in Ihrem Fahrzeugschein.",
+  "vinInfoSectionWhyTitle": "Warum wir danach fragen",
+  "vinInfoSectionWhyBody": "Das Entschlüsseln der FIN füllt automatisch Hubraum, Zylinderzahl, Modelljahr, Hauptkraftstoff und zulässiges Gesamtgewicht aus — so müssen Sie die technischen Daten nicht mühsam heraussuchen. Die OBD2-Verbrauchsberechnung nutzt diese Werte für genaue Zahlen.",
+  "vinInfoSectionPrivacyTitle": "Datenschutz",
+  "vinInfoSectionPrivacyBody": "Ihre FIN wird nur lokal in der verschlüsselten App-Datenbank gespeichert — sie wird niemals an Tankstellen-Server gesendet. Die NHTSA vPIC-Datenbank wird mit der FIN abgefragt, liefert jedoch ausschließlich anonyme Fahrzeugdaten zurück; NHTSA verknüpft die FIN mit keinerlei persönlichen Daten. Ohne Netzwerk liefert eine Offline-Suche nur Hersteller und Land.",
+  "vinInfoSectionWhereTitle": "Wo Sie sie finden",
+  "vinInfoSectionWhereBody": "Schauen Sie unten links in der Windschutzscheibe (Fahrerseite) durch das Glas, prüfen Sie den Aufkleber am Türrahmen der Fahrertür bei geöffneter Tür, oder lesen Sie sie in Ihrem Fahrzeugschein ab.",
+  "vinInfoDismiss": "Verstanden",
+  "vinConfirmPrivacyNote": "Wir haben Ihre FIN in NHTSA's kostenloser Fahrzeugdatenbank nachgeschlagen — nichts wurde an Tankstellen-Server gesendet."
+}

--- a/lib/l10n/_fragments/vin_info_en.arb
+++ b/lib/l10n/_fragments/vin_info_en.arb
@@ -1,0 +1,46 @@
+{
+  "vinInfoTooltip": "What is a VIN?",
+  "@vinInfoTooltip": {
+    "description": "Tooltip + Semantics label for the info icon next to the VIN field on EditVehicleScreen (#895)."
+  },
+  "vinInfoSectionWhatTitle": "What is a VIN?",
+  "@vinInfoSectionWhatTitle": {
+    "description": "Heading for the 'What VIN is' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhatBody": "The Vehicle Identification Number is a 17-character code unique to your car. It's stamped on the chassis and printed on your vehicle registration document.",
+  "@vinInfoSectionWhatBody": {
+    "description": "Body of the 'What VIN is' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhyTitle": "Why we ask",
+  "@vinInfoSectionWhyTitle": {
+    "description": "Heading for the 'Why we ask' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhyBody": "Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.",
+  "@vinInfoSectionWhyBody": {
+    "description": "Body of the 'Why we ask' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionPrivacyTitle": "Privacy",
+  "@vinInfoSectionPrivacyTitle": {
+    "description": "Heading for the 'Privacy' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionPrivacyBody": "Your VIN is stored only locally in the app's encrypted storage — it's never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.",
+  "@vinInfoSectionPrivacyBody": {
+    "description": "Body of the 'Privacy' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhereTitle": "Where to find it",
+  "@vinInfoSectionWhereTitle": {
+    "description": "Heading for the 'Where to find it' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhereBody": "Look through the windshield at the lower-left corner on the driver's side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).",
+  "@vinInfoSectionWhereBody": {
+    "description": "Body of the 'Where to find it' section of the VIN info sheet (#895)."
+  },
+  "vinInfoDismiss": "Got it",
+  "@vinInfoDismiss": {
+    "description": "Dismiss button label on the VIN info sheet (#895)."
+  },
+  "vinConfirmPrivacyNote": "We looked up your VIN on NHTSA's free vehicle database — nothing sent to Tankstellen servers.",
+  "@vinConfirmPrivacyNote": {
+    "description": "One-line privacy reassurance shown near the top of the VIN confirm dialog (#895)."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1320,5 +1320,16 @@
   "vinDecodeTooltip": "FIN entschlüsseln",
   "vinConfirmAction": "Ja, automatisch ausfüllen",
   "vinModifyAction": "Manuell anpassen",
-  "veResetAction": "Kalibrierung zurücksetzen"
+  "veResetAction": "Kalibrierung zurücksetzen",
+  "vinInfoTooltip": "Was ist eine FIN?",
+  "vinInfoSectionWhatTitle": "Was ist eine FIN?",
+  "vinInfoSectionWhatBody": "Die Fahrzeug-Identifizierungsnummer ist ein 17-stelliger Code, der Ihr Fahrzeug eindeutig kennzeichnet. Sie ist im Chassis eingeprägt und steht in Ihrem Fahrzeugschein.",
+  "vinInfoSectionWhyTitle": "Warum wir danach fragen",
+  "vinInfoSectionWhyBody": "Das Entschlüsseln der FIN füllt automatisch Hubraum, Zylinderzahl, Modelljahr, Hauptkraftstoff und zulässiges Gesamtgewicht aus — so müssen Sie die technischen Daten nicht mühsam heraussuchen. Die OBD2-Verbrauchsberechnung nutzt diese Werte für genaue Zahlen.",
+  "vinInfoSectionPrivacyTitle": "Datenschutz",
+  "vinInfoSectionPrivacyBody": "Ihre FIN wird nur lokal in der verschlüsselten App-Datenbank gespeichert — sie wird niemals an Tankstellen-Server gesendet. Die NHTSA vPIC-Datenbank wird mit der FIN abgefragt, liefert jedoch ausschließlich anonyme Fahrzeugdaten zurück; NHTSA verknüpft die FIN mit keinerlei persönlichen Daten. Ohne Netzwerk liefert eine Offline-Suche nur Hersteller und Land.",
+  "vinInfoSectionWhereTitle": "Wo Sie sie finden",
+  "vinInfoSectionWhereBody": "Schauen Sie unten links in der Windschutzscheibe (Fahrerseite) durch das Glas, prüfen Sie den Aufkleber am Türrahmen der Fahrertür bei geöffneter Tür, oder lesen Sie sie in Ihrem Fahrzeugschein ab.",
+  "vinInfoDismiss": "Verstanden",
+  "vinConfirmPrivacyNote": "Wir haben Ihre FIN in NHTSA's kostenloser Fahrzeugdatenbank nachgeschlagen — nichts wurde an Tankstellen-Server gesendet."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1754,5 +1754,49 @@
   "veResetAction": "Reset calibration",
   "@veResetAction": {
     "description": "Action on the vehicle edit screen that discards the learned volumetric-efficiency calibration (#815)."
+  },
+  "vinInfoTooltip": "What is a VIN?",
+  "@vinInfoTooltip": {
+    "description": "Tooltip + Semantics label for the info icon next to the VIN field on EditVehicleScreen (#895)."
+  },
+  "vinInfoSectionWhatTitle": "What is a VIN?",
+  "@vinInfoSectionWhatTitle": {
+    "description": "Heading for the 'What VIN is' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhatBody": "The Vehicle Identification Number is a 17-character code unique to your car. It's stamped on the chassis and printed on your vehicle registration document.",
+  "@vinInfoSectionWhatBody": {
+    "description": "Body of the 'What VIN is' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhyTitle": "Why we ask",
+  "@vinInfoSectionWhyTitle": {
+    "description": "Heading for the 'Why we ask' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhyBody": "Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.",
+  "@vinInfoSectionWhyBody": {
+    "description": "Body of the 'Why we ask' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionPrivacyTitle": "Privacy",
+  "@vinInfoSectionPrivacyTitle": {
+    "description": "Heading for the 'Privacy' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionPrivacyBody": "Your VIN is stored only locally in the app's encrypted storage — it's never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.",
+  "@vinInfoSectionPrivacyBody": {
+    "description": "Body of the 'Privacy' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhereTitle": "Where to find it",
+  "@vinInfoSectionWhereTitle": {
+    "description": "Heading for the 'Where to find it' section of the VIN info sheet (#895)."
+  },
+  "vinInfoSectionWhereBody": "Look through the windshield at the lower-left corner on the driver's side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).",
+  "@vinInfoSectionWhereBody": {
+    "description": "Body of the 'Where to find it' section of the VIN info sheet (#895)."
+  },
+  "vinInfoDismiss": "Got it",
+  "@vinInfoDismiss": {
+    "description": "Dismiss button label on the VIN info sheet (#895)."
+  },
+  "vinConfirmPrivacyNote": "We looked up your VIN on NHTSA's free vehicle database — nothing sent to Tankstellen servers.",
+  "@vinConfirmPrivacyNote": {
+    "description": "One-line privacy reassurance shown near the top of the VIN confirm dialog (#895)."
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6355,6 +6355,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Reset calibration'**
   String get veResetAction;
+
+  /// Tooltip + Semantics label for the info icon next to the VIN field on EditVehicleScreen (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'What is a VIN?'**
+  String get vinInfoTooltip;
+
+  /// Heading for the 'What VIN is' section of the VIN info sheet (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'What is a VIN?'**
+  String get vinInfoSectionWhatTitle;
+
+  /// Body of the 'What VIN is' section of the VIN info sheet (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.'**
+  String get vinInfoSectionWhatBody;
+
+  /// Heading for the 'Why we ask' section of the VIN info sheet (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'Why we ask'**
+  String get vinInfoSectionWhyTitle;
+
+  /// Body of the 'Why we ask' section of the VIN info sheet (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.'**
+  String get vinInfoSectionWhyBody;
+
+  /// Heading for the 'Privacy' section of the VIN info sheet (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'Privacy'**
+  String get vinInfoSectionPrivacyTitle;
+
+  /// Body of the 'Privacy' section of the VIN info sheet (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.'**
+  String get vinInfoSectionPrivacyBody;
+
+  /// Heading for the 'Where to find it' section of the VIN info sheet (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'Where to find it'**
+  String get vinInfoSectionWhereTitle;
+
+  /// Body of the 'Where to find it' section of the VIN info sheet (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).'**
+  String get vinInfoSectionWhereBody;
+
+  /// Dismiss button label on the VIN info sheet (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'Got it'**
+  String get vinInfoDismiss;
+
+  /// One-line privacy reassurance shown near the top of the VIN confirm dialog (#895).
+  ///
+  /// In en, this message translates to:
+  /// **'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.'**
+  String get vinConfirmPrivacyNote;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3391,4 +3391,42 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3391,4 +3391,42 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3389,4 +3389,42 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3419,4 +3419,42 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get veResetAction => 'Kalibrierung zurücksetzen';
+
+  @override
+  String get vinInfoTooltip => 'Was ist eine FIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'Was ist eine FIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'Die Fahrzeug-Identifizierungsnummer ist ein 17-stelliger Code, der Ihr Fahrzeug eindeutig kennzeichnet. Sie ist im Chassis eingeprägt und steht in Ihrem Fahrzeugschein.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Warum wir danach fragen';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Das Entschlüsseln der FIN füllt automatisch Hubraum, Zylinderzahl, Modelljahr, Hauptkraftstoff und zulässiges Gesamtgewicht aus — so müssen Sie die technischen Daten nicht mühsam heraussuchen. Die OBD2-Verbrauchsberechnung nutzt diese Werte für genaue Zahlen.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Datenschutz';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Ihre FIN wird nur lokal in der verschlüsselten App-Datenbank gespeichert — sie wird niemals an Tankstellen-Server gesendet. Die NHTSA vPIC-Datenbank wird mit der FIN abgefragt, liefert jedoch ausschließlich anonyme Fahrzeugdaten zurück; NHTSA verknüpft die FIN mit keinerlei persönlichen Daten. Ohne Netzwerk liefert eine Offline-Suche nur Hersteller und Land.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Wo Sie sie finden';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Schauen Sie unten links in der Windschutzscheibe (Fahrerseite) durch das Glas, prüfen Sie den Aufkleber am Türrahmen der Fahrertür bei geöffneter Tür, oder lesen Sie sie in Ihrem Fahrzeugschein ab.';
+
+  @override
+  String get vinInfoDismiss => 'Verstanden';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'Wir haben Ihre FIN in NHTSA\'s kostenloser Fahrzeugdatenbank nachgeschlagen — nichts wurde an Tankstellen-Server gesendet.';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3393,4 +3393,42 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3384,4 +3384,42 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3392,4 +3392,42 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3386,4 +3386,42 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3389,4 +3389,42 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3413,4 +3413,42 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3388,4 +3388,42 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3393,4 +3393,42 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3392,4 +3392,42 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3390,4 +3390,42 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3392,4 +3392,42 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3388,4 +3388,42 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3393,4 +3393,42 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3391,4 +3391,42 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3392,4 +3392,42 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3391,4 +3391,42 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3392,4 +3392,42 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3386,4 +3386,42 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3390,4 +3390,42 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get veResetAction => 'Reset calibration';
+
+  @override
+  String get vinInfoTooltip => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatTitle => 'What is a VIN?';
+
+  @override
+  String get vinInfoSectionWhatBody =>
+      'The Vehicle Identification Number is a 17-character code unique to your car. It\'s stamped on the chassis and printed on your vehicle registration document.';
+
+  @override
+  String get vinInfoSectionWhyTitle => 'Why we ask';
+
+  @override
+  String get vinInfoSectionWhyBody =>
+      'Decoding the VIN auto-fills engine displacement, cylinder count, model year, primary fuel type, and gross weight — saving you from looking up technical specs manually. The OBD2 fuel-rate calculation uses these values to give you accurate consumption numbers.';
+
+  @override
+  String get vinInfoSectionPrivacyTitle => 'Privacy';
+
+  @override
+  String get vinInfoSectionPrivacyBody =>
+      'Your VIN is stored only locally in the app\'s encrypted storage — it\'s never uploaded to Tankstellen servers. The NHTSA vPIC database is queried with the VIN but returns only anonymous technical specs; NHTSA does not link the VIN to any personal data. Without network, an offline lookup returns manufacturer and country only.';
+
+  @override
+  String get vinInfoSectionWhereTitle => 'Where to find it';
+
+  @override
+  String get vinInfoSectionWhereBody =>
+      'Look through the windshield at the lower-left corner on the driver\'s side, check the driver-side door-frame sticker when the door is open, or read it off your vehicle registration document (card / Carte Grise).';
+
+  @override
+  String get vinInfoDismiss => 'Got it';
+
+  @override
+  String get vinConfirmPrivacyNote =>
+      'We looked up your VIN on NHTSA\'s free vehicle database — nothing sent to Tankstellen servers.';
 }

--- a/test/features/vehicle/presentation/screens/vin_info_test.dart
+++ b/test/features/vehicle/presentation/screens/vin_info_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for the in-place VIN explanation sheet (#895).
+///
+/// The info icon next to the VIN field opens a bottom sheet with
+/// four labelled sections. These tests verify the tap target, the
+/// Semantics label, the four section headings, and that dismissing
+/// returns focus to the VIN field.
+void main() {
+  group('EditVehicleScreen — VIN info sheet (#895)', () {
+    testWidgets('renders the info icon with the correct Semantics label',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+      await _pumpEditScreen(tester);
+
+      // Tooltip is the primary mechanism; the Semantics wrapper
+      // mirrors it so screen readers announce the same thing.
+      expect(
+        find.byTooltip('What is a VIN?'),
+        findsOneWidget,
+        reason:
+            'The info icon must expose a tooltip identical to the Semantics label.',
+      );
+      expect(
+        find.bySemanticsLabel('What is a VIN?'),
+        findsWidgets,
+        reason: 'Semantics label must be set so TalkBack reads it aloud.',
+      );
+      expect(find.byIcon(Icons.info_outline), findsOneWidget);
+
+      handle.dispose();
+    });
+
+    testWidgets(
+      'tapping the info icon opens the sheet with all four '
+      'section headings',
+      (tester) async {
+        await _pumpEditScreen(tester);
+
+        await tester.tap(find.byTooltip('What is a VIN?'));
+        await tester.pumpAndSettle();
+
+        // Every section title must be visible — verifying by
+        // find.text catches both the top header (same text as the
+        // first section title) and each subsequent section heading.
+        expect(find.text('What is a VIN?'), findsWidgets);
+        expect(find.text('Why we ask'), findsOneWidget);
+        expect(find.text('Privacy'), findsOneWidget);
+        expect(find.text('Where to find it'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'dismissing the sheet returns focus to the VIN text field',
+      (tester) async {
+        // Use a taller test window so the full bottom sheet (with
+        // the dismiss button) fits without having to scroll.
+        await tester.binding.setSurfaceSize(const Size(800, 1200));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await _pumpEditScreen(tester);
+
+        await tester.tap(find.byTooltip('What is a VIN?'));
+        await tester.pumpAndSettle();
+
+        // Scroll the dismiss button into view and tap it.
+        await tester.ensureVisible(find.text('Got it'));
+        await tester.tap(find.text('Got it'));
+        await tester.pumpAndSettle();
+
+        // Sheet should be gone.
+        expect(find.text('Why we ask'), findsNothing);
+
+        // Focus must sit on the VIN TextFormField: find the
+        // EditableText descendant and check its FocusNode.
+        final editable = tester.widget<EditableText>(
+          find.descendant(
+            of: find.widgetWithText(TextFormField, 'VIN (optional)'),
+            matching: find.byType(EditableText),
+          ),
+        );
+        expect(
+          editable.focusNode.hasFocus,
+          isTrue,
+          reason:
+              'After the VIN info sheet closes, focus must return to '
+              'the VIN TextFormField so TalkBack users can keep '
+              'typing without hunting for the input.',
+        );
+      },
+    );
+
+    testWidgets(
+      'the info icon meets the 48dp Android tap-target guideline',
+      (tester) async {
+        await _pumpEditScreen(tester);
+
+        final handle = tester.ensureSemantics();
+        await expectLater(
+          tester,
+          meetsGuideline(androidTapTargetGuideline),
+        );
+        handle.dispose();
+      },
+    );
+  });
+}
+
+Future<void> _pumpEditScreen(WidgetTester tester) async {
+  final repo = VehicleProfileRepository(_FakeSettings());
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        vehicleProfileRepositoryProvider.overrideWithValue(repo),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: EditVehicleScreen(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/vehicle/presentation/widgets/vin_confirm_dialog_test.dart
+++ b/test/features/vehicle/presentation/widgets/vin_confirm_dialog_test.dart
@@ -68,5 +68,28 @@ void main() {
       expect(find.text('Yes, auto-fill'), findsOneWidget);
       expect(find.text('Modify manually'), findsOneWidget);
     });
+
+    testWidgets(
+      'renders the NHTSA privacy note at the top of the dialog (#895)',
+      (tester) async {
+        await pumpApp(tester, const VinConfirmDialog(data: fullVpic));
+
+        // The privacy note sits above the technical summary so the
+        // user sees the reassurance before committing to the
+        // auto-fill.
+        expect(
+          find.textContaining("NHTSA's free vehicle database"),
+          findsOneWidget,
+          reason:
+              'The dialog must reassure the user that the VIN was '
+              'looked up on a public NHTSA database, not a '
+              'Tankstellen server (#895).',
+        );
+        expect(
+          find.textContaining('Tankstellen servers'),
+          findsOneWidget,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

- Info icon (`Icons.info_outline`) next to the VIN field on `EditVehicleScreen` opens a bottom sheet with four labeled sections: What VIN is, Why we ask, Privacy, Where to find it.
- Matching one-line NHTSA privacy note at the top of `VinConfirmDialog` so users see the reassurance before auto-filling.
- Focus returns to the VIN text field after the sheet dismisses so TalkBack users don't lose their place.

## Why

Users saw "VIN (optional)" with no explanation — the app was not self-explaining and violated the product principle. This patches the UX gap without sending the user to a separate help page.

## Test plan

- [x] `flutter analyze` clean (0 issues).
- [x] `flutter test` passes (full suite, `--reporter compact` exit 0).
- [x] New tests in `test/features/vehicle/presentation/screens/vin_info_test.dart`:
  - Info icon renders with correct Semantics label + tooltip.
  - Tap opens the sheet with all four section headings.
  - Dismissing returns focus to the VIN TextFormField.
  - Info icon meets `androidTapTargetGuideline` (48dp).
- [x] Extended `vin_confirm_dialog_test.dart` verifies the new NHTSA privacy note renders at the top of the dialog.

Closes #895