### PR TITLE
refactor(station-detail): extract sections from station_detail_screen (Refs #563)

### DIFF
--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -3,53 +3,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
-import '../../../../core/widgets/animated_favorite_star.dart';
-import '../../../../core/widgets/brand_logo.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
-import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../alerts/domain/entities/price_alert.dart';
-import '../../../alerts/presentation/widgets/create_alert_dialog.dart';
-import '../../../alerts/providers/alert_provider.dart';
-import '../../../favorites/providers/favorites_provider.dart';
-import '../../../profile/providers/profile_provider.dart';
-import '../../../search/domain/entities/brand_registry.dart';
-import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
-import '../../../../core/utils/navigation_utils.dart';
-import '../../../../core/utils/station_extensions.dart';
-import 'package:share_plus/share_plus.dart';
-import '../../../payment/domain/qr_payment_decoder.dart';
-import '../../../payment/presentation/scan_payment_dispatcher.dart';
-import '../../../payment/presentation/widgets/unknown_qr_dialog.dart';
-import '../../../sync/presentation/widgets/qr_scanner_screen.dart';
 import '../../providers/station_detail_provider.dart';
 import '../widgets/price_history_section.dart';
-import '../widgets/price_tile.dart';
+import '../widgets/station_brand_header.dart';
+import '../widgets/station_brand_helpers.dart';
+import '../widgets/station_detail_app_bar_actions.dart';
 import '../widgets/station_info_section.dart';
+import '../widgets/station_prices_section.dart';
 import '../widgets/station_rating_section.dart';
 import '../widgets/station_status_row.dart';
-
-/// True when the station has a real, displayable brand — i.e. not
-/// empty and not one of the sentinel strings that parsers use when
-/// they cannot detect a brand (`'Station'` is the legacy sentinel,
-/// `BrandRegistry.independentLabel` is the new one from #482). Used
-/// everywhere the detail screen decides whether to render the brand
-/// text or fall back to the street address as the title.
-bool _hasRealBrand(Station s) {
-  if (s.brand.isEmpty) return false;
-  if (s.brand == 'Station') return false;
-  if (s.brand == BrandRegistry.independentLabel) return false;
-  return true;
-}
-
-/// True when the station's brand is the explicit "independent" sentinel
-/// (or the legacy `'Station'` value). The detail view uses this to
-/// render a localised "Station indépendante" subtitle so users can tell
-/// the difference between a genuine independent and a brand-detection
-/// bug (#482).
-bool _isIndependentSentinel(Station s) =>
-    s.brand == BrandRegistry.independentLabel || s.brand == 'Station';
 
 class StationDetailScreen extends ConsumerWidget {
   final String stationId;
@@ -59,15 +24,13 @@ class StationDetailScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final detailAsync = ref.watch(stationDetailProvider(stationId));
-    final isFav = ref.watch(isFavoriteProvider(stationId));
-    final l10n = AppLocalizations.of(context);
 
     // #595 — derive a display title from the loaded station so the Hero
     // flight from the search card lands on the matching brand/name.
     // Falls back to the generic "Station" label until data loads.
     final station = detailAsync.value?.data.station;
     final String appBarTitle = station != null
-        ? (_hasRealBrand(station) ? station.brand : station.street)
+        ? (hasRealBrand(station) ? station.brand : station.street)
         : (AppLocalizations.of(context)?.search ?? 'Station');
 
     return Scaffold(
@@ -109,39 +72,9 @@ class StationDetailScreen extends ConsumerWidget {
           tooltip: AppLocalizations.of(context)?.tooltipBack ?? 'Back',
         ),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.directions),
-            onPressed: () {
-              if (station != null) {
-                NavigationUtils.openInMaps(station.lat, station.lng,
-                    label: _hasRealBrand(station)
-                        ? station.brand
-                        : station.street);
-              }
-            },
-            tooltip: l10n?.navigate ?? 'Navigate',
-          ),
-          IconButton(
-            icon: const Icon(Icons.notifications_outlined),
-            onPressed: () => _showCreateAlertDialog(context, ref),
-            tooltip: l10n?.createAlert ?? 'Create price alert',
-          ),
-          IconButton(
-            icon: const Icon(Icons.qr_code_scanner),
-            onPressed: () => _startScanPayment(context),
-            tooltip: l10n?.scanPayment ?? 'Scan payment QR',
-          ),
-          IconButton(
-            icon: const Icon(Icons.flag_outlined),
-            onPressed: () => context.push('/report/$stationId'),
-            tooltip: l10n?.reportPrice ?? 'Report price',
-          ),
-          IconButton(
-            icon: AnimatedFavoriteStar(isFavorite: isFav),
-            onPressed: () {
-              ref.read(favoritesProvider.notifier).toggle(stationId, stationData: station);
-            },
-            tooltip: isFav ? 'Remove from favorites' : 'Add to favorites',
+          StationDetailAppBarActions(
+            stationId: stationId,
+            station: station,
           ),
         ],
       ),
