### PR TITLE
refactor(ui): ConsumptionScreen uses TabSwitcher (Refs #923 phase 3a)

### DIFF
--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -7,6 +7,7 @@ import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/help_banner.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/tab_switcher.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../achievements/presentation/widgets/badge_shelf.dart';
 import '../../../ev/domain/entities/charging_log.dart';
@@ -166,28 +167,25 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
           tooltip: l?.tooltipBack ?? 'Back',
           onPressed: () => context.pop(),
         ),
-        bottom: TabBar(
+        bottom: TabSwitcher(
           controller: tabController,
           tabs: [
-            Tab(
-              key: const Key('consumption_tab_fuel'),
-              icon: const Icon(Icons.local_gas_station_outlined),
-              text: l?.consumptionTabFuel ?? 'Fuel',
+            TabSwitcherEntry(
+              label: l?.consumptionTabFuel ?? 'Fuel',
+              icon: Icons.local_gas_station_outlined,
             ),
-            Tab(
-              key: const Key('consumption_tab_trajets'),
-              icon: const Icon(Icons.route_outlined),
-              text: l?.trajetsTabLabel ?? 'Trips',
+            TabSwitcherEntry(
+              label: l?.trajetsTabLabel ?? 'Trips',
+              icon: Icons.route_outlined,
             ),
             // #892 — Charging tab is hidden when the active vehicle
             // is a pure combustion engine. Hybrid and EV profiles
             // still see it; the no-vehicle case keeps the tab (a
             // dedicated onboarding story covers that path).
             if (showCharging)
-              Tab(
-                key: const Key('consumption_tab_charging'),
-                icon: const Icon(Icons.ev_station_outlined),
-                text: l?.consumptionTabCharging ?? 'Charging',
+              TabSwitcherEntry(
+                label: l?.consumptionTabCharging ?? 'Charging',
+                icon: Icons.ev_station_outlined,
               ),
           ],
         ),

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_tab_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_tab_test.dart
@@ -76,11 +76,11 @@ void main() {
   group('ConsumptionScreen tab toggle (#582 phase 2)', () {
     testWidgets('renders both Fuel and Charging tab headers', (tester) async {
       await _pumpScreen(tester);
-      expect(find.byKey(const Key('consumption_tab_fuel')), findsOneWidget);
-      expect(
-        find.byKey(const Key('consumption_tab_charging')),
-        findsOneWidget,
-      );
+      // #923 phase 3a — tabs now come from the canonical `TabSwitcher`
+      // widget whose `TabSwitcherEntry` contract has no `key:` field,
+      // so we assert on the localised label text instead.
+      expect(find.text('Fuel'), findsOneWidget);
+      expect(find.text('Charging'), findsOneWidget);
     });
 
     testWidgets('Fuel tab shows its empty state with 0 fill-ups',
@@ -93,7 +93,7 @@ void main() {
         'Charging tab shows its empty state with 0 charging logs',
         (tester) async {
       await _pumpScreen(tester);
-      await tester.tap(find.byKey(const Key('consumption_tab_charging')));
+      await tester.tap(find.text('Charging'));
       await tester.pumpAndSettle();
       expect(
         find.byKey(const Key('charging_empty_state')),
@@ -107,7 +107,7 @@ void main() {
       expect(find.byKey(const Key('fab_add_fillup')), findsOneWidget);
       expect(find.byKey(const Key('fab_add_charging')), findsNothing);
 
-      await tester.tap(find.byKey(const Key('consumption_tab_charging')));
+      await tester.tap(find.text('Charging'));
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('fab_add_charging')), findsOneWidget);
@@ -148,7 +148,7 @@ void main() {
         ),
       ];
       await _pumpScreen(tester, chargingLogs: logs);
-      await tester.tap(find.byKey(const Key('consumption_tab_charging')));
+      await tester.tap(find.text('Charging'));
       await tester.pumpAndSettle();
 
       expect(find.text('Ionity Castelnau'), findsOneWidget);

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
@@ -134,18 +134,21 @@ void main() {
           vehicles: const [_iceVehicle],
         );
 
+        // #923 phase 3a — tabs now come from the canonical
+        // `TabSwitcher` widget whose entries carry no per-tab `key:`.
+        // Assert on the localised label instead.
         expect(
-          find.byKey(const Key('consumption_tab_fuel')),
+          find.text('Fuel'),
           findsOneWidget,
           reason: 'Fuel tab must always render',
         );
         expect(
-          find.byKey(const Key('consumption_tab_trajets')),
+          find.text('Trips'),
           findsOneWidget,
           reason: 'Trajets tab must render for ICE vehicles',
         );
         expect(
-          find.byKey(const Key('consumption_tab_charging')),
+          find.text('Charging'),
           findsNothing,
           reason: 'Charging tab must be hidden for combustion vehicles',
         );
@@ -170,23 +173,14 @@ void main() {
           vehicles: const [_evVehicle],
         );
 
+        expect(find.text('Fuel'), findsOneWidget);
+        expect(find.text('Trips'), findsOneWidget);
         expect(
-          find.byKey(const Key('consumption_tab_fuel')),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(const Key('consumption_tab_trajets')),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(const Key('consumption_tab_charging')),
+          find.text('Charging'),
           findsOneWidget,
           reason: 'Charging tab must render for EV vehicles',
         );
         expect(find.byType(Tab), findsNWidgets(3));
-
-        // Default English ARB value for `consumptionTabCharging`.
-        expect(find.text('Charging'), findsOneWidget);
       },
     );
 
@@ -200,7 +194,7 @@ void main() {
         );
 
         expect(
-          find.byKey(const Key('consumption_tab_charging')),
+          find.text('Charging'),
           findsOneWidget,
           reason: 'Charging tab must render for hybrid vehicles',
         );
@@ -234,13 +228,10 @@ void main() {
         );
 
         // Sanity: Charging tab is there.
-        expect(
-          find.byKey(const Key('consumption_tab_charging')),
-          findsOneWidget,
-        );
+        expect(find.text('Charging'), findsOneWidget);
 
         // Tap onto Charging so we're ON the tab that will vanish.
-        await tester.tap(find.byKey(const Key('consumption_tab_charging')));
+        await tester.tap(find.text('Charging'));
         await tester.pumpAndSettle();
 
         // Flip the active vehicle to ICE — the tab set should shrink.
@@ -252,10 +243,6 @@ void main() {
         expect(tester.takeException(), isNull);
 
         // Charging tab is gone.
-        expect(
-          find.byKey(const Key('consumption_tab_charging')),
-          findsNothing,
-        );
         expect(find.text('Charging'), findsNothing);
 
         // We now have exactly 2 tabs.
@@ -280,7 +267,7 @@ void main() {
         activeNotifier.setVehicle(_evVehicle);
         await tester.pumpAndSettle();
         expect(
-          find.byKey(const Key('consumption_tab_charging')),
+          find.text('Charging'),
           findsOneWidget,
           reason: 'Charging tab must come back when vehicle is EV again',
         );

--- a/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
@@ -155,12 +155,12 @@ void main() {
         activeVehicle: vehicle,
         vehicles: [vehicle],
       );
-      expect(find.byKey(const Key('consumption_tab_fuel')), findsOneWidget);
-      expect(find.byKey(const Key('consumption_tab_trajets')), findsOneWidget);
-      expect(
-        find.byKey(const Key('consumption_tab_charging')),
-        findsOneWidget,
-      );
+      // #923 phase 3a — the canonical `TabSwitcher` has no key-per-tab
+      // contract, so we assert on the localised label text for each
+      // tab entry instead.
+      expect(find.text('Fuel'), findsOneWidget);
+      expect(find.text('Trips'), findsOneWidget);
+      expect(find.text('Charging'), findsOneWidget);
     });
 
     testWidgets('Trajets empty state renders CTA + "Start recording" button',
@@ -170,7 +170,7 @@ void main() {
         activeVehicle: vehicle,
         vehicles: [vehicle],
       );
-      await tester.tap(find.byKey(const Key('consumption_tab_trajets')));
+      await tester.tap(find.text('Trips'));
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('trajets_empty_state')), findsOneWidget);
@@ -220,7 +220,7 @@ void main() {
         activeVehicle: vehicle,
         vehicles: [vehicle],
       );
-      await tester.tap(find.byKey(const Key('consumption_tab_trajets')));
+      await tester.tap(find.text('Trips'));
       await tester.pumpAndSettle();
 
       // Every trip should render a row.
@@ -262,7 +262,7 @@ void main() {
         activeVehicle: vehicle,
         vehicles: [vehicle],
       );
-      await tester.tap(find.byKey(const Key('consumption_tab_trajets')));
+      await tester.tap(find.text('Trips'));
       await tester.pumpAndSettle();
 
       // Sanity — before tap, the detail stub hasn't been visited.


### PR DESCRIPTION
Refs #923 phase 3 — first screen migration. Swaps raw `TabBar` to canonical `TabSwitcher`. No behavior change.

## Summary
- Replace `TabBar(...)` in `ConsumptionScreen` with `TabSwitcher(tabs: [...], controller: tabController)` from `lib/core/widgets/tab_switcher.dart` (#927).
- Keep the existing `TabController` wiring — the canonical widget wraps `TabBar`, it doesn't replace `TabController`. Dynamic tab count per vehicle type (#892), FAB rebind per tab, and body switching are all preserved.
- This PR is ONLY the tab-row swap. Section headers, cards, AppBar migration land in later phase-3 PRs.

## Test plan
- Update the three Consumption-screen widget tests that reached in via `find.byKey(Key('consumption_tab_fuel'|'consumption_tab_trajets'|'consumption_tab_charging'))` — the canonical `TabSwitcherEntry` has no per-tab `key:` field by design, so the assertions/taps now match on the localised label text, which already mapped 1:1 to the keys.
- `flutter analyze` → clean.
- `flutter test` → all 5829 tests pass.

## Testing
- [x] `/c/dev/flutter/bin/flutter analyze` — No issues found.
- [x] `/c/dev/flutter/bin/flutter test` — All tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)