### PR TITLE
feat(obd2): adapter registry — SmartOBD, ieGeek, vLinker BM+ (#949)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ docs/guides/*
 !docs/guides/BLOCKER-IOS-PROVISIONING.md
 !docs/guides/BLOCKER-SUPABASE-MIGRATION.md
 !docs/guides/PLAY-STORE-LISTING-REFRESH.md
+!docs/guides/obd2-adapters.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/obd2-adapters.md
+++ b/docs/guides/obd2-adapters.md
@@ -1,0 +1,66 @@
+# Supported OBD2 Adapters
+
+This is the list of OBD2 adapter models Tankstellen recognises by
+Bluetooth advertisement name. If your adapter is not in the table,
+it falls through to the generic ELM327 profile — most of the time
+that still works; add your model here if you have a name-matching
+rule that improves the experience (for example a confident
+"this is brand X" label in the picker, or a longer init delay
+for a chip that misses the default timing).
+
+The registry source of truth is
+`lib/features/consumption/data/obd2/adapter_registry.dart`; the
+catalogue below is curated manually from that file.
+
+## Supported adapters
+
+| Display name | Transport | Name matchers | Notes |
+|---|---|---|---|
+| vLinker FS (Classic) | Classic BT | `vlinker fs`, `vlinker ms`, `vlink fs`, `vgate fs` | Dominant Amazon-EU model; Classic SPP |
+| vLinker FD / MC (BLE) | BLE | `vlinker fd`, `vlinker mc`, `vlink fd`, `vlink mc` | Nordic UART FFF0 family |
+| OBDLink MX+ | BLE | `obdlink` | Scantool premium adapter; custom 18f0 service |
+| Carista OBD2 | BLE | `carista` | Nordic UART FFF0 family |
+| Veepeak BLE+ | BLE | `veepeak` | Nordic UART FFF0 family |
+| SmartOBD (BLE) | BLE | `smartobd` | Generic ELM327 v1.5 clone |
+| SmartOBD (Classic) | Classic BT | `smartobd` | Same brand, Classic SPP variant |
+| ieGeek Scanner | BLE | `iegeek` | ELM327 v2.1 BLE clone |
+| vLinker BM+ (BLE) | BLE | `vlinker bm+`, `vlink bm+` | BLE-only sibling to vLinker BM; the "+" is load-bearing |
+| Konnwei KW902 | Classic BT | `konnwei`, `kw902` | ELM327 v1.5 Classic clone |
+| Vgate iCar Pro | BLE | `vgate`, `icar pro` | Chinese brand; BLE variant (WiFi variant handled by TCP facade) |
+| Panlong WiFi | Classic BT (no-op) | `panlong` | WiFi-only adapter; name kept so the UI can label a mis-paired Classic entry |
+| BAFX 34t5 | Classic BT | `bafx` | Legacy ELM327 v1.5 adapter, still sold in the US |
+| Generic ELM327 (BLE) | BLE | — (matched by FFF0 service UUID) | Catch-all for unfamiliar BLE FFF0 clones |
+| Generic ELM327 (Classic) | Classic BT | `obdii`, `obd-ii`, `obd ii`, `obd2`, `elm327` | Catch-all for unfamiliar Classic-SPP clones |
+
+## How to add a new adapter
+
+1. Open `lib/features/consumption/data/obd2/adapter_registry.dart`.
+2. Add a new `Obd2AdapterProfile(...)` entry in the `_defaultProfiles`
+   const list. Place it **before** the two generic fallbacks
+   (`generic-fff0`, `generic-classic`) — the generics must remain the
+   last two entries so unfamiliar devices still resolve to a
+   catch-all.
+3. Populate at minimum:
+   - `id` — stable internal id (`kebab-case`).
+   - `displayName` — marketing name shown in the picker.
+   - `transport` — `BluetoothTransport.ble` (default) or
+     `BluetoothTransport.classic`.
+   - `nameMatchers` — case-insensitive substrings the advertisement
+     name is matched against.
+4. If the adapter is BLE and uses a known GATT profile, also set
+   `serviceUuid`, `writeCharUuid`, `notifyCharUuid`. The Nordic UART
+   family is `0000fff0-…` / `0000fff2-…` / `0000fff1-…`.
+5. Add a name-match test to
+   `test/features/consumption/data/obd2/adapter_registry_test.dart`
+   that asserts `resolve(_candidate(name: '<brand-string>', …))`
+   returns your new profile id. Follow the pattern of the
+   `#949` block at the bottom of the file.
+6. Update the table in this document (`docs/guides/obd2-adapters.md`).
+7. Run `flutter analyze` and `flutter test` before sending the PR.
+
+## Reference
+
+- Registry source: `lib/features/consumption/data/obd2/adapter_registry.dart`
+- Tests: `test/features/consumption/data/obd2/adapter_registry_test.dart`
+- Related issues: #733 (initial registry), #761 (Classic transport),
+  #949 (expansion).

--- a/lib/features/consumption/data/obd2/adapter_registry.dart
+++ b/lib/features/consumption/data/obd2/adapter_registry.dart
@@ -237,6 +237,87 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
     nameMatchers: ['veepeak'],
   ),
