### PR TITLE
refactor(ui): last AppBar sites migrated to PageScaffold (Refs #923 phase 3t)

### DIFF
--- a/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
@@ -6,6 +6,7 @@ import 'package:latlong2/latlong.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/location/user_position_provider.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Full-screen map-picker for choosing the center of a [RadiusAlert]
@@ -145,27 +146,23 @@ class _RadiusAlertMapPickerState extends ConsumerState<RadiusAlertMapPicker> {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          l10n?.radiusAlertMapPickerTitle ?? 'Pick alert center',
-        ),
-        leading: IconButton(
-          icon: const Icon(Icons.close),
-          tooltip:
-              l10n?.radiusAlertMapPickerCancel ?? 'Cancel',
-          onPressed: _cancel,
-        ),
-        actions: [
-          TextButton(
-            onPressed: _confirm,
-            child: Text(
-              l10n?.radiusAlertMapPickerConfirm ?? 'Confirm',
-              style: TextStyle(color: theme.colorScheme.onPrimary),
-            ),
-          ),
-        ],
+    return PageScaffold(
+      title: l10n?.radiusAlertMapPickerTitle ?? 'Pick alert center',
+      bodyPadding: EdgeInsets.zero,
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        tooltip: l10n?.radiusAlertMapPickerCancel ?? 'Cancel',
+        onPressed: _cancel,
       ),
+      actions: [
+        TextButton(
+          onPressed: _confirm,
+          child: Text(
+            l10n?.radiusAlertMapPickerConfirm ?? 'Confirm',
+            style: TextStyle(color: theme.colorScheme.onPrimary),
+          ),
+        ),
+      ],
       body: Stack(
         alignment: Alignment.center,
         children: [

--- a/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../consumption/presentation/screens/add_charging_log_screen.dart';
 import '../../../favorites/providers/favorites_provider.dart';
@@ -25,34 +26,33 @@ class EvStationDetailScreen extends ConsumerWidget {
     final theme = Theme.of(context);
     final isFav = ref.watch(isFavoriteProvider(station.id));
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(station.name),
-        actions: [
-          IconButton(
-            icon: Icon(
-              isFav ? Icons.star : Icons.star_border,
-              color: isFav ? Colors.amber : null,
-            ),
-            tooltip: isFav
-                ? (l10n?.removeFavorite ?? 'Remove from favorites')
-                : (l10n?.addFavorite ?? 'Add to favorites'),
-            onPressed: () async {
-              // Await the toggle so the snackbar lies become impossible
-              // and the isFavoriteProvider has flipped before we show
-              // any feedback (#566).
-              await ref
-                  .read(favoritesProvider.notifier)
-                  .toggle(station.id, rawJson: station.toJson());
-              if (!context.mounted) return;
-              final msg = isFav
-                  ? (l10n?.removedFromFavorites ?? 'Removed from favorites')
-                  : (l10n?.addedToFavorites ?? 'Added to favorites');
-              SnackBarHelper.show(context, msg);
-            },
+    return PageScaffold(
+      title: station.name,
+      bodyPadding: EdgeInsets.zero,
+      actions: [
+        IconButton(
+          icon: Icon(
+            isFav ? Icons.star : Icons.star_border,
+            color: isFav ? Colors.amber : null,
           ),
-        ],
-      ),
+          tooltip: isFav
+              ? (l10n?.removeFavorite ?? 'Remove from favorites')
+              : (l10n?.addFavorite ?? 'Add to favorites'),
+          onPressed: () async {
+            // Await the toggle so the snackbar lies become impossible
+            // and the isFavoriteProvider has flipped before we show
+            // any feedback (#566).
+            await ref
+                .read(favoritesProvider.notifier)
+                .toggle(station.id, rawJson: station.toJson());
+            if (!context.mounted) return;
+            final msg = isFav
+                ? (l10n?.removedFromFavorites ?? 'Removed from favorites')
+                : (l10n?.addedToFavorites ?? 'Added to favorites');
+            SnackBarHelper.show(context, msg);
+          },
+        ),
+      ],
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -6,6 +6,7 @@ import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/widgets/star_rating.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../consumption/presentation/screens/add_charging_log_screen.dart';
 import '../../../ev/domain/entities/charging_station.dart';
@@ -102,62 +103,61 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
     final station = _station;
 
     final operatorName = station.operator ?? '';
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(operatorName.isNotEmpty ? operatorName : station.name),
-        actions: [
-          Consumer(builder: (context, ref, _) {
-            final isFav = ref.watch(isFavoriteProvider(station.id));
-            return IconButton(
-              icon: Icon(
-                isFav ? Icons.star : Icons.star_outline,
-                color: isFav ? Colors.amber : Colors.white70,
-                size: 26,
-              ),
-              tooltip: isFav ? (l10n?.removeFavorite ?? 'Remove from favorites') : (l10n?.addFavorite ?? 'Add to favorites'),
-              onPressed: () async {
-                // Await the toggle so the snackbar fires AFTER persistence
-                // and the isFavoriteProvider has flipped. Otherwise a quick
-                // back-navigation can cancel the in-flight Hive write and
-                // leave the favorite half-persisted (#566).
-                await ref.read(favoritesProvider.notifier).toggle(
-                      station.id,
-                      rawJson: station.toJson(),
-                    );
-                if (!context.mounted) return;
-                // Temporary diagnostic: surface live storage counts in the
-                // snackbar so a user on an APK without logcat can verify
-                // the favorite actually persisted.
-                final storage = ref.read(storageRepositoryProvider);
-                final evIds = storage.getEvFavoriteIds();
-                final savedCount = evIds
-                    .where((id) => storage.getEvFavoriteStationData(id) != null)
-                    .length;
-                final base = isFav
-                    ? (l10n?.removedFromFavorites ?? 'Removed from favorites')
-                    : (l10n?.addedToFavorites ?? 'Added to favorites');
-                SnackBarHelper.show(
-                  context,
-                  '$base (EV: ${evIds.length} ids / $savedCount saved)',
-                  duration: const Duration(seconds: 3),
-                );
-              },
-            );
-          }),
-          IconButton(
-            icon: _isRefreshing
-                ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white70))
-                : const Icon(Icons.refresh),
-            tooltip: l10n?.evRefreshStatus ?? 'Refresh status',
-            onPressed: _isRefreshing ? null : _refreshStation,
-          ),
-          IconButton(
-            icon: const Icon(Icons.navigation),
-            tooltip: l10n?.navigate ?? 'Navigate',
-            onPressed: _navigateToStation,
-          ),
-        ],
-      ),
+    return PageScaffold(
+      title: operatorName.isNotEmpty ? operatorName : station.name,
+      bodyPadding: EdgeInsets.zero,
+      actions: [
+        Consumer(builder: (context, ref, _) {
+          final isFav = ref.watch(isFavoriteProvider(station.id));
+          return IconButton(
+            icon: Icon(
+              isFav ? Icons.star : Icons.star_outline,
+              color: isFav ? Colors.amber : Colors.white70,
+              size: 26,
+            ),
+            tooltip: isFav ? (l10n?.removeFavorite ?? 'Remove from favorites') : (l10n?.addFavorite ?? 'Add to favorites'),
+            onPressed: () async {
+              // Await the toggle so the snackbar fires AFTER persistence
+              // and the isFavoriteProvider has flipped. Otherwise a quick
+              // back-navigation can cancel the in-flight Hive write and
+              // leave the favorite half-persisted (#566).
+              await ref.read(favoritesProvider.notifier).toggle(
+                    station.id,
+                    rawJson: station.toJson(),
+                  );
+              if (!context.mounted) return;
+              // Temporary diagnostic: surface live storage counts in the
+              // snackbar so a user on an APK without logcat can verify
+              // the favorite actually persisted.
+              final storage = ref.read(storageRepositoryProvider);
+              final evIds = storage.getEvFavoriteIds();
+              final savedCount = evIds
+                  .where((id) => storage.getEvFavoriteStationData(id) != null)
+                  .length;
+              final base = isFav
+                  ? (l10n?.removedFromFavorites ?? 'Removed from favorites')
+                  : (l10n?.addedToFavorites ?? 'Added to favorites');
+              SnackBarHelper.show(
+                context,
+                '$base (EV: ${evIds.length} ids / $savedCount saved)',
+                duration: const Duration(seconds: 3),
+              );
+            },
+          );
+        }),
+        IconButton(
+          icon: _isRefreshing
+              ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white70))
+              : const Icon(Icons.refresh),
+          tooltip: l10n?.evRefreshStatus ?? 'Refresh status',
+          onPressed: _isRefreshing ? null : _refreshStation,
+        ),
+        IconButton(
+          icon: const Icon(Icons.navigation),
+          tooltip: l10n?.navigate ?? 'Navigate',
+          onPressed: _navigateToStation,
+        ),
+      ],
       body: ListView(
         padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + MediaQuery.of(context).viewPadding.bottom + 24),
         children: [

--- a/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
+++ b/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../../../core/permissions/camera_permissions.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Full-screen QR code scanner for scanning TankSync credentials and
@@ -127,18 +128,17 @@ class _QrScannerScreenState extends State<QrScannerScreen> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n?.syncWizardScanQrCode ?? 'Scan QR Code'),
-        actions: _phase == _ScannerPhase.scanning
-            ? [
-                QrScannerTorchButton(
-                  state: _controller,
-                  onToggle: _controller.toggleTorch,
-                ),
-              ]
-            : null,
-      ),
+    return PageScaffold(
+      title: l10n?.syncWizardScanQrCode ?? 'Scan QR Code',
+      bodyPadding: EdgeInsets.zero,
+      actions: _phase == _ScannerPhase.scanning
+          ? [
+              QrScannerTorchButton(
+                state: _controller,
+                onToggle: _controller.toggleTorch,
+              ),
+            ]
+          : null,
       body: _buildBody(l10n),
     );
   }


