### PR TITLE
test(coverage): cover effective_fuel_type + search_filters providers (Refs #561)

### DIFF
--- a/test/features/profile/providers/effective_fuel_type_provider_test.dart
+++ b/test/features/profile/providers/effective_fuel_type_provider_test.dart
@@ -1,0 +1,313 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/effective_fuel_type_provider.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+/// Exhaustive coverage for `effectiveFuelTypeProvider` (#694/#700/#706).
+///
+/// Every branch of the priority chain is pinned so a future refactor of
+/// the vehicle-vs-profile resolution has a single test file to consult.
+
+class _FixedProfile extends ActiveProfile {
+  _FixedProfile(this._profile);
+  final UserProfile? _profile;
+  @override
+  UserProfile? build() => _profile;
+}
+
+class _FixedVehicles extends VehicleProfileList {
+  _FixedVehicles(this._list);
+  final List<VehicleProfile> _list;
+  @override
+  List<VehicleProfile> build() => _list;
+}
+
+ProviderContainer _container({
+  UserProfile? profile,
+  List<VehicleProfile> vehicles = const [],
+}) {
+  final c = ProviderContainer(
+    overrides: [
+      activeProfileProvider.overrideWith(() => _FixedProfile(profile)),
+      vehicleProfileListProvider.overrideWith(() => _FixedVehicles(vehicles)),
+    ],
+  );
+  addTearDown(c.dispose);
+  return c;
+}
+
+UserProfile _profile({
+  FuelType? preferredFuelType,
+  String? defaultVehicleId,
+  FuelType? hybridFuelChoice,
+}) {
+  // `preferredFuelType` has a freezed @Default of FuelType.e10, so a
+  // call site that passes `null` ends up with e10 unless we explicitly
+  // route around the default. All callers below pass an explicit value
+  // when they care; otherwise the test pinpoints the default branch.
+  return UserProfile(
+    id: 'p1',
+    name: 'p',
+    preferredFuelType: preferredFuelType ?? FuelType.e10,
+    defaultVehicleId: defaultVehicleId,
+    hybridFuelChoice: hybridFuelChoice,
+  );
+}
+
+void main() {
+  group('effectiveFuelTypeProvider — no-profile / profile-only branches', () {
+    test('no profile at all → FuelType.e10 (built-in fallback)', () {
+      final c = _container();
+      expect(c.read(effectiveFuelTypeProvider), FuelType.e10);
+    });
+
+    test(
+      'profile, no defaultVehicleId → profile.preferredFuelType wins',
+      () {
+        final c = _container(
+          profile: _profile(preferredFuelType: FuelType.diesel),
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.diesel);
+      },
+    );
+
+    test(
+      'defaultVehicleId set but no matching vehicle → profile.preferredFuelType',
+      () {
+        final c = _container(
+          profile: _profile(
+            preferredFuelType: FuelType.e5,
+            defaultVehicleId: 'ghost',
+          ),
+          vehicles: const [],
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.e5);
+      },
+    );
+  });
+
+  group('effectiveFuelTypeProvider — EV branch', () {
+    test('default vehicle is EV → FuelType.electric', () {
+      const ev = VehicleProfile(
+        id: 'v-ev',
+        name: 'Model 3',
+        type: VehicleType.ev,
+      );
+      final c = _container(
+        profile: _profile(
+          preferredFuelType: FuelType.e10,
+          defaultVehicleId: 'v-ev',
+        ),
+        vehicles: const [ev],
+      );
+      expect(c.read(effectiveFuelTypeProvider), FuelType.electric);
+    });
+  });
+
+  group('effectiveFuelTypeProvider — combustion branch', () {
+    test('combustion vehicle with fuel "diesel" → FuelType.diesel', () {
+      const v = VehicleProfile(
+        id: 'v-ice',
+        name: '208',
+        type: VehicleType.combustion,
+        preferredFuelType: 'diesel',
+      );
+      final c = _container(
+        profile: _profile(
+          preferredFuelType: FuelType.e10,
+          defaultVehicleId: 'v-ice',
+        ),
+        vehicles: const [v],
+      );
+      expect(c.read(effectiveFuelTypeProvider), FuelType.diesel);
+    });
+
+    test(
+      'combustion vehicle with fuel "E10" (uppercase) → FuelType.e10 '
+      '(fromString is case-insensitive)',
+      () {
+        const v = VehicleProfile(
+          id: 'v-ice',
+          name: 'Golf',
+          type: VehicleType.combustion,
+          preferredFuelType: 'E10',
+        );
+        final c = _container(
+          profile: _profile(
+            preferredFuelType: FuelType.diesel,
+            defaultVehicleId: 'v-ice',
+          ),
+          vehicles: const [v],
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.e10);
+      },
+    );
+
+    test('combustion vehicle with fuel "e5" → FuelType.e5', () {
+      const v = VehicleProfile(
+        id: 'v-ice',
+        name: 'Yaris',
+        type: VehicleType.combustion,
+        preferredFuelType: 'e5',
+      );
+      final c = _container(
+        profile: _profile(
+          preferredFuelType: FuelType.diesel,
+          defaultVehicleId: 'v-ice',
+        ),
+        vehicles: const [v],
+      );
+      expect(c.read(effectiveFuelTypeProvider), FuelType.e5);
+    });
+
+    test(
+      'combustion vehicle with null fuel → falls back to profile fuel',
+      () {
+        const v = VehicleProfile(
+          id: 'v-ice',
+          name: 'Unspecified',
+          type: VehicleType.combustion,
+          // preferredFuelType omitted (null by default).
+        );
+        final c = _container(
+          profile: _profile(
+            preferredFuelType: FuelType.e85,
+            defaultVehicleId: 'v-ice',
+          ),
+          vehicles: const [v],
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.e85);
+      },
+    );
+
+    test(
+      'combustion vehicle with empty-string fuel → falls back to profile fuel',
+      () {
+        const v = VehicleProfile(
+          id: 'v-ice',
+          name: 'Blank',
+          type: VehicleType.combustion,
+          preferredFuelType: '',
+        );
+        final c = _container(
+          profile: _profile(
+            preferredFuelType: FuelType.dieselPremium,
+            defaultVehicleId: 'v-ice',
+          ),
+          vehicles: const [v],
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.dieselPremium);
+      },
+    );
+
+    test(
+      'combustion vehicle with whitespace-only fuel → falls back to profile',
+      () {
+        const v = VehicleProfile(
+          id: 'v-ice',
+          name: 'Whitespace',
+          type: VehicleType.combustion,
+          preferredFuelType: '   ',
+        );
+        final c = _container(
+          profile: _profile(
+            preferredFuelType: FuelType.lpg,
+            defaultVehicleId: 'v-ice',
+          ),
+          vehicles: const [v],
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.lpg);
+      },
+    );
+  });
+
+  group('effectiveFuelTypeProvider — hybrid branch', () {
+    test(
+      'hybrid vehicle + profile.hybridFuelChoice = diesel → FuelType.diesel '
+      '(overrides the vehicle\'s own e10 label)',
+      () {
+        const v = VehicleProfile(
+          id: 'v-hybrid',
+          name: 'Prius',
+          type: VehicleType.hybrid,
+          preferredFuelType: 'e10',
+        );
+        final c = _container(
+          profile: _profile(
+            preferredFuelType: FuelType.e5,
+            defaultVehicleId: 'v-hybrid',
+            hybridFuelChoice: FuelType.diesel,
+          ),
+          vehicles: const [v],
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.diesel);
+      },
+    );
+
+    test(
+      'hybrid vehicle, null hybridFuelChoice, vehicle fuel "diesel" → diesel',
+      () {
+        const v = VehicleProfile(
+          id: 'v-hybrid',
+          name: 'Plug-in',
+          type: VehicleType.hybrid,
+          preferredFuelType: 'diesel',
+        );
+        final c = _container(
+          profile: _profile(
+            preferredFuelType: FuelType.e5,
+            defaultVehicleId: 'v-hybrid',
+          ),
+          vehicles: const [v],
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.diesel);
+      },
+    );
+
+    test(
+      'hybrid vehicle, null hybridFuelChoice, null vehicle fuel '
+      '→ falls back to profile.preferredFuelType',
+      () {
+        const v = VehicleProfile(
+          id: 'v-hybrid',
+          name: 'Unspecified',
+          type: VehicleType.hybrid,
+          // preferredFuelType omitted.
+        );
+        final c = _container(
+          profile: _profile(
+            preferredFuelType: FuelType.e98,
+            defaultVehicleId: 'v-hybrid',
+          ),
+          vehicles: const [v],
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.e98);
+      },
+    );
+
+    test(
+      'hybrid vehicle, null hybridFuelChoice, empty vehicle fuel '
+      '→ falls back to profile.preferredFuelType',
+      () {
+        const v = VehicleProfile(
+          id: 'v-hybrid',
+          name: 'Blank',
+          type: VehicleType.hybrid,
+          preferredFuelType: '',
+        );
+        final c = _container(
+          profile: _profile(
+            preferredFuelType: FuelType.e85,
+            defaultVehicleId: 'v-hybrid',
+          ),
+          vehicles: const [v],
+        );
+        expect(c.read(effectiveFuelTypeProvider), FuelType.e85);
+      },
+    );
+  });
+}

--- a/test/features/search/providers/search_filters_provider_test.dart
+++ b/test/features/search/providers/search_filters_provider_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/effective_fuel_type_provider.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+
+/// Coverage for the search-filters providers (#727):
+/// - [SearchLocation] — plain string holder.
+/// - [SelectedFuelType] — profile-aware chip selection with
+///   `FuelType.all` wildcard before onboarding.
+/// - [SearchRadius] — clamped to 1.0 … 25.0.
+/// - [fuelStations] — extracts [Station] objects from a unified search
+///   result stream, dropping EV entries.
+
+class _FixedProfile extends ActiveProfile {
+  _FixedProfile(this._profile);
+  final UserProfile? _profile;
+  @override
+  UserProfile? build() => _profile;
+}
+
+class _FakeSearchState extends SearchState {
+  _FakeSearchState(this._value);
+  final AsyncValue<ServiceResult<List<SearchResultItem>>> _value;
+
+  @override
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => _value;
+}
+
+AsyncValue<ServiceResult<List<SearchResultItem>>> _dataState(
+  List<SearchResultItem> items,
+) {
+  return AsyncValue.data(
+    ServiceResult(
+      data: items,
+      source: ServiceSource.cache,
+      fetchedAt: DateTime.now(),
+    ),
+  );
+}
+
+Station _station(String id) => Station(
+      id: id,
+      name: 'Station $id',
+      brand: 'TEST',
+      street: 'Teststr.',
+      postCode: '10115',
+      place: 'Testtown',
+      lat: 52.5,
+      lng: 13.4,
+      isOpen: true,
+    );
+
+ChargingStation _charger(String id) => ChargingStation(
+      id: id,
+      name: 'Charger $id',
+      latitude: 52.5,
+      longitude: 13.4,
+    );
+
+void main() {
+  group('SearchLocation notifier', () {
+    test('initial state is empty string', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      expect(c.read(searchLocationProvider), '');
+    });
+
+    test('set() updates the state', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      c.read(searchLocationProvider.notifier).set('12345 Berlin');
+      expect(c.read(searchLocationProvider), '12345 Berlin');
+    });
+  });
+
+  group('SelectedFuelType notifier', () {
+    test('no active profile → FuelType.all wildcard', () {
+      final c = ProviderContainer(
+        overrides: [
+          activeProfileProvider.overrideWith(() => _FixedProfile(null)),
+        ],
+      );
+      addTearDown(c.dispose);
+      expect(c.read(selectedFuelTypeProvider), FuelType.all);
+    });
+
+    test(
+      'profile present → reads effectiveFuelTypeProvider '
+      '(here overridden to diesel)',
+      () {
+        final c = ProviderContainer(
+          overrides: [
+            activeProfileProvider.overrideWith(
+              () => _FixedProfile(
+                const UserProfile(
+                  id: 'p1',
+                  name: 'p',
+                  preferredFuelType: FuelType.e10,
+                ),
+              ),
+            ),
+            effectiveFuelTypeProvider.overrideWithValue(FuelType.diesel),
+          ],
+        );
+        addTearDown(c.dispose);
+        expect(c.read(selectedFuelTypeProvider), FuelType.diesel);
+      },
+    );
+
+    test('select() updates the state', () {
+      final c = ProviderContainer(
+        overrides: [
+          activeProfileProvider.overrideWith(() => _FixedProfile(null)),
+        ],
+      );
+      addTearDown(c.dispose);
+      expect(c.read(selectedFuelTypeProvider), FuelType.all);
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.diesel);
+      expect(c.read(selectedFuelTypeProvider), FuelType.diesel);
+    });
+  });
+
+  group('SearchRadius notifier', () {
+    test('no profile → default 10.0 km', () {
+      final c = ProviderContainer(
+        overrides: [
+          activeProfileProvider.overrideWith(() => _FixedProfile(null)),
+        ],
+      );
+      addTearDown(c.dispose);
+      expect(c.read(searchRadiusProvider), 10.0);
+    });
+
+    test('profile with defaultSearchRadius: 5.0 → 5.0', () {
+      final c = ProviderContainer(
+        overrides: [
+          activeProfileProvider.overrideWith(
+            () => _FixedProfile(
+              const UserProfile(
+                id: 'p1',
+                name: 'p',
+                defaultSearchRadius: 5.0,
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(c.dispose);
+      expect(c.read(searchRadiusProvider), 5.0);
+    });
+
+    test('set(0.5) clamps up to 1.0', () {
+      final c = ProviderContainer(
+        overrides: [
+          activeProfileProvider.overrideWith(() => _FixedProfile(null)),
+        ],
+      );
+      addTearDown(c.dispose);
+      c.read(searchRadiusProvider.notifier).set(0.5);
+      expect(c.read(searchRadiusProvider), 1.0);
+    });
+
+    test('set(99) clamps down to 25.0', () {
+      final c = ProviderContainer(
+        overrides: [
+          activeProfileProvider.overrideWith(() => _FixedProfile(null)),
+        ],
+      );
+      addTearDown(c.dispose);
+      c.read(searchRadiusProvider.notifier).set(99);
+      expect(c.read(searchRadiusProvider), 25.0);
+    });
+
+    test('set(15) → 15.0 (inside bounds, no clamp)', () {
+      final c = ProviderContainer(
+        overrides: [
+          activeProfileProvider.overrideWith(() => _FixedProfile(null)),
+        ],
+      );
+      addTearDown(c.dispose);
+      c.read(searchRadiusProvider.notifier).set(15);
+      expect(c.read(searchRadiusProvider), 15.0);
+    });
+  });
+
+  group('fuelStations derived provider', () {
+    test('searchState without a value → empty list', () {
+      final c = ProviderContainer(
+        overrides: [
+          searchStateProvider.overrideWith(
+            () => _FakeSearchState(const AsyncValue.loading()),
+          ),
+        ],
+      );
+      addTearDown(c.dispose);
+      expect(c.read(fuelStationsProvider), isEmpty);
+    });
+
+    test(
+      'mixed EV + fuel results → only fuel stations are extracted in order',
+      () {
+        final s1 = _station('f1');
+        final s2 = _station('f2');
+        final ev1 = _charger('ev1');
+        final c = ProviderContainer(
+          overrides: [
+            searchStateProvider.overrideWith(
+              () => _FakeSearchState(
+                _dataState([
+                  FuelStationResult(s1),
+                  EVStationResult(ev1),
+                  FuelStationResult(s2),
+                ]),
+              ),
+            ),
+          ],
+        );
+        addTearDown(c.dispose);
+
+        final stations = c.read(fuelStationsProvider);
+        expect(stations.map((s) => s.id).toList(), ['f1', 'f2']);
+      },
+    );
+
+    test('all-EV result set → empty list', () {
+      final c = ProviderContainer(
+        overrides: [
+          searchStateProvider.overrideWith(
+            () => _FakeSearchState(
+              _dataState([
+                EVStationResult(_charger('ev1')),
+                EVStationResult(_charger('ev2')),
+              ]),
+            ),
+          ),
+        ],
+      );
+      addTearDown(c.dispose);
+      expect(c.read(fuelStationsProvider), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Why
Two zero-coverage Riverpod provider files:
- `effective_fuel_type_provider.dart` (70 LOC) — EV/combustion/hybrid fuel resolution (#694/#700/#706)
- `search_filters_provider.dart` (68 LOC) — search location/fuel/radius notifiers + fuel-stations derived list

## What
Exhaustive ProviderContainer tests: every priority-chain branch in `effectiveFuelType` (profile-only, EV, combustion with/without fuel, hybrid with/without choice), clamping in `SearchRadius.set`, `fuelStations` empty/filtered.

Refs #561