### PR TITLE
refactor(ui): TripRecordingScreen uses PageScaffold (Refs #923 phase 3m)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/trip_recorder.dart';
 import '../../providers/trip_recording_provider.dart';
@@ -161,72 +162,70 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
             : (l?.tripRecordingTitle ?? 'Recording trip');
 
     // After stop: show the summary. Until then: live view.
-    return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l?.tooltipBack ?? 'Back',
-          // Back from the recording screen DOES NOT stop the trip —
-          // it stays alive via the provider. The banner is the
-          // user's way back in.
-          onPressed: () {
-            if (Navigator.canPop(context)) {
-              Navigator.pop(context);
-            } else {
-              GoRouter.of(context).go('/');
-            }
-          },
-        ),
-        title: Text(title),
-        actions: stopped != null
-            ? null
-            : [
-                // #891 — wrap in Semantics so TalkBack announces the
-                // *next* action (Pin / Unpin) in addition to the
-                // tooltip's battery-cost hint. `container: true`
-                // merges the IconButton's tap semantics into the label.
-                Semantics(
-                  container: true,
-                  button: true,
-                  toggled: _pinned,
-                  label: _pinned
-                      ? (l?.tripRecordingPinSemanticOn ??
-                          'Unpin recording form')
-                      : (l?.tripRecordingPinSemanticOff ??
-                          'Pin recording form'),
-                  child: IconButton(
-                    key: const Key('tripPinButton'),
-                    icon: Icon(
-                      _pinned ? Icons.push_pin : Icons.push_pin_outlined,
-                      color: _pinned
-                          ? Theme.of(context).colorScheme.primary
-                          : null,
-                    ),
-                    tooltip: l?.tripRecordingPinTooltip ??
-                        'Pinning keeps the screen on — uses more battery',
-                    isSelected: _pinned,
-                    onPressed: _togglePin,
-                  ),
-                ),
-                IconButton(
-                  key: const Key('tripPauseButton'),
-                  icon: Icon(state.phase == TripRecordingPhase.paused
-                      ? Icons.play_arrow
-                      : Icons.pause),
-                  tooltip: state.phase == TripRecordingPhase.paused
-                      ? (l?.tripResume ?? 'Resume')
-                      : (l?.tripPause ?? 'Pause'),
-                  onPressed: state.isActive ? _togglePause : null,
-                ),
-                IconButton(
-                  key: const Key('tripStopButton'),
-                  icon: const Icon(Icons.stop_circle_outlined),
-                  tooltip: l?.tripStop ?? 'Stop recording',
-                  onPressed:
-                      _stopping || !state.isActive ? null : _onStop,
-                ),
-              ],
+    return PageScaffold(
+      title: title,
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: l?.tooltipBack ?? 'Back',
+        // Back from the recording screen DOES NOT stop the trip —
+        // it stays alive via the provider. The banner is the
+        // user's way back in.
+        onPressed: () {
+          if (Navigator.canPop(context)) {
+            Navigator.pop(context);
+          } else {
+            GoRouter.of(context).go('/');
+          }
+        },
       ),
+      actions: stopped != null
+          ? null
+          : [
+              // #891 — wrap in Semantics so TalkBack announces the
+              // *next* action (Pin / Unpin) in addition to the
+              // tooltip's battery-cost hint. `container: true`
+              // merges the IconButton's tap semantics into the label.
+              Semantics(
+                container: true,
+                button: true,
+                toggled: _pinned,
+                label: _pinned
+                    ? (l?.tripRecordingPinSemanticOn ??
+                        'Unpin recording form')
+                    : (l?.tripRecordingPinSemanticOff ??
+                        'Pin recording form'),
+                child: IconButton(
+                  key: const Key('tripPinButton'),
+                  icon: Icon(
+                    _pinned ? Icons.push_pin : Icons.push_pin_outlined,
+                    color: _pinned
+                        ? Theme.of(context).colorScheme.primary
+                        : null,
+                  ),
+                  tooltip: l?.tripRecordingPinTooltip ??
+                      'Pinning keeps the screen on — uses more battery',
+                  isSelected: _pinned,
+                  onPressed: _togglePin,
+                ),
+              ),
+              IconButton(
+                key: const Key('tripPauseButton'),
+                icon: Icon(state.phase == TripRecordingPhase.paused
+                    ? Icons.play_arrow
+                    : Icons.pause),
+                tooltip: state.phase == TripRecordingPhase.paused
+                    ? (l?.tripResume ?? 'Resume')
+                    : (l?.tripPause ?? 'Pause'),
+                onPressed: state.isActive ? _togglePause : null,
+              ),
+              IconButton(
+                key: const Key('tripStopButton'),
+                icon: const Icon(Icons.stop_circle_outlined),
+                tooltip: l?.tripStop ?? 'Stop recording',
+                onPressed: _stopping || !state.isActive ? null : _onStop,
+              ),
+            ],
+      bodyPadding: EdgeInsets.zero,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),

