### PR TITLE
refactor(ui): EditVehicleScreen uses PageScaffold (Refs #923 phase 3k)

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/utils/brand_logo_mapper.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/vehicle_profile.dart';
 import '../../domain/entities/vin_data.dart';
@@ -214,19 +215,18 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     final isEdit = _existingId != null || widget.vehicleId != null;
     final accent = _brandAccent(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(isEdit
-            ? (l?.vehicleEditTitle ?? 'Edit vehicle')
-            : (l?.vehicleAddTitle ?? 'Add vehicle')),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.check),
-            tooltip: l?.save ?? 'Save',
-            onPressed: _save,
-          ),
-        ],
-      ),
+    return PageScaffold(
+      title: isEdit
+          ? (l?.vehicleEditTitle ?? 'Edit vehicle')
+          : (l?.vehicleAddTitle ?? 'Add vehicle'),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.check),
+          tooltip: l?.save ?? 'Save',
+          onPressed: _save,
+        ),
+      ],
+      bodyPadding: EdgeInsets.zero,
       body: Form(
         key: _formKey,
         child: ListView(

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_page_scaffold_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_page_scaffold_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/widgets/page_scaffold.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Regression: EditVehicleScreen must render its chrome via
+/// [PageScaffold] (#923 phase 3k). The `bottomNavigationBar` is still
+/// wired through (pinned Save) so the save-bar button remains findable.
+void main() {
+  group('EditVehicleScreen — PageScaffold migration (#923 phase 3k)', () {
+    testWidgets('chrome is rendered via PageScaffold (add-new vehicle path)',
+        (tester) async {
+      await _pumpEditScreen(tester);
+
+      expect(find.byType(PageScaffold), findsOneWidget);
+    });
+
+    testWidgets('page title reads "Add vehicle" when creating a new profile',
+        (tester) async {
+      await _pumpEditScreen(tester);
+
+      // Title flows through PageScaffold → AppBar.title.
+      expect(find.text('Add vehicle'), findsOneWidget);
+    });
+
+    testWidgets('app-bar Save action is still wired as an IconButton',
+        (tester) async {
+      await _pumpEditScreen(tester);
+
+      // The app-bar action is the only IconButton with Icons.check in
+      // the tree (drivetrain/extras rows render distinct icons).
+      final saveAction = find.widgetWithIcon(IconButton, Icons.check);
+      expect(saveAction, findsOneWidget);
+    });
+
+    testWidgets('pinned bottom Save survives the PageScaffold migration',
+        (tester) async {
+      await _pumpEditScreen(tester);
+
+      // The VehicleSaveBar sits in PageScaffold.bottomNavigationBar;
+      // its Save button must still be findable.
+      expect(find.widgetWithText(FilledButton, 'Save'), findsOneWidget);
+    });
+  });
+}
+
+Future<void> _pumpEditScreen(
+  WidgetTester tester, {
+  VehicleProfileRepository? repoOverride,
+}) async {
+  // Tall canvas so the form and the pinned save bar both fit (see
+  // edit_vehicle_screen_restyle_test.dart for the same rationale).
+  tester.view.physicalSize = const Size(900, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final repo = repoOverride ?? VehicleProfileRepository(_FakeSettings());
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        vehicleProfileRepositoryProvider.overrideWithValue(repo),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: EditVehicleScreen(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}


### PR DESCRIPTION
## What
Migrates `EditVehicleScreen` from `Scaffold(appBar: AppBar(...))` to `PageScaffold(title: ..., actions: ..., body: ...)`.

## Why
Phase 3k of the #923 design-system consolidation — every top-level screen should route its outer chrome through `PageScaffold` so title semantics, action-tooltip contract, and bottom-nav passthrough land on one shape rather than drifting per-screen.

Kept the existing `ListView` padding (`EdgeInsets.fromLTRB(16, 16, 16, viewPadding.bottom + 96)`) untouched — it already reserves the vertical space the pinned save bar expects. Passing `bodyPadding: EdgeInsets.zero` to `PageScaffold` prevents the inset from being doubled. The `actions: [IconButton(Icons.check, tooltip: save)]` carries through unchanged, and `bottomNavigationBar: VehicleSaveBar(onSave: _save)` forwards via the existing `PageScaffold.bottomNavigationBar` slot.

## Testing
- New regression test: `test/features/vehicle/presentation/screens/edit_vehicle_screen_page_scaffold_test.dart` — asserts `find.byType(PageScaffold)`, the "Add vehicle" title, the app-bar Save `IconButton`, and the pinned bottom save button on the add-new-vehicle path (4 cases, all green).
- Existing `edit_vehicle_screen_restyle_test.dart` (which locks the `FormSectionCard`, pinned save bar, and tap-target guideline) still passes — full `test/features/vehicle/presentation/screens/` run: 30/30.
- `flutter analyze` (full project): clean, 0 issues.

Refs #923 phase 3k