### PR TITLE
feat(ui): PageScaffold supports bottom prop (Refs #923)

### DIFF
--- a/docs/design/DESIGN_SYSTEM.md
+++ b/docs/design/DESIGN_SYSTEM.md
@@ -244,6 +244,11 @@ screen is about" identified in the #923 audit.
   back button — pass a custom drawer icon when needed. Works with
   `automaticallyImplyLeading: false` when the caller wants full
   control.
+- `bottom: PreferredSizeWidget?` — optional widget rendered below the
+  app-bar title (pass-through to `AppBar.bottom`). Used by tabbed
+  screens (e.g. `FavoritesScreen`, `ConsumptionScreen`) to host a
+  `TabBar` / `TabSwitcher` under the title while keeping the rest of
+  the scaffold contract intact.
 - `automaticallyImplyLeading: bool` — whether the app bar shows its
   automatic leading. Default: `true`.
 - `toolbarHeight: double?` — optional override for the app-bar toolbar

--- a/lib/core/widgets/page_scaffold.dart
+++ b/lib/core/widgets/page_scaffold.dart
@@ -81,6 +81,13 @@ class PageScaffold extends StatelessWidget {
   /// above the system nav inset without stealing scrollable real estate.
   final Widget? bottomNavigationBar;
 
+  /// Optional [PreferredSizeWidget] below the app-bar title — e.g. a
+  /// `TabBar` or `TabSwitcher`. Pass-through to [AppBar.bottom]. Used
+  /// by tabbed screens (e.g. `FavoritesScreen`, `ConsumptionScreen`)
+  /// that swap content via a [DefaultTabController] sibling to this
+  /// scaffold.
+  final PreferredSizeWidget? bottom;
+
   const PageScaffold({
     super.key,
     required this.title,
@@ -97,6 +104,7 @@ class PageScaffold extends StatelessWidget {
     this.titleTextStyle,
     this.titleSpacing,
     this.bottomNavigationBar,
+    this.bottom,
   });
 
   @override
@@ -111,6 +119,7 @@ class PageScaffold extends StatelessWidget {
         toolbarHeight: toolbarHeight,
         titleTextStyle: titleTextStyle,
         titleSpacing: titleSpacing,
+        bottom: bottom,
       ),
       body: Column(
         children: [

--- a/test/core/widgets/page_scaffold_test.dart
+++ b/test/core/widgets/page_scaffold_test.dart
@@ -193,6 +193,28 @@ void main() {
       expect(find.byKey(const Key('pinned_save_bar')), findsOneWidget);
     });
 
+    testWidgets('passes bottom through to AppBar', (tester) async {
+      const bottomHeight = 48.0;
+      await pump(
+        tester,
+        PageScaffold(
+          title: 'Favorites',
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(bottomHeight),
+            child: Container(
+              key: const Key('tab_bar_stub'),
+              height: bottomHeight,
+            ),
+          ),
+          body: const SizedBox.shrink(),
+        ),
+      );
+      final appBar = tester.widget<AppBar>(find.byType(AppBar));
+      expect(appBar.bottom, isNotNull);
+      expect(appBar.bottom!.preferredSize.height, bottomHeight);
+      expect(find.byKey(const Key('tab_bar_stub')), findsOneWidget);
+    });
+
     testWidgets('forwards leading to the app bar', (tester) async {
       var tapped = false;
       await pump(


### PR DESCRIPTION
## What

Adds a `bottom: PreferredSizeWidget?` pass-through to `AppBar.bottom` on `PageScaffold`.

## Why

Refs #923 (design-system consolidation epic). Several remaining feature screens (`FavoritesScreen`, `ConsumptionScreen`) use `DefaultTabController + Scaffold(appBar: AppBar(bottom: TabSwitcher(...)))`. Without a `bottom` pass-through they can't migrate to `PageScaffold` without falling back to a raw `Scaffold + AppBar` (and violating the design-system static scan). This unblocks those migrations as follow-up PRs.

## Testing

- Added `passes bottom through to AppBar` widget test: pumps `PageScaffold` with a 48 dp `PreferredSize` child and asserts `tester.widget<AppBar>(find.byType(AppBar)).bottom` is non-null with the expected `preferredSize.height`.
- `flutter analyze` — zero warnings.
- `flutter test` — full suite green (6357 passed).

## Screenshots

N/A — additive API-only change; no visual impact on existing consumers.