### PR TITLE
feat(consumption): pin recording form keeps screen on (#891)

### DIFF
--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'385de86855a81d484d1978360a1d762e62450c68';
+String _$routerHash() => r'07857e07fee5f152d00b8a91d329688d7a46b529';

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -1,10 +1,14 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/trip_recorder.dart';
 import '../../providers/trip_recording_provider.dart';
+import '../../providers/wakelock_facade.dart';
 
 /// Result returned when the user saves a recorded trip as a fill-up
 /// (#726). Null means the user cancelled or discarded.
@@ -40,15 +44,81 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
   StoppedTripResult? _stopped;
   bool _stopping = false;
 
+  /// #891 — ephemeral pin state. Enabling keeps the screen on + hides
+  /// system bars so the live recording form stays readable at the
+  /// pump / on a dashboard mount. Intentionally NOT persisted: the
+  /// user opts back in each drive so battery-drain never lingers.
+  bool _pinned = false;
+
+  /// Cached facade handle so [dispose] can release the wake lock
+  /// without touching `ref` (Riverpod forbids `ref.read` after the
+  /// widget is deactivated). Populated the first time the user pins.
+  WakelockFacade? _cachedFacade;
+
+  @override
+  void dispose() {
+    // Auto-release the wake lock + restore system UI if the user
+    // exits the screen without unpinning. Best-effort; the facade
+    // swallows plugin errors on unsupported platforms. Fire-and-
+    // forget — `dispose` must stay synchronous.
+    if (_pinned) {
+      final facade = _cachedFacade;
+      if (facade != null) {
+        unawaited(facade.disable());
+      }
+      unawaited(
+        SystemChrome.setEnabledSystemUIMode(
+          SystemUiMode.manual,
+          overlays: SystemUiOverlay.values,
+        ),
+      );
+    }
+    super.dispose();
+  }
+
   Future<void> _onStop() async {
     if (_stopping) return;
     setState(() => _stopping = true);
     final result = await ref.read(tripRecordingProvider.notifier).stop();
     if (!mounted) return;
+    // #891 — when the recording ends, auto-release the wake lock
+    // even if the user forgot to unpin. The form will still be
+    // visible (summary screen) but there's no longer any reason
+    // to keep the device awake at the user's expense.
+    if (_pinned) {
+      await ref.read(wakelockFacadeProvider).disable();
+      await SystemChrome.setEnabledSystemUIMode(
+        SystemUiMode.manual,
+        overlays: SystemUiOverlay.values,
+      );
+      if (!mounted) return;
+    }
     setState(() {
       _stopped = result;
       _stopping = false;
+      _pinned = false;
     });
+  }
+
+  Future<void> _togglePin() async {
+    final facade = ref.read(wakelockFacadeProvider);
+    // Cache so [dispose] can call `disable()` without reading `ref`
+    // after the widget has been deactivated.
+    _cachedFacade = facade;
+    final nextPinned = !_pinned;
+    // Flip UI state first so the icon reflects intent even if the
+    // plugin call is slow — the facade swallows its own errors.
+    setState(() => _pinned = nextPinned);
+    if (nextPinned) {
+      await facade.enable();
+      await SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+    } else {
+      await facade.disable();
+      await SystemChrome.setEnabledSystemUIMode(
+        SystemUiMode.manual,
+        overlays: SystemUiOverlay.values,
+      );
+    }
   }
 
   void _togglePause() {
@@ -111,6 +181,33 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         actions: stopped != null
             ? null
             : [
+                // #891 — wrap in Semantics so TalkBack announces the
+                // *next* action (Pin / Unpin) in addition to the
+                // tooltip's battery-cost hint. `container: true`
+                // merges the IconButton's tap semantics into the label.
+                Semantics(
+                  container: true,
+                  button: true,
+                  toggled: _pinned,
+                  label: _pinned
+                      ? (l?.tripRecordingPinSemanticOn ??
+                          'Unpin recording form')
+                      : (l?.tripRecordingPinSemanticOff ??
+                          'Pin recording form'),
+                  child: IconButton(
+                    key: const Key('tripPinButton'),
+                    icon: Icon(
+                      _pinned ? Icons.push_pin : Icons.push_pin_outlined,
+                      color: _pinned
+                          ? Theme.of(context).colorScheme.primary
+                          : null,
+                    ),
+                    tooltip: l?.tripRecordingPinTooltip ??
+                        'Pinning keeps the screen on — uses more battery',
+                    isSelected: _pinned,
+                    onPressed: _togglePin,
+                  ),
+                ),
                 IconButton(
                   key: const Key('tripPauseButton'),
                   icon: Icon(state.phase == TripRecordingPhase.paused

--- a/lib/features/consumption/providers/wakelock_facade.dart
+++ b/lib/features/consumption/providers/wakelock_facade.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+
+part 'wakelock_facade.g.dart';
+
+/// Thin seam over `wakelock_plus` so the trip-recording pin toggle
+/// (#891) can be unit-tested without pulling the plugin's platform
+/// channel into widget tests. The default implementation in
+/// [wakelockFacadeProvider] delegates to [WakelockPlus.enable] /
+/// [WakelockPlus.disable]; tests inject a fake via
+/// `overrideWithValue(FakeWakelockFacade())`.
+abstract class WakelockFacade {
+  /// Keep the screen awake until [disable] is called. Safe to call
+  /// multiple times — implementations are idempotent.
+  Future<void> enable();
+
+  /// Release a previously acquired wake lock. Safe to call when the
+  /// lock was never enabled — treated as a no-op.
+  Future<void> disable();
+}
+
+/// Production implementation backed by `wakelock_plus`. Swallows
+/// plugin errors (e.g. unsupported platforms in widget tests) so the
+/// pin toggle never crashes the recording screen; a failed plugin
+/// call just means the screen may dim on schedule — not ideal, but
+/// no worse than the pre-#891 behaviour.
+class RealWakelockFacade implements WakelockFacade {
+  const RealWakelockFacade();
+
+  @override
+  Future<void> enable() async {
+    try {
+      await WakelockPlus.enable();
+    } catch (e) {
+      debugPrint('WakelockFacade.enable failed: $e');
+    }
+  }
+
+  @override
+  Future<void> disable() async {
+    try {
+      await WakelockPlus.disable();
+    } catch (e) {
+      debugPrint('WakelockFacade.disable failed: $e');
+    }
+  }
+}
+
+/// Provider seam — override in tests with a fake. `keepAlive: true`
+/// because the pin toggle on [TripRecordingScreen] is ephemeral UI
+/// state but the underlying facade has no per-screen state worth
+/// rebuilding.
+@Riverpod(keepAlive: true)
+WakelockFacade wakelockFacade(Ref ref) => const RealWakelockFacade();

--- a/lib/features/consumption/providers/wakelock_facade.g.dart
+++ b/lib/features/consumption/providers/wakelock_facade.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'wakelock_facade.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Provider seam — override in tests with a fake. `keepAlive: true`
+/// because the pin toggle on [TripRecordingScreen] is ephemeral UI
+/// state but the underlying facade has no per-screen state worth
+/// rebuilding.
+
+@ProviderFor(wakelockFacade)
+final wakelockFacadeProvider = WakelockFacadeProvider._();
+
+/// Provider seam — override in tests with a fake. `keepAlive: true`
+/// because the pin toggle on [TripRecordingScreen] is ephemeral UI
+/// state but the underlying facade has no per-screen state worth
+/// rebuilding.
+
+final class WakelockFacadeProvider
+    extends $FunctionalProvider<WakelockFacade, WakelockFacade, WakelockFacade>
+    with $Provider<WakelockFacade> {
+  /// Provider seam — override in tests with a fake. `keepAlive: true`
+  /// because the pin toggle on [TripRecordingScreen] is ephemeral UI
+  /// state but the underlying facade has no per-screen state worth
+  /// rebuilding.
+  WakelockFacadeProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'wakelockFacadeProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$wakelockFacadeHash();
+
+  @$internal
+  @override
+  $ProviderElement<WakelockFacade> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  WakelockFacade create(Ref ref) {
+    return wakelockFacade(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WakelockFacade value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WakelockFacade>(value),
+    );
+  }
+}
+
+String _$wakelockFacadeHash() => r'c5b23b20aef8595773123977f48edfd7d3e06878';

--- a/lib/l10n/_fragments/trip_recording_pin_de.arb
+++ b/lib/l10n/_fragments/trip_recording_pin_de.arb
@@ -1,0 +1,14 @@
+{
+  "tripRecordingPinTooltip": "Epinglen hält den Bildschirm an — verbraucht mehr Akku",
+  "@tripRecordingPinTooltip": {
+    "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."
+  },
+  "tripRecordingPinSemanticOn": "Aufnahmeformular lösen",
+  "@tripRecordingPinSemanticOn": {
+    "description": "Accessibility label when the pin toggle is currently ON. Tapping will unpin (disable wake lock + restore system UI)."
+  },
+  "tripRecordingPinSemanticOff": "Aufnahmeformular anpinnen",
+  "@tripRecordingPinSemanticOff": {
+    "description": "Accessibility label when the pin toggle is currently OFF. Tapping will pin (enable wake lock + immersive mode)."
+  }
+}

--- a/lib/l10n/_fragments/trip_recording_pin_en.arb
+++ b/lib/l10n/_fragments/trip_recording_pin_en.arb
@@ -1,0 +1,14 @@
+{
+  "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
+  "@tripRecordingPinTooltip": {
+    "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."
+  },
+  "tripRecordingPinSemanticOn": "Unpin recording form",
+  "@tripRecordingPinSemanticOn": {
+    "description": "Accessibility label when the pin toggle is currently ON. Tapping will unpin (disable wake lock + restore system UI)."
+  },
+  "tripRecordingPinSemanticOff": "Pin recording form",
+  "@tripRecordingPinSemanticOff": {
+    "description": "Accessibility label when the pin toggle is currently OFF. Tapping will pin (enable wake lock + immersive mode)."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1334,6 +1334,18 @@
   "trajetsRowDistance": "{km} km",
   "trajetsRowDuration": "{minutes} Min.",
   "trajetsRowAvgConsumption": "{value} {unit}",
+  "tripRecordingPinTooltip": "Epinglen hält den Bildschirm an — verbraucht mehr Akku",
+  "@tripRecordingPinTooltip": {
+    "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."
+  },
+  "tripRecordingPinSemanticOn": "Aufnahmeformular lösen",
+  "@tripRecordingPinSemanticOn": {
+    "description": "Accessibility label when the pin toggle is currently ON. Tapping will unpin (disable wake lock + restore system UI)."
+  },
+  "tripRecordingPinSemanticOff": "Aufnahmeformular anpinnen",
+  "@tripRecordingPinSemanticOff": {
+    "description": "Accessibility label when the pin toggle is currently OFF. Tapping will pin (enable wake lock + immersive mode)."
+  },
   "vinLabel": "FIN (optional)",
   "vinDecodeTooltip": "FIN entschlüsseln",
   "vinConfirmAction": "Ja, automatisch ausfüllen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1837,6 +1837,18 @@
       }
     }
   },
+  "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
+  "@tripRecordingPinTooltip": {
+    "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."
+  },
+  "tripRecordingPinSemanticOn": "Unpin recording form",
+  "@tripRecordingPinSemanticOn": {
+    "description": "Accessibility label when the pin toggle is currently ON. Tapping will unpin (disable wake lock + restore system UI)."
+  },
+  "tripRecordingPinSemanticOff": "Pin recording form",
+  "@tripRecordingPinSemanticOff": {
+    "description": "Accessibility label when the pin toggle is currently OFF. Tapping will pin (enable wake lock + immersive mode)."
+  },
   "vinLabel": "VIN (optional)",
   "vinDecodeTooltip": "Decode VIN",
   "vinConfirmAction": "Yes, auto-fill",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6434,6 +6434,24 @@ abstract class AppLocalizations {
   /// **'{value} {unit}'**
   String trajetsRowAvgConsumption(String value, String unit);
 
+  /// Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost.
+  ///
+  /// In en, this message translates to:
+  /// **'Pinning keeps the screen on — uses more battery'**
+  String get tripRecordingPinTooltip;
+
+  /// Accessibility label when the pin toggle is currently ON. Tapping will unpin (disable wake lock + restore system UI).
+  ///
+  /// In en, this message translates to:
+  /// **'Unpin recording form'**
+  String get tripRecordingPinSemanticOn;
+
+  /// Accessibility label when the pin toggle is currently OFF. Tapping will pin (enable wake lock + immersive mode).
+  ///
+  /// In en, this message translates to:
+  /// **'Pin recording form'**
+  String get tripRecordingPinSemanticOff;
+
   /// No description provided for @vinLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3442,6 +3442,16 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3442,6 +3442,16 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3440,6 +3440,16 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3470,6 +3470,16 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Epinglen hält den Bildschirm an — verbraucht mehr Akku';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Aufnahmeformular lösen';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Aufnahmeformular anpinnen';
+
+  @override
   String get vinLabel => 'FIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3444,6 +3444,16 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3435,6 +3435,16 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3443,6 +3443,16 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3437,6 +3437,16 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3440,6 +3440,16 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3464,6 +3464,16 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3439,6 +3439,16 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3444,6 +3444,16 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3443,6 +3443,16 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3441,6 +3441,16 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3443,6 +3443,16 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3439,6 +3439,16 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3444,6 +3444,16 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3442,6 +3442,16 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3443,6 +3443,16 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3442,6 +3442,16 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3443,6 +3443,16 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3437,6 +3437,16 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3441,6 +3441,16 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get tripRecordingPinTooltip =>
+      'Pinning keeps the screen on — uses more battery';
+
+  @override
+  String get tripRecordingPinSemanticOn => 'Unpin recording form';
+
+  @override
+  String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1841,6 +1841,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  wakelock_plus:
+    dependency: "direct main"
+    description:
+      name: wakelock_plus
+      sha256: "61713aa82b7f85c21c9f4cd0a148abd75f38a74ec645fcb1e446f882c82fd09b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
+  wakelock_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: wakelock_plus_platform_interface
+      sha256: "14b2e5b9e35c2631e656913c47adecdd71633ae92896a27a64c8f1fcfabc21cc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   watcher:
     dependency: transitive
     description:
@@ -1971,4 +1987,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=3.11.3 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.41.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   flutter_tts: ^4.2.0
   flutter_local_notifications: ^21.0.0
   supabase_flutter: ^2.12.4
+  wakelock_plus: ^1.2.8
 
 dev_dependencies:
   flutter_test:

--- a/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
+++ b/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// #891 — pin toggle on the active-recording screen must:
+/// - swap the icon (outlined ↔ filled) and flip the semantic label.
+/// - call `enable()` exactly once on pin, `disable()` exactly once on
+///   unpin — we don't want every frame to hammer the platform channel.
+/// - auto-release the lock when the recording stops, even if the user
+///   never tapped unpin.
+/// - hit the 48dp Material tap-target guideline.
+
+class _FakeWakelockFacade implements WakelockFacade {
+  int enableCalls = 0;
+  int disableCalls = 0;
+
+  @override
+  Future<void> enable() async {
+    enableCalls++;
+  }
+
+  @override
+  Future<void> disable() async {
+    disableCalls++;
+  }
+}
+
+/// Pinnable fake — start in `recording`, let tests call `stop()` to
+/// flip to `finished` without hitting the real Obd2 stack.
+class _FakeTripRecording extends TripRecording {
+  final TripRecordingState _initial;
+  _FakeTripRecording(this._initial);
+
+  @override
+  TripRecordingState build() => _initial;
+
+  @override
+  Future<StoppedTripResult> stop() async {
+    state = state.copyWith(phase: TripRecordingPhase.finished);
+    return const StoppedTripResult(
+      summary: TripSummary(
+        distanceKm: 0,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+      ),
+      odometerStartKm: null,
+      odometerLatestKm: null,
+    );
+  }
+
+  @override
+  void reset() {
+    state = const TripRecordingState();
+  }
+}
+
+TripRecordingState _recordingState() {
+  return const TripRecordingState(
+    phase: TripRecordingPhase.recording,
+    situation: DrivingSituation.highwayCruise,
+    band: ConsumptionBand.normal,
+  );
+}
+
+Future<void> _pumpRecordingScreen(
+  WidgetTester tester, {
+  required _FakeWakelockFacade facade,
+}) async {
+  await pumpApp(
+    tester,
+    const TripRecordingScreen(),
+    overrides: [
+      tripRecordingProvider.overrideWith(
+        () => _FakeTripRecording(_recordingState()),
+      ),
+      wakelockFacadeProvider.overrideWithValue(facade),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TripRecordingScreen pin toggle (#891)', () {
+    testWidgets('starts unpinned: outlined pin icon + "Pin" semantic',
+        (tester) async {
+      final facade = _FakeWakelockFacade();
+      await _pumpRecordingScreen(tester, facade: facade);
+
+      final pinButton = find.byKey(const Key('tripPinButton'));
+      expect(pinButton, findsOneWidget);
+      expect(
+        find.descendant(
+          of: pinButton,
+          matching: find.byIcon(Icons.push_pin_outlined),
+        ),
+        findsOneWidget,
+      );
+      // Sanity: nothing has been enabled/disabled yet.
+      expect(facade.enableCalls, 0);
+      expect(facade.disableCalls, 0);
+    });
+
+    testWidgets('tapping pin swaps icon to filled + calls enable() once',
+        (tester) async {
+      final facade = _FakeWakelockFacade();
+      await _pumpRecordingScreen(tester, facade: facade);
+
+      await tester.tap(find.byKey(const Key('tripPinButton')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('tripPinButton')),
+          matching: find.byIcon(Icons.push_pin),
+        ),
+        findsOneWidget,
+      );
+      expect(facade.enableCalls, 1);
+      expect(facade.disableCalls, 0);
+    });
+
+    testWidgets('tapping pin a second time calls disable() once '
+        'and restores the outlined icon', (tester) async {
+      final facade = _FakeWakelockFacade();
+      await _pumpRecordingScreen(tester, facade: facade);
+
+      final pin = find.byKey(const Key('tripPinButton'));
+      await tester.tap(pin);
+      await tester.pumpAndSettle();
+      await tester.tap(pin);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: pin,
+          matching: find.byIcon(Icons.push_pin_outlined),
+        ),
+        findsOneWidget,
+      );
+      expect(facade.enableCalls, 1);
+      expect(facade.disableCalls, 1);
+    });
+
+    testWidgets('recording stop auto-releases the wake lock '
+        'even if the user forgot to unpin', (tester) async {
+      final facade = _FakeWakelockFacade();
+      await _pumpRecordingScreen(tester, facade: facade);
+
+      // Pin first.
+      await tester.tap(find.byKey(const Key('tripPinButton')));
+      await tester.pumpAndSettle();
+      expect(facade.enableCalls, 1);
+      expect(facade.disableCalls, 0);
+
+      // Stop the recording — this should auto-release without a
+      // second user gesture on the pin toggle.
+      await tester.tap(find.byKey(const Key('tripStopButton')));
+      await tester.pumpAndSettle();
+
+      expect(facade.disableCalls, 1,
+          reason: 'stop must auto-release the wake lock');
+    });
+
+    testWidgets('screen dispose releases the lock when the user '
+        'forgot to unpin before navigating away', (tester) async {
+      final facade = _FakeWakelockFacade();
+      await _pumpRecordingScreen(tester, facade: facade);
+
+      await tester.tap(find.byKey(const Key('tripPinButton')));
+      await tester.pumpAndSettle();
+      expect(facade.disableCalls, 0);
+
+      // Replace the widget tree — triggers dispose on the screen.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      expect(facade.disableCalls, 1,
+          reason: 'dispose must also release the lock as a safety net');
+    });
+
+    testWidgets('pin button meets the Android tap-target guideline',
+        (tester) async {
+      final facade = _FakeWakelockFacade();
+      await _pumpRecordingScreen(tester, facade: facade);
+
+      await expectLater(
+        tester,
+        meetsGuideline(androidTapTargetGuideline),
+      );
+    });
+
+    testWidgets('semantic label flips between Pin / Unpin when toggled',
+        (tester) async {
+      final facade = _FakeWakelockFacade();
+      await _pumpRecordingScreen(tester, facade: facade);
+
+      // When unpinned, Semantics label should read "Pin recording form".
+      final handle = tester.ensureSemantics();
+      expect(
+        find.bySemanticsLabel('Pin recording form'),
+        findsOneWidget,
+        reason: 'Pin toggle should expose "Pin recording form" when unpinned',
+      );
+
+      await tester.tap(find.byKey(const Key('tripPinButton')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.bySemanticsLabel('Unpin recording form'),
+        findsOneWidget,
+        reason: 'Pin toggle should expose "Unpin recording form" when pinned',
+      );
+      handle.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## What
Adds a **Pin** toggle to the trip-recording AppBar. When pinned:
- `WakelockPlus.enable()` keeps the screen on.
- `SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky)` hides system bars.
- The pin icon switches to `Icons.push_pin` in the primary color.
- Accessibility label flips from "Pin recording form" to "Unpin recording form".

When unpinned (or on recording stop / dispose), both the wake lock and system UI are released — the device never stays pinned after the drive ends even if the user forgets to tap off.

## Why
Solves #891. The recording form is useless if the phone dims or the auto-lock steals focus while the user is looking at the pump or a dashboard mount. Since battery cost is real, the toggle is off by default and the tooltip warns about it explicitly ("Pinning keeps the screen on — uses more battery").

Serves the "behind-the-wheel" lens: the live L/100 km + eco band feedback only helps drive greener if the driver can actually see it.

## Testing
- `test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart` — 7 widget tests covering icon swap, semantic flip, `enable()` / `disable()` call-count, auto-release on stop, auto-release on dispose, and `androidTapTargetGuideline`.
- `flutter analyze` — zero issues.
- `flutter test` — all 5666 tests pass.

## Architecture
Introduces a `WakelockFacade` + `wakelockFacadeProvider` seam in `lib/features/consumption/providers/wakelock_facade.dart`. Production uses `WakelockPlus` directly; tests inject a fake via `overrideWithValue`. The screen caches the facade pointer the first time the user pins so `dispose` can release without calling `ref.read` on a deactivated widget (Riverpod forbids that).

Closes #891

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>