### PR DESCRIPTION
Refs #923 phase 3t

## What

Migrates the final batch of feature-level `Scaffold(appBar: AppBar(...))` sites to `PageScaffold`. After this, every active screen except the deferred `station_detail_screen.dart` (needs a `Widget`-typed title variant) lands on canonical chrome.

## Migration summary

- `lib/features/search/presentation/screens/ev_station_detail_screen.dart` — operator-as-title + 3 trailing actions (favorite, refresh, navigate). Body is a `ListView` keeping its own padding (the `+ viewPadding.bottom + 24` accounts for system nav).
- `lib/features/ev/presentation/screens/ev_station_detail_screen.dart` — station name + favorite-toggle action. Note: this duplicates the `search/` variant (router uses the search one, only `ev_map_overlay.dart` reaches this one). Flagging it for a separate dedupe PR — NOT touched here.
- `lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart` — custom `IconButton(close)` leading via `PageScaffold.leading` + `Confirm` `TextButton` action. Body keeps its full-bleed `Stack` (`bodyPadding: EdgeInsets.zero`).
- `lib/features/sync/presentation/widgets/qr_scanner_screen.dart` — conditional torch action; body is a phase-driven `Stack` (camera + scrim) with its own internal padding.

All four use `bodyPadding: EdgeInsets.zero` because each body widget owns its padding. No AppBar had `flexibleSpace`, transparent background, or `Semantics`-wrapped title `Widget`, so all four fit `PageScaffold`'s `String title` contract.

## Why

Closes the last gap in the #923 design-system rollout for non-`station_detail` screens.

## Testing

- `flutter analyze` → No issues found
- `flutter test` → All 6512 tests passed (no regressions; existing `find.byType(AppBar)` queries continue to work since `PageScaffold` renders an internal `AppBar`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)