### PR TITLE
refactor(consumption): extract pump_display_parser sections (Refs #563)

### DIFF
--- a/lib/features/consumption/data/_pump_display_helpers.dart
+++ b/lib/features/consumption/data/_pump_display_helpers.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/foundation.dart';
+
+import '_pump_display_patterns.dart';
+
+/// A single decimal number lifted out of an OCR'd pump-display line.
+///
+/// Tracks its magnitude ([value]), the number of decimal places seen
+/// ([decimals] — 3 suggests price-per-litre, 2 suggests total/litres),
+/// and the [line] it came from for diagnostics.
+@immutable
+class PumpDisplayCandidate {
+  final double value;
+  final int decimals;
+  final String line;
+  const PumpDisplayCandidate({
+    required this.value,
+    required this.decimals,
+    required this.line,
+  });
+}
+
+/// Output of positional inference — the three fields that the parser
+/// could recover from raw numeric ordering when labelled extraction
+/// didn't catch them.
+@immutable
+class PumpDisplayInferredTriple {
+  final double? totalCost;
+  final double? liters;
+  final double? pricePerLiter;
+  const PumpDisplayInferredTriple({
+    this.totalCost,
+    this.liters,
+    this.pricePerLiter,
+  });
+
+  static const empty = PumpDisplayInferredTriple();
+}
+
+/// Parses a decimal string that may use either "," or "." as the
+/// decimal separator. Returns null on malformed input and emits a
+/// debugPrint trace so silent swallow doesn't hide OCR bugs.
+double? parseDecimalFromOcr(String value) {
+  final n = double.tryParse(value.replaceAll(',', '.'));
+  if (n == null) debugPrint('PumpDisplayParser: bad decimal "$value"');
+  return n;
+}
+
+/// Rewrites common 7-segment OCR confusions (O↔0, I/l↔1, B↔8, S↔5,
+/// D↔0, Z↔2, g↔9) but ONLY inside tokens that look numeric by
+/// construction. Non-numeric tokens like "Diesel" are left untouched
+/// because they never match [kNumericTokenPattern] on their own.
+String normaliseDigits(String text) {
+  return text.replaceAllMapped(kNumericTokenPattern, (m) {
+    final tok = m.group(0)!;
+    if (!isLikelyNumeric(tok)) return tok;
+    return rewriteDigitLookalikes(tok);
+  });
+}
+
+/// A token is "likely numeric" if either
+/// - it contains a decimal separator AND every non-separator char
+///   is a digit or a known 7-segment lookalike letter
+///   (so `58,42`, `B.OO`, `1O.SO` all qualify); or
+/// - it is a pure digit sequence (catches the bare pump number
+///   like "8" on its own line).
+///
+/// This deliberately excludes single lookalike letters ("D") and
+/// multi-letter tokens without a separator ("Diesel") so the
+/// rewriter never corrupts German words.
+bool isLikelyNumeric(String token) {
+  if (token.isEmpty) return false;
+  if (!token.contains(RegExp(r'[.,]'))) {
+    return RegExp(r'^\d+$').hasMatch(token);
+  }
+  final core = token.replaceAll(RegExp(r'[.,]'), '');
+  if (core.isEmpty) return false;
+  for (final ch in core.split('')) {
+    if (!looksLikeDigit(ch)) return false;
+  }
+  return true;
+}
+
+/// Single-char predicate for [isLikelyNumeric]. Accepts digits plus
+/// known 7-segment confusions.
+bool looksLikeDigit(String ch) => kDigitLookalikePattern.hasMatch(ch);
+
+/// Rewrites a single token using [kDigitLookalikeMap]. Assumes the
+/// caller already confirmed the token is numeric — see
+/// [isLikelyNumeric].
+String rewriteDigitLookalikes(String token) {
+  final sb = StringBuffer();
+  for (final ch in token.split('')) {
+    sb.write(kDigitLookalikeMap[ch] ?? ch);
+  }
+  return sb.toString();
+}
+
+/// Scores the parser output in [0, 1]. +0.3 per extracted primary
+/// field; +0.1 bonus when all three are internally consistent
+/// (|liters * price - total| <= 0.02); +0.05 when they're close
+/// but off by at most 10 cents.
+double scorePumpDisplayConfidence({
+  required double? total,
+  required double? liters,
+  required double? price,
+}) {
+  var score = 0.0;
+  if (total != null) score += 0.3;
+  if (liters != null) score += 0.3;
+  if (price != null) score += 0.3;
+  if (total != null && liters != null && price != null) {
+    final predicted = liters * price;
+    final delta = (predicted - total).abs();
+    if (delta <= 0.02) {
+      score += 0.1;
+    } else if (delta <= 0.10) {
+      score += 0.05;
+    }
+  }
+  return score.clamp(0.0, 1.0);
+}

--- a/lib/features/consumption/data/_pump_display_patterns.dart
+++ b/lib/features/consumption/data/_pump_display_patterns.dart
@@ -1,0 +1,89 @@
+/// Regex patterns and lookup tables used by [PumpDisplayParser].
+///
+/// Centralised here so the parser class can stay focused on
+/// orchestration. These patterns are intentionally conservative —
+/// they match the German pump vocabulary and the most common
+/// 7-segment OCR misreads, and nothing else.
+library;
+
+// ---------------------------------------------------------------------
+// Labelled-extraction patterns
+// ---------------------------------------------------------------------
+
+/// Matches "Betrag 58,42", "Betrag € 58,42", "€ 58.42",
+/// "EUR 58,42", and the common OCR misread "Betraq" where the
+/// 'g' hook is thin.
+final List<RegExp> kBetragPatterns = <RegExp>[
+  // "Betrag 58,42", "Betrag € 58,42", "Betrag: 58,42".
+  RegExp(
+      r'betra[gq]\s*(?:€|EUR)?\s*[:=]?\s*(\d+[.,]\d{2})',
+      caseSensitive: false),
+  RegExp(r'(?:€|EUR)\s*[:=]?\s*(\d+[.,]\d{2})\b'),
+  RegExp(r'\b(\d+[.,]\d{2})\s*€\b'),
+];
+
+/// Matches "Abgabe 31,12", "Abgabe L 31,12", "Volume 31.12 L",
+/// "Liter 31,12", and the "Ab9abe" / "Abqabe" misreads where a
+/// small glyph is mistaken for 9 or q.
+final List<RegExp> kAbgabePatterns = <RegExp>[
+  // Allow an optional "L" or "Liter" unit between the label and
+  // the number — some pumps render "Abgabe L 31,12" across two
+  // visual rows and ML Kit flattens that into a single line.
+  RegExp(
+      r'ab[g9q]abe\s*(?:L|l|Liter)?\s*[:=]?\s*(\d+[.,]\d{1,3})',
+      caseSensitive: false),
+  RegExp(r'(?:volume|menge|quantit[eé])\s*[:=]?\s*(\d+[.,]\d{1,3})',
+      caseSensitive: false),
+  // "31,12 L" or "31.12 Liter" — only when the line has no €
+  // nearby (so we don't grab the Betrag by accident).
+  RegExp(r'\b(\d+[.,]\d{1,3})\s*(?:L|l|Liter|Litres?)\b'),
+];
+
+/// Matches "Preis/Liter 1,849", "PREIS/L 1.849",
+/// "CT / Preis/Liter 184,9" (cents-per-litre layout),
+/// "1,849 €/L", "EUR/L 1.849".
+final List<RegExp> kPricePerLiterPatterns = <RegExp>[
+  RegExp(
+      r'preis\s*/?\s*(?:liter|l)\s*[:=]?\s*(\d+[.,]\d{2,3})',
+      caseSensitive: false),
+  RegExp(r'(?:€|EUR)\s*/\s*(?:L|l|Liter)\s*[:=]?\s*(\d+[.,]\d{2,3})'),
+  RegExp(r'(\d+[.,]\d{2,3})\s*(?:€|EUR)\s*/\s*(?:L|l|Liter)'),
+];
+
+/// Cents-per-litre layout: "CT 184,9" means 184,9 ct = 1.849 €/L.
+final RegExp kCentsPerLiterPattern =
+    RegExp(r'\bCT\b\s*[:=]?\s*(\d{2,3}[.,]?\d?)', caseSensitive: false);
+
+/// Matches a lone digit 1-9 on a line — the large pump-number glyph
+/// printed on the cabinet.
+final RegExp kLonePumpDigitPattern = RegExp(r'^[1-9]$');
+
+/// Matches any decimal number inside a line (positional inference).
+final RegExp kDecimalNumberPattern = RegExp(r'(\d+[.,]\d{1,3})');
+
+/// Matches a numeric-ish token that might contain 7-segment
+/// lookalike letters. Used by [normaliseDigits] to restrict
+/// rewriting to plausible number tokens only.
+final RegExp kNumericTokenPattern =
+    RegExp(r'[0-9OoIlBSDZsdzbg]+(?:[.,][0-9OoIlBSDZsdzbg]+)*');
+
+/// Single-char check for "this glyph could be a digit". Includes
+/// real digits plus known 7-segment confusions.
+final RegExp kDigitLookalikePattern = RegExp(r'^[0-9OoIlBSDZsdzbg]$');
+
+// ---------------------------------------------------------------------
+// Digit lookalike rewrite table
+// ---------------------------------------------------------------------
+
+/// Maps 7-segment OCR confusions back to their intended digit.
+///
+/// Only applied inside tokens that [isLikelyNumeric] already accepts,
+/// so this table never corrupts German words like "Diesel" or "Super".
+const Map<String, String> kDigitLookalikeMap = <String, String>{
+  'O': '0', 'o': '0', 'D': '0',
+  'I': '1', 'l': '1',
+  'B': '8', 'b': '8',
+  'S': '5', 's': '5',
+  'Z': '2', 'z': '2',
+  'g': '9',
+};

--- a/lib/features/consumption/data/pump_display_parse_result.dart
+++ b/lib/features/consumption/data/pump_display_parse_result.dart
@@ -1,0 +1,61 @@
+/// Fields extracted from a fuel pump display (the 7-segment / LCD
+/// panel on the pump itself, NOT the paper receipt).
+///
+/// All fields are nullable because OCR is best-effort: bright
+/// sunlight, glare, a partially-visible display, or an unfamiliar
+/// layout can all blank a field. Use [hasUsableData] to decide
+/// whether the result is worth prefilling a form with.
+class PumpDisplayParseResult {
+  /// Volume dispensed in litres (the "Abgabe" / "Volume" line).
+  final double? liters;
+
+  /// Total amount charged on the pump (the "Betrag" / "€" line).
+  final double? totalCost;
+
+  /// Unit price per litre as shown on the pump (the "Preis/Liter" /
+  /// "€/L" line). This is typically 3-decimal precision (e.g. 1.849).
+  final double? pricePerLiter;
+
+  /// Pump number printed or displayed on the housing (e.g. "3" in a
+  /// large standalone digit on the cabinet). Optional — helps the
+  /// user confirm which pump they scanned.
+  final int? pumpNumber;
+
+  /// Confidence ∈ [0, 1] based on how many of the three primary
+  /// fields were extracted AND whether they are internally consistent
+  /// (totalCost ≈ liters * pricePerLiter within tolerance).
+  final double confidence;
+
+  const PumpDisplayParseResult({
+    this.liters,
+    this.totalCost,
+    this.pricePerLiter,
+    this.pumpNumber,
+    this.confidence = 0,
+  });
+
+  /// `true` when the parser extracted at least two of the three
+  /// primary numeric fields. One alone (e.g. just a total) is rarely
+  /// enough to auto-fill a fill-up log.
+  bool get hasUsableData {
+    final count = [liters, totalCost, pricePerLiter]
+        .where((v) => v != null)
+        .length;
+    return count >= 2;
+  }
+
+  /// `true` when totalCost, liters and pricePerLiter are all present
+  /// AND they satisfy `totalCost ≈ liters * pricePerLiter` within a
+  /// small rounding tolerance. The three-way agreement is the
+  /// strongest signal that OCR actually read the right numbers.
+  bool get isConsistent {
+    if (liters == null || totalCost == null || pricePerLiter == null) {
+      return false;
+    }
+    final predicted = liters! * pricePerLiter!;
+    final delta = (predicted - totalCost!).abs();
+    // Pump displays round to the cent. A 2 cent tolerance covers
+    // the rounding plus small OCR jitter on the last digit.
+    return delta <= 0.02;
+  }
+}

--- a/lib/features/consumption/data/pump_display_parser.dart
+++ b/lib/features/consumption/data/pump_display_parser.dart
@@ -1,66 +1,10 @@
-import 'package:flutter/foundation.dart';
+import '_pump_display_helpers.dart';
+import '_pump_display_patterns.dart';
+import 'pump_display_parse_result.dart';
 
-/// Fields extracted from a fuel pump display (the 7-segment / LCD
-/// panel on the pump itself, NOT the paper receipt).
-///
-/// All fields are nullable because OCR is best-effort: bright
-/// sunlight, glare, a partially-visible display, or an unfamiliar
-/// layout can all blank a field. Use [hasUsableData] to decide
-/// whether the result is worth prefilling a form with.
-class PumpDisplayParseResult {
-  /// Volume dispensed in litres (the "Abgabe" / "Volume" line).
-  final double? liters;
-
-  /// Total amount charged on the pump (the "Betrag" / "€" line).
-  final double? totalCost;
-
-  /// Unit price per litre as shown on the pump (the "Preis/Liter" /
-  /// "€/L" line). This is typically 3-decimal precision (e.g. 1.849).
-  final double? pricePerLiter;
-
-  /// Pump number printed or displayed on the housing (e.g. "3" in a
-  /// large standalone digit on the cabinet). Optional — helps the
-  /// user confirm which pump they scanned.
-  final int? pumpNumber;
-
-  /// Confidence ∈ [0, 1] based on how many of the three primary
-  /// fields were extracted AND whether they are internally consistent
-  /// (totalCost ≈ liters * pricePerLiter within tolerance).
-  final double confidence;
-
-  const PumpDisplayParseResult({
-    this.liters,
-    this.totalCost,
-    this.pricePerLiter,
-    this.pumpNumber,
-    this.confidence = 0,
-  });
-
-  /// `true` when the parser extracted at least two of the three
-  /// primary numeric fields. One alone (e.g. just a total) is rarely
-  /// enough to auto-fill a fill-up log.
-  bool get hasUsableData {
-    final count = [liters, totalCost, pricePerLiter]
-        .where((v) => v != null)
-        .length;
-    return count >= 2;
-  }
-
-  /// `true` when totalCost, liters and pricePerLiter are all present
-  /// AND they satisfy `totalCost ≈ liters * pricePerLiter` within a
-  /// small rounding tolerance. The three-way agreement is the
-  /// strongest signal that OCR actually read the right numbers.
-  bool get isConsistent {
-    if (liters == null || totalCost == null || pricePerLiter == null) {
-      return false;
-    }
-    final predicted = liters! * pricePerLiter!;
-    final delta = (predicted - totalCost!).abs();
-    // Pump displays round to the cent. A 2 cent tolerance covers
-    // the rounding plus small OCR jitter on the last digit.
-    return delta <= 0.02;
-  }
-}
+// Re-export so existing callers that `import 'pump_display_parser.dart'`
+// keep resolving [PumpDisplayParseResult] without changes.
+export 'pump_display_parse_result.dart';
 
 /// Parses raw OCR text from a fuel pump 7-segment / LCD display.
 ///
@@ -88,7 +32,7 @@ class PumpDisplayParser {
       return const PumpDisplayParseResult();
     }
 
-    final normalised = _normaliseDigits(rawText);
+    final normalised = normaliseDigits(rawText);
     final lines = normalised
         .split(RegExp(r'[\r\n]+'))
         .map((l) => l.trim())
@@ -118,7 +62,7 @@ class PumpDisplayParser {
     }
 
     final pump = _extractPumpNumber(rawText, lines);
-    final confidence = _scoreConfidence(
+    final confidence = scorePumpDisplayConfidence(
       total: total,
       liters: liters,
       price: price,
@@ -137,46 +81,19 @@ class PumpDisplayParser {
   // Labelled extraction
   // ---------------------------------------------------------------------
 
-  /// Matches "Betrag 58,42", "Betrag € 58,42", "€ 58.42",
-  /// "EUR 58,42", and the common OCR misread "Betraq" where the
-  /// 'g' hook is thin.
   double? _extractBetrag(String text) {
-    final patterns = <RegExp>[
-      // "Betrag 58,42", "Betrag € 58,42", "Betrag: 58,42".
-      RegExp(
-          r'betra[gq]\s*(?:€|EUR)?\s*[:=]?\s*(\d+[.,]\d{2})',
-          caseSensitive: false),
-      RegExp(r'(?:€|EUR)\s*[:=]?\s*(\d+[.,]\d{2})\b'),
-      RegExp(r'\b(\d+[.,]\d{2})\s*€\b'),
-    ];
-    for (final p in patterns) {
+    for (final p in kBetragPatterns) {
       final m = p.firstMatch(text);
       if (m != null) {
-        final value = _parseDecimal(m.group(1)!);
+        final value = parseDecimalFromOcr(m.group(1)!);
         if (value != null && value >= 0 && value < 10000) return value;
       }
     }
     return null;
   }
 
-  /// Matches "Abgabe 31,12", "Abgabe L 31,12", "Volume 31.12 L",
-  /// "Liter 31,12", and the "Ab9abe" / "Abqabe" misreads where a
-  /// small glyph is mistaken for 9 or q.
   double? _extractAbgabe(String text) {
-    final patterns = <RegExp>[
-      // Allow an optional "L" or "Liter" unit between the label and
-      // the number — some pumps render "Abgabe L 31,12" across two
-      // visual rows and ML Kit flattens that into a single line.
-      RegExp(
-          r'ab[g9q]abe\s*(?:L|l|Liter)?\s*[:=]?\s*(\d+[.,]\d{1,3})',
-          caseSensitive: false),
-      RegExp(r'(?:volume|menge|quantit[eé])\s*[:=]?\s*(\d+[.,]\d{1,3})',
-          caseSensitive: false),
-      // "31,12 L" or "31.12 Liter" — only when the line has no €
-      // nearby (so we don't grab the Betrag by accident).
-      RegExp(r'\b(\d+[.,]\d{1,3})\s*(?:L|l|Liter|Litres?)\b'),
-    ];
-    for (final p in patterns) {
+    for (final p in kAbgabePatterns) {
       final m = p.firstMatch(text);
       if (m != null) {
         // Skip if this looks like a price/litre (has "€" right after).
@@ -185,37 +102,24 @@ class PumpDisplayParser {
             tail.trimLeft().toLowerCase().startsWith('eur')) {
           continue;
         }
-        final value = _parseDecimal(m.group(1)!);
+        final value = parseDecimalFromOcr(m.group(1)!);
         if (value != null && value >= 0 && value < 2000) return value;
       }
     }
     return null;
   }
 
-  /// Matches "Preis/Liter 1,849", "PREIS/L 1.849",
-  /// "CT / Preis/Liter 184,9" (cents-per-litre layout),
-  /// "1,849 €/L", "EUR/L 1.849".
   double? _extractPricePerLiter(String text) {
-    final patterns = <RegExp>[
-      RegExp(
-          r'preis\s*/?\s*(?:liter|l)\s*[:=]?\s*(\d+[.,]\d{2,3})',
-          caseSensitive: false),
-      RegExp(r'(?:€|EUR)\s*/\s*(?:L|l|Liter)\s*[:=]?\s*(\d+[.,]\d{2,3})'),
-      RegExp(r'(\d+[.,]\d{2,3})\s*(?:€|EUR)\s*/\s*(?:L|l|Liter)'),
-    ];
-    for (final p in patterns) {
+    for (final p in kPricePerLiterPatterns) {
       final m = p.firstMatch(text);
       if (m != null) {
-        final value = _parseDecimal(m.group(1)!);
+        final value = parseDecimalFromOcr(m.group(1)!);
         if (value != null && value > 0 && value < 10) return value;
       }
     }
-    // Cents-per-litre layout: "CT 184,9" means 184,9 ct = 1.849 €/L.
-    final ctMatch =
-        RegExp(r'\bCT\b\s*[:=]?\s*(\d{2,3}[.,]?\d?)', caseSensitive: false)
-            .firstMatch(text);
+    final ctMatch = kCentsPerLiterPattern.firstMatch(text);
     if (ctMatch != null) {
-      final ct = _parseDecimal(ctMatch.group(1)!);
+      final ct = parseDecimalFromOcr(ctMatch.group(1)!);
       if (ct != null && ct >= 80 && ct <= 400) {
         return ct / 100.0;
       }
@@ -231,7 +135,7 @@ class PumpDisplayParser {
   int? _extractPumpNumber(String rawText, List<String> lines) {
     for (final line in lines) {
       final trimmed = line.trim();
-      if (RegExp(r'^[1-9]$').hasMatch(trimmed)) {
+      if (kLonePumpDigitPattern.hasMatch(trimmed)) {
         return int.parse(trimmed);
       }
     }
@@ -252,26 +156,27 @@ class PumpDisplayParser {
   /// This is deliberately conservative — when buckets overlap (e.g.
   /// a small fill-up of €1.80 could look like a price-per-litre),
   /// we leave the field null rather than guessing wrong.
-  _InferredTriple _inferFromNumericOrder(
+  PumpDisplayInferredTriple _inferFromNumericOrder(
     List<String> lines, {
     List<double> exclude = const [],
   }) {
-    final rawNumbers = <_Candidate>[];
+    final rawNumbers = <PumpDisplayCandidate>[];
     for (final line in lines) {
-      for (final m in RegExp(r'(\d+[.,]\d{1,3})').allMatches(line)) {
-        final v = _parseDecimal(m.group(1)!);
+      for (final m in kDecimalNumberPattern.allMatches(line)) {
+        final v = parseDecimalFromOcr(m.group(1)!);
         if (v == null) continue;
         final decimals = m.group(1)!.contains(',') || m.group(1)!.contains('.')
             ? m.group(1)!.split(RegExp(r'[.,]')).last.length
             : 0;
-        rawNumbers.add(_Candidate(value: v, decimals: decimals, line: line));
+        rawNumbers.add(
+            PumpDisplayCandidate(value: v, decimals: decimals, line: line));
       }
     }
     // Consume `exclude` once per occurrence so duplicate values
     // (e.g. the pump reading 0.00 on every line at idle) are not
     // all wiped out by the first match.
     final toSkip = List<double>.from(exclude);
-    final numbers = <_Candidate>[];
+    final numbers = <PumpDisplayCandidate>[];
     for (final c in rawNumbers) {
       final idx = toSkip.indexWhere((e) => (e - c.value).abs() < 1e-6);
       if (idx >= 0) {
@@ -280,11 +185,11 @@ class PumpDisplayParser {
         numbers.add(c);
       }
     }
-    if (numbers.isEmpty) return const _InferredTriple();
+    if (numbers.isEmpty) return PumpDisplayInferredTriple.empty;
 
-    _Candidate? price;
-    _Candidate? liters;
-    _Candidate? total;
+    PumpDisplayCandidate? price;
+    PumpDisplayCandidate? liters;
+    PumpDisplayCandidate? total;
 
     // Price-per-litre: smallest value in (0.5, 5) with 3 decimals.
     final priceCandidates = numbers
@@ -307,8 +212,8 @@ class PumpDisplayParser {
         .toList();
 
     if (price != null && twoDecimals.length >= 2) {
-      _Candidate? bestL;
-      _Candidate? bestT;
+      PumpDisplayCandidate? bestL;
+      PumpDisplayCandidate? bestT;
       var bestDelta = double.infinity;
       for (var i = 0; i < twoDecimals.length; i++) {
         for (var j = 0; j < twoDecimals.length; j++) {
@@ -340,127 +245,10 @@ class PumpDisplayParser {
       }
     }
 
-    return _InferredTriple(
+    return PumpDisplayInferredTriple(
       totalCost: total?.value,
       liters: liters?.value,
       pricePerLiter: price?.value,
     );
   }
-
-  // ---------------------------------------------------------------------
-  // Digit normalisation — fixes common 7-segment OCR confusions on
-  // digit-context characters only. We only rewrite characters that
-  // appear inside a numeric token so we don't destroy German words
-  // like "Diesel" or "Super".
-  // ---------------------------------------------------------------------
-
-  String _normaliseDigits(String text) {
-    // Find tokens that look like numeric values (digits with optional
-    // . , separators, possibly contaminated by lookalike letters such
-    // as 'B' for 8) and rewrite just those. Non-numeric tokens like
-    // 'Diesel' are left untouched by construction because they are
-    // never inside a match of the numeric-token regex below.
-    final tokenRe = RegExp(r'[0-9OoIlBSDZsdzbg]+(?:[.,][0-9OoIlBSDZsdzbg]+)*');
-    return text.replaceAllMapped(tokenRe, (m) {
-      final tok = m.group(0)!;
-      if (!_isLikelyNumeric(tok)) return tok;
-      return _rewriteDigitLookalikes(tok);
-    });
-  }
-
-  /// A token is "likely numeric" if either
-  /// - it contains a decimal separator AND every non-separator char
-  ///   is a digit or a known 7-segment lookalike letter
-  ///   (so `58,42`, `B.OO`, `1O.SO` all qualify); or
-  /// - it is a pure digit sequence (catches the bare pump number
-  ///   like "8" on its own line).
-  ///
-  /// This deliberately excludes single lookalike letters ("D") and
-  /// multi-letter tokens without a separator ("Diesel") so the
-  /// rewriter never corrupts German words.
-  bool _isLikelyNumeric(String token) {
-    if (token.isEmpty) return false;
-    if (!token.contains(RegExp(r'[.,]'))) {
-      return RegExp(r'^\d+$').hasMatch(token);
-    }
-    final core = token.replaceAll(RegExp(r'[.,]'), '');
-    if (core.isEmpty) return false;
-    for (final ch in core.split('')) {
-      if (!_looksLikeDigit(ch)) return false;
-    }
-    return true;
-  }
-
-  bool _looksLikeDigit(String ch) =>
-      RegExp(r'^[0-9OoIlBSDZsdzbg]$').hasMatch(ch);
-
-  String _rewriteDigitLookalikes(String token) {
-    final sb = StringBuffer();
-    for (final ch in token.split('')) {
-      sb.write(_digitMap[ch] ?? ch);
-    }
-    return sb.toString();
-  }
-
-  static const _digitMap = <String, String>{
-    'O': '0', 'o': '0', 'D': '0',
-    'I': '1', 'l': '1',
-    'B': '8', 'b': '8',
-    'S': '5', 's': '5',
-    'Z': '2', 'z': '2',
-    'g': '9',
-  };
-
-  // ---------------------------------------------------------------------
-  // Confidence scoring
-  // ---------------------------------------------------------------------
-
-  double _scoreConfidence({
-    required double? total,
-    required double? liters,
-    required double? price,
-  }) {
-    var score = 0.0;
-    if (total != null) score += 0.3;
-    if (liters != null) score += 0.3;
-    if (price != null) score += 0.3;
-    if (total != null && liters != null && price != null) {
-      final predicted = liters * price;
-      final delta = (predicted - total).abs();
-      if (delta <= 0.02) {
-        score += 0.1;
-      } else if (delta <= 0.10) {
-        score += 0.05;
-      }
-    }
-    return score.clamp(0.0, 1.0);
-  }
-
-  double? _parseDecimal(String value) {
-    final n = double.tryParse(value.replaceAll(',', '.'));
-    if (n == null) debugPrint('PumpDisplayParser: bad decimal "$value"');
-    return n;
-  }
-}
-
-class _Candidate {
-  final double value;
-  final int decimals;
-  final String line;
-  const _Candidate({
-    required this.value,
-    required this.decimals,
-    required this.line,
-  });
-}
-
-class _InferredTriple {
-  final double? totalCost;
-  final double? liters;
-  final double? pricePerLiter;
-  const _InferredTriple({
-    this.totalCost,
-    this.liters,
-    this.pricePerLiter,
-  });
 }

--- a/test/features/consumption/data/_pump_display_helpers_test.dart
+++ b/test/features/consumption/data/_pump_display_helpers_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/_pump_display_helpers.dart';
+
+void main() {
+  group('parseDecimalFromOcr', () {
+    test('accepts both "," and "." as decimal separator', () {
+      expect(parseDecimalFromOcr('58,42'), 58.42);
+      expect(parseDecimalFromOcr('58.42'), 58.42);
+    });
+
+    test('returns null on malformed input', () {
+      expect(parseDecimalFromOcr('abc'), isNull);
+      expect(parseDecimalFromOcr(''), isNull);
+    });
+  });
+
+  group('isLikelyNumeric', () {
+    test('accepts pure digit sequences', () {
+      expect(isLikelyNumeric('8'), isTrue);
+      expect(isLikelyNumeric('31'), isTrue);
+    });
+
+    test('accepts OCR-corrupted numeric tokens with a separator', () {
+      expect(isLikelyNumeric('B.OO'), isTrue);
+      expect(isLikelyNumeric('1O.SO'), isTrue);
+    });
+
+    test('rejects words and single lookalike letters', () {
+      expect(isLikelyNumeric('Diesel'), isFalse);
+      expect(isLikelyNumeric('D'), isFalse);
+      expect(isLikelyNumeric(''), isFalse);
+    });
+  });
+
+  group('normaliseDigits', () {
+    test('rewrites lookalikes inside numeric tokens only', () {
+      // "Diesel" must survive untouched.
+      final out = normaliseDigits('Diesel B.OO');
+      expect(out, contains('Diesel'));
+      expect(out, contains('8.00'));
+    });
+  });
+
+  group('scorePumpDisplayConfidence', () {
+    test('awards 0.3 per extracted field', () {
+      expect(
+        scorePumpDisplayConfidence(total: null, liters: null, price: null),
+        0.0,
+      );
+      expect(
+        scorePumpDisplayConfidence(total: 50, liters: null, price: null),
+        closeTo(0.3, 1e-9),
+      );
+    });
+
+    test('awards +0.1 bonus when all three agree within 2 cents', () {
+      final s = scorePumpDisplayConfidence(
+        total: 58.40,
+        liters: 32,
+        price: 1.825,
+      );
+      // 32 * 1.825 = 58.4 exactly — all three present + consistent.
+      expect(s, closeTo(1.0, 1e-9));
+    });
+
+    test('clamps to [0, 1]', () {
+      final s = scorePumpDisplayConfidence(
+        total: 100,
+        liters: 50,
+        price: 2,
+      );
+      // 50 * 2 = 100 — consistent. 0.9 + 0.1 = 1.0 exactly.
+      expect(s, lessThanOrEqualTo(1.0));
+      expect(s, greaterThanOrEqualTo(0.0));
+    });
+  });
+}


### PR DESCRIPTION
Refs #563 phase — pump_display_parser.dart extraction.

## Summary

Pure extraction refactor: split 466-LOC `pump_display_parser.dart` into four cohesive files so every file is under the 300 LOC epic-wide threshold. Zero behaviour change.

## Before / after

- `lib/features/consumption/data/pump_display_parser.dart` — **466 -> 254 LOC**

## Files extracted

| New file | LOC | Contents |
|---|---|---|
| `lib/features/consumption/data/pump_display_parse_result.dart` | 61 | `PumpDisplayParseResult` value class (`hasUsableData`, `isConsistent`) |
| `lib/features/consumption/data/_pump_display_patterns.dart` | 89 | All `RegExp` constants (Betrag / Abgabe / Preis / CT / numeric token) + `kDigitLookalikeMap` |
| `lib/features/consumption/data/_pump_display_helpers.dart` | 121 | `parseDecimalFromOcr`, `normaliseDigits`, `isLikelyNumeric`, `looksLikeDigit`, `rewriteDigitLookalikes`, `scorePumpDisplayConfidence` + `PumpDisplayCandidate` / `PumpDisplayInferredTriple` |

The `_`-prefixed filenames signal they are implementation details scoped to the consumption feature.

## Callers unchanged — grep-verified

`grep PumpDisplayParser|PumpDisplayParseResult -r lib/ test/` returns three files:

1. `lib/features/consumption/data/pump_display_parser.dart` — rewritten.
2. `lib/features/consumption/data/receipt_scan_service.dart` — unchanged. Still imports `pump_display_parser.dart` and receives `PumpDisplayParseResult` via the re-export.
3. `test/features/consumption/data/pump_display_parser_test.dart` — unchanged. Existing 23 tests pass exactly as-is.

This works because `pump_display_parser.dart` now does `export 'pump_display_parse_result.dart';` — callers don't need to add a second import.

## Tests

- All 23 existing `pump_display_parser_test.dart` tests pass, zero diff to that file.
- Added 9 focused unit tests in `test/features/consumption/data/_pump_display_helpers_test.dart` covering `parseDecimalFromOcr`, `isLikelyNumeric`, `normaliseDigits`, `scorePumpDisplayConfidence`.
- **Full suite: 5655 passed, 1 skipped, 0 failed.**

## Checks

- [x] `flutter analyze` — zero warnings (plain, no `--no-fatal-infos`).
- [x] `flutter test` — all 5655 tests pass.
- [x] `pump_display_parser.dart` LOC = 254 (≤ 300).
- [x] No parser semantics changed. Pure extraction.
- [x] No silent catches introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)