### PR TITLE
refactor(ui): AddFillUpScreen uses PageScaffold (Refs #923 phase 3i)

### DIFF
--- a/docs/design/DESIGN_SYSTEM.md
+++ b/docs/design/DESIGN_SYSTEM.md
@@ -236,8 +236,16 @@ screen is about" identified in the #923 audit.
   `null` uses `Scaffold`'s default (end-float); pass
   `FloatingActionButtonLocation.centerDocked` when pairing with a
   bottom bar.
-- `bottomNavigationBar: Widget?` — reserved for the shell; leaf
-  screens do not set this.
+- `bottomNavigationBar: Widget?` — pass-through to
+  [Scaffold.bottomNavigationBar]. Used by form screens
+  (e.g. `AddFillUpScreen`, `EditVehicleScreen`) to pin a Save button
+  above the system nav inset without stealing scrollable real estate.
+- `leading: Widget?` — optional leading app-bar widget. Normally the
+  back button — pass a custom drawer icon when needed. Works with
+  `automaticallyImplyLeading: false` when the caller wants full
+  control.
+- `automaticallyImplyLeading: bool` — whether the app bar shows its
+  automatic leading. Default: `true`.
 - `toolbarHeight: double?` — optional override for the app-bar toolbar
   height (pass-through to `AppBar.toolbarHeight`). Default `null` uses
   Material's default; compact layouts (e.g. `SearchScreen` in

--- a/lib/core/widgets/page_scaffold.dart
+++ b/lib/core/widgets/page_scaffold.dart
@@ -75,6 +75,12 @@ class PageScaffold extends StatelessWidget {
   /// ([NavigationToolbar.kMiddleSpacing] = 16).
   final double? titleSpacing;
 
+  /// Optional bottom bar — a pinned action bar below the body. Forwards
+  /// to [Scaffold.bottomNavigationBar]. Used by form screens
+  /// (e.g. `AddFillUpScreen`, `EditVehicleScreen`) to pin a Save button
+  /// above the system nav inset without stealing scrollable real estate.
+  final Widget? bottomNavigationBar;
+
   const PageScaffold({
     super.key,
     required this.title,
@@ -90,6 +96,7 @@ class PageScaffold extends StatelessWidget {
     this.toolbarHeight,
     this.titleTextStyle,
     this.titleSpacing,
+    this.bottomNavigationBar,
   });
 
   @override
@@ -123,6 +130,7 @@ class PageScaffold extends StatelessWidget {
       ),
       floatingActionButton: floatingActionButton,
       floatingActionButtonLocation: floatingActionButtonLocation,
+      bottomNavigationBar: bottomNavigationBar,
     );
   }
 }

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/widgets/form_section_card.dart';
 import '../../../../core/widgets/fuel_type_dropdown.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
@@ -337,48 +338,44 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     // #706 — consumption requires a vehicle. When none are configured,
     // show an empty-state CTA instead of the full form.
     if (vehicles.isEmpty) {
-      return Scaffold(
-        appBar: AppBar(
-          title: Text(l?.addFillUp ?? 'Add fill-up'),
-          leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            tooltip: l?.tooltipBack ?? 'Back',
-            onPressed: () => context.pop(),
-          ),
+      return PageScaffold(
+        title: l?.addFillUp ?? 'Add fill-up',
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          tooltip: l?.tooltipBack ?? 'Back',
+          onPressed: () => context.pop(),
         ),
-        body: Padding(
-          padding: const EdgeInsets.all(32),
-          child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.directions_car_outlined,
-                  size: 80,
-                  color: theme.colorScheme.primary,
-                ),
-                const SizedBox(height: 24),
-                Text(
-                  l?.consumptionNoVehicleTitle ?? 'Add a vehicle first',
-                  style: theme.textTheme.headlineSmall,
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  l?.consumptionNoVehicleBody ??
-                      'Fill-ups are attributed to a vehicle. Add your car '
-                          'to start logging consumption.',
-                  style: theme.textTheme.bodyMedium,
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 24),
-                FilledButton.icon(
-                  onPressed: () => context.push('/vehicles/edit'),
-                  icon: const Icon(Icons.add),
-                  label: Text(l?.vehicleAdd ?? 'Add vehicle'),
-                ),
-              ],
-            ),
+        bodyPadding: const EdgeInsets.all(32),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.directions_car_outlined,
+                size: 80,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                l?.consumptionNoVehicleTitle ?? 'Add a vehicle first',
+                style: theme.textTheme.headlineSmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                l?.consumptionNoVehicleBody ??
+                    'Fill-ups are attributed to a vehicle. Add your car '
+                        'to start logging consumption.',
+                style: theme.textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              FilledButton.icon(
+                onPressed: () => context.push('/vehicles/edit'),
+                icon: const Icon(Icons.add),
+                label: Text(l?.vehicleAdd ?? 'Add vehicle'),
+              ),
+            ],
           ),
         ),
       );
