### PR TITLE
refactor(ui): three small screens use PageScaffold (Refs #923 phase 3h)

### DIFF
--- a/lib/features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/station.dart';
@@ -40,15 +41,14 @@ class PickStationForFillUpScreen extends ConsumerWidget {
     final profileFuel =
         ref.watch(activeProfileProvider)?.preferredFuelType;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l?.pickStationTitle ?? 'Pick a station'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l?.tooltipBack ?? 'Back',
-          onPressed: () => context.pop(),
-        ),
+    return PageScaffold(
+      title: l?.pickStationTitle ?? 'Pick a station',
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: l?.tooltipBack ?? 'Back',
+        onPressed: () => context.pop(),
       ),
+      bodyPadding: EdgeInsets.zero,
       body: Column(
         children: [
           Padding(

--- a/lib/features/consumption/presentation/screens/trip_history_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_history_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/widgets/empty_state.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/trip_history_provider.dart';
 import '../widgets/trip_history_card.dart';
@@ -17,15 +18,14 @@ class TripHistoryScreen extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     final trips = ref.watch(tripHistoryListProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l?.tooltipBack ?? 'Back',
-          onPressed: () => context.pop(),
-        ),
-        title: Text(l?.tripHistoryTitle ?? 'Trip history'),
+    return PageScaffold(
+      title: l?.tripHistoryTitle ?? 'Trip history',
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: l?.tooltipBack ?? 'Back',
+        onPressed: () => context.pop(),
       ),
+      bodyPadding: EdgeInsets.zero,
       body: trips.isEmpty
           ? EmptyState(
               icon: Icons.route_outlined,

--- a/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
+++ b/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/widgets/help_banner.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/vehicle_providers.dart';
 import '../widgets/vehicle_card.dart';
@@ -18,10 +19,9 @@ class VehicleListScreen extends ConsumerWidget {
     final vehicles = ref.watch(vehicleProfileListProvider);
     final active = ref.watch(activeVehicleProfileProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l?.vehiclesTitle ?? 'My vehicles'),
-      ),
+    return PageScaffold(
+      title: l?.vehiclesTitle ?? 'My vehicles',
+      bodyPadding: EdgeInsets.zero,
       body: vehicles.isEmpty
           ? Column(
               children: [


### PR DESCRIPTION
## Summary

Phase 3h of the #923 design-system consolidation: migrate three small screens from hand-rolled Scaffold+AppBar to PageScaffold.

**Migrated:**
- `lib/features/vehicle/presentation/screens/vehicle_list_screen.dart` — plain title + FAB, passed through as `floatingActionButton`.
- `lib/features/consumption/presentation/screens/trip_history_screen.dart` — plain title + custom back leading preserved via `leading:`.
- `lib/features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart` — plain title + custom back leading preserved via `leading:`.

**Skipped:** none. All three screens had straightforward AppBar structure (plain string titles, no TabBar/flexibleSpace/PreferredSize wrapper) and fit the PageScaffold contract exactly.

Each body opts into `bodyPadding: EdgeInsets.zero` since the screens manage their own padding (ListView padding, Column + SafeArea wrapper) — matching earlier phases (SearchScreen, ProfileScreen, CarbonDashboardScreen).

Refs #923.

## Test plan

- [x] `flutter analyze` — zero warnings.
- [x] `flutter test` — full suite green (5950 tests).
- [x] Existing `pick_station_for_fill_up_screen_test.dart` still passes (it drives via `GoRouter` without asserting on `AppBar`/`Scaffold` types, so the PageScaffold swap is transparent).