### PR TITLE
fix(l10n): correct German 'Anpinnen' in pin tooltip

### DIFF
--- a/lib/l10n/_fragments/trip_recording_pin_de.arb
+++ b/lib/l10n/_fragments/trip_recording_pin_de.arb
@@ -1,5 +1,5 @@
 {
-  "tripRecordingPinTooltip": "Epinglen hält den Bildschirm an — verbraucht mehr Akku",
+  "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."
   },

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1359,7 +1359,7 @@
   "trajetDetailDeleteConfirmBody": "Diese Fahrt wird dauerhaft aus deinem Verlauf entfernt.",
   "trajetDetailDeleteConfirmCancel": "Abbrechen",
   "trajetDetailDeleteConfirmConfirm": "Löschen",
-  "tripRecordingPinTooltip": "Epinglen hält den Bildschirm an — verbraucht mehr Akku",
+  "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."
   },

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3548,7 +3548,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get tripRecordingPinTooltip =>
-      'Epinglen hält den Bildschirm an — verbraucht mehr Akku';
+      'Anpinnen hält den Bildschirm an — verbraucht mehr Akku';
 
   @override
   String get tripRecordingPinSemanticOn => 'Aufnahmeformular lösen';


### PR DESCRIPTION
One-line cosmetic fix flagged by the #911 worker: 'Epinglen' is a French loanword, not German. Corrected to 'Anpinnen'.