@@ -185,74 +118,12 @@ class StationDetailScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 12),
 
-          // Brand logo + Name
-          //
-          // #482: stations returned without a recognised brand previously
-          // rendered just the street address, leaving the user unsure
-          // whether the missing brand was a bug or the station genuinely
-          // had no chain affiliation. Now we also show an explicit
-          // "Station indépendante" subtitle when the parser flagged the
-          // station with the independent sentinel.
-          Semantics(
-            label:
-                '${_hasRealBrand(station) ? station.brand : station.street}'
-                '${_hasRealBrand(station) && station.brand != station.street ? ', ${station.street}' : ''}',
-            header: true,
-            excludeSemantics: true,
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                BrandLogo(brand: station.brand, size: 48),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        _hasRealBrand(station)
-                            ? station.brand
-                            : station.street,
-                        style: theme.textTheme.headlineSmall?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      if (_hasRealBrand(station) &&
-                          station.brand != station.street)
-                        Text(station.street, style: theme.textTheme.bodyLarge),
-                      if (_isIndependentSentinel(station))
-                        Padding(
-                          padding: const EdgeInsets.only(top: 2),
-                          child: Text(
-                            l10n?.independentStation ?? 'Independent station',
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
-                              fontStyle: FontStyle.italic,
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
+          // Brand logo + Name (+ "Independent station" subtitle — #482)
+          StationBrandHeader(station: station),
           const SizedBox(height: 16),
 
-          // Prices (compact)
-          Semantics(
-            header: true,
-            child: Text(l10n?.prices ?? 'Prices', style: theme.textTheme.titleMedium),
-          ),
-          const SizedBox(height: 6),
-          PriceTile(label: 'Super E5', price: station.e5, fuelType: FuelType.e5),
-          PriceTile(label: 'Super E10', price: station.e10, fuelType: FuelType.e10),
-          PriceTile(label: 'Diesel', price: station.diesel, fuelType: FuelType.diesel),
-          if (station.e98 != null) PriceTile(label: 'Super 98', price: station.e98, fuelType: FuelType.e98),
-          if (station.e85 != null) PriceTile(label: 'E85', price: station.e85, fuelType: FuelType.e85),
-          if (station.lpg != null) PriceTile(label: 'LPG', price: station.lpg, fuelType: FuelType.lpg),
-          if (station.cng != null) PriceTile(label: 'CNG', price: station.cng, fuelType: FuelType.cng),
-          const SizedBox(height: 12),
-          _LogFillUpButton(station: station),
+          // Prices (compact) + "Log fill-up" CTA
+          StationPricesSection(station: station),
           const SizedBox(height: 16),
 
           // Address, opening hours, fuels, location (services moved to bottom)
@@ -266,166 +137,13 @@ class StationDetailScreen extends ConsumerWidget {
           const SizedBox(height: 24),
           Semantics(
             header: true,
-            child: Text(l10n?.priceHistory ?? 'Price History', style: theme.textTheme.titleMedium),
+            child: Text(l10n?.priceHistory ?? 'Price History',
+                style: theme.textTheme.titleMedium),
           ),
           const SizedBox(height: 8),
           PriceHistorySection(stationId: stationId, station: station),
         ],
       ),
     );
-  }
-
-  Future<void> _showCreateAlertDialog(BuildContext context, WidgetRef ref) async {
-    final detailAsync = ref.read(stationDetailProvider(stationId));
-    final station = detailAsync.value?.data.station;
-    final stationName = station != null
-        ? (_hasRealBrand(station) ? station.brand : station.street)
-        : stationId;
-    final currentPrice = station?.diesel ?? station?.e10 ?? station?.e5;
-
-    final alert = await showDialog<PriceAlert>(
-      context: context,
-      builder: (context) => CreateAlertDialog(
-        stationId: stationId,
-        stationName: stationName,
-        currentPrice: currentPrice,
-      ),
-    );
-
-    if (alert != null && context.mounted) {
-      await ref.read(alertProvider.notifier).addAlert(alert);
-      if (context.mounted) {
-        final l10n = AppLocalizations.of(context);
-        SnackBarHelper.showSuccess(context, l10n?.alertCreated ?? 'Price alert created');
-      }
-    }
-  }
-
-  /// Opens the mobile_scanner surface, decodes the scanned value and
-  /// dispatches to url_launcher / a confirmation dialog / a fallback
-  /// sheet based on the [QrPaymentTarget] classification (#587).
-  Future<void> _startScanPayment(BuildContext context) async {
-    final raw = await Navigator.of(context).push<String>(
-      MaterialPageRoute(builder: (_) => const QrScannerScreen()),
-    );
-    if (raw == null || !context.mounted) return;
-
-    final target = QrPaymentDecoder.decode(raw);
-    final outcome = await ScanPaymentDispatcher.handle(target);
-    if (!context.mounted) return;
-
-    final l10n = AppLocalizations.of(context);
-    switch (outcome) {
-      case ScanPaymentOutcome.launched:
-        break;
-      case ScanPaymentOutcome.launchFailed:
-        SnackBarHelper.showError(
-          context,
-          l10n?.qrPaymentLaunchFailed ??
-              'No app available to open this code',
-        );
-      case ScanPaymentOutcome.confirmEpc:
-        final epc = target as QrPaymentEpc;
-        final confirmed = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => ScanPaymentDispatcher.buildEpcDialog(ctx, epc),
-        );
-        if (confirmed == true && context.mounted) {
-          final result = await ScanPaymentDispatcher.tryLaunchEpc(epc);
-          if (!context.mounted) break;
-          switch (result) {
-            case EpcLaunchOutcome.launched:
-              break;
-            case EpcLaunchOutcome.copiedToClipboard:
-              SnackBarHelper.showSuccess(
-                context,
-                l10n?.qrPaymentEpcCopied ??
-                    'Bank details copied — paste into your banking app',
-              );
-            case EpcLaunchOutcome.failed:
-              SnackBarHelper.showError(
-                context,
-                l10n?.qrPaymentLaunchFailed ??
-                    'No app available to open this code',
-              );
-          }
-        }
-      case ScanPaymentOutcome.unknown:
-        final unknown = target as QrPaymentUnknown;
-        await showDialog<void>(
-          context: context,
-          builder: (ctx) => UnknownQrDialog(
-            raw: unknown.raw,
-            onShare: (text, subject) => SharePlus.instance.share(
-              ShareParams(text: text, subject: subject),
-            ),
-          ),
-        );
-    }
-  }
-}
-
-/// "Log fill-up here" button. Reads the active profile's preferred fuel
-/// type and the station's current price for that fuel, then navigates to
-/// [AddFillUpScreen] with both pre-filled so the user only needs to type
-/// liters and odometer.
-class _LogFillUpButton extends ConsumerWidget {
-  final Station station;
-
-  const _LogFillUpButton({required this.station});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final profile = ref.watch(activeProfileProvider);
-    final preferredFuel = profile?.preferredFuelType;
-    // Fall back to any fuel the station reports if the profile fuel isn't
-    // available at this station (e.g. diesel-preferring user at a petrol-only
-    // bio station).
-    final pricedFuel = preferredFuel != null &&
-            station.priceFor(preferredFuel) != null
-        ? preferredFuel
-        : _firstAvailableFuel(station);
-    final pricePerLiter =
-        pricedFuel != null ? station.priceFor(pricedFuel) : null;
-    final stationName = station.brand.isNotEmpty &&
-            station.brand != 'Station' &&
-            station.brand != BrandRegistry.independentLabel
-        ? station.brand
-        : station.street;
-
-    return OutlinedButton.icon(
-      onPressed: () {
-        final extra = <String, Object>{
-          'stationId': station.id,
-          'stationName': stationName,
-        };
-        if (pricedFuel != null) extra['fuelType'] = pricedFuel;
-        if (pricePerLiter != null) extra['pricePerLiter'] = pricePerLiter;
-        context.push('/consumption/add', extra: extra);
-      },
-      icon: const Icon(Icons.local_gas_station_outlined),
-      label: Text(
-        AppLocalizations.of(context)?.addFillUp ?? 'Log fill-up here',
-      ),
-    );
-  }
-
-  /// Returns the first fuel type for which this station has a price, in a
-  /// predictable priority order. Used when the profile fuel isn't available
-  /// at the station, so the button can still pre-fill a reasonable default.
-  static FuelType? _firstAvailableFuel(Station s) {
-    const order = [
-      FuelType.e10,
-      FuelType.e5,
-      FuelType.diesel,
-      FuelType.e98,
-      FuelType.e85,
-      FuelType.lpg,
-      FuelType.cng,
-    ];
-    for (final f in order) {
-      if (s.priceFor(f) != null) return f;
-    }
-    return null;
   }
 }

