### PR TITLE
refactor(ui): MapScreen uses PageScaffold (Refs #923 phase 3g)

### DIFF
--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../driving/presentation/widgets/driving_mode_fab.dart';
 import '../../../ev/presentation/widgets/ev_filter_chips.dart';
@@ -68,16 +69,12 @@ class _MapScreenState extends ConsumerState<MapScreen> {
             mapController: _mapController,
           );
 
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(36),
-        child: AppBar(
-          title:
-              Text(l10n?.map ?? 'Map', style: const TextStyle(fontSize: 16)),
-          toolbarHeight: 36,
-          titleSpacing: 12,
-        ),
-      ),
+    return PageScaffold(
+      title: l10n?.map ?? 'Map',
+      toolbarHeight: 36,
+      titleSpacing: 12,
+      titleTextStyle: const TextStyle(fontSize: 16),
+      bodyPadding: EdgeInsets.zero,
       floatingActionButton: const DrivingModeFab(),
       body: Column(
         children: [

--- a/test/features/map/presentation/screens/map_screen_test.dart
+++ b/test/features/map/presentation/screens/map_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/widgets/page_scaffold.dart';
 import 'package:tankstellen/features/map/presentation/screens/map_screen.dart';
 
 import '../../../../helpers/mock_providers.dart';
@@ -40,6 +41,23 @@ void main() {
 
       // App bar should be present with preferredSize height of 36
       expect(find.byType(AppBar), findsAtLeast(1));
+    });
+
+    testWidgets('uses canonical PageScaffold chrome (Refs #923 phase 3g)',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const MapScreen(),
+        overrides: [
+          ...test.overrides,
+          userPositionNullOverride(),
+        ],
+      );
+
+      expect(find.byType(PageScaffold), findsOneWidget);
     });
 
     // #529 / #709 regression tests retired by #757. Previously


### PR DESCRIPTION
## Why
Phase 3g of the design-system epic (#923). MapScreen was the last top-level destination with a custom `Scaffold` + `PreferredSize(AppBar)` shell. PageScaffold now supports every prop MapScreen needs (toolbarHeight, titleSpacing, titleTextStyle, floatingActionButton, bodyPadding) after #937/#941/#943 landed.

## What
- Replace `Scaffold` + `PreferredSize(AppBar)` with `PageScaffold`.
- Pass `bodyPadding: EdgeInsets.zero` for full-bleed map content.
- Preserve `toolbarHeight: 36` / `titleSpacing: 12` / `TextStyle(fontSize: 16)` via `PageScaffold`'s pass-through props.
- Add a regression test asserting `find.byType(PageScaffold)`.

Refs #923 phase 3g