### PR TITLE
test(coverage): cover price_snapshot + vin_data + achievement entities (Refs #561)

### DIFF
--- a/test/features/achievements/domain/achievement_test.dart
+++ b/test/features/achievements/domain/achievement_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/achievements/domain/achievement.dart';
+
+void main() {
+  group('EarnedAchievement.toJson', () {
+    final ts = DateTime.utc(2026, 4, 24, 10, 30, 0);
+
+    for (final id in AchievementId.values) {
+      test('encodes ${id.name} with iso timestamp', () {
+        final earned = EarnedAchievement(id: id, earnedAt: ts);
+        final json = earned.toJson();
+        expect(json['id'], id.name);
+        expect(json['earnedAt'], ts.toIso8601String());
+      });
+    }
+  });
+
+  group('EarnedAchievement.fromJson — roundtrip per id', () {
+    final ts = DateTime.utc(2026, 4, 24, 10, 30, 0);
+
+    for (final id in AchievementId.values) {
+      test('${id.name} survives toJson→fromJson', () {
+        final original = EarnedAchievement(id: id, earnedAt: ts);
+        final restored = EarnedAchievement.fromJson(original.toJson());
+        expect(restored, isNotNull);
+        expect(restored!.id, id);
+        expect(restored.earnedAt, ts);
+      });
+    }
+  });
+
+  group('EarnedAchievement.fromJson — null / malformed branches', () {
+    test('returns null when id is missing', () {
+      final result = EarnedAchievement.fromJson({
+        'earnedAt': DateTime.utc(2026, 4, 24).toIso8601String(),
+      });
+      expect(result, isNull);
+    });
+
+    test('returns null when id is explicitly null', () {
+      final result = EarnedAchievement.fromJson({
+        'id': null,
+        'earnedAt': DateTime.utc(2026, 4, 24).toIso8601String(),
+      });
+      expect(result, isNull);
+    });
+
+    test('returns null when earnedAt is missing', () {
+      final result = EarnedAchievement.fromJson({
+        'id': AchievementId.firstTrip.name,
+      });
+      expect(result, isNull);
+    });
+
+    test('returns null when earnedAt is explicitly null', () {
+      final result = EarnedAchievement.fromJson({
+        'id': AchievementId.firstTrip.name,
+        'earnedAt': null,
+      });
+      expect(result, isNull);
+    });
+
+    test('returns null when id name is unknown', () {
+      final result = EarnedAchievement.fromJson({
+        'id': 'unknown',
+        'earnedAt': DateTime.utc(2026, 4, 24).toIso8601String(),
+      });
+      expect(result, isNull);
+    });
+
+    test('returns null when earnedAt is not parseable (catch branch)', () {
+      final result = EarnedAchievement.fromJson({
+        'id': AchievementId.firstTrip.name,
+        'earnedAt': 'not-a-date',
+      });
+      expect(result, isNull);
+    });
+
+    test('returns populated EarnedAchievement for valid id + valid iso', () {
+      final iso = DateTime.utc(2026, 1, 2, 3, 4, 5).toIso8601String();
+      final result = EarnedAchievement.fromJson({
+        'id': AchievementId.priceWin.name,
+        'earnedAt': iso,
+      });
+      expect(result, isNotNull);
+      expect(result!.id, AchievementId.priceWin);
+      expect(result.earnedAt, DateTime.utc(2026, 1, 2, 3, 4, 5));
+    });
+  });
+}

--- a/test/features/alerts/data/models/price_snapshot_test.dart
+++ b/test/features/alerts/data/models/price_snapshot_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/alerts/data/models/price_snapshot.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+void main() {
+  group('PriceSnapshot', () {
+    final baseTs = DateTime.utc(2026, 4, 1, 12, 0, 0);
+
+    PriceSnapshot makeSnapshot({
+      String stationId = 'st-1',
+      String fuelType = 'e10',
+      double price = 1.859,
+      double lat = 43.123,
+      double lng = 3.456,
+      DateTime? timestamp,
+    }) {
+      return PriceSnapshot(
+        stationId: stationId,
+        fuelType: fuelType,
+        price: price,
+        timestamp: timestamp ?? baseTs,
+        lat: lat,
+        lng: lng,
+      );
+    }
+
+    test('construction populates every field', () {
+      final snap = makeSnapshot();
+      expect(snap.stationId, 'st-1');
+      expect(snap.fuelType, 'e10');
+      expect(snap.price, 1.859);
+      expect(snap.timestamp, baseTs);
+      expect(snap.lat, 43.123);
+      expect(snap.lng, 3.456);
+    });
+
+    test('equality and hashCode are value-based', () {
+      final a = makeSnapshot();
+      final b = makeSnapshot();
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('instances with different fields are not equal', () {
+      final a = makeSnapshot();
+      final b = makeSnapshot(price: 1.999);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('copyWith mutates only the named field', () {
+      final a = makeSnapshot();
+      final b = a.copyWith(price: 2.099);
+      expect(b.price, 2.099);
+      expect(b.stationId, a.stationId);
+      expect(b.fuelType, a.fuelType);
+      expect(b.timestamp, a.timestamp);
+      expect(b.lat, a.lat);
+      expect(b.lng, a.lng);
+    });
+
+    test('toJson/fromJson roundtrip preserves every field', () {
+      final snap = makeSnapshot();
+      final json = snap.toJson();
+      expect(json['stationId'], 'st-1');
+      expect(json['fuelType'], 'e10');
+      expect(json['price'], 1.859);
+      expect(json['lat'], 43.123);
+      expect(json['lng'], 3.456);
+      // timestamp is serialized as ISO-8601 string by json_serializable.
+      expect(json['timestamp'], isA<String>());
+
+      final restored = PriceSnapshot.fromJson(json);
+      expect(restored, equals(snap));
+    });
+
+    group('forFuel', () {
+      test('maps FuelType.e10 to apiValue "e10"', () {
+        final snap = PriceSnapshot.forFuel(
+          stationId: 'st-2',
+          fuelType: FuelType.e10,
+          price: 1.799,
+          timestamp: baseTs,
+          lat: 48.0,
+          lng: 2.0,
+        );
+        expect(snap.fuelType, 'e10');
+        expect(snap.fuelType, FuelType.e10.apiValue);
+        expect(snap.stationId, 'st-2');
+        expect(snap.price, 1.799);
+      });
+
+      test('maps FuelType.diesel to apiValue "diesel"', () {
+        final snap = PriceSnapshot.forFuel(
+          stationId: 'st-3',
+          fuelType: FuelType.diesel,
+          price: 1.699,
+          timestamp: baseTs,
+          lat: 48.0,
+          lng: 2.0,
+        );
+        expect(snap.fuelType, 'diesel');
+        expect(snap.fuelType, FuelType.diesel.apiValue);
+      });
+
+      test('maps FuelType.dieselPremium to apiValue "diesel_premium"', () {
+        final snap = PriceSnapshot.forFuel(
+          stationId: 'st-4',
+          fuelType: FuelType.dieselPremium,
+          price: 1.999,
+          timestamp: baseTs,
+          lat: 48.0,
+          lng: 2.0,
+        );
+        expect(snap.fuelType, 'diesel_premium');
+      });
+    });
+  });
+}

--- a/test/features/vehicle/domain/entities/vin_data_test.dart
+++ b/test/features/vehicle/domain/entities/vin_data_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vin_data.dart';
+
+void main() {
+  group('VinData.isComplete', () {
+    test('returns true when make, model, and displacementL are all set', () {
+      const v = VinData(
+        vin: 'WVWZZZ1JZXW000001',
+        make: 'Volkswagen',
+        model: 'Golf',
+        displacementL: 1.6,
+      );
+      expect(v.isComplete, isTrue);
+    });
+
+    test('returns false when make is null', () {
+      const v = VinData(
+        vin: 'WVWZZZ1JZXW000001',
+        model: 'Golf',
+        displacementL: 1.6,
+      );
+      expect(v.isComplete, isFalse);
+    });
+
+    test('returns false when model is null', () {
+      const v = VinData(
+        vin: 'WVWZZZ1JZXW000001',
+        make: 'Volkswagen',
+        displacementL: 1.6,
+      );
+      expect(v.isComplete, isFalse);
+    });
+
+    test('returns false when displacementL is null', () {
+      const v = VinData(
+        vin: 'WVWZZZ1JZXW000001',
+        make: 'Volkswagen',
+        model: 'Golf',
+      );
+      expect(v.isComplete, isFalse);
+    });
+  });
+
+  group('VinDataSourceJsonConverter.fromJson', () {
+    const converter = VinDataSourceJsonConverter();
+
+    test('decodes "vpic" to VinDataSource.vpic', () {
+      expect(converter.fromJson('vpic'), VinDataSource.vpic);
+    });
+
+    test('decodes "wmiOffline" to VinDataSource.wmiOffline', () {
+      expect(converter.fromJson('wmiOffline'), VinDataSource.wmiOffline);
+    });
+
+    test('decodes "invalid" to VinDataSource.invalid', () {
+      expect(converter.fromJson('invalid'), VinDataSource.invalid);
+    });
+
+    test('falls back to invalid on unknown string', () {
+      expect(converter.fromJson('definitely-not-a-source'),
+          VinDataSource.invalid);
+    });
+
+    test('falls back to invalid on empty string', () {
+      expect(converter.fromJson(''), VinDataSource.invalid);
+    });
+  });
+
+  group('VinDataSourceJsonConverter.toJson', () {
+    const converter = VinDataSourceJsonConverter();
+
+    test('encodes VinDataSource.vpic to "vpic"', () {
+      expect(converter.toJson(VinDataSource.vpic), 'vpic');
+    });
+
+    test('encodes VinDataSource.wmiOffline to "wmiOffline"', () {
+      expect(converter.toJson(VinDataSource.wmiOffline), 'wmiOffline');
+    });
+
+    test('encodes VinDataSource.invalid to "invalid"', () {
+      expect(converter.toJson(VinDataSource.invalid), 'invalid');
+    });
+  });
+
+  group('VinData construction', () {
+    test('defaults source to VinDataSource.invalid', () {
+      const v = VinData(vin: 'A');
+      expect(v.source, VinDataSource.invalid);
+      expect(v.vin, 'A');
+      expect(v.make, isNull);
+      expect(v.model, isNull);
+      expect(v.displacementL, isNull);
+    });
+  });
+
+  group('VinData JSON roundtrip', () {
+    test('preserves every field through fromJson/toJson', () {
+      const original = VinData(
+        vin: '1HGCM82633A004352',
+        make: 'Honda',
+        model: 'Accord',
+        modelYear: 2003,
+        displacementL: 2.4,
+        cylinderCount: 4,
+        fuelTypePrimary: 'Gasoline',
+        engineHp: 160,
+        gvwrLbs: 4300,
+        country: 'United States',
+        source: VinDataSource.vpic,
+      );
+
+      final json = original.toJson();
+      expect(json['vin'], '1HGCM82633A004352');
+      expect(json['make'], 'Honda');
+      expect(json['model'], 'Accord');
+      expect(json['modelYear'], 2003);
+      expect(json['displacementL'], 2.4);
+      expect(json['cylinderCount'], 4);
+      expect(json['fuelTypePrimary'], 'Gasoline');
+      expect(json['engineHp'], 160);
+      expect(json['gvwrLbs'], 4300);
+      expect(json['country'], 'United States');
+      // source round-trips through the JsonConverter as the enum name.
+      expect(json['source'], 'vpic');
+
+      final restored = VinData.fromJson(json);
+      expect(restored, equals(original));
+    });
+
+    test('fromJson with unknown source string falls back to invalid', () {
+      final json = <String, dynamic>{
+        'vin': 'ABCDEFGHIJKLMNOPQ',
+        'source': 'sasquatch',
+      };
+      final restored = VinData.fromJson(json);
+      expect(restored.source, VinDataSource.invalid);
+      expect(restored.vin, 'ABCDEFGHIJKLMNOPQ');
+    });
+  });
+}


### PR DESCRIPTION
## Why
Three zero-coverage entity files:
- `alerts/data/models/price_snapshot.dart` (52 LOC, freezed)
- `vehicle/domain/entities/vin_data.dart` (84 LOC, freezed + JsonConverter)
- `achievements/domain/achievement.dart` (67 LOC, @immutable + json)

## What
Exhaustive coverage: every freezed/JSON roundtrip path, every `isComplete` combination, every `VinDataSourceJsonConverter` branch, every `EarnedAchievement.fromJson` null/malformed branch including the catch-on-bad-date.

Refs #561