### PR TITLE
refactor(ui): calculator + price_history + itineraries use PageScaffold (Refs #923 phase 3p)

### DIFF
--- a/lib/features/calculator/presentation/screens/calculator_screen.dart
+++ b/lib/features/calculator/presentation/screens/calculator_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/calculator_provider.dart';
 import '../widgets/calculator_empty_hint.dart';
@@ -59,15 +60,14 @@ class _CalculatorScreenState extends ConsumerState<CalculatorScreen> {
     final notifier = ref.read(calculatorProvider.notifier);
     final l10n = AppLocalizations.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n?.fuelCostCalculator ?? 'Fuel Cost Calculator'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l10n?.tooltipBack ?? 'Back',
-          onPressed: () => context.go('/'),
-        ),
+    return PageScaffold(
+      title: l10n?.fuelCostCalculator ?? 'Fuel Cost Calculator',
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: l10n?.tooltipBack ?? 'Back',
+        onPressed: () => context.go('/'),
       ),
+      bodyPadding: EdgeInsets.zero,
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/features/itinerary/presentation/screens/itineraries_screen.dart
+++ b/lib/features/itinerary/presentation/screens/itineraries_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/widgets/empty_state.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/swipe_to_delete.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -35,10 +36,9 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n?.savedRoutes ?? 'Saved Routes'),
-      ),
+    return PageScaffold(
+      title: l10n?.savedRoutes ?? 'Saved Routes',
+      bodyPadding: EdgeInsets.zero,
       body: itineraries.isEmpty
           ? EmptyState(
               icon: Icons.route,

--- a/lib/features/price_history/presentation/screens/price_history_screen.dart
+++ b/lib/features/price_history/presentation/screens/price_history_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../providers/price_history_provider.dart';
@@ -22,15 +23,14 @@ class PriceHistoryScreen extends ConsumerWidget {
 
     final l10n = AppLocalizations.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n?.priceHistory ?? 'Price History'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l10n?.tooltipBack ?? 'Back',
-          onPressed: () => context.pop(),
-        ),
+    return PageScaffold(
+      title: l10n?.priceHistory ?? 'Price History',
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: l10n?.tooltipBack ?? 'Back',
+        onPressed: () => context.pop(),
       ),
+      bodyPadding: EdgeInsets.zero,
       body: history.isEmpty
           ? Center(child: Text(l10n?.noPriceHistory ?? 'No price history yet'))
           : ListView(


### PR DESCRIPTION
Refs #923 phase 3p

## Summary

Migrates three small screens off bespoke `Scaffold(appBar: AppBar(...))` and onto the canonical `PageScaffold`:

- `lib/features/calculator/presentation/screens/calculator_screen.dart` — kept custom back-button leading + ListView body padding.
- `lib/features/price_history/presentation/screens/price_history_screen.dart` — kept custom back-button leading + empty-state center + ListView body padding.
- `lib/features/itinerary/presentation/screens/itineraries_screen.dart` — plain title + EmptyState/RefreshIndicator/ListView body.

All three pass `bodyPadding: EdgeInsets.zero` to preserve the existing inner ListView padding (16) and avoid double padding around full-bleed empty states.

## Why

Continues the design-system consolidation kicked off in #923 — every page chrome lives in one widget so a future visual change ships once.

## Testing

- `flutter analyze` — clean (no issues).
- `flutter test` — full suite green (6357 tests).

## Screenshots

No visual change — outer chrome is bytewise identical via `PageScaffold` (same `AppBar`, same back button, same body padding).