### PR TITLE
test(coverage): cover SelectedStation + StationTypeFilter providers + onboarding illustrations (#561)

### DIFF
--- a/test/features/search/providers/selected_station_provider_test.dart
+++ b/test/features/search/providers/selected_station_provider_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/providers/selected_station_provider.dart';
+
+/// Tests for [SelectedStation] — the inline-detail selection notifier.
+///
+/// The provider has a tiny surface (three methods) but each path controls
+/// whether the wide-screen split view shows station detail or not, so all
+/// three branches need an explicit guard.
+void main() {
+  ProviderContainer createContainer() {
+    final c = ProviderContainer();
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('SelectedStation.build', () {
+    test('starts with null (no station selected)', () {
+      final container = createContainer();
+      expect(container.read(selectedStationProvider), isNull);
+    });
+  });
+
+  group('SelectedStation.select', () {
+    test('stores the given station id', () {
+      final container = createContainer();
+
+      container.read(selectedStationProvider.notifier).select('shell-42');
+
+      expect(container.read(selectedStationProvider), 'shell-42');
+    });
+
+    test('overwrites a previously-selected station', () {
+      final container = createContainer();
+      final notifier = container.read(selectedStationProvider.notifier);
+
+      notifier.select('first');
+      expect(container.read(selectedStationProvider), 'first');
+
+      notifier.select('second');
+      expect(container.read(selectedStationProvider), 'second');
+    });
+
+    test('accepts the empty string as a distinct selected id', () {
+      // Defensive: UI guards that compare the state against null should
+      // not break if a consumer accidentally passes an empty id.
+      final container = createContainer();
+
+      container.read(selectedStationProvider.notifier).select('');
+
+      expect(container.read(selectedStationProvider), '');
+      // Critically: empty string is NOT null — readers that gate on
+      // `state != null` still render the detail pane.
+      expect(container.read(selectedStationProvider), isNotNull);
+    });
+  });
+
+  group('SelectedStation.clear', () {
+    test('resets the state to null', () {
+      final container = createContainer();
+      final notifier = container.read(selectedStationProvider.notifier);
+
+      notifier.select('aral-7');
+      expect(container.read(selectedStationProvider), 'aral-7');
+
+      notifier.clear();
+      expect(container.read(selectedStationProvider), isNull);
+    });
+
+    test('is a no-op when already cleared', () {
+      final container = createContainer();
+      final notifier = container.read(selectedStationProvider.notifier);
+
+      notifier.clear();
+      notifier.clear();
+
+      expect(container.read(selectedStationProvider), isNull);
+    });
+
+    test('can be reused after clearing', () {
+      final container = createContainer();
+      final notifier = container.read(selectedStationProvider.notifier);
+
+      notifier.select('first');
+      notifier.clear();
+      notifier.select('second');
+
+      expect(container.read(selectedStationProvider), 'second');
+    });
+  });
+}

--- a/test/features/search/providers/station_type_filter_provider_test.dart
+++ b/test/features/search/providers/station_type_filter_provider_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/domain/entities/station_type_filter.dart';
+import 'package:tankstellen/features/search/providers/station_type_filter_provider.dart';
+
+/// Tests for [ActiveStationTypeFilter] — the fuel-vs-EV toggle for the
+/// search screen. The notifier is `keepAlive: true` so a user's toggle
+/// choice survives the "nobody is listening" gap when the search tab is
+/// backgrounded (see #550-style auto-dispose regressions).
+void main() {
+  ProviderContainer createContainer() {
+    final c = ProviderContainer();
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('ActiveStationTypeFilter.build', () {
+    test('defaults to fuel (not EV) on a fresh install', () {
+      // Fresh-install default. If this ever flips to EV, the Tankerkoenig
+      // dispatcher test suite silently stops driving its happy path — so
+      // keep the assertion explicit.
+      final container = createContainer();
+      expect(
+        container.read(activeStationTypeFilterProvider),
+        StationTypeFilter.fuel,
+      );
+    });
+  });
+
+  group('ActiveStationTypeFilter.set', () {
+    test('switches to EV when requested', () {
+      final container = createContainer();
+
+      container
+          .read(activeStationTypeFilterProvider.notifier)
+          .set(StationTypeFilter.ev);
+
+      expect(
+        container.read(activeStationTypeFilterProvider),
+        StationTypeFilter.ev,
+      );
+    });
+
+    test('can toggle between fuel and EV repeatedly', () {
+      final container = createContainer();
+      final notifier = container.read(activeStationTypeFilterProvider.notifier);
+
+      notifier.set(StationTypeFilter.ev);
+      expect(
+        container.read(activeStationTypeFilterProvider),
+        StationTypeFilter.ev,
+      );
+
+      notifier.set(StationTypeFilter.fuel);
+      expect(
+        container.read(activeStationTypeFilterProvider),
+        StationTypeFilter.fuel,
+      );
+
+      notifier.set(StationTypeFilter.ev);
+      expect(
+        container.read(activeStationTypeFilterProvider),
+        StationTypeFilter.ev,
+      );
+    });
+
+    test('setting the same value twice is idempotent', () {
+      final container = createContainer();
+      final notifier = container.read(activeStationTypeFilterProvider.notifier);
+
+      notifier.set(StationTypeFilter.ev);
+      notifier.set(StationTypeFilter.ev);
+
+      expect(
+        container.read(activeStationTypeFilterProvider),
+        StationTypeFilter.ev,
+      );
+    });
+  });
+
+  group('ActiveStationTypeFilter keepAlive semantics', () {
+    test('two reads without an active listener return the SAME notifier', () {
+      // Guards against a regression where someone drops the
+      // `keepAlive: true` — dropping it would auto-dispose the notifier
+      // between reads and reset the filter back to fuel mid-session.
+      final container = createContainer();
+      final first = container.read(activeStationTypeFilterProvider.notifier);
+
+      // No .watch / .listen in between — just a second read.
+      final second = container.read(activeStationTypeFilterProvider.notifier);
+
+      expect(identical(first, second), isTrue);
+    });
+
+    test('state survives across reads after an explicit set', () {
+      final container = createContainer();
+      container
+          .read(activeStationTypeFilterProvider.notifier)
+          .set(StationTypeFilter.ev);
+
+      // Read again — on an auto-dispose notifier the state would reset.
+      expect(
+        container.read(activeStationTypeFilterProvider),
+        StationTypeFilter.ev,
+      );
+    });
+  });
+
+  group('StationTypeFilter enum', () {
+    test('contains exactly fuel and ev values', () {
+      // Surfaces the contract the search dispatcher and UI rely on:
+      // adding a third station type needs an explicit decision about
+      // which dispatcher path handles it, not a silent expansion.
+      expect(
+        StationTypeFilter.values,
+        containsAll([StationTypeFilter.fuel, StationTypeFilter.ev]),
+      );
+      expect(StationTypeFilter.values.length, 2);
+    });
+  });
+}

--- a/test/features/setup/presentation/widgets/illustrations/fuel_pump_illustration_test.dart
+++ b/test/features/setup/presentation/widgets/illustrations/fuel_pump_illustration_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/illustrations/fuel_pump_illustration.dart';
+
+import '../../../../../helpers/pump_app.dart';
+
+void main() {
+  group('FuelPumpIllustration rendering', () {
+    testWidgets('renders the fuel-pump icon as the hero glyph',
+        (tester) async {
+      await pumpApp(tester, const FuelPumpIllustration());
+
+      expect(find.byIcon(Icons.local_gas_station), findsOneWidget);
+    });
+
+    testWidgets('renders inside a SizedBox sized to the given dimension',
+        (tester) async {
+      await pumpApp(tester, const FuelPumpIllustration(size: 180));
+
+      final sizedBox = tester.widget<SizedBox>(
+        find
+            .descendant(
+              of: find.byType(FuelPumpIllustration),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(sizedBox.width, 180);
+      expect(sizedBox.height, 180);
+    });
+
+    testWidgets('defaults to 200dp square when no size is provided',
+        (tester) async {
+      await pumpApp(tester, const FuelPumpIllustration());
+
+      final sizedBox = tester.widget<SizedBox>(
+        find
+            .descendant(
+              of: find.byType(FuelPumpIllustration),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(sizedBox.width, 200);
+      expect(sizedBox.height, 200);
+    });
+
+    testWidgets('sparkline is painted by a CustomPaint behind the pump',
+        (tester) async {
+      await pumpApp(tester, const FuelPumpIllustration());
+
+      // The ticker's sparkline paints onto its own CustomPaint — confirm
+      // it actually exists so the illustration doesn't silently drop its
+      // "prices going down" hint.
+      expect(
+        find.descendant(
+          of: find.byType(FuelPumpIllustration),
+          matching: find.byType(CustomPaint),
+        ),
+        findsWidgets,
+      );
+    });
+
+    testWidgets('exposes a descriptive image Semantics label',
+        (tester) async {
+      await pumpApp(tester, const FuelPumpIllustration());
+
+      // Screen readers should announce the onboarding illustration as an
+      // image rather than reading out each icon individually.
+      expect(
+        find.bySemanticsLabel('Fuel pump with price ticker'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders without theme overflow when shrunk',
+        (tester) async {
+      // The illustration is sometimes rendered inside a small ConstrainedBox
+      // on short screens — verify a narrow size doesn't trigger layout
+      // assertions.
+      await pumpApp(tester, const FuelPumpIllustration(size: 80));
+
+      expect(find.byType(FuelPumpIllustration), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/setup/presentation/widgets/illustrations/globe_illustration_test.dart
+++ b/test/features/setup/presentation/widgets/illustrations/globe_illustration_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/illustrations/globe_illustration.dart';
+
+import '../../../../../helpers/pump_app.dart';
+
+void main() {
+  group('GlobeIllustration rendering', () {
+    testWidgets('renders the globe icon as the central glyph',
+        (tester) async {
+      await pumpApp(tester, const GlobeIllustration());
+
+      expect(find.byIcon(Icons.public), findsOneWidget);
+    });
+
+    testWidgets(
+        'renders three fuel-pump markers arranged around the globe',
+        (tester) async {
+      await pumpApp(tester, const GlobeIllustration());
+
+      // Three markers at 10 / 2 / 6 o'clock hint at multi-country
+      // coverage — if a refactor drops one of them, the illustration
+      // silently loses its semantic weight.
+      expect(find.byIcon(Icons.local_gas_station), findsNWidgets(3));
+    });
+
+    testWidgets('size parameter controls the SizedBox dimensions',
+        (tester) async {
+      await pumpApp(tester, const GlobeIllustration(size: 120));
+
+      final sizedBox = tester.widget<SizedBox>(
+        find
+            .descendant(
+              of: find.byType(GlobeIllustration),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(sizedBox.width, 120);
+      expect(sizedBox.height, 120);
+    });
+
+    testWidgets('defaults to 200dp square when no size is provided',
+        (tester) async {
+      await pumpApp(tester, const GlobeIllustration());
+
+      final sizedBox = tester.widget<SizedBox>(
+        find
+            .descendant(
+              of: find.byType(GlobeIllustration),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(sizedBox.width, 200);
+      expect(sizedBox.height, 200);
+    });
+
+    testWidgets('exposes a descriptive image Semantics label',
+        (tester) async {
+      await pumpApp(tester, const GlobeIllustration());
+
+      expect(
+        find.bySemanticsLabel('Globe with fuel station markers'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('includes a radial-gradient backdrop behind the globe',
+        (tester) async {
+      await pumpApp(tester, const GlobeIllustration());
+
+      // Locate the backdrop Container by its BoxDecoration shape. The
+      // radial gradient is what stops the globe from reading as a
+      // floating icon on dark backgrounds.
+      final containers = tester.widgetList<Container>(
+        find.descendant(
+          of: find.byType(GlobeIllustration),
+          matching: find.byType(Container),
+        ),
+      );
+
+      final hasRadialBackdrop = containers.any((c) {
+        final decoration = c.decoration;
+        return decoration is BoxDecoration &&
+            decoration.shape == BoxShape.circle &&
+            decoration.gradient is RadialGradient;
+      });
+
+      expect(hasRadialBackdrop, isTrue,
+          reason: 'Globe illustration needs the radial-gradient backdrop');
+    });
+
+    testWidgets('renders without error at a small size', (tester) async {
+      await pumpApp(tester, const GlobeIllustration(size: 60));
+
+      expect(find.byType(GlobeIllustration), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/setup/presentation/widgets/illustrations/shield_illustration_test.dart
+++ b/test/features/setup/presentation/widgets/illustrations/shield_illustration_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/setup/presentation/widgets/illustrations/shield_illustration.dart';
+
+import '../../../../../helpers/pump_app.dart';
+
+void main() {
+  group('ShieldIllustration rendering', () {
+    testWidgets('renders the shield icon as the hero glyph', (tester) async {
+      await pumpApp(tester, const ShieldIllustration());
+
+      expect(find.byIcon(Icons.verified_user), findsOneWidget);
+    });
+
+    testWidgets('renders the fuel-drop icon nested inside the shield',
+        (tester) async {
+      await pumpApp(tester, const ShieldIllustration());
+
+      // The water_drop icon is reused to represent a fuel drop inside
+      // the shield — matching the adaptive app icon's brand motif.
+      expect(find.byIcon(Icons.water_drop), findsOneWidget);
+    });
+
+    testWidgets('size parameter controls the SizedBox dimensions',
+        (tester) async {
+      await pumpApp(tester, const ShieldIllustration(size: 160));
+
+      final sizedBox = tester.widget<SizedBox>(
+        find
+            .descendant(
+              of: find.byType(ShieldIllustration),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(sizedBox.width, 160);
+      expect(sizedBox.height, 160);
+    });
+
+    testWidgets('defaults to 200dp square when no size is provided',
+        (tester) async {
+      await pumpApp(tester, const ShieldIllustration());
+
+      final sizedBox = tester.widget<SizedBox>(
+        find
+            .descendant(
+              of: find.byType(ShieldIllustration),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(sizedBox.width, 200);
+      expect(sizedBox.height, 200);
+    });
+
+    testWidgets('exposes a descriptive image Semantics label',
+        (tester) async {
+      await pumpApp(tester, const ShieldIllustration());
+
+      expect(
+        find.bySemanticsLabel('Privacy shield with fuel drop'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('includes a radial-gradient backdrop behind the shield',
+        (tester) async {
+      await pumpApp(tester, const ShieldIllustration());
+
+      final containers = tester.widgetList<Container>(
+        find.descendant(
+          of: find.byType(ShieldIllustration),
+          matching: find.byType(Container),
+        ),
+      );
+
+      final hasRadialBackdrop = containers.any((c) {
+        final decoration = c.decoration;
+        return decoration is BoxDecoration &&
+            decoration.shape == BoxShape.circle &&
+            decoration.gradient is RadialGradient;
+      });
+
+      expect(hasRadialBackdrop, isTrue,
+          reason: 'Shield illustration needs the radial-gradient backdrop');
+    });
+
+    testWidgets('renders without error at a small size', (tester) async {
+      await pumpApp(tester, const ShieldIllustration(size: 60));
+
+      expect(find.byType(ShieldIllustration), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('fuel-drop icon uses the onPrimary color (contrast against shield)',
+        (tester) async {
+      await pumpApp(tester, const ShieldIllustration());
+
+      // The drop has to read against the primary-tinted shield — if
+      // someone swaps it back to scheme.primary the two icons blend.
+      final icons = tester.widgetList<Icon>(
+        find.descendant(
+          of: find.byType(ShieldIllustration),
+          matching: find.byType(Icon),
+        ),
+      );
+      final drop = icons.firstWhere((i) => i.icon == Icons.water_drop);
+      final shield = icons.firstWhere((i) => i.icon == Icons.verified_user);
+
+      // Drop + shield colors must differ so the drop stays visible.
+      expect(drop.color, isNotNull);
+      expect(shield.color, isNotNull);
+      expect(drop.color, isNot(shield.color));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds tests for five previously zero-coverage files in the `lib/` tree:

- `lib/features/search/providers/selected_station_provider.dart` — inline-detail selection notifier (build/select/clear).
- `lib/features/search/providers/station_type_filter_provider.dart` — fuel-vs-EV toggle (default, set, keepAlive).
- `lib/features/setup/presentation/widgets/illustrations/fuel_pump_illustration.dart`
- `lib/features/setup/presentation/widgets/illustrations/globe_illustration.dart`
- `lib/features/setup/presentation/widgets/illustrations/shield_illustration.dart`

Tests cover default states, explicit state transitions, keepAlive semantics, size parameterisation, semantic labels (for screen readers), and the radial-gradient backdrop that keeps the onboarding glyphs readable in dark mode.

No `lib/` changes — test-only PR.

## Why

Phase 7 of the coverage epic. These are small, self-contained files whose behaviour is load-bearing (onboarding first impression, inline-detail split-view, dispatcher default) but previously had zero guard tests.

## Testing

- `flutter analyze` — 0 issues.
- `flutter test` — 5779 pass, 1 skipped, 0 fail.
- 35 new tests in this PR.

Refs #561 phase 7