--- a/test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/widgets/page_scaffold.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Regression: TripRecordingScreen must render its chrome via
+/// [PageScaffold] (#923 phase 3m). Pause / Resume / Stop and the #891
+/// pin toggle all flow through `PageScaffold.actions`, so their keys
+/// must remain findable after the migration.
+class _FakeTripRecording extends TripRecording {
+  final TripRecordingState _initial;
+  _FakeTripRecording(this._initial);
+
+  @override
+  TripRecordingState build() => _initial;
+}
+
+class _FakeWakelockFacade implements WakelockFacade {
+  @override
+  Future<void> enable() async {}
+
+  @override
+  Future<void> disable() async {}
+}
+
+TripRecordingState _recordingState() {
+  return const TripRecordingState(
+    phase: TripRecordingPhase.recording,
+    situation: DrivingSituation.highwayCruise,
+    band: ConsumptionBand.normal,
+  );
+}
+
+Future<void> _pumpRecordingScreen(WidgetTester tester) async {
+  await pumpApp(
+    tester,
+    const TripRecordingScreen(),
+    overrides: [
+      tripRecordingProvider.overrideWith(
+        () => _FakeTripRecording(_recordingState()),
+      ),
+      wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TripRecordingScreen — PageScaffold migration (#923 phase 3m)', () {
+    testWidgets('chrome is rendered via PageScaffold', (tester) async {
+      await _pumpRecordingScreen(tester);
+
+      expect(find.byType(PageScaffold), findsOneWidget);
+    });
+
+    testWidgets('page title reads "Recording trip" while actively recording',
+        (tester) async {
+      await _pumpRecordingScreen(tester);
+
+      // Title flows through PageScaffold → AppBar.title.
+      expect(find.text('Recording trip'), findsOneWidget);
+    });
+
+    testWidgets('pause / stop / pin action buttons survive the migration',
+        (tester) async {
+      await _pumpRecordingScreen(tester);
+
+      expect(find.byKey(const Key('tripPinButton')), findsOneWidget);
+      expect(find.byKey(const Key('tripPauseButton')), findsOneWidget);
+      expect(find.byKey(const Key('tripStopButton')), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## What
Migrate `TripRecordingScreen` to `PageScaffold` chrome.

## Why
Part of the #923 design-system rollout — every top-level screen routes its chrome through `PageScaffold` so the app-bar / banner / body contract stays consistent across the app. `TripRecordingScreen` was still rolling its own `Scaffold(appBar: AppBar(...))`.

The migration keeps every existing action wired through `PageScaffold.actions`:
- `tripPinButton` (#891 pin toggle with Semantics wrapper)
- `tripPauseButton` / `tripStopButton`

Body is passed with `bodyPadding: EdgeInsets.zero` so the screen's own `SafeArea > Padding(16)` wrapper keeps driving the layout — avoids double-padding. Pin / wakelock / system-UI logic is untouched; this PR is chrome-only.

## Testing
- `flutter analyze` — 0 issues.
- New test: `test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart` asserts the screen renders via `PageScaffold`, title reads "Recording trip", and the three action buttons (pin / pause / stop) remain findable by their stable keys.
- Existing `active_recording_screen_pin_test.dart` (#891) — all 7 scenarios still pass (pin toggle, auto-release on stop, dispose safety net, tap-target guideline, semantic label flip).

Refs #923 phase 3m