### PR TITLE
feat(consumption): Charging tab gated on hybrid/electric vehicle (#892)

### DIFF
--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -10,6 +10,7 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../achievements/presentation/widgets/badge_shelf.dart';
 import '../../../ev/domain/entities/charging_log.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/csv_exporter.dart';
 import '../../providers/charging_charts_provider.dart';
@@ -44,29 +45,68 @@ class ConsumptionScreen extends ConsumerStatefulWidget {
 }
 
 class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
-    with SingleTickerProviderStateMixin {
-  late final TabController _tabController;
+    with TickerProviderStateMixin {
+  // Lazily created in the first `build`. Recreated whenever the
+  // active vehicle's powertrain flips the Charging tab on/off (#892):
+  // TabController requires its `length` to match the TabBar's `tabs`
+  // length exactly, so we tear down the old controller and instantiate
+  // a fresh one with the new length (clamping the selected index so
+  // the user doesn't land on a missing tab).
+  TabController? _tabController;
 
-  @override
-  void initState() {
-    super.initState();
-    // #889 — three tabs now: Fuel, Trajets, Charging. Trajets is
-    // always visible once the Consumption screen is visible (gated on
-    // an active vehicle per #893); Charging stays present — #892 will
-    // tailor visibility per vehicle type in a follow-up.
-    _tabController = TabController(length: 3, vsync: this);
-    _tabController.addListener(() {
+  /// Whether the Charging tab should appear for the given vehicle.
+  ///
+  /// - ICE (`VehicleType.combustion`) → false
+  /// - Hybrid / EV → true
+  /// - No active vehicle → true (keep current behaviour; the
+  ///   no-vehicle onboarding flow lives in a separate issue).
+  static bool _shouldShowCharging(VehicleProfile? vehicle) {
+    if (vehicle == null) return true;
+    return vehicle.isEv;
+  }
+
+  void _ensureTabController({
+    required bool showCharging,
+    int? preferredIndex,
+  }) {
+    final newLength = showCharging ? 3 : 2;
+    final previous = _tabController;
+    if (previous != null && previous.length == newLength) {
+      return;
+    }
+
+    // Clamp the previous index into the new controller's range so we
+    // don't strand the user on a now-missing tab. When the Charging
+    // tab vanishes while the user is on it, fall back to Trajets
+    // (index 1) rather than Fuel — it's the closest neighbour in the
+    // mental model of "what I was just looking at".
+    final oldIndex = preferredIndex ?? previous?.index ?? 0;
+    final int initialIndex;
+    if (!showCharging && oldIndex >= newLength) {
+      initialIndex = 1; // Trajets
+    } else {
+      initialIndex = oldIndex.clamp(0, newLength - 1);
+    }
+
+    final controller = TabController(
+      length: newLength,
+      vsync: this,
+      initialIndex: initialIndex,
+    );
+    controller.addListener(() {
       // The FAB label changes when the tab changes, so trigger a
       // rebuild on every tab transition (indexIsChanging covers the
       // animated swipe case too).
       if (!mounted) return;
       setState(() {});
     });
+    previous?.dispose();
+    _tabController = controller;
   }
 
   @override
   void dispose() {
-    _tabController.dispose();
+    _tabController?.dispose();
     super.dispose();
   }
 
@@ -76,6 +116,14 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     final chargingLogsAsync = ref.watch(chargingLogsProvider);
     final stats = ref.watch(consumptionStatsProvider);
     final activeVehicle = ref.watch(activeVehicleProfileProvider);
+    final showCharging = _shouldShowCharging(activeVehicle);
+    // Recreate the TabController when the tab-set cardinality
+    // changes (#892). Doing this in build — rather than in initState
+    // — lets us react to live vehicle switches without a ref.listen
+    // round-trip, and keeps the controller's length always consistent
+    // with the rendered Tab list (length mismatch throws at runtime).
+    _ensureTabController(showCharging: showCharging);
+    final tabController = _tabController!;
     final l = AppLocalizations.of(context);
 
     // #815 — surface the η_v calibration outcome as a one-shot
@@ -100,14 +148,15 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
       ref.read(lastVeLearnResultProvider.notifier).set(null);
     });
 
-    // #889 — three tabs: 0 Fuel, 1 Trajets, 2 Charging. The FAB
-    // rebinds per-tab: Fuel -> pick-station sheet, Trajets hides the
-    // FAB (the "Start recording" CTA lives inside the tab header),
-    // Charging -> Add charging log sheet.
-    final tabIndex = _tabController.index;
+    // #889 — tabs are 0 Fuel, 1 Trajets, and (ICE vehicles excepted
+    // per #892) 2 Charging. The FAB rebinds per-tab: Fuel ->
+    // pick-station sheet, Trajets hides the FAB (the "Start
+    // recording" CTA lives inside the tab header), Charging -> Add
+    // charging log sheet.
+    final tabIndex = tabController.index;
     final isFuelTab = tabIndex == 0;
     final isTrajetsTab = tabIndex == 1;
-    final isChargingTab = tabIndex == 2;
+    final isChargingTab = showCharging && tabIndex == 2;
 
     return Scaffold(
       appBar: AppBar(
@@ -118,7 +167,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
           onPressed: () => context.pop(),
         ),
         bottom: TabBar(
-          controller: _tabController,
+          controller: tabController,
           tabs: [
             Tab(
               key: const Key('consumption_tab_fuel'),
@@ -130,11 +179,16 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
               icon: const Icon(Icons.route_outlined),
               text: l?.trajetsTabLabel ?? 'Trips',
             ),
-            Tab(
-              key: const Key('consumption_tab_charging'),
-              icon: const Icon(Icons.ev_station_outlined),
-              text: l?.consumptionTabCharging ?? 'Charging',
-            ),
+            // #892 — Charging tab is hidden when the active vehicle
+            // is a pure combustion engine. Hybrid and EV profiles
+            // still see it; the no-vehicle case keeps the tab (a
+            // dedicated onboarding story covers that path).
+            if (showCharging)
+              Tab(
+                key: const Key('consumption_tab_charging'),
+                icon: const Icon(Icons.ev_station_outlined),
+                text: l?.consumptionTabCharging ?? 'Charging',
+              ),
           ],
         ),
         actions: [
@@ -213,11 +267,16 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
               ),
             ),
       body: TabBarView(
-        controller: _tabController,
+        controller: tabController,
         children: [
           _FuelTab(fillUps: fillUps, stats: stats, l: l),
           TrajetsTab(vehicleId: activeVehicle?.id),
-          _ChargingTab(async: chargingLogsAsync, l: l),
+          // Charging view is only mounted when the active vehicle
+          // can actually charge — hiding it for ICE profiles (#892)
+          // removes a dead-end tap for combustion-only users without
+          // touching `chargingLogsProvider`, so flipping back to a
+          // hybrid/EV restores the logs exactly.
+          if (showCharging) _ChargingTab(async: chargingLogsAsync, l: l),
         ],
       ),
     );

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/consumption_screen.dart';
+import 'package:tankstellen/features/consumption/providers/charging_logs_provider.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// #892 — the Charging tab on [ConsumptionScreen] is hidden for ICE
+/// vehicles (combustion) and visible for hybrid / EV profiles. The
+/// underlying `chargingLogsProvider` stays untouched, so flipping back
+/// to a hybrid/EV restores the logs unchanged.
+///
+/// These tests map 1:1 to the acceptance criteria on the issue:
+///   1. ICE vehicle → 2 tabs, no "Charging" label
+///   2. EV vehicle → 3 tabs, "Charging" label present
+///   3. Hybrid vehicle → 3 tabs
+///   4. Live switch EV → ICE while on Charging tab → 2 tabs, no
+///      crash, user lands on Trajets (index 1)
+
+class _FixedFillUpList extends FillUpList {
+  final List<FillUp> _value;
+  _FixedFillUpList(this._value);
+
+  @override
+  List<FillUp> build() => _value;
+}
+
+class _FixedChargingLogs extends ChargingLogs {
+  final List<ChargingLog> _value;
+  _FixedChargingLogs(this._value);
+
+  @override
+  Future<List<ChargingLog>> build() async => _value;
+}
+
+/// Mutable active-vehicle notifier so a single test can flip the
+/// powertrain mid-flight (acceptance criterion #5).
+class _MutableActiveVehicle extends ActiveVehicleProfile {
+  final VehicleProfile? initialValue;
+  _MutableActiveVehicle(this.initialValue);
+
+  @override
+  VehicleProfile? build() => initialValue;
+
+  void setVehicle(VehicleProfile? vehicle) {
+    state = vehicle;
+  }
+}
+
+class _FixedVehicleProfileList extends VehicleProfileList {
+  final List<VehicleProfile> _value;
+  _FixedVehicleProfileList(this._value);
+
+  @override
+  List<VehicleProfile> build() => _value;
+}
+
+const _iceVehicle = VehicleProfile(
+  id: 'v-ice',
+  name: 'Peugeot 107',
+  type: VehicleType.combustion,
+);
+
+const _evVehicle = VehicleProfile(
+  id: 'v-ev',
+  name: 'Tesla Model 3',
+  type: VehicleType.ev,
+);
+
+const _hybridVehicle = VehicleProfile(
+  id: 'v-hybrid',
+  name: 'Toyota Prius',
+  type: VehicleType.hybrid,
+);
+
+Future<_MutableActiveVehicle> _pumpScreen(
+  WidgetTester tester, {
+  required VehicleProfile? activeVehicle,
+  List<VehicleProfile> vehicles = const [],
+  List<ChargingLog> chargingLogs = const [],
+}) async {
+  final activeNotifier = _MutableActiveVehicle(activeVehicle);
+
+  final router = GoRouter(
+    initialLocation: '/consumption',
+    routes: [
+      GoRoute(
+        path: '/consumption',
+        builder: (_, _) => const ConsumptionScreen(),
+      ),
+      GoRoute(path: '/consumption/add', builder: (_, _) => const SizedBox()),
+      GoRoute(
+        path: '/consumption/pick-station',
+        builder: (_, _) => const SizedBox(),
+      ),
+      GoRoute(path: '/carbon', builder: (_, _) => const SizedBox()),
+      GoRoute(path: '/trip-history', builder: (_, _) => const SizedBox()),
+      GoRoute(path: '/vehicles/edit', builder: (_, _) => const SizedBox()),
+    ],
+  );
+
+  await pumpApp(
+    tester,
+    MaterialApp.router(routerConfig: router),
+    overrides: [
+      fillUpListProvider.overrideWith(() => _FixedFillUpList(const [])),
+      chargingLogsProvider
+          .overrideWith(() => _FixedChargingLogs(chargingLogs)),
+      activeVehicleProfileProvider.overrideWith(() => activeNotifier),
+      vehicleProfileListProvider
+          .overrideWith(() => _FixedVehicleProfileList(vehicles)),
+    ],
+  );
+
+  return activeNotifier;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ConsumptionScreen Charging tab visibility (#892)', () {
+    testWidgets(
+      'ICE vehicle active → 2 tabs, no "Charging" label [AC1]',
+      (tester) async {
+        await _pumpScreen(
+          tester,
+          activeVehicle: _iceVehicle,
+          vehicles: const [_iceVehicle],
+        );
+
+        expect(
+          find.byKey(const Key('consumption_tab_fuel')),
+          findsOneWidget,
+          reason: 'Fuel tab must always render',
+        );
+        expect(
+          find.byKey(const Key('consumption_tab_trajets')),
+          findsOneWidget,
+          reason: 'Trajets tab must render for ICE vehicles',
+        );
+        expect(
+          find.byKey(const Key('consumption_tab_charging')),
+          findsNothing,
+          reason: 'Charging tab must be hidden for combustion vehicles',
+        );
+
+        // Exactly 2 Tab widgets on screen.
+        expect(find.byType(Tab), findsNWidgets(2));
+
+        // The localised tab labels for Charging must not appear.
+        expect(find.text('Charging'), findsNothing);
+        expect(find.text('Aufladung'), findsNothing);
+        expect(find.text('Laden'), findsNothing);
+        expect(find.text('Recharge'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'EV vehicle active → 3 tabs including Charging [AC2]',
+      (tester) async {
+        await _pumpScreen(
+          tester,
+          activeVehicle: _evVehicle,
+          vehicles: const [_evVehicle],
+        );
+
+        expect(
+          find.byKey(const Key('consumption_tab_fuel')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('consumption_tab_trajets')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('consumption_tab_charging')),
+          findsOneWidget,
+          reason: 'Charging tab must render for EV vehicles',
+        );
+        expect(find.byType(Tab), findsNWidgets(3));
+
+        // Default English ARB value for `consumptionTabCharging`.
+        expect(find.text('Charging'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Hybrid vehicle active → 3 tabs [AC3]',
+      (tester) async {
+        await _pumpScreen(
+          tester,
+          activeVehicle: _hybridVehicle,
+          vehicles: const [_hybridVehicle],
+        );
+
+        expect(
+          find.byKey(const Key('consumption_tab_charging')),
+          findsOneWidget,
+          reason: 'Charging tab must render for hybrid vehicles',
+        );
+        expect(find.byType(Tab), findsNWidgets(3));
+      },
+    );
+
+    testWidgets(
+      'Live switch EV → ICE while on Charging tab: '
+      'tab disappears, no crash, user on Trajets [AC4]',
+      (tester) async {
+        // Start on the EV profile with the Charging tab visible and a
+        // couple of logs seeded so the data layer has state we can
+        // observe *doesn't* get cleared by the switch.
+        final activeNotifier = await _pumpScreen(
+          tester,
+          activeVehicle: _evVehicle,
+          vehicles: const [_evVehicle, _iceVehicle],
+          chargingLogs: [
+            ChargingLog(
+              id: 'c1',
+              vehicleId: 'v-ev',
+              date: DateTime.utc(2026, 4, 20),
+              kWh: 30.0,
+              costEur: 12.0,
+              chargeTimeMin: 30,
+              odometerKm: 10000,
+              stationName: 'Ionity Castelnau',
+            ),
+          ],
+        );
+
+        // Sanity: Charging tab is there.
+        expect(
+          find.byKey(const Key('consumption_tab_charging')),
+          findsOneWidget,
+        );
+
+        // Tap onto Charging so we're ON the tab that will vanish.
+        await tester.tap(find.byKey(const Key('consumption_tab_charging')));
+        await tester.pumpAndSettle();
+
+        // Flip the active vehicle to ICE — the tab set should shrink.
+        activeNotifier.setVehicle(_iceVehicle);
+        await tester.pumpAndSettle();
+
+        // No exception was surfaced by the harness (TestWidgetsFlutter
+        // Binding rethrows on pump if one occurred).
+        expect(tester.takeException(), isNull);
+
+        // Charging tab is gone.
+        expect(
+          find.byKey(const Key('consumption_tab_charging')),
+          findsNothing,
+        );
+        expect(find.text('Charging'), findsNothing);
+
+        // We now have exactly 2 tabs.
+        expect(find.byType(Tab), findsNWidgets(2));
+
+        // The TabController should have landed on Trajets (index 1)
+        // — the closest neighbour to the old Charging index (2).
+        // Reach in via the TabBar widget's own `controller`.
+        final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+        expect(tabBar.controller, isNotNull);
+        expect(tabBar.controller!.length, equals(2));
+        expect(
+          tabBar.controller!.index,
+          equals(1),
+          reason:
+              'When Charging vanishes under the user, the selection '
+              'should snap to Trajets (index 1), not Fuel.',
+        );
+
+        // Flip back to EV — Charging tab must return and the logs
+        // must still be available from the unchanged provider.
+        activeNotifier.setVehicle(_evVehicle);
+        await tester.pumpAndSettle();
+        expect(
+          find.byKey(const Key('consumption_tab_charging')),
+          findsOneWidget,
+          reason: 'Charging tab must come back when vehicle is EV again',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #892

## Summary
- ICE (`VehicleType.combustion`) profiles now see 2 tabs on the Consumption screen (Fuel, Trajets); Hybrid and EV profiles keep all 3 (Fuel, Trajets, Charging).
- No active vehicle → keeps the current 3-tab behaviour (no-vehicle onboarding is tracked in a separate issue).
- Live vehicle switch from hybrid/EV → ICE while the user is on the Charging tab: `TabController` is rebuilt with the new length, the selected index is clamped, and selection snaps to Trajets (the closest neighbour to the vanished Charging index) rather than stranding the user on a missing tab or falling back to Fuel. No crash.
- Underlying `chargingLogsProvider` is untouched, so flipping back to a hybrid/EV vehicle restores the charging logs exactly.

## Why
Dead UI for combustion-only drivers — they never have charging sessions to log. Hiding the tab keeps the Consumption screen honest for ICE profiles, while the data layer stays inert so the app remains zero-loss when the user ever transitions to a hybrid/EV.

## Implementation notes
- Switched `_ConsumptionScreenState` from `SingleTickerProviderStateMixin` to `TickerProviderStateMixin` so the `TabController` can be safely disposed and re-created mid-lifetime.
- A small `_ensureTabController` helper rebuilds the controller only when the cardinality (`length`) changes — no-op on ordinary vehicle-switch events where both the old and new vehicle pass the EV check.
- Both the `TabBar` tabs and the `TabBarView` children are gated by the same `showCharging` boolean, so a length mismatch is structurally impossible.

## Testing
`test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart` — 4 tests mapping 1:1 to acceptance criteria:
- ICE vehicle → 2 tabs, no "Charging" / "Aufladung" / "Laden" / "Recharge" label
- EV vehicle → 3 tabs, "Charging" label present
- Hybrid vehicle → 3 tabs
- Live switch EV → ICE while on Charging tab: no crash, 2 tabs, selection on Trajets (index 1); flipping back to EV restores the Charging tab

Full suite: **5673 passed, 1 skipped** (pre-existing).
`flutter analyze`: zero issues.