### PR TITLE
docs(backlog): unblock #594 #713 #9 with refreshed copy + handoff docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ docs/guides/*
 !docs/guides/DEV-GIT-WORKTREES.md
 !docs/guides/AUTONOMOUS-LOOP-PROTOCOL.md
 !docs/guides/ARB_FRAGMENTS.md
+!docs/guides/BLOCKER-IOS-PROVISIONING.md
+!docs/guides/BLOCKER-SUPABASE-MIGRATION.md
+!docs/guides/PLAY-STORE-LISTING-REFRESH.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/BLOCKER-IOS-PROVISIONING.md
+++ b/docs/guides/BLOCKER-IOS-PROVISIONING.md
@@ -1,0 +1,71 @@
+# Blocker — iOS platform support (#9)
+
+## Status on master
+
+The iOS target has most of the code-side scaffolding in place but is
+blocked on external provisioning (Apple Developer enrollment, code
+signing certificates, App Store Connect listing). Until those exist no
+TestFlight build can be produced and `build-ios` in CI stays commented
+out.
+
+### What already works on master
+- `ios/Runner.xcodeproj` and `ios/Runner.xcworkspace` exist.
+- `ios/Runner/Info.plist` already declares:
+  - `NSLocationWhenInUseUsageDescription`
+  - `NSLocationAlwaysAndWhenInUseUsageDescription`
+  - `NSLocationAlwaysUsageDescription`
+  - `UIBackgroundModes = fetch + processing + remote-notification`
+  - `BGTaskSchedulerPermittedIdentifiers = de.tankstellen.tankstellen.background`
+  - Scene manifest + launch storyboard
+- `ios/Runner/AppDelegate.swift` + `SceneDelegate.swift` are in place.
+- Supported orientations declared for iPhone and iPad.
+
+### What is missing
+1. **Apple Developer Program enrollment** — $99 / year, requires a
+   real Apple ID and identity verification. Single-person accounts are
+   fine for a solo dev.
+2. **Bundle identifier** in App Store Connect — reserve
+   `de.tankstellen.tankstellen` to match `PRODUCT_BUNDLE_IDENTIFIER`.
+3. **Signing certificates + provisioning profiles** — development and
+   distribution pairs. Fastlane Match is recommended; alternatively
+   Xcode's automatic signing works for a solo account.
+4. **CocoaPods lockfile** — the project has a `Podfile` but no
+   `Podfile.lock` has been committed; the first `pod install` on a Mac
+   will produce one.
+5. **Push notification entitlement** — needed if local notifications
+   are promoted to remote (server-side alerts). The current app uses
+   `flutter_local_notifications` only, which does not require APNs, so
+   this is optional at launch.
+6. **CI job re-enabled** — uncomment `build-ios` in
+   `.github/workflows/ci.yml`. Needs a `macos-latest` runner, signing
+   secrets stored in GitHub Actions, and `fastlane pilot upload` or
+   `xcodebuild -exportArchive` for TestFlight delivery.
+7. **App Store Connect listing** — separate from the Google Play
+   listing tracked in `#594`; iOS has its own metadata dimensions
+   (6.5" + 5.5" screenshots, app preview videos, etc.).
+
+## Checklist for the user (order matters)
+
+1. Enroll in Apple Developer Program.
+2. Reserve the bundle identifier in App Store Connect.
+3. On a Mac: `cd ios && pod install` — commits `Podfile.lock`.
+4. Create development + distribution certificates in Xcode or Fastlane
+   Match. Export signing secrets for CI if automating.
+5. In Xcode: select the Runner target → Signing & Capabilities → tick
+   "Automatically manage signing" → pick the team → build a test run
+   on a physical device.
+6. Verify the Flutter plugins compile (`flutter build ios --no-codesign`
+   from the repo root; iOS-only plugins that were never used on Android
+   may surface here — `sentry_flutter`, `workmanager`, etc.).
+7. Upload the first build to TestFlight (internal track) and
+   self-invite to confirm install works.
+8. Re-enable `build-ios` in `.github/workflows/ci.yml` once the above
+   manual steps produced a green local build.
+
+## What this repo can do autonomously
+
+Nothing — every step above requires the user's Apple ID and physical
+Mac access. Opening this issue was the right call; marking it a
+long-term blocker rather than a fixable-in-session task is the
+honest position. Keep the issue open with `blocked` and `needs-user`
+labels and come back after the developer enrollment completes.

