### PR TITLE
feat(ui): PageScaffold supports toolbarHeight + header semantics

### DIFF
--- a/docs/design/DESIGN_SYSTEM.md
+++ b/docs/design/DESIGN_SYSTEM.md
@@ -231,6 +231,15 @@ screen is about" identified in the #923 audit.
 - `floatingActionButton: Widget?`
 - `bottomNavigationBar: Widget?` — reserved for the shell; leaf
   screens do not set this.
+- `toolbarHeight: double?` — optional override for the app-bar toolbar
+  height (pass-through to `AppBar.toolbarHeight`). Default `null` uses
+  Material's default; compact layouts (e.g. `SearchScreen` in
+  landscape) pass `40`.
+
+**Accessibility:** the app-bar title is wrapped in
+`Semantics(header: true, …)` so TalkBack/VoiceOver announce the
+`pageTitle` with the heading role. Callers get this for free — no
+action required.
 
 **Visual contract:**
 

--- a/lib/core/widgets/page_scaffold.dart
+++ b/lib/core/widgets/page_scaffold.dart
@@ -51,6 +51,11 @@ class PageScaffold extends StatelessWidget {
   /// Whether the app bar shows its automatic leading. Default: true.
   final bool automaticallyImplyLeading;
 
+  /// Optional override for the app-bar toolbar height. Pass-through to
+  /// [AppBar.toolbarHeight]. Leave `null` to use the Material default.
+  /// Compact screens (e.g. `SearchScreen` in landscape) shrink to ~40.
+  final double? toolbarHeight;
+
   const PageScaffold({
     super.key,
     required this.title,
@@ -62,6 +67,7 @@ class PageScaffold extends StatelessWidget {
     this.floatingActionButton,
     this.leading,
     this.automaticallyImplyLeading = true,
+    this.toolbarHeight,
   });
 
   @override
@@ -69,10 +75,11 @@ class PageScaffold extends StatelessWidget {
     final effectivePadding = bodyPadding ?? Spacing.screenPadding;
     return Scaffold(
       appBar: AppBar(
-        title: Text(title),
+        title: Semantics(header: true, child: Text(title)),
         actions: actions,
         leading: leading,
         automaticallyImplyLeading: automaticallyImplyLeading,
+        toolbarHeight: toolbarHeight,
       ),
       body: Column(
         children: [

--- a/test/core/widgets/page_scaffold_test.dart
+++ b/test/core/widgets/page_scaffold_test.dart
@@ -99,5 +99,42 @@ void main() {
       );
       expect(find.byType(FloatingActionButton), findsOneWidget);
     });
+
+    testWidgets('passes toolbarHeight through to AppBar', (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Search',
+          toolbarHeight: 40,
+          body: SizedBox.shrink(),
+        ),
+      );
+      final appBar = tester.widget<AppBar>(find.byType(AppBar));
+      expect(appBar.toolbarHeight, 40);
+    });
+
+    testWidgets('title has header semantics', (tester) async {
+      final handle = tester.ensureSemantics();
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Privacy',
+          body: SizedBox.shrink(),
+        ),
+      );
+      // The title Text is wrapped in Semantics(header: true, ...).
+      // Locate the Semantics node that carries both the header flag
+      // and the "Privacy" label — asserting the flag is the whole
+      // point of the test, so we don't fall back to find.text.
+      final semantics = tester
+          .getSemantics(find.text('Privacy'))
+          .getSemanticsData();
+      expect(
+        semantics.flagsCollection.isHeader,
+        isTrue,
+        reason: 'PageScaffold title must expose the TalkBack heading role',
+      );
+      handle.dispose();
+    });
   });
 }


### PR DESCRIPTION
## Summary
Surgical extension to the canonical `PageScaffold` so more screens can migrate to the design-system widget without regressing their existing chrome:

- Adds `toolbarHeight: double?` pass-through to the internal `AppBar` (default `null` = Material default).
- Wraps the app-bar title `Text(title)` in `Semantics(header: true, …)` so TalkBack/VoiceOver announce the page title with the heading role. Additive for every existing consumer (Privacy, Storage, Theme, Consumption, Carbon dashboards).

## Why
Refs #923 — design-system consolidation epic.

Phase 3e (migrating `SearchScreen` from raw `Scaffold` + `AppBar` to `PageScaffold`) is blocked because:
1. `SearchScreen` shrinks the toolbar to 40dp in landscape — there was no prop for it.
2. `SearchScreen` wraps its title in `Semantics(header: true, …)` — `PageScaffold` didn't.

Both gaps are one-line fixes applied to the core widget, so every future `PageScaffold` caller inherits them instead of re-implementing the workaround.

This PR only extends `PageScaffold`. The actual `SearchScreen` migration ships in a follow-up.

## Testing
- `flutter analyze` — zero warnings.
- `flutter test` — full suite green (5846 passed, 1 pre-existing skip).
- Two new tests in `test/core/widgets/page_scaffold_test.dart`:
  - `passes toolbarHeight through to AppBar` — pumps a `PageScaffold(toolbarHeight: 40)`, reads `AppBar.toolbarHeight`.
  - `title has header semantics` — asserts `flagsCollection.isHeader` on the title's semantics node.

## Scope guard
- Does NOT touch `SearchScreen`, any existing `PageScaffold` consumer, or any other prop.
- Does NOT rename or reshape existing params.
- `docs/design/DESIGN_SYSTEM.md` §PageScaffold updated to list `toolbarHeight` and the header-semantics guarantee.

Refs #923 — unblocks phase 3e SearchScreen migration.