### PR TITLE
refactor(obd2): extract TripRecordingPhase + HapticFeedbackPolicy + TripRecordingState (Refs #563)

### DIFF
--- a/lib/features/consumption/providers/haptic_feedback_policy.dart
+++ b/lib/features/consumption/providers/haptic_feedback_policy.dart
@@ -1,0 +1,26 @@
+import '../domain/cold_start_baselines.dart';
+
+/// Haptic strength emitted when the consumption band changes (#767).
+enum HapticIntensity { none, light, medium }
+
+/// Decide which haptic (if any) fires when [previous] transitions to
+/// [current]. Pure function: no platform calls, easily unit-tested.
+/// Only escalations vibrate — heavy or worse. Positive transitions
+/// (eco / normal) stay silent so the feedback is a corrective nudge,
+/// not constant noise.
+HapticIntensity hapticForBandTransition(
+  ConsumptionBand previous,
+  ConsumptionBand current,
+) {
+  if (previous == current) return HapticIntensity.none;
+  if (current == ConsumptionBand.veryHeavy &&
+      previous != ConsumptionBand.veryHeavy) {
+    return HapticIntensity.medium;
+  }
+  if (current == ConsumptionBand.heavy &&
+      previous != ConsumptionBand.heavy &&
+      previous != ConsumptionBand.veryHeavy) {
+    return HapticIntensity.light;
+  }
+  return HapticIntensity.none;
+}

--- a/lib/features/consumption/providers/trip_recording_phase.dart
+++ b/lib/features/consumption/providers/trip_recording_phase.dart
@@ -1,0 +1,8 @@
+/// Lifecycle phase of the app-wide OBD2 trip recording (#726).
+///
+/// #797 phase 1 adds [pausedDueToDrop] for the "Bluetooth link lost
+/// mid-recording" case. Distinct from [paused] because the user did
+/// not pause; the partial trip is auto-persisted to the paused-trips
+/// Hive box and a grace timer ticks in the controller. Phase 2 wires
+/// this into a banner + auto-reconnect scanner.
+enum TripRecordingPhase { idle, recording, paused, pausedDueToDrop, finished }

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -22,89 +22,22 @@ import '../data/trip_history_repository.dart';
 import '../domain/cold_start_baselines.dart';
 import '../domain/situation_classifier.dart';
 import '../domain/trip_recorder.dart';
+import 'haptic_feedback_policy.dart';
 import 'trip_history_provider.dart';
+import 'trip_recording_phase.dart';
+import 'trip_recording_state.dart';
+
+// Re-export the phase, state, and haptic-policy types so existing
+// callers (widgets, screens, tests) that import this file keep
+// resolving without touching every import site after the #563
+// provider-split refactor. New callers should import the individual
+// files directly.
+export 'haptic_feedback_policy.dart'
+    show HapticIntensity, hapticForBandTransition;
+export 'trip_recording_phase.dart' show TripRecordingPhase;
+export 'trip_recording_state.dart' show TripRecordingState;
 
 part 'trip_recording_provider.g.dart';
-
-/// Lifecycle phase of the app-wide OBD2 trip recording (#726).
-///
-/// #797 phase 1 adds [pausedDueToDrop] for the "Bluetooth link lost
-/// mid-recording" case. Distinct from [paused] because the user did
-/// not pause; the partial trip is auto-persisted to the paused-trips
-/// Hive box and a grace timer ticks in the controller. Phase 2 wires
-/// this into a banner + auto-reconnect scanner.
-enum TripRecordingPhase { idle, recording, paused, pausedDueToDrop, finished }
-
-/// Haptic strength emitted when the consumption band changes (#767).
-enum HapticIntensity { none, light, medium }
-
-/// Decide which haptic (if any) fires when [previous] transitions to
-/// [current]. Pure function: no platform calls, easily unit-tested.
-/// Only escalations vibrate — heavy or worse. Positive transitions
-/// (eco / normal) stay silent so the feedback is a corrective nudge,
-/// not constant noise.
-HapticIntensity hapticForBandTransition(
-  ConsumptionBand previous,
-  ConsumptionBand current,
-) {
-  if (previous == current) return HapticIntensity.none;
-  if (current == ConsumptionBand.veryHeavy &&
-      previous != ConsumptionBand.veryHeavy) {
-    return HapticIntensity.medium;
-  }
-  if (current == ConsumptionBand.heavy &&
-      previous != ConsumptionBand.heavy &&
-      previous != ConsumptionBand.veryHeavy) {
-    return HapticIntensity.light;
-  }
-  return HapticIntensity.none;
-}
-
-/// Immutable snapshot the UI observes.
-@immutable
-class TripRecordingState {
-  final TripRecordingPhase phase;
-  final TripLiveReading? live;
-  final DrivingSituation situation;
-  final ConsumptionBand band;
-
-  /// How far live consumption deviates from the situation's baseline
-  /// as a signed fraction (e.g. -0.08 = 8 % below baseline). Null
-  /// when the car doesn't report fuel rate or a live L/100 km can't
-  /// be computed (idle uses L/h — caller formats it differently).
-  final double? liveDeltaFraction;
-
-  const TripRecordingState({
-    this.phase = TripRecordingPhase.idle,
-    this.live,
-    this.situation = DrivingSituation.idle,
-    this.band = ConsumptionBand.normal,
-    this.liveDeltaFraction,
-  });
-
-  TripRecordingState copyWith({
-    TripRecordingPhase? phase,
-    TripLiveReading? live,
-    DrivingSituation? situation,
-    ConsumptionBand? band,
-    double? liveDeltaFraction,
-    bool clearDelta = false,
-  }) =>
-      TripRecordingState(
-        phase: phase ?? this.phase,
-        live: live ?? this.live,
-        situation: situation ?? this.situation,
-        band: band ?? this.band,
-        liveDeltaFraction: clearDelta
-            ? null
-            : (liveDeltaFraction ?? this.liveDeltaFraction),
-      );
-
-  bool get isActive =>
-      phase == TripRecordingPhase.recording ||
-      phase == TripRecordingPhase.paused ||
-      phase == TripRecordingPhase.pausedDueToDrop;
-}
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/consumption/providers/trip_recording_state.dart
+++ b/lib/features/consumption/providers/trip_recording_state.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/obd2/trip_live_reading.dart';
+import '../domain/cold_start_baselines.dart';
+import '../domain/situation_classifier.dart';
+import 'trip_recording_phase.dart';
+
+/// Immutable snapshot the UI observes.
+@immutable
+class TripRecordingState {
+  final TripRecordingPhase phase;
+  final TripLiveReading? live;
+  final DrivingSituation situation;
+  final ConsumptionBand band;
+
+  /// How far live consumption deviates from the situation's baseline
+  /// as a signed fraction (e.g. -0.08 = 8 % below baseline). Null
+  /// when the car doesn't report fuel rate or a live L/100 km can't
+  /// be computed (idle uses L/h — caller formats it differently).
+  final double? liveDeltaFraction;
+
+  const TripRecordingState({
+    this.phase = TripRecordingPhase.idle,
+    this.live,
+    this.situation = DrivingSituation.idle,
+    this.band = ConsumptionBand.normal,
+    this.liveDeltaFraction,
+  });
+
+  TripRecordingState copyWith({
+    TripRecordingPhase? phase,
+    TripLiveReading? live,
+    DrivingSituation? situation,
+    ConsumptionBand? band,
+    double? liveDeltaFraction,
+    bool clearDelta = false,
+  }) =>
+      TripRecordingState(
+        phase: phase ?? this.phase,
+        live: live ?? this.live,
+        situation: situation ?? this.situation,
+        band: band ?? this.band,
+        liveDeltaFraction: clearDelta
+            ? null
+            : (liveDeltaFraction ?? this.liveDeltaFraction),
+      );
+
+  bool get isActive =>
+      phase == TripRecordingPhase.recording ||
+      phase == TripRecordingPhase.paused ||
+      phase == TripRecordingPhase.pausedDueToDrop;
+}

--- a/test/features/consumption/providers/haptic_feedback_policy_test.dart
+++ b/test/features/consumption/providers/haptic_feedback_policy_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/providers/haptic_feedback_policy.dart';
+
+void main() {
+  group('hapticForBandTransition (#767)', () {
+    test('returns none when previous and current are identical', () {
+      for (final band in ConsumptionBand.values) {
+        expect(
+          hapticForBandTransition(band, band),
+          HapticIntensity.none,
+          reason: 'no-op transition for $band should stay silent',
+        );
+      }
+    });
+
+    test('escalation into heavy fires a light haptic', () {
+      expect(
+        hapticForBandTransition(ConsumptionBand.normal, ConsumptionBand.heavy),
+        HapticIntensity.light,
+      );
+      expect(
+        hapticForBandTransition(ConsumptionBand.eco, ConsumptionBand.heavy),
+        HapticIntensity.light,
+      );
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.transient,
+          ConsumptionBand.heavy,
+        ),
+        HapticIntensity.light,
+      );
+    });
+
+    test('escalation into veryHeavy fires a medium haptic', () {
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.normal,
+          ConsumptionBand.veryHeavy,
+        ),
+        HapticIntensity.medium,
+      );
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.eco,
+          ConsumptionBand.veryHeavy,
+        ),
+        HapticIntensity.medium,
+      );
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.transient,
+          ConsumptionBand.veryHeavy,
+        ),
+        HapticIntensity.medium,
+      );
+    });
+
+    test('direct heavy -> veryHeavy still fires a medium haptic', () {
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.heavy,
+          ConsumptionBand.veryHeavy,
+        ),
+        HapticIntensity.medium,
+        reason: 'entering veryHeavy is always a medium nudge',
+      );
+    });
+
+    test('downgrade out of veryHeavy stays silent — positive transition', () {
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.veryHeavy,
+          ConsumptionBand.heavy,
+        ),
+        HapticIntensity.none,
+        reason:
+            'dropping from veryHeavy to heavy is an improvement; no feedback',
+      );
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.veryHeavy,
+          ConsumptionBand.normal,
+        ),
+        HapticIntensity.none,
+      );
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.veryHeavy,
+          ConsumptionBand.eco,
+        ),
+        HapticIntensity.none,
+      );
+    });
+
+    test('downgrade out of heavy stays silent', () {
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.heavy,
+          ConsumptionBand.normal,
+        ),
+        HapticIntensity.none,
+      );
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.heavy,
+          ConsumptionBand.eco,
+        ),
+        HapticIntensity.none,
+      );
+    });
+
+    test('transitions between non-heavy bands stay silent', () {
+      expect(
+        hapticForBandTransition(ConsumptionBand.eco, ConsumptionBand.normal),
+        HapticIntensity.none,
+      );
+      expect(
+        hapticForBandTransition(ConsumptionBand.normal, ConsumptionBand.eco),
+        HapticIntensity.none,
+      );
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.normal,
+          ConsumptionBand.transient,
+        ),
+        HapticIntensity.none,
+      );
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.transient,
+          ConsumptionBand.normal,
+        ),
+        HapticIntensity.none,
+      );
+    });
+
+    test('transient -> heavy fires light (transient is neutral)', () {
+      expect(
+        hapticForBandTransition(
+          ConsumptionBand.transient,
+          ConsumptionBand.heavy,
+        ),
+        HapticIntensity.light,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Continues the #563 provider-split work started in #929. Pulls three cohesive modules out of the 706-line `trip_recording_provider.dart`:

- **`trip_recording_phase.dart`** — the `TripRecordingPhase` enum (idle / recording / paused / pausedDueToDrop / finished).
- **`haptic_feedback_policy.dart`** — the `HapticIntensity` enum + the pure `hapticForBandTransition(previous, current)` function that decides whether a band change should ping a light or medium haptic.
- **`trip_recording_state.dart`** — the `@immutable TripRecordingState` DTO and its `copyWith`.

All three are re-exported from `trip_recording_provider.dart` via `export 'foo.dart' show ...;`, matching the pattern already used by `trip_recording_controller.dart` after #929. Every caller (widgets, screens, tests) keeps importing a single file and nothing else had to change.

## Why

The provider had grown into a god-file mixing lifecycle state, the pure haptic policy, the immutable DTO, and the actual service-ownership logic. Splitting lets each module be reasoned about and tested in isolation, and makes the follow-up phases (extract the service-ownership notifier, extract the baseline/sync side, etc.) easier to land as small PRs.

This is **one phase** of #563 — the issue stays open; coordinator will close when the full split is in.

## Testing

- New focused unit test at `test/features/consumption/providers/haptic_feedback_policy_test.dart` covering every band-transition case (same band stays silent, escalation into heavy fires light, escalation into veryHeavy fires medium from every other band, downgrades stay silent, transient transitions behave correctly).
- Existing `trip_recording_provider_test.dart` kept unchanged — all 64 tests in that directory still pass.
- Full suite green: 5837 pass / 1 skip.
- `flutter analyze` clean (zero issues).

## Metrics

- `trip_recording_provider.dart`: **706 → 639 LOC** (-67, -9.5%).
- No `.g.dart` regeneration needed — the provider annotation surface didn't change.

Refs #563 — phase, not closing.