### PR TITLE
refactor(ui): SearchScreen uses PageScaffold (Refs #923 phase 3e)

### DIFF
--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -8,6 +8,7 @@ import '../../../../core/location/location_consent.dart';
 import '../../../../core/location/user_position_provider.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/utils/frame_callbacks.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../map/presentation/widgets/inline_map.dart';
@@ -122,14 +123,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     final isLandscape =
         MediaQuery.of(context).orientation == Orientation.landscape;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Semantics(
-          header: true,
-          child: Text(l10n?.appTitle ?? 'Fuel Prices'),
-        ),
-        toolbarHeight: isLandscape ? 40 : null,
-      ),
+    return PageScaffold(
+      title: l10n?.appTitle ?? 'Fuel Prices',
+      toolbarHeight: isLandscape ? 40 : null,
+      bodyPadding: EdgeInsets.zero,
       body: isWide
           ? _buildWideLayout(context)
           : _buildSearchContent(context),


### PR DESCRIPTION
## What

Migrates `SearchScreen` to the canonical `PageScaffold` chrome (phase 3e of the design-system consolidation epic).

Refs #923.

## Why

Every top-level destination should share one app-bar + title contract so accessibility semantics, toolbar sizing, and future banner/action tweaks happen in one place instead of N scaffolds. The previous attempt was blocked on two missing affordances in `PageScaffold` — `toolbarHeight` passthrough and header `Semantics` on the title — both of which shipped in #937.

## Change

- `Scaffold(appBar: AppBar(title: Semantics(header: true, Text(...)), toolbarHeight: …))` → `PageScaffold(title: …, toolbarHeight: …, bodyPadding: EdgeInsets.zero, body: …)`
- The explicit `Semantics(header: true, ...)` wrapper is dropped — `PageScaffold` wraps the title in a header-flagged Semantics node internally.
- `bodyPadding: EdgeInsets.zero` preserves the existing full-bleed layout (`DemoModeBanner` / `SearchSummaryBar` / `UserPositionBar` span edge-to-edge, and the results list owns its own inner padding).
- Landscape's compact 40-px toolbar is preserved via `toolbarHeight: isLandscape ? 40 : null`.
- Nothing else in the file changes — `_buildWideLayout`, `_buildSearchContent`, `_autoSearchAttempted`, `initState` are untouched.

## Testing

- `flutter analyze` — zero warnings.
- `flutter test` — all 5868 tests pass, including `test/features/search/presentation/screens/search_screen_test.dart` (still finds Scaffold via `findsAtLeast(1)` because `PageScaffold` internally renders `Scaffold`).

## Screenshots

No visual change — same app bar, same header text, same landscape compact height, same body layout.