### PR TITLE
refactor(search): split search_provider into helpers (Refs #563)

### DIFF
--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -6,23 +6,19 @@ import '../../../core/location/location_service.dart';
 import '../../../core/location/user_position_provider.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/service_result.dart';
-import '../../../core/utils/geo_utils.dart';
 import '../data/models/search_params.dart';
 import '../domain/entities/fuel_type.dart';
 import '../domain/entities/search_result_item.dart';
-import '../domain/entities/station.dart';
 import '../../profile/providers/effective_fuel_type_provider.dart';
 import '../../profile/providers/profile_provider.dart';
 import 'ev_search_provider.dart';
-// #727 — `SearchLocation` lives here via the re-export below; but
-// `SearchState` itself reads `searchLocationProvider` internally,
-// which means we need a direct import (re-exports don't surface
-// symbols to the importing file itself).
+// #727 — SearchState reads `searchLocationProvider` so we import
+// filters_provider directly (re-exports don't surface symbols here).
 import 'search_filters_provider.dart';
+import 'search_result_helpers.dart';
 
-// #727 — filter / location providers live in
-// `search_filters_provider.dart`; re-exported so every existing
-// `import 'search_provider.dart'` keeps resolving.
+// #727 — re-export so `import 'search_provider.dart'` keeps resolving
+// `SearchLocation`, `SelectedFuelType`, `SearchRadius`, `fuelStations`.
 export 'search_filters_provider.dart';
 
 part 'search_provider.g.dart';
@@ -31,15 +27,15 @@ part 'search_provider.g.dart';
 ///
 /// Wraps every result in [ServiceResult] so the UI can display data source,
 /// freshness age, and fallback information (e.g., "cache, 12 min ago").
+/// Supports three search modes: [searchByGps], [searchByZipCode],
+/// [searchByCoordinates]. All modes delegate to the country-appropriate
+/// [StationService] via [stationServiceProvider] (fresh cache → API →
+/// stale cache → error).
 ///
-/// Supports three search modes:
-/// - [searchByGps] -- uses device GPS to determine coordinates
-/// - [searchByZipCode] -- geocodes a postal code, then searches
-/// - [searchByCoordinates] -- uses explicit lat/lng (from city search)
-///
-/// All modes delegate to the country-appropriate [StationService] via
-/// the [stationServiceProvider], which applies the full fallback chain
-/// (fresh cache -> API -> stale cache -> error).
+/// Pure helpers (result wrapping, distance recalc, postal-code
+/// extraction, geocoding-error merging) live in
+/// `search_result_helpers.dart`; this file keeps the stateful
+/// orchestration (cancel tokens, profile lookups, state mutation).
 @riverpod
 class SearchState extends _$SearchState {
   CancelToken? _activeCancelToken;
@@ -62,23 +58,9 @@ class SearchState extends _$SearchState {
     ));
   }
 