--- a/lib/features/station_detail/presentation/widgets/station_brand_header.dart
+++ b/lib/features/station_detail/presentation/widgets/station_brand_header.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/widgets/brand_logo.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/station.dart';
+import 'station_brand_helpers.dart';
+
+/// Brand logo + station name block at the top of the station detail body.
+///
+/// #482: stations returned without a recognised brand previously rendered
+/// just the street address, leaving the user unsure whether the missing
+/// brand was a bug or the station genuinely had no chain affiliation.
+/// Now we also show an explicit "Station indépendante" subtitle when the
+/// parser flagged the station with the independent sentinel.
+class StationBrandHeader extends StatelessWidget {
+  final Station station;
+
+  const StationBrandHeader({super.key, required this.station});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Semantics(
+      label:
+          '${hasRealBrand(station) ? station.brand : station.street}'
+          '${hasRealBrand(station) && station.brand != station.street ? ', ${station.street}' : ''}',
+      header: true,
+      excludeSemantics: true,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          BrandLogo(brand: station.brand, size: 48),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  hasRealBrand(station) ? station.brand : station.street,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                if (hasRealBrand(station) && station.brand != station.street)
+                  Text(station.street, style: theme.textTheme.bodyLarge),
+                if (isIndependentSentinel(station))
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      l10n?.independentStation ?? 'Independent station',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/station_detail/presentation/widgets/station_brand_helpers.dart
+++ b/lib/features/station_detail/presentation/widgets/station_brand_helpers.dart
@@ -1,0 +1,23 @@
+import '../../../search/domain/entities/brand_registry.dart';
+import '../../../search/domain/entities/station.dart';
+
+/// True when the station has a real, displayable brand — i.e. not
+/// empty and not one of the sentinel strings that parsers use when
+/// they cannot detect a brand (`'Station'` is the legacy sentinel,
+/// `BrandRegistry.independentLabel` is the new one from #482). Used
+/// everywhere the detail screen decides whether to render the brand
+/// text or fall back to the street address as the title.
+bool hasRealBrand(Station s) {
+  if (s.brand.isEmpty) return false;
+  if (s.brand == 'Station') return false;
+  if (s.brand == BrandRegistry.independentLabel) return false;
+  return true;
+}
+
+/// True when the station's brand is the explicit "independent" sentinel
+/// (or the legacy `'Station'` value). The detail view uses this to
+/// render a localised "Station indépendante" subtitle so users can tell
+/// the difference between a genuine independent and a brand-detection
+/// bug (#482).
+bool isIndependentSentinel(Station s) =>
+    s.brand == BrandRegistry.independentLabel || s.brand == 'Station';

--- a/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
+++ b/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../../../core/utils/navigation_utils.dart';
+import '../../../../core/widgets/animated_favorite_star.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../alerts/domain/entities/price_alert.dart';
+import '../../../alerts/presentation/widgets/create_alert_dialog.dart';
+import '../../../alerts/providers/alert_provider.dart';
+import '../../../favorites/providers/favorites_provider.dart';
+import '../../../payment/domain/qr_payment_decoder.dart';
+import '../../../payment/presentation/scan_payment_dispatcher.dart';
+import '../../../payment/presentation/widgets/unknown_qr_dialog.dart';
+import '../../../search/domain/entities/station.dart';
+import '../../../sync/presentation/widgets/qr_scanner_screen.dart';
+import '../../providers/station_detail_provider.dart';
+import 'station_brand_helpers.dart';
+
+/// AppBar actions cluster for [StationDetailScreen]: directions, create
+/// price alert, scan payment QR, report price, favorite toggle.
+///
+/// Extracted so the screen stays under the 300-LOC cap (#563). Public
+/// behaviour is identical to the previous inline implementation —
+/// same tooltips, same ordering, same callbacks.
+class StationDetailAppBarActions extends ConsumerWidget {
+  final String stationId;
+  final Station? station;
+
+  const StationDetailAppBarActions({
+    super.key,
+    required this.stationId,
+    required this.station,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final isFav = ref.watch(isFavoriteProvider(stationId));
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.directions),
+          onPressed: () {
+            final s = station;
+            if (s != null) {
+              NavigationUtils.openInMaps(
+                s.lat,
+                s.lng,
+                label: hasRealBrand(s) ? s.brand : s.street,
+              );
+            }
+          },
+          tooltip: l10n?.navigate ?? 'Navigate',
+        ),
+        IconButton(
+          icon: const Icon(Icons.notifications_outlined),
+          onPressed: () => _showCreateAlertDialog(context, ref),
+          tooltip: l10n?.createAlert ?? 'Create price alert',
+        ),
+        IconButton(
+          icon: const Icon(Icons.qr_code_scanner),
+          onPressed: () => _startScanPayment(context),
+          tooltip: l10n?.scanPayment ?? 'Scan payment QR',
+        ),
+        IconButton(
+          icon: const Icon(Icons.flag_outlined),
+          onPressed: () => context.push('/report/$stationId'),
+          tooltip: l10n?.reportPrice ?? 'Report price',
+        ),
+        IconButton(
+          icon: AnimatedFavoriteStar(isFavorite: isFav),
+          onPressed: () {
+            ref
+                .read(favoritesProvider.notifier)
+                .toggle(stationId, stationData: station);
+          },
+          tooltip: isFav ? 'Remove from favorites' : 'Add to favorites',
+        ),
+      ],
+    );
+  }
+
+  Future<void> _showCreateAlertDialog(
+      BuildContext context, WidgetRef ref) async {
+    final detailAsync = ref.read(stationDetailProvider(stationId));
+    final s = detailAsync.value?.data.station;
+    final stationName = s != null
+        ? (hasRealBrand(s) ? s.brand : s.street)
+        : stationId;
+    final currentPrice = s?.diesel ?? s?.e10 ?? s?.e5;
+
+    final alert = await showDialog<PriceAlert>(
+      context: context,
+      builder: (context) => CreateAlertDialog(
+        stationId: stationId,
+        stationName: stationName,
+        currentPrice: currentPrice,
+      ),
+    );
+
+    if (alert != null && context.mounted) {
+      await ref.read(alertProvider.notifier).addAlert(alert);
+      if (context.mounted) {
+        final l10n = AppLocalizations.of(context);
+        SnackBarHelper.showSuccess(
+            context, l10n?.alertCreated ?? 'Price alert created');
+      }
+    }
+  }
+
+  /// Opens the mobile_scanner surface, decodes the scanned value and
+  /// dispatches to url_launcher / a confirmation dialog / a fallback
+  /// sheet based on the [QrPaymentTarget] classification (#587).
+  Future<void> _startScanPayment(BuildContext context) async {
+    final raw = await Navigator.of(context).push<String>(
+      MaterialPageRoute(builder: (_) => const QrScannerScreen()),
+    );
+    if (raw == null || !context.mounted) return;
+
+    final target = QrPaymentDecoder.decode(raw);
+    final outcome = await ScanPaymentDispatcher.handle(target);
+    if (!context.mounted) return;
+
+    final l10n = AppLocalizations.of(context);
+    switch (outcome) {
+      case ScanPaymentOutcome.launched:
+        break;
+      case ScanPaymentOutcome.launchFailed:
+        SnackBarHelper.showError(
+          context,
+          l10n?.qrPaymentLaunchFailed ??
+              'No app available to open this code',
+        );
+      case ScanPaymentOutcome.confirmEpc:
+        final epc = target as QrPaymentEpc;
+        final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => ScanPaymentDispatcher.buildEpcDialog(ctx, epc),
+        );
+        if (confirmed == true && context.mounted) {
+          final result = await ScanPaymentDispatcher.tryLaunchEpc(epc);
+          if (!context.mounted) break;
+          switch (result) {
+            case EpcLaunchOutcome.launched:
+              break;
+            case EpcLaunchOutcome.copiedToClipboard:
+              SnackBarHelper.showSuccess(
+                context,
+                l10n?.qrPaymentEpcCopied ??
+                    'Bank details copied — paste into your banking app',
+              );
+            case EpcLaunchOutcome.failed:
+              SnackBarHelper.showError(
+                context,
+                l10n?.qrPaymentLaunchFailed ??
+                    'No app available to open this code',
+              );
+          }
+        }
+      case ScanPaymentOutcome.unknown:
+        final unknown = target as QrPaymentUnknown;
+        await showDialog<void>(
+          context: context,
+          builder: (ctx) => UnknownQrDialog(
+            raw: unknown.raw,
+            onShare: (text, subject) => SharePlus.instance.share(
+              ShareParams(text: text, subject: subject),
+            ),
+          ),
+        );
+    }
+  }
+}

