### PR TITLE
refactor(ui): AddChargingLogScreen uses PageScaffold (Refs #923 phase 3j)

### DIFF
--- a/lib/features/consumption/presentation/screens/add_charging_log_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_charging_log_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/domain/charging_cost_calculator.dart';
 import '../../../ev/domain/entities/charging_log.dart';
@@ -255,42 +256,33 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
     _initVehicleIfNeeded(vehicles);
 
     if (vehicles.isEmpty) {
-      return Scaffold(
-        appBar: AppBar(
-          title: Text(l?.addChargingLogTitle ?? 'Log charging session'),
-          leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            tooltip: l?.tooltipBack ?? 'Back',
-            onPressed: () => Navigator.of(context).pop(),
-          ),
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(32),
-          child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.directions_car_outlined,
-                  size: 80,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-                const SizedBox(height: 24),
-                Text(
-                  l?.consumptionNoVehicleTitle ?? 'Add a vehicle first',
-                  style: Theme.of(context).textTheme.headlineSmall,
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  l?.consumptionNoVehicleBody ??
-                      'Charging sessions are attributed to a vehicle. '
-                          'Add your car to start logging.',
-                  style: Theme.of(context).textTheme.bodyMedium,
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
+      return PageScaffold(
+        title: l?.addChargingLogTitle ?? 'Log charging session',
+        bodyPadding: const EdgeInsets.all(32),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.directions_car_outlined,
+                size: 80,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                l?.consumptionNoVehicleTitle ?? 'Add a vehicle first',
+                style: Theme.of(context).textTheme.headlineSmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                l?.consumptionNoVehicleBody ??
+                    'Charging sessions are attributed to a vehicle. '
+                        'Add your car to start logging.',
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+            ],
           ),
         ),
       );
@@ -300,15 +292,9 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
         '${_date.year}-${_pad(_date.month)}-${_pad(_date.day)}';
     final derived = _deriveReadout();
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l?.addChargingLogTitle ?? 'Log charging session'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l?.tooltipBack ?? 'Back',
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ),
+    return PageScaffold(
+      title: l?.addChargingLogTitle ?? 'Log charging session',
+      bodyPadding: EdgeInsets.zero,
       body: Form(
         key: _formKey,
         child: ListView(

--- a/test/features/consumption/presentation/screens/add_charging_log_screen_test.dart
+++ b/test/features/consumption/presentation/screens/add_charging_log_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/widgets/page_scaffold.dart';
 import 'package:tankstellen/features/consumption/presentation/screens/add_charging_log_screen.dart';
 import 'package:tankstellen/features/consumption/providers/charging_logs_provider.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
@@ -56,6 +57,25 @@ void main() {
       );
       expect(find.textContaining('Add a vehicle'), findsWidgets);
       expect(find.byKey(const Key('charging_save_button')), findsNothing);
+      // #923 phase 3j — empty branch renders via PageScaffold.
+      expect(find.byType(PageScaffold), findsOneWidget);
+    });
+
+    testWidgets('with vehicles, main form renders via PageScaffold (#923 3j)',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const AddChargingLogScreen(),
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _EvVehicleList()),
+          chargingLogsProvider
+              .overrideWith(() => _PreloadedChargingLogs(const [])),
+        ],
+      );
+      expect(find.byType(PageScaffold), findsOneWidget);
+      // Sanity: the save button still renders inside the PageScaffold
+      // body (proves we didn't lose the Form tree in the migration).
+      expect(find.byKey(const Key('charging_save_button')), findsOneWidget);
     });
 
     testWidgets(


### PR DESCRIPTION
## What

Migrates `AddChargingLogScreen` (both the empty-vehicle-state branch and the main form branch) from `Scaffold(appBar: AppBar(...))` to `PageScaffold`. Drops the custom `leading: IconButton(Icons.arrow_back)` — `PageScaffold` defaults to `automaticallyImplyLeading: true`, so Material's implicit back button (with `MaterialLocalizations.backButtonTooltip`) takes over.

## Why

Refs #923 phase 3j. `PageScaffold` is the canonical outer chrome for every top-level screen: consistent app bar, `Semantics(header: true)` on the title, and a single place to wire in future cross-screen chrome (banner strip, etc.). Unifying `AddChargingLogScreen` with the other migrated screens (`VehicleListScreen`, `TripHistoryScreen`, `PickStationForFillUpScreen`, etc.) keeps the consumption flow visually coherent.

- Empty branch: body = `Center` column wrapped with `bodyPadding: EdgeInsets.all(32)` (the previous inline `Padding(32)` is now pushed into `PageScaffold`).
- Main branch: body keeps its `Form(key: ..., child: ListView(padding: EdgeInsets.all(16), ...))`, so we pass `bodyPadding: EdgeInsets.zero` to avoid double padding.

## Testing

- `flutter analyze` (plain, no scope): **0 issues**.
- `flutter test test/features/consumption/presentation/screens/add_charging_log_screen_test.dart`: **5/5 pass**, including two new `find.byType(PageScaffold)` regression assertions — one covering the empty-vehicle branch, one covering the with-vehicles main form.
- No silent `catch (_) {}` introduced (the existing `catch (e) { debugPrint(...) }` on `_save` is untouched).

Refs #923 phase 3j