### PR TITLE
fix(ui): Theme section UX parity (#897)

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../core/theme/theme_mode_provider.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../../core/theme/theme_mode_tile.dart';
 import '../../../consent/presentation/widgets/consent_settings_section.dart';
 import '../widgets/about_section.dart';
 import '../widgets/api_key_section.dart';
@@ -11,6 +11,7 @@ import '../widgets/profile_list_section.dart';
 import '../widgets/settings_menu_tile.dart';
 import '../widgets/storage_section.dart';
 import '../widgets/tank_sync_section.dart';
+import 'theme_settings_screen.dart';
 
 /// Settings / profile screen that composes extracted section widgets.
 ///
@@ -85,8 +86,29 @@ class ProfileScreen extends ConsumerWidget {
           // `lib/app/router.dart` for direct navigation (station
           // detail CTA, deep links).
 
-          // Theme mode — light / dark / follow system (#752).
-          const ThemeModeTile(),
+          // Theme — light / dark / follow system (#752, #897).
+          // Same widget class as the Privacy Dashboard and My vehicles
+          // menu tiles so the Settings screen reads as a consistent
+          // list of top-level destinations. Subtitle shows the active
+          // mode ("Current: Follow system") and rebuilds live when the
+          // user changes it on the `ThemeSettingsScreen`.
+          Consumer(
+            builder: (context, ref, _) {
+              final mode = ref.watch(themeModeSettingProvider);
+              final subtitlePrefix =
+                  l?.themeSettingsSubtitlePrefix ?? 'Current: ';
+              return SettingsMenuTile(
+                icon: Icons.palette_outlined,
+                title: l?.themeSettingTitle ?? 'Theme',
+                subtitle: '$subtitlePrefix${themeModeLabel(mode, l)}',
+                onTap: () => Navigator.of(context).push<void>(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const ThemeSettingsScreen(),
+                  ),
+                ),
+              );
+            },
+          ),
           const SizedBox(height: 8),
 
           // Storage & Cache

--- a/lib/features/profile/presentation/screens/theme_settings_screen.dart
+++ b/lib/features/profile/presentation/screens/theme_settings_screen.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/theme/theme_mode_provider.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Dedicated settings screen for the app's theme mode (#897).
+///
+/// Mirrors the layout/style of `PrivacyDashboardScreen` and the Storage
+/// Dashboard:
+///   * `Scaffold` with a plain `AppBar` titled "Theme".
+///   * `ListView` body, padded 16 dp on every edge + bottom viewPadding.
+///   * A coloured banner at the top explaining what the setting does.
+///   * A `Card` hosting three `RadioListTile`s (Light / Dark / Follow
+///     system) — extracted from the previous inline `ThemeModeTile`
+///     bottom-sheet picker.
+///
+/// Selecting a mode updates `themeModeSettingProvider` immediately; the
+/// Settings screen subtitle rebuilds live from the same provider, so the
+/// user can see the change reflected without re-navigating.
+class ThemeSettingsScreen extends ConsumerWidget {
+  const ThemeSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
+    final mode = ref.watch(themeModeSettingProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l?.themeSettingTitle ?? 'Theme'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _ThemeSettingsBanner(),
+          const SizedBox(height: 16),
+          Card(
+            margin: EdgeInsets.zero,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                    child: Text(
+                      l?.themeSettingsPickerHeader ?? 'Appearance',
+                      style: theme.textTheme.titleSmall
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  RadioGroup<ThemeMode>(
+                    groupValue: mode,
+                    onChanged: (v) {
+                      if (v != null) {
+                        ref
+                            .read(themeModeSettingProvider.notifier)
+                            .set(v);
+                      }
+                    },
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _themeOption(
+                          mode: ThemeMode.light,
+                          icon: Icons.light_mode,
+                          label: l?.themeModeLight ?? 'Light',
+                          keyValue: 'themeSettingsOptionLight',
+                        ),
+                        _themeOption(
+                          mode: ThemeMode.dark,
+                          icon: Icons.dark_mode,
+                          label: l?.themeModeDark ?? 'Dark',
+                          keyValue: 'themeSettingsOptionDark',
+                        ),
+                        _themeOption(
+                          mode: ThemeMode.system,
+                          icon: Icons.smartphone,
+                          label: l?.themeModeSystem ?? 'Follow system',
+                          keyValue: 'themeSettingsOptionSystem',
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
+        ],
+      ),
+    );
+  }
+
+  Widget _themeOption({
+    required ThemeMode mode,
+    required IconData icon,
+    required String label,
+    required String keyValue,
+  }) {
+    return RadioListTile<ThemeMode>(
+      key: Key(keyValue),
+      value: mode,
+      title: Row(
+        children: [
+          Icon(icon, size: 20),
+          const SizedBox(width: 8),
+          Text(label),
+        ],
+      ),
+    );
+  }
+}
+
+/// Top banner — same look as `PrivacyBanner` but themed with the
+/// `Icons.palette_outlined` glyph.
+class _ThemeSettingsBanner extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.palette_outlined,
+            color: theme.colorScheme.primary,
+            size: 32,
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              l?.themeSettingsDescription ??
+                  'Choose how the app looks. "Follow system" matches your '
+                      'device\'s light/dark preference.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Helper used by `ProfileScreen` to render the "Current: X" subtitle on
+/// the Theme menu tile. Kept in this file next to the screen so the mode
+/// -> label mapping stays in one place.
+String themeModeLabel(ThemeMode mode, AppLocalizations? l) => switch (mode) {
+      ThemeMode.light => l?.themeModeLight ?? 'Light',
+      ThemeMode.dark => l?.themeModeDark ?? 'Dark',
+      ThemeMode.system => l?.themeModeSystem ?? 'Follow system',
+    };

--- a/lib/l10n/_fragments/theme_settings_de.arb
+++ b/lib/l10n/_fragments/theme_settings_de.arb
@@ -1,0 +1,5 @@
+{
+  "themeSettingsSubtitlePrefix": "Aktuell: ",
+  "themeSettingsDescription": "Wähle, wie die App aussehen soll. „Systemeinstellung“ übernimmt die Hell-/Dunkel-Einstellung deines Geräts.",
+  "themeSettingsPickerHeader": "Darstellung"
+}

--- a/lib/l10n/_fragments/theme_settings_en.arb
+++ b/lib/l10n/_fragments/theme_settings_en.arb
@@ -1,0 +1,14 @@
+{
+  "themeSettingsSubtitlePrefix": "Current: ",
+  "@themeSettingsSubtitlePrefix": {
+    "description": "Prefix for the Theme settings card subtitle on the Settings screen. Followed by the localized current theme mode label (Light / Dark / Follow system)."
+  },
+  "themeSettingsDescription": "Choose how the app looks. \"Follow system\" matches your device's light/dark preference.",
+  "@themeSettingsDescription": {
+    "description": "Body copy on the Theme settings screen explaining what the three theme modes do. Matches the banner/body style of the Privacy Dashboard and Storage Dashboard screens."
+  },
+  "themeSettingsPickerHeader": "Appearance",
+  "@themeSettingsPickerHeader": {
+    "description": "Section header above the three-radio theme picker on the Theme settings screen (Light / Dark / Follow system)."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1316,6 +1316,9 @@
   "@splashLoadingLabel": {
     "description": "Barrierefreiheits-Label, das TalkBack/VoiceOver während des animierten Splash-Screens ansagt. Wird nicht sichtbar gerendert; kurz und sprechbar halten."
   },
+  "themeSettingsSubtitlePrefix": "Aktuell: ",
+  "themeSettingsDescription": "Wähle, wie die App aussehen soll. „Systemeinstellung“ übernimmt die Hell-/Dunkel-Einstellung deines Geräts.",
+  "themeSettingsPickerHeader": "Darstellung",
   "vinLabel": "FIN (optional)",
   "vinDecodeTooltip": "FIN entschlüsseln",
   "vinConfirmAction": "Ja, automatisch ausfüllen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1747,6 +1747,18 @@
   "@splashLoadingLabel": {
     "description": "Accessibility label announced by TalkBack/VoiceOver while the animated splash screen is visible. Not rendered visually; keep it concise and speakable."
   },
+  "themeSettingsSubtitlePrefix": "Current: ",
+  "@themeSettingsSubtitlePrefix": {
+    "description": "Prefix for the Theme settings card subtitle on the Settings screen. Followed by the localized current theme mode label (Light / Dark / Follow system)."
+  },
+  "themeSettingsDescription": "Choose how the app looks. \"Follow system\" matches your device's light/dark preference.",
+  "@themeSettingsDescription": {
+    "description": "Body copy on the Theme settings screen explaining what the three theme modes do. Matches the banner/body style of the Privacy Dashboard and Storage Dashboard screens."
+  },
+  "themeSettingsPickerHeader": "Appearance",
+  "@themeSettingsPickerHeader": {
+    "description": "Section header above the three-radio theme picker on the Theme settings screen (Light / Dark / Follow system)."
+  },
   "vinLabel": "VIN (optional)",
   "vinDecodeTooltip": "Decode VIN",
   "vinConfirmAction": "Yes, auto-fill",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6326,6 +6326,24 @@ abstract class AppLocalizations {
   /// **'Loading Tankstellen'**
   String get splashLoadingLabel;
 
+  /// Prefix for the Theme settings card subtitle on the Settings screen. Followed by the localized current theme mode label (Light / Dark / Follow system).
+  ///
+  /// In en, this message translates to:
+  /// **'Current: '**
+  String get themeSettingsSubtitlePrefix;
+
+  /// Body copy on the Theme settings screen explaining what the three theme modes do. Matches the banner/body style of the Privacy Dashboard and Storage Dashboard screens.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.'**
+  String get themeSettingsDescription;
+
+  /// Section header above the three-radio theme picker on the Theme settings screen (Light / Dark / Follow system).
+  ///
+  /// In en, this message translates to:
+  /// **'Appearance'**
+  String get themeSettingsPickerHeader;
+
   /// No description provided for @vinLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3378,6 +3378,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3378,6 +3378,16 @@ class AppLocalizationsCs extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3376,6 +3376,16 @@ class AppLocalizationsDa extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3406,6 +3406,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get splashLoadingLabel => 'Tankstellen wird geladen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Aktuell: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Wähle, wie die App aussehen soll. „Systemeinstellung“ übernimmt die Hell-/Dunkel-Einstellung deines Geräts.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Darstellung';
+
+  @override
   String get vinLabel => 'FIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3380,6 +3380,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3371,6 +3371,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3379,6 +3379,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3373,6 +3373,16 @@ class AppLocalizationsEt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3376,6 +3376,16 @@ class AppLocalizationsFi extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3400,6 +3400,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3375,6 +3375,16 @@ class AppLocalizationsHr extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3380,6 +3380,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3379,6 +3379,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3377,6 +3377,16 @@ class AppLocalizationsLt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3379,6 +3379,16 @@ class AppLocalizationsLv extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3375,6 +3375,16 @@ class AppLocalizationsNb extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3380,6 +3380,16 @@ class AppLocalizationsNl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3378,6 +3378,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3379,6 +3379,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3378,6 +3378,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3379,6 +3379,16 @@ class AppLocalizationsSk extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3373,6 +3373,16 @@ class AppLocalizationsSl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3377,6 +3377,16 @@ class AppLocalizationsSv extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get themeSettingsSubtitlePrefix => 'Current: ';
+
+  @override
+  String get themeSettingsDescription =>
+      'Choose how the app looks. \"Follow system\" matches your device\'s light/dark preference.';
+
+  @override
+  String get themeSettingsPickerHeader => 'Appearance';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -208,8 +208,8 @@ void main() {
     });
 
     testWidgets(
-        '#896: renders exactly two SettingsMenuTile rows — the '
-        'Consumption log tile was the third and is removed',
+        '#896/#897: renders exactly three SettingsMenuTile rows — '
+        'My vehicles, Theme, Privacy Dashboard',
         (tester) async {
       await pumpApp(
         tester,
@@ -229,10 +229,12 @@ void main() {
 
       // Before #896 the Settings screen rendered three top-level
       // destinations: My vehicles, Consumption log, Privacy Dashboard.
-      // After #896 only My vehicles and Privacy Dashboard remain — a
-      // decrease of exactly one. `SettingsMenuTile.title` survives the
-      // lazy-list dispose, so we collect titles from every match we
-      // see instead of trusting the instant count.
+      // After #896 the Consumption log tile was removed. #897 then
+      // restyled the Theme section to use the same SettingsMenuTile,
+      // bringing the count back to three (My vehicles, Theme, Privacy
+      // Dashboard). `SettingsMenuTile.title` survives the lazy-list
+      // dispose, so we collect titles from every match we see instead
+      // of trusting the instant count.
       final observedTitles = <String>{};
       void collect() {
         for (final t in tester
@@ -253,6 +255,11 @@ void main() {
         reason: 'My vehicles tile should still render after #896',
       );
       expect(
+        observedTitles.contains('Theme'),
+        isTrue,
+        reason: '#897: Theme tile must render as a SettingsMenuTile',
+      );
+      expect(
         observedTitles.contains('Privacy Dashboard'),
         isTrue,
         reason: 'Privacy Dashboard tile should still render after #896',
@@ -264,10 +271,10 @@ void main() {
       );
       expect(
         observedTitles.length,
-        2,
-        reason: '#896: expected exactly two distinct SettingsMenuTile '
-            'titles (My vehicles, Privacy Dashboard) after removing '
-            'Consumption log; found $observedTitles',
+        3,
+        reason: '#897: expected exactly three distinct SettingsMenuTile '
+            'titles (My vehicles, Theme, Privacy Dashboard); '
+            'found $observedTitles',
       );
     });
 

--- a/test/features/profile/presentation/screens/settings_screen_theme_card_test.dart
+++ b/test/features/profile/presentation/screens/settings_screen_theme_card_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/features/profile/presentation/screens/profile_screen.dart';
+import 'package:tankstellen/features/profile/presentation/screens/theme_settings_screen.dart';
+import 'package:tankstellen/features/profile/presentation/widgets/settings_menu_tile.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../mocks/mocks.dart';
+
+/// Regression tests for #897 — the Theme section on the Settings screen
+/// must use the same reusable widget class (`SettingsMenuTile`) as the
+/// Privacy Dashboard and Storage sections, render the chevron/icon/
+/// title/subtitle trio, and navigate to a dedicated `ThemeSettingsScreen`.
+void main() {
+  group('Settings screen Theme card (#897)', () {
+    late MockHiveStorage mockStorage;
+    late List<Object> overrides;
+
+    setUp(() {
+      mockStorage = MockHiveStorage();
+      when(() => mockStorage.hasApiKey()).thenReturn(false);
+      when(() => mockStorage.getApiKey()).thenReturn(null);
+      when(() => mockStorage.getActiveProfileId()).thenReturn(null);
+      when(() => mockStorage.getAllProfiles()).thenReturn([]);
+      when(() => mockStorage.getRatings()).thenReturn({});
+      when(() => mockStorage.getIgnoredIds()).thenReturn([]);
+      when(() => mockStorage.getSetting(any())).thenReturn(null);
+      when(() => mockStorage.storageStats).thenReturn((
+        settings: 0,
+        profiles: 0,
+        favorites: 0,
+        cache: 0,
+        priceHistory: 0,
+        alerts: 0,
+        total: 0,
+      ));
+      when(() => mockStorage.profileCount).thenReturn(0);
+      when(() => mockStorage.favoriteCount).thenReturn(0);
+      when(() => mockStorage.cacheEntryCount).thenReturn(0);
+      when(() => mockStorage.priceHistoryEntryCount).thenReturn(0);
+      when(() => mockStorage.alertCount).thenReturn(0);
+      when(() => mockStorage.getFavoriteIds()).thenReturn([]);
+      when(() => mockStorage.getAlerts()).thenReturn([]);
+      when(() => mockStorage.getEvApiKey()).thenReturn(null);
+      when(() => mockStorage.hasCustomEvApiKey()).thenReturn(false);
+
+      final test = standardTestOverrides();
+      overrides = [
+        hiveStorageProvider.overrideWithValue(mockStorage),
+        ...test.overrides.skip(1),
+      ];
+    });
+
+    testWidgets(
+        'renders the Theme section via the same SettingsMenuTile class '
+        'as the Privacy Dashboard tile', (tester) async {
+      await pumpApp(tester, const ProfileScreen(), overrides: overrides);
+
+      // Scroll far enough down to realise every bottom-half tile in
+      // the lazy ListView.
+      await tester.scrollUntilVisible(
+        find.text('Privacy Dashboard'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      final tileTitles = tester
+          .widgetList<SettingsMenuTile>(find.byType(SettingsMenuTile))
+          .map((t) => t.title)
+          .toList();
+
+      expect(
+        tileTitles.contains('Theme'),
+        isTrue,
+        reason: '#897: Theme must render via SettingsMenuTile, not a '
+            'bespoke widget — found titles $tileTitles',
+      );
+      expect(
+        tileTitles.contains('Privacy Dashboard'),
+        isTrue,
+        reason: 'Privacy Dashboard baseline must still render as a '
+            'SettingsMenuTile',
+      );
+    });
+
+    testWidgets(
+        'Theme tile shows Icons.palette_outlined leading, a subtitle, '
+        'and a trailing chevron', (tester) async {
+      await pumpApp(tester, const ProfileScreen(), overrides: overrides);
+
+      await tester.scrollUntilVisible(
+        find.text('Theme'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      final themeTile = tester
+          .widgetList<SettingsMenuTile>(find.byType(SettingsMenuTile))
+          .firstWhere((t) => t.title == 'Theme');
+
+      expect(themeTile.icon, Icons.palette_outlined);
+      expect(
+        themeTile.subtitle.startsWith('Current: '),
+        isTrue,
+        reason: 'subtitle should surface the active theme mode '
+            '(found "${themeTile.subtitle}")',
+      );
+
+      final tileFinder = find.ancestor(
+        of: find.text('Theme'),
+        matching: find.byType(SettingsMenuTile),
+      );
+      expect(
+        find.descendant(
+          of: tileFinder,
+          matching: find.byIcon(Icons.chevron_right),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: tileFinder,
+          matching: find.byIcon(Icons.palette_outlined),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'tapping the Theme tile navigates to ThemeSettingsScreen',
+        (tester) async {
+      await pumpApp(tester, const ProfileScreen(), overrides: overrides);
+
+      await tester.scrollUntilVisible(
+        find.text('Theme'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      await tester.tap(find.text('Theme'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ThemeSettingsScreen), findsOneWidget);
+    });
+  });
+}

--- a/test/features/profile/presentation/screens/theme_settings_screen_test.dart
+++ b/test/features/profile/presentation/screens/theme_settings_screen_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tankstellen/core/theme/theme_mode_provider.dart';
+import 'package:tankstellen/features/profile/presentation/screens/theme_settings_screen.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for the dedicated `ThemeSettingsScreen` introduced in
+/// #897. The screen should follow the `PrivacyDashboardScreen` layout
+/// conventions (AppBar + ListView + top banner + card-bodied picker),
+/// and selecting a theme mode should update the persisted
+/// `themeModeSettingProvider` immediately.
+void main() {
+  group('ThemeSettingsScreen (#897)', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    Future<ProviderContainer> pumpScreen(WidgetTester tester) async {
+      final container = ProviderContainer(overrides: const []);
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: Locale('en'),
+            home: ThemeSettingsScreen(),
+          ),
+        ),
+      );
+      // Let the provider's async `_load` settle to its persisted value
+      // before running assertions.
+      await tester.pumpAndSettle();
+      return container;
+    }
+
+    testWidgets(
+        'header layout mirrors Privacy Dashboard — Scaffold + AppBar + '
+        'ListView body', (tester) async {
+      await pumpScreen(tester);
+
+      // AppBar title uses the existing `themeSettingTitle` key.
+      expect(find.widgetWithText(AppBar, 'Theme'), findsOneWidget);
+
+      // Body is a single scrollable ListView, matching the privacy /
+      // storage dashboards.
+      expect(find.byType(ListView), findsOneWidget);
+
+      // Banner icon — palette_outlined glyph, same visual weight as
+      // the shield in the privacy dashboard.
+      expect(find.byIcon(Icons.palette_outlined), findsOneWidget);
+
+      // The picker renders all three mode labels regardless of which
+      // mode is currently selected.
+      expect(find.text('Light'), findsOneWidget);
+      expect(find.text('Dark'), findsOneWidget);
+      expect(find.text('Follow system'), findsOneWidget);
+    });
+
+    testWidgets(
+        'picking a new ThemeMode updates the provider live — the card '
+        'subtitle surface reads the new value on the next rebuild',
+        (tester) async {
+      final container = await pumpScreen(tester);
+
+      // Baseline — starts on `system` (nothing persisted).
+      expect(container.read(themeModeSettingProvider), ThemeMode.system);
+
+      // Tap Dark.
+      await tester.tap(find.byKey(const Key('themeSettingsOptionDark')));
+      await tester.pumpAndSettle();
+      expect(container.read(themeModeSettingProvider), ThemeMode.dark);
+
+      // Tap Light.
+      await tester.tap(find.byKey(const Key('themeSettingsOptionLight')));
+      await tester.pumpAndSettle();
+      expect(container.read(themeModeSettingProvider), ThemeMode.light);
+
+      // Tap Follow system — returns to default.
+      await tester.tap(find.byKey(const Key('themeSettingsOptionSystem')));
+      await tester.pumpAndSettle();
+      expect(container.read(themeModeSettingProvider), ThemeMode.system);
+    });
+
+    test(
+        'themeModeLabel returns the ARB-localized fallback for each '
+        'ThemeMode when AppLocalizations is null', () {
+      expect(themeModeLabel(ThemeMode.light, null), 'Light');
+      expect(themeModeLabel(ThemeMode.dark, null), 'Dark');
+      expect(themeModeLabel(ThemeMode.system, null), 'Follow system');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Replaces the bespoke `ThemeModeTile` (Card + inline `RadioGroup` bottom-sheet) on the Settings screen with a `SettingsMenuTile` — the same reusable class already used for "My vehicles" and "Privacy Dashboard".
- Adds a dedicated `ThemeSettingsScreen` (lib/features/profile/presentation/screens/theme_settings_screen.dart) whose layout mirrors the Privacy Dashboard: AppBar titled "Theme", top primary-tinted banner with `Icons.palette_outlined`, and a card-bodied `RadioGroup<ThemeMode>` inside a padded ListView.
- New ARB fragments `lib/l10n/_fragments/theme_settings_{en,de}.arb` add three keys (`themeSettingsSubtitlePrefix`, `themeSettingsDescription`, `themeSettingsPickerHeader`); existing `themeSettingTitle`/`themeModeLight`/`themeModeDark`/`themeModeSystem` stay in `_base_*.arb` since `ThemeModeTile` still lives in core.
- Navigation uses `Navigator.of(context).push(MaterialPageRoute(...))` to stay within the `lib/features/profile/**` scope — no router changes needed.

## Why

Resolves the inconsistent visual weight between the Theme row (small Card + leading mode-specific icon) and every other top-level destination on Settings (Privacy Dashboard, My vehicles). The subtitle now surfaces the current mode live (\"Current: Follow system\"), and the three-mode picker moves out of an ephemeral bottom-sheet onto a persistent screen with room for copy explaining what each mode does.

## Testing

- [x] `dart run tool/build_arb.dart` + `flutter gen-l10n`
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 5629 tests pass
- [x] New tests: `test/features/profile/presentation/screens/settings_screen_theme_card_test.dart` (3 cases — tile class, icon/subtitle/chevron, navigation)
- [x] New tests: `test/features/profile/presentation/screens/theme_settings_screen_test.dart` (3 cases — header layout, live provider update, label fallbacks)
- [x] Updated `profile_screen_test.dart` — tile count now asserts 3 (My vehicles, Theme, Privacy Dashboard) instead of the #896 count of 2.

Closes #897