--- a/docs/guides/BLOCKER-SUPABASE-MIGRATION.md
+++ b/docs/guides/BLOCKER-SUPABASE-MIGRATION.md
@@ -1,0 +1,73 @@
+# Blocker — Apply 20260418 Supabase migration (#713)
+
+The `vehicles` and `fill_ups` tables added in the 5.0.0+5032 build are
+defined but not yet applied to the hosted Supabase project. Until they
+exist, `SyncService.syncVehicles` and `syncFillUps` silently no-op —
+linked devices share favorites + alerts but NOT vehicles and fuel logs
+(a regression against what the sync wizard advertises).
+
+This is a one-time operation. Running it requires credentials that the
+coding agent does not have, so the user must apply it themselves.
+
+## Migration file
+
+```
+supabase/migrations/20260418000001_vehicles_and_fillups.sql
+```
+
+Contents (already committed to this repo):
+- `public.vehicles` — `(user_id, id)` primary key, JSONB `data` blob,
+  RLS policy allowing the owner full access.
+- `public.fill_ups` — `(user_id, id)` primary key with `vehicle_id` +
+  `recorded_at` columns, JSONB `data` blob, RLS policy allowing the
+  owner full access.
+- Indexes on `user_id` for both tables.
+
+## Option A — Supabase CLI (recommended)
+
+```bash
+# One-time setup
+npm install -g supabase        # or use the MSI from supabase.com/docs/guides/cli
+supabase login                  # opens a browser, authenticate as the project owner
+
+# From repo root
+cd supabase
+supabase link --project-ref <PROJECT_REF>   # the ref is in the Supabase dashboard URL
+supabase db push                             # applies all pending migrations
+
+# Verify
+supabase db remote query "SELECT COUNT(*) FROM public.vehicles;"
+# returns 0 — good, the table exists and is empty
+```
+
+## Option B — Dashboard paste (no CLI needed)
+
+1. Open https://supabase.com/dashboard/project/<PROJECT_REF>/sql/new
+2. Paste the contents of
+   `supabase/migrations/20260418000001_vehicles_and_fillups.sql`.
+3. Hit **Run**. Expect "Success. No rows returned."
+4. Inspect the Table Editor to confirm both `vehicles` and `fill_ups`
+   appear under the `public` schema with RLS enabled.
+
+## Verification from the app
+
+1. Trigger a sync: open the app → Settings → Cloud Sync → tap "Sync
+   now".
+2. Watch the Supabase dashboard → Logs → API for `POST /rest/v1/vehicles`
+   and `POST /rest/v1/fill_ups` calls. A 201/200 status confirms the
+   write path works. If you see `42P01 relation does not exist`, the
+   migration did not apply.
+3. On a second linked device, run "Import from linked device" — the
+   vehicles and fill-ups should now appear.
+
+## Autonomous agent limitation
+
+The agent cannot apply the migration because:
+- The Supabase CLI requires an interactive browser-based `supabase
+  login` flow.
+- Hosted project access uses a service-role key that is (correctly) not
+  checked into the repo.
+
+After the migration is applied manually, the `#713` issue can be
+closed. No code changes accompany the migration — the Dart sync layer
+already handles the table's presence gracefully.

