### PR TITLE
refactor(vehicle): extract edit_vehicle_screen form sections (Refs #563)

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -1,22 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:uuid/uuid.dart';
 
 import '../../../../core/utils/brand_logo_mapper.dart';
-import '../../../../core/widgets/form_section_card.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../consumption/presentation/widgets/vehicle_adapter_section.dart';
-import '../../../consumption/presentation/widgets/vehicle_baseline_section.dart';
-import '../../../consumption/providers/consumption_providers.dart';
-import '../../../profile/providers/profile_provider.dart';
-import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/vehicle_profile.dart';
 import '../../domain/entities/vin_data.dart';
 import '../../providers/vehicle_providers.dart';
 import '../../providers/vin_decoder_provider.dart';
-import '../widgets/service_reminder_section.dart';
-import '../widgets/vehicle_combustion_section.dart';
-import '../widgets/vehicle_ev_section.dart';
+import '../widgets/ve_reset_confirm_dialog.dart';
+import '../widgets/vehicle_drivetrain_section.dart';
+import '../widgets/vehicle_extras_section.dart';
+import '../widgets/vehicle_form_controllers.dart';
+import '../widgets/vehicle_header.dart';
+import '../widgets/vehicle_identity_section.dart';
+import '../widgets/vehicle_save_actions.dart';
+import '../widgets/vehicle_save_bar.dart';
 import '../widgets/vin_confirm_dialog.dart';
 import '../widgets/vin_info_sheet.dart';
 
@@ -33,210 +31,104 @@ class EditVehicleScreen extends ConsumerStatefulWidget {
 }
 
 class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
-  static const _uuid = Uuid();
-
   final _formKey = GlobalKey<FormState>();
-  final _nameCtrl = TextEditingController();
-  final _batteryCtrl = TextEditingController();
-  final _maxKwCtrl = TextEditingController();
-  final _tankCtrl = TextEditingController();
-  // Pre-fill a sensible default so the "Preferred fuel" dropdown shows
-  // E10 rather than the empty "Not set" option (#710). For EV the save
-  // flow ignores this value anyway.
-  final _fuelTypeCtrl = TextEditingController(text: 'e10');
-  final _minSocCtrl = TextEditingController(text: '20');
-  final _maxSocCtrl = TextEditingController(text: '80');
-  // VIN onboarding (#812 phase 2). The controller feeds the decode
-  // provider; the populated engine fields are stored separately and
-  // carried through _save.
-  final _vinCtrl = TextEditingController();
-  // Focus node for the VIN field — we grab focus back after the
-  // in-place explanation sheet (#895) dismisses, so TalkBack users
-  // don't lose their place on the form.
-  final _vinFocus = FocusNode();
+  final _ctrl = VehicleFormControllers();
 
-  // Combustion is the dominant case; start there and let the user
-  // flip to Hybrid/Electric if needed (#710).
+  // #710 — combustion default; user can flip to Hybrid/Electric.
   VehicleType _type = VehicleType.combustion;
   final Set<ConnectorType> _connectors = {};
   String? _existingId;
   String? _adapterMac;
   String? _adapterName;
 
-  // Engine params populated by the VIN decoder (#812 phase 2).
-  // The form has no direct UI for these yet — they live alongside
-  // the VIN field and will feed the OBD2 fuel-rate math in phase 3.
+  // #812 phase 2 — engine params populated by the VIN decoder;
+  // carried through _save for phase-3 OBD2 math.
   int? _engineDisplacementCc;
   int? _engineCylinders;
   int? _curbWeightKg;
 
-  // Decode button state — flips to true while the vPIC request is in
-  // flight so the UI shows a spinner instead of the magnifying glass.
+  // True while the vPIC request is in flight → VIN field spinner.
   bool _decodingVin = false;
 
   @override
   void initState() {
     super.initState();
-    // Rebuild the header on every name keystroke so the big title
-    // tracks what the user is typing. The controller itself is the
-    // source of truth, we just need `setState` to flush the view.
-    _nameCtrl.addListener(_refresh);
+    // Rebuild on every name keystroke so the header title tracks input.
+    _ctrl.nameController.addListener(_refresh);
     if (widget.vehicleId != null) {
-      // Load after first frame so we have access to ref.
       WidgetsBinding.instance.addPostFrameCallback((_) => _loadExisting());
     }
   }
 
-  void _refresh() {
-    if (mounted) setState(() {});
-  }
+  void _refresh() => mounted ? setState(() {}) : null;
 
   void _loadExisting() {
     final list = ref.read(vehicleProfileListProvider);
     final existing = list.where((v) => v.id == widget.vehicleId).firstOrNull;
     if (existing == null) return;
+    final snap = _ctrl.load(existing);
     setState(() {
-      _existingId = existing.id;
-      _nameCtrl.text = existing.name;
-      _type = existing.type;
-      _batteryCtrl.text = existing.batteryKwh?.toString() ?? '';
-      _maxKwCtrl.text = existing.maxChargingKw?.toString() ?? '';
-      _tankCtrl.text = existing.tankCapacityL?.toString() ?? '';
-      _fuelTypeCtrl.text = existing.preferredFuelType ?? '';
-      _minSocCtrl.text = existing.chargingPreferences.minSocPercent.toString();
-      _maxSocCtrl.text = existing.chargingPreferences.maxSocPercent.toString();
+      _existingId = snap.id;
+      _type = snap.type;
       _connectors
         ..clear()
-        ..addAll(existing.supportedConnectors);
-      _adapterMac = existing.obd2AdapterMac;
-      _adapterName = existing.obd2AdapterName;
-      _vinCtrl.text = existing.vin ?? '';
-      _engineDisplacementCc = existing.engineDisplacementCc;
-      _engineCylinders = existing.engineCylinders;
-      _curbWeightKg = existing.curbWeightKg;
+        ..addAll(snap.connectors);
+      _adapterMac = snap.adapterMac;
+      _adapterName = snap.adapterName;
+      _engineDisplacementCc = snap.engineDisplacementCc;
+      _engineCylinders = snap.engineCylinders;
+      _curbWeightKg = snap.curbWeightKg;
     });
   }
 
   @override
   void dispose() {
-    _nameCtrl.removeListener(_refresh);
-    _nameCtrl.dispose();
-    _batteryCtrl.dispose();
-    _maxKwCtrl.dispose();
-    _tankCtrl.dispose();
-    _fuelTypeCtrl.dispose();
-    _minSocCtrl.dispose();
-    _maxSocCtrl.dispose();
-    _vinCtrl.dispose();
-    _vinFocus.dispose();
+    _ctrl.nameController.removeListener(_refresh);
+    _ctrl.dispose();
     super.dispose();
   }
 
-  /// Open the in-place VIN explanation (#895). After the sheet is
-  /// dismissed focus returns to the VIN text field so the user can
-  /// resume typing without hunting for the input.
+  /// Open the VIN explanation sheet (#895). Restores focus on dismiss
+  /// so TalkBack users don't lose their place.
   Future<void> _showVinInfo() async {
     await VinInfoSheet.show(context);
     if (!mounted) return;
-    _vinFocus.requestFocus();
+    _ctrl.vinFocusNode.requestFocus();
   }
 
-  double? _parseDouble(String text) {
-    final trimmed = text.trim().replaceAll(',', '.');
-    if (trimmed.isEmpty) return null;
-    return double.tryParse(trimmed);
-  }
-
-  /// Shared validator for the optional numeric inputs on the form. Empty
-  /// values are accepted (they map to `null` in the saved profile); only
-  /// non-empty values that fail to parse get an error message.
+  /// Shared validator for optional numeric inputs. Empty is fine
+  /// (→ null); non-empty must parse.
   String? _validateOptionalNumber(String? v) {
-    final l = AppLocalizations.of(context);
     if (v == null || v.trim().isEmpty) return null;
-    return _parseDouble(v) == null
-        ? (l?.fieldInvalidNumber ?? 'Invalid number')
-        : null;
-  }
-
-  int _parseIntOr(String text, int fallback) {
-    final parsed = int.tryParse(text.trim());
-    return parsed ?? fallback;
+    final parsed = double.tryParse(v.trim().replaceAll(',', '.'));
+    if (parsed != null) return null;
+    return AppLocalizations.of(context)?.fieldInvalidNumber ?? 'Invalid number';
   }
 
   Future<void> _save() async {
     final form = _formKey.currentState;
     if (form == null || !form.validate()) return;
-
-    final profile = VehicleProfile(
-      id: _existingId ?? _uuid.v4(),
-      name: _nameCtrl.text.trim(),
+    final profile = _ctrl.buildProfile(
+      existingId: _existingId,
       type: _type,
-      batteryKwh:
-          _type == VehicleType.combustion ? null : _parseDouble(_batteryCtrl.text),
-      maxChargingKw:
-          _type == VehicleType.combustion ? null : _parseDouble(_maxKwCtrl.text),
-      supportedConnectors:
-          _type == VehicleType.combustion ? <ConnectorType>{} : {..._connectors},
-      tankCapacityL:
-          _type == VehicleType.ev ? null : _parseDouble(_tankCtrl.text),
-      preferredFuelType: _type == VehicleType.ev
-          ? null
-          : (_fuelTypeCtrl.text.trim().isEmpty
-              ? null
-              : _fuelTypeCtrl.text.trim()),
-      chargingPreferences: ChargingPreferences(
-        minSocPercent: _parseIntOr(_minSocCtrl.text, 20).clamp(0, 100),
-        maxSocPercent: _parseIntOr(_maxSocCtrl.text, 80).clamp(0, 100),
-      ),
-      obd2AdapterMac: _adapterMac,
-      obd2AdapterName: _adapterName,
-      vin: _vinCtrl.text.trim().isEmpty ? null : _vinCtrl.text.trim(),
+      connectors: _connectors,
+      adapterMac: _adapterMac,
+      adapterName: _adapterName,
       engineDisplacementCc: _engineDisplacementCc,
       engineCylinders: _engineCylinders,
       curbWeightKg: _curbWeightKg,
     );
-
     await ref.read(vehicleProfileListProvider.notifier).save(profile);
-
-    // #710 — auto-set this vehicle as the profile's default and sync
-    // the profile's `preferredFuelType` to the vehicle's fuel when:
-    //   (a) no default is currently set, OR
-    //   (b) the user is editing the vehicle already flagged as default.
-    // This eliminates the bug where the preferences step's fuel chips
-    // ignored the just-configured vehicle.
-    try {
-      final profileRepo = ref.read(profileRepositoryProvider);
-      final activeProfile = ref.read(activeProfileProvider);
-      if (activeProfile != null) {
-        final shouldBecomeDefault =
-            activeProfile.defaultVehicleId == null ||
-                activeProfile.defaultVehicleId == profile.id;
-        if (shouldBecomeDefault) {
-          final derived = _deriveFuelTypeFromVehicle(profile);
-          final updated = activeProfile.copyWith(
-            defaultVehicleId: profile.id,
-            preferredFuelType: derived ?? activeProfile.preferredFuelType,
-          );
-          await profileRepo.updateProfile(updated);
-          ref.read(activeProfileProvider.notifier).refresh();
-        }
-      }
-    } catch (e) {
-      debugPrint('EditVehicleScreen: profile sync failed: $e');
-    }
+    await ref.syncActiveProfile(profile);
     if (!mounted) return;
     Navigator.of(context).pop();
   }
 
-  /// Decode the value currently in [_vinCtrl] via the VIN decoder
-  /// provider (#812 phase 2). On a successful decode the user sees a
-  /// confirmation dialog summarising the decoded data; accepting it
-  /// auto-fills the engine-parameter fields on the profile. Invalid
-  /// input surfaces as a snackbar — the dialog is skipped entirely
-  /// so the user isn't prompted to "confirm" an empty summary.
+  /// Decode the current VIN (#812 phase 2). Success → confirm dialog
+  /// → optional auto-fill. Invalid → snackbar; dialog is skipped.
   Future<void> _decodeVin() async {
     final l = AppLocalizations.of(context);
-    final vin = _vinCtrl.text.trim();
+    final vin = _ctrl.vinController.text.trim();
     if (vin.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l?.vinInvalidFormat ?? 'Invalid VIN format')),
@@ -268,119 +160,58 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
 
     final outcome = await VinConfirmDialog.show(context, decoded);
     if (!mounted) return;
-    if (outcome == VinConfirmOutcome.confirm) {
-      _applyDecodedVin(decoded);
-    }
+    if (outcome == VinConfirmOutcome.confirm) _applyDecodedVin(decoded);
   }
 
-  /// Copy non-null engine fields from [data] into the form state
-  /// (#812 phase 2). Displacement is in litres on [VinData] and must
-  /// be converted to cubic centimetres for [VehicleProfile].
-  ///
-  /// GVWR (pounds) is the vPIC stand-in for curb weight — a real
-  /// curb weight is GVWR minus payload, but vPIC doesn't expose
-  /// payload, so we approximate. The profile stores the value as an
-  /// integer kilogram, and the conversion factor is 1 lb = 0.4536 kg
-  /// (`lbs / 2.205`).
+  /// Copy non-null engine fields from [data] (#812 phase 2).
+  /// Displacement: L → cc. Curb weight ≈ GVWR / 2.205 (vPIC has no
+  /// payload field, so GVWR is the best proxy for now).
   void _applyDecodedVin(VinData data) {
     setState(() {
       if (data.displacementL != null) {
         _engineDisplacementCc = (data.displacementL! * 1000).round();
       }
-      if (data.cylinderCount != null) {
-        _engineCylinders = data.cylinderCount;
-      }
+      if (data.cylinderCount != null) _engineCylinders = data.cylinderCount;
       if (data.gvwrLbs != null) {
-        // Approx — GVWR is gross weight, not curb weight. Phase 3
-        // will swap this for a real curb-weight lookup.
         _curbWeightKg = (data.gvwrLbs! / 2.205).round();
       }
     });
   }
 
-  /// Reset the learned η_v for this vehicle (#815). Shows a confirm
-  /// dialog first — destructive actions should always be explicit —
-  /// then writes the default (0.85) back through the repository and
-  /// clears the sample counter. Safe to call before _save because
-  /// the user hasn't necessarily pressed Save on their other
-  /// changes; the reset targets the stored profile independently.
+  void _onAdapterChanged(String? name, String? mac) {
+    setState(() {
+      _adapterName = name;
+      _adapterMac = mac;
+    });
+    _save();
+  }
+
+  /// #815 — confirm-dialog → write default η_v (0.85), reset samples.
   Future<void> _resetVolumetricEfficiency() async {
     final id = _existingId;
     if (id == null) return;
-    final l = AppLocalizations.of(context);
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: Text(l?.veResetConfirmTitle ?? 'Reset calibration?'),
-        content: Text(
-          l?.veResetConfirmBody ??
-              'This will discard the learned per-vehicle calibration '
-                  'and restore the default value (0.85).',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: Text(l?.cancel ?? 'Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: Text(l?.veResetAction ?? 'Reset calibration'),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true) return;
-    if (!mounted) return;
-    try {
-      final list = ref.read(vehicleProfileListProvider);
-      final existing = list.where((v) => v.id == id).firstOrNull;
-      if (existing == null) return;
-      final cleared = existing.copyWith(
-        volumetricEfficiency: 0.85,
-        volumetricEfficiencySamples: 0,
-      );
-      await ref.read(vehicleProfileListProvider.notifier).save(cleared);
-    } catch (e) {
-      debugPrint('EditVehicleScreen: VE reset failed: $e');
-    }
+    final confirmed = await VeResetConfirmDialog.show(context);
+    if (confirmed != true || !mounted) return;
+    await ref.resetVolumetricEfficiency(id);
   }
 
-  /// Latest odometer reading logged for [vehicleId], picked from the
-  /// fill-up history (#584). Falls back to null so the reminder
-  /// section can prompt the user for a manual entry.
-  double? _latestOdometerKm(String vehicleId) {
-    try {
-      final fillUps = ref.watch(fillUpListProvider);
-      final forVehicle = fillUps.where((f) => f.vehicleId == vehicleId);
-      if (forVehicle.isEmpty) return null;
-      final latest = forVehicle.reduce(
-        (a, b) => a.odometerKm > b.odometerKm ? a : b,
-      );
-      return latest.odometerKm;
-    } catch (e) {
-      debugPrint('EditVehicleScreen: odometer lookup failed: $e');
-      return null;
+  /// Brand-accent colour from the vehicle name. Falls back to the
+  /// theme primary when no brand matches. The brand mapper is shared
+  /// with fuel stations — overlap is rare but harmless.
+  Color _brandAccent(BuildContext context) {
+    final primary = Theme.of(context).colorScheme.primary;
+    final name = _ctrl.nameController.text;
+    if (name.isEmpty) return primary;
+    for (final token in name.toLowerCase().split(RegExp(r'\s+'))) {
+      if (BrandLogoMapper.hasLogo(token)) return primary;
     }
-  }
-
-  /// Translates a vehicle's type + stored `preferredFuelType` into the
-  /// canonical [FuelType] the rest of the app uses (#710). EV always
-  /// maps to electric; combustion parses via [FuelType.fromString].
-  /// Hybrid keeps the vehicle's combustion fuel as the default until
-  /// #704 ships `hybridFuelChoice`.
-  FuelType? _deriveFuelTypeFromVehicle(VehicleProfile v) {
-    if (v.type == VehicleType.ev) return FuelType.electric;
-    final raw = v.preferredFuelType;
-    if (raw == null || raw.trim().isEmpty) return null;
-    return FuelType.fromString(raw);
+    return primary;
   }
 
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final isEdit = _existingId != null || widget.vehicleId != null;
-    final showEv = _type != VehicleType.combustion;
-    final showCombustion = _type != VehicleType.ev;
     final accent = _brandAccent(context);
 
     return Scaffold(
@@ -399,389 +230,70 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
       body: Form(
         key: _formKey,
         child: ListView(
-          padding: EdgeInsets.fromLTRB(
-            16,
-            16,
-            16,
-            MediaQuery.of(context).viewPadding.bottom + 96,
-          ),
+          padding: EdgeInsets.fromLTRB(16, 16, 16,
+              MediaQuery.of(context).viewPadding.bottom + 96),
           children: [
-            // Big brand-tinted header — #751 §3 bullet 2.
-            _VehicleHeader(
-              name: _nameCtrl.text,
+            // Big brand-tinted header — #751 §3.
+            VehicleHeader(
+              name: _ctrl.nameController.text,
               accent: accent,
               type: _type,
             ),
             const SizedBox(height: 16),
             // Card 1: Identity (name + VIN).
-            FormSectionCard(
-              title: l?.vehicleSectionIdentityTitle ?? 'Identity',
-              subtitle: l?.vehicleSectionIdentitySubtitle ?? 'Name & VIN',
-              icon: Icons.badge_outlined,
+            VehicleIdentitySection(
+              nameController: _ctrl.nameController,
+              vinController: _ctrl.vinController,
+              vinFocus: _ctrl.vinFocusNode,
               accent: accent,
-              children: [
-                FormFieldTile(
-                  icon: Icons.directions_car_outlined,
-                  color: accent,
-                  content: TextFormField(
-                    controller: _nameCtrl,
-                    decoration: InputDecoration(
-                      labelText: l?.vehicleNameLabel ?? 'Name',
-                      hintText: l?.vehicleNameHint ?? 'e.g. My Tesla Model 3',
-                      border: const OutlineInputBorder(),
-                    ),
-                    validator: (v) => (v == null || v.trim().isEmpty)
-                        ? (l?.fieldRequired ?? 'Required')
-                        : null,
-                  ),
-                ),
-                // VIN row — the FormFieldTile keeps the existing
-                // input layout, and a trailing info icon button
-                // (#895) opens the in-place explanation sheet.
-                // Tooltip + Semantics satisfy
-                // androidTapTargetGuideline and TalkBack
-                // announcement requirements.
-                Row(
-                  children: [
-                    Expanded(
-                      child: FormFieldTile(
-                        icon: Icons.qr_code_2_outlined,
-                        color: accent,
-                        content: TextFormField(
-                          controller: _vinCtrl,
-                          focusNode: _vinFocus,
-                          decoration: InputDecoration(
-                            labelText: l?.vinLabel ?? 'VIN (optional)',
-                            border: const OutlineInputBorder(),
-                            suffixIcon: _decodingVin
-                                ? const Padding(
-                                    padding: EdgeInsets.all(12),
-                                    child: SizedBox(
-                                      width: 20,
-                                      height: 20,
-                                      child: CircularProgressIndicator(
-                                          strokeWidth: 2),
-                                    ),
-                                  )
-                                : IconButton(
-                                    icon: const Icon(Icons.search),
-                                    tooltip:
-                                        l?.vinDecodeTooltip ?? 'Decode VIN',
-                                    onPressed: _decodeVin,
-                                  ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    Semantics(
-                      label: l?.vinInfoTooltip ?? 'What is a VIN?',
-                      button: true,
-                      child: IconButton(
-                        icon: const Icon(Icons.info_outline),
-                        tooltip: l?.vinInfoTooltip ?? 'What is a VIN?',
-                        onPressed: _showVinInfo,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
+              decodingVin: _decodingVin,
+              onDecodeVin: _decodeVin,
+              onShowVinInfo: _showVinInfo,
             ),
             const SizedBox(height: 16),
             // Card 2: Drivetrain (type + type-specific fields).
-            FormSectionCard(
-              title: l?.vehicleSectionDrivetrainTitle ?? 'Drivetrain',
-              subtitle: l?.vehicleSectionDrivetrainSubtitle ??
-                  'How this vehicle moves',
-              icon: Icons.settings_outlined,
+            VehicleDrivetrainSection(
+              type: _type,
+              onTypeChanged: (t) => setState(() => _type = t),
               accent: accent,
-              children: [
-                _TypeSelector(
-                  selected: _type,
-                  onChanged: (t) => setState(() => _type = t),
-                ),
-                const SizedBox(height: 8),
-                if (showEv) ...[
-                  VehicleEvSection(
-                    batteryController: _batteryCtrl,
-                    maxChargingKwController: _maxKwCtrl,
-                    minSocController: _minSocCtrl,
-                    maxSocController: _maxSocCtrl,
-                    connectors: _connectors,
-                    onToggleConnector: (c) => setState(() {
-                      if (_connectors.contains(c)) {
-                        _connectors.remove(c);
-                      } else {
-                        _connectors.add(c);
-                      }
-                    }),
-                    numberValidator: _validateOptionalNumber,
-                  ),
-                  const SizedBox(height: 16),
-                ],
-                if (showCombustion)
-                  VehicleCombustionSection(
-                    tankController: _tankCtrl,
-                    fuelTypeController: _fuelTypeCtrl,
-                    numberValidator: _validateOptionalNumber,
-                  ),
-              ],
+              batteryController: _ctrl.batteryController,
+              maxChargingKwController: _ctrl.maxChargingKwController,
+              minSocController: _ctrl.minSocController,
+              maxSocController: _ctrl.maxSocController,
+              connectors: _connectors,
+              onToggleConnector: (c) => setState(() {
+                if (_connectors.contains(c)) {
+                  _connectors.remove(c);
+                } else {
+                  _connectors.add(c);
+                }
+              }),
+              tankController: _ctrl.tankController,
+              fuelTypeController: _ctrl.fuelTypeController,
+              numberValidator: _validateOptionalNumber,
             ),
-            // Card 3: OBD2 adapter pairing (#779). Shown for saved
-            // vehicles only — pairing needs a stable vehicle id so
-            // the adapter MAC attaches to something that already
-            // exists in storage.
-            if (_existingId != null) ...[
-              const SizedBox(height: 16),
-              VehicleAdapterSection(
+            // Extras for saved vehicles — adapter, baselines, VE
+            // reset, service reminders. All need a stable id.
+            // Spread a List<Widget> instead of wrapping in a Column
+            // so tester.scrollUntilVisible still works on the rows
+            // below the fold (see feedback_ci_column_in_listview.md).
+            if (_existingId != null)
+              ...VehicleExtrasSection.build(
+                context: context,
+                vehicleId: _existingId!,
                 adapterMac: _adapterMac,
                 adapterName: _adapterName,
-                onPaired: (name, mac) {
-                  setState(() {
-                    _adapterName = name;
-                    _adapterMac = mac;
-                  });
-                  _save();
-                },
-                onForget: () {
-                  setState(() {
-                    _adapterName = null;
-                    _adapterMac = null;
-                  });
-                  _save();
-                },
+                onAdapterPaired: (name, mac) => _onAdapterChanged(name, mac),
+                onAdapterForget: () => _onAdapterChanged(null, null),
+                onResetVolumetricEfficiency: _resetVolumetricEfficiency,
+                currentOdometerKm: ref.latestOdometerKm(_existingId!),
               ),
-            ],
-            // Baseline calibration section (#779). Only meaningful
-            // for saved vehicles that might already have learned
-            // baselines from previous OBD2 trips — hide it during
-            // the Add flow to avoid confusing the first-run UX.
-            if (_existingId != null) ...[
-              const SizedBox(height: 16),
-              VehicleBaselineSection(vehicleId: _existingId!),
-            ],
-            // η_v calibration reset (#815). Lives in the same
-            // "learned calibration" band as the baseline section
-            // above — a user who wants to wipe one will often want
-            // to wipe the other.
-            if (_existingId != null) ...[
-              const SizedBox(height: 12),
-              OutlinedButton.icon(
-                onPressed: _resetVolumetricEfficiency,
-                icon: const Icon(Icons.restart_alt_outlined),
-                label: Text(l?.veResetAction ?? 'Reset calibration'),
-              ),
-            ],
-            // Service reminders (#584). Needs a stable vehicle id —
-            // the id is the foreign key stored on each reminder — so
-            // the section only renders for saved vehicles. Users
-            // adding a new vehicle hit Save first, then return to
-            // edit and see this section.
-            if (_existingId != null) ...[
-              const SizedBox(height: 16),
-              ServiceReminderSection(
-                vehicleId: _existingId!,
-                currentOdometerKm: _latestOdometerKm(_existingId!),
-              ),
-            ],
           ],
         ),
       ),
-      // Big primary Save pinned at the bottom (#751 §3). Using
-      // `bottomNavigationBar` guarantees the widget is always in
-      // the element tree even when the form scrolls off screen —
-      // which tests (and TalkBack) depend on for `ensureVisible`.
-      bottomNavigationBar: _VehicleSaveBar(onSave: _save),
-    );
-  }
-
-  /// Resolve a brand-accent color from the vehicle name when we can
-  /// recognise a known brand. Falls back to the theme primary when
-  /// no brand can be matched — which keeps first-run vehicles from
-  /// looking under-styled.
-  Color _brandAccent(BuildContext context) {
-    final theme = Theme.of(context);
-    final name = _nameCtrl.text;
-    if (name.isEmpty) return theme.colorScheme.primary;
-    // Brand mapper works on fuel-station brands; we share it because
-    // a lot of vehicle nameplates overlap (Shell, Esso obviously not;
-    // Aral no; but users type names like "Shell car" rarely). The
-    // hasLogo check proves the brand is mapped.
-    final lower = name.toLowerCase();
-    for (final token in lower.split(RegExp(r'\s+'))) {
-      if (BrandLogoMapper.hasLogo(token)) {
-        return theme.colorScheme.primary;
-      }
-    }
-    return theme.colorScheme.primary;
-  }
-}
-
-/// Pinned bottom Save bar on the restyled edit-vehicle form
-/// (#751 §3). Uses `bottomNavigationBar` so the CTA is always one
-/// tap away regardless of scroll position, and respects the system
-/// nav-bar inset (see `feedback_scaffold_inset_doubling.md`).
-class _VehicleSaveBar extends StatelessWidget {
-  final VoidCallback onSave;
-  const _VehicleSaveBar({required this.onSave});
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    return Material(
-      elevation: 8,
-      color: theme.colorScheme.surface,
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-          child: FilledButton.icon(
-            onPressed: onSave,
-            style: FilledButton.styleFrom(
-              minimumSize: const Size.fromHeight(52),
-            ),
-            icon: const Icon(Icons.save),
-            label: Text(l?.save ?? 'Save'),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Card-free big header rendered at the top of the restyled form
-/// (#751 §3). Shows the vehicle's name as a large title plus a tiny
-/// "plate" chip with the drivetrain icon — a visual anchor that
-/// turns the edit screen into "this vehicle's page" instead of "a
-/// long list of fields".
-class _VehicleHeader extends StatelessWidget {
-  final String name;
-  final Color accent;
-  final VehicleType type;
-
-  const _VehicleHeader({
-    required this.name,
-    required this.accent,
-    required this.type,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l = AppLocalizations.of(context);
-    final displayName = name.trim().isEmpty
-        ? (l?.vehicleHeaderUntitled ?? 'New vehicle')
-        : name.trim();
-    final typeLabel = switch (type) {
-      VehicleType.ev => l?.vehicleTypeEv ?? 'Electric',
-      VehicleType.hybrid => l?.vehicleTypeHybrid ?? 'Hybrid',
-      VehicleType.combustion => l?.vehicleTypeCombustion ?? 'Combustion',
-    };
-    final typeIcon = switch (type) {
-      VehicleType.ev => Icons.electric_car,
-      VehicleType.hybrid => Icons.directions_car_filled,
-      VehicleType.combustion => Icons.local_gas_station,
-    };
-
-    return Semantics(
-      container: true,
-      label: '$displayName · $typeLabel',
-      child: ExcludeSemantics(
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Container(
-              width: 64,
-              height: 64,
-              decoration: BoxDecoration(
-                color: accent.withValues(alpha: 0.14),
-                borderRadius: BorderRadius.circular(20),
-              ),
-              child: Icon(typeIcon, size: 36, color: accent),
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    displayName,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  _PlateChip(label: typeLabel, accent: accent),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _PlateChip extends StatelessWidget {
-  final String label;
-  final Color accent;
-
-  const _PlateChip({required this.label, required this.accent});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: accent.withValues(alpha: 0.10),
-        border: Border.all(color: accent.withValues(alpha: 0.4)),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        label,
-        style: theme.textTheme.labelSmall?.copyWith(
-          color: accent,
-          fontWeight: FontWeight.w600,
-          letterSpacing: 1.2,
-        ),
-      ),
-    );
-  }
-}
-
-class _TypeSelector extends StatelessWidget {
-  final VehicleType selected;
-  final ValueChanged<VehicleType> onChanged;
-
-  const _TypeSelector({required this.selected, required this.onChanged});
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    return SegmentedButton<VehicleType>(
-      segments: [
-        ButtonSegment(
-          value: VehicleType.combustion,
-          label: Text(l?.vehicleTypeCombustion ?? 'Combustion'),
-          icon: const Icon(Icons.local_gas_station),
-        ),
-        ButtonSegment(
-          value: VehicleType.hybrid,
-          label: Text(l?.vehicleTypeHybrid ?? 'Hybrid'),
-          icon: const Icon(Icons.directions_car_filled),
-        ),
-        ButtonSegment(
-          value: VehicleType.ev,
-          label: Text(l?.vehicleTypeEv ?? 'Electric'),
-          icon: const Icon(Icons.electric_car),
-        ),
-      ],
-      selected: {selected},
-      onSelectionChanged: (set) => onChanged(set.first),
+      // Pinned bottom Save (#751 §3) — always in the tree regardless
+      // of scroll, which tests and TalkBack rely on.
+      bottomNavigationBar: VehicleSaveBar(onSave: _save),
     );
   }
 }

--- a/lib/features/vehicle/presentation/widgets/ve_reset_confirm_dialog.dart
+++ b/lib/features/vehicle/presentation/widgets/ve_reset_confirm_dialog.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Destructive-action confirmation dialog for the η_v calibration
+/// reset (#815). The caller decides what to do with the returned
+/// bool — this widget only asks the user.
+class VeResetConfirmDialog {
+  VeResetConfirmDialog._();
+
+  /// Returns `true` only when the user explicitly taps the reset
+  /// action. Cancel / barrier dismiss / back-button all return
+  /// `null`, which callers should treat as "do nothing".
+  static Future<bool?> show(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(l?.veResetConfirmTitle ?? 'Reset calibration?'),
+        content: Text(
+          l?.veResetConfirmBody ??
+              'This will discard the learned per-vehicle calibration '
+                  'and restore the default value (0.85).',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(l?.cancel ?? 'Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(l?.veResetAction ?? 'Reset calibration'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_drivetrain_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_drivetrain_section.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/widgets/form_section_card.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/vehicle_profile.dart';
+import 'vehicle_combustion_section.dart';
+import 'vehicle_ev_section.dart';
+import 'vehicle_type_selector.dart';
+
+/// Drivetrain card on the edit-vehicle form — type picker plus the
+/// type-specific EV / Combustion sub-sections.
+///
+/// Keeps the parent form responsible for owning controllers and the
+/// connector set; we only assemble the three existing building blocks
+/// into the grouped `FormSectionCard` layout (#751 §3).
+class VehicleDrivetrainSection extends StatelessWidget {
+  final VehicleType type;
+  final ValueChanged<VehicleType> onTypeChanged;
+  final Color accent;
+
+  // EV controllers / connectors — used when type != combustion.
+  final TextEditingController batteryController;
+  final TextEditingController maxChargingKwController;
+  final TextEditingController minSocController;
+  final TextEditingController maxSocController;
+  final Set<ConnectorType> connectors;
+  final ValueChanged<ConnectorType> onToggleConnector;
+
+  // Combustion controllers — used when type != ev.
+  final TextEditingController tankController;
+  final TextEditingController fuelTypeController;
+
+  final String? Function(String?) numberValidator;
+
+  const VehicleDrivetrainSection({
+    super.key,
+    required this.type,
+    required this.onTypeChanged,
+    required this.accent,
+    required this.batteryController,
+    required this.maxChargingKwController,
+    required this.minSocController,
+    required this.maxSocController,
+    required this.connectors,
+    required this.onToggleConnector,
+    required this.tankController,
+    required this.fuelTypeController,
+    required this.numberValidator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final showEv = type != VehicleType.combustion;
+    final showCombustion = type != VehicleType.ev;
+    return FormSectionCard(
+      title: l?.vehicleSectionDrivetrainTitle ?? 'Drivetrain',
+      subtitle:
+          l?.vehicleSectionDrivetrainSubtitle ?? 'How this vehicle moves',
+      icon: Icons.settings_outlined,
+      accent: accent,
+      children: [
+        VehicleTypeSelector(selected: type, onChanged: onTypeChanged),
+        const SizedBox(height: 8),
+        if (showEv) ...[
+          VehicleEvSection(
+            batteryController: batteryController,
+            maxChargingKwController: maxChargingKwController,
+            minSocController: minSocController,
+            maxSocController: maxSocController,
+            connectors: connectors,
+            onToggleConnector: onToggleConnector,
+            numberValidator: numberValidator,
+          ),
+          const SizedBox(height: 16),
+        ],
+        if (showCombustion)
+          VehicleCombustionSection(
+            tankController: tankController,
+            fuelTypeController: fuelTypeController,
+            numberValidator: numberValidator,
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_extras_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_extras_section.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/presentation/widgets/vehicle_adapter_section.dart';
+import '../../../consumption/presentation/widgets/vehicle_baseline_section.dart';
+import 'service_reminder_section.dart';
+
+/// "Extras for a saved vehicle" band on the edit screen — OBD2
+/// adapter pairing, learned baselines, volumetric-efficiency reset
+/// and service reminders. All four depend on a stable vehicle id
+/// and are hidden while a brand-new vehicle is still being created.
+///
+/// Returns a `List<Widget>` that the caller spreads into its
+/// enclosing scrollable's `children`. Wrapping them in a single
+/// widget's `Column` would break `tester.scrollUntilVisible` for the
+/// reset/reminder rows (see `feedback_ci_column_in_listview.md`).
+class VehicleExtrasSection {
+  VehicleExtrasSection._();
+
+  static List<Widget> build({
+    required BuildContext context,
+    required String vehicleId,
+    required String? adapterMac,
+    required String? adapterName,
+    required void Function(String name, String mac) onAdapterPaired,
+    required VoidCallback onAdapterForget,
+    required VoidCallback onResetVolumetricEfficiency,
+    required double? currentOdometerKm,
+  }) {
+    final l = AppLocalizations.of(context);
+    return [
+      // Card 3: OBD2 adapter pairing (#779). Stable vehicle id only.
+      const SizedBox(height: 16),
+      VehicleAdapterSection(
+        adapterMac: adapterMac,
+        adapterName: adapterName,
+        onPaired: onAdapterPaired,
+        onForget: onAdapterForget,
+      ),
+      // Baseline calibration section (#779). Only renders once a
+      // vehicle is saved — hidden during the Add flow.
+      const SizedBox(height: 16),
+      VehicleBaselineSection(vehicleId: vehicleId),
+      // η_v calibration reset (#815). Pairs visually with baseline
+      // above — users who reset one often reset the other.
+      const SizedBox(height: 12),
+      OutlinedButton.icon(
+        onPressed: onResetVolumetricEfficiency,
+        icon: const Icon(Icons.restart_alt_outlined),
+        label: Text(l?.veResetAction ?? 'Reset calibration'),
+      ),
+      // Service reminders (#584). Keyed by vehicle id; hidden on Add.
+      const SizedBox(height: 16),
+      ServiceReminderSection(
+        vehicleId: vehicleId,
+        currentOdometerKm: currentOdometerKm,
+      ),
+    ];
+  }
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/widgets.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../domain/entities/vehicle_profile.dart';
+
+/// Bundles the text controllers, focus node, and scalar form state
+/// used by [EditVehicleScreen]. Keeps the screen class focused on
+/// build-method composition and async actions while centralising
+/// controller lifetime and profile round-tripping in one place.
+///
+/// All fields are plain instance state — the owner is still a
+/// StatefulWidget's `State`, which must call [load] from
+/// [widget.vehicleId] lookup logic and [dispose] from its own
+/// `dispose`. The form-state flags ([type], [connectors], adapter
+/// ids, decoded engine ids) live on the screen since they drive
+/// `setState` rebuilds.
+class VehicleFormControllers {
+  static const _uuid = Uuid();
+
+  final nameController = TextEditingController();
+  final batteryController = TextEditingController();
+  final maxChargingKwController = TextEditingController();
+  final tankController = TextEditingController();
+  // #710 — pre-fill E10 so the Preferred-fuel dropdown isn't "Not set".
+  final fuelTypeController = TextEditingController(text: 'e10');
+  final minSocController = TextEditingController(text: '20');
+  final maxSocController = TextEditingController(text: '80');
+  final vinController = TextEditingController();
+  final vinFocusNode = FocusNode();
+
+  /// Copy the saved [profile] fields into the text controllers.
+  /// Non-controller fields (type, connectors, engine ids, adapter
+  /// ids) are returned as a snapshot for the caller to copy into
+  /// its own state fields.
+  VehicleFormSnapshot load(VehicleProfile profile) {
+    nameController.text = profile.name;
+    batteryController.text = profile.batteryKwh?.toString() ?? '';
+    maxChargingKwController.text = profile.maxChargingKw?.toString() ?? '';
+    tankController.text = profile.tankCapacityL?.toString() ?? '';
+    fuelTypeController.text = profile.preferredFuelType ?? '';
+    minSocController.text =
+        profile.chargingPreferences.minSocPercent.toString();
+    maxSocController.text =
+        profile.chargingPreferences.maxSocPercent.toString();
+    vinController.text = profile.vin ?? '';
+    return VehicleFormSnapshot(
+      id: profile.id,
+      type: profile.type,
+      connectors: {...profile.supportedConnectors},
+      adapterMac: profile.obd2AdapterMac,
+      adapterName: profile.obd2AdapterName,
+      engineDisplacementCc: profile.engineDisplacementCc,
+      engineCylinders: profile.engineCylinders,
+      curbWeightKg: profile.curbWeightKg,
+    );
+  }
+
+  /// Construct a [VehicleProfile] from the current controller values
+  /// combined with the non-controller state passed in by the caller.
+  VehicleProfile buildProfile({
+    required String? existingId,
+    required VehicleType type,
+    required Set<ConnectorType> connectors,
+    required String? adapterMac,
+    required String? adapterName,
+    required int? engineDisplacementCc,
+    required int? engineCylinders,
+    required int? curbWeightKg,
+  }) {
+    return VehicleProfile(
+      id: existingId ?? _uuid.v4(),
+      name: nameController.text.trim(),
+      type: type,
+      batteryKwh: type == VehicleType.combustion
+          ? null
+          : _parseDouble(batteryController.text),
+      maxChargingKw: type == VehicleType.combustion
+          ? null
+          : _parseDouble(maxChargingKwController.text),
+      supportedConnectors:
+          type == VehicleType.combustion ? <ConnectorType>{} : {...connectors},
+      tankCapacityL:
+          type == VehicleType.ev ? null : _parseDouble(tankController.text),
+      preferredFuelType: type == VehicleType.ev
+          ? null
+          : (fuelTypeController.text.trim().isEmpty
+              ? null
+              : fuelTypeController.text.trim()),
+      chargingPreferences: ChargingPreferences(
+        minSocPercent: _parseIntOr(minSocController.text, 20).clamp(0, 100),
+        maxSocPercent: _parseIntOr(maxSocController.text, 80).clamp(0, 100),
+      ),
+      obd2AdapterMac: adapterMac,
+      obd2AdapterName: adapterName,
+      vin: vinController.text.trim().isEmpty
+          ? null
+          : vinController.text.trim(),
+      engineDisplacementCc: engineDisplacementCc,
+      engineCylinders: engineCylinders,
+      curbWeightKg: curbWeightKg,
+    );
+  }
+
+  void dispose() {
+    nameController.dispose();
+    batteryController.dispose();
+    maxChargingKwController.dispose();
+    tankController.dispose();
+    fuelTypeController.dispose();
+    minSocController.dispose();
+    maxSocController.dispose();
+    vinController.dispose();
+    vinFocusNode.dispose();
+  }
+
+  static double? _parseDouble(String text) {
+    final trimmed = text.trim().replaceAll(',', '.');
+    if (trimmed.isEmpty) return null;
+    return double.tryParse(trimmed);
+  }
+
+  static int _parseIntOr(String text, int fallback) =>
+      int.tryParse(text.trim()) ?? fallback;
+}
+
+/// Snapshot of the non-controller fields on a loaded profile, so the
+/// owning state can copy them into its own `setState` locals.
+class VehicleFormSnapshot {
+  final String id;
+  final VehicleType type;
+  final Set<ConnectorType> connectors;
+  final String? adapterMac;
+  final String? adapterName;
+  final int? engineDisplacementCc;
+  final int? engineCylinders;
+  final int? curbWeightKg;
+
+  VehicleFormSnapshot({
+    required this.id,
+    required this.type,
+    required this.connectors,
+    required this.adapterMac,
+    required this.adapterName,
+    required this.engineDisplacementCc,
+    required this.engineCylinders,
+    required this.curbWeightKg,
+  });
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_header.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_header.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/vehicle_profile.dart';
+
+/// Card-free big header rendered at the top of the restyled
+/// edit-vehicle form (#751 §3). Shows the vehicle's name as a large
+/// title plus a tiny "plate" chip with the drivetrain icon — a
+/// visual anchor that turns the edit screen into "this vehicle's
+/// page" instead of "a long list of fields".
+class VehicleHeader extends StatelessWidget {
+  final String name;
+  final Color accent;
+  final VehicleType type;
+
+  const VehicleHeader({
+    super.key,
+    required this.name,
+    required this.accent,
+    required this.type,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
+    final displayName = name.trim().isEmpty
+        ? (l?.vehicleHeaderUntitled ?? 'New vehicle')
+        : name.trim();
+    final typeLabel = switch (type) {
+      VehicleType.ev => l?.vehicleTypeEv ?? 'Electric',
+      VehicleType.hybrid => l?.vehicleTypeHybrid ?? 'Hybrid',
+      VehicleType.combustion => l?.vehicleTypeCombustion ?? 'Combustion',
+    };
+    final typeIcon = switch (type) {
+      VehicleType.ev => Icons.electric_car,
+      VehicleType.hybrid => Icons.directions_car_filled,
+      VehicleType.combustion => Icons.local_gas_station,
+    };
+
+    return Semantics(
+      container: true,
+      label: '$displayName · $typeLabel',
+      child: ExcludeSemantics(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              width: 64,
+              height: 64,
+              decoration: BoxDecoration(
+                color: accent.withValues(alpha: 0.14),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Icon(typeIcon, size: 36, color: accent),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    displayName,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  _PlateChip(label: typeLabel, accent: accent),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PlateChip extends StatelessWidget {
+  final String label;
+  final Color accent;
+
+  const _PlateChip({required this.label, required this.accent});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.10),
+        border: Border.all(color: accent.withValues(alpha: 0.4)),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: accent,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 1.2,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/widgets/form_section_card.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Identity card on the edit-vehicle form — name + VIN.
+///
+/// Carries the VIN decode-button + VIN info-sheet affordances
+/// introduced in #812 / #895 / #900. The parent form owns the
+/// controllers, focus node, and the callbacks for decode / info —
+/// this widget is intentionally dumb so all VIN-decoder state stays
+/// at the screen level where the provider already lives.
+class VehicleIdentitySection extends StatelessWidget {
+  final TextEditingController nameController;
+  final TextEditingController vinController;
+  final FocusNode vinFocus;
+  final Color accent;
+  final bool decodingVin;
+  final VoidCallback onDecodeVin;
+  final VoidCallback onShowVinInfo;
+
+  const VehicleIdentitySection({
+    super.key,
+    required this.nameController,
+    required this.vinController,
+    required this.vinFocus,
+    required this.accent,
+    required this.decodingVin,
+    required this.onDecodeVin,
+    required this.onShowVinInfo,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return FormSectionCard(
+      title: l?.vehicleSectionIdentityTitle ?? 'Identity',
+      subtitle: l?.vehicleSectionIdentitySubtitle ?? 'Name & VIN',
+      icon: Icons.badge_outlined,
+      accent: accent,
+      children: [
+        FormFieldTile(
+          icon: Icons.directions_car_outlined,
+          color: accent,
+          content: TextFormField(
+            controller: nameController,
+            decoration: InputDecoration(
+              labelText: l?.vehicleNameLabel ?? 'Name',
+              hintText: l?.vehicleNameHint ?? 'e.g. My Tesla Model 3',
+              border: const OutlineInputBorder(),
+            ),
+            validator: (v) => (v == null || v.trim().isEmpty)
+                ? (l?.fieldRequired ?? 'Required')
+                : null,
+          ),
+        ),
+        // VIN row — the FormFieldTile keeps the existing input layout,
+        // and a trailing info icon button (#895) opens the in-place
+        // explanation sheet. Tooltip + Semantics satisfy
+        // androidTapTargetGuideline and TalkBack announcement
+        // requirements.
+        Row(
+          children: [
+            Expanded(
+              child: FormFieldTile(
+                icon: Icons.qr_code_2_outlined,
+                color: accent,
+                content: TextFormField(
+                  controller: vinController,
+                  focusNode: vinFocus,
+                  decoration: InputDecoration(
+                    labelText: l?.vinLabel ?? 'VIN (optional)',
+                    border: const OutlineInputBorder(),
+                    suffixIcon: decodingVin
+                        ? const Padding(
+                            padding: EdgeInsets.all(12),
+                            child: SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                  strokeWidth: 2),
+                            ),
+                          )
+                        : IconButton(
+                            icon: const Icon(Icons.search),
+                            tooltip: l?.vinDecodeTooltip ?? 'Decode VIN',
+                            onPressed: onDecodeVin,
+                          ),
+                  ),
+                ),
+              ),
+            ),
+            Semantics(
+              label: l?.vinInfoTooltip ?? 'What is a VIN?',
+              button: true,
+              child: IconButton(
+                icon: const Icon(Icons.info_outline),
+                tooltip: l?.vinInfoTooltip ?? 'What is a VIN?',
+                onPressed: onShowVinInfo,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_save_actions.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_save_actions.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../consumption/providers/consumption_providers.dart';
+import '../../../profile/providers/profile_provider.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+import '../../domain/entities/vehicle_profile.dart';
+import '../../providers/vehicle_providers.dart';
+
+/// Cross-cutting actions the edit-vehicle screen runs against
+/// Riverpod providers: default-profile sync, volumetric-efficiency
+/// reset, latest-odometer lookup. Gathering them here keeps the
+/// screen focused on form composition.
+extension VehicleSaveActions on WidgetRef {
+  /// #710 — auto-set [profile] as the active profile's default and
+  /// sync its preferredFuelType when (a) no default is set, or
+  /// (b) editing the already-default vehicle. Silently swallows
+  /// errors (with a debugPrint) because the primary save has
+  /// already succeeded by the time we hit this path.
+  Future<void> syncActiveProfile(VehicleProfile profile) async {
+    try {
+      final profileRepo = read(profileRepositoryProvider);
+      final activeProfile = read(activeProfileProvider);
+      if (activeProfile == null) return;
+      final shouldBecomeDefault = activeProfile.defaultVehicleId == null ||
+          activeProfile.defaultVehicleId == profile.id;
+      if (!shouldBecomeDefault) return;
+      final derived = deriveFuelTypeFromVehicle(profile);
+      final updated = activeProfile.copyWith(
+        defaultVehicleId: profile.id,
+        preferredFuelType: derived ?? activeProfile.preferredFuelType,
+      );
+      await profileRepo.updateProfile(updated);
+      read(activeProfileProvider.notifier).refresh();
+    } catch (e) {
+      debugPrint('EditVehicleScreen: profile sync failed: $e');
+    }
+  }
+
+  /// #815 — reset the learned η_v for [vehicleId] back to the
+  /// default (0.85) and clear the sample counter.
+  Future<void> resetVolumetricEfficiency(String vehicleId) async {
+    try {
+      final list = read(vehicleProfileListProvider);
+      final existing = list.where((v) => v.id == vehicleId).firstOrNull;
+      if (existing == null) return;
+      final cleared = existing.copyWith(
+        volumetricEfficiency: 0.85,
+        volumetricEfficiencySamples: 0,
+      );
+      await read(vehicleProfileListProvider.notifier).save(cleared);
+    } catch (e) {
+      debugPrint('EditVehicleScreen: VE reset failed: $e');
+    }
+  }
+
+  /// #584 — latest odometer reading logged for [vehicleId]. Returns
+  /// null when no fill-ups exist so the reminder section can prompt
+  /// the user for a manual entry.
+  double? latestOdometerKm(String vehicleId) {
+    try {
+      final fillUps = watch(fillUpListProvider);
+      final forVehicle = fillUps.where((f) => f.vehicleId == vehicleId);
+      if (forVehicle.isEmpty) return null;
+      final latest =
+          forVehicle.reduce((a, b) => a.odometerKm > b.odometerKm ? a : b);
+      return latest.odometerKm;
+    } catch (e) {
+      debugPrint('EditVehicleScreen: odometer lookup failed: $e');
+      return null;
+    }
+  }
+}
+
+/// #710 — translate a vehicle's type + stored preferredFuelType into
+/// the canonical [FuelType]. EV → electric; combustion parses via
+/// [FuelType.fromString]. Hybrid keeps the combustion fuel until
+/// #704 ships `hybridFuelChoice`.
+FuelType? deriveFuelTypeFromVehicle(VehicleProfile v) {
+  if (v.type == VehicleType.ev) return FuelType.electric;
+  final raw = v.preferredFuelType;
+  if (raw == null || raw.trim().isEmpty) return null;
+  return FuelType.fromString(raw);
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_save_bar.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_save_bar.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Pinned bottom Save bar on the restyled edit-vehicle form
+/// (#751 §3). Uses `bottomNavigationBar` so the CTA is always one
+/// tap away regardless of scroll position, and respects the system
+/// nav-bar inset (see `feedback_scaffold_inset_doubling.md`).
+class VehicleSaveBar extends StatelessWidget {
+  final VoidCallback onSave;
+  const VehicleSaveBar({super.key, required this.onSave});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Material(
+      elevation: 8,
+      color: theme.colorScheme.surface,
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+          child: FilledButton.icon(
+            onPressed: onSave,
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(52),
+            ),
+            icon: const Icon(Icons.save),
+            label: Text(l?.save ?? 'Save'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/vehicle/presentation/widgets/vehicle_type_selector.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_type_selector.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/vehicle_profile.dart';
+
+/// Drivetrain toggle on the edit-vehicle form — a three-segment
+/// [SegmentedButton] that flips the form between Combustion, Hybrid,
+/// and Electric. Pure UI; owning state stays on the parent form.
+class VehicleTypeSelector extends StatelessWidget {
+  final VehicleType selected;
+  final ValueChanged<VehicleType> onChanged;
+
+  const VehicleTypeSelector({
+    super.key,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return SegmentedButton<VehicleType>(
+      segments: [
+        ButtonSegment(
+          value: VehicleType.combustion,
+          label: Text(l?.vehicleTypeCombustion ?? 'Combustion'),
+          icon: const Icon(Icons.local_gas_station),
+        ),
+        ButtonSegment(
+          value: VehicleType.hybrid,
+          label: Text(l?.vehicleTypeHybrid ?? 'Hybrid'),
+          icon: const Icon(Icons.directions_car_filled),
+        ),
+        ButtonSegment(
+          value: VehicleType.ev,
+          label: Text(l?.vehicleTypeEv ?? 'Electric'),
+          icon: const Icon(Icons.electric_car),
+        ),
+      ],
+      selected: {selected},
+      onSelectionChanged: (set) => onChanged(set.first),
+    );
+  }
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_drivetrain_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_drivetrain_section_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_drivetrain_section.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required VehicleType type,
+}) async {
+  final batteryCtrl = TextEditingController();
+  final maxKwCtrl = TextEditingController();
+  final minSocCtrl = TextEditingController(text: '20');
+  final maxSocCtrl = TextEditingController(text: '80');
+  final tankCtrl = TextEditingController();
+  final fuelTypeCtrl = TextEditingController(text: 'e10');
+  addTearDown(() {
+    batteryCtrl.dispose();
+    maxKwCtrl.dispose();
+    minSocCtrl.dispose();
+    maxSocCtrl.dispose();
+    tankCtrl.dispose();
+    fuelTypeCtrl.dispose();
+  });
+
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: Form(
+            child: VehicleDrivetrainSection(
+              type: type,
+              onTypeChanged: (_) {},
+              accent: Colors.blue,
+              batteryController: batteryCtrl,
+              maxChargingKwController: maxKwCtrl,
+              minSocController: minSocCtrl,
+              maxSocController: maxSocCtrl,
+              connectors: const {},
+              onToggleConnector: (_) {},
+              tankController: tankCtrl,
+              fuelTypeController: fuelTypeCtrl,
+              numberValidator: (_) => null,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('VehicleDrivetrainSection (extracted from #563 edit_vehicle_screen)',
+      () {
+    testWidgets('renders the combustion fields on a combustion vehicle',
+        (tester) async {
+      await _pump(tester, type: VehicleType.combustion);
+      // Combustion sub-section exposes a tank capacity field.
+      expect(find.text('Tank capacity (L)'), findsOneWidget);
+      // Type selector still renders all three segments.
+      expect(find.text('Combustion'), findsWidgets);
+    });
+
+    testWidgets('renders the EV fields on an EV vehicle', (tester) async {
+      await _pump(tester, type: VehicleType.ev);
+      // EV sub-section exposes the battery capacity field.
+      expect(find.text('Battery capacity (kWh)'), findsOneWidget);
+      // Combustion-only tank field is gone when type is pure EV.
+      expect(find.text('Tank capacity (L)'), findsNothing);
+    });
+  });
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_extras_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_extras_section_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_extras_section.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('extras_widget_');
+    Hive.init(tempDir.path);
+    await Hive.openBox<String>(HiveBoxes.serviceReminders);
+    await Hive.openBox<String>(HiveBoxes.obd2Baselines);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  group('VehicleExtrasSection (extracted from #563 edit_vehicle_screen)', () {
+    testWidgets('build() returns the reset calibration action in the list',
+        (tester) async {
+      // Tall canvas so all four rows fit without virtualization —
+      // scrollUntilVisible would work too, but a simpler viewport
+      // keeps the test focused on the widget's contract.
+      tester.view.physicalSize = const Size(900, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => ListView(
+                  children: VehicleExtrasSection.build(
+                    context: context,
+                    vehicleId: 'v1',
+                    adapterMac: null,
+                    adapterName: null,
+                    onAdapterPaired: (_, _) {},
+                    onAdapterForget: () {},
+                    onResetVolumetricEfficiency: () {},
+                    currentOdometerKm: null,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The reset-calibration OutlinedButton must be present — the
+      // VE reset test depends on this label being scroll-reachable.
+      expect(find.text('Reset calibration'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_header_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_header_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_header.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+Future<void> _pump(WidgetTester tester, VehicleHeader header) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: header),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('VehicleHeader (extracted from #563 edit_vehicle_screen)', () {
+    testWidgets('renders the typed name and combustion plate chip',
+        (tester) async {
+      await _pump(
+        tester,
+        const VehicleHeader(
+          name: 'My Peugeot 107',
+          accent: Colors.blue,
+          type: VehicleType.combustion,
+        ),
+      );
+      expect(find.text('My Peugeot 107'), findsOneWidget);
+      expect(find.text('Combustion'), findsOneWidget);
+    });
+
+    testWidgets('falls back to the "New vehicle" placeholder on empty name',
+        (tester) async {
+      await _pump(
+        tester,
+        const VehicleHeader(
+          name: '',
+          accent: Colors.blue,
+          type: VehicleType.ev,
+        ),
+      );
+      expect(find.text('New vehicle'), findsOneWidget);
+      expect(find.text('Electric'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_identity_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_identity_section_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_identity_section.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  group('VehicleIdentitySection (extracted from #563 edit_vehicle_screen)',
+      () {
+    testWidgets('renders the name + VIN fields and the decode/info actions',
+        (tester) async {
+      final nameCtrl = TextEditingController();
+      final vinCtrl = TextEditingController();
+      final vinFocus = FocusNode();
+      addTearDown(() {
+        nameCtrl.dispose();
+        vinCtrl.dispose();
+        vinFocus.dispose();
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Form(
+              child: VehicleIdentitySection(
+                nameController: nameCtrl,
+                vinController: vinCtrl,
+                vinFocus: vinFocus,
+                accent: Colors.blue,
+                decodingVin: false,
+                onDecodeVin: () {},
+                onShowVinInfo: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Name'), findsOneWidget);
+      expect(find.text('VIN (optional)'), findsOneWidget);
+      expect(find.byTooltip('Decode VIN'), findsOneWidget);
+      expect(find.byTooltip('What is a VIN?'), findsOneWidget);
+    });
+
+    testWidgets('shows a progress spinner when decodingVin is true',
+        (tester) async {
+      final nameCtrl = TextEditingController();
+      final vinCtrl = TextEditingController();
+      final vinFocus = FocusNode();
+      addTearDown(() {
+        nameCtrl.dispose();
+        vinCtrl.dispose();
+        vinFocus.dispose();
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Form(
+              child: VehicleIdentitySection(
+                nameController: nameCtrl,
+                vinController: vinCtrl,
+                vinFocus: vinFocus,
+                accent: Colors.blue,
+                decodingVin: true,
+                onDecodeVin: () {},
+                onShowVinInfo: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byTooltip('Decode VIN'), findsNothing);
+    });
+  });
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_save_bar_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_save_bar_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_save_bar.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  group('VehicleSaveBar (extracted from #563 edit_vehicle_screen)', () {
+    testWidgets('renders the Save filled button and forwards taps',
+        (tester) async {
+      var tapped = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            bottomNavigationBar: VehicleSaveBar(onSave: () => tapped++),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(FilledButton, 'Save'), findsOneWidget);
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pump();
+      expect(tapped, 1);
+    });
+  });
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_type_selector_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_type_selector_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_type_selector.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+void main() {
+  group('VehicleTypeSelector (extracted from #563 edit_vehicle_screen)', () {
+    testWidgets('renders all three drivetrain segments', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VehicleTypeSelector(
+              selected: VehicleType.combustion,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Combustion'), findsOneWidget);
+      expect(find.text('Hybrid'), findsOneWidget);
+      expect(find.text('Electric'), findsOneWidget);
+    });
+
+    testWidgets('forwards the tapped segment via onChanged', (tester) async {
+      VehicleType? picked;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VehicleTypeSelector(
+              selected: VehicleType.combustion,
+              onChanged: (t) => picked = t,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Electric'));
+      await tester.pumpAndSettle();
+      expect(picked, VehicleType.ev);
+    });
+  });
+}


### PR DESCRIPTION
Refs #563 phase N

## Summary

`edit_vehicle_screen.dart`: **787 → 299 LOC** (≤ 300 target hit).

Pure structural refactor — behavior is unchanged. Same ARB keys, same
field order, same validators, same save handler, same VIN-decoder flow
(#812 / #895 / #900 paths preserved).

## Extracted widgets (`lib/features/vehicle/presentation/widgets/`)

| File | LOC | Role |
|---|---|---|
| `vehicle_header.dart` | 109 | Big vehicle-page header + plate chip |
| `vehicle_save_bar.dart` | 36 | Pinned bottom Save button |
| `vehicle_type_selector.dart` | 44 | Combustion / Hybrid / Electric segmented button |
| `vehicle_identity_section.dart` | 107 | Name + VIN + decode + info-sheet card |
| `vehicle_drivetrain_section.dart` | 86 | Type picker + EV / Combustion sub-sections |
| `vehicle_extras_section.dart` | 60 | Adapter + baseline + VE reset + reminders (static `build()` → `List<Widget>` so `tester.scrollUntilVisible` keeps working past the fold; see `feedback_ci_column_in_listview.md`) |
| `ve_reset_confirm_dialog.dart` | 38 | η_v reset confirmation dialog (#815) |
| `vehicle_form_controllers.dart` | 148 | Bundles 9 `TextEditingController` + `FocusNode`, owns `load()` / `buildProfile()` / `dispose()` |
| `vehicle_save_actions.dart` | 84 | `WidgetRef` extension for `syncActiveProfile` / `resetVolumetricEfficiency` / `latestOdometerKm` |

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — **5665 pass / 1 skipped** (network-gated test already skipped on master)
- [x] `flutter test test/features/vehicle/` — 164 pass
- [x] Existing screen tests unchanged and green: `edit_vehicle_screen_restyle_test.dart`, `edit_vehicle_screen_vin_test.dart`, `edit_vehicle_screen_ve_reset_test.dart`, `vin_info_test.dart`
- [x] 6 new smoke tests added (one per extracted section widget / save-bar / header / type-selector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)