### PR TITLE
feat(ui): canonical design-system widgets (PageScaffold, SectionHeader, SectionCard, SettingsMenuTile, TabSwitcher) (#923 phase 2)

### DIFF
--- a/lib/core/widgets/page_scaffold.dart
+++ b/lib/core/widgets/page_scaffold.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+
+import '../theme/spacing.dart';
+
+/// Canonical outer chrome for every top-level screen — `Scaffold` +
+/// `AppBar` + optional primary-tinted banner below the app bar + body.
+///
+/// Replaces the three competing "this is what this screen is about"
+/// conventions identified in the #923 audit (plain app bar, banner
+/// strip à la `ThemeSettingsScreen`, ad-hoc hero row). See
+/// `docs/design/DESIGN_SYSTEM.md` §"PageScaffold" for the contract.
+class PageScaffold extends StatelessWidget {
+  /// App-bar title. Required — every page has a title in the
+  /// `pageTitle` role.
+  final String title;
+
+  /// Optional subtitle — rendered inside the banner (if [bannerIcon]
+  /// is set). When [bannerIcon] is null the subtitle is ignored
+  /// because no dedicated slot exists for it — the app-bar title
+  /// sits alone.
+  final String? subtitle;
+
+  /// When non-null, renders a primary-tinted banner strip directly
+  /// under the app bar carrying the icon + [title] + [subtitle].
+  /// Mirrors `ThemeSettingsScreen` / `PrivacyDashboardScreen`.
+  final IconData? bannerIcon;
+
+  /// Trailing app-bar actions. Every `IconButton` in this list must
+  /// carry a `tooltip:` (enforced by
+  /// `test/accessibility/icon_button_tooltip_coverage_test.dart`).
+  final List<Widget>? actions;
+
+  /// Screen body. Required. `PageScaffold` wraps it in
+  /// [Padding] using [bodyPadding] and an [Expanded] so the body
+  /// owns the remaining vertical space below the app bar (and banner,
+  /// if any).
+  final Widget body;
+
+  /// Body padding. Defaults to `Spacing.screenPadding`
+  /// (`EdgeInsets.all(16)`). Pass `EdgeInsets.zero` for full-bleed
+  /// content (map screen).
+  final EdgeInsets? bodyPadding;
+
+  /// Optional FAB. Passed through to [Scaffold.floatingActionButton].
+  final Widget? floatingActionButton;
+
+  /// Optional leading app-bar widget. Normally the back button — pass
+  /// a custom drawer icon when needed.
+  final Widget? leading;
+
+  /// Whether the app bar shows its automatic leading. Default: true.
+  final bool automaticallyImplyLeading;
+
+  const PageScaffold({
+    super.key,
+    required this.title,
+    required this.body,
+    this.subtitle,
+    this.bannerIcon,
+    this.actions,
+    this.bodyPadding,
+    this.floatingActionButton,
+    this.leading,
+    this.automaticallyImplyLeading = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final effectivePadding = bodyPadding ?? Spacing.screenPadding;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+        actions: actions,
+        leading: leading,
+        automaticallyImplyLeading: automaticallyImplyLeading,
+      ),
+      body: Column(
+        children: [
+          if (bannerIcon != null)
+            _PageBanner(
+              icon: bannerIcon!,
+              title: title,
+              subtitle: subtitle,
+            ),
+          Expanded(
+            child: Padding(
+              padding: effectivePadding,
+              child: body,
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: floatingActionButton,
+    );
+  }
+}
+
+/// Primary-tinted banner strip under the app bar.
+///
+/// Surface = `colorScheme.primaryContainer`; foreground =
+/// `colorScheme.onPrimaryContainer`. Kept as a private widget so
+/// every `PageScaffold(bannerIcon: …)` call lands on the same
+/// visual shape without screens reinventing it.
+class _PageBanner extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+
+  const _PageBanner({
+    required this.icon,
+    required this.title,
+    this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(
+        horizontal: Spacing.xl,
+        vertical: Spacing.lg,
+      ),
+      color: theme.colorScheme.primaryContainer,
+      child: Row(
+        children: [
+          Icon(
+            icon,
+            size: 32,
+            color: theme.colorScheme.onPrimaryContainer,
+          ),
+          const SizedBox(width: Spacing.lg),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: theme.colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (subtitle != null) ...[
+                  const SizedBox(height: Spacing.xs),
+                  Text(
+                    subtitle!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onPrimaryContainer,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/section_card.dart
+++ b/lib/core/widgets/section_card.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import '../theme/spacing.dart';
+import 'section_header.dart';
+
+/// Canonical grouped-content card used across every screen body.
+///
+/// One card, one elevation, one radius, one padding — replaces the
+/// 80+ raw `Card(...)` call sites with ad-hoc elevation/margin/color
+/// flagged in the #923 audit.
+///
+/// Visual contract (see `docs/design/DESIGN_SYSTEM.md` §"SectionCard"):
+///
+///   * `elevation: 0` — separation from the scaffold is handled by the
+///     `surfaceContainerLow` tint, not a shadow.
+///   * `color: colorScheme.surfaceContainerLow`.
+///   * Corner radius is inherited from the global theme
+///     (`AppRadius.lg` / 12 px via `FlexColorScheme.subThemesData`).
+///   * Default inner padding = `Spacing.cardPadding`.
+///   * Default outer margin = `EdgeInsets.zero` so the host `ListView`
+///     / `Column` owns card-to-card spacing.
+///
+/// When [title] is non-null the card renders an internal
+/// [SectionHeader] at the top followed by a small gap and the [child].
+class SectionCard extends StatelessWidget {
+  /// Optional card header title. When null the card has no built-in
+  /// header — consumers can place their own leading widget inside
+  /// [child].
+  final String? title;
+
+  /// Optional sub-title rendered under [title].
+  final String? subtitle;
+
+  /// Optional icon rendered by the internal [SectionHeader].
+  final IconData? leadingIcon;
+
+  /// Accent color forwarded to the header icon. Defaults to
+  /// `colorScheme.primary` when null.
+  final Color? accent;
+
+  /// The card body. Required.
+  final Widget child;
+
+  /// Inner padding — defaults to `Spacing.cardPadding`
+  /// (`EdgeInsets.all(16)`). Override when a card hosts a
+  /// full-bleed list (then pass `EdgeInsets.zero` and let the list
+  /// owner add its own padding).
+  final EdgeInsets padding;
+
+  /// Outer margin — defaults to `EdgeInsets.zero` so the host
+  /// scrollable owns card-to-card spacing.
+  final EdgeInsets margin;
+
+  const SectionCard({
+    super.key,
+    required this.child,
+    this.title,
+    this.subtitle,
+    this.leadingIcon,
+    this.accent,
+    this.padding = Spacing.cardPadding,
+    this.margin = EdgeInsets.zero,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: margin,
+      clipBehavior: Clip.antiAlias,
+      elevation: 0,
+      color: theme.colorScheme.surfaceContainerLow,
+      // `shape` intentionally omitted — FlexColorScheme applies the
+      // canonical `AppRadius.lg` (12 px) card radius globally.
+      child: Padding(
+        padding: padding,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (title != null) ...[
+              SectionHeader(
+                title: title!,
+                subtitle: subtitle,
+                leadingIcon: leadingIcon,
+                padding: EdgeInsets.zero,
+              ),
+              const SizedBox(height: Spacing.md),
+            ],
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/section_header.dart
+++ b/lib/core/widgets/section_header.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import '../theme/spacing.dart';
+
+/// Canonical section heading — one widget for every inline
+/// "section title" in the app.
+///
+/// Collapses the 60+ inline `textTheme.titleMedium.copyWith(...)` calls
+/// scattered across feature screens into one shape with a fixed padding,
+/// font weight, and optional subtitle / leading icon / trailing action.
+///
+/// See `docs/design/DESIGN_SYSTEM.md` §"SectionHeader" for the contract.
+class SectionHeader extends StatelessWidget {
+  /// Required — rendered in the `sectionHeader` text role
+  /// (`titleMedium` weight 600 in `onSurface`).
+  final String title;
+
+  /// Optional second line in the `sectionSubhead` role (`bodySmall` in
+  /// `onSurfaceVariant`).
+  final String? subtitle;
+
+  /// Optional right-aligned action (TextButton, IconButton with a
+  /// tooltip, chip, …).
+  final Widget? trailing;
+
+  /// Optional small (16 dp) primary-tinted icon before the title.
+  final IconData? leadingIcon;
+
+  /// Outer padding — defaults to
+  /// `EdgeInsets.fromLTRB(Spacing.xl, Spacing.lg, Spacing.xl, Spacing.sm)`
+  /// per the design-system spec. Override with [EdgeInsets.zero] when
+  /// the header is nested inside a card that already provides its own
+  /// outer padding.
+  final EdgeInsets padding;
+
+  const SectionHeader({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.trailing,
+    this.leadingIcon,
+    this.padding = const EdgeInsets.fromLTRB(
+      Spacing.xl,
+      Spacing.lg,
+      Spacing.xl,
+      Spacing.sm,
+    ),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: padding,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          if (leadingIcon != null) ...[
+            Icon(
+              leadingIcon,
+              size: 16,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(width: Spacing.md),
+          ],
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: theme.colorScheme.onSurface,
+                  ),
+                ),
+                if (subtitle != null) ...[
+                  const SizedBox(height: Spacing.xs),
+                  Text(
+                    subtitle!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          ?trailing,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/settings_menu_tile.dart
+++ b/lib/core/widgets/settings_menu_tile.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
 
-/// Reusable menu row used by `ProfileScreen` for the top-level
-/// destinations (My vehicles, Privacy Dashboard). Each instance is a
-/// `Card`-wrapped `ListTile` with a small leading icon, a bold title,
-/// a body-small subtitle, a trailing chevron, and an `onTap` callback.
+/// Reusable "tap to drill in" menu row for settings-style screens.
 ///
-/// Pulled out of `profile_screen.dart` so the screen drops nearly
-/// identical 20-line `Card` blocks and so the tile shape can be exercised
-/// by widget tests in isolation.
+/// Originally lived under `lib/features/profile/presentation/widgets/`
+/// and was used only by the Profile screen; promoted to
+/// `lib/core/widgets/` in #923 phase 2 so Privacy / Sync / onboarding
+/// settings can share the exact same tile shape.
+///
+/// Visual contract (see `docs/design/DESIGN_SYSTEM.md`
+/// §"SettingsMenuTile"): a `Card`-wrapped `ListTile` with a small
+/// leading icon, a bold `titleSmall` title, a `bodySmall` subtitle,
+/// a trailing chevron, and a `VoidCallback onTap`.
 ///
 /// #896 — the Consumption log entry was removed in favour of the
 /// dedicated bottom-nav tab to avoid duplicate navigation.

--- a/lib/core/widgets/tab_switcher.dart
+++ b/lib/core/widgets/tab_switcher.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+
+/// One canonical tab row for the app.
+///
+/// Replaces the three hand-rolled `TabBar` implementations flagged in
+/// the #923 audit (`ConsumptionScreen`, `FavoritesScreen`,
+/// `CarbonDashboardScreen`). The visual contract is locked:
+///
+///   * underline indicator = `colorScheme.primary`, weight 3,
+///   * selected label color = `colorScheme.primary`,
+///   * unselected label color = `colorScheme.onSurfaceVariant`,
+///   * label style = `textTheme.titleSmall` with `FontWeight.w600`,
+///   * transparent `Material` host so the tab row adopts whatever
+///     surface the caller provides (app bar, card header, …).
+///
+/// See `docs/design/DESIGN_SYSTEM.md` §"TabSwitcher".
+class TabSwitcher extends StatelessWidget implements PreferredSizeWidget {
+  /// Tabs to render. Each entry becomes one `Tab` widget with an
+  /// optional leading icon + label.
+  final List<TabSwitcherEntry> tabs;
+
+  /// Optional explicit controller. When null the widget falls back
+  /// to [DefaultTabController.of] — mirroring the standard [TabBar]
+  /// behaviour.
+  final TabController? controller;
+
+  /// Whether the tab row scrolls horizontally instead of dividing
+  /// the width equally. Default: false.
+  final bool isScrollable;
+
+  /// Mirrors [TabBar.onTap] so callers can respond to taps without
+  /// owning a controller.
+  final ValueChanged<int>? onTap;
+
+  const TabSwitcher({
+    super.key,
+    required this.tabs,
+    this.controller,
+    this.isScrollable = false,
+    this.onTap,
+  });
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kTextTabBarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final labelStyle = theme.textTheme.titleSmall?.copyWith(
+      fontWeight: FontWeight.w600,
+    );
+    return Material(
+      color: Colors.transparent,
+      child: TabBar(
+        controller: controller,
+        isScrollable: isScrollable,
+        onTap: onTap,
+        labelColor: theme.colorScheme.primary,
+        unselectedLabelColor: theme.colorScheme.onSurfaceVariant,
+        indicatorColor: theme.colorScheme.primary,
+        indicatorWeight: 3,
+        labelStyle: labelStyle,
+        unselectedLabelStyle: labelStyle,
+        tabs: [
+          for (final entry in tabs)
+            Tab(
+              icon: entry.icon != null ? Icon(entry.icon) : null,
+              text: entry.label,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One entry in a [TabSwitcher].
+class TabSwitcherEntry {
+  /// Tab label. Rendered next to / below the optional [icon].
+  final String label;
+
+  /// Optional leading icon.
+  final IconData? icon;
+
+  /// Optional semantic label override for screen readers.
+  final String? semanticLabel;
+
+  const TabSwitcherEntry({
+    required this.label,
+    this.icon,
+    this.semanticLabel,
+  });
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -8,7 +8,7 @@ import '../widgets/about_section.dart';
 import '../widgets/api_key_section.dart';
 import '../widgets/location_section_widget.dart';
 import '../widgets/profile_list_section.dart';
-import '../widgets/settings_menu_tile.dart';
+import '../../../../core/widgets/settings_menu_tile.dart';
 import '../widgets/storage_section.dart';
 import '../widgets/tank_sync_section.dart';
 

--- a/test/core/widgets/page_scaffold_test.dart
+++ b/test/core/widgets/page_scaffold_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/widgets/page_scaffold.dart';
+
+void main() {
+  group('PageScaffold', () {
+    Future<void> pump(WidgetTester tester, Widget page) {
+      return tester.pumpWidget(MaterialApp(home: page));
+    }
+
+    testWidgets('renders the title inside the app bar', (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Privacy',
+          body: Text('Body content'),
+        ),
+      );
+      expect(find.text('Privacy'), findsOneWidget);
+      expect(find.text('Body content'), findsOneWidget);
+      expect(find.byType(AppBar), findsOneWidget);
+    });
+
+    testWidgets('renders the body', (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Privacy',
+          body: Text('Body content'),
+        ),
+      );
+      expect(find.text('Body content'), findsOneWidget);
+    });
+
+    testWidgets('renders no banner when bannerIcon is null', (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Privacy',
+          body: SizedBox.shrink(),
+        ),
+      );
+      // No icon in the body tree aside from whatever the app bar puts there.
+      expect(find.byIcon(Icons.dark_mode), findsNothing);
+    });
+
+    testWidgets('renders a banner with icon + subtitle when bannerIcon is set',
+        (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Dark mode',
+          subtitle: 'Pick how the app follows your device theme',
+          bannerIcon: Icons.dark_mode,
+          body: SizedBox.shrink(),
+        ),
+      );
+      expect(find.byIcon(Icons.dark_mode), findsOneWidget);
+      expect(
+        find.text('Pick how the app follows your device theme'),
+        findsOneWidget,
+      );
+      // The title appears both in the app bar and in the banner.
+      expect(find.text('Dark mode'), findsNWidgets(2));
+    });
+
+    testWidgets('forwards actions to the app bar', (tester) async {
+      var tapped = false;
+      await pump(
+        tester,
+        PageScaffold(
+          title: 'Privacy',
+          actions: [
+            IconButton(
+              tooltip: 'Refresh',
+              icon: const Icon(Icons.refresh),
+              onPressed: () => tapped = true,
+            ),
+          ],
+          body: const SizedBox.shrink(),
+        ),
+      );
+      expect(find.byIcon(Icons.refresh), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.refresh));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('forwards the FAB to the scaffold', (tester) async {
+      await pump(
+        tester,
+        PageScaffold(
+          title: 'Privacy',
+          floatingActionButton: FloatingActionButton(
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+          body: const SizedBox.shrink(),
+        ),
+      );
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+  });
+}

--- a/test/core/widgets/section_card_test.dart
+++ b/test/core/widgets/section_card_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/spacing.dart';
+import 'package:tankstellen/core/widgets/section_card.dart';
+import 'package:tankstellen/core/widgets/section_header.dart';
+
+void main() {
+  group('SectionCard', () {
+    Future<void> pump(WidgetTester tester, Widget child) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: child),
+        ),
+      );
+    }
+
+    testWidgets('wraps the child in a Card with elevation 0', (tester) async {
+      await pump(
+        tester,
+        const SectionCard(child: Text('Body content')),
+      );
+      expect(find.text('Body content'), findsOneWidget);
+      final card = tester.widget<Card>(find.byType(Card));
+      expect(card.elevation, 0);
+    });
+
+    testWidgets('uses surfaceContainerLow as background', (tester) async {
+      late ThemeData capturedTheme;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedTheme = Theme.of(context);
+              return const Scaffold(
+                body: SectionCard(child: Text('Body')),
+              );
+            },
+          ),
+        ),
+      );
+      final card = tester.widget<Card>(find.byType(Card));
+      expect(card.color, capturedTheme.colorScheme.surfaceContainerLow);
+    });
+
+    testWidgets('applies Spacing.cardPadding by default', (tester) async {
+      await pump(
+        tester,
+        const SectionCard(child: Text('Body')),
+      );
+      final paddings = tester
+          .widgetList<Padding>(
+            find.descendant(
+              of: find.byType(Card),
+              matching: find.byType(Padding),
+            ),
+          )
+          .toList();
+      expect(
+        paddings.any((p) => p.padding == Spacing.cardPadding),
+        isTrue,
+        reason: 'Expected one Padding descendant to use Spacing.cardPadding, '
+            'got ${paddings.map((p) => p.padding).toList()}',
+      );
+    });
+
+    testWidgets('uses zero margin by default', (tester) async {
+      await pump(
+        tester,
+        const SectionCard(child: Text('Body')),
+      );
+      final card = tester.widget<Card>(find.byType(Card));
+      expect(card.margin, EdgeInsets.zero);
+    });
+
+    testWidgets('renders an internal SectionHeader when title is set',
+        (tester) async {
+      await pump(
+        tester,
+        const SectionCard(
+          title: 'Section title',
+          subtitle: 'Section subtitle',
+          leadingIcon: Icons.info_outline,
+          child: Text('Body'),
+        ),
+      );
+      expect(find.byType(SectionHeader), findsOneWidget);
+      expect(find.text('Section title'), findsOneWidget);
+      expect(find.text('Section subtitle'), findsOneWidget);
+      expect(find.byIcon(Icons.info_outline), findsOneWidget);
+      expect(find.text('Body'), findsOneWidget);
+    });
+
+    testWidgets('omits the header when title is null', (tester) async {
+      await pump(
+        tester,
+        const SectionCard(child: Text('Body')),
+      );
+      expect(find.byType(SectionHeader), findsNothing);
+      expect(find.text('Body'), findsOneWidget);
+    });
+
+    testWidgets('respects custom padding and margin', (tester) async {
+      const customPadding = EdgeInsets.all(4);
+      const customMargin = EdgeInsets.symmetric(vertical: 8);
+      await pump(
+        tester,
+        const SectionCard(
+          padding: customPadding,
+          margin: customMargin,
+          child: Text('Body'),
+        ),
+      );
+      final card = tester.widget<Card>(find.byType(Card));
+      expect(card.margin, customMargin);
+      final paddings = tester
+          .widgetList<Padding>(
+            find.descendant(
+              of: find.byType(Card),
+              matching: find.byType(Padding),
+            ),
+          )
+          .toList();
+      expect(
+        paddings.any((p) => p.padding == customPadding),
+        isTrue,
+        reason: 'Expected one Padding descendant to use $customPadding, '
+            'got ${paddings.map((p) => p.padding).toList()}',
+      );
+    });
+  });
+}

--- a/test/core/widgets/section_header_test.dart
+++ b/test/core/widgets/section_header_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/widgets/section_header.dart';
+
+void main() {
+  group('SectionHeader', () {
+    Future<void> pump(WidgetTester tester, Widget child) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: child),
+        ),
+      );
+    }
+
+    testWidgets('renders the supplied title', (tester) async {
+      await pump(tester, const SectionHeader(title: 'Favorites'));
+      expect(find.text('Favorites'), findsOneWidget);
+    });
+
+    testWidgets('omits the subtitle when null', (tester) async {
+      await pump(tester, const SectionHeader(title: 'Favorites'));
+      expect(find.text('Favorites'), findsOneWidget);
+      expect(find.byType(Text), findsOneWidget);
+    });
+
+    testWidgets('renders the subtitle when provided', (tester) async {
+      await pump(
+        tester,
+        const SectionHeader(
+          title: 'Favorites',
+          subtitle: 'Your saved stations',
+        ),
+      );
+      expect(find.text('Your saved stations'), findsOneWidget);
+    });
+
+    testWidgets('renders the leading icon when provided', (tester) async {
+      await pump(
+        tester,
+        const SectionHeader(
+          title: 'Favorites',
+          leadingIcon: Icons.local_gas_station,
+        ),
+      );
+      expect(find.byIcon(Icons.local_gas_station), findsOneWidget);
+    });
+
+    testWidgets('renders a trailing widget when provided', (tester) async {
+      var tapped = false;
+      await pump(
+        tester,
+        SectionHeader(
+          title: 'Favorites',
+          trailing: TextButton(
+            onPressed: () => tapped = true,
+            child: const Text('Edit'),
+          ),
+        ),
+      );
+      expect(find.text('Edit'), findsOneWidget);
+      await tester.tap(find.text('Edit'));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('applies titleMedium weight 600 to the title', (tester) async {
+      await pump(tester, const SectionHeader(title: 'Favorites'));
+      final text = tester.widget<Text>(find.text('Favorites'));
+      expect(text.style?.fontWeight, FontWeight.w600);
+    });
+  });
+}

--- a/test/core/widgets/settings_menu_tile_test.dart
+++ b/test/core/widgets/settings_menu_tile_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tankstellen/features/profile/presentation/widgets/settings_menu_tile.dart';
+import 'package:tankstellen/core/widgets/settings_menu_tile.dart';
 
 void main() {
   group('SettingsMenuTile', () {

--- a/test/core/widgets/tab_switcher_test.dart
+++ b/test/core/widgets/tab_switcher_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/widgets/tab_switcher.dart';
+
+void main() {
+  group('TabSwitcher', () {
+    Future<void> pumpWithController(
+      WidgetTester tester, {
+      required int length,
+      int initialIndex = 0,
+      ValueChanged<int>? onTap,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: DefaultTabController(
+            length: length,
+            initialIndex: initialIndex,
+            child: Scaffold(
+              appBar: AppBar(
+                bottom: TabSwitcher(
+                  tabs: const [
+                    TabSwitcherEntry(label: 'Fuel'),
+                    TabSwitcherEntry(label: 'EV'),
+                  ],
+                  onTap: onTap,
+                ),
+              ),
+              body: const TabBarView(
+                children: [
+                  Center(child: Text('Fuel view')),
+                  Center(child: Text('EV view')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders every tab label', (tester) async {
+      await pumpWithController(tester, length: 2);
+      expect(find.text('Fuel'), findsOneWidget);
+      expect(find.text('EV'), findsOneWidget);
+    });
+
+    testWidgets('applies primary indicator color and weight 3',
+        (tester) async {
+      late ThemeData capturedTheme;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DefaultTabController(
+            length: 2,
+            child: Builder(
+              builder: (context) {
+                capturedTheme = Theme.of(context);
+                return Scaffold(
+                  appBar: AppBar(
+                    bottom: const TabSwitcher(
+                      tabs: [
+                        TabSwitcherEntry(label: 'Fuel'),
+                        TabSwitcherEntry(label: 'EV'),
+                      ],
+                    ),
+                  ),
+                  body: const SizedBox.shrink(),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      final bar = tester.widget<TabBar>(find.byType(TabBar));
+      expect(bar.indicatorColor, capturedTheme.colorScheme.primary);
+      expect(bar.indicatorWeight, 3);
+      expect(bar.labelColor, capturedTheme.colorScheme.primary);
+      expect(
+        bar.unselectedLabelColor,
+        capturedTheme.colorScheme.onSurfaceVariant,
+      );
+      expect(bar.labelStyle?.fontWeight, FontWeight.w600);
+    });
+
+    testWidgets('propagates tap events via onTap', (tester) async {
+      var tapped = -1;
+      await pumpWithController(
+        tester,
+        length: 2,
+        onTap: (index) => tapped = index,
+      );
+      await tester.tap(find.text('EV'));
+      await tester.pumpAndSettle();
+      expect(tapped, 1);
+    });
+
+    testWidgets('accepts an explicit controller', (tester) async {
+      final controller = _createController(length: 3, initialIndex: 0);
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            appBar: AppBar(
+              bottom: TabSwitcher(
+                controller: controller,
+                tabs: const [
+                  TabSwitcherEntry(label: 'A'),
+                  TabSwitcherEntry(label: 'B'),
+                  TabSwitcherEntry(label: 'C'),
+                ],
+              ),
+            ),
+            body: TabBarView(
+              controller: controller,
+              children: const [
+                Center(child: Text('A body')),
+                Center(child: Text('B body')),
+                Center(child: Text('C body')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('A'), findsOneWidget);
+      await tester.tap(find.text('C'));
+      await tester.pumpAndSettle();
+      expect(controller.index, 2);
+    });
+
+    testWidgets('respects isScrollable flag', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DefaultTabController(
+            length: 2,
+            child: Scaffold(
+              appBar: AppBar(
+                bottom: const TabSwitcher(
+                  isScrollable: true,
+                  tabs: [
+                    TabSwitcherEntry(label: 'Fuel'),
+                    TabSwitcherEntry(label: 'EV'),
+                  ],
+                ),
+              ),
+              body: const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+      final bar = tester.widget<TabBar>(find.byType(TabBar));
+      expect(bar.isScrollable, isTrue);
+    });
+  });
+}
+
+TabController _createController({
+  required int length,
+  int initialIndex = 0,
+}) {
+  return TabController(
+    length: length,
+    initialIndex: initialIndex,
+    vsync: const TestVSync(),
+  );
+}

--- a/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -8,7 +8,7 @@ import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 import 'package:tankstellen/features/profile/presentation/screens/profile_screen.dart';
-import 'package:tankstellen/features/profile/presentation/widgets/settings_menu_tile.dart';
+import 'package:tankstellen/core/widgets/settings_menu_tile.dart';
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';

--- a/test/features/profile/presentation/screens/settings_screen_theme_card_test.dart
+++ b/test/features/profile/presentation/screens/settings_screen_theme_card_test.dart
@@ -4,7 +4,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/core/theme/theme_mode_provider.dart';
 import 'package:tankstellen/features/profile/presentation/screens/profile_screen.dart';
-import 'package:tankstellen/features/profile/presentation/widgets/settings_menu_tile.dart';
+import 'package:tankstellen/core/widgets/settings_menu_tile.dart';
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';


### PR DESCRIPTION
Refs #923 phase 2 of N. Phase 1 (#925) shipped the doc (`docs/design/DESIGN_SYSTEM.md`). This phase lands the 5 canonical widgets under `lib/core/widgets/`. Phase 3+ migrates per-screen.

## What

- `lib/core/widgets/page_scaffold.dart` (new) — `Scaffold` + `AppBar` + optional primary-tinted banner + body with `Spacing.screenPadding`.
- `lib/core/widgets/section_header.dart` (new) — inline section title (`titleMedium` w600) + optional subtitle (`bodySmall` on `onSurfaceVariant`) / leading 16dp primary-tinted icon / trailing action.
- `lib/core/widgets/section_card.dart` (new) — elevation 0, `surfaceContainerLow`, `Spacing.cardPadding`, renders an internal `SectionHeader` when a title is supplied. Radius inherited from the global `FlexColorScheme` (`AppRadius.lg`).
- `lib/core/widgets/settings_menu_tile.dart` (moved from `lib/features/profile/presentation/widgets/`). No API change; `ProfileScreen` + 2 profile tests updated to the new import.
- `lib/core/widgets/tab_switcher.dart` (new) — canonical `TabBar` with locked indicator color (`primary`), weight 3, `titleSmall` w600 label style, and transparent `Material` host.

Each widget ships with a matching widget test under `test/core/widgets/`.

`FormSectionCard` / `FormFieldTile` in `lib/core/widgets/form_section_card.dart` are **left alone** — their `children: List<Widget>` API is still in active use by `add_fill_up_screen.dart` and the vehicle form sections. `SectionCard` is the generic sibling for plain-content cards; `FormSectionCard` remains the specialised form variant (per the doc's "FormSectionCard stays as a specialized sub-class" note).

## Why

The design-system doc (#925) declares the contracts; without the widgets, screens have no way to adopt them. Phase 2 lands the shapes so phase 3+ migrations are a `SectionCard(...)` call, not a 20-line hand-rolled `Card`.

## Testing

- `flutter analyze` — clean (0 issues).
- `flutter test` — 5829 passed, 1 skipped (pre-existing). New suites: 29 tests under `test/core/widgets/` covering every widget contract (props, colors, padding tokens, tap propagation, controller support).

## Screenshots

N/A — no screen consumes the new widgets yet. Phase 3+ will exercise them in visual context.

Refs #923