### PR TITLE
refactor(ui): three more screens use PageScaffold (Refs #923 phase 3s)

### DIFF
--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -7,6 +7,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import '../../../../core/error_tracing/storage/trace_storage.dart';
 import '../../../../core/export/data_exporter.dart';
 import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/privacy_data_provider.dart';
@@ -37,10 +38,9 @@ class _PrivacyDashboardScreenState
     final snapshot = ref.watch(privacyDataProvider);
     final l = AppLocalizations.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l?.privacyDashboardTitle ?? 'Privacy Dashboard'),
-      ),
+    return PageScaffold(
+      title: l?.privacyDashboardTitle ?? 'Privacy Dashboard',
+      bodyPadding: EdgeInsets.zero,
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/features/profile/presentation/screens/theme_settings_screen.dart
+++ b/lib/features/profile/presentation/screens/theme_settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/theme/theme_mode_provider.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Dedicated Theme settings screen (#897).
@@ -24,10 +25,9 @@ class ThemeSettingsScreen extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     final mode = ref.watch(themeModeSettingProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l?.themeSettingsScreenTitle ?? 'Theme'),
-      ),
+    return PageScaffold(
+      title: l?.themeSettingsScreenTitle ?? 'Theme',
+      bodyPadding: EdgeInsets.zero,
       body: RadioGroup<ThemeMode>(
         groupValue: mode,
         onChanged: (picked) => _select(ref, picked),

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -7,6 +7,7 @@ import '../../../../core/services/location_search_service.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/help_banner.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
@@ -134,15 +135,14 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final openOnly = ref.watch(openOnlyFilterProvider);
     final amenities = ref.watch(selectedAmenitiesProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n?.searchCriteriaTitle ?? 'Search criteria'),
-        leading: IconButton(
-          icon: const Icon(Icons.close),
-          tooltip: AppLocalizations.of(context)?.tooltipClose ?? 'Close',
-          onPressed: () => Navigator.of(context).pop(),
-        ),
+    return PageScaffold(
+      title: l10n?.searchCriteriaTitle ?? 'Search criteria',
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        tooltip: AppLocalizations.of(context)?.tooltipClose ?? 'Close',
+        onPressed: () => Navigator.of(context).pop(),
       ),
+      bodyPadding: EdgeInsets.zero,
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),


### PR DESCRIPTION
Refs #923 phase 3s — design-system consolidation, three more migrations.

## Migrations
- `lib/features/profile/presentation/screens/theme_settings_screen.dart` — `Scaffold` + `AppBar` -> `PageScaffold(title:)`. RadioGroup + ListView body preserved; `bodyPadding: EdgeInsets.zero` keeps the inner `EdgeInsets.all(16)` and viewPadding-aware spacer.
- `lib/features/profile/presentation/screens/privacy_dashboard_screen.dart` — same swap; ListView body unchanged.
- `lib/features/search/presentation/screens/search_criteria_screen.dart` — uses `PageScaffold(leading: IconButton(close))`; `SafeArea` + `SingleChildScrollView` body verbatim, padding `(16, 8, 16, 16)` preserved via `bodyPadding: EdgeInsets.zero`.

No screen was skipped — each AppBar fit the canonical props (title-only or title + custom leading).

## Why
Removes three more bespoke `Scaffold(appBar: AppBar(...), ...)` headers in favour of the single canonical chrome. Title gains the implicit `Semantics(header: true)` from `PageScaffold` for free.

## Testing
- `flutter analyze` — zero issues.
- `flutter test` — 6512 passed (full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)