### PR TITLE
refactor(ui): station detail sections use SectionCard + SectionHeader (Refs #923 phase 3f)

### DIFF
--- a/lib/features/station_detail/presentation/widgets/station_info_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_info_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
+import '../../../../core/widgets/section_header.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../search/presentation/widgets/amenity_chips.dart';
@@ -10,6 +11,18 @@ import '../../../search/presentation/widgets/pay_with_app_button.dart';
 import '../../../search/presentation/widgets/payment_method_chips.dart';
 
 /// Address, opening hours, fuels, services, and location info for a station.
+///
+/// #923 phase 3f — the five plain-text `titleMedium` sub-headings
+/// (Address / Opening hours / Zone / Amenities / Payment methods)
+/// are rendered through the canonical [SectionHeader] so the headings
+/// share the design-system role, weight, and color with every other
+/// section on the screen. The body stays in a single Column — the
+/// screen already owns outer card-vs-card spacing via its parent
+/// [SizedBox]s and the section layout was not wrapped in a Card before
+/// this migration, so no visual regressions are introduced here. The
+/// bottom `ExpansionTile` for "Services (N)" keeps its own
+/// `titleMedium` label because that slot is an ExpansionTile title,
+/// not a stand-alone section heading.
 class StationInfoSection extends StatelessWidget {
   final Station station;
   final StationDetail detail;
@@ -29,7 +42,10 @@ class StationInfoSection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         // Address
-        Text(l10n?.address ?? 'Address', style: theme.textTheme.titleMedium),
+        SectionHeader(
+          title: l10n?.address ?? 'Address',
+          padding: EdgeInsets.zero,
+        ),
         const SizedBox(height: 8),
         ListTile(
           leading: const Icon(Icons.location_on),
@@ -49,7 +65,10 @@ class StationInfoSection extends StatelessWidget {
         const SizedBox(height: 24),
 
         // Opening times
-        Text(l10n?.openingHours ?? 'Opening hours', style: theme.textTheme.titleMedium),
+        SectionHeader(
+          title: l10n?.openingHours ?? 'Opening hours',
+          padding: EdgeInsets.zero,
+        ),
         const SizedBox(height: 8),
         if (station.is24h)
           ListTile(
@@ -79,7 +98,10 @@ class StationInfoSection extends StatelessWidget {
 
         // Location info
         if (station.department != null || station.region != null) ...[
-          Text(l10n?.zone ?? 'Zone', style: theme.textTheme.titleMedium),
+          SectionHeader(
+            title: l10n?.zone ?? 'Zone',
+            padding: EdgeInsets.zero,
+          ),
           const SizedBox(height: 8),
           ListTile(
             dense: true,
@@ -96,7 +118,10 @@ class StationInfoSection extends StatelessWidget {
 
         // Amenities (icon chips) — at the bottom
         if (station.amenities.isNotEmpty) ...[
-          Text(l10n?.amenities ?? 'Amenities', style: theme.textTheme.titleMedium),
+          SectionHeader(
+            title: l10n?.amenities ?? 'Amenities',
+            padding: EdgeInsets.zero,
+          ),
           const SizedBox(height: 8),
           AmenityChips(amenities: station.amenities, maxVisible: 8),
           const SizedBox(height: 24),
@@ -104,9 +129,9 @@ class StationInfoSection extends StatelessWidget {
 
         // Payment methods (inferred from brand — no API data available)
         if (station.brand.trim().isNotEmpty) ...[
-          Text(
-            l10n?.paymentMethods ?? 'Payment methods',
-            style: theme.textTheme.titleMedium,
+          SectionHeader(
+            title: l10n?.paymentMethods ?? 'Payment methods',
+            padding: EdgeInsets.zero,
           ),
           const SizedBox(height: 8),
           PaymentMethodChips(brand: station.brand, maxVisible: 8),

--- a/lib/features/station_detail/presentation/widgets/station_prices_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_prices_section.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/widgets/section_card.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/brand_registry.dart';
@@ -15,6 +16,12 @@ import 'price_tile.dart';
 /// Extracted from [StationDetailScreen] so the screen stays under the
 /// 300-LOC cap (#563). Public behaviour is unchanged — same fuel
 /// ordering, same optional-tile gating, same localisation lookups.
+///
+/// #923 phase 3f — the raw `Text(…, titleMedium)` + plain Column
+/// wrapper is replaced by the canonical [SectionCard] so the Prices
+/// block shares the design-system surface tint, radius, padding, and
+/// header role (`SectionHeader`) with every other section on the
+/// station-detail screen.
 class StationPricesSection extends StatelessWidget {
   final Station station;
 
@@ -22,32 +29,28 @@ class StationPricesSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Semantics(
-          header: true,
-          child: Text(l10n?.prices ?? 'Prices',
-              style: theme.textTheme.titleMedium),
-        ),
-        const SizedBox(height: 6),
-        PriceTile(label: 'Super E5', price: station.e5, fuelType: FuelType.e5),
-        PriceTile(label: 'Super E10', price: station.e10, fuelType: FuelType.e10),
-        PriceTile(label: 'Diesel', price: station.diesel, fuelType: FuelType.diesel),
-        if (station.e98 != null)
-          PriceTile(label: 'Super 98', price: station.e98, fuelType: FuelType.e98),
-        if (station.e85 != null)
-          PriceTile(label: 'E85', price: station.e85, fuelType: FuelType.e85),
-        if (station.lpg != null)
-          PriceTile(label: 'LPG', price: station.lpg, fuelType: FuelType.lpg),
-        if (station.cng != null)
-          PriceTile(label: 'CNG', price: station.cng, fuelType: FuelType.cng),
-        const SizedBox(height: 12),
-        LogFillUpButton(station: station),
-      ],
+    return SectionCard(
+      title: l10n?.prices ?? 'Prices',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          PriceTile(label: 'Super E5', price: station.e5, fuelType: FuelType.e5),
+          PriceTile(label: 'Super E10', price: station.e10, fuelType: FuelType.e10),
+          PriceTile(label: 'Diesel', price: station.diesel, fuelType: FuelType.diesel),
+          if (station.e98 != null)
+            PriceTile(label: 'Super 98', price: station.e98, fuelType: FuelType.e98),
+          if (station.e85 != null)
+            PriceTile(label: 'E85', price: station.e85, fuelType: FuelType.e85),
+          if (station.lpg != null)
+            PriceTile(label: 'LPG', price: station.lpg, fuelType: FuelType.lpg),
+          if (station.cng != null)
+            PriceTile(label: 'CNG', price: station.cng, fuelType: FuelType.cng),
+          const SizedBox(height: 12),
+          LogFillUpButton(station: station),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/station_detail/presentation/widgets/station_rating_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_rating_section.dart
@@ -1,11 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/widgets/section_card.dart';
 import '../../../../core/widgets/star_rating.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/providers/station_rating_provider.dart';
 
 /// User rating section showing interactive star rating for a station.
+///
+/// #923 phase 3f — migrated from an inline `Text(…, titleMedium)` +
+/// Column layout to the canonical [SectionCard] so the rating block
+/// matches the other section surfaces on the station-detail screen
+/// (same radius, tint, padding, and header role).
 class StationRatingSection extends StatelessWidget {
   final String stationId;
 
@@ -15,30 +21,25 @@ class StationRatingSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(l10n?.yourRating ?? 'Your rating',
-            style: theme.textTheme.titleMedium),
-        const SizedBox(height: 8),
-        Consumer(builder: (context, ref, _) {
-          final rating = ref.watch(stationRatingProvider(stationId));
-          return Row(
-            children: [
-              StarRating(
-                rating: rating,
-                onRatingChanged: (stars) {
-                  ref.read(stationRatingsProvider.notifier).rate(stationId, stars);
-                },
-              ),
-              if (rating != null) ...[
-                const SizedBox(width: 12),
-                Text('$rating/5', style: theme.textTheme.bodyMedium),
-              ],
+    return SectionCard(
+      title: l10n?.yourRating ?? 'Your rating',
+      child: Consumer(builder: (context, ref, _) {
+        final rating = ref.watch(stationRatingProvider(stationId));
+        return Row(
+          children: [
+            StarRating(
+              rating: rating,
+              onRatingChanged: (stars) {
+                ref.read(stationRatingsProvider.notifier).rate(stationId, stars);
+              },
+            ),
+            if (rating != null) ...[
+              const SizedBox(width: 12),
+              Text('$rating/5', style: theme.textTheme.bodyMedium),
             ],
-          );
-        }),
-      ],
+          ],
+        );
+      }),
     );
   }
 }


### PR DESCRIPTION
## Summary

Phase 3f of the #923 design-system epic — migrates the title-bearing section widgets on the station-detail screen body to the canonical `SectionCard` + `SectionHeader` primitives introduced in phase 2.

- `StationPricesSection`: inline `Text(..., titleMedium)` + Column wrapper replaced by `SectionCard(title: l10n.prices, child: ...)`. The `PriceTile` rows and `LogFillUpButton` CTA ride inside the card.
- `StationRatingSection`: same migration — `SectionCard(title: l10n.yourRating, ...)` hosts the `StarRating` + score readout.
- `StationInfoSection`: the five plain-text `titleMedium` sub-headings (Address / Opening hours / Zone / Amenities / Payment methods) now use `SectionHeader(padding: EdgeInsets.zero)`. The widget stays a single column — it was never wrapped in a Card, so wrapping each sub-section in a `SectionCard` would have altered vertical layout beyond the scope of this PR. The "Services (N)" `ExpansionTile` keeps its own `titleMedium` because that slot is an ExpansionTile title, not a stand-alone heading.

Left untouched (per scope):
- `station_detail_screen.dart` outer `Scaffold` + `AppBar` — the composed brand Hero title is a separate migration.
- `station_brand_header.dart` — intentional custom composition.
- `station_status_row.dart`, `price_history_section.dart` — no Card/title wrapper to migrate.
- `station_detail_inline.dart` — left for a follow-up to keep the diff focused.

## Why

Aligns the station-detail screen with the `surfaceContainerLow` tint + `AppRadius.lg` + `Spacing.cardPadding` + `SectionHeader` role that every other migrated screen now uses. Also clears five of the top inline `titleMedium` call-sites ahead of the `no_inline_title_theme_test` lint scan planned for a later phase.

## Testing

- [x] `flutter analyze` — zero warnings.
- [x] `flutter test` — full suite green (5936 passed, 1 skipped network baseline).
- [x] `flutter test test/features/station_detail/` — all 42 station-detail tests pass (widget tests use `find.text('Address')`, `find.text('Prices')`, etc. — SectionHeader renders the same text node so no test updates are needed).

Refs #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)