### PR TITLE
refactor(ui): FavoritesScreen outer AppBar uses PageScaffold (Refs #923 phase 3n)

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/sync/sync_provider.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/tab_switcher.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/favorites_provider.dart';
@@ -43,29 +44,25 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
 
     return DefaultTabController(
       length: 2,
-      child: Scaffold(
-        appBar: AppBar(
-          title: Semantics(
-            header: true,
-            child: Text(l10n?.favorites ?? 'Favorites'),
-          ),
-          actions: [
-            if (favoriteIds.isNotEmpty)
-              IconButton(
-                icon: const Icon(Icons.refresh),
-                onPressed: () {
-                  ref.read(favoriteStationsProvider.notifier).loadAndRefresh();
-                },
-                tooltip: l10n?.refreshPrices ?? 'Refresh prices',
-              ),
+      child: PageScaffold(
+        title: l10n?.favorites ?? 'Favorites',
+        actions: [
+          if (favoriteIds.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              onPressed: () {
+                ref.read(favoriteStationsProvider.notifier).loadAndRefresh();
+              },
+              tooltip: l10n?.refreshPrices ?? 'Refresh prices',
+            ),
+        ],
+        bottom: TabSwitcher(
+          tabs: [
+            TabSwitcherEntry(label: l10n?.favorites ?? 'Favorites'),
+            TabSwitcherEntry(label: l10n?.priceAlerts ?? 'Price Alerts'),
           ],
-          bottom: TabSwitcher(
-            tabs: [
-              TabSwitcherEntry(label: l10n?.favorites ?? 'Favorites'),
-              TabSwitcherEntry(label: l10n?.priceAlerts ?? 'Price Alerts'),
-            ],
-          ),
         ),
+        bodyPadding: EdgeInsets.zero,
         body: const TabBarView(
           children: [
             FavoritesFuelTab(),


### PR DESCRIPTION
Refs #923 phase 3n

## What
Migrate `FavoritesScreen`'s outer `Scaffold` + `AppBar` to `PageScaffold`, using the new `bottom:` pass-through added in #966.

## Why
Phase 3n of the design-system consolidation epic. Every top-level screen should render its chrome via `PageScaffold` so the app-bar contract (title semantics, tooltip enforcement, banner slot) lives in one place.

## Changes
- Swap `Scaffold(appBar: AppBar(...))` for `PageScaffold(...)`.
- Drop the redundant `Semantics(header: true)` wrapper around the title — `PageScaffold` applies it internally.
- Keep the `DefaultTabController`, `TabSwitcher`, and `TabBarView` untouched.
- `bodyPadding: EdgeInsets.zero` preserves the pre-migration full-bleed `TabBarView` behavior.

## Testing
- `flutter analyze` — 0 issues.
- `flutter test` — 6357 tests pass.