### PR TITLE
test(coverage): cover location_consent + pump_display helpers (Refs #561)

### DIFF
--- a/test/core/location/location_consent_test.dart
+++ b/test/core/location/location_consent_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/location/location_consent.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Behaviour of the GDPR location-consent dialog (#561 coverage).
+///
+/// * Persistence helpers — `hasConsent` / `recordConsent` read and
+///   write the `location_consent_given` flag on the narrow
+///   [SettingsStorage] interface, NOT the legacy `location_consent`
+///   key used elsewhere.
+/// * Dialog UX — `show` returns `true` on Accept, `false` on Decline,
+///   renders the GDPR bullets, and falls back to English for locales
+///   the `_ConsentTexts` map does not cover.
+void main() {
+  group('LocationConsentDialog — persistence', () {
+    test('hasConsent returns false on a fresh storage', () {
+      final storage = _FakeSettingsStorage();
+      expect(LocationConsentDialog.hasConsent(storage), isFalse);
+    });
+
+    test('hasConsent returns true after recordConsent', () async {
+      final storage = _FakeSettingsStorage();
+      await LocationConsentDialog.recordConsent(storage);
+      expect(LocationConsentDialog.hasConsent(storage), isTrue);
+    });
+
+    test('recordConsent writes the canonical key, not the legacy key',
+        () async {
+      final storage = _FakeSettingsStorage();
+      await LocationConsentDialog.recordConsent(storage);
+      // The hasConsent method reads `location_consent_given`; verify
+      // the storage saw exactly that write so the two helpers agree.
+      expect(storage.data, {'location_consent_given': true});
+    });
+
+    test('hasConsent is false when only the legacy key is stored', () {
+      final storage = _FakeSettingsStorage()
+        ..data['location_consent'] = true;
+      // Legacy key must not be picked up by this narrow API — that
+      // prevents a consent leak between the two storage domains.
+      expect(LocationConsentDialog.hasConsent(storage), isFalse);
+    });
+
+    test('hasConsent requires strict boolean true', () {
+      final storage = _FakeSettingsStorage()
+        ..data['location_consent_given'] = 1;
+      // Strict `== true` comparison — a numeric 1 or String must NOT
+      // count as consent.
+      expect(LocationConsentDialog.hasConsent(storage), isFalse);
+
+      storage.data['location_consent_given'] = 'true';
+      expect(LocationConsentDialog.hasConsent(storage), isFalse);
+
+      storage.data['location_consent_given'] = false;
+      expect(LocationConsentDialog.hasConsent(storage), isFalse);
+    });
+  });
+
+  group('LocationConsentDialog — dialog behaviour (English)', () {
+    testWidgets('returns true when user taps Accept', (tester) async {
+      final future = await _openDialog(tester, const Locale('en'));
+      await tester.tap(find.text('Accept'));
+      await tester.pumpAndSettle();
+      expect(await future, isTrue);
+    });
+
+    testWidgets('returns false when user taps Decline', (tester) async {
+      final future = await _openDialog(tester, const Locale('en'));
+      await tester.tap(find.text('Decline'));
+      await tester.pumpAndSettle();
+      expect(await future, isFalse);
+    });
+
+    testWidgets('renders all three privacy bullets', (tester) async {
+      final future = await _openDialog(tester, const Locale('en'));
+      expect(
+        find.textContaining('sent to the fuel price API'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('not stored on any server'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('not used for advertising'),
+        findsOneWidget,
+      );
+      // Clean up.
+      await tester.tap(find.text('Decline'));
+      await tester.pumpAndSettle();
+      await future;
+    });
+
+    testWidgets('shows the GDPR legal-basis line', (tester) async {
+      final future = await _openDialog(tester, const Locale('en'));
+      expect(find.textContaining('Art. 6(1)(a) GDPR'), findsOneWidget);
+      await tester.tap(find.text('Decline'));
+      await tester.pumpAndSettle();
+      await future;
+    });
+
+    testWidgets('dialog is not dismissible by tapping the barrier',
+        (tester) async {
+      // barrierDismissible: false — tapping outside the dialog must NOT
+      // resolve the future. Protects against accidental dismissal
+      // being misread as an explicit decline.
+      final future = await _openDialog(tester, const Locale('en'));
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+      // Dialog is still up.
+      expect(find.text('Accept'), findsOneWidget);
+      // Clean up so the pending future doesn't leak.
+      await tester.tap(find.text('Decline'));
+      await tester.pumpAndSettle();
+      expect(await future, isFalse);
+    });
+  });
+
+  group('LocationConsentDialog — localisation', () {
+    testWidgets('renders German labels for de locale', (tester) async {
+      final future = await _openDialog(tester, const Locale('de'));
+      expect(find.text('Standortfreigabe'), findsOneWidget);
+      expect(find.text('Zustimmen'), findsOneWidget);
+      expect(find.text('Ablehnen'), findsOneWidget);
+      await tester.tap(find.text('Ablehnen'));
+      await tester.pumpAndSettle();
+      await future;
+    });
+
+    testWidgets('renders French labels for fr locale', (tester) async {
+      final future = await _openDialog(tester, const Locale('fr'));
+      expect(find.text('Accès à la localisation'), findsOneWidget);
+      expect(find.text('Accepter'), findsOneWidget);
+      expect(find.text('Refuser'), findsOneWidget);
+      await tester.tap(find.text('Refuser'));
+      await tester.pumpAndSettle();
+      await future;
+    });
+
+    testWidgets('falls back to English for a locale missing from the map',
+        (tester) async {
+      // 'bg' (Bulgarian) is an app locale but is NOT in the
+      // `_ConsentTexts` map — the internal `_t` must return the
+      // English value rather than crash.
+      final future = await _openDialog(tester, const Locale('bg'));
+      expect(find.text('Location Access'), findsOneWidget);
+      expect(find.text('Accept'), findsOneWidget);
+      expect(find.text('Decline'), findsOneWidget);
+      await tester.tap(find.text('Decline'));
+      await tester.pumpAndSettle();
+      await future;
+    });
+  });
+}
+
+/// Pumps an app whose only widget is a button that opens the consent
+/// dialog, taps it, and returns the in-flight `Future<bool>` so the
+/// caller can assert on its resolved value after the interaction.
+Future<Future<bool>> _openDialog(WidgetTester tester, Locale locale) async {
+  late Future<bool> future;
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: const [
+        Locale('en'),
+        Locale('de'),
+        Locale('fr'),
+        Locale('bg'),
+      ],
+      locale: locale,
+      home: Builder(
+        builder: (ctx) {
+          return Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  future = LocationConsentDialog.show(ctx);
+                },
+                child: const Text('open'),
+              ),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+  return future;
+}
+
+/// Minimal in-memory [SettingsStorage] fake. Only the two methods the
+/// production code calls need to behave realistically; the remaining
+/// abstract members throw so accidental usage is loud.
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> data = <String, dynamic>{};
+
+  @override
+  dynamic getSetting(String key) => data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    data[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => throw UnimplementedError();
+
+  @override
+  bool get isSetupSkipped => throw UnimplementedError();
+
+  @override
+  Future<void> resetSetupSkip() => throw UnimplementedError();
+
+  @override
+  Future<void> skipSetup() => throw UnimplementedError();
+}

--- a/test/features/consumption/data/_pump_display_patterns_test.dart
+++ b/test/features/consumption/data/_pump_display_patterns_test.dart
@@ -1,0 +1,310 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/_pump_display_patterns.dart';
+
+/// Direct behavioural tests for the regex patterns used by
+/// [PumpDisplayParser]. These patterns are indirectly exercised by
+/// `pump_display_parser_test.dart`, but asserting them in isolation
+/// catches regressions that the orchestrator would mask (e.g. a
+/// pattern that starts matching too greedily still produces the same
+/// parser output because later heuristics override the match).
+///
+/// Refs #561 — targeted coverage of the patterns module.
+void main() {
+  group('kBetragPatterns — labelled total extraction', () {
+    test('labelled "Betrag" with euro sign yields the amount', () {
+      final match = _firstMatch(kBetragPatterns, 'Betrag € 58,42');
+      expect(match, '58,42');
+    });
+
+    test('labelled "Betrag" without currency still matches', () {
+      final match = _firstMatch(kBetragPatterns, 'Betrag 58,42');
+      expect(match, '58,42');
+    });
+
+    test('handles "Betraq" OCR glyph confusion', () {
+      // When the 'g' hook is thin the OCR often reads 'q'.
+      final match = _firstMatch(kBetragPatterns, 'Betraq € 72,50');
+      expect(match, '72,50');
+    });
+
+    test('accepts either "," or "." as decimal separator', () {
+      expect(_firstMatch(kBetragPatterns, 'Betrag 58.42'), '58.42');
+      expect(_firstMatch(kBetragPatterns, 'Betrag 58,42'), '58,42');
+    });
+
+    test('matches a trailing € adjacent to word context', () {
+      // Pattern 3 is `\b(\d+[.,]\d{2})\s*€\b`. The `\b` after € only
+      // fires when a word character follows the currency symbol — so
+      // we anchor with trailing text.
+      final match = _firstMatch(kBetragPatterns, '42,18 €gesamt');
+      expect(match, '42,18');
+    });
+
+    test('matches EUR prefix as well as €', () {
+      final match = _firstMatch(kBetragPatterns, 'EUR 58,42');
+      expect(match, '58,42');
+    });
+
+    test('requires exactly two decimal digits for totals', () {
+      // A 3-decimal number is NOT a Betrag — it's a price-per-litre.
+      // The labelled pattern should not match "58,421".
+      final pattern = RegExp(
+        r'(?:€|EUR)\s*[:=]?\s*(\d+[.,]\d{2})\b',
+      );
+      expect(pattern.hasMatch('€ 58,42 '), isTrue);
+      // Even though "58,421" contains "58,42", \d{2}\b requires a
+      // word boundary after the two decimals, which the extra digit
+      // breaks.
+      expect(pattern.hasMatch('€ 58,421'), isFalse);
+    });
+
+    test('ignores tokens without the expected labelling', () {
+      final any = kBetragPatterns.any((p) => p.hasMatch('Diesel'));
+      expect(any, isFalse);
+    });
+  });
+
+  group('kAbgabePatterns — labelled volume extraction', () {
+    test('labelled "Abgabe" yields the volume', () {
+      final match = _firstMatch(kAbgabePatterns, 'Abgabe 31,65');
+      expect(match, '31,65');
+    });
+
+    test('labelled "Abgabe L" across visual rows still matches', () {
+      // ML Kit sometimes flattens the L unit row into the label line.
+      final match = _firstMatch(kAbgabePatterns, 'Abgabe L 31,65');
+      expect(match, '31,65');
+    });
+
+    test('handles "Ab9abe" and "Abqabe" OCR misreads', () {
+      expect(_firstMatch(kAbgabePatterns, 'Ab9abe 40,05'), '40,05');
+      expect(_firstMatch(kAbgabePatterns, 'Abqabe 40,05'), '40,05');
+    });
+
+    test('matches Volume and Menge labels (multilingual)', () {
+      expect(_firstMatch(kAbgabePatterns, 'Volume 31.65'), '31.65');
+      expect(_firstMatch(kAbgabePatterns, 'Menge 31,65'), '31,65');
+      expect(_firstMatch(kAbgabePatterns, 'Quantité 31,65'), '31,65');
+    });
+
+    test('matches trailing L or Liter unit', () {
+      expect(_firstMatch(kAbgabePatterns, '31,65 L'), '31,65');
+      expect(_firstMatch(kAbgabePatterns, '31.65 Liter'), '31.65');
+      expect(_firstMatch(kAbgabePatterns, '31,65 Litres'), '31,65');
+    });
+
+    test('accepts 1 to 3 decimal places for volume', () {
+      expect(_firstMatch(kAbgabePatterns, 'Abgabe 31,6'), '31,6');
+      expect(_firstMatch(kAbgabePatterns, 'Abgabe 31,65'), '31,65');
+      expect(_firstMatch(kAbgabePatterns, 'Abgabe 31,655'), '31,655');
+    });
+  });
+
+  group('kPricePerLiterPatterns — labelled unit price extraction', () {
+    test('labelled "Preis/Liter" yields the unit price', () {
+      final match = _firstMatch(kPricePerLiterPatterns, 'Preis/Liter 1,849');
+      expect(match, '1,849');
+    });
+
+    test('PREIS/L uppercase variant matches', () {
+      final match = _firstMatch(kPricePerLiterPatterns, 'PREIS/L 1.849');
+      expect(match, '1.849');
+    });
+
+    test('EUR/L and €/L labellings match', () {
+      expect(_firstMatch(kPricePerLiterPatterns, 'EUR/L 1.849'), '1.849');
+      expect(_firstMatch(kPricePerLiterPatterns, '€/L 1,849'), '1,849');
+    });
+
+    test('trailing unit like "1,849 €/L" matches', () {
+      expect(_firstMatch(kPricePerLiterPatterns, '1,849 €/L'), '1,849');
+      expect(_firstMatch(kPricePerLiterPatterns, '1,849 EUR/L'), '1,849');
+    });
+
+    test('accepts 2 and 3 decimal precision (1,84 and 1,849)', () {
+      expect(_firstMatch(kPricePerLiterPatterns, 'Preis/Liter 1,84'), '1,84');
+      expect(
+        _firstMatch(kPricePerLiterPatterns, 'Preis/Liter 1,849'),
+        '1,849',
+      );
+    });
+  });
+
+  group('kCentsPerLiterPattern — cents layout', () {
+    test('matches "CT 184,9" as cents per litre', () {
+      final m = kCentsPerLiterPattern.firstMatch('CT 184,9');
+      expect(m, isNotNull);
+      expect(m!.group(1), '184,9');
+    });
+
+    test('matches "CT 184" without decimals', () {
+      final m = kCentsPerLiterPattern.firstMatch('CT 184');
+      expect(m, isNotNull);
+      expect(m!.group(1), '184');
+    });
+
+    test('matches lowercase "ct" (caseSensitive:false)', () {
+      expect(kCentsPerLiterPattern.hasMatch('ct 184,9'), isTrue);
+    });
+
+    test('requires whole-word "CT" boundary', () {
+      // `CTX` must not match — \b before CT guards against partial
+      // words inside a longer token.
+      expect(kCentsPerLiterPattern.hasMatch('CTX 184,9'), isFalse);
+    });
+  });
+
+  group('kLonePumpDigitPattern — standalone pump number', () {
+    test('matches single digits 1..9', () {
+      for (var d = 1; d <= 9; d++) {
+        expect(kLonePumpDigitPattern.hasMatch('$d'), isTrue, reason: '$d');
+      }
+    });
+
+    test('does NOT match the digit 0', () {
+      // "0" is never a valid pump number — the pattern is [1-9].
+      expect(kLonePumpDigitPattern.hasMatch('0'), isFalse);
+    });
+
+    test('does not match multi-digit tokens', () {
+      expect(kLonePumpDigitPattern.hasMatch('12'), isFalse);
+      expect(kLonePumpDigitPattern.hasMatch('31,65'), isFalse);
+    });
+
+    test('does not match a digit with leading or trailing text', () {
+      expect(kLonePumpDigitPattern.hasMatch(' 3'), isFalse);
+      expect(kLonePumpDigitPattern.hasMatch('3 '), isFalse);
+      expect(kLonePumpDigitPattern.hasMatch('D3'), isFalse);
+    });
+  });
+
+  group('kDecimalNumberPattern — any decimal in a line', () {
+    test('captures the first decimal number', () {
+      final m = kDecimalNumberPattern.firstMatch('Abgabe L 31,65');
+      expect(m, isNotNull);
+      expect(m!.group(1), '31,65');
+    });
+
+    test('supports both separators', () {
+      expect(
+        kDecimalNumberPattern.firstMatch('total 58.42')!.group(1),
+        '58.42',
+      );
+    });
+
+    test('finds the first when multiple decimals are present', () {
+      final all = kDecimalNumberPattern
+          .allMatches('58,42 und 1,849')
+          .map((m) => m.group(1))
+          .toList();
+      expect(all, ['58,42', '1,849']);
+    });
+
+    test('does not match pure integers', () {
+      expect(kDecimalNumberPattern.hasMatch('1234'), isFalse);
+    });
+  });
+
+  group('kNumericTokenPattern — numeric-ish token bounds', () {
+    test('matches a pure digit sequence', () {
+      expect(
+        kNumericTokenPattern.firstMatch('58')!.group(0),
+        '58',
+      );
+    });
+
+    test('matches digits + lookalike letters', () {
+      expect(
+        kNumericTokenPattern.firstMatch('1O.SO')!.group(0),
+        '1O.SO',
+      );
+    });
+
+    test('matches across decimal separator', () {
+      expect(
+        kNumericTokenPattern.firstMatch('B.OO')!.group(0),
+        'B.OO',
+      );
+    });
+
+    test('stops at non-lookalike characters like space', () {
+      // The global replaceAllMapped usage in the parser relies on this
+      // being token-bounded.
+      final match = kNumericTokenPattern.firstMatch('B.OO andere');
+      expect(match!.group(0), 'B.OO');
+    });
+  });
+
+  group('kDigitLookalikePattern — single-char predicate', () {
+    test('matches digits 0-9', () {
+      for (var d = 0; d <= 9; d++) {
+        expect(kDigitLookalikePattern.hasMatch('$d'), isTrue);
+      }
+    });
+
+    test('matches all mapped lookalike letters', () {
+      for (final letter in kDigitLookalikeMap.keys) {
+        expect(
+          kDigitLookalikePattern.hasMatch(letter),
+          isTrue,
+          reason: 'expected $letter to match lookalike predicate',
+        );
+      }
+    });
+
+    test('rejects non-lookalike letters', () {
+      for (final ch in ['e', 'a', 'r', 'N', 'X', '@', '#']) {
+        expect(kDigitLookalikePattern.hasMatch(ch), isFalse);
+      }
+    });
+
+    test('rejects empty and multi-char inputs', () {
+      expect(kDigitLookalikePattern.hasMatch(''), isFalse);
+      expect(kDigitLookalikePattern.hasMatch('12'), isFalse);
+      expect(kDigitLookalikePattern.hasMatch('OO'), isFalse);
+    });
+  });
+
+  group('kDigitLookalikeMap — rewrite table', () {
+    test('maps each known lookalike to the intended digit', () {
+      expect(kDigitLookalikeMap['O'], '0');
+      expect(kDigitLookalikeMap['o'], '0');
+      expect(kDigitLookalikeMap['D'], '0');
+      expect(kDigitLookalikeMap['I'], '1');
+      expect(kDigitLookalikeMap['l'], '1');
+      expect(kDigitLookalikeMap['B'], '8');
+      expect(kDigitLookalikeMap['b'], '8');
+      expect(kDigitLookalikeMap['S'], '5');
+      expect(kDigitLookalikeMap['s'], '5');
+      expect(kDigitLookalikeMap['Z'], '2');
+      expect(kDigitLookalikeMap['z'], '2');
+      expect(kDigitLookalikeMap['g'], '9');
+    });
+
+    test('every mapped key is recognised by the single-char predicate', () {
+      // Guarantees the rewrite table and the predicate stay in sync.
+      for (final key in kDigitLookalikeMap.keys) {
+        expect(kDigitLookalikePattern.hasMatch(key), isTrue);
+      }
+    });
+
+    test('does not contain stray mappings for regular letters', () {
+      // "e", "a", "n" etc. must NOT be in the table so German words
+      // like "Diesel" / "Menge" stay intact after rewrite.
+      expect(kDigitLookalikeMap.containsKey('e'), isFalse);
+      expect(kDigitLookalikeMap.containsKey('a'), isFalse);
+      expect(kDigitLookalikeMap.containsKey('n'), isFalse);
+      expect(kDigitLookalikeMap.containsKey('r'), isFalse);
+    });
+  });
+}
+
+/// Returns the first captured group from the first pattern in [patterns]
+/// that matches [input], or `null` if no pattern matches.
+String? _firstMatch(List<RegExp> patterns, String input) {
+  for (final p in patterns) {
+    final m = p.firstMatch(input);
+    if (m != null) return m.group(1) ?? m.group(0);
+  }
+  return null;
+}

--- a/test/features/consumption/data/pump_display_parse_result_test.dart
+++ b/test/features/consumption/data/pump_display_parse_result_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/pump_display_parse_result.dart';
+
+/// Focused unit tests for [PumpDisplayParseResult] (#561 coverage).
+///
+/// The production parser owns end-to-end coverage; these tests
+/// exercise the DTO's contract directly so construction defaults,
+/// `hasUsableData`, and `isConsistent` are pinned regardless of how
+/// the parser behaves.
+void main() {
+  group('PumpDisplayParseResult — construction defaults', () {
+    test('empty constructor fills every field with null and 0 confidence',
+        () {
+      const r = PumpDisplayParseResult();
+      expect(r.liters, isNull);
+      expect(r.totalCost, isNull);
+      expect(r.pricePerLiter, isNull);
+      expect(r.pumpNumber, isNull);
+      expect(r.confidence, 0);
+    });
+
+    test('named arguments land in the matching fields', () {
+      const r = PumpDisplayParseResult(
+        liters: 31.65,
+        totalCost: 58.43,
+        pricePerLiter: 1.846,
+        pumpNumber: 3,
+        confidence: 0.95,
+      );
+      expect(r.liters, 31.65);
+      expect(r.totalCost, 58.43);
+      expect(r.pricePerLiter, 1.846);
+      expect(r.pumpNumber, 3);
+      expect(r.confidence, 0.95);
+    });
+  });
+
+  group('PumpDisplayParseResult — hasUsableData', () {
+    test('false when no fields are present', () {
+      const r = PumpDisplayParseResult();
+      expect(r.hasUsableData, isFalse);
+    });
+
+    test('false when only one of the three primary fields is present', () {
+      const onlyTotal = PumpDisplayParseResult(totalCost: 58.43);
+      const onlyLiters = PumpDisplayParseResult(liters: 31.65);
+      const onlyPrice = PumpDisplayParseResult(pricePerLiter: 1.846);
+      expect(onlyTotal.hasUsableData, isFalse);
+      expect(onlyLiters.hasUsableData, isFalse);
+      expect(onlyPrice.hasUsableData, isFalse);
+    });
+
+    test('true when any two of the three primary fields are present', () {
+      const totalLiters = PumpDisplayParseResult(
+        totalCost: 58.43,
+        liters: 31.65,
+      );
+      const totalPrice = PumpDisplayParseResult(
+        totalCost: 58.43,
+        pricePerLiter: 1.846,
+      );
+      const litersPrice = PumpDisplayParseResult(
+        liters: 31.65,
+        pricePerLiter: 1.846,
+      );
+      expect(totalLiters.hasUsableData, isTrue);
+      expect(totalPrice.hasUsableData, isTrue);
+      expect(litersPrice.hasUsableData, isTrue);
+    });
+
+    test('true when all three primary fields are present', () {
+      const r = PumpDisplayParseResult(
+        totalCost: 58.43,
+        liters: 31.65,
+        pricePerLiter: 1.846,
+      );
+      expect(r.hasUsableData, isTrue);
+    });
+
+    test('pump number alone does NOT qualify as usable data', () {
+      // pumpNumber is a convenience — it should never unlock auto-fill.
+      const r = PumpDisplayParseResult(pumpNumber: 3);
+      expect(r.hasUsableData, isFalse);
+    });
+  });
+
+  group('PumpDisplayParseResult — isConsistent', () {
+    test('false when any primary field is null', () {
+      const missingPrice = PumpDisplayParseResult(
+        totalCost: 58.43,
+        liters: 31.65,
+      );
+      const missingLiters = PumpDisplayParseResult(
+        totalCost: 58.43,
+        pricePerLiter: 1.846,
+      );
+      const missingTotal = PumpDisplayParseResult(
+        liters: 31.65,
+        pricePerLiter: 1.846,
+      );
+      expect(missingPrice.isConsistent, isFalse);
+      expect(missingLiters.isConsistent, isFalse);
+      expect(missingTotal.isConsistent, isFalse);
+    });
+
+    test('true when liters * price equals total exactly', () {
+      const r = PumpDisplayParseResult(
+        liters: 10,
+        pricePerLiter: 1.5,
+        totalCost: 15,
+      );
+      expect(r.isConsistent, isTrue);
+    });
+
+    test('true when delta is within 2 cents (pump rounding)', () {
+      // 31.65 * 1.846 = 58.4259 — pump rounds to 58.43 or 58.42;
+      // either must read as consistent.
+      const a = PumpDisplayParseResult(
+        liters: 31.65,
+        pricePerLiter: 1.846,
+        totalCost: 58.43,
+      );
+      const b = PumpDisplayParseResult(
+        liters: 31.65,
+        pricePerLiter: 1.846,
+        totalCost: 58.42,
+      );
+      expect(a.isConsistent, isTrue);
+      expect(b.isConsistent, isTrue);
+    });
+
+    test('true exactly at the 2-cent tolerance boundary', () {
+      // Predicted 10.00, actual 10.02 — delta == 0.02 must still be
+      // consistent (the comparison is `<= 0.02`).
+      const r = PumpDisplayParseResult(
+        liters: 5,
+        pricePerLiter: 2.0,
+        totalCost: 10.02,
+      );
+      expect(r.isConsistent, isTrue);
+    });
+
+    test('false when delta exceeds the 2-cent tolerance', () {
+      // 10 * 1.5 = 15 — total 15.03 is 3c off -> not consistent.
+      const r = PumpDisplayParseResult(
+        liters: 10,
+        pricePerLiter: 1.5,
+        totalCost: 15.03,
+      );
+      expect(r.isConsistent, isFalse);
+    });
+
+    test('false when the triple disagrees wildly (OCR swap)', () {
+      // 10 * 1.5 = 15 but displayed total is 30 — strong signal that
+      // OCR misread one of the fields.
+      const r = PumpDisplayParseResult(
+        liters: 10,
+        pricePerLiter: 1.5,
+        totalCost: 30,
+      );
+      expect(r.isConsistent, isFalse);
+    });
+
+    test('handles tiny positive floating-point error without drama', () {
+      // 31.65 * 1.846 = 58.4259 — assigning the exact product as total
+      // must still read as consistent.
+      const r = PumpDisplayParseResult(
+        liters: 31.65,
+        pricePerLiter: 1.846,
+        totalCost: 58.4259,
+      );
+      expect(r.isConsistent, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds direct unit tests for three previously-untested library files under the #561 coverage push:

- `lib/core/location/location_consent.dart` (164 LOC) — GDPR consent persistence + AlertDialog UX.
- `lib/features/consumption/data/_pump_display_patterns.dart` (89 LOC) — OCR regex patterns + digit-lookalike table.
- `lib/features/consumption/data/pump_display_parse_result.dart` (61 LOC) — DTO + `hasUsableData` / `isConsistent` contracts.

## Why

These three files were zero-coverage (patterns + parse_result only had indirect coverage via the parser orchestrator, and many DTO branches were missed). Direct tests pin their contracts so regressions surface independently of the parser, and the consent dialog's legal-basis / locale-fallback / barrier-dismissal behaviour is now enforced end-to-end.

Refs #561 — phase PR, not closing.

## Testing

- `flutter analyze` — clean.
- `flutter test test/core/location/location_consent_test.dart test/features/consumption/data/_pump_display_patterns_test.dart test/features/consumption/data/pump_display_parse_result_test.dart` — 69 new tests, all pass.
- `flutter test` — full 5935-test suite green.
- `flutter test --coverage` on the three new files → **100 % line coverage** on each target file:
  - `location_consent.dart` 43/43
  - `_pump_display_patterns.dart` 19/19
  - `pump_display_parse_result.dart` 11/11