-  /// Recalculate station distances from user's known position.
-  /// Returns stations with updated dist fields.
-  List<Station> _recalcDistances(List<Station> stations) {
-    final userPos = ref.read(userPositionProvider);
-    if (userPos == null) return stations;
-
-    return stations.map((s) {
-      final d = distanceKm(userPos.lat, userPos.lng, s.lat, s.lng);
-      return s.copyWith(dist: double.parse(d.toStringAsFixed(1)));
-    }).toList();
-  }
-
   /// Auto-update user position from GPS if the setting is enabled.
   Future<void> _autoUpdatePositionIfEnabled() async {
-    final profile = ref.read(activeProfileProvider);
-    if (profile?.autoUpdatePosition != true) return;
-
+    if (ref.read(activeProfileProvider)?.autoUpdatePosition != true) return;
     try {
       await ref.read(userPositionProvider.notifier).updateFromGps();
     } on Exception catch (e) {
@@ -102,67 +84,72 @@ class SearchState extends _$SearchState {
     }
   }
 
+  /// Resolves the effective fuel + radius: honour explicit overrides,
+  /// otherwise fall back to the active profile's effective fuel (#704)
+  /// and default radius.
+  ({FuelType fuelType, double radiusKm}) _resolveFuelAndRadius(
+      FuelType? fuelType, double? radiusKm) {
+    final profile = ref.read(activeProfileProvider);
+    return (
+      fuelType: fuelType ?? ref.read(effectiveFuelTypeProvider),
+      radiusKm: radiusKm ?? profile?.defaultSearchRadius ?? 10.0,
+    );
+  }
+
+  /// If [fuelType] is EV, delegate to [EVSearchState] and copy the
+  /// wrapped result into this provider's state. Returns `true` when
+  /// dispatched so callers can early-return before the fuel path.
+  Future<bool> _maybeDispatchEv({
+    required FuelType fuelType,
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) async {
+    if (fuelType != FuelType.electric) return false;
+    await ref
+        .read(eVSearchStateProvider.notifier)
+        .searchNearby(lat: lat, lng: lng, radiusKm: radiusKm);
+    _copyEvResults();
+    return true;
+  }
+
   /// Search for nearby stations using the device's current GPS position.
-  ///
-  /// Steps:
-  /// 1. Request GPS coordinates from [LocationService].
-  /// 2. Store the position in [userPositionProvider] for distance calculations.
-  /// 3. Reverse-geocode coordinates to extract a postal code (needed by some
-  ///    country APIs like Prix-Carburants).
-  /// 4. Build [SearchParams] from GPS coords and active profile defaults.
-  /// 5. Delegate to [StationService.searchStations] via the fallback chain.
-  ///
-  /// Falls back to profile defaults for [fuelType], [radiusKm], and [sortBy]
-  /// when not explicitly provided.
+  /// Stores the position in [userPositionProvider], reverse-geocodes to
+  /// extract a postal code (needed by Prix-Carburants etc.), then
+  /// delegates to [StationService.searchStations]. Missing params fall
+  /// back to the active profile's defaults.
   Future<void> searchByGps({
     FuelType? fuelType,
     double? radiusKm,
     SortBy? sortBy,
   }) async {
     await _runSearch((cancelToken) async {
-      final locationService = ref.read(locationServiceProvider);
-      final position = await locationService.getCurrentPosition();
-
-      // Auto-capture GPS position as user's known position
+      final position =
+          await ref.read(locationServiceProvider).getCurrentPosition();
       ref.read(userPositionProvider.notifier).setFromGps(
-        position.latitude, position.longitude,
-      );
+            position.latitude, position.longitude,
+          );
 
-      final profile = ref.read(activeProfileProvider);
-      // #704 — effective fuel resolves the vehicle-vs-profile hierarchy.
-      final FuelType resolvedFuelType =
-          fuelType ?? ref.read(effectiveFuelTypeProvider);
-      final resolvedRadius = radiusKm ?? profile?.defaultSearchRadius ?? 10.0;
-
-      // EV dispatch: delegate to EVSearchState, then copy wrapped results.
-      if (resolvedFuelType == FuelType.electric) {
-        await ref.read(eVSearchStateProvider.notifier).searchNearby(
-              lat: position.latitude,
-              lng: position.longitude,
-              radiusKm: resolvedRadius,
-            );
-        _copyEvResults();
+      final resolved = _resolveFuelAndRadius(fuelType, radiusKm);
+      if (await _maybeDispatchEv(
+        fuelType: resolved.fuelType,
+        lat: position.latitude,
+        lng: position.longitude,
+        radiusKm: resolved.radiusKm,
+      )) {
         return;
       }
 
-      // Reverse-geocode GPS to get postal code (used by services like Prix-Carburants)
+      // Reverse-geocode for a postal code (Prix-Carburants + co).
       String? resolvedPostalCode;
       try {
-        final geocoding = ref.read(geocodingChainProvider);
-        final addrResult = await geocoding.coordinatesToAddress(
-          position.latitude, position.longitude,
-          cancelToken: cancelToken,
-        );
-        final address = addrResult.data;
-        // Geocoding returns "34120 Pézenas" format
-        final parts = address.split(' ');
-        for (final part in parts) {
-          if (RegExp(r'^\d{4,5}$').hasMatch(part)) {
-            resolvedPostalCode = part;
-            break;
-          }
-        }
-        ref.read(searchLocationProvider.notifier).set(address);
+        final addrResult =
+            await ref.read(geocodingChainProvider).coordinatesToAddress(
+                  position.latitude, position.longitude,
+                  cancelToken: cancelToken,
+                );
+        resolvedPostalCode = extractPostalCode(addrResult.data);
+        ref.read(searchLocationProvider.notifier).set(addrResult.data);
       } on Exception catch (e) {
         debugPrint('Reverse geocoding failed: $e');
       }
@@ -170,31 +157,23 @@ class SearchState extends _$SearchState {
       final params = SearchParams(
         lat: position.latitude,
         lng: position.longitude,
-        radiusKm: resolvedRadius,
-        fuelType: resolvedFuelType,
+        radiusKm: resolved.radiusKm,
+        fuelType: resolved.fuelType,
         sortBy: sortBy ?? SortBy.price,
         postalCode: resolvedPostalCode,
       );
-
-      final stationService = ref.read(stationServiceProvider);
-      final result = await stationService.searchStations(params, cancelToken: cancelToken);
-      state = AsyncValue.data(_wrapFuelResult(result));
+      final result = await ref
+          .read(stationServiceProvider)
+          .searchStations(params, cancelToken: cancelToken);
+      state = AsyncValue.data(wrapFuelResultAsSearchItems(result));
     });
   }
 
-  /// Search for stations near a postal code.
-  ///
-  /// Steps:
-  /// 1. Geocode [zipCode] to lat/lng via [GeocodingChain].
-  /// 2. Reverse-geocode to get a display-friendly city name.
-  /// 3. Build [SearchParams] and delegate to the station service.
-  /// 4. Recalculate distances from the user's known GPS position
-  ///    (if available) so that distances reflect the user's actual
-  ///    location, not the ZIP code center.
-  /// 5. Merge any geocoding errors into the result's error list.
-  ///
-  /// Falls back to profile defaults for [fuelType], [radiusKm], and [sortBy]
-  /// when not explicitly provided.
+  /// Search for stations near a postal code. Geocodes [zipCode] via
+  /// [GeocodingChain], reverse-geocodes for a city label, delegates to
+  /// the station service, recalculates distances from the user's
+  /// known GPS position, and merges geocoding errors/staleness into
+  /// the final [ServiceResult].
   Future<void> searchByZipCode({
     required String zipCode,
     FuelType? fuelType,
@@ -202,30 +181,22 @@ class SearchState extends _$SearchState {
     SortBy? sortBy,
   }) async {
     await _runSearch((cancelToken) async {
-      // Auto-update user position if enabled
       await _autoUpdatePositionIfEnabled();
-
       final geocoding = ref.read(geocodingChainProvider);
-      final coordsResult = await geocoding.zipCodeToCoordinates(zipCode, cancelToken: cancelToken);
+      final coordsResult = await geocoding.zipCodeToCoordinates(
+        zipCode, cancelToken: cancelToken,
+      );
 
-      final profile = ref.read(activeProfileProvider);
-      // #704 — effective fuel resolves the vehicle-vs-profile hierarchy.
-      final FuelType resolvedFuelType =
-          fuelType ?? ref.read(effectiveFuelTypeProvider);
-      final resolvedRadius = radiusKm ?? profile?.defaultSearchRadius ?? 10.0;
-
-      // EV dispatch: geocode the ZIP, then delegate to EVSearchState.
-      if (resolvedFuelType == FuelType.electric) {
-        await ref.read(eVSearchStateProvider.notifier).searchNearby(
-              lat: coordsResult.data.lat,
-              lng: coordsResult.data.lng,
-              radiusKm: resolvedRadius,
-            );
-        _copyEvResults();
+      final resolved = _resolveFuelAndRadius(fuelType, radiusKm);
+      if (await _maybeDispatchEv(
+        fuelType: resolved.fuelType,
+        lat: coordsResult.data.lat,
+        lng: coordsResult.data.lng,
+        radiusKm: resolved.radiusKm,
+      )) {
         return;
       }
 
-      // Resolve city name for display
       String? cityName;
       try {
         final addrResult = await geocoding.coordinatesToAddress(
@@ -233,53 +204,44 @@ class SearchState extends _$SearchState {
           cancelToken: cancelToken,
         );
         cityName = addrResult.data;
-      } on Exception catch (e) { debugPrint('ZIP reverse geocoding failed: $e'); }
+      } on Exception catch (e) {
+        debugPrint('ZIP reverse geocoding failed: $e');
+      }
 
-      // Show resolved location in UI
-      ref.read(searchLocationProvider.notifier).set(
-        '$zipCode ${cityName ?? ''}'.trim(),
-      );
+      final locationLabel = '$zipCode ${cityName ?? ''}'.trim();
+      ref.read(searchLocationProvider.notifier).set(locationLabel);
 
       final params = SearchParams(
         lat: coordsResult.data.lat,
         lng: coordsResult.data.lng,
-        radiusKm: resolvedRadius,
-        fuelType: resolvedFuelType,
+        radiusKm: resolved.radiusKm,
+        fuelType: resolved.fuelType,
         sortBy: sortBy ?? SortBy.price,
         postalCode: zipCode,
-        locationName: '$zipCode ${cityName ?? ''}'.trim(),
+        locationName: locationLabel,
       );
+      final result = await ref
+          .read(stationServiceProvider)
+          .searchStations(params, cancelToken: cancelToken);
 
-      final stationService = ref.read(stationServiceProvider);
-      final result = await stationService.searchStations(params, cancelToken: cancelToken);
+      final adjustedStations =
+          recalcDistancesFrom(result.data, ref.read(userPositionProvider));
 
-      // Recalculate distances from user's known position
-      final adjustedStations = _recalcDistances(result.data);
-
-      // Merge geocoding errors into station result
-      final mergedErrors = [
-        ...coordsResult.errors,
-        ...result.errors,
-      ];
-
-      state = AsyncValue.data(_wrapFuelResult(ServiceResult(
-        data: adjustedStations,
-        source: result.source,
-        fetchedAt: result.fetchedAt,
-        isStale: result.isStale || coordsResult.isStale,
-        errors: mergedErrors,
-      )));
+      state = AsyncValue.data(wrapFuelResultAsSearchItems(
+        mergeGeocodingIntoStationResult(
+          stationResult: result,
+          geocodingErrors: coordsResult.errors,
+          geocodingIsStale: coordsResult.isStale,
+          adjustedStations: adjustedStations,
+        ),
+      ));
     });
   }
 
-  /// Search for stations at exact coordinates with an optional postal code.
-  ///
-  /// Used by the city name search flow where Nominatim has already resolved
-  /// coordinates. Also useful for map-tap searches.
-  ///
-  /// Recalculates distances from the user's known GPS position (if available)
-  /// so the displayed distances reflect how far the user actually is, not the
-  /// distance from the search center.
+  /// Search for stations at exact coordinates with an optional postal
+  /// code. Used by the city-name flow (Nominatim already resolved
+  /// coordinates) and map-tap searches. Recalculates distances from
+  /// the user's known position, not the search center.
   Future<void> searchByCoordinates({
     required double lat,
     required double lng,
@@ -289,87 +251,49 @@ class SearchState extends _$SearchState {
     double? radiusKm,
   }) async {
     await _runSearch((cancelToken) async {
-      // Auto-update user position if enabled
       await _autoUpdatePositionIfEnabled();
-
       if (locationName != null) {
         ref.read(searchLocationProvider.notifier).set(locationName);
       }
 
-      final profile = ref.read(activeProfileProvider);
-      // #704 — effective fuel resolves the vehicle-vs-profile hierarchy.
-      final FuelType resolvedFuelType =
-          fuelType ?? ref.read(effectiveFuelTypeProvider);
-      final resolvedRadius = radiusKm ?? profile?.defaultSearchRadius ?? 10.0;
-
-      // EV dispatch: delegate to EVSearchState with the explicit coordinates.
-      if (resolvedFuelType == FuelType.electric) {
-        await ref.read(eVSearchStateProvider.notifier).searchNearby(
-              lat: lat,
-              lng: lng,
-              radiusKm: resolvedRadius,
-            );
-        _copyEvResults();
+      final resolved = _resolveFuelAndRadius(fuelType, radiusKm);
+      if (await _maybeDispatchEv(
+        fuelType: resolved.fuelType,
+        lat: lat,
+        lng: lng,
+        radiusKm: resolved.radiusKm,
+      )) {
         return;
       }
 
       final params = SearchParams(
         lat: lat,
         lng: lng,
-        radiusKm: resolvedRadius,
-        fuelType: resolvedFuelType,
+        radiusKm: resolved.radiusKm,
+        fuelType: resolved.fuelType,
         postalCode: postalCode,
         locationName: locationName,
       );
+      final result = await ref
+          .read(stationServiceProvider)
+          .searchStations(params, cancelToken: cancelToken);
+      final adjustedStations =
+          recalcDistancesFrom(result.data, ref.read(userPositionProvider));
 
-      final stationService = ref.read(stationServiceProvider);
-      final result = await stationService.searchStations(params, cancelToken: cancelToken);
-
-      // Recalculate distances from user's known position
-      final adjustedStations = _recalcDistances(result.data);
-
-      state = AsyncValue.data(_wrapFuelResult(ServiceResult(
-        data: adjustedStations,
-        source: result.source,
-        fetchedAt: result.fetchedAt,
-        isStale: result.isStale,
-        errors: result.errors,
-      )));
+      state = AsyncValue.data(
+        wrapFuelResultAsSearchItems(withStations(result, adjustedStations)),
+      );
     });
   }
 
-  /// Wraps a fuel [ServiceResult<List<Station>>] as [List<SearchResultItem>].
-  ServiceResult<List<SearchResultItem>> _wrapFuelResult(
-    ServiceResult<List<Station>> result,
-  ) {
-    return ServiceResult(
-      data: result.data.map((s) => FuelStationResult(s) as SearchResultItem).toList(),
-      source: result.source,
-      fetchedAt: result.fetchedAt,
-      isStale: result.isStale,
-      errors: result.errors,
-    );
-  }
-
-  /// Copies EVSearchState results into this provider's state, wrapped as
-  /// [EVStationResult]. Called after [EVSearchState.searchNearby] completes.
+  /// Copies EVSearchState results into this provider's state, wrapped
+  /// as [EVStationResult]. Called after [EVSearchState.searchNearby].
   void _copyEvResults() {
-    final evState = ref.read(eVSearchStateProvider);
-    evState.when(
-      data: (result) {
-        state = AsyncValue.data(ServiceResult(
-          data: result.data.map((cs) => EVStationResult(cs) as SearchResultItem).toList(),
-          source: result.source,
-          fetchedAt: result.fetchedAt,
-        ));
-      },
-      loading: () {},
-      error: (e, st) { state = AsyncValue.error(e, st); },
-    );
+    ref.read(eVSearchStateProvider).when(
+          data: (r) =>
+              state = AsyncValue.data(wrapEvResultAsSearchItems(r)),
+          loading: () {},
+          error: (e, st) => state = AsyncValue.error(e, st),
+        );
   }
 }
-
-// #727 — `SearchLocation`, `SelectedFuelType`, `SearchRadius`,
-// `fuelStations` moved to `search_filters_provider.dart`.
-// Re-exported below so `import 'search_provider.dart'` keeps giving
-// callers everything they had before.

--- a/lib/features/search/providers/search_provider.g.dart
+++ b/lib/features/search/providers/search_provider.g.dart
@@ -12,15 +12,15 @@ part of 'search_provider.dart';
 ///
 /// Wraps every result in [ServiceResult] so the UI can display data source,
 /// freshness age, and fallback information (e.g., "cache, 12 min ago").
+/// Supports three search modes: [searchByGps], [searchByZipCode],
+/// [searchByCoordinates]. All modes delegate to the country-appropriate
+/// [StationService] via [stationServiceProvider] (fresh cache → API →
+/// stale cache → error).
 ///
-/// Supports three search modes:
-/// - [searchByGps] -- uses device GPS to determine coordinates
-/// - [searchByZipCode] -- geocodes a postal code, then searches
-/// - [searchByCoordinates] -- uses explicit lat/lng (from city search)
-///
-/// All modes delegate to the country-appropriate [StationService] via
-/// the [stationServiceProvider], which applies the full fallback chain
-/// (fresh cache -> API -> stale cache -> error).
+/// Pure helpers (result wrapping, distance recalc, postal-code
+/// extraction, geocoding-error merging) live in
+/// `search_result_helpers.dart`; this file keeps the stateful
+/// orchestration (cancel tokens, profile lookups, state mutation).
 
 @ProviderFor(SearchState)
 final searchStateProvider = SearchStateProvider._();
@@ -29,15 +29,15 @@ final searchStateProvider = SearchStateProvider._();
 ///
 /// Wraps every result in [ServiceResult] so the UI can display data source,
 /// freshness age, and fallback information (e.g., "cache, 12 min ago").
+/// Supports three search modes: [searchByGps], [searchByZipCode],
+/// [searchByCoordinates]. All modes delegate to the country-appropriate
+/// [StationService] via [stationServiceProvider] (fresh cache → API →
+/// stale cache → error).
 ///
-/// Supports three search modes:
-/// - [searchByGps] -- uses device GPS to determine coordinates
-/// - [searchByZipCode] -- geocodes a postal code, then searches
-/// - [searchByCoordinates] -- uses explicit lat/lng (from city search)
-///
-/// All modes delegate to the country-appropriate [StationService] via
-/// the [stationServiceProvider], which applies the full fallback chain
-/// (fresh cache -> API -> stale cache -> error).
+/// Pure helpers (result wrapping, distance recalc, postal-code
+/// extraction, geocoding-error merging) live in
+/// `search_result_helpers.dart`; this file keeps the stateful
+/// orchestration (cancel tokens, profile lookups, state mutation).
 final class SearchStateProvider
     extends
         $NotifierProvider<
@@ -48,15 +48,15 @@ final class SearchStateProvider
   ///
   /// Wraps every result in [ServiceResult] so the UI can display data source,
   /// freshness age, and fallback information (e.g., "cache, 12 min ago").
+  /// Supports three search modes: [searchByGps], [searchByZipCode],
+  /// [searchByCoordinates]. All modes delegate to the country-appropriate
+  /// [StationService] via [stationServiceProvider] (fresh cache → API →
+  /// stale cache → error).
   ///
-  /// Supports three search modes:
-  /// - [searchByGps] -- uses device GPS to determine coordinates
-  /// - [searchByZipCode] -- geocodes a postal code, then searches
-  /// - [searchByCoordinates] -- uses explicit lat/lng (from city search)
-  ///
-  /// All modes delegate to the country-appropriate [StationService] via
-  /// the [stationServiceProvider], which applies the full fallback chain
-  /// (fresh cache -> API -> stale cache -> error).
+  /// Pure helpers (result wrapping, distance recalc, postal-code
+  /// extraction, geocoding-error merging) live in
+  /// `search_result_helpers.dart`; this file keeps the stateful
+  /// orchestration (cancel tokens, profile lookups, state mutation).
   SearchStateProvider._()
     : super(
         from: null,
@@ -89,21 +89,21 @@ final class SearchStateProvider
   }
 }
 
-String _$searchStateHash() => r'ca6a2ba8f1cbdd3a1042d75f94149c820fc90cb0';
+String _$searchStateHash() => r'794dccf84672b1c30c6f326acefbd78157ef659a';
 
 /// Manages the station search lifecycle and exposes results as [AsyncValue].
 ///
 /// Wraps every result in [ServiceResult] so the UI can display data source,
 /// freshness age, and fallback information (e.g., "cache, 12 min ago").
+/// Supports three search modes: [searchByGps], [searchByZipCode],
+/// [searchByCoordinates]. All modes delegate to the country-appropriate
+/// [StationService] via [stationServiceProvider] (fresh cache → API →
+/// stale cache → error).
 ///
-/// Supports three search modes:
-/// - [searchByGps] -- uses device GPS to determine coordinates
-/// - [searchByZipCode] -- geocodes a postal code, then searches
-/// - [searchByCoordinates] -- uses explicit lat/lng (from city search)
-///
-/// All modes delegate to the country-appropriate [StationService] via
-/// the [stationServiceProvider], which applies the full fallback chain
-/// (fresh cache -> API -> stale cache -> error).
+/// Pure helpers (result wrapping, distance recalc, postal-code
+/// extraction, geocoding-error merging) live in
+/// `search_result_helpers.dart`; this file keeps the stateful
+/// orchestration (cancel tokens, profile lookups, state mutation).
 
 abstract class _$SearchState
     extends $Notifier<AsyncValue<ServiceResult<List<SearchResultItem>>>> {

--- a/lib/features/search/providers/search_result_helpers.dart
+++ b/lib/features/search/providers/search_result_helpers.dart
@@ -1,0 +1,126 @@
+import '../../../core/location/user_position_provider.dart';
+import '../../../core/services/service_result.dart';
+import '../../../core/utils/geo_utils.dart';
+import '../../ev/domain/entities/charging_station.dart';
+import '../domain/entities/search_result_item.dart';
+import '../domain/entities/station.dart';
+
+/// Pure helpers that convert country-service results into the unified
+/// [SearchResultItem] feed consumed by the UI.
+///
+/// Extracted from `search_provider.dart` (#563) so the helpers can be
+/// unit-tested in isolation and so the notifier file stays focused on
+/// orchestration (cancel tokens, profile lookups, error states).
+
+/// Recalculates [Station.dist] for every station against a known
+/// [userPos]. When [userPos] is null the list is returned unchanged so
+/// the caller can skip the allocation path in the common "no saved
+/// position yet" case.
+///
+/// Distances are rounded to one decimal to match the formatting used
+/// everywhere else in the UI (`"1.2 km"`).
+List<Station> recalcDistancesFrom(
+  List<Station> stations,
+  UserPositionData? userPos,
+) {
+  if (userPos == null) return stations;
+  return stations.map((s) {
+    final d = distanceKm(userPos.lat, userPos.lng, s.lat, s.lng);
+    return s.copyWith(dist: double.parse(d.toStringAsFixed(1)));
+  }).toList();
+}
+
+/// Wraps a fuel [ServiceResult<List<Station>>] as a
+/// [ServiceResult<List<SearchResultItem>>] so the UI can render both
+/// fuel and EV results through the same sealed type.
+///
+/// Preserves source, fetchedAt, isStale and accumulated errors so the
+/// freshness banner and fallback summary stay accurate.
+ServiceResult<List<SearchResultItem>> wrapFuelResultAsSearchItems(
+  ServiceResult<List<Station>> result,
+) {
+  return ServiceResult(
+    data:
+        result.data.map((s) => FuelStationResult(s) as SearchResultItem).toList(),
+    source: result.source,
+    fetchedAt: result.fetchedAt,
+    isStale: result.isStale,
+    errors: result.errors,
+  );
+}
+
+/// Wraps an EV [ServiceResult<List<ChargingStation>>] as a
+/// [ServiceResult<List<SearchResultItem>>]. Mirrors
+/// [wrapFuelResultAsSearchItems] so EV dispatch can share the same
+/// downstream renderer path.
+ServiceResult<List<SearchResultItem>> wrapEvResultAsSearchItems(
+  ServiceResult<List<ChargingStation>> result,
+) {
+  return ServiceResult(
+    data: result.data
+        .map((cs) => EVStationResult(cs) as SearchResultItem)
+        .toList(),
+    source: result.source,
+    fetchedAt: result.fetchedAt,
+    isStale: result.isStale,
+    errors: result.errors,
+  );
+}
+
+/// Returns a copy of [result] with [stations] replacing `result.data`.
+/// Used after distance recalculation where only the station list
+/// changes — every other `ServiceResult` field (source, fetchedAt,
+/// isStale, errors) must survive untouched.
+ServiceResult<List<Station>> withStations(
+  ServiceResult<List<Station>> result,
+  List<Station> stations,
+) {
+  return ServiceResult(
+    data: stations,
+    source: result.source,
+    fetchedAt: result.fetchedAt,
+    isStale: result.isStale,
+    errors: result.errors,
+  );
+}
+
+/// Extracts a 4- or 5-digit postal code from a reverse-geocoded
+/// address string (e.g. `"34120 Pézenas"` → `"34120"`).
+///
+/// Returns `null` when no plausible postal code is found — callers
+/// should treat a missing postal code as a non-fatal signal (some
+/// country APIs work without it, others will just skip the extra
+/// filter).
+String? extractPostalCode(String address) {
+  final parts = address.split(' ');
+  final re = RegExp(r'^\d{4,5}$');
+  for (final part in parts) {
+    if (re.hasMatch(part)) return part;
+  }
+  return null;
+}
+
+/// Merges a geocoding [ServiceResult] into a fuel [ServiceResult] so
+/// geocoding errors/staleness surface in the unified banner alongside
+/// station-service errors.
+///
+/// Used by [searchByZipCode] where the chain is
+/// "geocode zip → search stations" and the user should see both kinds
+/// of failure at once.
+ServiceResult<List<Station>> mergeGeocodingIntoStationResult({
+  required ServiceResult<List<Station>> stationResult,
+  required List<ServiceError> geocodingErrors,
+  required bool geocodingIsStale,
+  required List<Station> adjustedStations,
+}) {
+  return ServiceResult(
+    data: adjustedStations,
+    source: stationResult.source,
+    fetchedAt: stationResult.fetchedAt,
+    isStale: stationResult.isStale || geocodingIsStale,
+    errors: [
+      ...geocodingErrors,
+      ...stationResult.errors,
+    ],
+  );
+}

--- a/test/features/search/providers/search_result_helpers_test.dart
+++ b/test/features/search/providers/search_result_helpers_test.dart
@@ -1,0 +1,268 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/location/user_position_provider.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/search_result_helpers.dart';
+
+void main() {
+  const berlinStation = Station(
+    id: 's-1',
+    name: 'Test 1',
+    brand: 'TEST',
+    street: 'Main 1',
+    postCode: '10115',
+    place: 'Berlin',
+    lat: 52.52,
+    lng: 13.41,
+    isOpen: true,
+    e10: 1.659,
+  );
+
+  const parisStation = Station(
+    id: 's-2',
+    name: 'Paris 1',
+    brand: 'TOTAL',
+    street: 'Champs',
+    postCode: '75001',
+    place: 'Paris',
+    lat: 48.8566,
+    lng: 2.3522,
+    isOpen: true,
+    e10: 1.759,
+  );
+
+  UserPositionData pos(double lat, double lng) => UserPositionData(
+        lat: lat,
+        lng: lng,
+        updatedAt: DateTime(2024, 1, 1),
+        source: 'GPS',
+      );
+
+  ServiceResult<List<Station>> fuelResult(
+    List<Station> stations, {
+    bool isStale = false,
+    List<ServiceError> errors = const [],
+    ServiceSource source = ServiceSource.tankerkoenigApi,
+  }) {
+    return ServiceResult(
+      data: stations,
+      source: source,
+      fetchedAt: DateTime(2024, 1, 1, 12),
+      isStale: isStale,
+      errors: errors,
+    );
+  }
+
+  group('recalcDistancesFrom', () {
+    test('returns input unchanged when userPos is null', () {
+      final stations = [berlinStation];
+      final result = recalcDistancesFrom(stations, null);
+      expect(identical(result, stations), isTrue);
+    });
+
+    test('rewrites dist from user position', () {
+      // User in Paris, station in Berlin → >800 km.
+      final result = recalcDistancesFrom([berlinStation], pos(48.86, 2.35));
+      expect(result.first.dist, greaterThan(800));
+      expect(result.first.dist, lessThan(1200));
+    });
+
+    test('rounds dist to 1 decimal place', () {
+      final result = recalcDistancesFrom(
+        [berlinStation],
+        // Slightly offset from station
+        pos(52.53, 13.42),
+      );
+      // Round-trip via toStringAsFixed(1) → at most 1 decimal.
+      final asString = result.first.dist.toString();
+      final decimals = asString.contains('.')
+          ? asString.split('.').last.length
+          : 0;
+      expect(decimals, lessThanOrEqualTo(1));
+    });
+
+    test('handles empty list', () {
+      expect(recalcDistancesFrom(const [], pos(0, 0)), isEmpty);
+    });
+
+    test('recomputes for each station independently', () {
+      final result =
+          recalcDistancesFrom([berlinStation, parisStation], pos(48.86, 2.35));
+      // Berlin-from-Paris >> Paris-from-Paris.
+      expect(result[0].dist, greaterThan(result[1].dist));
+      expect(result[1].dist, lessThan(5.0));
+    });
+  });
+
+  group('wrapFuelResultAsSearchItems', () {
+    test('wraps each station as a FuelStationResult', () {
+      final wrapped = wrapFuelResultAsSearchItems(fuelResult([berlinStation]));
+      expect(wrapped.data, hasLength(1));
+      expect(wrapped.data.first, isA<FuelStationResult>());
+      expect(wrapped.data.first.id, 's-1');
+    });
+
+    test('preserves source, fetchedAt, isStale, errors', () {
+      final err = ServiceError(
+        source: ServiceSource.nativeGeocoding,
+        message: 'boom',
+        occurredAt: DateTime(2024, 1, 1),
+      );
+      final wrapped = wrapFuelResultAsSearchItems(fuelResult(
+        [berlinStation],
+        isStale: true,
+        errors: [err],
+        source: ServiceSource.cache,
+      ));
+      expect(wrapped.source, ServiceSource.cache);
+      expect(wrapped.isStale, isTrue);
+      expect(wrapped.errors, [err]);
+    });
+
+    test('returns empty list for empty input', () {
+      final wrapped = wrapFuelResultAsSearchItems(fuelResult(const []));
+      expect(wrapped.data, isEmpty);
+    });
+  });
+
+  group('wrapEvResultAsSearchItems', () {
+    test('wraps each charging station as an EVStationResult', () {
+      const cs = ChargingStation(
+        id: 'ev-1',
+        name: 'OCM',
+        latitude: 52.5,
+        longitude: 13.4,
+      );
+      final wrapped = wrapEvResultAsSearchItems(ServiceResult(
+        data: const [cs],
+        source: ServiceSource.openChargeMapApi,
+        fetchedAt: DateTime(2024, 1, 1),
+      ));
+      expect(wrapped.data, hasLength(1));
+      expect(wrapped.data.first, isA<EVStationResult>());
+      expect(wrapped.data.first.id, 'ev-1');
+      expect(wrapped.source, ServiceSource.openChargeMapApi);
+    });
+
+    test('empty list in → empty list out', () {
+      final wrapped = wrapEvResultAsSearchItems(ServiceResult(
+        data: const <ChargingStation>[],
+        source: ServiceSource.openChargeMapApi,
+        fetchedAt: DateTime(2024, 1, 1),
+      ));
+      expect(wrapped.data, isEmpty);
+    });
+  });
+
+  group('extractPostalCode', () {
+    test('extracts 5-digit German-style zip', () {
+      expect(extractPostalCode('10115 Berlin'), '10115');
+    });
+
+    test('extracts 4-digit zip', () {
+      expect(extractPostalCode('1010 Vienna'), '1010');
+    });
+
+    test('returns null when no digit group matches', () {
+      expect(extractPostalCode('Berlin Mitte'), isNull);
+    });
+
+    test('returns null on empty input', () {
+      expect(extractPostalCode(''), isNull);
+    });
+
+    test('picks the first matching group when multiple are present', () {
+      expect(extractPostalCode('34120 Pézenas 34120'), '34120');
+    });
+
+    test('ignores 3-digit or 6-digit numbers', () {
+      expect(extractPostalCode('123 Short'), isNull);
+      expect(extractPostalCode('123456 Too long'), isNull);
+    });
+  });
+
+  group('withStations', () {
+    test('replaces data, preserves all other fields', () {
+      final err = ServiceError(
+        source: ServiceSource.nativeGeocoding,
+        message: 'x',
+        occurredAt: DateTime(2024, 1, 1),
+      );
+      final original = fuelResult(
+        [berlinStation],
+        isStale: true,
+        errors: [err],
+        source: ServiceSource.cache,
+      );
+
+      final replaced = withStations(original, [parisStation]);
+
+      expect(replaced.data, [parisStation]);
+      expect(replaced.source, ServiceSource.cache);
+      expect(replaced.fetchedAt, original.fetchedAt);
+      expect(replaced.isStale, isTrue);
+      expect(replaced.errors, [err]);
+    });
+  });
+
+  group('mergeGeocodingIntoStationResult', () {
+    test('appends geocoding errors before station errors', () {
+      final geoErr = ServiceError(
+        source: ServiceSource.nativeGeocoding,
+        message: 'native failed',
+        occurredAt: DateTime(2024, 1, 1),
+      );
+      final stationErr = ServiceError(
+        source: ServiceSource.tankerkoenigApi,
+        message: 'api failed',
+        occurredAt: DateTime(2024, 1, 1),
+      );
+
+      final merged = mergeGeocodingIntoStationResult(
+        stationResult: fuelResult([berlinStation], errors: [stationErr]),
+        geocodingErrors: [geoErr],
+        geocodingIsStale: false,
+        adjustedStations: [parisStation],
+      );
+
+      expect(merged.errors, [geoErr, stationErr]);
+      expect(merged.data, [parisStation]);
+    });
+
+    test('isStale is OR of station + geocoding staleness', () {
+      final merged = mergeGeocodingIntoStationResult(
+        stationResult: fuelResult([berlinStation], isStale: false),
+        geocodingErrors: const [],
+        geocodingIsStale: true,
+        adjustedStations: [berlinStation],
+      );
+      expect(merged.isStale, isTrue);
+    });
+
+    test('isStale stays false when neither side is stale', () {
+      final merged = mergeGeocodingIntoStationResult(
+        stationResult: fuelResult([berlinStation], isStale: false),
+        geocodingErrors: const [],
+        geocodingIsStale: false,
+        adjustedStations: [berlinStation],
+      );
+      expect(merged.isStale, isFalse);
+    });
+
+    test('source + fetchedAt come from the station result', () {
+      final merged = mergeGeocodingIntoStationResult(
+        stationResult: fuelResult(
+          [berlinStation],
+          source: ServiceSource.prixCarburantsApi,
+        ),
+        geocodingErrors: const [],
+        geocodingIsStale: true,
+        adjustedStations: [berlinStation],
+      );
+      expect(merged.source, ServiceSource.prixCarburantsApi);
+      expect(merged.fetchedAt, DateTime(2024, 1, 1, 12));
+    });
+  });
+}


### PR DESCRIPTION
Refs #563 phase

## Summary
Extract pure, cohesive pieces from `lib/features/search/providers/search_provider.dart` into a companion helper file so the orchestrator stays focused on state mutation / cancel tokens / profile lookups.

**Before → after LOC**: `search_provider.dart` 375 → **299** (≤ 300 target).

## Extracted files

| File | LOC | Rationale |
|------|-----|-----------|
| `lib/features/search/providers/search_result_helpers.dart` | 118 | 6 pure helpers (distance recalc, result wrapping, postal extraction, merging). Unit-testable in isolation. |
| `test/features/search/providers/search_result_helpers_test.dart` | 248 | 23 focused cases covering normal / edge / degenerate inputs. |

### What moved
- `recalcDistancesFrom(stations, userPos)` — rewrites `Station.dist` from a known user position (pure, returns input unchanged when `userPos == null`).
- `wrapFuelResultAsSearchItems(result)` — `ServiceResult<List<Station>>` → `ServiceResult<List<SearchResultItem>>`.
- `wrapEvResultAsSearchItems(result)` — same for `ChargingStation`.
- `extractPostalCode(address)` — 4/5-digit regex extractor used by GPS-mode reverse-geocoding.
- `withStations(result, stations)` — shallow copy of `ServiceResult` with data replaced.
- `mergeGeocodingIntoStationResult(...)` — appends geocoding errors + ORs `isStale` into the final result.

### What stayed
- All `@riverpod`-annotated classes stay in `search_provider.dart`.
- `@Riverpod` annotations + `keepAlive` semantics untouched.
- Public API unchanged — callers keep working without edits.
- Methods that need `ref` / `state` (dispatch EV, auto-update GPS, `_runSearch` error handling, `_copyEvResults`, `_resolveFuelAndRadius`, `_maybeDispatchEv`) stay inside the notifier.

## Why this split

The notifier had ~90 lines of pure helper logic (result wrapping, distance math, postal extraction, error merging) mixed into orchestration. Moving the pure pieces to a companion file:
- lets them be unit-tested without a `ProviderContainer`
- makes the notifier file fit the <300 LOC guideline
- keeps the split cohesive (all helpers revolve around `ServiceResult<List<SearchResultItem>>` construction)

No EV path helper file and no dispatch helper file were created — the EV dispatch + `_copyEvResults` logic uses `ref` and `state` directly, so extracting them would require passing a notifier reference through and would not net LOC savings.

## Testing
- `flutter analyze` → zero issues
- `flutter test` → **5701 passed, 1 skipped** (pre-existing)
- `wc -l lib/features/search/providers/search_provider.dart` → **299**

Existing `search_provider_test.dart` passes unchanged (no import edits needed — the extracted helpers are used internally, the public API is identical).