--- a/lib/features/station_detail/presentation/widgets/station_prices_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_prices_section.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../profile/providers/profile_provider.dart';
+import '../../../search/domain/entities/brand_registry.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+import '../../../search/domain/entities/station.dart';
+import '../../../../core/utils/station_extensions.dart';
+import 'price_tile.dart';
+
+/// "Prices" header + per-fuel [PriceTile] rows + "Log fill-up" CTA.
+///
+/// Extracted from [StationDetailScreen] so the screen stays under the
+/// 300-LOC cap (#563). Public behaviour is unchanged — same fuel
+/// ordering, same optional-tile gating, same localisation lookups.
+class StationPricesSection extends StatelessWidget {
+  final Station station;
+
+  const StationPricesSection({super.key, required this.station});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Semantics(
+          header: true,
+          child: Text(l10n?.prices ?? 'Prices',
+              style: theme.textTheme.titleMedium),
+        ),
+        const SizedBox(height: 6),
+        PriceTile(label: 'Super E5', price: station.e5, fuelType: FuelType.e5),
+        PriceTile(label: 'Super E10', price: station.e10, fuelType: FuelType.e10),
+        PriceTile(label: 'Diesel', price: station.diesel, fuelType: FuelType.diesel),
+        if (station.e98 != null)
+          PriceTile(label: 'Super 98', price: station.e98, fuelType: FuelType.e98),
+        if (station.e85 != null)
+          PriceTile(label: 'E85', price: station.e85, fuelType: FuelType.e85),
+        if (station.lpg != null)
+          PriceTile(label: 'LPG', price: station.lpg, fuelType: FuelType.lpg),
+        if (station.cng != null)
+          PriceTile(label: 'CNG', price: station.cng, fuelType: FuelType.cng),
+        const SizedBox(height: 12),
+        LogFillUpButton(station: station),
+      ],
+    );
+  }
+}
+
+/// "Log fill-up here" button. Reads the active profile's preferred fuel
+/// type and the station's current price for that fuel, then navigates to
+/// `/consumption/add` with both pre-filled so the user only needs to
+/// type liters and odometer.
+class LogFillUpButton extends ConsumerWidget {
+  final Station station;
+
+  const LogFillUpButton({super.key, required this.station});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profile = ref.watch(activeProfileProvider);
+    final preferredFuel = profile?.preferredFuelType;
+    // Fall back to any fuel the station reports if the profile fuel isn't
+    // available at this station (e.g. diesel-preferring user at a petrol-only
+    // bio station).
+    final pricedFuel = preferredFuel != null &&
+            station.priceFor(preferredFuel) != null
+        ? preferredFuel
+        : _firstAvailableFuel(station);
+    final pricePerLiter =
+        pricedFuel != null ? station.priceFor(pricedFuel) : null;
+    final stationName = station.brand.isNotEmpty &&
+            station.brand != 'Station' &&
+            station.brand != BrandRegistry.independentLabel
+        ? station.brand
+        : station.street;
+
+    return OutlinedButton.icon(
+      onPressed: () {
+        final extra = <String, Object>{
+          'stationId': station.id,
+          'stationName': stationName,
+        };
+        if (pricedFuel != null) extra['fuelType'] = pricedFuel;
+        if (pricePerLiter != null) extra['pricePerLiter'] = pricePerLiter;
+        context.push('/consumption/add', extra: extra);
+      },
+      icon: const Icon(Icons.local_gas_station_outlined),
+      label: Text(
+        AppLocalizations.of(context)?.addFillUp ?? 'Log fill-up here',
+      ),
+    );
+  }
+
+  /// Returns the first fuel type for which this station has a price, in a
+  /// predictable priority order. Used when the profile fuel isn't available
+  /// at the station, so the button can still pre-fill a reasonable default.
+  static FuelType? _firstAvailableFuel(Station s) {
+    const order = [
+      FuelType.e10,
+      FuelType.e5,
+      FuelType.diesel,
+      FuelType.e98,
+      FuelType.e85,
+      FuelType.lpg,
+      FuelType.cng,
+    ];
+    for (final f in order) {
+      if (s.priceFor(f) != null) return f;
+    }
+    return null;
+  }
+}

