### PR TITLE
refactor(ui): alerts + report use PageScaffold (Refs #923 phase 3q)

### DIFF
--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/empty_state.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/price_alert.dart';
@@ -21,14 +22,13 @@ class AlertsScreen extends ConsumerWidget {
     final alertsAsync = ref.watch(alertsAsyncProvider);
     final l10n = AppLocalizations.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n?.priceAlerts ?? 'Price Alerts'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l10n?.tooltipBack ?? 'Back',
-          onPressed: () => context.pop(),
-        ),
+    return PageScaffold(
+      title: l10n?.priceAlerts ?? 'Price Alerts',
+      bodyPadding: EdgeInsets.zero,
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: l10n?.tooltipBack ?? 'Back',
+        onPressed: () => context.pop(),
       ),
       body: alertsAsync.when(
         data: (alerts) => _AlertsBody(alerts: alerts),

--- a/lib/features/report/presentation/screens/report_screen.dart
+++ b/lib/features/report/presentation/screens/report_screen.dart
@@ -10,6 +10,7 @@ import '../../../../core/services/report_service.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/sync/sync_provider.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/community_report_service.dart';
@@ -262,18 +263,17 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
     final selectedIsGitHubRouted =
         selectedType != null && selectedType.routesToGitHub;
 
-    return Scaffold(
-      appBar: AppBar(
-        // #484 — was "Signaler un prix" but two of the existing options
-        // (open/closed status) are not about prices and the rework will
-        // add metadata-only report types. Generic "Report a problem"
-        // matches the actual scope.
-        title: Text(l10n?.reportIssueTitle ?? 'Report a problem'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l10n?.tooltipBack ?? 'Back',
-          onPressed: () => context.pop(),
-        ),
+    // #484 — was "Signaler un prix" but two of the existing options
+    // (open/closed status) are not about prices and the rework will
+    // add metadata-only report types. Generic "Report a problem"
+    // matches the actual scope.
+    return PageScaffold(
+      title: l10n?.reportIssueTitle ?? 'Report a problem',
+      bodyPadding: EdgeInsets.zero,
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: l10n?.tooltipBack ?? 'Back',
+        onPressed: () => context.pop(),
       ),
       // RadioGroup sits OUTSIDE the ListView so every lazy-built
       // RadioListTile can look up the ancestor at any scroll position


### PR DESCRIPTION
## Summary

Refs #923 phase 3q — continues the design-system consolidation epic.

### Migrations (2/2)
- `lib/features/alerts/presentation/screens/alerts_screen.dart` — plain title + back-button AppBar, fits the contract.
- `lib/features/report/presentation/screens/report_screen.dart` — plain title + back-button AppBar, fits the contract.

Both screens pass `bodyPadding: EdgeInsets.zero` so their own ListView padding (alerts: `vertical: 8`, report: `all(16)`) is preserved exactly as before.

### Test plan
- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — full suite 6357 passed
- [x] Targeted: `test/features/alerts` + `test/features/report` — all green