### PR TITLE
refactor(ui): ProfileScreen uses PageScaffold + canonical SectionHeader (Refs #923 phase 3d)

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -3,12 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/theme/theme_mode_provider.dart';
+import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../core/widgets/section_header.dart';
+import '../../../../core/widgets/settings_menu_tile.dart';
 import '../../../consent/presentation/widgets/consent_settings_section.dart';
 import '../widgets/about_section.dart';
 import '../widgets/api_key_section.dart';
 import '../widgets/location_section_widget.dart';
 import '../widgets/profile_list_section.dart';
-import '../../../../core/widgets/settings_menu_tile.dart';
 import '../widgets/storage_section.dart';
 import '../widgets/tank_sync_section.dart';
 
@@ -23,21 +25,24 @@ class ProfileScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l?.settings ?? 'Settings'),
-      ),
+    return PageScaffold(
+      title: l?.settings ?? 'Settings',
+      // #530 — compact vertical spacing. Was `EdgeInsets.all(16)` plus
+      // `SizedBox(height: 32)` between every major section, which ate
+      // ~180 dp of whitespace on a single screen. Tightened to 8 dp
+      // top / 16 dp sides + 16 dp section gaps + 4 dp header-to-body.
+      bodyPadding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
       body: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        // #530 — compact vertical spacing. Was `EdgeInsets.all(16)` plus
-        // `SizedBox(height: 32)` between every major section, which ate
-        // ~180 dp of whitespace on a single screen. Tightened to 8 dp
-        // top / 16 dp sides + 16 dp section gaps + 4 dp header-to-body.
-        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        padding: EdgeInsets.zero,
         children: [
           // Profiles — always visible, the primary interaction on the
           // Settings screen.
-          _SectionHeader(icon: Icons.person, title: l?.sectionProfile ?? 'Profile'),
+          SectionHeader(
+            leadingIcon: Icons.person,
+            title: l?.sectionProfile ?? 'Profile',
+            padding: EdgeInsets.zero,
+          ),
           const SizedBox(height: 4),
           const ProfileListSection(),
           const SizedBox(height: 16),
@@ -125,8 +130,11 @@ class ProfileScreen extends ConsumerWidget {
           const SizedBox(height: 16),
 
           // #534 — About moved to the very end, below Privacy.
-          _SectionHeader(
-              icon: Icons.info_outline, title: l?.about ?? 'About'),
+          SectionHeader(
+            leadingIcon: Icons.info_outline,
+            title: l?.about ?? 'About',
+            padding: EdgeInsets.zero,
+          ),
           const SizedBox(height: 4),
           const AboutSection(),
           SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
@@ -189,23 +197,3 @@ String _themeSubtitle(WidgetRef ref, AppLocalizations? l) {
   }
 }
 
-class _SectionHeader extends StatelessWidget {
-  final IconData icon;
-  final String title;
-
-  const _SectionHeader({required this.icon, required this.title});
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      header: true,
-      child: Row(
-        children: [
-          ExcludeSemantics(child: Icon(icon, size: 20)),
-          const SizedBox(width: 8),
-          Text(title, style: Theme.of(context).textTheme.titleMedium),
-        ],
-      ),
-    );
-  }
-}


### PR DESCRIPTION
## Summary
- Migrate `ProfileScreen` to canonical `PageScaffold` (replaces raw `Scaffold` + `AppBar`).
- Delete the local `_SectionHeader` class; both Profile and About section titles now render through the canonical `SectionHeader` with `leadingIcon`.
- Preserve the #530 compact body padding (`8 dp top / 16 dp sides / 16 dp bottom`) via `PageScaffold.bodyPadding`.

Out of scope on purpose: `_FoldableSection` and every extracted section widget (`LocationSectionWidget`, `ProfileListSection`, `ApiKeySection`, `StorageSection`, `TankSyncSection`, `ConsentSettingsSection`, `AboutSection`) are left untouched for later phases.

Refs #923

## Why
Consolidates the Settings landing screen onto the design-system primitives from `lib/core/widgets/`, clearing the one-off `_SectionHeader` and one more raw `AppBar` call site. Keeps visual parity (section icons, spacing, Settings title) and all existing ProfileScreen widget tests still pass without edits.

## Testing
- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — full suite green (5836 passed, 1 skipped network)
- [x] `flutter test test/features/profile/presentation/screens/profile_screen_test.dart` — 13 tests pass including the #530 no-tall-spacer regression, #519 Data & Privacy absence, #896/#897 `SettingsMenuTile` count, #520/#528 inset sanity
- [x] `flutter test test/features/profile/presentation/screens/settings_screen_theme_card_test.dart` — 4 theme-card tests pass

## Screenshots
No visual regression — `PageScaffold` renders the same `Scaffold` + `AppBar` shape; `SectionHeader` keeps the section icons (now 16 dp primary-tinted per the design-system spec instead of 20 dp neutral, matching every other settings-style screen).