--- a/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/domain/entities/brand_registry.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/station_brand_header.dart';
+
+import '../../../../fixtures/stations.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('StationBrandHeader', () {
+    testWidgets('renders real brand as headline and street as subtitle',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const StationBrandHeader(station: testStation),
+      );
+
+      // Real brand renders as headline (STAR), street renders as subtitle.
+      expect(find.text('STAR'), findsOneWidget);
+      expect(find.text('Hauptstr.'), findsOneWidget);
+    });
+
+    testWidgets('shows "Independent station" subtitle for independent sentinel',
+        (tester) async {
+      const independent = Station(
+        id: 's-indep',
+        name: 'Independent',
+        brand: BrandRegistry.independentLabel,
+        street: 'Some Street',
+        houseNumber: '1',
+        postCode: '10115',
+        place: 'Berlin',
+        lat: 52.52,
+        lng: 13.40,
+        dist: 1.0,
+        isOpen: true,
+      );
+
+      await pumpApp(
+        tester,
+        const StationBrandHeader(station: independent),
+      );
+
+      // Independent stations fall back to street as headline and expose
+      // the localised "Independent station" subtitle.
+      expect(find.text('Some Street'), findsOneWidget);
+      expect(find.text('Independent station'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/search/domain/entities/brand_registry.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';

--- a/test/features/station_detail/presentation/widgets/station_detail_app_bar_actions_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_detail_app_bar_actions_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart';
+
+import '../../../../fixtures/stations.dart';
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('StationDetailAppBarActions', () {
+    testWidgets('renders the five action buttons with tooltips',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const StationDetailAppBarActions(
+          stationId: '51d4b477-a095-1aa0-e100-80009459e03a',
+          station: testStation,
+        ),
+        overrides: [
+          favoritesOverride(const []),
+          isFavoriteOverride('51d4b477-a095-1aa0-e100-80009459e03a', false),
+        ],
+      );
+
+      // Five icon buttons: directions, alert, scan QR, report, favorite.
+      expect(find.byIcon(Icons.directions), findsOneWidget);
+      expect(find.byIcon(Icons.notifications_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.qr_code_scanner), findsOneWidget);
+      expect(find.byIcon(Icons.flag_outlined), findsOneWidget);
+      // Favorite is an AnimatedFavoriteStar — assert the un-favorited
+      // border icon is present.
+      expect(find.byIcon(Icons.star_border), findsWidgets);
+    });
+
+    testWidgets('shows filled star when station is favorited',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const StationDetailAppBarActions(
+          stationId: '51d4b477-a095-1aa0-e100-80009459e03a',
+          station: testStation,
+        ),
+        overrides: [
+          favoritesOverride(const ['51d4b477-a095-1aa0-e100-80009459e03a']),
+          isFavoriteOverride(
+              '51d4b477-a095-1aa0-e100-80009459e03a', true),
+        ],
+      );
+
+      // Favorited -> filled star icon.
+      expect(find.byIcon(Icons.star), findsWidgets);
+    });
+  });
+}