+  // SmartOBD — generic ELM327 v1.5 clone, widely shipped on Amazon
+  // (#949). BLE variant rides on FFF0 like the rest of the Nordic-UART
+  // family; a Classic-BT sibling also exists under the same name, so a
+  // separate Classic entry follows this one.
+  Obd2AdapterProfile(
+    id: 'smartobd-ble',
+    displayName: 'SmartOBD (BLE)',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['smartobd'],
+  ),
+  Obd2AdapterProfile(
+    id: 'smartobd-classic',
+    displayName: 'SmartOBD (Classic)',
+    transport: BluetoothTransport.classic,
+    nameMatchers: ['smartobd'],
+  ),
+  // ieGeek Scanner — ELM327 v2.1 BLE clone, advertises as "ieGeek…"
+  // (#949). Nordic UART FFF0 family.
+  Obd2AdapterProfile(
+    id: 'iegeek',
+    displayName: 'ieGeek Scanner',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['iegeek'],
+  ),
+  // vLinker BM+ — BLE-only sibling of the vLinker BM. The "+" is the
+  // distinguishing glyph, so the matchers require it to win over a
+  // future plain-"bm" entry; listed as 'vlinker bm+' / 'vlink bm+'
+  // (#949). Same Nordic UART FFF0 family.
+  Obd2AdapterProfile(
+    id: 'vlinker-bm-plus',
+    displayName: 'vLinker BM+ (BLE)',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['vlinker bm+', 'vlink bm+'],
+  ),
+  // Konnwei KW902 — Classic Bluetooth ELM327 v1.5 clone, extremely
+  // common on Amazon / AliExpress. Advertises as "KONNWEI" or "KW902"
+  // in bonded-device lists (#949).
+  Obd2AdapterProfile(
+    id: 'konnwei-kw902',
+    displayName: 'Konnwei KW902',
+    transport: BluetoothTransport.classic,
+    nameMatchers: ['konnwei', 'kw902'],
+  ),
+  // Vgate iCar Pro — Chinese-brand ELM327, ships in BLE and WiFi
+  // variants (#949). The BLE model lands on the FFF0 Nordic-UART
+  // family; the WiFi model is handled by a TCP adapter outside this
+  // registry. Name advertises as "Vgate iCar Pro" / "iCar Pro".
+  Obd2AdapterProfile(
+    id: 'vgate-icar-pro',
+    displayName: 'Vgate iCar Pro',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['vgate', 'icar pro'],
+  ),
+  // Panlong WiFi — entry-level WiFi adapter (#949). Not reachable via
+  // BLE scan, but a Classic-bonded-device list may still carry the
+  // name if the user mis-paired it; keep the matcher available so the
+  // UI labels the device correctly before the connection attempt
+  // fails. Transport set to classic as the nearest no-op (WiFi
+  // adapters connect through a TCP facade).
+  Obd2AdapterProfile(
+    id: 'panlong-wifi',
+    displayName: 'Panlong WiFi',
+    transport: BluetoothTransport.classic,
+    nameMatchers: ['panlong'],
+  ),
+  // BAFX 34t5 — legacy ELM327 v1.5 Classic-BT adapter, still widely
+  // sold in the US (#949). Advertises simply as "BAFX".
+  Obd2AdapterProfile(
+    id: 'bafx',
+    displayName: 'BAFX 34t5',
+    transport: BluetoothTransport.classic,
+    nameMatchers: ['bafx'],
+  ),
   // Generic ELM327 BLE fallback. Matches any clone that advertises
   // the FFF0 service but has an unfamiliar name (plenty on Amazon).
   // No nameMatchers — reached only via service-UUID pass.

