### PR TITLE
fix(ui): Theme section as card matching Privacy/Storage (#897)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -10,6 +10,7 @@ import '../features/favorites/presentation/screens/favorites_screen.dart';
 import '../features/map/presentation/screens/map_screen.dart';
 import '../features/profile/presentation/screens/privacy_dashboard_screen.dart';
 import '../features/profile/presentation/screens/profile_screen.dart';
+import '../features/profile/presentation/screens/theme_settings_screen.dart';
 import '../features/search/presentation/screens/search_criteria_screen.dart';
 import '../features/search/presentation/screens/search_screen.dart';
 import '../features/setup/presentation/screens/onboarding_wizard_screen.dart';
@@ -370,6 +371,14 @@ GoRouter router(Ref ref) {
       GoRoute(
         path: '/privacy-dashboard',
         builder: (context, state) => const PrivacyDashboardScreen(),
+      ),
+      // #897 — dedicated Theme settings screen, pushed from the
+      // Theme card on the profile/settings screen. Extracted from
+      // the inline bottom sheet so the Theme entry matches the
+      // Privacy + Storage card pattern.
+      GoRoute(
+        path: '/theme-settings',
+        builder: (context, state) => const ThemeSettingsScreen(),
       ),
     ],
   );

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../../core/theme/theme_mode_tile.dart';
+import '../../../../core/theme/theme_mode_provider.dart';
 import '../../../consent/presentation/widgets/consent_settings_section.dart';
 import '../widgets/about_section.dart';
 import '../widgets/api_key_section.dart';
@@ -85,8 +85,17 @@ class ProfileScreen extends ConsumerWidget {
           // `lib/app/router.dart` for direct navigation (station
           // detail CTA, deep links).
 
-          // Theme mode — light / dark / follow system (#752).
-          const ThemeModeTile(),
+          // Theme — light / dark / follow system (#752, #897).
+          // #897 — restyled as a `SettingsMenuTile` that navigates to
+          // the dedicated `/theme-settings` screen so the Theme entry
+          // matches the Privacy Dashboard and Storage card pattern
+          // instead of opening a modal bottom sheet inline.
+          SettingsMenuTile(
+            icon: Icons.palette_outlined,
+            title: l?.themeCardTitle ?? 'Theme',
+            subtitle: _themeSubtitle(ref, l),
+            onTap: () => context.push('/theme-settings'),
+          ),
           const SizedBox(height: 8),
 
           // Storage & Cache
@@ -164,6 +173,19 @@ class _FoldableSection extends StatelessWidget {
         children: [child],
       ),
     );
+  }
+}
+
+/// Active-mode subtitle on the Theme `SettingsMenuTile` (#897).
+String _themeSubtitle(WidgetRef ref, AppLocalizations? l) {
+  final mode = ref.watch(themeModeSettingProvider);
+  switch (mode) {
+    case ThemeMode.light:
+      return l?.themeCardSubtitleLight ?? 'Light';
+    case ThemeMode.dark:
+      return l?.themeCardSubtitleDark ?? 'Dark';
+    case ThemeMode.system:
+      return l?.themeCardSubtitleSystem ?? 'System';
   }
 }
 

