### PR TITLE
feat(ui): PageScaffold supports titleTextStyle + titleSpacing (Refs #923)

### DIFF
--- a/docs/design/DESIGN_SYSTEM.md
+++ b/docs/design/DESIGN_SYSTEM.md
@@ -242,6 +242,14 @@ screen is about" identified in the #923 audit.
   height (pass-through to `AppBar.toolbarHeight`). Default `null` uses
   Material's default; compact layouts (e.g. `SearchScreen` in
   landscape) pass `40`.
+- `titleTextStyle: TextStyle?` — optional override for the app-bar
+  title text style (pass-through to `AppBar.titleTextStyle`). Default
+  `null` uses Material's default; compact layouts (e.g. `MapScreen`
+  in landscape) pass `TextStyle(fontSize: 16)`.
+- `titleSpacing: double?` — optional override for the horizontal
+  space between the leading widget and the title (pass-through to
+  `AppBar.titleSpacing`). Default `null` uses `NavigationToolbar.kMiddleSpacing`
+  (16); compact layouts (e.g. `MapScreen` in landscape) pass `12`.
 
 **Accessibility:** the app-bar title is wrapped in
 `Semantics(header: true, …)` so TalkBack/VoiceOver announce the

--- a/lib/core/widgets/page_scaffold.dart
+++ b/lib/core/widgets/page_scaffold.dart
@@ -63,6 +63,18 @@ class PageScaffold extends StatelessWidget {
   /// Compact screens (e.g. `SearchScreen` in landscape) shrink to ~40.
   final double? toolbarHeight;
 
+  /// Optional override for the app-bar title text style. Pass-through to
+  /// [AppBar.titleTextStyle]. Leave `null` to use the Material default.
+  /// Compact screens (e.g. `MapScreen` in landscape) pass
+  /// `TextStyle(fontSize: 16)`.
+  final TextStyle? titleTextStyle;
+
+  /// Optional override for the app-bar title spacing (horizontal space
+  /// between the leading widget and the title). Pass-through to
+  /// [AppBar.titleSpacing]. Leave `null` to use the Material default
+  /// ([NavigationToolbar.kMiddleSpacing] = 16).
+  final double? titleSpacing;
+
   const PageScaffold({
     super.key,
     required this.title,
@@ -76,6 +88,8 @@ class PageScaffold extends StatelessWidget {
     this.leading,
     this.automaticallyImplyLeading = true,
     this.toolbarHeight,
+    this.titleTextStyle,
+    this.titleSpacing,
   });
 
   @override
@@ -88,6 +102,8 @@ class PageScaffold extends StatelessWidget {
         leading: leading,
         automaticallyImplyLeading: automaticallyImplyLeading,
         toolbarHeight: toolbarHeight,
+        titleTextStyle: titleTextStyle,
+        titleSpacing: titleSpacing,
       ),
       body: Column(
         children: [

--- a/test/core/widgets/page_scaffold_test.dart
+++ b/test/core/widgets/page_scaffold_test.dart
@@ -149,6 +149,32 @@ void main() {
       expect(appBar.toolbarHeight, 40);
     });
 
+    testWidgets('passes titleTextStyle through to AppBar', (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Map',
+          titleTextStyle: TextStyle(fontSize: 16),
+          body: SizedBox.shrink(),
+        ),
+      );
+      final appBar = tester.widget<AppBar>(find.byType(AppBar));
+      expect(appBar.titleTextStyle?.fontSize, 16);
+    });
+
+    testWidgets('passes titleSpacing through to AppBar', (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Map',
+          titleSpacing: 12,
+          body: SizedBox.shrink(),
+        ),
+      );
+      final appBar = tester.widget<AppBar>(find.byType(AppBar));
+      expect(appBar.titleSpacing, 12);
+    });
+
     testWidgets('title has header semantics', (tester) async {
       final handle = tester.ensureSemantics();
       await pump(


### PR DESCRIPTION
## What

Add two pass-through props to `PageScaffold`:

- `titleTextStyle: TextStyle?` → `AppBar.titleTextStyle`
- `titleSpacing: double?` → `AppBar.titleSpacing`

Both default to `null`, preserving Material defaults for existing callers.

## Why

Unblocks phase 3g: MapScreen migration to `PageScaffold`. MapScreen's landscape-compact app bar currently sets `title: Text('Map', style: TextStyle(fontSize: 16)), toolbarHeight: 36, titleSpacing: 12` directly. Without these pass-throughs the migration would either (a) regress the compact landscape layout or (b) force a bespoke `AppBar` inside the body — both no-gos.

Follows the exact pattern of #937 (`toolbarHeight`) and #941 (`floatingActionButton`).

Refs #923

## Testing

- Added `passes titleTextStyle through to AppBar` — pumps with `TextStyle(fontSize: 16)`, asserts `appBar.titleTextStyle?.fontSize == 16`.
- Added `passes titleSpacing through to AppBar` — pumps with `titleSpacing: 12`, asserts `appBar.titleSpacing == 12`.
- `flutter analyze` — zero warnings.
- `flutter test` — all 5950 tests pass (1 pre-existing skip).

## Screenshots

None — no UI change for existing consumers; both props default to `null`.