### PR TITLE
refactor(ui): sync screens use PageScaffold (Refs #923 phase 3r)

### DIFF
--- a/lib/features/sync/presentation/screens/auth_screen.dart
+++ b/lib/features/sync/presentation/screens/auth_screen.dart
@@ -6,6 +6,7 @@ import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/utils/password_validator.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/auth_form_provider.dart';
@@ -169,8 +170,9 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     final form = ref.watch(authFormControllerProvider);
     final isEmailUser = syncConfig.hasEmail;
 
-    return Scaffold(
-      appBar: AppBar(title: Text(l10n?.account ?? 'Account')),
+    return PageScaffold(
+      title: l10n?.account ?? 'Account',
+      bodyPadding: EdgeInsets.zero,
       body: ListView(
         padding: EdgeInsets.fromLTRB(
             16, 16, 16, 16 + MediaQuery.of(context).viewPadding.bottom),

--- a/lib/features/sync/presentation/screens/data_transparency_screen.dart
+++ b/lib/features/sync/presentation/screens/data_transparency_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/sync/sync_provider.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/data_transparency_provider.dart';
@@ -134,8 +135,9 @@ class DataTransparencyScreen extends ConsumerWidget {
     final uiState = ref.watch(dataTransparencyControllerProvider);
     final theme = Theme.of(context);
 
-    return Scaffold(
-      appBar: AppBar(title: Text(AppLocalizations.of(context)?.myServerData ?? 'My server data')),
+    return PageScaffold(
+      title: AppLocalizations.of(context)?.myServerData ?? 'My server data',
+      bodyPadding: EdgeInsets.zero,
       body: uiState.loading
           ? const Center(child: CircularProgressIndicator())
           : uiState.error != null

--- a/lib/features/sync/presentation/screens/link_device_screen.dart
+++ b/lib/features/sync/presentation/screens/link_device_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/sync/supabase_client.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../widgets/link_device_how_it_works_card.dart';
 import '../widgets/link_device_import_card.dart';
@@ -31,10 +32,9 @@ class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n?.linkDeviceScreenTitle ?? 'Link Device'),
-      ),
+    return PageScaffold(
+      title: l10n?.linkDeviceScreenTitle ?? 'Link Device',
+      bodyPadding: EdgeInsets.zero,
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/features/sync/presentation/screens/sync_setup_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_setup_screen.dart
@@ -9,6 +9,7 @@ import '../../providers/sync_setup_provider.dart';
 import '../widgets/auth_form_widget.dart';
 import '../widgets/qr_scanner_screen.dart';
 import '../widgets/sync_credentials_step.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../widgets/sync_done_step.dart';
@@ -131,18 +132,14 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
   @override
   Widget build(BuildContext context) {
     final setup = ref.watch(syncSetupControllerProvider);
-    return Scaffold(
-      appBar: AppBar(
-        title: Semantics(
-          header: true,
-          child: Text(_titleFor(setup.step, setup.selectedMode)),
-        ),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: _onBack,
-          tooltip: 'Back',
-        ),
+    return PageScaffold(
+      title: _titleFor(setup.step, setup.selectedMode),
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        onPressed: _onBack,
+        tooltip: 'Back',
       ),
+      bodyPadding: EdgeInsets.zero,
       body: AnimatedSwitcher(
         duration: const Duration(milliseconds: 250),
         child: _buildStep(setup),

--- a/lib/features/sync/presentation/screens/sync_wizard_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_wizard_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/utils/password_validator.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/sync/schema_verifier.dart';
@@ -100,23 +101,22 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
   @override
   Widget build(BuildContext context) {
     final wizard = ref.watch(syncWizardControllerProvider);
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Connect TankSync'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: AppLocalizations.of(context)?.tooltipBack ?? 'Back',
-          onPressed: () {
-            if (wizard.mode == SyncWizardMode.choose) {
-              Navigator.pop(context);
-            } else if (wizard.mode == SyncWizardMode.schema) {
-              _notifier.setMode(SyncWizardMode.auth);
-            } else {
-              _notifier.setMode(SyncWizardMode.choose);
-            }
-          },
-        ),
+    return PageScaffold(
+      title: 'Connect TankSync',
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: AppLocalizations.of(context)?.tooltipBack ?? 'Back',
+        onPressed: () {
+          if (wizard.mode == SyncWizardMode.choose) {
+            Navigator.pop(context);
+          } else if (wizard.mode == SyncWizardMode.schema) {
+            _notifier.setMode(SyncWizardMode.auth);
+          } else {
+            _notifier.setMode(SyncWizardMode.choose);
+          }
+        },
       ),
+      bodyPadding: EdgeInsets.zero,
       body: ListView(
         padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + MediaQuery.of(context).viewPadding.bottom),
         children: [


### PR DESCRIPTION
Refs #923 phase 3r

## What

Migrates all five sync feature screens off bespoke `Scaffold(appBar: AppBar(...))` onto the canonical `PageScaffold`:

| Screen | Notes |
|---|---|
| `auth_screen.dart` | Plain title, no leading — straightforward swap |
| `data_transparency_screen.dart` | Plain title — straightforward swap |
| `link_device_screen.dart` | Plain title — straightforward swap |
| `sync_setup_screen.dart` | Custom leading back button retained; dropped explicit `Semantics(header: true)` wrapper since `PageScaffold` already provides it |
| `sync_wizard_screen.dart` | Custom leading back button retained |

Each screen owns its own `ListView` padding (including `MediaQuery.viewPadding.bottom`), so `bodyPadding: EdgeInsets.zero` is passed through to avoid double-padding.

## Why

Phase 3r of the #923 design-system consolidation — collapse the three competing "outer chrome" conventions onto a single `PageScaffold` contract.

## Testing

- `flutter analyze` — zero warnings
- `flutter test` — 6470 pass, 1 skipped

No screens skipped — all five fit `PageScaffold`'s prop surface cleanly.