### PR TITLE
refactor(ui): FavoritesScreen uses TabSwitcher (Refs #923 phase 3b)

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/sync/sync_provider.dart';
+import '../../../../core/widgets/tab_switcher.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/favorites_provider.dart';
 import '../widgets/alerts_tab.dart';
@@ -58,10 +59,10 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
                 tooltip: l10n?.refreshPrices ?? 'Refresh prices',
               ),
           ],
-          bottom: TabBar(
+          bottom: TabSwitcher(
             tabs: [
-              Tab(text: l10n?.favorites ?? 'Favorites'),
-              Tab(text: l10n?.priceAlerts ?? 'Price Alerts'),
+              TabSwitcherEntry(label: l10n?.favorites ?? 'Favorites'),
+              TabSwitcherEntry(label: l10n?.priceAlerts ?? 'Price Alerts'),
             ],
           ),
         ),

--- a/test/features/favorites/presentation/screens/favorites_screen_test.dart
+++ b/test/features/favorites/presentation/screens/favorites_screen_test.dart
@@ -84,7 +84,7 @@ void main() {
         overrides: test.overrides,
       );
 
-      // TabBar should have both tabs
+      // TabSwitcher should have both tabs
       expect(find.text('Favorites'), findsAtLeast(2)); // Tab + AppBar
       expect(find.text('Price Alerts'), findsOneWidget);
     });


### PR DESCRIPTION
Refs #923 phase 3 second screen migration.

## Summary
- Replace raw `TabBar(...)` in `FavoritesScreen` with the canonical `TabSwitcher` + `TabSwitcherEntry` (shipped in #927).
- `DefaultTabController` wrapper, `TabBarView` body, tab count, and behavior all preserved. AppBar, list tiles, and cards are untouched — future phase PRs.
- Pattern mirrors PR #928 (ConsumptionScreen migration).

## Test plan
- `flutter analyze` — No issues found.
- `flutter test` — All 5829 tests pass.
- Existing `favorites_screen_test.dart` assertions were already text-label based (no `byKey` on tabs), so only a stale comment was updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)