--- a/docs/guides/PLAY-STORE-LISTING-REFRESH.md
+++ b/docs/guides/PLAY-STORE-LISTING-REFRESH.md
@@ -1,0 +1,97 @@
+# Play Store listing refresh (#594)
+
+The Fastlane metadata under `fastlane/metadata/android/{en-US,de-DE,fr-FR}/`
+was last updated when the app shipped 7 countries and 10 languages.
+Current production state is 15 country configurations and 23
+localisations. This doc tracks the listing refresh and the screenshot
+production plan.
+
+## What this PR does
+
+1. Refreshes `short_description.txt` and `full_description.txt` for
+   en-US, de-DE, and fr-FR with:
+   - Correct country count (15).
+   - Correct language count (23).
+   - EV charging story (OpenChargeMap integration).
+   - OBD2 / consumption logging story (Bluetooth ELM327, fill-up
+     history, fuzzy calibration).
+   - Updated feature list: route search, velocity alerts, vehicle
+     profiles, Android home-screen widgets.
+2. Adds a new entry under `changelogs/` for the next release (placeholder
+   number; `build-release` bumps it at APK-build time).
+3. Establishes the screenshot production plan below. The agent cannot
+   render real device screenshots — the user produces them and drops
+   them in `phoneScreenshots/` using the filenames listed below.
+
+## Screenshot plan — user produces these, agent only scaffolds
+
+Fastlane expects phone screenshots under
+`fastlane/metadata/android/<locale>/images/phoneScreenshots/`. Required
+dimensions: 1080x1920 (portrait) or 1920x1080 (landscape). File format
+PNG or JPEG. Filename must be numerical prefix for sort order.
+
+### Target set (8 screenshots per locale)
+
+| # | Screen | Why it sells the app |
+|---|---|---|
+| 01 | Search results list with cheapest badge | Core value prop — price visible |
+| 02 | Map view with marker clusters | Visual density, quick spot check |
+| 03 | Station detail with price history chart | Savings timing story |
+| 04 | Favorites list | Daily-use habit |
+| 05 | EV charging station detail with connectors | Multi-fuel story |
+| 06 | Trajets / consumption log with per-trip stats | "Save twice" — behind the wheel |
+| 07 | Radius + velocity price alert settings | Smart notifications story |
+| 08 | Android home-screen widget on a home screen | Glanceable |
+
+### Locale coverage
+
+- **en-US**, **de-DE**, **fr-FR** — mandatory (top 3 markets).
+- **it-IT**, **es-ES** — nice to have; fallback to en-US is acceptable.
+- Other 18 locales — Play Store auto-falls-back to en-US. Do not block
+  launch on localising screenshots for every language.
+
+### Screenshot generation options
+
+- **Android Studio screenshot tool** — `adb exec-out screencap -p >
+  file.png` on a Galaxy S23 or emulator. Raw 1080x2340; crop to
+  1080x1920 or keep full-height (Play Store auto-scales).
+- **screenshots.pro** — free device frames, drag-and-drop.
+- **Figma with device mockup plugins** — best for a designer-polished
+  look with captions.
+
+Keep filenames stable so future listing updates only swap images:
+```
+fastlane/metadata/android/en-US/images/phoneScreenshots/
+├── 01_search_results.png
+├── 02_map_view.png
+├── 03_station_detail.png
+├── 04_favorites.png
+├── 05_ev_station.png
+├── 06_consumption_log.png
+├── 07_price_alerts.png
+└── 08_widget_home.png
+```
+
+### Feature graphic (1024x500)
+
+Exists at `fastlane/metadata/android/<locale>/images/feature_graphic.png`
+for all three locales but should be refreshed to include:
+- The current tagline: "Smarter pump. Smarter drive. Save twice."
+- Flags from 15 supported countries (or a map silhouette).
+- Privacy shield badge ("No ads. No tracking.").
+
+The existing feature graphic is a serviceable placeholder; replace it
+opportunistically, not as a launch blocker.
+
+## Autonomous agent limitation
+
+- The agent refreshed the text (short + full descriptions, changelogs).
+- The agent cannot capture app screenshots from the device. The user
+  runs the app on a Galaxy S23 (per project memory), captures the eight
+  scenes listed above, and drops the PNGs into `phoneScreenshots/`.
+- Once the screenshots land, `fastlane supply --track production
+  --skip_upload_apk` pushes the text + images to Play Console.
+
+Until screenshots are produced the listing can still be updated with
+refreshed copy; Play Console accepts metadata changes independent of
+screenshots.

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -1,23 +1,32 @@
-Tankstellen ist eine kostenlose Open-Source-App zum Vergleich von Kraftstoffpreisen, die Ihnen hilft, das guenstigste Benzin und Diesel in Ihrer Naehe zu finden. Datenschutz steht im Mittelpunkt: keine Werbung, kein Tracking, keine Telemetrie. Ihre Standortdaten verlassen niemals Ihr Geraet, es sei denn, Sie aktivieren die optionale Cloud-Synchronisation.
+Tankstellen ist eine kostenlose Open-Source-App zum Vergleich von Kraftstoff- und EV-Ladepreisen, die Ihnen hilft, an der Zapfsaeule weniger zu zahlen und am Steuer weniger zu verbrauchen. Datenschutz steht im Mittelpunkt: keine Werbung, kein Tracking, keine Telemetrie. Ihre Standortdaten verlassen niemals Ihr Geraet, es sei denn, Sie aktivieren die optionale Cloud-Synchronisation.
 
 FUNKTIONEN
 
