### PR TITLE
test(coverage): cover brand detection + csv parser utilities (Refs #561)

### DIFF
--- a/test/core/services/utils/brand_detector_test.dart
+++ b/test/core/services/utils/brand_detector_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/utils/brand_detector.dart';
+
+void main() {
+  group('BrandDetector.detect — international brands', () {
+    test('TOTALENERGIES → TotalEnergies', () {
+      expect(BrandDetector.detect('TOTALENERGIES Station A75'), 'TotalEnergies');
+    });
+
+    test('"TOTAL " (trailing space) → Total', () {
+      expect(BrandDetector.detect('TOTAL Station'), 'Total');
+    });
+
+    test('SHELL → Shell', () {
+      expect(BrandDetector.detect('SHELL Highway'), 'Shell');
+    });
+
+    test('"BP " (trailing space) → BP', () {
+      expect(BrandDetector.detect('BP Station 42'), 'BP');
+    });
+
+    test('ESSO → Esso', () {
+      expect(BrandDetector.detect('ESSO Express'), 'Esso');
+    });
+
+    test('AVIA → AVIA', () {
+      expect(BrandDetector.detect('AVIA XPress'), 'AVIA');
+    });
+  });
+
+  group('BrandDetector.detect — France', () {
+    test('LECLERC → E.Leclerc', () {
+      expect(BrandDetector.detect('E.LECLERC Béziers'), 'E.Leclerc');
+    });
+
+    test('CARREFOUR → Carrefour', () {
+      expect(BrandDetector.detect('CARREFOUR Market'), 'Carrefour');
+    });
+
+    test('INTERMARCHE (no accent) → Intermarché', () {
+      expect(BrandDetector.detect('INTERMARCHE Contact'), 'Intermarché');
+    });
+
+    test('INTERMARCHÉ (with accent) → Intermarché', () {
+      expect(BrandDetector.detect('INTERMARCHÉ Super'), 'Intermarché');
+    });
+
+    test('AUCHAN → Auchan', () {
+      expect(BrandDetector.detect('AUCHAN Drive'), 'Auchan');
+    });
+
+    test('SUPER U → Super U', () {
+      expect(BrandDetector.detect('SUPER U Pezenas'), 'Super U');
+    });
+
+    test('SYSTEME U (no accent) → Système U', () {
+      expect(BrandDetector.detect('SYSTEME U Distrib'), 'Système U');
+    });
+
+    test('SYSTÈME U (with accent) → Système U', () {
+      expect(BrandDetector.detect('SYSTÈME U Market'), 'Système U');
+    });
+
+    test('CASINO → Casino', () {
+      expect(BrandDetector.detect('CASINO Shop'), 'Casino');
+    });
+
+    test('VITO → Vito', () {
+      expect(BrandDetector.detect('VITO Station'), 'Vito');
+    });
+
+    test('NETTO → Netto', () {
+      expect(BrandDetector.detect('NETTO Discount'), 'Netto');
+    });
+
+    test('DYNEFF → Dyneff', () {
+      expect(BrandDetector.detect('DYNEFF Languedoc'), 'Dyneff');
+    });
+  });
+
+  group('BrandDetector.detect — Austria', () {
+    test('OMV → OMV', () {
+      expect(BrandDetector.detect('OMV Wien'), 'OMV');
+    });
+
+    test('JET → Jet', () {
+      expect(BrandDetector.detect('JET Tankstelle'), 'Jet');
+    });
+
+    test('ENI → Eni', () {
+      expect(BrandDetector.detect('ENI Station'), 'Eni');
+    });
+
+    test('AVANTI → Avanti', () {
+      expect(BrandDetector.detect('AVANTI Autobahn'), 'Avanti');
+    });
+
+    test('TURMÖL → Turmöl', () {
+      expect(BrandDetector.detect('TURMÖL Graz'), 'Turmöl');
+    });
+
+    test('IQ → IQ', () {
+      expect(BrandDetector.detect('IQ Station'), 'IQ');
+    });
+
+    test('GENOL → Genol', () {
+      expect(BrandDetector.detect('GENOL Salzburg'), 'Genol');
+    });
+
+    test('LAGERHAUS → Lagerhaus', () {
+      expect(BrandDetector.detect('LAGERHAUS Country'), 'Lagerhaus');
+    });
+  });
+
+  group('BrandDetector.detect — Spain', () {
+    test('REPSOL → Repsol', () {
+      expect(BrandDetector.detect('REPSOL Madrid'), 'Repsol');
+    });
+
+    test('CEPSA → Cepsa', () {
+      expect(BrandDetector.detect('CEPSA Barcelona'), 'Cepsa');
+    });
+
+    test('GALP → Galp', () {
+      expect(BrandDetector.detect('GALP Lisboa'), 'Galp');
+    });
+  });
+
+  group('BrandDetector.detect — Italy', () {
+    test('IP → IP', () {
+      expect(BrandDetector.detect('IP Milano'), 'IP');
+    });
+
+    test('Q8 → Q8', () {
+      expect(BrandDetector.detect('Q8 Torino'), 'Q8');
+    });
+
+    test('TOTALERG → TotalErg', () {
+      expect(BrandDetector.detect('TOTALERG Italia'), 'TotalErg');
+    });
+
+    test('TAMOIL → Tamoil', () {
+      expect(BrandDetector.detect('TAMOIL Napoli'), 'Tamoil');
+    });
+  });
+
+  group('BrandDetector.detect — Germany', () {
+    test('ARAL → ARAL', () {
+      expect(BrandDetector.detect('ARAL Autobahn'), 'ARAL');
+    });
+
+    test('STAR → STAR', () {
+      expect(BrandDetector.detect('STAR Tankstelle'), 'STAR');
+    });
+
+    test('HEM → HEM', () {
+      expect(BrandDetector.detect('HEM Berlin'), 'HEM');
+    });
+  });
+
+  group('BrandDetector.detect — case insensitivity', () {
+    test('lowercase "total " matches', () {
+      expect(BrandDetector.detect('total station'), 'Total');
+    });
+
+    test('mixed case "Shell" matches', () {
+      expect(BrandDetector.detect('Shell Highway'), 'Shell');
+    });
+
+    test('mixed case "Carrefour" matches', () {
+      expect(BrandDetector.detect('Carrefour Express'), 'Carrefour');
+    });
+  });
+
+  group('BrandDetector.detect — priority / iteration order', () {
+    test('TOTALENERGIES beats CARREFOUR when both appear', () {
+      // Map iteration order: TOTALENERGIES is first (international bucket)
+      // and matches before CARREFOUR.
+      expect(
+        BrandDetector.detect('TOTALENERGIES Carrefour Market'),
+        'TotalEnergies',
+      );
+    });
+
+    test('SHELL beats LECLERC when both appear', () {
+      expect(
+        BrandDetector.detect('Shell partnership Leclerc'),
+        'Shell',
+      );
+    });
+
+    test('TOTALENERGIES beats the "TOTAL " fallback', () {
+      // "TOTALENERGIES" is checked before "TOTAL ". Because the text also
+      // contains "TOTAL " (followed by a space) we verify the first-key wins.
+      expect(
+        BrandDetector.detect('TOTALENERGIES TOTAL Supplier'),
+        'TotalEnergies',
+      );
+    });
+  });
+
+  group('BrandDetector.detect — fallback behaviour', () {
+    test('empty string returns default fallback "Station"', () {
+      expect(BrandDetector.detect(''), 'Station');
+    });
+
+    test('empty string honors a custom fallback', () {
+      expect(BrandDetector.detect('', fallback: 'Unknown'), 'Unknown');
+    });
+
+    test('unrecognised text returns first word (space split)', () {
+      expect(BrandDetector.detect('Zebra Crossing 123'), 'Zebra');
+    });
+
+    test('unrecognised text returns first word (dash split)', () {
+      expect(BrandDetector.detect('Foo-Bar'), 'Foo');
+    });
+
+    test('unrecognised text returns first word (mixed space+dash)', () {
+      expect(BrandDetector.detect('Alpha Beta-Gamma'), 'Alpha');
+    });
+
+    test('single unrecognised word returns itself', () {
+      expect(BrandDetector.detect('Zzzz'), 'Zzzz');
+    });
+  });
+}

--- a/test/core/services/utils/csv_parser_test.dart
+++ b/test/core/services/utils/csv_parser_test.dart
@@ -1,0 +1,218 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/utils/csv_parser.dart';
+
+void main() {
+  group('CsvParser.parseLine', () {
+    test('plain CSV without quotes uses fast path', () {
+      expect(
+        CsvParser.parseLine('a,b,c'),
+        <String>['a', 'b', 'c'],
+      );
+    });
+
+    test('trims whitespace on fast path', () {
+      expect(
+        CsvParser.parseLine(' a , b , c '),
+        <String>['a', 'b', 'c'],
+      );
+    });
+
+    test('handles quoted fields with embedded comma', () {
+      expect(
+        CsvParser.parseLine('"field1","field with, comma","field3"'),
+        <String>['field1', 'field with, comma', 'field3'],
+      );
+    });
+
+    test('supports custom separator (semicolon)', () {
+      expect(
+        CsvParser.parseLine('a;b;c', separator: ';'),
+        <String>['a', 'b', 'c'],
+      );
+    });
+
+    test('handles custom separator with quotes', () {
+      expect(
+        CsvParser.parseLine('"a";"b;with semi";"c"', separator: ';'),
+        <String>['a', 'b;with semi', 'c'],
+      );
+    });
+
+    test('returns empty fields as empty strings', () {
+      expect(
+        CsvParser.parseLine('a,,c'),
+        <String>['a', '', 'c'],
+      );
+    });
+
+    test('handles trailing empty field', () {
+      expect(
+        CsvParser.parseLine('a,b,'),
+        <String>['a', 'b', ''],
+      );
+    });
+
+    test('single field, no separator', () {
+      expect(CsvParser.parseLine('hello'), <String>['hello']);
+    });
+
+    test('handles empty string as single empty field', () {
+      expect(CsvParser.parseLine(''), <String>['']);
+    });
+
+    test('quoted empty fields produce empty strings', () {
+      expect(
+        CsvParser.parseLine('"","b",""'),
+        <String>['', 'b', ''],
+      );
+    });
+
+    test('mixed quoted + unquoted fields', () {
+      expect(
+        CsvParser.parseLine('a,"b, quoted",c'),
+        <String>['a', 'b, quoted', 'c'],
+      );
+    });
+
+    test('quoted field trims surrounding whitespace', () {
+      expect(
+        CsvParser.parseLine(' "a" , "b" '),
+        <String>['a', 'b'],
+      );
+    });
+  });
+
+  group('CsvParser.parseAll', () {
+    test('skips 1 header line by default', () {
+      const csv = 'col1,col2\na,b\nc,d';
+      expect(
+        CsvParser.parseAll(csv),
+        <List<String>>[
+          <String>['a', 'b'],
+          <String>['c', 'd'],
+        ],
+      );
+    });
+
+    test('skipLines=0 includes every line', () {
+      const csv = 'a,b\nc,d';
+      expect(
+        CsvParser.parseAll(csv, skipLines: 0),
+        <List<String>>[
+          <String>['a', 'b'],
+          <String>['c', 'd'],
+        ],
+      );
+    });
+
+    test('skipLines=2 skips multiple header rows', () {
+      const csv = 'meta\ncol1,col2\na,b\nc,d';
+      expect(
+        CsvParser.parseAll(csv, skipLines: 2),
+        <List<String>>[
+          <String>['a', 'b'],
+          <String>['c', 'd'],
+        ],
+      );
+    });
+
+    test('respects custom separator', () {
+      const csv = 'col1;col2\na;b\nc;d';
+      expect(
+        CsvParser.parseAll(csv, separator: ';'),
+        <List<String>>[
+          <String>['a', 'b'],
+          <String>['c', 'd'],
+        ],
+      );
+    });
+
+    test('skips empty lines inside the body', () {
+      const csv = 'col1,col2\na,b\n\nc,d\n   \n';
+      expect(
+        CsvParser.parseAll(csv),
+        <List<String>>[
+          <String>['a', 'b'],
+          <String>['c', 'd'],
+        ],
+      );
+    });
+
+    test('handles CRLF line endings via LineSplitter', () {
+      const csv = 'col1,col2\r\na,b\r\nc,d';
+      expect(
+        CsvParser.parseAll(csv),
+        <List<String>>[
+          <String>['a', 'b'],
+          <String>['c', 'd'],
+        ],
+      );
+    });
+
+    test('handles a CSV body with quoted commas', () {
+      const csv = 'col1,col2\n"hello, world","x"\n"a","b"';
+      expect(
+        CsvParser.parseAll(csv),
+        <List<String>>[
+          <String>['hello, world', 'x'],
+          <String>['a', 'b'],
+        ],
+      );
+    });
+
+    test('returns empty list when CSV only has the header', () {
+      const csv = 'col1,col2';
+      expect(CsvParser.parseAll(csv), <List<String>>[]);
+    });
+
+    test('returns empty list for empty input', () {
+      expect(CsvParser.parseAll(''), <List<String>>[]);
+    });
+  });
+
+  group('CsvParser.parseCommaDouble', () {
+    test('null input returns null', () {
+      expect(CsvParser.parseCommaDouble(null), isNull);
+    });
+
+    test('empty string returns null', () {
+      expect(CsvParser.parseCommaDouble(''), isNull);
+    });
+
+    test('whitespace-only string returns null', () {
+      expect(CsvParser.parseCommaDouble('   '), isNull);
+    });
+
+    test('comma decimal "1,817" parses to 1.817', () {
+      expect(CsvParser.parseCommaDouble('1,817'), closeTo(1.817, 1e-9));
+    });
+
+    test('dot decimal "1.817" parses to 1.817', () {
+      expect(CsvParser.parseCommaDouble('1.817'), closeTo(1.817, 1e-9));
+    });
+
+    test('integer string "2" parses to 2.0', () {
+      expect(CsvParser.parseCommaDouble('2'), 2.0);
+    });
+
+    test('invalid numeric returns null', () {
+      expect(CsvParser.parseCommaDouble('abc'), isNull);
+    });
+
+    test('leading/trailing whitespace', () {
+      // trim().isEmpty check is the only trim; the actual number parse uses
+      // the raw string (minus replaced commas). double.tryParse accepts
+      // surrounding whitespace.
+      expect(CsvParser.parseCommaDouble(' 1,5 '), closeTo(1.5, 1e-9));
+    });
+
+    test('negative comma decimal', () {
+      expect(CsvParser.parseCommaDouble('-0,5'), closeTo(-0.5, 1e-9));
+    });
+
+    test('two commas produce invalid double → null', () {
+      // "1,8,17" → "1.8.17" → not a valid double
+      expect(CsvParser.parseCommaDouble('1,8,17'), isNull);
+    });
+  });
+}

--- a/test/features/consumption/data/receipt_parser/brand_detection_test.dart
+++ b/test/features/consumption/data/receipt_parser/brand_detection_test.dart
@@ -1,0 +1,241 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/receipt_parser/brand_detection.dart';
+
+void main() {
+  group('detectBrand', () {
+    test('returns super_u for "super u"', () {
+      expect(detectBrand(const [], 'welcome to super u receipt'), 'super_u');
+    });
+
+    test('returns super_u for "système u" (accent)', () {
+      expect(detectBrand(const [], 'Système U - Castelnau'), 'super_u');
+    });
+
+    test('returns super_u for "systeme u" (no accent)', () {
+      expect(detectBrand(const [], 'SYSTEME U PEZENAS'), 'super_u');
+    });
+
+    test('returns carrefour', () {
+      expect(detectBrand(const [], 'CARREFOUR MARKET'), 'carrefour');
+    });
+
+    test('returns total for "totalenergies"', () {
+      expect(detectBrand(const [], 'TOTALENERGIES station'), 'total');
+    });
+
+    test('returns total for "total " (trailing space)', () {
+      expect(detectBrand(const [], 'TOTAL STATION'), 'total');
+    });
+
+    test('does NOT return total for "total" without trailing space only', () {
+      // "total" alone (no space, no "total ") should not match the "total "
+      // branch. And without "totalenergies" either, returns null.
+      expect(detectBrand(const [], 'total'), isNull);
+    });
+
+    test('returns intermarche for "intermarché" (accent)', () {
+      expect(detectBrand(const [], 'Intermarché Super'), 'intermarche');
+    });
+
+    test('returns intermarche for "intermarche" (no accent)', () {
+      expect(detectBrand(const [], 'INTERMARCHE CONTACT'), 'intermarche');
+    });
+
+    test('returns leclerc', () {
+      expect(detectBrand(const [], 'E.LECLERC station service'), 'leclerc');
+    });
+
+    test('returns shell', () {
+      expect(detectBrand(const [], 'SHELL A9'), 'shell');
+    });
+
+    test('returns esso', () {
+      expect(detectBrand(const [], 'ESSO express'), 'esso');
+    });
+
+    test('returns aral', () {
+      expect(detectBrand(const [], 'ARAL Autobahn'), 'aral');
+    });
+
+    test('returns null when no brand matches', () {
+      expect(detectBrand(const [], 'generic fuel station'), isNull);
+    });
+
+    test('returns null for empty string', () {
+      expect(detectBrand(const [], ''), isNull);
+    });
+
+    test('matching is case-insensitive (uppercase input)', () {
+      expect(detectBrand(const [], 'SUPER U'), 'super_u');
+      expect(detectBrand(const [], 'CARREFOUR'), 'carrefour');
+      expect(detectBrand(const [], 'SHELL'), 'shell');
+    });
+
+    test('dispatch order: super_u before total even if both match', () {
+      // Both super u AND total energies in text — super_u checked first.
+      expect(
+        detectBrand(const [], 'super u — partenaire TotalEnergies'),
+        'super_u',
+      );
+    });
+
+    test('dispatch order: carrefour before total', () {
+      expect(
+        detectBrand(const [], 'carrefour partenaire totalenergies'),
+        'carrefour',
+      );
+    });
+
+    test('dispatch order: total before intermarche', () {
+      expect(
+        detectBrand(const [], 'totalenergies — concurrent intermarché'),
+        'total',
+      );
+    });
+
+    test('ignores the lines list (only fullText matters)', () {
+      // Lines contain SHELL, but fullText does not — should return null.
+      expect(detectBrand(const ['SHELL'], 'no brand here'), isNull);
+    });
+  });
+
+  group('extractStationName', () {
+    test('matches whole-line equal to brand', () {
+      expect(extractStationName(const ['Total']), 'Total');
+    });
+
+    test('matches line starting with brand + space', () {
+      expect(
+        extractStationName(const ['Total Station Castelnau']),
+        'Total Station Castelnau',
+      );
+    });
+
+    test('matches line starting with brand + tab', () {
+      expect(
+        extractStationName(const ['Total\tStation Castelnau']),
+        'Total\tStation Castelnau',
+      );
+    });
+
+    test('is case-insensitive but returns original line', () {
+      expect(
+        extractStationName(const ['TOTAL Station']),
+        'TOTAL Station',
+      );
+    });
+
+    test('trims whitespace before matching', () {
+      expect(
+        extractStationName(const ['  shell highway  ']),
+        '  shell highway  ',
+      );
+    });
+
+    test('only looks at the first 5 lines', () {
+      final lines = [
+        'Ticket de caisse',
+        'Date: 2024-01-01',
+        'Ref: ABC',
+        'Lorem ipsum',
+        'Dolor sit amet',
+        'Total Station', // 6th line — should be ignored
+      ];
+      expect(extractStationName(lines), isNull);
+    });
+
+    test('matches within the first 5 lines', () {
+      final lines = [
+        'Ticket de caisse',
+        'Date',
+        'Total Station', // 3rd line — within first 5
+        'x',
+        'y',
+      ];
+      expect(extractStationName(lines), 'Total Station');
+    });
+
+    test('returns null when no brand appears in first 5 lines', () {
+      expect(
+        extractStationName(const ['Ticket', 'Date', 'Ref', 'x', 'y']),
+        isNull,
+      );
+    });
+
+    test('returns null for empty list', () {
+      expect(extractStationName(const []), isNull);
+    });
+
+    test('does not match when brand is substring but not at start', () {
+      // "TOTAL" is in the middle, not at start
+      expect(
+        extractStationName(const ['Merci pour votre visite TOTAL']),
+        isNull,
+      );
+    });
+
+    test('matches Intermarché with accent', () {
+      expect(
+        extractStationName(const ['Intermarché Super']),
+        'Intermarché Super',
+      );
+    });
+
+    test('matches intermarche without accent', () {
+      expect(
+        extractStationName(const ['intermarche contact']),
+        'intermarche contact',
+      );
+    });
+
+    test('matches super u as brand', () {
+      expect(extractStationName(const ['Super U Pezenas']), 'Super U Pezenas');
+    });
+
+    test('matches systeme u without accent', () {
+      expect(
+        extractStationName(const ['systeme u marché']),
+        'systeme u marché',
+      );
+    });
+
+    test('matches système u with accent', () {
+      expect(
+        extractStationName(const ['Système U Distrib']),
+        'Système U Distrib',
+      );
+    });
+
+    test('matches totalenergies', () {
+      expect(
+        extractStationName(const ['TotalEnergies A75']),
+        'TotalEnergies A75',
+      );
+    });
+
+    test('matches bp, aral, esso, avia, jet, elf, agip, q8, omv, mol, orlen',
+        () {
+      expect(extractStationName(const ['BP Station']), 'BP Station');
+      expect(extractStationName(const ['Aral 123']), 'Aral 123');
+      expect(extractStationName(const ['Esso Express']), 'Esso Express');
+      expect(extractStationName(const ['Avia XPress']), 'Avia XPress');
+      expect(extractStationName(const ['Jet Auto']), 'Jet Auto');
+      expect(extractStationName(const ['Elf Station']), 'Elf Station');
+      expect(extractStationName(const ['Agip IP']), 'Agip IP');
+      expect(extractStationName(const ['Q8 Kuwait']), 'Q8 Kuwait');
+      expect(extractStationName(const ['OMV Austria']), 'OMV Austria');
+      expect(extractStationName(const ['MOL Magyar']), 'MOL Magyar');
+      expect(extractStationName(const ['Orlen Polska']), 'Orlen Polska');
+    });
+
+    test('matches leclerc, carrefour, auchan, casino', () {
+      expect(extractStationName(const ['Leclerc A9']), 'Leclerc A9');
+      expect(
+        extractStationName(const ['Carrefour Market']),
+        'Carrefour Market',
+      );
+      expect(extractStationName(const ['Auchan Drive']), 'Auchan Drive');
+      expect(extractStationName(const ['Casino Shop']), 'Casino Shop');
+    });
+  });
+}


### PR DESCRIPTION
## Why
Three zero-coverage pure-logic files:
- `receipt_parser/brand_detection.dart` (51 LOC)
- `core/services/utils/csv_parser.dart` (57 LOC)
- `core/services/utils/brand_detector.dart` (70 LOC)

All three are leaf utilities with no dependencies — easy, high-value coverage wins for epic #561.

## What
Exhaustive branch coverage: every brand mapping, every regex branch, every CSV edge case (quoted fields, custom separator, empty rows, comma decimal). 100% line coverage on all three.

Refs #561