### PR TITLE
feat(ui): PageScaffold supports floatingActionButton (Refs #923)

### DIFF
--- a/docs/design/DESIGN_SYSTEM.md
+++ b/docs/design/DESIGN_SYSTEM.md
@@ -228,7 +228,14 @@ screen is about" identified in the #923 audit.
 - **required** `body: Widget` — scrollable content. `PageScaffold`
   applies `Spacing.screenPadding` to the body by default; opt out via
   `bodyPadding: EdgeInsets.zero` for full-bleed content (map screen).
-- `floatingActionButton: Widget?`
+- `floatingActionButton: Widget?` — pass-through to
+  [Scaffold.floatingActionButton]. Enables MapScreen's
+  `DrivingModeFab` to live inside `PageScaffold`.
+- `floatingActionButtonLocation: FloatingActionButtonLocation?` —
+  pass-through to [Scaffold.floatingActionButtonLocation]. Default
+  `null` uses `Scaffold`'s default (end-float); pass
+  `FloatingActionButtonLocation.centerDocked` when pairing with a
+  bottom bar.
 - `bottomNavigationBar: Widget?` — reserved for the shell; leaf
   screens do not set this.
 - `toolbarHeight: double?` — optional override for the app-bar toolbar

--- a/lib/core/widgets/page_scaffold.dart
+++ b/lib/core/widgets/page_scaffold.dart
@@ -44,6 +44,13 @@ class PageScaffold extends StatelessWidget {
   /// Optional FAB. Passed through to [Scaffold.floatingActionButton].
   final Widget? floatingActionButton;
 
+  /// Optional FAB position. Passed through to
+  /// [Scaffold.floatingActionButtonLocation]. Default `null` lets
+  /// `Scaffold` pick its default (end-float). Use e.g.
+  /// [FloatingActionButtonLocation.centerDocked] when pairing with a
+  /// bottom bar.
+  final FloatingActionButtonLocation? floatingActionButtonLocation;
+
   /// Optional leading app-bar widget. Normally the back button — pass
   /// a custom drawer icon when needed.
   final Widget? leading;
@@ -65,6 +72,7 @@ class PageScaffold extends StatelessWidget {
     this.actions,
     this.bodyPadding,
     this.floatingActionButton,
+    this.floatingActionButtonLocation,
     this.leading,
     this.automaticallyImplyLeading = true,
     this.toolbarHeight,
@@ -98,6 +106,7 @@ class PageScaffold extends StatelessWidget {
         ],
       ),
       floatingActionButton: floatingActionButton,
+      floatingActionButtonLocation: floatingActionButtonLocation,
     );
   }
 }

--- a/test/core/widgets/page_scaffold_test.dart
+++ b/test/core/widgets/page_scaffold_test.dart
@@ -100,6 +100,42 @@ void main() {
       expect(find.byType(FloatingActionButton), findsOneWidget);
     });
 
+    testWidgets('renders floatingActionButton when provided', (tester) async {
+      await pump(
+        tester,
+        PageScaffold(
+          title: 'Map',
+          floatingActionButton: FloatingActionButton(
+            onPressed: () {},
+            child: const Icon(Icons.drive_eta),
+          ),
+          body: const SizedBox.shrink(),
+        ),
+      );
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('passes floatingActionButtonLocation through to Scaffold',
+        (tester) async {
+      await pump(
+        tester,
+        PageScaffold(
+          title: 'Map',
+          floatingActionButton: FloatingActionButton(
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+          floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+          body: const SizedBox.shrink(),
+        ),
+      );
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold));
+      expect(
+        scaffold.floatingActionButtonLocation,
+        FloatingActionButtonLocation.centerDocked,
+      );
+    });
+
     testWidgets('passes toolbarHeight through to AppBar', (tester) async {
       await pump(
         tester,


### PR DESCRIPTION
## What

Adds `floatingActionButtonLocation` passthrough to `PageScaffold`, extending the existing `floatingActionButton` prop. Updates the `DESIGN_SYSTEM.md` props table in the same row-style #937 used for `toolbarHeight`, and adds two widget tests matching that style:

- `renders floatingActionButton when provided`
- `passes floatingActionButtonLocation through to Scaffold`

## Why

Unblocks MapScreen's PageScaffold migration (phase 3f). MapScreen owns a `DrivingModeFab` (`lib/features/map/presentation/screens/map_screen.dart:81`) and needs FAB positional flexibility to land inside the canonical scaffold. Refs #923.

## Testing

- `flutter analyze` — clean, no issues.
- `flutter test` — 5939 passed, zero regressions.
- Existing `PageScaffold` consumers unchanged (new param defaults `null`).

## Don't merge list

- MapScreen migration stays in a follow-up PR.