--- a/test/features/station_detail/presentation/widgets/station_prices_section_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_prices_section_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/profile/domain/entities/user_profile.dart';
 import 'package:tankstellen/features/profile/providers/profile_provider.dart';

--- a/test/features/station_detail/presentation/widgets/station_prices_section_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_prices_section_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/profile/domain/entities/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/station_prices_section.dart';
+
+import '../../../../fixtures/stations.dart';
+import '../../../../helpers/pump_app.dart';
+
+class _NullActiveProfile extends ActiveProfile {
+  @override
+  UserProfile? build() => null;
+}
+
+void main() {
+  group('StationPricesSection', () {
+    testWidgets('renders the prices header and the base-fuel tiles',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const StationPricesSection(station: testStation),
+        overrides: [
+          activeProfileProvider.overrideWith(() => _NullActiveProfile()),
+        ],
+      );
+
+      // The localized "Prices" header should be present.
+      expect(find.text('Prices'), findsOneWidget);
+      // Each of the three base fuel types must render as a PriceTile.
+      expect(find.text('Super E5'), findsOneWidget);
+      expect(find.text('Super E10'), findsOneWidget);
+      expect(find.text('Diesel'), findsOneWidget);
+      // The "Log fill-up" CTA must render (locale = en -> "Add fill-up").
+      expect(find.text('Add fill-up'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Split `lib/features/station_detail/presentation/screens/station_detail_screen.dart`
from **431 LOC → 149 LOC** so the screen satisfies the 300-LOC presentation-layer cap
called out in the oversized-files epic. Pure extraction — zero behaviour change, no
ARB touch, no provider surface change.

Widgets extracted (all under `lib/features/station_detail/presentation/widgets/`):

- `StationDetailAppBarActions` (178 LOC) — the 5-IconButton cluster
  (directions / create-alert / scan-QR / report / favorite) plus the
  create-alert + scan-payment dispatch logic that previously lived as
  private methods on the screen.
- `StationBrandHeader` (66 LOC) — brand logo + name + "Independent
  station" subtitle (#482) block.
- `StationPricesSection` (118 LOC) — "Prices" heading, per-fuel tiles
  (E5/E10/diesel + optional E98/E85/LPG/CNG), and the promoted public
  `LogFillUpButton`.
- `station_brand_helpers.dart` (23 LOC) — shared `hasRealBrand` /
  `isIndependentSentinel` predicates so the screen title and the brand
  header agree on sentinels.

## Why

`station_detail_screen.dart` was the last genuinely oversized screen
listed in #563 (the other candidates — report_screen, station_card,
search_results_list, profile_edit_sheet — are already under 300 LOC).
This phase unblocks the epic's forward progress without touching any
OBD2, consumption, or country-service files.

## Testing

- `flutter analyze` — no issues (plain, no `--no-fatal-infos`).
- `flutter test` — **5638 passed, 1 skipped** (full suite).
- Existing `station_detail_screen_test.dart` passes unchanged — confirms
  public behaviour (hero tag, fuel tiles, favorite button, address,
  freshness line) is preserved.
- 3 new smoke tests added covering the extracted widgets:
  - `station_brand_header_test.dart` (2 cases)
  - `station_prices_section_test.dart` (1 case)
  - `station_detail_app_bar_actions_test.dart` (2 cases)

## Refs

Refs #563 phase (station_detail_screen extraction).
Epic stays open — other files listed in #563 remain for future phases.