### PR TITLE
fix(map): retry client ignores cancellation + explicit abortObsoleteRequests (#930)

### DIFF
--- a/lib/features/map/data/retry_network_tile_provider.dart
+++ b/lib/features/map/data/retry_network_tile_provider.dart
@@ -146,6 +146,19 @@ class RetryingTileHttpClient extends http.BaseClient {
         lastStack = s;
         _logAttempt(request.url, attempt, 'TimeoutException: $e');
       } on http.ClientException catch (e, s) {
+        // #930 — flutter_map 8.x aborts in-flight tile HTTP requests
+        // when the viewport moves and the tile becomes obsolete. The
+        // underlying http client surfaces that abort as a
+        // ClientException with a message containing "canceled",
+        // "cancelled", or "aborted". Retrying it is pointless (the
+        // caller has moved on) and actively harmful: burning our 3
+        // attempts on a cancelled request produces an error tile,
+        // which `evictErrorTileStrategy.notVisibleRespectMargin`
+        // keeps on screen as gray when the user stops panning.
+        // Rethrow immediately — no retry, no sleep.
+        if (_isCancellation(e)) {
+          Error.throwWithStackTrace(e, s);
+        }
         lastError = e;
         lastStack = s;
         _logAttempt(request.url, attempt, 'ClientException: $e');
@@ -162,6 +175,22 @@ class RetryingTileHttpClient extends http.BaseClient {
     throw http.ClientException(
         'RetryNetworkTileProvider: retries exhausted without response');
   }
+
+  /// Detects the cancellation/abort signal produced when
+  /// flutter_map aborts an in-flight tile fetch because the tile
+  /// became obsolete (viewport moved before the fetch completed).
+  /// The underlying `http` package surfaces these aborts as
+  /// `http.ClientException` with a message containing "canceled",
+  /// "cancelled", or "aborted" (case varies by platform + package
+  /// version). See #930 for the gray-tile regression this prevents.
+  @visibleForTesting
+  static bool isCancellationException(http.ClientException e) {
+    final msg = e.message.toLowerCase();
+    return msg.contains('cancel') || msg.contains('abort');
+  }
+
+  static bool _isCancellation(http.ClientException e) =>
+      isCancellationException(e);
 
   /// Which HTTP status codes should trigger a retry.
   ///

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -87,7 +87,18 @@ class StationMapLayers extends StatelessWidget {
               // replaces the symptom-level workarounds from #496,
               // #532, #696, #707, #709, and #711 (zoom-jiggle,
               // subtree rebuild, ImageCache sizing).
-              tileProvider: RetryNetworkTileProvider(),
+              //
+              // #930 — flutter_map's default aborts in-flight tile
+              // fetches on pan. Our retry layer must not see those
+              // cancellations as errors, and we prefer the tiny
+              // bandwidth cost of finishing the fetch over
+              // race-induced gray tiles when the user stops panning
+              // with a mid-flight tile still in view. Hence explicit
+              // `abortObsoleteRequests: false` here (belt) plus
+              // cancellation-aware retry logic in the provider
+              // itself (suspenders).
+              tileProvider:
+                  RetryNetworkTileProvider(abortObsoleteRequests: false),
               evictErrorTileStrategy:
                   EvictErrorTileStrategy.notVisibleRespectMargin,
               errorTileCallback: (tile, error, stackTrace) {

--- a/test/features/map/data/retry_network_tile_provider_test.dart
+++ b/test/features/map/data/retry_network_tile_provider_test.dart
@@ -215,6 +215,161 @@ void main() {
       expect(d2.inMilliseconds, greaterThan(d1.inMilliseconds));
     });
 
+    group('cancellation handling (#930)', () {
+      // flutter_map 8.x aborts in-flight tile HTTP requests when
+      // the viewport moves and the tile becomes obsolete. The
+      // retry client must treat those cancellations as a hard
+      // rethrow (not a transient failure) so it does not burn its
+      // retries producing an error tile that
+      // `evictErrorTileStrategy.notVisibleRespectMargin` then
+      // strands on-screen as gray. See #930 for the full trace.
+
+      test('ClientException("Request canceled") rethrows immediately — '
+          'zero retries, zero sleeps', () async {
+        final inner = _FakeClient(errors: [
+          http.ClientException('Request canceled'),
+          // Unreachable — if the retry loop keeps going, it would
+          // hit this and produce a misleading success.
+          http.ClientException('Request canceled'),
+          http.ClientException('Request canceled'),
+        ]);
+        final slept = <Duration>[];
+        final client = RetryingTileHttpClient(
+          inner: inner,
+          sleep: (d) async => slept.add(d),
+        );
+
+        await expectLater(
+          client.get(Uri.parse('https://tile/cancel.png')),
+          throwsA(isA<http.ClientException>()),
+        );
+        expect(inner.sentCount, 1,
+            reason: 'cancellation must NOT retry — the caller '
+                '(flutter_map) has moved on, retrying wastes '
+                'bandwidth and produces a bogus error tile.');
+        expect(slept, isEmpty,
+            reason: 'zero sleeps — the rethrow is immediate.');
+      });
+
+      test('ClientException with "aborted" rethrows immediately', () async {
+        final inner = _FakeClient(errors: [
+          http.ClientException('Connection aborted by client'),
+          http.ClientException('still aborted'),
+        ]);
+        final slept = <Duration>[];
+        final client = RetryingTileHttpClient(
+          inner: inner,
+          sleep: (d) async => slept.add(d),
+        );
+
+        await expectLater(
+          client.get(Uri.parse('https://tile/abort.png')),
+          throwsA(isA<http.ClientException>()),
+        );
+        expect(inner.sentCount, 1);
+        expect(slept, isEmpty);
+      });
+
+      test('ClientException with "Cancelled" (capital C) rethrows — '
+          'match is case-insensitive', () async {
+        final inner = _FakeClient(errors: [
+          http.ClientException('Request Cancelled'),
+          http.ClientException('still cancelled'),
+        ]);
+        final slept = <Duration>[];
+        final client = RetryingTileHttpClient(
+          inner: inner,
+          sleep: (d) async => slept.add(d),
+        );
+
+        await expectLater(
+          client.get(Uri.parse('https://tile/Cancelled.png')),
+          throwsA(isA<http.ClientException>()),
+        );
+        expect(inner.sentCount, 1);
+        expect(slept, isEmpty);
+      });
+
+      test('SocketException still retries — cancellation branch did not '
+          'overshoot into transient connection errors', () async {
+        // Regression guard: if the #930 fix accidentally short-
+        // circuits SocketException too, we lose retries on legitimate
+        // transient network blips.
+        final inner = _FakeClient(errors: [
+          const SocketException('connection blip 1'),
+          const SocketException('connection blip 2'),
+          const SocketException('connection blip 3'),
+        ]);
+        final slept = <Duration>[];
+        final client = RetryingTileHttpClient(
+          inner: inner,
+          sleep: (d) async => slept.add(d),
+        );
+
+        await expectLater(
+          client.get(Uri.parse('https://tile/socket.png')),
+          throwsA(isA<SocketException>()),
+        );
+        expect(inner.sentCount, 3,
+            reason: 'SocketException is transient — must still hit the '
+                'full maxAttempts retry path.');
+        expect(slept, hasLength(2),
+            reason: 'two backoff sleeps between three attempts.');
+      });
+
+      test('ClientException without cancel/abort keyword still retries',
+          () async {
+        // Another regression guard: generic http.ClientException
+        // (e.g. "Connection closed before full header was received")
+        // is transient and must keep its 3-attempt retry.
+        final inner = _FakeClient(errors: [
+          http.ClientException('Connection closed before full '
+              'header was received'),
+          http.ClientException('Connection closed'),
+          http.ClientException('Connection closed'),
+        ]);
+        final client = RetryingTileHttpClient(
+          inner: inner,
+          sleep: (_) async {},
+        );
+
+        await expectLater(
+          client.get(Uri.parse('https://tile/closed.png')),
+          throwsA(isA<http.ClientException>()),
+        );
+        expect(inner.sentCount, 3,
+            reason: 'non-cancellation ClientException remains retryable.');
+      });
+
+      test('isCancellationException matches the expected keyword set', () {
+        expect(
+            RetryingTileHttpClient.isCancellationException(
+                http.ClientException('Request canceled')),
+            isTrue);
+        expect(
+            RetryingTileHttpClient.isCancellationException(
+                http.ClientException('request Cancelled')),
+            isTrue);
+        expect(
+            RetryingTileHttpClient.isCancellationException(
+                http.ClientException('aborted by client')),
+            isTrue);
+        expect(
+            RetryingTileHttpClient.isCancellationException(
+                http.ClientException('Aborted')),
+            isTrue);
+        // Does NOT match generic transient errors.
+        expect(
+            RetryingTileHttpClient.isCancellationException(
+                http.ClientException('Connection closed')),
+            isFalse);
+        expect(
+            RetryingTileHttpClient.isCancellationException(
+                http.ClientException('Timed out')),
+            isFalse);
+      });
+    });
+
     test('RetryingTileHttpClient.isRetryableStatusCode matches policy', () {
       // Permanent 4xx — no retry.
       expect(RetryingTileHttpClient.isRetryableStatusCode(400), isFalse);

--- a/test/lint/retry_tile_provider_call_site_test.dart
+++ b/test/lint/retry_tile_provider_call_site_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#930): every `RetryNetworkTileProvider(`
+/// instantiation in `lib/features/map/` MUST pass an explicit
+/// `abortObsoleteRequests:` argument.
+///
+/// Why: flutter_map 8.x's default is `abortObsoleteRequests: true`,
+/// which aborts in-flight tile HTTP requests when the viewport
+/// moves. Our retry layer used to treat those cancellations as
+/// transient failures and burned its 3-attempt retry budget
+/// producing an error tile. Combined with
+/// `evictErrorTileStrategy.notVisibleRespectMargin`, the error tile
+/// then stranded on-screen as gray whenever the user stopped panning
+/// with a mid-flight tile still in view.
+///
+/// The runtime fix is two-part:
+///   1. Provider rethrows cancellation exceptions immediately (no
+///      retry).
+///   2. Call site passes `abortObsoleteRequests: false` to stop the
+///      abort at the source.
+///
+/// This scan enforces part 2: even if a future author removes the
+/// `false` argument (or inlines it to the default), the missing
+/// keyword will trip this test and force them to re-read #930 before
+/// shipping. Either explicit value is accepted — the test only
+/// enforces that the argument is present and named.
+void main() {
+  test('every RetryNetworkTileProvider(...) in lib/features/map passes '
+      'abortObsoleteRequests explicitly (#930)', () {
+    final mapRoot = Directory('lib/features/map');
+    expect(mapRoot.existsSync(), isTrue,
+        reason: 'lib/features/map must exist — worktree misconfigured');
+
+    final offenders = <String>[];
+
+    for (final entity in mapRoot.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      if (entity.path.endsWith('.g.dart') ||
+          entity.path.endsWith('.freezed.dart')) {
+        continue;
+      }
+      // Skip the provider definition file itself — it declares the
+      // class and references the constructor in doc comments, but
+      // does not INSTANTIATE it (the instantiations live at call
+      // sites in presentation/widgets). The scan targets call sites
+      // only.
+      if (entity.path.replaceAll('\\', '/').endsWith(
+          'lib/features/map/data/retry_network_tile_provider.dart')) {
+        continue;
+      }
+
+      final text = entity.readAsStringSync();
+      // Match `RetryNetworkTileProvider(` with a token boundary on
+      // the left so we don't get false positives from a hypothetical
+      // `MyRetryNetworkTileProvider(` subclass.
+      final tokenRe = RegExp(r'(?<![A-Za-z0-9_])RetryNetworkTileProvider\(');
+      for (final match in tokenRe.allMatches(text)) {
+        final idx = match.start;
+        final end =
+            _matchingCloseParen(text, idx + 'RetryNetworkTileProvider('.length - 1);
+        if (end < 0) {
+          offenders.add('${entity.path} near char $idx: '
+              'unbalanced RetryNetworkTileProvider(...) — cannot verify '
+              'abortObsoleteRequests argument. See #930.');
+          continue;
+        }
+        final snippet = text.substring(idx, end + 1);
+        if (!snippet.contains('abortObsoleteRequests')) {
+          final line = _lineNumber(text, idx);
+          offenders.add('${entity.path}:$line — RetryNetworkTileProvider '
+              'without explicit abortObsoleteRequests. See #930 '
+              '(gray-tile regression from flutter_map cancellations).');
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: offenders.join('\n'),
+    );
+  });
+}
+
+int _matchingCloseParen(String text, int openIdx) {
+  var depth = 0;
+  for (var i = openIdx; i < text.length; i++) {
+    final c = text[i];
+    if (c == '(') depth++;
+    if (c == ')') {
+      depth--;
+      if (depth == 0) return i;
+    }
+  }
+  return -1;
+}
+
+int _lineNumber(String text, int index) {
+  var line = 1;
+  for (var i = 0; i < index; i++) {
+    if (text.codeUnitAt(i) == 0x0A) line++;
+  }
+  return line;
+}


### PR DESCRIPTION
## What
- `RetryingTileHttpClient.send` now rethrows `http.ClientException` immediately when the message indicates a cancellation/abort (`cancel`/`cancelled`/`aborted`, case-insensitive). No retries, no sleeps.
- `station_map_layers.dart` explicitly passes `abortObsoleteRequests: false` to `RetryNetworkTileProvider(...)`.
- New static scan `test/lint/retry_tile_provider_call_site_test.dart` enforces that every `RetryNetworkTileProvider(...)` in `lib/features/map/` passes `abortObsoleteRequests` explicitly.
- Four new unit tests in `retry_network_tile_provider_test.dart` cover the cancellation rethrow + a regression guard that `SocketException` still retries.

## Why
Gray tiles regressed after #843. flutter_map 8.x aborts in-flight tile HTTP requests when the viewport pans and a tile becomes obsolete. The retry client was treating that abort as a transient failure and burning all 3 retries on a request flutter_map had already dropped — producing an error tile that `evictErrorTileStrategy.notVisibleRespectMargin` then stranded on-screen as gray whenever the user stopped panning with a mid-flight tile still in view. Only zoom-out-then-in recovered the tile (new `z` coords bypass the error cache).

Belt-and-suspenders fix: stop the abort at the call site AND teach the retry client to not retry cancellations. Either change alone would likely close the bug, but shipping both makes the fix robust against future flutter_map default changes.

## Testing
- `flutter analyze` — zero warnings.
- `flutter test test/features/map/ test/lint/` — 117 tests pass including 6 new cancellation-related tests.
- `flutter test` full suite — 5836 tests pass.
- Device validation deferred to coordinator admin-merge + APK rebuild step.

Closes #930