--- a/test/features/consumption/data/obd2/adapter_registry_test.dart
+++ b/test/features/consumption/data/obd2/adapter_registry_test.dart
@@ -84,6 +84,135 @@ void main() {
     });
   });
 
+  group('Obd2AdapterRegistry.resolve — expanded catalog (#949)', () {
+    // Each assertion below mirrors the "resolve by advertised name"
+    // path used by the BLE scan flow. The picker feeds the registry
+    // via Obd2AdapterCandidate; these tests ensure each new #949
+    // entry is reachable without relying on a service-UUID hit.
+
+    test('SmartOBD BLE advert is labelled as SmartOBD (not generic)', () {
+      final hit = _candidate(
+        name: 'SmartOBD-BT',
+        services: const ['0000fff0-0000-1000-8000-00805f9b34fb'],
+      );
+      final profile = registry.resolve(hit);
+      expect(profile, isNotNull);
+      expect(profile!.id, 'smartobd-ble');
+      expect(profile.transport, BluetoothTransport.ble);
+    });
+
+    test('SmartOBD Classic bonded-device name lands on a SmartOBD profile',
+        () {
+      // Classic devices have no advertised services — the name is
+      // all we get. BLE and Classic SmartOBD entries share the
+      // matcher; the BLE entry is listed first, so the assertion
+      // below accepts either SmartOBD id — the guard is against the
+      // generic fallback winning.
+      final hit = _candidate(name: 'SmartOBD', services: []);
+      final profile = registry.resolve(hit);
+      expect(profile, isNotNull);
+      expect(profile!.id, startsWith('smartobd'));
+    });
+
+    test('ieGeek Scanner matched by name (#949)', () {
+      final hit = _candidate(
+        name: 'ieGeek 123',
+        services: const ['0000fff0-0000-1000-8000-00805f9b34fb'],
+      );
+      expect(registry.resolve(hit)?.id, 'iegeek');
+    });
+
+    test('vLinker BM+ matches the new BM+ profile, not a generic', () {
+      final hit = _candidate(
+        name: 'vLinker BM+ BLE',
+        services: const ['0000fff0-0000-1000-8000-00805f9b34fb'],
+      );
+      final profile = registry.resolve(hit);
+      expect(profile, isNotNull);
+      expect(profile!.id, 'vlinker-bm-plus');
+    });
+
+    test('vLinker BM (no plus) does NOT collide with the BM+ entry', () {
+      // Regression guard: a plain "vLinker BM" advert must not be
+      // hijacked by the BM+ matcher — the "+" is the distinguishing
+      // glyph. With the current catalog there is no named BM-only
+      // profile, so the advert falls through to the generic FFF0
+      // BLE fallback (via the advertised Nordic-UART service).
+      final hit = _candidate(
+        name: 'vLinker BM',
+        services: const ['0000fff0-0000-1000-8000-00805f9b34fb'],
+      );
+      final profile = registry.resolve(hit);
+      expect(profile, isNotNull);
+      expect(profile!.id, isNot('vlinker-bm-plus'));
+      expect(profile.id, 'generic-fff0');
+    });
+
+    test('Konnwei / KW902 → konnwei-kw902 (#949)', () {
+      expect(
+        registry.resolve(_candidate(name: 'KONNWEI KW902', services: []))?.id,
+        'konnwei-kw902',
+      );
+      expect(
+        registry.resolve(_candidate(name: 'KW902-OBD', services: []))?.id,
+        'konnwei-kw902',
+      );
+    });
+
+    test('Vgate iCar Pro matched by "Vgate" and by "iCar Pro" (#949)', () {
+      expect(
+        registry
+            .resolve(_candidate(name: 'Vgate iCar Pro BLE', services: []))
+            ?.id,
+        'vgate-icar-pro',
+      );
+      expect(
+        registry.resolve(_candidate(name: 'iCar Pro 2', services: []))?.id,
+        'vgate-icar-pro',
+      );
+    });
+
+    test('Panlong WiFi matched by name (#949)', () {
+      expect(
+        registry
+            .resolve(_candidate(name: 'Panlong WiFi OBD', services: []))
+            ?.id,
+        'panlong-wifi',
+      );
+    });
+
+    test('BAFX matched by name (#949)', () {
+      expect(
+        registry
+            .resolve(_candidate(name: 'BAFX Products 34t5', services: []))
+            ?.id,
+        'bafx',
+      );
+    });
+
+    test('"random device" name with no OBD signature is rejected', () {
+      // Regression guard on the generic fallback: a noisy advert
+      // with no OBD signature and no relevant service UUID must not
+      // be matched by any of the new #949 entries. The generic-
+      // classic profile only fires when the name contains "obd" /
+      // "elm327" etc., so "random device" lands on null and the UI
+      // hides it.
+      final hit = _candidate(name: 'random device', services: []);
+      expect(registry.resolve(hit), isNull);
+    });
+
+    test('generic Classic ELM327 clone still reaches generic-classic after '
+        '#949 additions', () {
+      // Guard on the "last entry is the catch-all" contract. A
+      // name that carries an OBD signature but matches none of the
+      // named profiles must land on the generic-classic fallback.
+      final hit = _candidate(name: 'OBD-II Random Clone', services: []);
+      final profile = registry.resolve(hit);
+      expect(profile, isNotNull);
+      expect(profile!.id, 'generic-classic');
+    });
+  });
+
   group('Obd2AdapterRegistry.allServiceUuids', () {
     test('only BLE profiles contribute service UUIDs (#761)', () {
       // Classic profiles have no advertised service UUID — including


### PR DESCRIPTION
Closes #949

## Summary

Expands the OBD2 adapter registry (`lib/features/consumption/data/obd2/adapter_registry.dart`) with name-matching entries for popular ELM327 clones so the scan picker shows the brand name instead of "Generic ELM327".

Adapter profiles added (all inserted **before** the two generic fallbacks, which remain the last entries — preserving the catch-all contract):

- **SmartOBD (BLE)** — `smartobd`, Nordic UART FFF0 family
- **SmartOBD (Classic)** — same brand, Classic SPP variant
- **ieGeek Scanner** — `iegeek`, ELM327 v2.1 BLE clone
- **vLinker BM+ (BLE)** — `vlinker bm+` / `vlink bm+`; the "+" is load-bearing to avoid hijacking a future bare-"BM" entry
- **Konnwei KW902** — `konnwei` / `kw902`, Classic-BT
- **Vgate iCar Pro** — `vgate` / `icar pro`, BLE
- **Panlong WiFi** — `panlong`, name kept for mis-paired Classic listings
- **BAFX 34t5** — `bafx`, legacy Classic-BT

No other OBD2 code paths touched (`obd2_service.dart`, `elm327_commands.dart`, etc. are untouched — additive only).

## Why

Users currently see "Generic ELM327" in the picker for any adapter that is not vLinker / OBDLink / Carista / Veepeak. Surfacing the actual brand name reduces "did I pick the right one?" friction in the onboarding flow and makes support tickets easier to triage.

## Testing

- `test/features/consumption/data/obd2/adapter_registry_test.dart` — new `#949` group covers every new entry by advertised name, plus two regression guards:
  - "vLinker BM" (no plus) still lands on `generic-fff0`, not the new BM+ entry.
  - "random device" (no OBD signature) still resolves to `null`; the new matchers do not widen the catch-all.
- `flutter analyze` — zero warnings (plain, not `--no-fatal-infos`).
- `flutter test` — full suite green (6235 tests).

## Docs

- New `docs/guides/obd2-adapters.md` — intro, table of all supported adapters, and a "how to add a new adapter" recipe referencing this file and the test file.
- `.gitignore` — allow-listed the new doc under `docs/guides/`.

## Screenshots

Registry is pure data + tests + docs — no UI change in this PR. The picker will automatically display the new `displayName` values when a scanned device matches a new `nameMatchers` entry.