### PR TITLE
fix(widget): add regression guards + instrumentation for #753 diagnosis

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
@@ -267,6 +267,13 @@ object StationWidgetRenderer {
         // Tap the row → open the station detail screen. The id comes from
         // the JSON produced by HomeWidgetService.
         val stationId = station.optString("id", "")
+        // #753 diagnostic — one log per bound row so `adb logcat -s
+        // TankstellenWidget` during repro shows exactly which id was
+        // wired to which visual row. No control-flow change.
+        android.util.Log.d(
+            "TankstellenWidget",
+            "buildRow widgetId=$appWidgetId index=$index id=$stationId brand=${station.optString("brand", "")}",
+        )
         if (stationId.isNotBlank()) {
             val uri = Uri.parse("tankstellenwidget://station?id=$stationId")
             row.setOnClickPendingIntent(

--- a/lib/features/widget/data/home_widget_json.dart
+++ b/lib/features/widget/data/home_widget_json.dart
@@ -1,0 +1,21 @@
+import 'dart:convert';
+
+/// Testable seam for the JSON the home-screen widget reads (#753).
+///
+/// `HomeWidgetService` writes the stations list into SharedPreferences
+/// under `stations_json` / `nearest_json`, and the native Android widget
+/// reads that string back, parses row ids from each entry, and wires
+/// them into the row's PendingIntent. If the list encoding ever drops,
+/// reorders, duplicates, or malforms an `id`, a tap on row N opens the
+/// wrong station — exactly the symptom reported in #753.
+///
+/// Keeping the encoding in a standalone top-level function (no Flutter
+/// or platform-channel dependency) lets a pure Dart test prove the
+/// contract that matters: one id per entry, ids are unique, ids match
+/// the caller's input, and order is preserved.
+///
+/// This is intentionally a thin `jsonEncode` wrapper — the value is the
+/// testability, not the encoding logic.
+String encodeStationsForWidget(List<Map<String, dynamic>> stations) {
+  return jsonEncode(stations);
+}

--- a/lib/features/widget/data/home_widget_service.dart
+++ b/lib/features/widget/data/home_widget_service.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -9,6 +8,7 @@ import '../../../core/data/storage_repository.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/storage/storage_keys.dart';
 import '../../search/domain/entities/fuel_type.dart';
+import 'home_widget_json.dart';
 import 'nearest_widget_data_builder.dart';
 
 /// Manages data for the Android home screen widgets.
@@ -62,7 +62,10 @@ class HomeWidgetService {
       final stations = _buildStationList(storage, favoriteIds, context);
 
       await HomeWidget.saveWidgetData('station_count', stations.length);
-      await HomeWidget.saveWidgetData('stations_json', jsonEncode(stations));
+      await HomeWidget.saveWidgetData(
+        'stations_json',
+        encodeStationsForWidget(stations),
+      );
       await HomeWidget.saveWidgetData(
         'updated_at',
         DateTime.now().toIso8601String(),
@@ -146,7 +149,10 @@ class HomeWidgetService {
       );
 
       await HomeWidget.saveWidgetData('nearest_count', stations.length);
-      await HomeWidget.saveWidgetData('nearest_json', jsonEncode(stations));
+      await HomeWidget.saveWidgetData(
+        'nearest_json',
+        encodeStationsForWidget(stations),
+      );
       await HomeWidget.saveWidgetData(
         'nearest_updated_at',
         DateTime.now().toIso8601String(),

--- a/lib/features/widget/presentation/widget_click_listener.dart
+++ b/lib/features/widget/presentation/widget_click_listener.dart
@@ -44,6 +44,13 @@ class WidgetLaunchHandler {
 
   void handle(Uri? uri) {
     final path = widgetUriToPath(uri);
+    // #753 diagnostic — prints every widget launch so the user can
+    // diff what Kotlin bound to the row (see StationWidgetRenderer
+    // `TankstellenWidget` logcat tag) against what Flutter received.
+    debugPrint(
+      'WidgetLaunchHandler.handle uri=$uri path=$path '
+      'outcome=${path == null ? "rejected" : "pushed"}',
+    );
     if (path == null) return;
     try {
       _router.push(path);

--- a/test/features/widget/data/home_widget_service_json_schema_test.dart
+++ b/test/features/widget/data/home_widget_service_json_schema_test.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/widget/data/home_widget_json.dart';
+
+/// JSON-schema regression guards for the home-screen widget payload (#753).
+///
+/// The widget-tap-opens-wrong-station bug has four suspect hypotheses.
+/// The existing `station_detail_provider_regression_test.dart` locks
+/// down H1/H2/H3 (search-state short-circuit, cross-country collision,
+/// API fallback). THIS file covers H4: the JSON producer itself must
+/// emit exactly one `id` per entry, and those ids must round-trip 1:1
+/// from the input list (same order, same values, no duplicates).
+///
+/// If a regression ever drops, reorders, or malforms the `id` field,
+/// Kotlin's `buildRow` would bind row N's PendingIntent to the wrong
+/// station — precisely the symptom in #753.
+///
+/// These tests intentionally do NOT exercise `home_widget`
+/// platform-channel code (not available in unit tests). They pin the
+/// pure-Dart producer contract via the `encodeStationsForWidget` seam.
+void main() {
+  group('encodeStationsForWidget (#753 — JSON integrity / H4)', () {
+    test('emits one entry per input station, preserving order', () {
+      final stations = [
+        {'id': 'de-1', 'brand': 'Shell'},
+        {'id': 'de-2', 'brand': 'Total'},
+        {'id': 'de-3', 'brand': 'BP'},
+        {'id': 'de-4', 'brand': 'Aral'},
+        {'id': 'de-5', 'brand': 'Esso'},
+      ];
+      final decoded =
+          jsonDecode(encodeStationsForWidget(stations)) as List<dynamic>;
+
+      expect(decoded.length, stations.length,
+          reason: 'JSON length must equal input length — a dropped entry '
+              'shifts every subsequent row to the wrong station id.');
+      for (var i = 0; i < stations.length; i++) {
+        final entry = decoded[i] as Map<String, dynamic>;
+        expect(entry['id'], stations[i]['id'],
+            reason: 'Row $i id must round-trip identical to input; any '
+                'reorder would bind the wrong PendingIntent in Kotlin.');
+      }
+    });
+
+    test('every entry has exactly one `id` field (no malformed rows)', () {
+      final stations = [
+        {'id': 'a', 'brand': 'A'},
+        {'id': 'b', 'brand': 'B'},
+        {'id': 'c', 'brand': 'C'},
+      ];
+      final decoded =
+          jsonDecode(encodeStationsForWidget(stations)) as List<dynamic>;
+
+      for (final raw in decoded) {
+        final entry = raw as Map<String, dynamic>;
+        expect(entry.containsKey('id'), isTrue,
+            reason: 'Missing id would make Kotlin fall back to empty '
+                'string and skip the tap handler entirely.');
+        expect(entry['id'], isA<String>(),
+            reason: 'Kotlin calls optString("id", "") — a non-string '
+                '(e.g. int, null) would silently become "".');
+        expect((entry['id'] as String).isNotEmpty, isTrue,
+            reason: 'Empty id would be a no-op tap — worse than wrong '
+                'tap because the user has no idea why nothing happened.');
+      }
+    });
+
+    test('ids across the payload are unique (no collisions)', () {
+      final stations = [
+        {'id': 'de-1', 'brand': 'Shell'},
+        {'id': 'de-2', 'brand': 'Total'},
+        {'id': 'de-3', 'brand': 'BP'},
+      ];
+      final decoded =
+          jsonDecode(encodeStationsForWidget(stations)) as List<dynamic>;
+
+      final ids = decoded
+          .map((e) => (e as Map<String, dynamic>)['id'] as String)
+          .toList();
+      expect(ids.toSet().length, ids.length,
+          reason: 'Duplicate ids at the widget layer would make two rows '
+              'resolve to the same station — not #753 directly, but the '
+              'canonical sibling bug that would produce similar reports.');
+    });
+
+    test('empty list encodes to `[]`, not null or invalid JSON', () {
+      final encoded = encodeStationsForWidget([]);
+      expect(encoded, '[]');
+      expect(jsonDecode(encoded), isEmpty);
+    });
+
+    test('ids with special chars (slash, dash, encoded) are preserved', () {
+      // OCM ids contain dashes, and a future country API may include
+      // characters that need URI encoding downstream. The JSON layer
+      // must NOT mangle them — the encoding concern belongs to the URI
+      // builder on the Kotlin side (see `Uri.parse("tankstellenwidget://
+      // station?id=$stationId")`), not this payload.
+      final stations = [
+        {'id': 'ocm-42', 'brand': 'EV A'},
+        {'id': 'de-abc/123', 'brand': 'Slash station'},
+        {'id': 'fr-ee-bordeaux-01', 'brand': 'Long id'},
+        {'id': 'it-42 with space', 'brand': 'Space station'},
+      ];
+      final decoded =
+          jsonDecode(encodeStationsForWidget(stations)) as List<dynamic>;
+
+      expect((decoded[0] as Map)['id'], 'ocm-42');
+      expect((decoded[1] as Map)['id'], 'de-abc/123');
+      expect((decoded[2] as Map)['id'], 'fr-ee-bordeaux-01');
+      expect((decoded[3] as Map)['id'], 'it-42 with space');
+    });
+
+    test('output is valid JSON that a JSON parser can round-trip', () {
+      final stations = [
+        {
+          'id': 'de-1',
+          'brand': 'Shell',
+          'name': 'Shell Unter den Linden',
+          'street': 'Unter den Linden 1',
+          'postCode': '10117',
+          'place': 'Berlin',
+          'e5': 1.899,
+          'e10': 1.849,
+          'diesel': 1.799,
+          'isOpen': true,
+          'currency': '€',
+          'distance_km': 2.3,
+        },
+      ];
+      final encoded = encodeStationsForWidget(stations);
+      final decoded = jsonDecode(encoded) as List<dynamic>;
+      expect(decoded.length, 1);
+      final entry = decoded[0] as Map<String, dynamic>;
+      expect(entry['id'], 'de-1');
+      expect(entry['e10'], 1.849);
+      expect(entry['isOpen'], true);
+      expect(entry['currency'], '€');
+    });
+
+    test('extra fields are preserved (no schema strip that could drop id)',
+        () {
+      // Defence-in-depth — if someone refactors the encoder to project
+      // only a known subset of fields, this test ensures `id` survives
+      // alongside whatever else the builder emits. Any schema change
+      // should be a deliberate breaking edit of this test.
+      final stations = [
+        {
+          'id': 'de-1',
+          'brand': 'Shell',
+          'new_future_field': 'value',
+          'another_new_field': 42,
+        },
+      ];
+      final decoded =
+          jsonDecode(encodeStationsForWidget(stations)) as List<dynamic>;
+      final entry = decoded[0] as Map<String, dynamic>;
+      expect(entry['id'], 'de-1');
+      expect(entry['new_future_field'], 'value');
+      expect(entry['another_new_field'], 42);
+    });
+  });
+}

--- a/test/features/widget/presentation/widget_click_listener_test.dart
+++ b/test/features/widget/presentation/widget_click_listener_test.dart
@@ -54,6 +54,87 @@ void main() {
     });
   });
 
+  group('widgetUriToPath (#753 — URI encoding edge cases)', () {
+    // Every station id that reaches the URI builder on the Kotlin side
+    // gets interpolated raw via `Uri.parse("tankstellenwidget://station?
+    // id=$stationId")`. If an id ever contains characters that Uri's
+    // query parser treats specially (`&`, `=`, `%xx`, spaces), the
+    // decoded `queryParameters['id']` can silently differ from the
+    // original. These cases lock in the exact behaviour so any future
+    // regression (e.g. a country whose ids contain `&`) produces a test
+    // failure rather than a wrong-station tap.
+
+    test('id containing `&` — Uri query parser splits at the ampersand, '
+        'the resulting path uses only the pre-`&` portion', () {
+      // When the native side builds `...?id=foo&bar`, `Uri.parse`
+      // treats `&bar` as a separate parameter — the `id` query value is
+      // just `foo`. This pins that behaviour so #753 follow-up can
+      // decide whether to encode ampersands on the Kotlin side.
+      final path = widgetUriToPath(
+        Uri.parse('tankstellenwidget://station?id=foo&bar'),
+      );
+      expect(path, '/station/foo',
+          reason: 'Unencoded `&` in an id truncates it — documenting '
+              'the exact current behaviour so a future encoding fix '
+              'trips this test and forces a review.');
+    });
+
+    test('id with URL-encoded slash (ocm-42%2Ffoo) round-trips to '
+        'the decoded form', () {
+      // `%2F` decodes to `/`. The router path will contain a `/`, which
+      // downstream GoRoute parsing may treat as a path separator — but
+      // THAT is the router's concern. Here we only assert the id is
+      // passed through as decoded by `queryParameters`.
+      final path = widgetUriToPath(
+        Uri.parse('tankstellenwidget://station?id=ocm-42%2Ffoo'),
+      );
+      expect(path, '/ev-station/ocm-42/foo',
+          reason: 'Encoded slash decodes to a literal slash in the id, '
+              'which then becomes part of the router path. If the '
+              'router rejects that, the user sees a no-op instead of a '
+              'wrong station — acceptable trade-off.');
+    });
+
+    test('id with URL-encoded space (%20) round-trips to literal space', () {
+      final path = widgetUriToPath(
+        Uri.parse('tankstellenwidget://station?id=it-42%20milano'),
+      );
+      expect(path, '/station/it-42 milano',
+          reason: 'Space-in-id is a pathological but legal input; the '
+              'decoder should pass it through unchanged so the router '
+              'decides what to do — rather than silently mangling it '
+              'into a different id.');
+    });
+
+    test('id with a literal space — Uri parse treats as separator; '
+        'behaviour must be deterministic (not random across runs)', () {
+      // An un-encoded space in a URI is illegal but `Uri.parse` is
+      // forgiving. Behaviour is deterministic across Dart VM runs;
+      // lock it in so a future `Uri` upgrade doesn't silently change
+      // what the widget tap does.
+      final uri = Uri.parse('tankstellenwidget://station?id=de abc');
+      final path = widgetUriToPath(uri);
+      // Dart's Uri parser keeps the space as-is in queryParameters.
+      expect(path, '/station/de abc');
+    });
+
+    test('id with `+` decodes to space per `application/x-www-form-urlencoded` '
+        '(form-encoded query — the exact behaviour of Uri.queryParameters)',
+        () {
+      // Not the bug, but #753 diagnostics need to know `+` is not a
+      // literal plus in this decoder. If a country's id ever contains
+      // `+`, the native side must `%2B`-encode it or the Flutter side
+      // will see a space.
+      final path = widgetUriToPath(
+        Uri.parse('tankstellenwidget://station?id=a+b'),
+      );
+      expect(path, '/station/a b',
+          reason: 'Uri.queryParameters decodes `+` as space. A real id '
+              'containing `+` must be pre-encoded as `%2B` on the '
+              'Kotlin side or the app will open a sibling station.');
+    });
+  });
+
   group('WidgetLaunchHandler (#587 widget → detail)', () {
     testWidgets(
         'handle() pushes /station/:id onto the real router when called from '
@@ -156,6 +237,58 @@ void main() {
 
       expect(landedOn, '/ev-station/ocm-42');
       expect(find.text('ev ocm-42'), findsOneWidget);
+    });
+
+    testWidgets(
+        'two consecutive handle() calls with different ids — second wins, '
+        'no stale router state (#753 — rapid-tap regression guard)',
+        (tester) async {
+      // If the second tap ever resolved to the first station (e.g. a
+      // lingering setState or a cached path), #753 would reproduce in
+      // isolation. This locks the rapid-tap ordering so a future
+      // refactor of `WidgetLaunchHandler` cannot silently introduce a
+      // race.
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const Text('home')),
+          GoRoute(
+            path: '/station/:id',
+            builder: (_, state) =>
+                Text('station ${state.pathParameters['id']}'),
+          ),
+        ],
+      );
+
+      final container = ProviderContainer(
+        overrides: [routerProvider.overrideWith((_) => router)],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            builder: (context, child) => WidgetClickListener(
+              child: child ?? const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+
+      final handler = container.read(widgetLaunchHandlerProvider);
+      handler.handle(Uri.parse('tankstellenwidget://station?id=first'));
+      await tester.pumpAndSettle();
+      // Router has /station/first on top of the stack.
+      expect(router.state.matchedLocation, '/station/first');
+
+      handler.handle(Uri.parse('tankstellenwidget://station?id=second'));
+      await tester.pumpAndSettle();
+      expect(router.state.matchedLocation, '/station/second',
+          reason: 'Second handle() must win — if this ever fails, the '
+              'widget would open the previously-tapped station instead '
+              'of the one the user just tapped. #753 in isolation.');
     });
 
     testWidgets('invalid URI is a no-op — stays on home', (tester) async {


### PR DESCRIPTION
## Summary

Defensive observability + testable seam for widget-tap-opens-wrong-station (#753). **This is NOT the fix** — no user repro yet. The goal is to make the next report diagnosable in a single session.

Refs #753

## Why

#753 is P0 but has no reliable repro. Rather than speculate a fix, this PR:
1. Closes testable gaps on the last uncovered hypothesis (H4 — JSON integrity).
2. Adds one log line on each side of the native → Flutter boundary so the user's next repro produces a diff-able trace without redeploying.

Hypotheses 1/2/3 (search-state short-circuit, cross-country id collision, API fallback) are already covered by `test/features/station_detail/providers/station_detail_provider_regression_test.dart`.

## What changed

### New testable seam — `lib/features/widget/data/home_widget_json.dart`
Pure-Dart `encodeStationsForWidget(stations)` helper used by `HomeWidgetService`. Lets a unit test pin the payload contract (one id per entry, unique, order preserved, round-trips) without platform channels. Complements the existing ordering test at a lower layer.

### New tests
- `test/features/widget/data/home_widget_service_json_schema_test.dart` — **7 cases** covering H4: JSON integrity (order, uniqueness, exactly-one-id, empty list, special chars, full round-trip, extra-field preservation).
- `test/features/widget/presentation/widget_click_listener_test.dart` — **+6 cases**: 5 URI-encoding edge cases (`&`, `%2F`, `%20`, literal space, `+`) plus a rapid-tap regression guard (second `handle()` wins, no stale router state).

### Instrumentation (logs only — no control-flow change)
- `WidgetLaunchHandler.handle` — one `debugPrint` per invocation with `uri`, parsed `path`, and outcome (`pushed` / `rejected`).
- `StationWidgetRenderer.buildRow` — one `android.util.Log.d("TankstellenWidget", ...)` per bound row with `appWidgetId`, `index`, station `id`, `brand`.

During repro the user can run `adb logcat -s TankstellenWidget` and correlate what Kotlin bound to row N against what Flutter received — pinpointing the exact layer the id is lost at.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test test/features/widget/` — 51 pass
- [x] `flutter test` — 5757 pass
- [x] No RemoteViews / PendingIntent construction changes on Kotlin side — ONLY the new Log.d line
- [x] No behavioural changes in `widgetUriToPath` / `WidgetLaunchHandler.handle` routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)