@@ -386,15 +383,14 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
 
     final importBusy = _scanning || _scanningPump || _obdReading;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l?.addFillUp ?? 'Add fill-up'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l?.tooltipBack ?? 'Back',
-          onPressed: () => context.pop(),
-        ),
+    return PageScaffold(
+      title: l?.addFillUp ?? 'Add fill-up',
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: l?.tooltipBack ?? 'Back',
+        onPressed: () => context.pop(),
       ),
+      bodyPadding: EdgeInsets.zero,
       body: Form(
         key: _formKey,
         child: ListView(

--- a/test/core/widgets/page_scaffold_test.dart
+++ b/test/core/widgets/page_scaffold_test.dart
@@ -175,6 +175,43 @@ void main() {
       expect(appBar.titleSpacing, 12);
     });
 
+    testWidgets('forwards bottomNavigationBar to the scaffold',
+        (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Add fill-up',
+          body: SizedBox.shrink(),
+          bottomNavigationBar: SizedBox(
+            key: Key('pinned_save_bar'),
+            height: 56,
+          ),
+        ),
+      );
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold));
+      expect(scaffold.bottomNavigationBar, isNotNull);
+      expect(find.byKey(const Key('pinned_save_bar')), findsOneWidget);
+    });
+
+    testWidgets('forwards leading to the app bar', (tester) async {
+      var tapped = false;
+      await pump(
+        tester,
+        PageScaffold(
+          title: 'Add fill-up',
+          leading: IconButton(
+            tooltip: 'Back',
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => tapped = true,
+          ),
+          body: const SizedBox.shrink(),
+        ),
+      );
+      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      expect(tapped, isTrue);
+    });
+
     testWidgets('title has header semantics', (tester) async {
       final handle = tester.ensureSemantics();
       await pump(


### PR DESCRIPTION
## What

Phase 3i of the design-system consolidation epic (#923): migrate `AddFillUpScreen` (both empty-vehicle and populated form branches) from bare `Scaffold` + `AppBar` to `PageScaffold`.

**PageScaffold was extended** with one new prop — `bottomNavigationBar` — because this screen (and the pending `EditVehicleScreen` migration) pin a Save button at the bottom. Split into two commits:

1. `refactor(ui): add bottomNavigationBar passthrough to PageScaffold` — ~5-line extension + one widget test + DESIGN_SYSTEM props-table update. Also documents the existing `leading` and `automaticallyImplyLeading` props that were already implemented but undocumented.
2. `refactor(ui): AddFillUpScreen uses PageScaffold` — migrates both Scaffold blocks, preserving the back-button leading, the per-state body padding (`EdgeInsets.all(32)` for empty state, `EdgeInsets.zero` for the ListView form), and the `_PinnedSaveBar` bottom bar.

## Why

Consolidates two more `Scaffold` call sites behind the canonical chrome widget (#923). The `bottomNavigationBar` passthrough unblocks the remaining form-screen migrations (`EditVehicleScreen` has the same pattern).

## Testing

- `flutter analyze` — zero warnings.
- `flutter test` — full suite green (6139 passed, 1 skipped). `add_fill_up_screen_prefill`, `add_fill_up_screen_restyle`, `add_fill_up_vehicle_mandatory` all still pass since `PageScaffold` internally renders `AppBar`.
- New `PageScaffold` tests cover `bottomNavigationBar` passthrough and `leading` tap.

Refs #923 phase 3i