-- Echtzeit-Kraftstoffpreise von offiziellen Regierungs-APIs in 7 europaeischen Laendern: Deutschland (Tankerkoenig/MTS-K), Frankreich (Prix Carburants), Italien (MASE/MiSE), Spanien (Geoportal), Polen (UOKiK), Oesterreich (Spritpreisrechner) und Kroatien (MINGOR)
-- Interaktive Karte mit OpenStreetMap-Kacheln und Marker-Clustering fuer schnelles Navigieren auch in dichten Stadtgebieten
-- Suche nach Stadtname, Postleitzahl oder GPS-Position mit einstellbarem Radius
-- Favoritenliste fuer schnellen Zugriff auf Ihre Stammtankstellen
-- Preisverlauf-Diagramme zur Ermittlung des besten Tankzeitpunkts
-- Hintergrund-Preisalarme mit lokalen Benachrichtigungen, wenn Preise unter Ihren Zielwert fallen
-- Material 3 Design mit hellem und dunklem Thema
-- Vollstaendige Lokalisierung in 10 Sprachen: Deutsch, Englisch, Franzoesisch, Italienisch, Spanisch, Polnisch, Kroatisch, Niederlaendisch, Portugiesisch und Tuerkisch
+Preisvergleich in 15 Laendern
+- Echtzeit-Kraftstoffpreise von offiziellen Regierungs-APIs in Deutschland (Tankerkoenig/MTS-K), Frankreich (Prix Carburants), Oesterreich (Spritpreisrechner), Spanien (Geoportal), Italien (MASE/MiSE), Daenemark, Portugal (DGEG), Grossbritannien (GOV.UK), Australien (FuelWatch), Slowenien, Luxemburg, Suedkorea (Opinet), Chile (CNE), Argentinien und Mexiko.
+- Interaktive Karte mit OpenStreetMap-Kacheln und Marker-Clustering fuer schnelles Navigieren auch in dichten Stadtgebieten.
+- Suche nach Stadt, Postleitzahl oder GPS-Position mit einstellbarem Radius.
+- EV-Ladestationen von OpenChargeMap mit Stecker- und Leistungsdetails neben den Kraftstoffpreisen.
+
+Klueger fahren, doppelt sparen
+- Fahrtaufzeichnung ueber den OBD2-Adapter Ihres Fahrzeugs (Bluetooth ELM327) fuer echte Verbrauchsdaten.
+- Trajets-Tab mit Statistiken pro Fahrt, VIN-Dekodierung und Fuzzy-Trainingskalibrierung.
+- Tank-Historie mit Beleg-OCR fuer Super U, Carrefour und generische Layouts.
+- Fahrzeugprofile und CO2-Berechnung pro Fahrt.
+
+Informiert bleiben
+- Radius- und Geschwindigkeits-Preisalarme mit lokalen Push-Benachrichtigungen bei fallenden Preisen.
+- Favoriten, Preisverlaufs-Diagramme und statistisch optimaler Tankzeitpunkt.
+- Android-Startbildschirm-Widgets fuer Favoriten und naechstgelegene Tankstellen.
+- Grenzueberschreitender Preisvergleich fuer Routen, die eine Landesgrenze queren.
 
 DATENSCHUTZ
 
-Tankstellen benoetigt die Standortberechtigung nur bei der aktiven Suche nach Tankstellen in der Naehe. Kein Konto erforderlich. Es werden keine Daten an Dritte uebermittelt. Die App funktioniert vollstaendig offline fuer zwischengespeicherte Ergebnisse.
+Tankstellen benoetigt die Standortberechtigung nur bei der aktiven Suche. Kein Konto erforderlich. Standardmaessig werden keine Daten an Dritte uebermittelt. Die App funktioniert vollstaendig offline fuer zwischengespeicherte Ergebnisse. Vollstaendige Lokalisierung in 23 Sprachen.
 
 OPTIONALE CLOUD-SYNCHRONISATION (TankSync)
 
