### PR TITLE
feat(consumption): Charging tab visible only for hybrid/EV (#892)

### DIFF
--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -10,6 +10,7 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../achievements/presentation/widgets/badge_shelf.dart';
 import '../../../ev/domain/entities/charging_log.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/csv_exporter.dart';
 import '../../providers/charging_charts_provider.dart';
@@ -26,11 +27,18 @@ import 'add_charging_log_screen.dart';
 
 /// Lists all logged fill-ups and charging sessions.
 ///
-/// Two-tab scaffold (#582 phase 2):
-///   * **Fuel** — existing fill-up list with its CSV export + stats card.
-///   * **Charging** — new EV charging logs backed by
-///     [chargingLogsProvider]. Phase-3 will add per-vehicle charts
-///     and the deep-link from the EV station detail screen.
+/// Tab shape depends on the active vehicle's powertrain (#892):
+///   * **Fuel** — always visible; existing fill-up list with its CSV
+///     export and stats card.
+///   * **Trajets** — always visible (#889); trip history for the
+///     active vehicle.
+///   * **Charging** — visible only when the active vehicle is hybrid
+///     or electric. Hidden for ICE so the UI doesn't advertise a
+///     feature the user can't use.
+///
+/// When the active vehicle is unknown (null), we keep all three tabs
+/// because #892 explicitly defers the "no vehicle" case to a separate
+/// issue and existing callers rely on the full tab row.
 ///
 /// The FAB rebinds to the active tab so the user always sees the
 /// most obvious "log what I just did" action for the list they're
@@ -44,30 +52,56 @@ class ConsumptionScreen extends ConsumerStatefulWidget {
 }
 
 class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
-    with SingleTickerProviderStateMixin {
-  late final TabController _tabController;
-
-  @override
-  void initState() {
-    super.initState();
-    // #889 — three tabs now: Fuel, Trajets, Charging. Trajets is
-    // always visible once the Consumption screen is visible (gated on
-    // an active vehicle per #893); Charging stays present — #892 will
-    // tailor visibility per vehicle type in a follow-up.
-    _tabController = TabController(length: 3, vsync: this);
-    _tabController.addListener(() {
-      // The FAB label changes when the tab changes, so trigger a
-      // rebuild on every tab transition (indexIsChanging covers the
-      // animated swipe case too).
-      if (!mounted) return;
-      setState(() {});
-    });
-  }
+    with TickerProviderStateMixin {
+  /// Tracks the current controller length so we can detect when the
+  /// visible-tab count changes (vehicle type switched) and rebuild
+  /// the [TabController] — its length is immutable.
+  TabController? _tabController;
+  int _controllerLength = 0;
 
   @override
   void dispose() {
-    _tabController.dispose();
+    _tabController?.dispose();
     super.dispose();
+  }
+
+  /// Re-create the [TabController] for [length] tabs while preserving
+  /// the selected index when possible.
+  ///
+  /// When the Charging tab disappears (length 3 -> 2) and the user was
+  /// on it (index 2), snap to Trajets (index 1) so the view doesn't
+  /// land out of range.
+  void _ensureController(int length) {
+    final previous = _tabController;
+    if (previous != null && _controllerLength == length) return;
+
+    int initialIndex = 0;
+    if (previous != null) {
+      final oldIndex = previous.index;
+      if (oldIndex < length) {
+        initialIndex = oldIndex;
+      } else {
+        // Old index exceeds the new length — for a 3 -> 2 shrink this
+        // means the user was on the Charging tab, so snap to Trajets
+        // rather than Fuel to stay on the adjacent list.
+        initialIndex = length - 1;
+      }
+    }
+
+    final next = TabController(
+      length: length,
+      vsync: this,
+      initialIndex: initialIndex,
+    );
+    next.addListener(() {
+      // The FAB label changes when the tab changes, so trigger a
+      // rebuild on every tab transition.
+      if (!mounted) return;
+      setState(() {});
+    });
+    previous?.dispose();
+    _tabController = next;
+    _controllerLength = length;
   }
 
   @override
@@ -77,6 +111,17 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     final stats = ref.watch(consumptionStatsProvider);
     final activeVehicle = ref.watch(activeVehicleProfileProvider);
     final l = AppLocalizations.of(context);
+
+    // #892 — Charging tab is only relevant for vehicles that can
+    // actually charge. ICE vehicles hide it. When no vehicle is
+    // configured we preserve the full tab row (the issue scopes the
+    // "no vehicle" hide to a separate future change).
+    final showCharging = activeVehicle == null ||
+        activeVehicle.type == VehicleType.ev ||
+        activeVehicle.type == VehicleType.hybrid;
+
+    _ensureController(showCharging ? 3 : 2);
+    final tabController = _tabController!;
 
     // #815 — surface the η_v calibration outcome as a one-shot
     // snackbar when the fill-up save path learns a new value for the
@@ -100,14 +145,12 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
       ref.read(lastVeLearnResultProvider.notifier).set(null);
     });
 
-    // #889 — three tabs: 0 Fuel, 1 Trajets, 2 Charging. The FAB
-    // rebinds per-tab: Fuel -> pick-station sheet, Trajets hides the
-    // FAB (the "Start recording" CTA lives inside the tab header),
-    // Charging -> Add charging log sheet.
-    final tabIndex = _tabController.index;
+    // Tab indices depend on whether Charging is present. Fuel/Trajets
+    // are always 0/1; Charging is 2 when visible.
+    final tabIndex = tabController.index;
     final isFuelTab = tabIndex == 0;
     final isTrajetsTab = tabIndex == 1;
-    final isChargingTab = tabIndex == 2;
+    final isChargingTab = showCharging && tabIndex == 2;
 
     return Scaffold(
       appBar: AppBar(
@@ -118,7 +161,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
           onPressed: () => context.pop(),
         ),
         bottom: TabBar(
-          controller: _tabController,
+          controller: tabController,
           tabs: [
             Tab(
               key: const Key('consumption_tab_fuel'),
@@ -130,11 +173,12 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
               icon: const Icon(Icons.route_outlined),
               text: l?.trajetsTabLabel ?? 'Trips',
             ),
-            Tab(
-              key: const Key('consumption_tab_charging'),
-              icon: const Icon(Icons.ev_station_outlined),
-              text: l?.consumptionTabCharging ?? 'Charging',
-            ),
+            if (showCharging)
+              Tab(
+                key: const Key('consumption_tab_charging'),
+                icon: const Icon(Icons.ev_station_outlined),
+                text: l?.consumptionTabCharging ?? 'Charging',
+              ),
           ],
         ),
         actions: [
@@ -213,11 +257,11 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
               ),
             ),
       body: TabBarView(
-        controller: _tabController,
+        controller: tabController,
         children: [
           _FuelTab(fillUps: fillUps, stats: stats, l: l),
           TrajetsTab(vehicleId: activeVehicle?.id),
-          _ChargingTab(async: chargingLogsAsync, l: l),
+          if (showCharging) _ChargingTab(async: chargingLogsAsync, l: l),
         ],
       ),
     );

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/consumption_screen.dart';
+import 'package:tankstellen/features/consumption/providers/charging_logs_provider.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// #892 — the Charging tab on `ConsumptionScreen` is gated by the
+/// active vehicle's powertrain. ICE vehicles see Fuel + Trajets only;
+/// hybrid and EV vehicles see all three tabs. Switching live from EV
+/// to ICE while Charging was selected snaps the selection to Trajets
+/// so the user doesn't land on a non-existent index.
+
+class _FixedFillUpList extends FillUpList {
+  final List<FillUp> _value;
+  _FixedFillUpList(this._value);
+
+  @override
+  List<FillUp> build() => _value;
+}
+
+class _FixedChargingLogs extends ChargingLogs {
+  final List<ChargingLog> _value;
+  _FixedChargingLogs(this._value);
+
+  @override
+  Future<List<ChargingLog>> build() async => _value;
+}
+
+/// Mutable active-vehicle notifier so one test can flip the vehicle
+/// type after the initial pump — mirrors the real vehicle switcher.
+class _MutableActiveVehicle extends ActiveVehicleProfile {
+  _MutableActiveVehicle(this._initial);
+  final VehicleProfile? _initial;
+
+  @override
+  VehicleProfile? build() => _initial;
+
+  void set(VehicleProfile? next) {
+    state = next;
+  }
+}
+
+class _FixedVehicleProfileList extends VehicleProfileList {
+  final List<VehicleProfile> _value;
+  _FixedVehicleProfileList(this._value);
+
+  @override
+  List<VehicleProfile> build() => _value;
+}
+
+const _iceVehicle = VehicleProfile(
+  id: 'v-ice',
+  name: 'ICE commuter',
+  type: VehicleType.combustion,
+);
+
+const _evVehicle = VehicleProfile(
+  id: 'v-ev',
+  name: 'Daily EV',
+  type: VehicleType.ev,
+);
+
+const _hybridVehicle = VehicleProfile(
+  id: 'v-hybrid',
+  name: 'Plug-in hybrid',
+  type: VehicleType.hybrid,
+);
+
+Future<_MutableActiveVehicle> _pumpScreen(
+  WidgetTester tester, {
+  required VehicleProfile? activeVehicle,
+  List<VehicleProfile> vehicles = const [],
+  List<FillUp> fillUps = const [],
+  List<ChargingLog> chargingLogs = const [],
+}) async {
+  final activeNotifier = _MutableActiveVehicle(activeVehicle);
+  final router = GoRouter(
+    initialLocation: '/consumption',
+    routes: [
+      GoRoute(
+        path: '/consumption',
+        builder: (_, _) => const ConsumptionScreen(),
+      ),
+      GoRoute(
+        path: '/consumption/pick-station',
+        builder: (_, _) => const SizedBox(),
+      ),
+      GoRoute(path: '/carbon', builder: (_, _) => const SizedBox()),
+      GoRoute(path: '/trip-history', builder: (_, _) => const SizedBox()),
+      GoRoute(path: '/vehicles/edit', builder: (_, _) => const SizedBox()),
+    ],
+  );
+
+  await pumpApp(
+    tester,
+    MaterialApp.router(routerConfig: router),
+    overrides: [
+      fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
+      chargingLogsProvider.overrideWith(() => _FixedChargingLogs(chargingLogs)),
+      activeVehicleProfileProvider.overrideWith(() => activeNotifier),
+      vehicleProfileListProvider
+          .overrideWith(() => _FixedVehicleProfileList(vehicles)),
+    ],
+  );
+  return activeNotifier;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ConsumptionScreen Charging visibility (#892)', () {
+    testWidgets('ICE vehicle -> 2 tabs, no Charging label', (tester) async {
+      await _pumpScreen(
+        tester,
+        activeVehicle: _iceVehicle,
+        vehicles: const [_iceVehicle],
+      );
+
+      expect(find.byKey(const Key('consumption_tab_fuel')), findsOneWidget);
+      expect(
+        find.byKey(const Key('consumption_tab_trajets')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('consumption_tab_charging')),
+        findsNothing,
+      );
+
+      // The text "Charging" must not appear in the tab row — the tab
+      // bar is the only place in the AppBar that would render that
+      // label. Other call sites (menus, badges) live off-screen for
+      // this scaffold.
+      expect(find.text('Charging'), findsNothing);
+    });
+
+    testWidgets('EV vehicle -> 3 tabs including Charging', (tester) async {
+      await _pumpScreen(
+        tester,
+        activeVehicle: _evVehicle,
+        vehicles: const [_evVehicle],
+      );
+
+      expect(find.byKey(const Key('consumption_tab_fuel')), findsOneWidget);
+      expect(
+        find.byKey(const Key('consumption_tab_trajets')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('consumption_tab_charging')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Hybrid vehicle -> 3 tabs including Charging', (tester) async {
+      await _pumpScreen(
+        tester,
+        activeVehicle: _hybridVehicle,
+        vehicles: const [_hybridVehicle],
+      );
+
+      expect(find.byKey(const Key('consumption_tab_fuel')), findsOneWidget);
+      expect(
+        find.byKey(const Key('consumption_tab_trajets')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('consumption_tab_charging')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'switching EV -> ICE while Charging selected snaps to Trajets '
+        'without crashing',
+        (tester) async {
+      final activeNotifier = await _pumpScreen(
+        tester,
+        activeVehicle: _evVehicle,
+        vehicles: const [_evVehicle, _iceVehicle],
+      );
+
+      // Start on the Charging tab (index 2). The user explicitly
+      // navigated there before switching vehicles.
+      await tester.tap(find.byKey(const Key('consumption_tab_charging')));
+      await tester.pumpAndSettle();
+
+      // Flip the active vehicle to ICE — the Charging tab must
+      // disappear. The screen rebuilds without throwing.
+      activeNotifier.set(_iceVehicle);
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(const Key('consumption_tab_charging')),
+        findsNothing,
+      );
+      expect(find.text('Charging'), findsNothing);
+
+      // The now-visible tab row has 2 entries; the selection must be
+      // Trajets (the previously-adjacent tab) so the body still shows
+      // something meaningful.
+      final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+      expect(tabBar.controller!.length, 2);
+      expect(tabBar.controller!.index, 1);
+    });
+  });
+}


### PR DESCRIPTION
## What
Gate the Charging tab on `ConsumptionScreen` behind the active vehicle's powertrain (#892). ICE vehicles now see a 2-tab scaffold (Fuel + Trajets); hybrid and EV vehicles keep the full 3-tab view (Fuel + Trajets + Charging).

## Why
The Charging tab advertises a feature combustion-only users can't meaningfully engage with. Hiding it for ICE keeps the consumption UI focused on what each user can actually act on, and removes one source of "what is this for?" confusion.

Per the leitmotiv this stays firmly in the behind-the-wheel savings lens — same feature, lighter UI for users whose drivetrain can't charge.

## How
- `ConsumptionScreen` now computes `showCharging` from the active vehicle's `VehicleType` (ev/hybrid only) and builds the `TabBar` / `TabBarView` accordingly.
- `TabController.length` is immutable, so the screen swaps it out when the count changes — preserving the selected index when possible, and snapping from Charging (2) to Trajets (1) on the 3 -> 2 shrink so the user never lands out of range.
- When the active vehicle is null the full 3-tab row is preserved (per the issue's scope note — the "no vehicle" case is a separate follow-up, and existing consumption tests assume 3 tabs in that case).

## Testing
- New widget suite `test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart`:
  - ICE active -> 2 tabs, no "Charging" label.
  - EV active -> 3 tabs including Charging.
  - Hybrid active -> 3 tabs including Charging.
  - EV -> ICE switch while Charging was selected -> selection snaps to Trajets, no crash, no leaked "Charging" label.
- Full suite green: `flutter analyze` clean, `flutter test` 5663 tests pass (1 pre-existing skip).

Closes #892