### PR TITLE
chore: bump build number to 5102 for device testing

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 11 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 5.0.0+5092
+version: 5.0.0+5102
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
## Summary

Version bump + APK build covering the 7 PRs that merged this session.

Shipped:
- #917 docs backlog unblock (#594 #713 #9)
- #918 widget diagnostic guards + logging (Refs #753)
- #919 receipt_parser split (Refs #563)
- #920 provider + illustration tests (Refs #561)
- #921 elm327_protocol split (Refs #563)
- #922 widget color-scheme drawables + plumbing (Refs #607 phase 1)
- #924 widget config activity + per-widget profile (Refs #607, Refs #610)

APK: `tankstellen-5.0.0+5102-play.apk` (74.9 MB) already copied to `C:\Users\fditt\OneDrive\Android\`.

## Test plan

- [x] Full test suite green across all 7 component PRs.
- [ ] Install `tankstellen-5.0.0+5102-play.apk` on Galaxy S23.
- [ ] Place widget, open config activity → pick profile + color scheme → Save → widget reflects choice.
- [ ] Confirm #753 diagnostic logs fire on widget row tap: `adb logcat -s TankstellenWidget` should show `buildRow widgetId=X index=N id=<id>` on each visible row and `WidgetLaunchHandler.handle uri=... path=... outcome=pushed` on tap.
- [ ] Regression check: favorites widget still renders unchanged when no config is saved.