-Fuer Benutzer, die Favoriten und Preisalarme geraeteuebergreifend synchronisieren moechten, unterstuetzt Tankstellen ein optionales selbst gehostetes Supabase-Backend namens TankSync. Sie betreiben Ihre eigene Instanz, geben URL und anonymen Schluessel ein, und die App synchronisiert Ihre Daten auf Ihren eigenen Server. Volle Datentransparenz: Sie koennen jederzeit alles, was auf dem Server gespeichert ist, einsehen, exportieren oder loeschen.
+Fuer Benutzer, die Favoriten, Fahrzeuge, Tankungen und Alarme geraeteuebergreifend synchronisieren moechten, unterstuetzt Tankstellen ein optionales selbst gehostetes Supabase-Backend namens TankSync. Sie betreiben Ihre eigene Instanz, geben URL und anonymen Schluessel ein, und die App synchronisiert Ihre Daten auf Ihren eigenen Server. Volle Datentransparenz: Sie koennen jederzeit alles einsehen, exportieren oder loeschen.
 
 Push-Benachrichtigungen fuer Preisalarme werden ueber ntfy.sh geliefert, einen Open-Source-Push-Benachrichtigungsdienst, sodass keine Google Play Services oder Firebase erforderlich sind.
 
@@ -27,8 +36,9 @@ Tankstellen ist unter MIT lizenziert. Der vollstaendige Quellcode, Supabase-Migr
 
 UNTERSTUETZTE PLATTFORMEN
 
-- Android (primaere Zielplattform, einschliesslich Android Auto)
-- Chromebook (ueber Android-APK)
+- Android (primaere Zielplattform, einschliesslich Android Auto).
+- Chromebook (ueber Android-APK).
+- iOS — in Entwicklung.
 
 TECHNISCHE DETAILS
 

--- a/fastlane/metadata/android/de-DE/short_description.txt
+++ b/fastlane/metadata/android/de-DE/short_description.txt
@@ -1,1 +1,1 @@
-Kostenloser Spritpreisvergleich. Open Source, keine Werbung, 7 Laender.
+Kostenlose Kraftstoff- und EV-Ladepreise in 15 Laendern. Werbefrei. Ohne Tracking.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,35 +1,47 @@
-Tankstellen is a free, open-source fuel price comparison app that helps you find the cheapest petrol and diesel near you. Built with privacy as a core principle, it contains no ads, no tracking, and no telemetry. Your location data never leaves your device unless you explicitly opt into cloud sync.
+Tankstellen is a free, open-source fuel and EV charging price comparison app that helps you spend less at the pump and burn less fuel behind the wheel. Built with privacy as a core principle, it contains no ads, no tracking, and no telemetry. Your location never leaves your device unless you explicitly opt into cloud sync.
 
 FEATURES
 
-- Real-time fuel prices from official government APIs in 7 European countries: Germany (Tankerkoenig/MTS-K), France (Prix Carburants), Italy (MASE/MiSE), Spain (Geoportal), Poland (UOKiK), Austria (Spritpreisrechner), and Croatia (MINGOR)
-- Interactive map with OpenStreetMap tiles and marker clustering for fast browsing even in dense urban areas
-- Search by city name, postal code, or GPS position with configurable radius
-- Favorites list for quick access to your regular stations
-- Price history charts to identify the best time to fill up
-- Background price alerts with local notifications when prices drop below your target
-- Material 3 design with light and dark themes
-- Full localization in 10 languages: German, English, French, Italian, Spanish, Polish, Croatian, Dutch, Portuguese, and Turkish
+Price comparison across 15 countries
+- Real-time fuel prices from official government APIs in Germany (Tankerkoenig/MTS-K), France (Prix Carburants), Austria (Spritpreisrechner), Spain (Geoportal), Italy (MASE/MiSE), Denmark, Portugal (DGEG), United Kingdom (GOV.UK), Australia (FuelWatch), Slovenia, Luxembourg, South Korea (Opinet), Chile (CNE), Argentina, and Mexico.
+- Interactive map with OpenStreetMap tiles and marker clustering for fast browsing even in dense urban areas.
+- Search by city, postal code, or GPS position with a configurable radius.
+- EV charging stations from OpenChargeMap with connector and power details alongside fuel prices.
 