--- a/lib/features/profile/presentation/screens/theme_settings_screen.dart
+++ b/lib/features/profile/presentation/screens/theme_settings_screen.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/theme/theme_mode_provider.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Dedicated Theme settings screen (#897).
+///
+/// Opened from the Theme [SettingsMenuTile] on the profile/settings
+/// screen. Presents the three theme-mode choices (System / Light /
+/// Dark) as full-width radio rows with descriptive copy below each
+/// option — the same layout convention as `PrivacyDashboardScreen`:
+/// `Scaffold` + `AppBar` + `ListView` body with 16 dp padding.
+///
+/// The picker was previously inlined on the Settings screen as a
+/// `Card` + bottom sheet (`ThemeModeTile`). Extracting it here lets
+/// the Theme entry match the Privacy and Storage entries, which both
+/// push to a dedicated screen rather than opening a sheet.
+class ThemeSettingsScreen extends ConsumerWidget {
+  const ThemeSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context);
+    final mode = ref.watch(themeModeSettingProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l?.themeSettingsScreenTitle ?? 'Theme'),
+      ),
+      body: RadioGroup<ThemeMode>(
+        groupValue: mode,
+        onChanged: (picked) => _select(ref, picked),
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            _ThemeModeOption(
+              mode: ThemeMode.system,
+              icon: Icons.smartphone,
+              label: l?.themeSettingsSystemLabel ?? 'Follow system',
+              description: l?.themeSettingsSystemDescription ??
+                  'Match the current device appearance.',
+              selected: mode == ThemeMode.system,
+              onTap: () => _select(ref, ThemeMode.system),
+              keyValue: 'themeSettingsOptionSystem',
+            ),
+            const SizedBox(height: 8),
+            _ThemeModeOption(
+              mode: ThemeMode.light,
+              icon: Icons.light_mode,
+              label: l?.themeSettingsLightLabel ?? 'Light',
+              description: l?.themeSettingsLightDescription ??
+                  'Bright backgrounds — best for daytime use.',
+              selected: mode == ThemeMode.light,
+              onTap: () => _select(ref, ThemeMode.light),
+              keyValue: 'themeSettingsOptionLight',
+            ),
+            const SizedBox(height: 8),
+            _ThemeModeOption(
+              mode: ThemeMode.dark,
+              icon: Icons.dark_mode,
+              label: l?.themeSettingsDarkLabel ?? 'Dark',
+              description: l?.themeSettingsDarkDescription ??
+                  'Dark backgrounds — easier on the eyes at night and '
+                      'saves battery on OLED screens.',
+              selected: mode == ThemeMode.dark,
+              onTap: () => _select(ref, ThemeMode.dark),
+              keyValue: 'themeSettingsOptionDark',
+            ),
+            SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _select(WidgetRef ref, ThemeMode? picked) async {
+    if (picked == null) return;
+    await ref.read(themeModeSettingProvider.notifier).set(picked);
+  }
+}
+
+/// A single radio row on the theme settings screen — card-wrapped
+/// for visual parity with the rest of the profile surface.
+class _ThemeModeOption extends StatelessWidget {
+  final ThemeMode mode;
+  final bool selected;
+  final IconData icon;
+  final String label;
+  final String description;
+  final VoidCallback onTap;
+  final String keyValue;
+
+  const _ThemeModeOption({
+    required this.mode,
+    required this.selected,
+    required this.icon,
+    required this.label,
+    required this.description,
+    required this.onTap,
+    required this.keyValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      key: Key(keyValue),
+      margin: EdgeInsets.zero,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(8, 8, 16, 12),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Radio<ThemeMode>(value: mode),
+              const SizedBox(width: 4),
+              Icon(icon, size: 20),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 10),
+                    Text(
+                      label,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight:
+                            selected ? FontWeight.bold : FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      description,
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/_fragments/theme_settings_de.arb
+++ b/lib/l10n/_fragments/theme_settings_de.arb
@@ -1,0 +1,13 @@
+{
+  "themeCardTitle": "Design",
+  "themeCardSubtitleSystem": "System",
+  "themeCardSubtitleLight": "Hell",
+  "themeCardSubtitleDark": "Dunkel",
+  "themeSettingsScreenTitle": "Design",
+  "themeSettingsSystemLabel": "Systemeinstellung folgen",
+  "themeSettingsLightLabel": "Hell",
+  "themeSettingsDarkLabel": "Dunkel",
+  "themeSettingsSystemDescription": "Verwendet die aktuelle Darstellung des Geräts.",
+  "themeSettingsLightDescription": "Helle Hintergründe — ideal tagsüber.",
+  "themeSettingsDarkDescription": "Dunkle Hintergründe — augenschonend bei Nacht und stromsparend auf OLED-Displays."
+}

--- a/lib/l10n/_fragments/theme_settings_en.arb
+++ b/lib/l10n/_fragments/theme_settings_en.arb
@@ -1,0 +1,46 @@
+{
+  "themeCardTitle": "Theme",
+  "@themeCardTitle": {
+    "description": "Title of the Theme card on the Settings screen (#897). The card matches the Privacy + Storage card pattern and navigates to a dedicated theme picker screen."
+  },
+  "themeCardSubtitleSystem": "System",
+  "@themeCardSubtitleSystem": {
+    "description": "Subtitle on the Theme card when the active theme mode is System (follow device setting) (#897)."
+  },
+  "themeCardSubtitleLight": "Light",
+  "@themeCardSubtitleLight": {
+    "description": "Subtitle on the Theme card when the active theme mode is Light (#897)."
+  },
+  "themeCardSubtitleDark": "Dark",
+  "@themeCardSubtitleDark": {
+    "description": "Subtitle on the Theme card when the active theme mode is Dark (#897)."
+  },
+  "themeSettingsScreenTitle": "Theme",
+  "@themeSettingsScreenTitle": {
+    "description": "AppBar title of the dedicated Theme settings screen (#897)."
+  },
+  "themeSettingsSystemLabel": "Follow system",
+  "@themeSettingsSystemLabel": {
+    "description": "Radio option label for the System theme mode on the Theme settings screen (#897)."
+  },
+  "themeSettingsLightLabel": "Light",
+  "@themeSettingsLightLabel": {
+    "description": "Radio option label for the Light theme mode on the Theme settings screen (#897)."
+  },
+  "themeSettingsDarkLabel": "Dark",
+  "@themeSettingsDarkLabel": {
+    "description": "Radio option label for the Dark theme mode on the Theme settings screen (#897)."
+  },
+  "themeSettingsSystemDescription": "Match the current device appearance.",
+  "@themeSettingsSystemDescription": {
+    "description": "Description text under the System option on the Theme settings screen (#897)."
+  },
+  "themeSettingsLightDescription": "Bright backgrounds — best for daytime use.",
+  "@themeSettingsLightDescription": {
+    "description": "Description text under the Light option on the Theme settings screen (#897)."
+  },
+  "themeSettingsDarkDescription": "Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.",
+  "@themeSettingsDarkDescription": {
+    "description": "Description text under the Dark option on the Theme settings screen (#897)."
+  }
+}

--- a/lib/l10n/_fragments/theme_settings_fr.arb
+++ b/lib/l10n/_fragments/theme_settings_fr.arb
@@ -1,0 +1,13 @@
+{
+  "themeCardTitle": "Thème",
+  "themeCardSubtitleSystem": "Système",
+  "themeCardSubtitleLight": "Clair",
+  "themeCardSubtitleDark": "Sombre",
+  "themeSettingsScreenTitle": "Thème",
+  "themeSettingsSystemLabel": "Suivre le système",
+  "themeSettingsLightLabel": "Clair",
+  "themeSettingsDarkLabel": "Sombre",
+  "themeSettingsSystemDescription": "Utilise l'apparence actuelle de l'appareil.",
+  "themeSettingsLightDescription": "Arrière-plans clairs — idéal en journée.",
+  "themeSettingsDarkDescription": "Arrière-plans sombres — plus doux pour les yeux la nuit et économe en batterie sur les écrans OLED."
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1316,6 +1316,17 @@
   "@splashLoadingLabel": {
     "description": "Barrierefreiheits-Label, das TalkBack/VoiceOver während des animierten Splash-Screens ansagt. Wird nicht sichtbar gerendert; kurz und sprechbar halten."
   },
+  "themeCardTitle": "Design",
+  "themeCardSubtitleSystem": "System",
+  "themeCardSubtitleLight": "Hell",
+  "themeCardSubtitleDark": "Dunkel",
+  "themeSettingsScreenTitle": "Design",
+  "themeSettingsSystemLabel": "Systemeinstellung folgen",
+  "themeSettingsLightLabel": "Hell",
+  "themeSettingsDarkLabel": "Dunkel",
+  "themeSettingsSystemDescription": "Verwendet die aktuelle Darstellung des Geräts.",
+  "themeSettingsLightDescription": "Helle Hintergründe — ideal tagsüber.",
+  "themeSettingsDarkDescription": "Dunkle Hintergründe — augenschonend bei Nacht und stromsparend auf OLED-Displays.",
   "vinLabel": "FIN (optional)",
   "vinDecodeTooltip": "FIN entschlüsseln",
   "vinConfirmAction": "Ja, automatisch ausfüllen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1747,6 +1747,50 @@
   "@splashLoadingLabel": {
     "description": "Accessibility label announced by TalkBack/VoiceOver while the animated splash screen is visible. Not rendered visually; keep it concise and speakable."
   },
+  "themeCardTitle": "Theme",
+  "@themeCardTitle": {
+    "description": "Title of the Theme card on the Settings screen (#897). The card matches the Privacy + Storage card pattern and navigates to a dedicated theme picker screen."
+  },
+  "themeCardSubtitleSystem": "System",
+  "@themeCardSubtitleSystem": {
+    "description": "Subtitle on the Theme card when the active theme mode is System (follow device setting) (#897)."
+  },
+  "themeCardSubtitleLight": "Light",
+  "@themeCardSubtitleLight": {
+    "description": "Subtitle on the Theme card when the active theme mode is Light (#897)."
+  },
+  "themeCardSubtitleDark": "Dark",
+  "@themeCardSubtitleDark": {
+    "description": "Subtitle on the Theme card when the active theme mode is Dark (#897)."
+  },
+  "themeSettingsScreenTitle": "Theme",
+  "@themeSettingsScreenTitle": {
+    "description": "AppBar title of the dedicated Theme settings screen (#897)."
+  },
+  "themeSettingsSystemLabel": "Follow system",
+  "@themeSettingsSystemLabel": {
+    "description": "Radio option label for the System theme mode on the Theme settings screen (#897)."
+  },
+  "themeSettingsLightLabel": "Light",
+  "@themeSettingsLightLabel": {
+    "description": "Radio option label for the Light theme mode on the Theme settings screen (#897)."
+  },
+  "themeSettingsDarkLabel": "Dark",
+  "@themeSettingsDarkLabel": {
+    "description": "Radio option label for the Dark theme mode on the Theme settings screen (#897)."
+  },
+  "themeSettingsSystemDescription": "Match the current device appearance.",
+  "@themeSettingsSystemDescription": {
+    "description": "Description text under the System option on the Theme settings screen (#897)."
+  },
+  "themeSettingsLightDescription": "Bright backgrounds — best for daytime use.",
+  "@themeSettingsLightDescription": {
+    "description": "Description text under the Light option on the Theme settings screen (#897)."
+  },
+  "themeSettingsDarkDescription": "Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.",
+  "@themeSettingsDarkDescription": {
+    "description": "Description text under the Dark option on the Theme settings screen (#897)."
+  },
   "vinLabel": "VIN (optional)",
   "vinDecodeTooltip": "Decode VIN",
   "vinConfirmAction": "Yes, auto-fill",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -848,5 +848,16 @@
   "onboardingObd2SkipButton": "Plus tard",
   "onboardingObd2ReadingVin": "Lecture du VIN en cours...",
   "onboardingObd2VinReadFailed": "Impossible de lire le VIN — saisie manuelle",
-  "onboardingObd2ConnectFailed": "Connexion impossible — vérifiez l'adaptateur ou passez l'étape"
+  "onboardingObd2ConnectFailed": "Connexion impossible — vérifiez l'adaptateur ou passez l'étape",
+  "themeCardTitle": "Thème",
+  "themeCardSubtitleSystem": "Système",
+  "themeCardSubtitleLight": "Clair",
+  "themeCardSubtitleDark": "Sombre",
+  "themeSettingsScreenTitle": "Thème",
+  "themeSettingsSystemLabel": "Suivre le système",
+  "themeSettingsLightLabel": "Clair",
+  "themeSettingsDarkLabel": "Sombre",
+  "themeSettingsSystemDescription": "Utilise l'apparence actuelle de l'appareil.",
+  "themeSettingsLightDescription": "Arrière-plans clairs — idéal en journée.",
+  "themeSettingsDarkDescription": "Arrière-plans sombres — plus doux pour les yeux la nuit et économe en batterie sur les écrans OLED."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6326,6 +6326,72 @@ abstract class AppLocalizations {
   /// **'Loading Tankstellen'**
   String get splashLoadingLabel;
 
+  /// Title of the Theme card on the Settings screen (#897). The card matches the Privacy + Storage card pattern and navigates to a dedicated theme picker screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Theme'**
+  String get themeCardTitle;
+
+  /// Subtitle on the Theme card when the active theme mode is System (follow device setting) (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'System'**
+  String get themeCardSubtitleSystem;
+
+  /// Subtitle on the Theme card when the active theme mode is Light (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'Light'**
+  String get themeCardSubtitleLight;
+
+  /// Subtitle on the Theme card when the active theme mode is Dark (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'Dark'**
+  String get themeCardSubtitleDark;
+
+  /// AppBar title of the dedicated Theme settings screen (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'Theme'**
+  String get themeSettingsScreenTitle;
+
+  /// Radio option label for the System theme mode on the Theme settings screen (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'Follow system'**
+  String get themeSettingsSystemLabel;
+
+  /// Radio option label for the Light theme mode on the Theme settings screen (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'Light'**
+  String get themeSettingsLightLabel;
+
+  /// Radio option label for the Dark theme mode on the Theme settings screen (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'Dark'**
+  String get themeSettingsDarkLabel;
+
+  /// Description text under the System option on the Theme settings screen (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'Match the current device appearance.'**
+  String get themeSettingsSystemDescription;
+
+  /// Description text under the Light option on the Theme settings screen (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'Bright backgrounds — best for daytime use.'**
+  String get themeSettingsLightDescription;
+
+  /// Description text under the Dark option on the Theme settings screen (#897).
+  ///
+  /// In en, this message translates to:
+  /// **'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.'**
+  String get themeSettingsDarkDescription;
+
   /// No description provided for @vinLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3378,6 +3378,42 @@ class AppLocalizationsBg extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3378,6 +3378,42 @@ class AppLocalizationsCs extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3376,6 +3376,42 @@ class AppLocalizationsDa extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3406,6 +3406,42 @@ class AppLocalizationsDe extends AppLocalizations {
   String get splashLoadingLabel => 'Tankstellen wird geladen';
 
   @override
+  String get themeCardTitle => 'Design';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Hell';
+
+  @override
+  String get themeCardSubtitleDark => 'Dunkel';
+
+  @override
+  String get themeSettingsScreenTitle => 'Design';
+
+  @override
+  String get themeSettingsSystemLabel => 'Systemeinstellung folgen';
+
+  @override
+  String get themeSettingsLightLabel => 'Hell';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dunkel';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Verwendet die aktuelle Darstellung des Geräts.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Helle Hintergründe — ideal tagsüber.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dunkle Hintergründe — augenschonend bei Nacht und stromsparend auf OLED-Displays.';
+
+  @override
   String get vinLabel => 'FIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3380,6 +3380,42 @@ class AppLocalizationsEl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3371,6 +3371,42 @@ class AppLocalizationsEn extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3379,6 +3379,42 @@ class AppLocalizationsEs extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3373,6 +3373,42 @@ class AppLocalizationsEt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3376,6 +3376,42 @@ class AppLocalizationsFi extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3400,6 +3400,42 @@ class AppLocalizationsFr extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Thème';
+
+  @override
+  String get themeCardSubtitleSystem => 'Système';
+
+  @override
+  String get themeCardSubtitleLight => 'Clair';
+
+  @override
+  String get themeCardSubtitleDark => 'Sombre';
+
+  @override
+  String get themeSettingsScreenTitle => 'Thème';
+
+  @override
+  String get themeSettingsSystemLabel => 'Suivre le système';
+
+  @override
+  String get themeSettingsLightLabel => 'Clair';
+
+  @override
+  String get themeSettingsDarkLabel => 'Sombre';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Utilise l\'apparence actuelle de l\'appareil.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Arrière-plans clairs — idéal en journée.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Arrière-plans sombres — plus doux pour les yeux la nuit et économe en batterie sur les écrans OLED.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3375,6 +3375,42 @@ class AppLocalizationsHr extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3380,6 +3380,42 @@ class AppLocalizationsHu extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3379,6 +3379,42 @@ class AppLocalizationsIt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3377,6 +3377,42 @@ class AppLocalizationsLt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3379,6 +3379,42 @@ class AppLocalizationsLv extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3375,6 +3375,42 @@ class AppLocalizationsNb extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3380,6 +3380,42 @@ class AppLocalizationsNl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3378,6 +3378,42 @@ class AppLocalizationsPl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3379,6 +3379,42 @@ class AppLocalizationsPt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3378,6 +3378,42 @@ class AppLocalizationsRo extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3379,6 +3379,42 @@ class AppLocalizationsSk extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3373,6 +3373,42 @@ class AppLocalizationsSl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3377,6 +3377,42 @@ class AppLocalizationsSv extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeCardTitle => 'Theme';
+
+  @override
+  String get themeCardSubtitleSystem => 'System';
+
+  @override
+  String get themeCardSubtitleLight => 'Light';
+
+  @override
+  String get themeCardSubtitleDark => 'Dark';
+
+  @override
+  String get themeSettingsScreenTitle => 'Theme';
+
+  @override
+  String get themeSettingsSystemLabel => 'Follow system';
+
+  @override
+  String get themeSettingsLightLabel => 'Light';
+
+  @override
+  String get themeSettingsDarkLabel => 'Dark';
+
+  @override
+  String get themeSettingsSystemDescription =>
+      'Match the current device appearance.';
+
+  @override
+  String get themeSettingsLightDescription =>
+      'Bright backgrounds — best for daytime use.';
+
+  @override
+  String get themeSettingsDarkDescription =>
+      'Dark backgrounds — easier on the eyes at night and saves battery on OLED screens.';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -208,8 +208,8 @@ void main() {
     });
 
     testWidgets(
-        '#896: renders exactly two SettingsMenuTile rows — the '
-        'Consumption log tile was the third and is removed',
+        '#896/#897: renders exactly three SettingsMenuTile rows — '
+        'My vehicles, Theme, Privacy Dashboard',
         (tester) async {
       await pumpApp(
         tester,
@@ -227,12 +227,12 @@ void main() {
         scrollable: find.byType(Scrollable).first,
       );
 
-      // Before #896 the Settings screen rendered three top-level
-      // destinations: My vehicles, Consumption log, Privacy Dashboard.
-      // After #896 only My vehicles and Privacy Dashboard remain — a
-      // decrease of exactly one. `SettingsMenuTile.title` survives the
-      // lazy-list dispose, so we collect titles from every match we
-      // see instead of trusting the instant count.
+      // #896 removed Consumption log. #897 restyled the Theme entry
+      // from a bespoke `ThemeModeTile` (Card + bottom sheet) into a
+      // third `SettingsMenuTile` that matches Privacy + Storage and
+      // pushes to a dedicated `/theme-settings` screen. The Settings
+      // screen now renders My vehicles, Theme, Privacy Dashboard as
+      // SettingsMenuTile rows.
       final observedTitles = <String>{};
       void collect() {
         for (final t in tester
@@ -258,16 +258,22 @@ void main() {
         reason: 'Privacy Dashboard tile should still render after #896',
       );
       expect(
+        observedTitles.contains('Theme'),
+        isTrue,
+        reason: '#897: Theme tile must render as a SettingsMenuTile '
+            '(card matching Privacy + Storage pattern)',
+      );
+      expect(
         observedTitles.contains('Consumption log'),
         isFalse,
         reason: '#896: Consumption log tile must not render any more',
       );
       expect(
         observedTitles.length,
-        2,
-        reason: '#896: expected exactly two distinct SettingsMenuTile '
-            'titles (My vehicles, Privacy Dashboard) after removing '
-            'Consumption log; found $observedTitles',
+        3,
+        reason: '#897: expected exactly three distinct SettingsMenuTile '
+            'titles (My vehicles, Theme, Privacy Dashboard); '
+            'found $observedTitles',
       );
     });
 

--- a/test/features/profile/presentation/screens/settings_screen_theme_card_test.dart
+++ b/test/features/profile/presentation/screens/settings_screen_theme_card_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/core/theme/theme_mode_provider.dart';
+import 'package:tankstellen/features/profile/presentation/screens/profile_screen.dart';
+import 'package:tankstellen/features/profile/presentation/widgets/settings_menu_tile.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../mocks/mocks.dart';
+
+/// Test-only ThemeModeSetting that exposes a fixed `build()` value and
+/// skips the real provider's SharedPreferences load — it would fail in
+/// widget tests where plugin channels are not registered.
+class _FixedThemeMode extends ThemeModeSetting {
+  final ThemeMode _initial;
+  _FixedThemeMode(this._initial);
+
+  @override
+  ThemeMode build() => _initial;
+
+  @override
+  Future<void> set(ThemeMode mode) async {
+    state = mode;
+  }
+}
+
+void main() {
+  group('ProfileScreen Theme card (#897)', () {
+    late MockHiveStorage mockStorage;
+
+    List<Object> buildOverrides(ThemeMode themeMode) {
+      mockStorage = MockHiveStorage();
+      when(() => mockStorage.hasApiKey()).thenReturn(false);
+      when(() => mockStorage.getApiKey()).thenReturn(null);
+      when(() => mockStorage.getActiveProfileId()).thenReturn(null);
+      when(() => mockStorage.getAllProfiles()).thenReturn([]);
+      when(() => mockStorage.getRatings()).thenReturn({});
+      when(() => mockStorage.getIgnoredIds()).thenReturn([]);
+      when(() => mockStorage.getSetting(any())).thenReturn(null);
+      when(() => mockStorage.storageStats).thenReturn((
+        settings: 0,
+        profiles: 0,
+        favorites: 0,
+        cache: 0,
+        priceHistory: 0,
+        alerts: 0,
+        total: 0,
+      ));
+      when(() => mockStorage.profileCount).thenReturn(0);
+      when(() => mockStorage.favoriteCount).thenReturn(0);
+      when(() => mockStorage.cacheEntryCount).thenReturn(0);
+      when(() => mockStorage.priceHistoryEntryCount).thenReturn(0);
+      when(() => mockStorage.alertCount).thenReturn(0);
+      when(() => mockStorage.getFavoriteIds()).thenReturn([]);
+      when(() => mockStorage.getAlerts()).thenReturn([]);
+      when(() => mockStorage.getEvApiKey()).thenReturn(null);
+      when(() => mockStorage.hasCustomEvApiKey()).thenReturn(false);
+
+      final test = standardTestOverrides();
+      return [
+        hiveStorageProvider.overrideWithValue(mockStorage),
+        ...test.overrides.skip(1),
+        themeModeSettingProvider.overrideWith(() => _FixedThemeMode(themeMode)),
+      ];
+    }
+
+    testWidgets(
+        'Theme row is a SettingsMenuTile — same shape as Privacy + Storage '
+        'instead of a bespoke bottom-sheet tile', (tester) async {
+      await pumpApp(
+        tester,
+        const ProfileScreen(),
+        overrides: buildOverrides(ThemeMode.system),
+      );
+
+      // Scroll so the Theme card is realized in the ListView.
+      await tester.scrollUntilVisible(
+        find.text('Theme'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      // A SettingsMenuTile exists with title "Theme" and a subtitle
+      // that reflects the active ThemeMode (here: System).
+      final themeTiles = tester
+          .widgetList<SettingsMenuTile>(find.byType(SettingsMenuTile))
+          .where((t) => t.title == 'Theme')
+          .toList();
+      expect(
+        themeTiles.length,
+        1,
+        reason: '#897: there must be exactly one Theme SettingsMenuTile '
+            'on the Settings screen',
+      );
+      expect(
+        themeTiles.single.subtitle,
+        'System',
+        reason: '#897: the Theme card subtitle reflects the active '
+            'ThemeMode.system — "System"',
+      );
+    });
+
+    testWidgets('Theme subtitle reads "Light" when ThemeMode is light',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const ProfileScreen(),
+        overrides: buildOverrides(ThemeMode.light),
+      );
+
+      await tester.scrollUntilVisible(
+        find.text('Theme'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      final themeTile = tester
+          .widgetList<SettingsMenuTile>(find.byType(SettingsMenuTile))
+          .firstWhere((t) => t.title == 'Theme');
+      expect(themeTile.subtitle, 'Light');
+    });
+
+    testWidgets('Theme subtitle reads "Dark" when ThemeMode is dark',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const ProfileScreen(),
+        overrides: buildOverrides(ThemeMode.dark),
+      );
+
+      await tester.scrollUntilVisible(
+        find.text('Theme'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      final themeTile = tester
+          .widgetList<SettingsMenuTile>(find.byType(SettingsMenuTile))
+          .firstWhere((t) => t.title == 'Theme');
+      expect(themeTile.subtitle, 'Dark');
+    });
+
+    testWidgets(
+        'legacy ThemeModeTile widget is NOT used on the Settings screen '
+        '— it was replaced by a SettingsMenuTile in #897', (tester) async {
+      await pumpApp(
+        tester,
+        const ProfileScreen(),
+        overrides: buildOverrides(ThemeMode.system),
+      );
+
+      // The bespoke Theme bottom-sheet tile had key 'themeModeTile'.
+      // After #897 that widget no longer appears on the Settings
+      // screen — navigation goes to /theme-settings instead of
+      // opening a sheet.
+      expect(find.byKey(const Key('themeModeTile')), findsNothing);
+    });
+  });
+}

--- a/test/features/profile/presentation/screens/settings_screen_theme_card_test.dart
+++ b/test/features/profile/presentation/screens/settings_screen_theme_card_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';

--- a/test/features/profile/presentation/screens/theme_settings_screen_test.dart
+++ b/test/features/profile/presentation/screens/theme_settings_screen_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/theme_mode_provider.dart';
+import 'package:tankstellen/features/profile/presentation/screens/theme_settings_screen.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Test-only ThemeModeSetting that exposes a fixed `build()` value and
+/// skips the real provider's SharedPreferences load — widget tests do
+/// not register plugin channels for SharedPreferences.
+class _FixedThemeMode extends ThemeModeSetting {
+  final ThemeMode _initial;
+  _FixedThemeMode(this._initial);
+
+  @override
+  ThemeMode build() => _initial;
+
+  @override
+  Future<void> set(ThemeMode mode) async {
+    state = mode;
+  }
+}
+
+void main() {
+  group('ThemeSettingsScreen (#897)', () {
+    testWidgets('renders Scaffold + AppBar with Theme title',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const ThemeSettingsScreen(),
+        overrides: [
+          themeModeSettingProvider
+              .overrideWith(() => _FixedThemeMode(ThemeMode.system)),
+        ],
+      );
+
+      expect(find.byType(Scaffold), findsAtLeast(1));
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.text('Theme'), findsOneWidget);
+    });
+
+    testWidgets('renders all three theme mode options', (tester) async {
+      await pumpApp(
+        tester,
+        const ThemeSettingsScreen(),
+        overrides: [
+          themeModeSettingProvider
+              .overrideWith(() => _FixedThemeMode(ThemeMode.system)),
+        ],
+      );
+
+      expect(find.text('Follow system'), findsOneWidget);
+      expect(find.text('Light'), findsOneWidget);
+      expect(find.text('Dark'), findsOneWidget);
+
+      // Each option has a descriptive body underneath.
+      expect(
+        find.textContaining('Match the current device appearance'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Bright backgrounds'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Dark backgrounds'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping Light option updates ThemeModeSetting',
+        (tester) async {
+      late ProviderContainer container;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            themeModeSettingProvider
+                .overrideWith(() => _FixedThemeMode(ThemeMode.system)),
+          ],
+          child: Builder(
+            builder: (ctx) {
+              container = ProviderScope.containerOf(ctx);
+              return const MaterialApp(home: ThemeSettingsScreen());
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Baseline — System is active.
+      expect(container.read(themeModeSettingProvider), ThemeMode.system);
+
+      // Tap the Light card.
+      await tester.tap(find.byKey(const Key('themeSettingsOptionLight')));
+      await tester.pumpAndSettle();
+
+      expect(container.read(themeModeSettingProvider), ThemeMode.light);
+    });
+
+    testWidgets('tapping Dark option updates ThemeModeSetting',
+        (tester) async {
+      late ProviderContainer container;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            themeModeSettingProvider
+                .overrideWith(() => _FixedThemeMode(ThemeMode.system)),
+          ],
+          child: Builder(
+            builder: (ctx) {
+              container = ProviderScope.containerOf(ctx);
+              return const MaterialApp(home: ThemeSettingsScreen());
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(container.read(themeModeSettingProvider), ThemeMode.system);
+
+      await tester.tap(find.byKey(const Key('themeSettingsOptionDark')));
+      await tester.pumpAndSettle();
+
+      expect(container.read(themeModeSettingProvider), ThemeMode.dark);
+    });
+
+    testWidgets('tapping System option from Dark resets to System',
+        (tester) async {
+      late ProviderContainer container;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            themeModeSettingProvider
+                .overrideWith(() => _FixedThemeMode(ThemeMode.dark)),
+          ],
+          child: Builder(
+            builder: (ctx) {
+              container = ProviderScope.containerOf(ctx);
+              return const MaterialApp(home: ThemeSettingsScreen());
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(container.read(themeModeSettingProvider), ThemeMode.dark);
+
+      await tester.tap(find.byKey(const Key('themeSettingsOptionSystem')));
+      await tester.pumpAndSettle();
+
+      expect(container.read(themeModeSettingProvider), ThemeMode.system);
+    });
+
+    testWidgets('all interactive options meet the 48dp tap-target guideline',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const ThemeSettingsScreen(),
+        overrides: [
+          themeModeSettingProvider
+              .overrideWith(() => _FixedThemeMode(ThemeMode.system)),
+        ],
+      );
+
+      await expectLater(
+        tester,
+        meetsGuideline(androidTapTargetGuideline),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Restyle the Theme entry on the profile/settings screen to match the Privacy Dashboard and Storage card pattern.

- Theme row now uses `SettingsMenuTile` (card + leading icon + title + subtitle + chevron) — same widget as Privacy Dashboard and My vehicles.
- Tapping the card pushes to a new `/theme-settings` screen (`ThemeSettingsScreen`) with a `Scaffold` + `AppBar` + `RadioGroup` body. Mirrors `PrivacyDashboardScreen` layout conventions.
- Subtitle on the card reflects the active `ThemeMode` — "System" / "Light" / "Dark".
- The legacy bespoke `ThemeModeTile` (Card + bottom sheet) is no longer rendered on the Settings screen; the widget file itself is untouched (out of allowlist) but has no remaining callers.

## ARB keys added (11, via fragment pattern)

`theme_settings_{en,de,fr}.arb`:
- `themeCardTitle`
- `themeCardSubtitleSystem`
- `themeCardSubtitleLight`
- `themeCardSubtitleDark`
- `themeSettingsScreenTitle`
- `themeSettingsSystemLabel`
- `themeSettingsLightLabel`
- `themeSettingsDarkLabel`
- `themeSettingsSystemDescription`
- `themeSettingsLightDescription`
- `themeSettingsDarkDescription`

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — full suite passes (5633 tests, 1 skipped, 0 failures)
- [x] `test/l10n/localization_completeness_test.dart` — passes (de has every new key, fr added for parity)
- [x] `test/features/profile/presentation/screens/settings_screen_theme_card_test.dart` — 4 new tests (card type, subtitle reflects mode for System/Light/Dark, legacy widget gone)
- [x] `test/features/profile/presentation/screens/theme_settings_screen_test.dart` — 6 new tests (AppBar title, all three options render, tap Light/Dark/System updates provider, androidTapTargetGuideline)
- [x] Existing `profile_screen_test.dart` updated: "exactly two SettingsMenuTile rows" assertion now expects three (My vehicles, Theme, Privacy Dashboard)

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)