### PR TITLE
refactor(consumption): split receipt_parser into extractor modules (Refs #563)

### DIFF
--- a/lib/features/consumption/data/receipt_parser.dart
+++ b/lib/features/consumption/data/receipt_parser.dart
@@ -1,51 +1,14 @@
-import 'package:flutter/foundation.dart';
-
 import '../../search/domain/entities/fuel_type.dart';
 import 'receipt_override_registry.dart';
+import 'receipt_parser/brand_detection.dart';
+import 'receipt_parser/brand_layouts.dart';
+import 'receipt_parser/receipt_field_extractors.dart';
+import 'receipt_parser/receipt_parse_result.dart';
 
-/// Structured fields extracted from a fuel receipt by [ReceiptParser].
-///
-/// All fields are nullable because OCR is best-effort: any combination
-/// may be missing depending on the receipt layout. Use [hasData] to check
-/// whether the parser found anything actionable.
-class ReceiptParseResult {
-  /// Volume dispensed in litres, or `null` if no volume could be parsed.
-  final double? liters;
-
-  /// Total amount charged (currency is implicit — typically EUR).
-  final double? totalCost;
-
-  /// Unit price per litre as printed on the receipt.
-  final double? pricePerLiter;
-
-  /// Receipt date if a recognised format was found.
-  final DateTime? date;
-
-  /// Detected station brand (matched against a small built-in list).
-  final String? stationName;
-
-  /// Detected fuel type from the receipt, e.g. "SP95-E10" → [FuelType.e10].
-  /// Null when the receipt doesn't name a recognisable product.
-  final FuelType? fuelType;
-
-  /// Brand layout the parser used — "super_u", "carrefour", or "generic".
-  /// Exposed so tests and telemetry can verify dispatch went to the
-  /// specialised branch when a well-known receipt layout is scanned.
-  final String brandLayout;
-
-  const ReceiptParseResult({
-    this.liters,
-    this.totalCost,
-    this.pricePerLiter,
-    this.date,
-    this.stationName,
-    this.fuelType,
-    this.brandLayout = 'generic',
-  });
-
-  /// `true` when the parser extracted at least volume or total cost.
-  bool get hasData => liters != null || totalCost != null;
-}
+// Re-export the result type so every existing caller that does
+// `import 'receipt_parser.dart'` continues to see `ReceiptParseResult`
+// without touching its own import list (#563 phase: file split only).
+export 'receipt_parser/receipt_parse_result.dart' show ReceiptParseResult;
 
 /// Parses raw OCR text from a fuel station receipt into a
 /// [ReceiptParseResult].
@@ -78,15 +41,15 @@ class ReceiptParser {
     final lines = text.split('\n').map((l) => l.trim()).toList();
     final fullText = lines.join(' ');
 
-    final brand = _detectBrand(lines, fullText);
+    final brand = detectBrand(lines, fullText);
     final initial = switch (brand) {
-      'super_u' => _parseSuperU(fullText, lines),
-      'carrefour' => _parseCarrefour(fullText, lines),
-      _ => _parseGeneric(fullText, lines),
+      'super_u' => parseSuperU(fullText, lines),
+      'carrefour' => parseCarrefour(fullText, lines),
+      _ => parseGeneric(fullText, lines),
     };
 
     final withOverrides = _applyOverrides(initial, text, stationId);
-    return _reconcile(withOverrides);
+    return reconcile(withOverrides);
   }
 
   /// Apply per-station overrides on top of the brand-layout result. Any
@@ -122,7 +85,9 @@ class ReceiptParser {
 
     final overrideDateRaw = spec.date?.extract(text);
     if (overrideDateRaw != null) {
-      final parsed = _parseOverrideDate(overrideDateRaw);
+      // Delegate to the generic extractor so 2-digit years, "-"/"/" /
+      // "." separators all work exactly the way they do elsewhere.
+      final parsed = extractDate(overrideDateRaw);
       if (parsed != null) date = parsed;
     }
 
@@ -133,7 +98,7 @@ class ReceiptParser {
 
     final overrideFuel = spec.fuelType?.extract(text);
     if (overrideFuel != null && overrideFuel.isNotEmpty) {
-      final mapped = _extractFuelType(overrideFuel);
+      final mapped = extractFuelType(overrideFuel);
       if (mapped != null) fuelType = mapped;
     }
 
@@ -154,454 +119,6 @@ class ReceiptParser {
     if (field == null) return null;
     final raw = field.extract(text);
     if (raw == null) return null;
-    return _parseDecimal(raw);
-  }
-
-  /// Run an override-captured date string through the generic date
-  /// builder. Accepts the same DD/MM/YYYY-ish variants the main date
-  /// extractor handles, so a regex that pulls out just the date fragment
-  /// still produces a [DateTime].
-  DateTime? _parseOverrideDate(String raw) {
-    // Delegate to the generic extractor so 2-digit years, "-"/"/" /
-    // "." separators all work exactly the way they do elsewhere.
-    return _extractDate(raw);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Cross-field reconciliation
-  // ---------------------------------------------------------------------------
-
-  /// Enforce the `liters × pricePerLiter ≈ totalCost` invariant. OCR
-  /// routinely loses one of the three, and sometimes grabs the unit
-  /// price as the total (the "2 €" vs "10.47 €" bug on a column-layout
-  /// Super U receipt). Post-process so:
-  ///
-  /// - any two known values derive the third;
-  /// - when all three are known but the product check disagrees by
-  ///   more than 15 %, trust the PAIR that agrees (the two biggest
-  ///   hints: total + pricePerLiter are most often correct from the
-  ///   label regex, so liters gets recomputed);
-  /// - nothing is overwritten when only one field is known.
-  ReceiptParseResult _reconcile(ReceiptParseResult r) {
-    final liters = r.liters;
-    final total = r.totalCost;
-    final ppl = r.pricePerLiter;
-
-    // Fill in any single missing field from the other two.
-    if (liters == null && total != null && ppl != null && ppl > 0) {
-      return _copyWith(r, liters: _round(total / ppl, 2));
-    }
-    if (total == null && liters != null && ppl != null) {
-      return _copyWith(r, totalCost: _round(liters * ppl, 2));
-    }
-    if (ppl == null && liters != null && total != null && liters > 0) {
-      return _copyWith(r, pricePerLiter: _round(total / liters, 3));
-    }
-
-    // All three known: sanity-check their product. OCR's most common
-    // mistake is grabbing the unit price as the total (€ 1.999 instead
-    // of € 10.47), which blows this check by an order of magnitude.
-    if (liters != null && total != null && ppl != null) {
-      final expected = liters * ppl;
-      if (expected > 0 && (total - expected).abs() / expected > 0.15) {
-        // Trust the larger-signal pair. pricePerLiter comes from a
-        // label with a "/L" marker — very reliable. liters comes from
-        // an "X L" suffix — reliable too. Recompute the total.
-        return _copyWith(r, totalCost: _round(expected, 2));
-      }
-    }
-    return r;
-  }
-
-  ReceiptParseResult _copyWith(
-    ReceiptParseResult r, {
-    double? liters,
-    double? totalCost,
-    double? pricePerLiter,
-  }) {
-    return ReceiptParseResult(
-      liters: liters ?? r.liters,
-      totalCost: totalCost ?? r.totalCost,
-      pricePerLiter: pricePerLiter ?? r.pricePerLiter,
-      date: r.date,
-      stationName: r.stationName,
-      fuelType: r.fuelType,
-      brandLayout: r.brandLayout,
-    );
-  }
-
-  double _round(double value, int digits) {
-    const pow10 = [1, 10, 100, 1000];
-    final p = pow10[digits.clamp(0, pow10.length - 1)];
-    return (value * p).round() / p;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Brand detection
-  // ---------------------------------------------------------------------------
-
-  /// Returns a coarse brand key — `super_u`, `carrefour`, `total`, …, or
-  /// `null` when no known retailer is recognised in the first few lines
-  /// or anywhere in the receipt. The key is used to dispatch to
-  /// brand-specific extractors.
-  String? _detectBrand(List<String> lines, String fullText) {
-    final haystack = fullText.toLowerCase();
-    if (haystack.contains('super u') || haystack.contains('système u') ||
-        haystack.contains('systeme u')) {
-      return 'super_u';
-    }
-    if (haystack.contains('carrefour')) return 'carrefour';
-    if (haystack.contains('totalenergies') || haystack.contains('total ')) {
-      return 'total';
-    }
-    if (haystack.contains('intermarché') || haystack.contains('intermarche')) {
-      return 'intermarche';
-    }
-    if (haystack.contains('leclerc')) return 'leclerc';
-    if (haystack.contains('shell')) return 'shell';
-    if (haystack.contains('esso')) return 'esso';
-    if (haystack.contains('aral')) return 'aral';
-    return null;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Brand-specific parsers
-  // ---------------------------------------------------------------------------
-
-  /// Super U / Système U layout. Labels observed on real receipts:
-  ///   Volume   5.24 L
-  ///   Prix     € 1.999/L
-  ///   TOT TTC  € 10.47
-  ReceiptParseResult _parseSuperU(String text, List<String> lines) {
-    return ReceiptParseResult(
-      liters: _extractLiters(text),
-      totalCost: _matchFirst(text, [
-        RegExp(r'tot\s*ttc\s*:?\s*€?\s*(\d+[.,]\d+)', caseSensitive: false),
-        RegExp(r'total\s*ttc\s*:?\s*€?\s*(\d+[.,]\d+)',
-            caseSensitive: false),
-      ]) ?? _extractTotalCost(text),
-      pricePerLiter: _extractPricePerLiter(text),
-      date: _extractDate(text),
-      stationName: _extractStationName(lines),
-      fuelType: _extractFuelType(text),
-      brandLayout: 'super_u',
-    );
-  }
-
-  /// Carrefour / Carrefour Market / Carrefour Express layout. Observed:
-  ///   No pompe    = 6
-  ///   Carburant   = SP95
-  ///   Quantite    = 5.27 L
-  ///   Prix unit.  = 2,028 EUR
-  ///   MONTANT REEL : 10.69 EUR
-  ReceiptParseResult _parseCarrefour(String text, List<String> lines) {
-    return ReceiptParseResult(
-      liters: _matchFirst(text, [
-        RegExp(r'quantit[eé]\s*[:=]\s*(\d+[.,]\d+)', caseSensitive: false),
-      ]) ?? _extractLiters(text),
-      totalCost: _matchFirst(text, [
-        RegExp(r'montant\s*(?:reel|r[eé]el|ttc)?\s*[:=]?\s*€?\s*(\d+[.,]\d+)',
-            caseSensitive: false),
-      ]) ?? _extractTotalCost(text),
-      pricePerLiter: _matchFirst(text, [
-        RegExp(r'prix\s*unit\.?\s*[:=]?\s*€?\s*(\d+[.,]\d{2,3})',
-            caseSensitive: false),
-      ]) ?? _extractPricePerLiter(text),
-      date: _extractDate(text),
-      stationName: _extractStationName(lines),
-      fuelType: _extractFuelType(text),
-      brandLayout: 'carrefour',
-    );
-  }
-
-  /// Generic fallback — everything that isn't a known retailer.
-  ReceiptParseResult _parseGeneric(String text, List<String> lines) {
-    return ReceiptParseResult(
-      liters: _extractLiters(text),
-      totalCost: _extractTotalCost(text),
-      pricePerLiter: _extractPricePerLiter(text),
-      date: _extractDate(text),
-      stationName: _extractStationName(lines),
-      fuelType: _extractFuelType(text),
-    );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Shared extractors
-  // ---------------------------------------------------------------------------
-
-  /// Detect the fuel product code on the receipt. Supports European labels
-  /// like "SP95-E10", "Super E10", "E10", "Gazole", "Diesel", "E85",
-  /// "GPL", "GNV/CNG", etc.
-  ///
-  /// French retailers (TotalEnergies, Intermarché) emit compound codes
-  /// with no separator — `SP95E5`, `SP95E10`, `SP98E5` — which the old
-  /// `sp95-e10` / `\be10\b` regexes missed because there was no word
-  /// boundary between the `5` and the `e10`. The compound forms now
-  /// have explicit patterns; order still matters (E10 before E5 before
-  /// E85 so longer codes win).
-  FuelType? _extractFuelType(String text) {
-    final lower = text.toLowerCase();
-    // E85 first — "e85" contains "e5" as a substring-via-boundary edge
-    // case on some OCR outputs where the 8 reads as 3 or falls out.
-    if (RegExp(r'\be85\b|sp95\s*-?\s*e?\s*85|bio\s*[eé]thanol')
-        .hasMatch(lower)) {
-      return FuelType.e85;
-    }
-    // E10 — match compound (SP95E10, SP95-E10, SP95 E10) and standalone.
-    if (RegExp(r'sp95\s*-?\s*e\s*10|sp95e10|\be10\b|super\s*e10')
-        .hasMatch(lower)) {
-      return FuelType.e10;
-    }
-    // E5 — SP95 without an E10 suffix, or compound SP95E5.
-    if (RegExp(r'sp95\s*-?\s*e\s*5\b|sp95e5\b|\be5\b|sp95(?!\s*-?\s*e\s*10)|super\s*e5')
-        .hasMatch(lower)) {
-      return FuelType.e5;
-    }
-    if (RegExp(r'\be98\b|sp98|super\s*98').hasMatch(lower)) {
-      return FuelType.e98;
-    }
-    if (RegExp(r'diesel\s*premium|premium\s*diesel|gazole\s*premium')
-        .hasMatch(lower)) {
-      return FuelType.dieselPremium;
-    }
-    if (RegExp(r'\bdiesel\b|\bgazole\b|\bb7\b').hasMatch(lower)) {
-      return FuelType.diesel;
-    }
-    if (RegExp(r'\bgpl\b|\blpg\b').hasMatch(lower)) {
-      return FuelType.lpg;
-    }
-    if (RegExp(r'\bgnv\b|\bcng\b').hasMatch(lower)) {
-      return FuelType.cng;
-    }
-    return null;
-  }
-
-  /// Matches patterns like "42.35 L", "42,35 l", "42.35litres" (no
-  /// space, happens when OCR eats the separator), "VOLUME 42.35",
-  /// "Quantité = 5.27".
-  ///
-  /// Filters pathological matches: the value must be in [0.1, 300] L,
-  /// the typical fill range for passenger cars (excludes things like
-  /// "20.00" from "TVA 20.00 %" or year fragments from a date).
-  double? _extractLiters(String text) {
-    final patterns = [
-      // "42.35 L" / "42,35 l" / "5.24L" / "42.35 litres" / "5.24 ℓ".
-      // The U+2113 script `ℓ` symbol is what French thermal printers
-      // use for the litre unit — ML Kit OCR passes it through verbatim
-      // and Latin-only [lL] silently misses it (user report 2026-04-20
-      // on a Super U Pomerols receipt). The \b anchor is dropped for
-      // ℓ because Dart regex treats the character as non-word, so the
-      // original word boundary never held anyway.
-      RegExp(r'(\d{1,3}[.,]\d{1,3})\s*(?:l(?:itres?)?\b|L\b|\u2113)'),
-      // "VOLUME : 42.35" / "Volume: 42,35" / "Quantité = 5.27"
-      RegExp(
-        r'(?:volume|quantit[eé])\s*[:=]?\s*(\d{1,3}[.,]\d{1,3})',
-        caseSensitive: false,
-      ),
-      // "5,00 x SP95E5" / "42,50 X GAZOLE" / "10,00 × SP98" — French
-      // line-item format used by TotalEnergies, Intermarché and many
-      // independents (user report 2026-04-21, #801). Fuel codes after
-      // `x` are the French standard: SP95/SP98/E85/GAZOLE/GPL with
-      // compound E5/E10 suffixes.
-      RegExp(
-        r'(\d{1,3}[.,]\d{1,3})\s*[xX×]\s*'
-        r'(?:sp95e?5|sp95e10|sp98e?5|sp95|sp98|e85|gazole|gpl|gplc|b7|diesel|go)\b',
-        caseSensitive: false,
-      ),
-    ];
-    for (final pattern in patterns) {
-      for (final match in pattern.allMatches(text)) {
-        final value = _parseDecimal(match.group(1)!);
-        if (value != null && value > 0.1 && value < 300) return value;
-      }
-    }
-    return null;
-  }
-
-  /// Matches patterns like "TOTAL 58.42", "MONTANT 58,42 EUR",
-  /// "TOT TTC 10.47", "MONTANT REEL : 10.69", "€ 58.42".
-  ///
-  /// The generic `€ [amount]` fallback is only used when no explicit label
-  /// matches and the amount is NOT immediately followed by `/L` — otherwise
-  /// we would pick up the unit price as the total.
-  double? _extractTotalCost(String text) {
-    final labelled = _matchFirst(text, [
-      // TOTAL / TOT TTC / MONTANT[ REEL / TTC] / TTC / German labels.
-      // Accept ":" or "=" between label and amount, optional €.
-      RegExp(
-        r'(?:total|tot\s*ttc|montant(?:\s*(?:ttc|reel|r[eé]el))?|ttc|'
-        r'betrag|summe|gesamt)'
-        r'\s*[:=]?\s*€?\s*(\d+[.,]\d+)',
-        caseSensitive: false,
-      ),
-    ]);
-    if (labelled != null) return labelled;
-
-    // Heuristic fallback: gather every standalone amount attached to
-    // €/EUR that isn't a price-per-liter (no "/L" suffix), then pick
-    // the LARGEST. Rationale: on a fuel receipt the unit price, tax,
-    // and net all live around the total, but the total is almost
-    // always the biggest number on the paper. Picking "first" grabs
-    // the price-per-liter on column-layout receipts like Super U,
-    // where OCR emits "€ 1.999/L ... € 10.47" — or even skips the
-    // "/L" suffix, so "first" becomes 1.999.
-    final currencyPattern = RegExp(
-      r'(?:€\s*(\d+[.,]\d+)|(\d+[.,]\d+)\s*(?:€|EUR))(\s*/\s*[lL])?',
-    );
-    double? best;
-    for (final match in currencyPattern.allMatches(text)) {
-      if (match.group(3) != null) continue; // "/L" suffix → unit price
-      final raw = match.group(1) ?? match.group(2);
-      if (raw == null) continue;
-      final value = _parseDecimal(raw);
-      if (value == null || value <= 0) continue;
-      // Filter obvious non-totals: nobody's total is < 1 €, nobody's
-      // total is > 10 000 €.
-      if (value < 1 || value > 10000) continue;
-      // #801 — 3-decimal European amounts like `1,990 €` are fuel
-      // price-per-liter, never totals. Without this guard on the
-      // TotalEnergies receipt the parser grabbed `1,990 €` as the
-      // total and the user saw 1.99 € in the form instead of 9.95 €.
-      // Totals are always 2-decimal in EUR.
-      if (_decimalDigitCount(raw) >= 3 && value < 5) continue;
-      if (best == null || value > best) best = value;
-    }
-    return best;
-  }
-
-  /// Count decimal digits in a European-formatted decimal string
-  /// (accepts `.` or `,` as separator). Returns 0 when no separator
-  /// is found. Used to distinguish 3-decimal fuel prices from
-  /// 2-decimal totals without trusting `double` precision.
-  int _decimalDigitCount(String raw) {
-    final sepIndex = raw.lastIndexOf(RegExp(r'[.,]'));
-    if (sepIndex < 0) return 0;
-    return raw.length - sepIndex - 1;
-  }
-
-  /// Matches price-per-liter: "1.899 €/L", "€ 1,999/L", "PU: 1,899",
-  /// "PRIX/L 1.899", "Prix unit. = 2,028 EUR", "Literpreis: 1.799".
-  double? _extractPricePerLiter(String text) {
-    final labelled = _matchFirst(text, [
-      // "1.899 €/L" or "1,899 EUR/L" — also "1.999 €/ℓ" (U+2113).
-      RegExp(r'(\d+[.,]\d{2,3})\s*(?:€|EUR)\s*/\s*[lL\u2113]'),
-      // "€ 1.999/L" or "EUR 1,999/L" / "€ 1.999/ℓ" — currency before number.
-      RegExp(r'(?:€|EUR)\s*(\d+[.,]\d{2,3})\s*/\s*[lL\u2113]'),
-      // Labels: PRIX/L, PU, Preis/L, Literpreis, Prix unit(.), Preis je Liter.
-      // Also accepts `ℓ` in place of `l` in the slash-L forms.
-      RegExp(
-        r'(?:prix\s*/\s*[l\u2113]|prix\s*unit\.?|pu|preis\s*/\s*[l\u2113]|'
-        r'preis\s*je\s*liter|literpreis)'
-        r'\s*[:=]?\s*€?\s*(\d+[.,]\d{2,3})',
-        caseSensitive: false,
-      ),
-    ]);
-    if (labelled != null) return labelled;
-
-    // #801 — TotalEnergies / independent French receipts often emit
-    // the unit price as a bare `1,990 €` (3-decimal digits, no `/L`
-    // suffix) on the line below a `QTY x FUELCODE` item line. Without
-    // this heuristic the amount was either missed entirely or grabbed
-    // as the total. 3 decimal digits + euro suffix + plausible
-    // fuel-price range (0.5-3.0 €/L) is a strong enough signal to
-    // accept without the explicit `/L` marker.
-    // Note on the lookbehind-free check: `\b` after `€` doesn't hold
-    // (both `€` and a trailing space are non-word chars in Dart
-    // regex, so no boundary sits between them). The negative
-    // lookahead for `/L` is the only disambiguator we need — any
-    // 3-decimal euro amount NOT followed by `/L` is the unit price.
-    final bareFuelPrice =
-        RegExp(r'(\d+[.,]\d{3})\s*(?:€|EUR)(?!\s*/\s*[lLℓ])');
-    for (final match in bareFuelPrice.allMatches(text)) {
-      final raw = match.group(1);
-      if (raw == null) continue;
-      final value = _parseDecimal(raw);
-      if (value == null) continue;
-      if (value >= 0.5 && value <= 3.0) return value;
-    }
-    return null;
-  }
-
-  /// Matches common date formats: DD/MM/YYYY, DD.MM.YYYY, DD-MM-YYYY,
-  /// plus 2-digit-year variants like "19/04/26" (assumed 20xx).
-  ///
-  /// Iterates all matches (not just the first) because phone numbers
-  /// like "04.67.77.29.10" look enough like `DD.MM.YY` that the first
-  /// match is often noise. The first match whose day + month pass the
-  /// calendar sanity check wins.
-  DateTime? _extractDate(String text) {
-    // 4-digit year — preferred when present.
-    final fourDigit = RegExp(r'(\d{2})[/.\-](\d{2})[/.\-](\d{4})');
-    for (final match in fourDigit.allMatches(text)) {
-      final d = _buildDate(match.group(1)!, match.group(2)!, match.group(3)!);
-      if (d != null) return d;
-    }
-    // 2-digit year fallback — covers "19/04/26" on Carrefour receipts.
-    final twoDigit =
-        RegExp(r'(?<!\d)(\d{2})[/.\-](\d{2})[/.\-](\d{2})(?!\d)');
-    for (final match in twoDigit.allMatches(text)) {
-      final d = _buildDate(
-        match.group(1)!,
-        match.group(2)!,
-        '20${match.group(3)!}', // assume post-2000 for receipts
-      );
-      if (d != null) return d;
-    }
-    return null;
-  }
-
-  DateTime? _buildDate(String dayStr, String monthStr, String yearStr) {
-    try {
-      final day = int.parse(dayStr);
-      final month = int.parse(monthStr);
-      final year = int.parse(yearStr);
-      if (month < 1 || month > 12) return null;
-      if (day < 1 || day > 31) return null;
-      return DateTime(year, month, day);
-    } on FormatException catch (e) {
-      debugPrint('Receipt date parse failed for "$dayStr/$monthStr/$yearStr": $e');
-      return null;
-    }
-  }
-
-  /// Try to find a station brand name in the first few lines.
-  String? _extractStationName(List<String> lines) {
-    const brands = [
-      'total', 'totalenergies', 'shell', 'bp', 'aral', 'esso',
-      'avia', 'jet', 'elf', 'agip', 'q8', 'omv', 'mol', 'orlen',
-      'intermarché', 'intermarche', 'leclerc', 'carrefour', 'auchan',
-      'super u', 'système u', 'systeme u', 'casino',
-    ];
-
-    for (final line in lines.take(5)) {
-      final lower = line.toLowerCase().trim();
-      for (final brand in brands) {
-        // Match brand as a standalone word or the whole line
-        if (lower == brand ||
-            lower.startsWith('$brand ') ||
-            lower.startsWith('$brand\t')) {
-          return line;
-        }
-      }
-    }
-    return null;
-  }
-
-  /// Returns the first successful captured group decimal across
-  /// [patterns], or null if none match.
-  double? _matchFirst(String text, List<RegExp> patterns) {
-    for (final pattern in patterns) {
-      final match = pattern.firstMatch(text);
-      if (match != null && match.group(1) != null) {
-        return _parseDecimal(match.group(1)!);
-      }
-    }
-    return null;
-  }
-
-  double? _parseDecimal(String value) {
-    final normalized = value.replaceAll(',', '.');
-    return double.tryParse(normalized);
+    return parseDecimal(raw);
   }
 }

--- a/lib/features/consumption/data/receipt_parser/brand_detection.dart
+++ b/lib/features/consumption/data/receipt_parser/brand_detection.dart
@@ -1,0 +1,51 @@
+// Brand-name heuristics that sit between the raw OCR lines and the
+// per-layout parsers in `brand_layouts.dart`. Kept separate from the
+// numeric field extractors so the brand string list is easy to grow
+// without spilling into regex territory.
+
+/// Returns a coarse brand key — `super_u`, `carrefour`, `total`, …, or
+/// `null` when no known retailer is recognised anywhere in the receipt.
+/// The key is used by `ReceiptParser.parse` to dispatch to brand-
+/// specific extractors.
+String? detectBrand(List<String> lines, String fullText) {
+  final haystack = fullText.toLowerCase();
+  if (haystack.contains('super u') || haystack.contains('système u') ||
+      haystack.contains('systeme u')) {
+    return 'super_u';
+  }
+  if (haystack.contains('carrefour')) return 'carrefour';
+  if (haystack.contains('totalenergies') || haystack.contains('total ')) {
+    return 'total';
+  }
+  if (haystack.contains('intermarché') || haystack.contains('intermarche')) {
+    return 'intermarche';
+  }
+  if (haystack.contains('leclerc')) return 'leclerc';
+  if (haystack.contains('shell')) return 'shell';
+  if (haystack.contains('esso')) return 'esso';
+  if (haystack.contains('aral')) return 'aral';
+  return null;
+}
+
+/// Try to find a station brand name in the first few lines.
+String? extractStationName(List<String> lines) {
+  const brands = [
+    'total', 'totalenergies', 'shell', 'bp', 'aral', 'esso',
+    'avia', 'jet', 'elf', 'agip', 'q8', 'omv', 'mol', 'orlen',
+    'intermarché', 'intermarche', 'leclerc', 'carrefour', 'auchan',
+    'super u', 'système u', 'systeme u', 'casino',
+  ];
+
+  for (final line in lines.take(5)) {
+    final lower = line.toLowerCase().trim();
+    for (final brand in brands) {
+      // Match brand as a standalone word or the whole line
+      if (lower == brand ||
+          lower.startsWith('$brand ') ||
+          lower.startsWith('$brand\t')) {
+        return line;
+      }
+    }
+  }
+  return null;
+}

--- a/lib/features/consumption/data/receipt_parser/brand_layouts.dart
+++ b/lib/features/consumption/data/receipt_parser/brand_layouts.dart
@@ -1,0 +1,134 @@
+import 'brand_detection.dart';
+import 'receipt_field_extractors.dart';
+import 'receipt_parse_result.dart';
+
+// Per-brand dispatch + cross-field reconciliation. These functions
+// compose the pure extractors from `receipt_field_extractors.dart`
+// into a `ReceiptParseResult`. Split out of `ReceiptParser` so each
+// layout is independently readable + unit-testable.
+
+/// Super U / Système U layout. Labels observed on real receipts:
+///   Volume   5.24 L
+///   Prix     € 1.999/L
+///   TOT TTC  € 10.47
+ReceiptParseResult parseSuperU(String text, List<String> lines) {
+  return ReceiptParseResult(
+    liters: extractLiters(text),
+    totalCost: matchFirst(text, [
+      RegExp(r'tot\s*ttc\s*:?\s*€?\s*(\d+[.,]\d+)', caseSensitive: false),
+      RegExp(r'total\s*ttc\s*:?\s*€?\s*(\d+[.,]\d+)', caseSensitive: false),
+    ]) ?? extractTotalCost(text),
+    pricePerLiter: extractPricePerLiter(text),
+    date: extractDate(text),
+    stationName: extractStationName(lines),
+    fuelType: extractFuelType(text),
+    brandLayout: 'super_u',
+  );
+}
+
+/// Carrefour / Carrefour Market / Carrefour Express layout. Observed:
+///   No pompe    = 6
+///   Carburant   = SP95
+///   Quantite    = 5.27 L
+///   Prix unit.  = 2,028 EUR
+///   MONTANT REEL : 10.69 EUR
+ReceiptParseResult parseCarrefour(String text, List<String> lines) {
+  return ReceiptParseResult(
+    liters: matchFirst(text, [
+      RegExp(r'quantit[eé]\s*[:=]\s*(\d+[.,]\d+)', caseSensitive: false),
+    ]) ?? extractLiters(text),
+    totalCost: matchFirst(text, [
+      RegExp(r'montant\s*(?:reel|r[eé]el|ttc)?\s*[:=]?\s*€?\s*(\d+[.,]\d+)',
+          caseSensitive: false),
+    ]) ?? extractTotalCost(text),
+    pricePerLiter: matchFirst(text, [
+      RegExp(r'prix\s*unit\.?\s*[:=]?\s*€?\s*(\d+[.,]\d{2,3})',
+          caseSensitive: false),
+    ]) ?? extractPricePerLiter(text),
+    date: extractDate(text),
+    stationName: extractStationName(lines),
+    fuelType: extractFuelType(text),
+    brandLayout: 'carrefour',
+  );
+}
+
+/// Generic fallback — everything that isn't a known retailer.
+ReceiptParseResult parseGeneric(String text, List<String> lines) {
+  return ReceiptParseResult(
+    liters: extractLiters(text),
+    totalCost: extractTotalCost(text),
+    pricePerLiter: extractPricePerLiter(text),
+    date: extractDate(text),
+    stationName: extractStationName(lines),
+    fuelType: extractFuelType(text),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-field reconciliation
+// ---------------------------------------------------------------------------
+
+/// Enforce the `liters × pricePerLiter ≈ totalCost` invariant. OCR
+/// routinely loses one of the three, and sometimes grabs the unit
+/// price as the total (the "2 €" vs "10.47 €" bug on a column-layout
+/// Super U receipt). Post-process so:
+///
+/// - any two known values derive the third;
+/// - when all three are known but the product check disagrees by
+///   more than 15 %, trust the PAIR that agrees (the two biggest
+///   hints: total + pricePerLiter are most often correct from the
+///   label regex, so liters gets recomputed);
+/// - nothing is overwritten when only one field is known.
+ReceiptParseResult reconcile(ReceiptParseResult r) {
+  final liters = r.liters;
+  final total = r.totalCost;
+  final ppl = r.pricePerLiter;
+
+  // Fill in any single missing field from the other two.
+  if (liters == null && total != null && ppl != null && ppl > 0) {
+    return _copyWith(r, liters: _round(total / ppl, 2));
+  }
+  if (total == null && liters != null && ppl != null) {
+    return _copyWith(r, totalCost: _round(liters * ppl, 2));
+  }
+  if (ppl == null && liters != null && total != null && liters > 0) {
+    return _copyWith(r, pricePerLiter: _round(total / liters, 3));
+  }
+
+  // All three known: sanity-check their product. OCR's most common
+  // mistake is grabbing the unit price as the total (€ 1.999 instead
+  // of € 10.47), which blows this check by an order of magnitude.
+  if (liters != null && total != null && ppl != null) {
+    final expected = liters * ppl;
+    if (expected > 0 && (total - expected).abs() / expected > 0.15) {
+      // Trust the larger-signal pair. pricePerLiter comes from a
+      // label with a "/L" marker — very reliable. liters comes from
+      // an "X L" suffix — reliable too. Recompute the total.
+      return _copyWith(r, totalCost: _round(expected, 2));
+    }
+  }
+  return r;
+}
+
+ReceiptParseResult _copyWith(
+  ReceiptParseResult r, {
+  double? liters,
+  double? totalCost,
+  double? pricePerLiter,
+}) {
+  return ReceiptParseResult(
+    liters: liters ?? r.liters,
+    totalCost: totalCost ?? r.totalCost,
+    pricePerLiter: pricePerLiter ?? r.pricePerLiter,
+    date: r.date,
+    stationName: r.stationName,
+    fuelType: r.fuelType,
+    brandLayout: r.brandLayout,
+  );
+}
+
+double _round(double value, int digits) {
+  const pow10 = [1, 10, 100, 1000];
+  final p = pow10[digits.clamp(0, pow10.length - 1)];
+  return (value * p).round() / p;
+}

--- a/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
@@ -1,0 +1,262 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../search/domain/entities/fuel_type.dart';
+
+// Pure-function extractors shared by the generic matcher and the
+// per-brand layouts. Kept top-level + stateless so they can be unit-
+// tested and composed without instantiating `ReceiptParser`.
+//
+// Brand detection (brand key + station-name lookup) lives next door in
+// `brand_detection.dart`.
+
+/// Detect the fuel product code on the receipt. Supports European labels
+/// like "SP95-E10", "Super E10", "E10", "Gazole", "Diesel", "E85",
+/// "GPL", "GNV/CNG", etc.
+///
+/// French retailers (TotalEnergies, Intermarché) emit compound codes
+/// with no separator — `SP95E5`, `SP95E10`, `SP98E5` — which the old
+/// `sp95-e10` / `\be10\b` regexes missed because there was no word
+/// boundary between the `5` and the `e10`. The compound forms now
+/// have explicit patterns; order still matters (E10 before E5 before
+/// E85 so longer codes win).
+FuelType? extractFuelType(String text) {
+  final lower = text.toLowerCase();
+  // E85 first — "e85" contains "e5" as a substring-via-boundary edge
+  // case on some OCR outputs where the 8 reads as 3 or falls out.
+  if (RegExp(r'\be85\b|sp95\s*-?\s*e?\s*85|bio\s*[eé]thanol')
+      .hasMatch(lower)) {
+    return FuelType.e85;
+  }
+  // E10 — match compound (SP95E10, SP95-E10, SP95 E10) and standalone.
+  if (RegExp(r'sp95\s*-?\s*e\s*10|sp95e10|\be10\b|super\s*e10')
+      .hasMatch(lower)) {
+    return FuelType.e10;
+  }
+  // E5 — SP95 without an E10 suffix, or compound SP95E5.
+  if (RegExp(r'sp95\s*-?\s*e\s*5\b|sp95e5\b|\be5\b|sp95(?!\s*-?\s*e\s*10)|super\s*e5')
+      .hasMatch(lower)) {
+    return FuelType.e5;
+  }
+  if (RegExp(r'\be98\b|sp98|super\s*98').hasMatch(lower)) {
+    return FuelType.e98;
+  }
+  if (RegExp(r'diesel\s*premium|premium\s*diesel|gazole\s*premium')
+      .hasMatch(lower)) {
+    return FuelType.dieselPremium;
+  }
+  if (RegExp(r'\bdiesel\b|\bgazole\b|\bb7\b').hasMatch(lower)) {
+    return FuelType.diesel;
+  }
+  if (RegExp(r'\bgpl\b|\blpg\b').hasMatch(lower)) {
+    return FuelType.lpg;
+  }
+  if (RegExp(r'\bgnv\b|\bcng\b').hasMatch(lower)) {
+    return FuelType.cng;
+  }
+  return null;
+}
+
+/// Matches patterns like "42.35 L", "42,35 l", "42.35litres" (no
+/// space, happens when OCR eats the separator), "VOLUME 42.35",
+/// "Quantité = 5.27".
+///
+/// Filters pathological matches: the value must be in [0.1, 300] L,
+/// the typical fill range for passenger cars (excludes things like
+/// "20.00" from "TVA 20.00 %" or year fragments from a date).
+double? extractLiters(String text) {
+  final patterns = [
+    // "42.35 L" / "42,35 l" / "5.24L" / "42.35 litres" / "5.24 ℓ".
+    // The U+2113 script `ℓ` symbol is what French thermal printers
+    // use for the litre unit — ML Kit OCR passes it through verbatim
+    // and Latin-only [lL] silently misses it (user report 2026-04-20
+    // on a Super U Pomerols receipt). The \b anchor is dropped for
+    // ℓ because Dart regex treats the character as non-word, so the
+    // original word boundary never held anyway.
+    RegExp(r'(\d{1,3}[.,]\d{1,3})\s*(?:l(?:itres?)?\b|L\b|ℓ)'),
+    // "VOLUME : 42.35" / "Volume: 42,35" / "Quantité = 5.27"
+    RegExp(
+      r'(?:volume|quantit[eé])\s*[:=]?\s*(\d{1,3}[.,]\d{1,3})',
+      caseSensitive: false,
+    ),
+    // "5,00 x SP95E5" / "42,50 X GAZOLE" / "10,00 × SP98" — French
+    // line-item format used by TotalEnergies, Intermarché and many
+    // independents (user report 2026-04-21, #801). Fuel codes after
+    // `x` are the French standard: SP95/SP98/E85/GAZOLE/GPL with
+    // compound E5/E10 suffixes.
+    RegExp(
+      r'(\d{1,3}[.,]\d{1,3})\s*[xX×]\s*'
+      r'(?:sp95e?5|sp95e10|sp98e?5|sp95|sp98|e85|gazole|gpl|gplc|b7|diesel|go)\b',
+      caseSensitive: false,
+    ),
+  ];
+  for (final pattern in patterns) {
+    for (final match in pattern.allMatches(text)) {
+      final value = parseDecimal(match.group(1)!);
+      if (value != null && value > 0.1 && value < 300) return value;
+    }
+  }
+  return null;
+}
+
+/// Matches patterns like "TOTAL 58.42", "MONTANT 58,42 EUR",
+/// "TOT TTC 10.47", "MONTANT REEL : 10.69", "€ 58.42".
+///
+/// The generic `€ [amount]` fallback is only used when no explicit label
+/// matches and the amount is NOT immediately followed by `/L` — otherwise
+/// we would pick up the unit price as the total.
+double? extractTotalCost(String text) {
+  final labelled = matchFirst(text, [
+    // TOTAL / TOT TTC / MONTANT[ REEL / TTC] / TTC / German labels.
+    // Accept ":" or "=" between label and amount, optional €.
+    RegExp(
+      r'(?:total|tot\s*ttc|montant(?:\s*(?:ttc|reel|r[eé]el))?|ttc|'
+      r'betrag|summe|gesamt)'
+      r'\s*[:=]?\s*€?\s*(\d+[.,]\d+)',
+      caseSensitive: false,
+    ),
+  ]);
+  if (labelled != null) return labelled;
+
+  // Heuristic fallback: gather every standalone amount attached to
+  // €/EUR that isn't a price-per-liter (no "/L" suffix), then pick
+  // the LARGEST. Rationale: on a fuel receipt the unit price, tax,
+  // and net all live around the total, but the total is almost
+  // always the biggest number on the paper. Picking "first" grabs
+  // the price-per-liter on column-layout receipts like Super U,
+  // where OCR emits "€ 1.999/L ... € 10.47" — or even skips the
+  // "/L" suffix, so "first" becomes 1.999.
+  final currencyPattern = RegExp(
+    r'(?:€\s*(\d+[.,]\d+)|(\d+[.,]\d+)\s*(?:€|EUR))(\s*/\s*[lL])?',
+  );
+  double? best;
+  for (final match in currencyPattern.allMatches(text)) {
+    if (match.group(3) != null) continue; // "/L" suffix → unit price
+    final raw = match.group(1) ?? match.group(2);
+    if (raw == null) continue;
+    final value = parseDecimal(raw);
+    if (value == null || value <= 0) continue;
+    // Filter obvious non-totals: nobody's total is < 1 €, nobody's
+    // total is > 10 000 €.
+    if (value < 1 || value > 10000) continue;
+    // #801 — 3-decimal European amounts like `1,990 €` are fuel
+    // price-per-liter, never totals. Without this guard on the
+    // TotalEnergies receipt the parser grabbed `1,990 €` as the
+    // total and the user saw 1.99 € in the form instead of 9.95 €.
+    // Totals are always 2-decimal in EUR.
+    if (decimalDigitCount(raw) >= 3 && value < 5) continue;
+    if (best == null || value > best) best = value;
+  }
+  return best;
+}
+
+/// Count decimal digits in a European-formatted decimal string
+/// (accepts `.` or `,` as separator). Returns 0 when no separator
+/// is found. Used to distinguish 3-decimal fuel prices from
+/// 2-decimal totals without trusting `double` precision.
+int decimalDigitCount(String raw) {
+  final sepIndex = raw.lastIndexOf(RegExp(r'[.,]'));
+  if (sepIndex < 0) return 0;
+  return raw.length - sepIndex - 1;
+}
+
+/// Matches price-per-liter: "1.899 €/L", "€ 1,999/L", "PU: 1,899",
+/// "PRIX/L 1.899", "Prix unit. = 2,028 EUR", "Literpreis: 1.799".
+double? extractPricePerLiter(String text) {
+  final labelled = matchFirst(text, [
+    // "1.899 €/L" or "1,899 EUR/L" — also "1.999 €/ℓ" (U+2113).
+    RegExp(r'(\d+[.,]\d{2,3})\s*(?:€|EUR)\s*/\s*[lLℓ]'),
+    // "€ 1.999/L" or "EUR 1,999/L" / "€ 1.999/ℓ" — currency before number.
+    RegExp(r'(?:€|EUR)\s*(\d+[.,]\d{2,3})\s*/\s*[lLℓ]'),
+    // Labels: PRIX/L, PU, Preis/L, Literpreis, Prix unit(.), Preis je Liter.
+    // Also accepts `ℓ` in place of `l` in the slash-L forms.
+    RegExp(
+      r'(?:prix\s*/\s*[lℓ]|prix\s*unit\.?|pu|preis\s*/\s*[lℓ]|'
+      r'preis\s*je\s*liter|literpreis)'
+      r'\s*[:=]?\s*€?\s*(\d+[.,]\d{2,3})',
+      caseSensitive: false,
+    ),
+  ]);
+  if (labelled != null) return labelled;
+
+  // #801 — TotalEnergies / independent French receipts often emit
+  // the unit price as a bare `1,990 €` (3-decimal digits, no `/L`
+  // suffix) on the line below a `QTY x FUELCODE` item line. Without
+  // this heuristic the amount was either missed entirely or grabbed
+  // as the total. 3 decimal digits + euro suffix + plausible
+  // fuel-price range (0.5-3.0 €/L) is a strong enough signal to
+  // accept without the explicit `/L` marker.
+  // Note on the lookbehind-free check: `\b` after `€` doesn't hold
+  // (both `€` and a trailing space are non-word chars in Dart
+  // regex, so no boundary sits between them). The negative
+  // lookahead for `/L` is the only disambiguator we need — any
+  // 3-decimal euro amount NOT followed by `/L` is the unit price.
+  final bareFuelPrice =
+      RegExp(r'(\d+[.,]\d{3})\s*(?:€|EUR)(?!\s*/\s*[lLℓ])');
+  for (final match in bareFuelPrice.allMatches(text)) {
+    final raw = match.group(1);
+    if (raw == null) continue;
+    final value = parseDecimal(raw);
+    if (value == null) continue;
+    if (value >= 0.5 && value <= 3.0) return value;
+  }
+  return null;
+}
+
+/// Matches common date formats: DD/MM/YYYY, DD.MM.YYYY, DD-MM-YYYY,
+/// plus 2-digit-year variants like "19/04/26" (assumed 20xx).
+///
+/// Iterates all matches (not just the first) because phone numbers
+/// like "04.67.77.29.10" look enough like `DD.MM.YY` that the first
+/// match is often noise. The first match whose day + month pass the
+/// calendar sanity check wins.
+DateTime? extractDate(String text) {
+  // 4-digit year — preferred when present.
+  final fourDigit = RegExp(r'(\d{2})[/.\-](\d{2})[/.\-](\d{4})');
+  for (final match in fourDigit.allMatches(text)) {
+    final d = buildDate(match.group(1)!, match.group(2)!, match.group(3)!);
+    if (d != null) return d;
+  }
+  // 2-digit year fallback — covers "19/04/26" on Carrefour receipts.
+  final twoDigit =
+      RegExp(r'(?<!\d)(\d{2})[/.\-](\d{2})[/.\-](\d{2})(?!\d)');
+  for (final match in twoDigit.allMatches(text)) {
+    final d = buildDate(
+      match.group(1)!,
+      match.group(2)!,
+      '20${match.group(3)!}', // assume post-2000 for receipts
+    );
+    if (d != null) return d;
+  }
+  return null;
+}
+
+DateTime? buildDate(String dayStr, String monthStr, String yearStr) {
+  try {
+    final day = int.parse(dayStr);
+    final month = int.parse(monthStr);
+    final year = int.parse(yearStr);
+    if (month < 1 || month > 12) return null;
+    if (day < 1 || day > 31) return null;
+    return DateTime(year, month, day);
+  } on FormatException catch (e) {
+    debugPrint('Receipt date parse failed for "$dayStr/$monthStr/$yearStr": $e');
+    return null;
+  }
+}
+
+/// Returns the first successful captured group decimal across
+/// [patterns], or null if none match.
+double? matchFirst(String text, List<RegExp> patterns) {
+  for (final pattern in patterns) {
+    final match = pattern.firstMatch(text);
+    if (match != null && match.group(1) != null) {
+      return parseDecimal(match.group(1)!);
+    }
+  }
+  return null;
+}
+
+double? parseDecimal(String value) {
+  final normalized = value.replaceAll(',', '.');
+  return double.tryParse(normalized);
+}

--- a/lib/features/consumption/data/receipt_parser/receipt_parse_result.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_parse_result.dart
@@ -1,0 +1,45 @@
+import '../../../search/domain/entities/fuel_type.dart';
+
+/// Structured fields extracted from a fuel receipt by `ReceiptParser`.
+///
+/// All fields are nullable because OCR is best-effort: any combination
+/// may be missing depending on the receipt layout. Use [hasData] to check
+/// whether the parser found anything actionable.
+class ReceiptParseResult {
+  /// Volume dispensed in litres, or `null` if no volume could be parsed.
+  final double? liters;
+
+  /// Total amount charged (currency is implicit — typically EUR).
+  final double? totalCost;
+
+  /// Unit price per litre as printed on the receipt.
+  final double? pricePerLiter;
+
+  /// Receipt date if a recognised format was found.
+  final DateTime? date;
+
+  /// Detected station brand (matched against a small built-in list).
+  final String? stationName;
+
+  /// Detected fuel type from the receipt, e.g. "SP95-E10" → [FuelType.e10].
+  /// Null when the receipt doesn't name a recognisable product.
+  final FuelType? fuelType;
+
+  /// Brand layout the parser used — "super_u", "carrefour", or "generic".
+  /// Exposed so tests and telemetry can verify dispatch went to the
+  /// specialised branch when a well-known receipt layout is scanned.
+  final String brandLayout;
+
+  const ReceiptParseResult({
+    this.liters,
+    this.totalCost,
+    this.pricePerLiter,
+    this.date,
+    this.stationName,
+    this.fuelType,
+    this.brandLayout = 'generic',
+  });
+
+  /// `true` when the parser extracted at least volume or total cost.
+  bool get hasData => liters != null || totalCost != null;
+}


### PR DESCRIPTION
Refs #563 phase (receipt_parser split)

## Summary

Split `lib/features/consumption/data/receipt_parser.dart` from **607 LOC into four cohesive files** under `receipt_parser/`, all under the 300-LOC guideline called out by the oversized-files epic. Pure extraction — zero behaviour change, no ARB touch, no public-API change.

**Before → after LOC** of the top-level entry point: **607 → 124**. The thin file now holds only the `ReceiptParser` class, its override-dispatch logic, and a re-export of `ReceiptParseResult` so every existing import keeps working.

## Files

| File | LOC | Role |
|------|-----|------|
| `lib/features/consumption/data/receipt_parser.dart` | 124 | Public entry point: `ReceiptParser` + override dispatch + re-export of `ReceiptParseResult` |
| `lib/features/consumption/data/receipt_parser/receipt_parse_result.dart` | 45 | `ReceiptParseResult` data class |
| `lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart` | 262 | Pure-function extractors: fuel type, liters, total cost, price/L, date, `matchFirst` / `parseDecimal` / `decimalDigitCount` helpers |
| `lib/features/consumption/data/receipt_parser/brand_detection.dart` | 51 | `detectBrand` + `extractStationName` |
| `lib/features/consumption/data/receipt_parser/brand_layouts.dart` | 134 | Per-brand dispatch (`parseSuperU`, `parseCarrefour`, `parseGeneric`) + `reconcile` cross-field guard |

## Why

`receipt_parser.dart` was the next oversized file queued in #563 after #906 / #907 / #909 / #913. The monolith mixed three concerns — a data class, many regex helpers, and the per-brand dispatch — which makes adding a new brand layout (Intermarché, TotalEnergies) touch the same 600-line file. Splitting lets each brand/extractor grow independently and keeps the top-level file tiny.

## Callers — unchanged

- `lib/features/consumption/data/receipt_scan_service.dart`
- `test/features/consumption/data/receipt_parser_test.dart`
- `test/features/consumption/data/receipt_parser_override_test.dart`
- `test/features/consumption/presentation/widgets/bad_scan_report_sheet_test.dart`

All four continue to `import '...receipt_parser.dart'` and pick up `ReceiptParser` + `ReceiptParseResult` through the re-export.

## Testing

- `flutter analyze` — plain, no `--no-fatal-infos`. Zero issues.
- `flutter test test/features/consumption/` — 703 passed.
- `flutter test` (full suite) — **5744 passed, 1 skipped** (pre-existing skip).
- No build_runner touched, no generated files drifted.

## Refs

Refs #563 — epic stays open; other oversized files remain for future phases.