-PRIVACY FIRST
+Drive smarter, save twice
+- Trip recording with your car's OBD2 adapter (Bluetooth ELM327) for real consumption data.
+- Trajets tab with per-trip statistics, VIN decoding, and fuzzy-training calibration.
+- Fill-up history with receipt OCR for Super U, Carrefour, and generic layouts.
+- Vehicle profiles and per-trip carbon tracking.
 
-Tankstellen requires location permission only when actively searching for nearby stations. No account is needed. No data is collected or transmitted to any third party. The app works entirely offline for cached results.
+Stay in the know
+- Radius and velocity price alerts with local push notifications when prices drop.
+- Station favorites, price history charts, and best-time-to-fill statistics.
+- Android home-screen widgets for favorites and nearest stations.
+- Cross-border price comparison for routes that cross a national boundary.
+
+Privacy-first
+- Location is requested only when actively searching.
+- No account required. No data sent to third parties by default.
+- Works offline for cached results.
+- Full localisation in 23 languages.
 
 OPTIONAL CLOUD SYNC (TankSync)
 
-For users who want to sync favorites and price alerts across multiple devices, Tankstellen supports an optional self-hosted Supabase backend called TankSync. You deploy your own instance, enter the URL and anonymous key, and the app syncs your data to your own server. Full data transparency: you can view, export, or delete everything stored on the server at any time from within the app.
+For users who want to sync favorites, vehicles, fill-ups, and alerts across multiple devices, Tankstellen supports an optional self-hosted Supabase backend called TankSync. You deploy your own instance, enter the URL and anonymous key, and the app syncs to your own server. Full data transparency: view, export, or delete everything at any time from within the app.
 
-Push notifications for price alerts are delivered through ntfy.sh, an open-source push notification service, so no Google Play Services or Firebase is required.
+Push notifications for price alerts are delivered via ntfy.sh, an open-source push notification service, so no Google Play Services or Firebase are required.
 
 OPEN SOURCE
 
-Tankstellen is licensed under MIT. The full source code, Supabase migration scripts, and deployment documentation are available on GitHub. Contributions and translations are welcome.
+Tankstellen is licensed under MIT. Full source code, Supabase migration scripts, and deployment documentation are available on GitHub. Contributions and translations are welcome.
 
 SUPPORTED PLATFORMS
 
-- Android (primary target, including Android Auto)
-- Chromebook (via Android APK)
+- Android (primary target, including Android Auto).
+- Chromebook (via the Android APK).
+- iOS — in development.
 
 TECHNICAL DETAILS
 
-Built with Flutter and Riverpod for state management. All data is stored locally using Hive. Network requests go through a service abstraction layer with automatic fallback chains and caching. The app respects API rate limits and caches responses to minimize network usage.
+Built with Flutter and Riverpod for state management. All data is stored locally with Hive. Network requests go through a service abstraction layer with automatic fallback chains and caching. The app respects API rate limits and caches responses to minimise network usage.

