### PR TITLE
refactor(obd2): extract fuel_rate_estimator from obd2_service (Refs #563)

### DIFF
--- a/lib/features/consumption/data/obd2/fuel_rate_estimator.dart
+++ b/lib/features/consumption/data/obd2/fuel_rate_estimator.dart
@@ -1,0 +1,123 @@
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+
+/// Pure-math fuel-rate estimator + stoichiometric constants (#800,
+/// #810, #812, #813). Extracted from `obd2_service.dart` as part of
+/// the #563 service-split refactor so the speed-density math and the
+/// AFR / density constants can be unit-tested in isolation, shared
+/// across consumers ([TripRecordingController] re-implements the same
+/// branches on cached live samples), and mutated without touching the
+/// transport-coupled [Obd2Service].
+///
+/// `Obd2Service` still re-exposes the constants and functions as
+/// static members so existing callers keep compiling — see the
+/// forwarders in `obd2_service.dart`.
+
+/// Stoichiometric AFR for petrol / gasoline (#800). Approximately
+/// 14.7 kg of air per kg of fuel at perfect combustion.
+const double kPetrolAfr = 14.7;
+
+/// Stoichiometric AFR for diesel (#800). Slightly leaner burn than
+/// petrol — ~14.5 kg of air per kg of diesel.
+const double kDieselAfr = 14.5;
+
+/// Petrol density in g/L at ~15 °C (#800). Published range
+/// 720–775 g/L; 740 is the legacy Tankstellen constant, kept stable
+/// so pre-#800 fuel-rate samples don't shift by ~0.7 % after the
+/// diesel branch landed.
+const double kPetrolDensityGPerL = 740.0;
+
+/// Diesel density in g/L at ~15 °C (#800). Denser than petrol at
+/// ~820–845 g/L; 832 is the EN 590 reference point.
+const double kDieselDensityGPerL = 832.0;
+
+/// Fallback engine displacement used by the speed-density fuel-rate
+/// estimator when the active vehicle profile doesn't expose one
+/// (#810, #812). 1000 cc = 1.0 L NA petrol — matches the Peugeot 107
+/// / Aygo / C1 class that originally motivated the fallback. Kept as
+/// a named constant so the no-profile case is obvious at a glance
+/// and easy to update if the default assumption ever changes.
+const int kDefaultEngineDisplacementCc = 1000;
+
+/// Fallback volumetric efficiency for the speed-density estimator
+/// (#810, #812). 0.85 is a sensible midpoint for a NA petrol engine
+/// at cruise; adaptive calibration (#815) will later narrow this per
+/// vehicle from tankful reconciliation.
+const double kDefaultVolumetricEfficiency = 0.85;
+
+/// Specific gas constant for dry air in J/(kg·K). Used by the
+/// ideal-gas-law air-mass step of [estimateFuelRateLPerHourFromMap].
+const double _gasConstant = 287.0;
+
+/// `true` when [vehicle]'s preferred fuel type reads like a diesel
+/// variant (#800). Matching is done on the normalised string instead
+/// of a typed enum because `preferredFuelType` is a free-text field
+/// populated from several sources (user onboarding, VIN decoder,
+/// home-widget mirror) — all of which use `"diesel"` /
+/// `"dieselPremium"` as the key. Returns `false` for null, empty, or
+/// any non-diesel value (which is the safe default — petrol AFR /
+/// density produce slightly lower L/h numbers than diesel at the
+/// same MAF, so under-counting is preferable to over-counting).
+bool isDieselProfile(VehicleProfile? vehicle) {
+  final key = vehicle?.preferredFuelType?.trim().toLowerCase();
+  if (key == null || key.isEmpty) return false;
+  return key.contains('diesel');
+}
+
+/// Pure-math fuel-trim correction factor (#813). Exposed for unit
+/// tests and for callers that already hold the trim values.
+///
+/// Formula: `corrected = raw × (1 + (STFT + LTFT) / 100)`. Positive
+/// trims mean the ECU is enriching the mixture — real fuel flow is
+/// higher than what stoichiometric math predicts. Negative trims
+/// mean the opposite. Summing STFT and LTFT is standard practice
+/// (HEM Data's canonical formula); they capture fast and slow
+/// corrections respectively.
+double applyFuelTrimCorrection(
+  double raw, {
+  required double stft,
+  required double ltft,
+}) {
+  return raw * (1.0 + (stft + ltft) / 100.0);
+}
+
+/// Pure-math speed-density fuel-rate estimator (#800). Split out so
+/// unit tests can verify the formula without mocking the transport.
+///
+/// Formula:
+///   air_flow_g_per_s = (MAP_Pa × displacement_m³ × (RPM / 120) × η_v)
+///                      / (R × IAT_K)
+///   fuel_rate_L_per_h = air_flow_g_per_s × 3600 / (AFR × density)
+///
+/// R = 287 J/(kg·K) is the specific gas constant for dry air.
+/// `RPM / 120` converts crank revolutions to intake strokes per
+/// second on a 4-stroke engine (one intake per 2 crank revs).
+/// Returns null when any input is non-positive — the ideal gas law
+/// breaks down at 0 K / 0 pressure and callers should surface "no
+/// data" rather than a bogus number.
+double? estimateFuelRateLPerHourFromMap({
+  required double mapKpa,
+  required double iatCelsius,
+  required double rpm,
+  required int engineDisplacementCc,
+  required double volumetricEfficiency,
+  double afr = kPetrolAfr,
+  double fuelDensityGPerL = kPetrolDensityGPerL,
+}) {
+  final iatKelvin = iatCelsius + 273.15;
+  if (mapKpa <= 0 ||
+      iatKelvin <= 0 ||
+      rpm <= 0 ||
+      engineDisplacementCc <= 0 ||
+      volumetricEfficiency <= 0) {
+    return null;
+  }
+  final mapPa = mapKpa * 1000.0;
+  final displacementM3 = engineDisplacementCc / 1_000_000.0;
+  final intakesPerSecond = rpm / 120.0;
+  // Kilograms of air per second (ideal gas law × VE).
+  final airMassKgPerS =
+      (mapPa * displacementM3 * intakesPerSecond * volumetricEfficiency) /
+          (_gasConstant * iatKelvin);
+  final airMassGPerS = airMassKgPerS * 1000.0;
+  return airMassGPerS * 3600.0 / (afr * fuelDensityGPerL);
+}

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -2,22 +2,27 @@ import 'package:flutter/foundation.dart';
 
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import 'elm327_protocol.dart';
+import 'fuel_rate_estimator.dart' as estimator;
 import 'obd2_transport.dart';
 import 'supported_pids_cache.dart';
 
-/// Fallback engine displacement used by the speed-density fuel-rate
-/// estimator when the active vehicle profile doesn't expose one
-/// (#810, #812). 1000 cc = 1.0 L NA petrol — matches the Peugeot 107
-/// / Aygo / C1 class that originally motivated the fallback. Kept as
-/// a named constant so the no-profile case is obvious at a glance
-/// and easy to update if the default assumption ever changes.
-const int _defaultEngineDisplacementCc = 1000;
-
-/// Fallback volumetric efficiency for the speed-density estimator
-/// (#810, #812). 0.85 is a sensible midpoint for a NA petrol engine
-/// at cruise; adaptive calibration (#815) will later narrow this per
-/// vehicle from tankful reconciliation.
-const double _defaultVolumetricEfficiency = 0.85;
+// Re-export the pure-math estimator + stoichiometric constants so
+// callers that only need the math (e.g. [TripRecordingController]'s
+// cached live sampler) can import one file instead of chasing statics
+// on [Obd2Service]. New callers should import `fuel_rate_estimator.dart`
+// directly; the static forwarders on [Obd2Service] stay for backwards
+// compatibility with pre-#563 call sites.
+export 'fuel_rate_estimator.dart'
+    show
+        kPetrolAfr,
+        kDieselAfr,
+        kPetrolDensityGPerL,
+        kDieselDensityGPerL,
+        kDefaultEngineDisplacementCc,
+        kDefaultVolumetricEfficiency,
+        isDieselProfile,
+        applyFuelTrimCorrection,
+        estimateFuelRateLPerHourFromMap;
 
 /// High-level OBD-II service for reading vehicle data.
 ///
@@ -352,7 +357,7 @@ class Obd2Service {
   /// step-3 speed-density fallback the car's real engine displacement
   /// and volumetric efficiency (#812 phase 3). When [vehicle] is null
   /// or its engine fields are null, the method falls back to
-  /// [_defaultEngineDisplacementCc] / [_defaultVolumetricEfficiency]
+  /// [kDefaultEngineDisplacementCc] / [kDefaultVolumetricEfficiency]
   /// — still honest, just tuned for the 1.0 L NA petrol class (Peugeot
   /// 107 / Aygo / C1) that originally motivated the fallback.
   /// Partial profiles (e.g. displacement known, VE unknown) use the
@@ -372,16 +377,17 @@ class Obd2Service {
   /// unrecognised we default to petrol — that's the class of car
   /// (Peugeot 107 / Aygo / C1) that motivated this fallback.
   Future<double?> readFuelRateLPerHour({VehicleProfile? vehicle}) async {
-    final engineDisplacementCc =
-        vehicle?.engineDisplacementCc ?? _defaultEngineDisplacementCc;
+    final engineDisplacementCc = vehicle?.engineDisplacementCc ??
+        estimator.kDefaultEngineDisplacementCc;
     // VE on VehicleProfile is a non-nullable double with its own
     // default (0.85). Using it directly here is equivalent to the
     // service-level fallback for that field.
     final volumetricEfficiency =
-        vehicle?.volumetricEfficiency ?? _defaultVolumetricEfficiency;
-    final isDiesel = _isDieselProfile(vehicle);
-    final afr = isDiesel ? dieselAfr : petrolAfr;
-    final fuelDensityGPerL = isDiesel ? dieselDensityGPerL : petrolDensityGPerL;
+        vehicle?.volumetricEfficiency ?? estimator.kDefaultVolumetricEfficiency;
+    final isDiesel = estimator.isDieselProfile(vehicle);
+    final afr = isDiesel ? estimator.kDieselAfr : estimator.kPetrolAfr;
+    final fuelDensityGPerL =
+        isDiesel ? estimator.kDieselDensityGPerL : estimator.kPetrolDensityGPerL;
     // Step 1: direct fuel-rate PID (already post-trim — no correction).
     // Skipped when #811 discovery proved the car doesn't implement PID 5E.
     if (isPidSupported(0x5E)) {
@@ -417,7 +423,7 @@ class Obd2Service {
     final iatCelsius = await readIntakeAirTempCelsius();
     final rpm = await readRpm();
     if (mapKpa == null || iatCelsius == null || rpm == null) return null;
-    final rate = estimateFuelRateLPerHourFromMap(
+    final rate = estimator.estimateFuelRateLPerHourFromMap(
       mapKpa: mapKpa,
       iatCelsius: iatCelsius,
       rpm: rpm,
@@ -432,36 +438,29 @@ class Obd2Service {
 
   /// Stoichiometric AFR for petrol / gasoline (#800). Approximately
   /// 14.7 kg of air per kg of fuel at perfect combustion.
-  static const double petrolAfr = 14.7;
+  ///
+  /// Backwards-compat forwarder for [kPetrolAfr] from
+  /// `fuel_rate_estimator.dart` — kept so pre-#563 call sites
+  /// (`Obd2Service.petrolAfr`) compile unchanged.
+  static const double petrolAfr = estimator.kPetrolAfr;
 
   /// Stoichiometric AFR for diesel (#800). Slightly leaner burn than
   /// petrol — ~14.5 kg of air per kg of diesel.
-  static const double dieselAfr = 14.5;
+  ///
+  /// Backwards-compat forwarder for [kDieselAfr].
+  static const double dieselAfr = estimator.kDieselAfr;
 
   /// Petrol density in g/L at ~15 °C (#800). Published range
-  /// 720–775 g/L; 740 is the legacy Tankstellen constant, kept stable
-  /// so pre-#800 fuel-rate samples don't shift by ~0.7 % after the
-  /// diesel branch landed.
-  static const double petrolDensityGPerL = 740.0;
+  /// 720–775 g/L; 740 is the legacy Tankstellen constant.
+  ///
+  /// Backwards-compat forwarder for [kPetrolDensityGPerL].
+  static const double petrolDensityGPerL = estimator.kPetrolDensityGPerL;
 
   /// Diesel density in g/L at ~15 °C (#800). Denser than petrol at
   /// ~820–845 g/L; 832 is the EN 590 reference point.
-  static const double dieselDensityGPerL = 832.0;
-
-  /// `true` when [vehicle]'s preferred fuel type reads like a diesel
-  /// variant (#800). Matching is done on the normalised string instead
-  /// of a typed enum because `preferredFuelType` is a free-text field
-  /// populated from several sources (user onboarding, VIN decoder,
-  /// home-widget mirror) — all of which use `"diesel"` /
-  /// `"dieselPremium"` as the key. Returns `false` for null, empty, or
-  /// any non-diesel value (which is the safe default — petrol AFR /
-  /// density produce slightly lower L/h numbers than diesel at the
-  /// same MAF, so under-counting is preferable to over-counting).
-  static bool _isDieselProfile(VehicleProfile? vehicle) {
-    final key = vehicle?.preferredFuelType?.trim().toLowerCase();
-    if (key == null || key.isEmpty) return false;
-    return key.contains('diesel');
-  }
+  ///
+  /// Backwards-compat forwarder for [kDieselDensityGPerL].
+  static const double dieselDensityGPerL = estimator.kDieselDensityGPerL;
 
   /// Multiply a stoichiometric-assumption fuel rate by
   /// `(1 + (STFT + LTFT) / 100)` when both trims are readable (#813).
@@ -472,68 +471,45 @@ class Obd2Service {
     final stft = await readShortTermFuelTrimPercent();
     final ltft = await readLongTermFuelTrimPercent();
     if (stft == null || ltft == null) return raw;
-    return applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
+    return estimator.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
   }
 
-  /// Pure-math fuel-trim correction factor (#813). Exposed for unit
-  /// tests and for callers that already hold the trim values.
+  /// Pure-math fuel-trim correction factor (#813).
   ///
-  /// Formula: `corrected = raw × (1 + (STFT + LTFT) / 100)`. Positive
-  /// trims mean the ECU is enriching the mixture — real fuel flow is
-  /// higher than what stoichiometric math predicts. Negative trims
-  /// mean the opposite. Summing STFT and LTFT is standard practice
-  /// (HEM Data's canonical formula); they capture fast and slow
-  /// corrections respectively.
+  /// Backwards-compat forwarder for
+  /// [estimator.applyFuelTrimCorrection] from `fuel_rate_estimator.dart`.
+  /// New call sites should import the top-level function directly.
   static double applyFuelTrimCorrection(
     double raw, {
     required double stft,
     required double ltft,
-  }) {
-    return raw * (1.0 + (stft + ltft) / 100.0);
-  }
+  }) =>
+      estimator.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
 
-  /// Pure-math speed-density fuel-rate estimator (#800). Split out so
-  /// unit tests can verify the formula without mocking the transport.
+  /// Pure-math speed-density fuel-rate estimator (#800).
   ///
-  /// Formula:
-  ///   air_flow_g_per_s = (MAP_Pa × displacement_m³ × (RPM / 120) × η_v)
-  ///                      / (R × IAT_K)
-  ///   fuel_rate_L_per_h = air_flow_g_per_s × 3600 / (AFR × density)
-  ///
-  /// R = 287 J/(kg·K) is the specific gas constant for dry air.
-  /// `RPM / 120` converts crank revolutions to intake strokes per
-  /// second on a 4-stroke engine (one intake per 2 crank revs).
-  /// Returns null when any input is non-positive — the ideal gas law
-  /// breaks down at 0 K / 0 pressure and callers should surface "no
-  /// data" rather than a bogus number.
+  /// Backwards-compat forwarder for
+  /// [estimator.estimateFuelRateLPerHourFromMap] from
+  /// `fuel_rate_estimator.dart`. New call sites should import the
+  /// top-level function directly.
   static double? estimateFuelRateLPerHourFromMap({
     required double mapKpa,
     required double iatCelsius,
     required double rpm,
     required int engineDisplacementCc,
     required double volumetricEfficiency,
-    double afr = 14.7,
-    double fuelDensityGPerL = 740.0,
-  }) {
-    final iatKelvin = iatCelsius + 273.15;
-    if (mapKpa <= 0 ||
-        iatKelvin <= 0 ||
-        rpm <= 0 ||
-        engineDisplacementCc <= 0 ||
-        volumetricEfficiency <= 0) {
-      return null;
-    }
-    const gasConstant = 287.0; // J/(kg·K), dry air
-    final mapPa = mapKpa * 1000.0;
-    final displacementM3 = engineDisplacementCc / 1_000_000.0;
-    final intakesPerSecond = rpm / 120.0;
-    // Kilograms of air per second (ideal gas law × VE).
-    final airMassKgPerS =
-        (mapPa * displacementM3 * intakesPerSecond * volumetricEfficiency) /
-            (gasConstant * iatKelvin);
-    final airMassGPerS = airMassKgPerS * 1000.0;
-    return airMassGPerS * 3600.0 / (afr * fuelDensityGPerL);
-  }
+    double afr = estimator.kPetrolAfr,
+    double fuelDensityGPerL = estimator.kPetrolDensityGPerL,
+  }) =>
+      estimator.estimateFuelRateLPerHourFromMap(
+        mapKpa: mapKpa,
+        iatCelsius: iatCelsius,
+        rpm: rpm,
+        engineDisplacementCc: engineDisplacementCc,
+        volumetricEfficiency: volumetricEfficiency,
+        afr: afr,
+        fuelDensityGPerL: fuelDensityGPerL,
+      );
 
   /// Read mass air flow in g/s. (#717)
   Future<double?> readMafGramsPerSecond() => _readDouble(

--- a/test/features/consumption/data/obd2/fuel_rate_estimator_test.dart
+++ b/test/features/consumption/data/obd2/fuel_rate_estimator_test.dart
@@ -1,0 +1,224 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/fuel_rate_estimator.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+/// Guardrails for the pure-math fuel-rate estimator extracted out of
+/// `obd2_service.dart` in the #563 service-split refactor. These
+/// assertions duplicate the service-level coverage in
+/// `obd2_service_test.dart`, but wiring them directly against the
+/// top-level functions means future callers that bypass [Obd2Service]
+/// (e.g. the home-widget isolate — which can't instantiate the
+/// transport) get covered too.
+void main() {
+  group('applyFuelTrimCorrection — #813', () {
+    test('positive trims enrich (factor > 1)', () {
+      expect(
+        applyFuelTrimCorrection(10.0, stft: 6.0, ltft: 4.0),
+        closeTo(11.0, 0.001),
+      );
+    });
+
+    test('negative trims lean (factor < 1)', () {
+      expect(
+        applyFuelTrimCorrection(10.0, stft: -5.0, ltft: -5.0),
+        closeTo(9.0, 0.001),
+      );
+    });
+
+    test('zero trims pass through unchanged', () {
+      expect(
+        applyFuelTrimCorrection(10.0, stft: 0, ltft: 0),
+        closeTo(10.0, 0.001),
+      );
+    });
+
+    test('asymmetric trims sum (HEM Data canonical formula)', () {
+      // STFT +2 % and LTFT +3 % → (1 + 0.05) = 1.05.
+      expect(
+        applyFuelTrimCorrection(20.0, stft: 2.0, ltft: 3.0),
+        closeTo(21.0, 0.001),
+      );
+    });
+  });
+
+  group('estimateFuelRateLPerHourFromMap — #800', () {
+    test('Peugeot 107 cruise canonical reading: 2500 RPM, 65 kPa, '
+        '30 °C → plausible 2.5–6 L/h', () {
+      final rate = estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: kDefaultEngineDisplacementCc,
+        volumetricEfficiency: kDefaultVolumetricEfficiency,
+      );
+      expect(rate, isNotNull);
+      expect(rate, greaterThan(2.5));
+      expect(rate, lessThan(6.0));
+    });
+
+    test('returns null on non-positive MAP', () {
+      expect(
+        estimateFuelRateLPerHourFromMap(
+          mapKpa: 0,
+          iatCelsius: 25,
+          rpm: 800,
+          engineDisplacementCc: 1000,
+          volumetricEfficiency: 0.85,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null at absolute zero (ideal gas law breaks down)', () {
+      expect(
+        estimateFuelRateLPerHourFromMap(
+          mapKpa: 40,
+          iatCelsius: -273.15,
+          rpm: 800,
+          engineDisplacementCc: 1000,
+          volumetricEfficiency: 0.85,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null on engine off (rpm == 0)', () {
+      expect(
+        estimateFuelRateLPerHourFromMap(
+          mapKpa: 40,
+          iatCelsius: 25,
+          rpm: 0,
+          engineDisplacementCc: 1000,
+          volumetricEfficiency: 0.85,
+        ),
+        isNull,
+      );
+    });
+
+    test('doubles with displacement at identical operating point', () {
+      final small = estimateFuelRateLPerHourFromMap(
+        mapKpa: 50,
+        iatCelsius: 20,
+        rpm: 2000,
+        engineDisplacementCc: 1000,
+        volumetricEfficiency: 0.85,
+      )!;
+      final big = estimateFuelRateLPerHourFromMap(
+        mapKpa: 50,
+        iatCelsius: 20,
+        rpm: 2000,
+        engineDisplacementCc: 2000,
+        volumetricEfficiency: 0.85,
+      )!;
+      expect(big / small, closeTo(2.0, 0.01));
+    });
+
+    test('diesel branch: denser fuel + leaner AFR produce lower L/h '
+        'per air mass than petrol', () {
+      // Same inputs, different AFR + density. Diesel denominator
+      // (14.5 × 832) = 12_064 is larger than petrol (14.7 × 740) =
+      // 10_878, so a given air-mass flow maps to *less* diesel
+      // fuel per hour — the expected relationship.
+      final petrol = estimateFuelRateLPerHourFromMap(
+        mapKpa: 80,
+        iatCelsius: 25,
+        rpm: 2000,
+        engineDisplacementCc: 1600,
+        volumetricEfficiency: 0.85,
+      )!;
+      final diesel = estimateFuelRateLPerHourFromMap(
+        mapKpa: 80,
+        iatCelsius: 25,
+        rpm: 2000,
+        engineDisplacementCc: 1600,
+        volumetricEfficiency: 0.85,
+        afr: kDieselAfr,
+        fuelDensityGPerL: kDieselDensityGPerL,
+      )!;
+      expect(diesel, lessThan(petrol));
+      // Ratio equals denominator ratio.
+      expect(
+        petrol / diesel,
+        closeTo(
+          (kDieselAfr * kDieselDensityGPerL) / (kPetrolAfr * kPetrolDensityGPerL),
+          0.001,
+        ),
+      );
+    });
+  });
+
+  group('isDieselProfile — #800', () {
+    test('null profile → false (safe default is petrol)', () {
+      expect(isDieselProfile(null), isFalse);
+    });
+
+    test('empty preferredFuelType → false', () {
+      const vehicle = VehicleProfile(id: 'x', name: 'Test');
+      expect(isDieselProfile(vehicle), isFalse);
+    });
+
+    test('preferredFuelType "diesel" → true', () {
+      const vehicle = VehicleProfile(
+        id: 'x',
+        name: 'Test',
+        preferredFuelType: 'diesel',
+      );
+      expect(isDieselProfile(vehicle), isTrue);
+    });
+
+    test('preferredFuelType with diesel variant (dieselPremium) → true', () {
+      const vehicle = VehicleProfile(
+        id: 'x',
+        name: 'Test',
+        preferredFuelType: 'dieselPremium',
+      );
+      expect(isDieselProfile(vehicle), isTrue);
+    });
+
+    test('petrol-class fuel types → false', () {
+      for (final fuel in ['e5', 'e10', 'super', 'petrol', 'Gasoline']) {
+        final vehicle = VehicleProfile(
+          id: 'x',
+          name: 'Test',
+          preferredFuelType: fuel,
+        );
+        expect(isDieselProfile(vehicle), isFalse, reason: 'for $fuel');
+      }
+    });
+
+    test('whitespace + mixed case normalisation', () {
+      const vehicle = VehicleProfile(
+        id: 'x',
+        name: 'Test',
+        preferredFuelType: '  DIESEL  ',
+      );
+      expect(isDieselProfile(vehicle), isTrue);
+    });
+  });
+
+  group('stoichiometric constants — #800', () {
+    test('petrol AFR ~14.7 kg/kg', () {
+      expect(kPetrolAfr, closeTo(14.7, 0.0001));
+    });
+
+    test('diesel AFR ~14.5 kg/kg', () {
+      expect(kDieselAfr, closeTo(14.5, 0.0001));
+    });
+
+    test('petrol density 740 g/L (legacy Tankstellen constant)', () {
+      expect(kPetrolDensityGPerL, closeTo(740.0, 0.0001));
+    });
+
+    test('diesel density 832 g/L (EN 590 reference)', () {
+      expect(kDieselDensityGPerL, closeTo(832.0, 0.0001));
+    });
+
+    test('default displacement 1000 cc (Peugeot 107 class)', () {
+      expect(kDefaultEngineDisplacementCc, 1000);
+    });
+
+    test('default volumetric efficiency 0.85', () {
+      expect(kDefaultVolumetricEfficiency, closeTo(0.85, 0.0001));
+    });
+  });
+}


### PR DESCRIPTION
## What

Third phase of the #563 obd2 service-layer split. Pulls the pure-math speed-density estimator, fuel-trim correction formula, diesel-profile detector, and stoichiometric constants (AFR / density / default displacement / default volumetric efficiency) out of the transport-coupled \`Obd2Service\` and into a standalone \`fuel_rate_estimator.dart\` module.

## Why

- **Pure math stops being coupled to the transport.** \`estimateFuelRateLPerHourFromMap\` and \`applyFuelTrimCorrection\` were already \`static\` on \`Obd2Service\`, but living next to 300+ lines of transport-bound methods made them awkward to consume from callers that can't (or shouldn't) instantiate the service — e.g. \`trip_recording_controller.dart\`'s cached live sampler, and the future home-widget isolate.
- **Constants get a single source of truth.** \`kPetrolAfr\` / \`kDieselAfr\` / densities / \`kDefaultEngineDisplacementCc\` / \`kDefaultVolumetricEfficiency\` are now top-level consts. \`Obd2Service.petrolAfr\` etc. stay as forwarders so pre-#563 call sites (\`trip_recording_controller.dart\` line 932+, \`obd2_service_test.dart\`) keep compiling.
- **Follows the export-pattern established by #929 and #934** — \`trip_recording_controller.dart\` still re-exports \`TripLiveReading\` / distance-source constants; \`obd2_service.dart\` now re-exports every new top-level symbol the same way.

\`obd2_service.dart\` drops from 602 → 578 LOC. The forwarder stubs add lines back, but the extracted module (\`fuel_rate_estimator.dart\`, 123 LOC) is cleanly testable in isolation.

## Testing

- \`flutter analyze\` — zero issues
- \`flutter test\` — full suite passes (5866 passed, 1 pre-existing skip)
- New \`fuel_rate_estimator_test.dart\`: 18 cases covering the pure-math estimator, fuel-trim correction, diesel-profile detection (null / empty / diesel / dieselPremium / petrol variants / whitespace + mixed case), and every stoichiometric constant value
- Existing \`obd2_service_test.dart\` \`applyFuelTrimCorrection\` + \`estimateFuelRateLPerHourFromMap\` groups still pass — forwarders preserve the public API
- \`trip_recording_controller.dart\` still compiles against \`Obd2Service.petrolAfr\`/\`dieselAfr\`/\`petrolDensityGPerL\`/\`dieselDensityGPerL\`/\`applyFuelTrimCorrection\`/\`estimateFuelRateLPerHourFromMap\` — no call-site changes needed

## Notes

Refs #563 — service-split phase, not closing the issue. Prior phases: #929 (trip_live_reading + trip_distance_source), #934 (TripRecordingPhase + HapticFeedbackPolicy + TripRecordingState).