### PR TITLE
test(coverage): cover trip_recording_state + trip_live_reading entities (Refs #561)

### DIFF
--- a/test/features/consumption/data/obd2/trip_live_reading_test.dart
+++ b/test/features/consumption/data/obd2/trip_live_reading_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_live_reading.dart';
+
+void main() {
+  group('TripLiveReading constructor', () {
+    test('optional fields default to null when only required are supplied',
+        () {
+      const reading = TripLiveReading(
+        distanceKmSoFar: 1.5,
+        elapsed: Duration(seconds: 45),
+      );
+      expect(reading.distanceKmSoFar, 1.5);
+      expect(reading.elapsed, const Duration(seconds: 45));
+      expect(reading.speedKmh, isNull);
+      expect(reading.rpm, isNull);
+      expect(reading.fuelRateLPerHour, isNull);
+      expect(reading.fuelLevelPercent, isNull);
+      expect(reading.engineLoadPercent, isNull);
+      expect(reading.throttlePercent, isNull);
+      expect(reading.fuelLitersSoFar, isNull);
+      expect(reading.odometerStartKm, isNull);
+      expect(reading.odometerNowKm, isNull);
+    });
+  });
+
+  group('TripLiveReading.liveAvgLPer100Km', () {
+    test('returns null when fuelLitersSoFar is null', () {
+      const reading = TripLiveReading(
+        distanceKmSoFar: 10.0,
+        elapsed: Duration(minutes: 5),
+      );
+      expect(reading.liveAvgLPer100Km, isNull);
+    });
+
+    test('returns null when distanceKmSoFar is exactly 0.0', () {
+      const reading = TripLiveReading(
+        distanceKmSoFar: 0.0,
+        elapsed: Duration(seconds: 10),
+        fuelLitersSoFar: 0.2,
+      );
+      expect(reading.liveAvgLPer100Km, isNull);
+    });
+
+    test('returns null when distanceKmSoFar is below the 0.01 km floor', () {
+      const reading = TripLiveReading(
+        distanceKmSoFar: 0.005,
+        elapsed: Duration(seconds: 5),
+        fuelLitersSoFar: 0.01,
+      );
+      expect(reading.liveAvgLPer100Km, isNull);
+    });
+
+    test('returns a value at the boundary distanceKmSoFar == 0.01 km', () {
+      // Boundary: the guard is `< 0.01`, so 0.01 exactly is *not* rejected.
+      const reading = TripLiveReading(
+        distanceKmSoFar: 0.01,
+        elapsed: Duration(seconds: 5),
+        fuelLitersSoFar: 0.001,
+      );
+      final value = reading.liveAvgLPer100Km;
+      expect(value, isNotNull);
+      expect(value, closeTo(10.0, 1e-9));
+    });
+
+    test('realistic values: 1 L over 20 km → 5.0 L/100km', () {
+      const reading = TripLiveReading(
+        distanceKmSoFar: 20.0,
+        elapsed: Duration(minutes: 15),
+        fuelLitersSoFar: 1.0,
+      );
+      expect(reading.liveAvgLPer100Km, closeTo(5.0, 1e-9));
+    });
+
+    test('free-coast case: 0 L over 10 km → 0.0 L/100km', () {
+      const reading = TripLiveReading(
+        distanceKmSoFar: 10.0,
+        elapsed: Duration(minutes: 5),
+        fuelLitersSoFar: 0.0,
+      );
+      expect(reading.liveAvgLPer100Km, 0.0);
+    });
+
+    test('very small distance above floor: 0.01 L over 0.02 km → 50.0 L/100km',
+        () {
+      const reading = TripLiveReading(
+        distanceKmSoFar: 0.02,
+        elapsed: Duration(seconds: 2),
+        fuelLitersSoFar: 0.01,
+      );
+      expect(reading.liveAvgLPer100Km, closeTo(50.0, 1e-9));
+    });
+  });
+}

--- a/test/features/consumption/providers/trip_recording_state_test.dart
+++ b/test/features/consumption/providers/trip_recording_state_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_live_reading.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_phase.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_state.dart';
+
+void main() {
+  group('TripRecordingState default constructor', () {
+    test('fields default to idle/null/normal', () {
+      const state = TripRecordingState();
+      expect(state.phase, TripRecordingPhase.idle);
+      expect(state.live, isNull);
+      expect(state.situation, DrivingSituation.idle);
+      expect(state.band, ConsumptionBand.normal);
+      expect(state.liveDeltaFraction, isNull);
+    });
+
+    test('isActive is false on default (idle)', () {
+      const state = TripRecordingState();
+      expect(state.isActive, isFalse);
+    });
+  });
+
+  group('TripRecordingState.copyWith', () {
+    const baseLive = TripLiveReading(
+      distanceKmSoFar: 1.0,
+      elapsed: Duration(seconds: 30),
+    );
+    const base = TripRecordingState(
+      phase: TripRecordingPhase.recording,
+      live: baseLive,
+      situation: DrivingSituation.urbanCruise,
+      band: ConsumptionBand.eco,
+      liveDeltaFraction: -0.05,
+    );
+
+    test('changing only phase preserves other fields', () {
+      final next = base.copyWith(phase: TripRecordingPhase.paused);
+      expect(next.phase, TripRecordingPhase.paused);
+      expect(next.live, same(baseLive));
+      expect(next.situation, DrivingSituation.urbanCruise);
+      expect(next.band, ConsumptionBand.eco);
+      expect(next.liveDeltaFraction, -0.05);
+    });
+
+    test('changing only live preserves other fields', () {
+      const newReading = TripLiveReading(
+        distanceKmSoFar: 2.5,
+        elapsed: Duration(minutes: 1),
+      );
+      final next = base.copyWith(live: newReading);
+      expect(next.live, same(newReading));
+      expect(next.phase, TripRecordingPhase.recording);
+      expect(next.situation, DrivingSituation.urbanCruise);
+      expect(next.band, ConsumptionBand.eco);
+      expect(next.liveDeltaFraction, -0.05);
+    });
+
+    test('changing only situation preserves other fields', () {
+      final next = base.copyWith(situation: DrivingSituation.highwayCruise);
+      expect(next.situation, DrivingSituation.highwayCruise);
+      expect(next.phase, TripRecordingPhase.recording);
+      expect(next.live, same(baseLive));
+      expect(next.band, ConsumptionBand.eco);
+      expect(next.liveDeltaFraction, -0.05);
+    });
+
+    test('changing only band preserves other fields', () {
+      final next = base.copyWith(band: ConsumptionBand.heavy);
+      expect(next.band, ConsumptionBand.heavy);
+      expect(next.phase, TripRecordingPhase.recording);
+      expect(next.live, same(baseLive));
+      expect(next.situation, DrivingSituation.urbanCruise);
+      expect(next.liveDeltaFraction, -0.05);
+    });
+
+    test('changing only liveDeltaFraction preserves other fields', () {
+      final next = base.copyWith(liveDeltaFraction: 0.08);
+      expect(next.liveDeltaFraction, 0.08);
+      expect(next.phase, TripRecordingPhase.recording);
+      expect(next.live, same(baseLive));
+      expect(next.situation, DrivingSituation.urbanCruise);
+      expect(next.band, ConsumptionBand.eco);
+    });
+
+    test('clearDelta: true forces liveDeltaFraction to null '
+        'even when original was non-null', () {
+      final next = base.copyWith(clearDelta: true);
+      expect(next.liveDeltaFraction, isNull);
+      // Other fields still preserved.
+      expect(next.phase, TripRecordingPhase.recording);
+      expect(next.live, same(baseLive));
+    });
+
+    test('clearDelta: true overrides an explicit liveDeltaFraction value', () {
+      final next = base.copyWith(
+        clearDelta: true,
+        liveDeltaFraction: 0.1,
+      );
+      expect(next.liveDeltaFraction, isNull);
+    });
+
+    test('copyWith(live: ...) on state with null live adds the reading', () {
+      const empty = TripRecordingState();
+      const reading = TripLiveReading(
+        distanceKmSoFar: 0.5,
+        elapsed: Duration(seconds: 15),
+      );
+      final next = empty.copyWith(live: reading);
+      expect(next.live, same(reading));
+    });
+
+    test('copyWith(live: ...) on state with existing live replaces it', () {
+      const newReading = TripLiveReading(
+        distanceKmSoFar: 10.0,
+        elapsed: Duration(minutes: 5),
+      );
+      final next = base.copyWith(live: newReading);
+      expect(next.live, same(newReading));
+      expect(next.live, isNot(same(baseLive)));
+    });
+  });
+
+  group('TripRecordingState.isActive', () {
+    test('true when phase is recording', () {
+      const state =
+          TripRecordingState(phase: TripRecordingPhase.recording);
+      expect(state.isActive, isTrue);
+    });
+
+    test('true when phase is paused', () {
+      const state = TripRecordingState(phase: TripRecordingPhase.paused);
+      expect(state.isActive, isTrue);
+    });
+
+    test('true when phase is pausedDueToDrop', () {
+      const state =
+          TripRecordingState(phase: TripRecordingPhase.pausedDueToDrop);
+      expect(state.isActive, isTrue);
+    });
+
+    test('false when phase is idle', () {
+      const state = TripRecordingState(phase: TripRecordingPhase.idle);
+      expect(state.isActive, isFalse);
+    });
+
+    test('false when phase is finished', () {
+      const state = TripRecordingState(phase: TripRecordingPhase.finished);
+      expect(state.isActive, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Why
Two zero-coverage pure entities extracted during the OBD2 split (#929/#934 from the prior session):
- `trip_recording_state.dart` (52 LOC) — immutable state snapshot with `copyWith` + `isActive`
- `trip_live_reading.dart` (53 LOC) — immutable DTO with `liveAvgLPer100Km` pure getter

## What
Full branch coverage: every `copyWith` field + `clearDelta` priority, every `isActive` enum value, every `liveAvgLPer100Km` null/boundary/realistic branch.

Refs #561