--- a/fastlane/metadata/android/en-US/images/phoneScreenshots/README.md
+++ b/fastlane/metadata/android/en-US/images/phoneScreenshots/README.md
@@ -1,0 +1,23 @@
+# Phone screenshots — en-US
+
+Drop 8 PNGs (1080x1920 preferred) in this directory with the filenames
+below. Fastlane Supply uploads them in numerical order.
+
+| File | Scene |
+|------|------|
+| `01_search_results.png` | Search results list with cheapest-price badge |
+| `02_map_view.png` | Map view with marker clusters |
+| `03_station_detail.png` | Station detail with price history chart |
+| `04_favorites.png` | Favorites tab |
+| `05_ev_station.png` | EV charging station detail (connectors + power) |
+| `06_consumption_log.png` | Trajets / consumption log with per-trip stats |
+| `07_price_alerts.png` | Radius + velocity alert settings |
+| `08_widget_home.png` | Android home-screen widget on a home screen |
+
+**These are temporary placeholders until real captures land.** Replace
+each file one-for-one; the filenames are the stable contract. After
+replacement, delete this README or update the table if the screen set
+changes.
+
+See `docs/guides/PLAY-STORE-LISTING-REFRESH.md` for the full
+production plan and the de-DE / fr-FR localisation strategy.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Free, open-source fuel price comparison. No ads, no tracking, 7 countries.
+Free fuel + EV charging prices across 15 countries. No ads. No tracking. No limits.

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -1,23 +1,32 @@
-Tankstellen est une application gratuite et open source de comparaison des prix des carburants qui vous aide a trouver l'essence et le diesel les moins chers pres de chez vous. Concue avec la vie privee comme principe fondamental, elle ne contient aucune publicite, aucun tracage et aucune telemetrie. Vos donnees de localisation ne quittent jamais votre appareil, sauf si vous activez la synchronisation cloud optionnelle.
+Tankstellen est une application gratuite et open source de comparaison des prix des carburants et de la recharge electrique qui vous aide a payer moins cher a la pompe et a consommer moins au volant. Concue avec la vie privee comme principe fondamental, elle ne contient aucune publicite, aucun tracage et aucune telemetrie. Vos donnees de localisation ne quittent jamais votre appareil, sauf si vous activez la synchronisation cloud optionnelle.
 
 FONCTIONNALITES
 
-- Prix des carburants en temps reel provenant des API gouvernementales officielles dans 7 pays europeens : Allemagne (Tankerkoenig/MTS-K), France (Prix Carburants), Italie (MASE/MiSE), Espagne (Geoportal), Pologne (UOKiK), Autriche (Spritpreisrechner) et Croatie (MINGOR)
-- Carte interactive avec tuiles OpenStreetMap et regroupement de marqueurs pour une navigation rapide meme dans les zones urbaines denses
-- Recherche par nom de ville, code postal ou position GPS avec rayon configurable
-- Liste de favoris pour un acces rapide a vos stations habituelles
-- Graphiques d'historique des prix pour identifier le meilleur moment pour faire le plein
-- Alertes de prix en arriere-plan avec notifications locales quand les prix descendent sous votre seuil
-- Design Material 3 avec themes clair et sombre
-- Localisation complete en 10 langues : allemand, anglais, francais, italien, espagnol, polonais, croate, neerlandais, portugais et turc
+Comparaison de prix dans 15 pays
+- Prix en temps reel provenant des API gouvernementales officielles en Allemagne (Tankerkoenig/MTS-K), France (Prix Carburants), Autriche (Spritpreisrechner), Espagne (Geoportal), Italie (MASE/MiSE), Danemark, Portugal (DGEG), Royaume-Uni (GOV.UK), Australie (FuelWatch), Slovenie, Luxembourg, Coree du Sud (Opinet), Chili (CNE), Argentine et Mexique.
+- Carte interactive avec tuiles OpenStreetMap et regroupement de marqueurs pour une navigation rapide meme dans les zones urbaines denses.
+- Recherche par nom de ville, code postal ou position GPS avec rayon configurable.
+- Bornes de recharge electrique OpenChargeMap avec details des connecteurs et de la puissance a cote des prix des carburants.
+
+Conduire malin, economiser deux fois
+- Enregistrement de trajets via l'adaptateur OBD2 de votre vehicule (Bluetooth ELM327) pour des donnees de consommation reelles.
+- Onglet Trajets avec statistiques par trajet, decodage VIN et calibration par entrainement flou.
+- Historique des pleins avec OCR pour les tickets Super U, Carrefour et generiques.
+- Profils de vehicule et suivi CO2 par trajet.
+
+Restez informe
+- Alertes de prix par rayon et par vitesse avec notifications push locales lorsque les prix baissent.
+- Favoris, graphiques d'historique des prix et meilleur moment statistique pour faire le plein.
+- Widgets d'ecran d'accueil Android pour les favoris et les stations les plus proches.
+- Comparaison transfrontaliere pour les trajets qui traversent une frontiere.
 
 VIE PRIVEE
 
-Tankstellen ne demande la permission de localisation que lors de la recherche active de stations a proximite. Aucun compte necessaire. Aucune donnee n'est collectee ou transmise a un tiers. L'application fonctionne entierement hors ligne pour les resultats mis en cache.
+Tankstellen ne demande la permission de localisation que lors de la recherche active. Aucun compte necessaire. Par defaut, aucune donnee n'est transmise a un tiers. L'application fonctionne entierement hors ligne pour les resultats mis en cache. Localisation complete en 23 langues.
 
 SYNCHRONISATION CLOUD OPTIONNELLE (TankSync)
 
-Pour les utilisateurs souhaitant synchroniser leurs favoris et alertes de prix entre plusieurs appareils, Tankstellen prend en charge un backend Supabase auto-heberge optionnel appele TankSync. Vous deployez votre propre instance, entrez l'URL et la cle anonyme, et l'application synchronise vos donnees sur votre propre serveur. Transparence totale des donnees : vous pouvez consulter, exporter ou supprimer tout ce qui est stocke sur le serveur a tout moment depuis l'application.
+Pour les utilisateurs souhaitant synchroniser leurs favoris, vehicules, pleins et alertes entre plusieurs appareils, Tankstellen prend en charge un backend Supabase auto-heberge optionnel appele TankSync. Vous deployez votre propre instance, entrez l'URL et la cle anonyme, et l'application synchronise vos donnees sur votre propre serveur. Transparence totale des donnees : vous pouvez consulter, exporter ou supprimer tout a tout moment depuis l'application.
 
 Les notifications push pour les alertes de prix sont envoyees via ntfy.sh, un service de notifications push open source, de sorte qu'aucun Google Play Services ni Firebase n'est necessaire.
 
@@ -27,8 +36,9 @@ Tankstellen est sous licence MIT. Le code source complet, les scripts de migrati
 
 PLATEFORMES SUPPORTEES
 
-- Android (plateforme cible principale, y compris Android Auto)
-- Chromebook (via APK Android)
+- Android (plateforme cible principale, y compris Android Auto).
+- Chromebook (via APK Android).
+- iOS — en developpement.
 
 DETAILS TECHNIQUES
 

--- a/fastlane/metadata/android/fr-FR/short_description.txt
+++ b/fastlane/metadata/android/fr-FR/short_description.txt
@@ -1,1 +1,1 @@
-Comparateur de prix carburants gratuit et open source. Sans pub, 7 pays.
+Carburants + recharge electrique dans 15 pays. Sans publicite. Sans tracage.


### PR DESCRIPTION
## Summary

Docs-and-metadata PR that unblocks the three "needs external input" items in the backlog.

- **Refs #594** — Play Store listing: the fastlane copy still advertised 7 countries and 10 languages. Refreshed en-US / de-DE / fr-FR short + full descriptions to 15 countries and 23 languages, added EV charging, Trajets/OBD2, receipt OCR, and home-widget features. Seeded `phoneScreenshots/README.md` with the 8-file contract so the user drops real screenshots using stable filenames.
- **Refs #713** — Supabase migration: `docs/guides/BLOCKER-SUPABASE-MIGRATION.md` walks both the Supabase CLI (`supabase link && supabase db push`) and dashboard-paste paths for applying `20260418000001_vehicles_and_fillups.sql`.
- **Refs #9** — iOS: `docs/guides/BLOCKER-IOS-PROVISIONING.md` audits what's already in `ios/Runner/Info.plist` (location perms, `BGTaskSchedulerPermittedIdentifiers`, background modes) and lists the external steps only the user can do (Apple Dev enrollment, signing, `pod install` on a Mac, re-enabling `build-ios` in CI).

All three resources are explicitly labelled as replaceable placeholders.

## Test plan

- [ ] `flutter analyze` — no source changes, nothing to regress.
- [ ] User reviews fastlane copy for tone / accuracy.
- [ ] User produces real phone screenshots and drops them in `phoneScreenshots/` using the 8 stable filenames from the README.
- [ ] After real screenshots land, delete `phoneScreenshots/README.md`.

## Notes

- Three new tracked docs required `!docs/guides/<name>.md` un-ignore lines in `.gitignore` (same pattern as `NEW_COUNTRY.md`, `AUTONOMOUS-LOOP-PROTOCOL.md`, etc.).
- Does NOT close #594 / #713 / #9 — each still needs the external-input step described in the corresponding doc.