### PR TITLE
test(design-system): static-scan lints lock canonical widgets (#923 final)

### DIFF
--- a/test/lint/no_inline_title_theme_test.dart
+++ b/test/lint/no_inline_title_theme_test.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#923 final): feature `presentation/
+/// screens/` files MUST NOT reach for `textTheme.titleMedium`,
+/// `textTheme.titleLarge`, or `textTheme.headlineSmall` directly when
+/// rendering a section heading. Use `SectionHeader`
+/// (`lib/core/widgets/section_header.dart`) instead.
+///
+/// The design-system epic (#923) collapsed 60+ inline title-theme
+/// `copyWith(...)` callsites onto a single canonical heading widget so
+/// that font weight, padding, semantic role, and dark-mode tinting stay
+/// consistent. This scan locks in the migration: once a screen ships a
+/// new inline `textTheme.titleX` style, the test trips and the author
+/// has to use `SectionHeader` (or, for the rare value-display case,
+/// document the reason in the allowlist below).
+///
+/// Scope: only `lib/features/**/presentation/screens/*.dart`. Widget
+/// files (`presentation/widgets/`) hold the inner-card / value-display
+/// styles that are NOT section headers, so the rule does not extend
+/// to them — they get reviewed individually.
+///
+/// The allowlist below is the closed set of pre-existing screen-level
+/// title-theme uses that survived #923's migration. Each entry cites
+/// the line, the style, and the reason it isn't a section header (or
+/// is a deferred case). New entries must follow the same comment
+/// format — adding an unexplained allowlist entry defeats the lint.
+void main() {
+  test(
+    'no inline `textTheme.titleMedium / titleLarge / headlineSmall` in '
+    'lib/features/**/presentation/screens/*.dart (#923 final)',
+    () {
+      // Path : rationale-comment map. The map preserves the
+      // grep-derived list of pre-existing legitimate uses; everything
+      // not in the map is either a section header (use SectionHeader)
+      // or deferred (file-level entry with a #923-deferred citation).
+      // Each entry is a pre-existing legitimate use surfaced when this
+      // lint first ran against master. The grouped block below is the
+      // running rationale list — keep adjacent to the Set so future
+      // additions stay justified.
+      //
+      // - carbon_dashboard_screen.dart  : `titleLarge` for big total
+      //   cost / total CO2 numbers on two SectionCards. Numeric
+      //   value emphasis, not a heading.
+      // - ev/ev_station_detail_screen.dart : `titleMedium` "Connectors"
+      //   label. Migration to SectionHeader tracked as #923-followup.
+      // - alerts_screen.dart : `titleMedium` "Radius alerts (n)"
+      //   header with a trailing IconButton. Migration to
+      //   SectionHeader.trailing tracked as #923-followup.
+      // - price_history_screen.dart : `titleMedium` fuel-type display
+      //   inside a card. Value display, not a heading.
+      // - add_charging_log_screen.dart : `headlineSmall` centered
+      //   empty-state ("Add a vehicle first"). Empty states use a
+      //   larger style than SectionHeader.
+      // - trip_detail_screen.dart : `titleMedium` "Summary" inside a
+      //   SectionCard with its own padding. Migration tracked as
+      //   #923-followup.
+      // - trip_recording_screen.dart : `titleLarge` for big metric
+      //   values (distance, duration). Value display, not a heading.
+      // - add_fill_up_screen.dart : `headlineSmall` empty state +
+      //   `titleMedium` station-name confirmation row. Both
+      //   value/empty displays, not section headers.
+      // - search/ev_station_detail_screen.dart : `titleMedium`
+      //   "Your rating" tile label inside a Card. Migration tracked
+      //   separately.
+      // - station_detail_screen.dart : deferred — needs PageScaffold
+      //   `title: Widget` variant (#923-deferred). Two uses:
+      //   `titleLarge` in Hero flight + `titleMedium` "Price History"
+      //   section header.
+      const allowlist = <String>{
+        'lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart',
+        'lib/features/ev/presentation/screens/ev_station_detail_screen.dart',
+        'lib/features/alerts/presentation/screens/alerts_screen.dart',
+        'lib/features/price_history/presentation/screens/price_history_screen.dart',
+        'lib/features/consumption/presentation/screens/add_charging_log_screen.dart',
+        'lib/features/consumption/presentation/screens/trip_detail_screen.dart',
+        'lib/features/consumption/presentation/screens/trip_recording_screen.dart',
+        'lib/features/consumption/presentation/screens/add_fill_up_screen.dart',
+        'lib/features/search/presentation/screens/ev_station_detail_screen.dart',
+        'lib/features/station_detail/presentation/screens/station_detail_screen.dart',
+      };
+
+      final re = RegExp(
+        r'textTheme\.(titleMedium|titleLarge|headlineSmall)\b',
+      );
+
+      final offenders = <String>[];
+      for (final entity
+          in Directory('lib/features').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('.g.dart') ||
+            entity.path.endsWith('.freezed.dart')) {
+          continue;
+        }
+        final posix = entity.path.replaceAll('\\', '/');
+        if (!posix.contains('/presentation/screens/')) continue;
+        if (allowlist.any(posix.endsWith)) continue;
+
+        final src = entity.readAsStringSync();
+        for (final m in re.allMatches(src)) {
+          final line = src.substring(0, m.start).split('\n').length;
+          offenders.add('$posix:$line  ${m.group(0)}');
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'Inline textTheme.title* / headlineSmall found. Use '
+            'SectionHeader (lib/core/widgets/section_header.dart). '
+            'See #923. Offending sites:\n${offenders.join("\n")}',
+      );
+    },
+  );
+}

--- a/test/lint/no_raw_appbar_in_features_test.dart
+++ b/test/lint/no_raw_appbar_in_features_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#923 final): feature presentation files
+/// MUST use `PageScaffold` (`lib/core/widgets/page_scaffold.dart`) instead
+/// of a raw `Scaffold(appBar: AppBar(...))` pattern.
+///
+/// The design-system epic (#923) migrated every feature screen across
+/// phases 3a–3t. This scan locks the migration in: a future PR that
+/// reaches for the bare `AppBar` constructor inside
+/// `lib/features/**/presentation/` trips the test and is forced back
+/// onto `PageScaffold` (which already centralises title/leading/actions
+/// styling, system-nav padding, and bottom-sheet helpers).
+///
+/// Allowlist: `lib/features/station_detail/presentation/screens/
+/// station_detail_screen.dart` is the one screen still on raw `AppBar`.
+/// It uses a `Hero`-flighted custom title widget, which `PageScaffold`
+/// cannot express until the `title: Widget` variant lands (deferred,
+/// tracked separately under #923-deferred). When that variant ships,
+/// remove the entry below.
+void main() {
+  test(
+    'no raw `appBar: AppBar(...)` in lib/features/**/presentation '
+    '(#923 final)',
+    () {
+      // Posix paths so the allowlist matches on every host OS.
+      // Deferred — needs PageScaffold `title: Widget` variant for the
+      // Hero-flighted station-name title. See #923-deferred.
+      const allowlist = <String>{
+        'lib/features/station_detail/presentation/screens/station_detail_screen.dart',
+      };
+
+      // Match `appBar: AppBar(` with optional whitespace. Paired
+      // constructor-name boundary: an identifier char before `AppBar`
+      // would mean a subclass like `MyAppBar` and is allowed.
+      final re = RegExp(r'appBar:\s*(?<![A-Za-z0-9_])AppBar\b');
+
+      final offenders = <String>[];
+      for (final entity
+          in Directory('lib/features').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('.g.dart') ||
+            entity.path.endsWith('.freezed.dart')) {
+          continue;
+        }
+        final posix = entity.path.replaceAll('\\', '/');
+        // Scope: only presentation/screens/* and presentation/widgets/*
+        // — providers/models/data files have no UI.
+        final inScope = posix.contains('/presentation/screens/') ||
+            posix.contains('/presentation/widgets/');
+        if (!inScope) continue;
+        if (allowlist.any(posix.endsWith)) continue;
+
+        final src = entity.readAsStringSync();
+        for (final m in re.allMatches(src)) {
+          final line = src.substring(0, m.start).split('\n').length;
+          offenders.add('$posix:$line  ${m.group(0)}');
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'Raw AppBar found in feature presentation file. Use '
+            'PageScaffold (lib/core/widgets/page_scaffold.dart) instead. '
+            'See docs/design/DESIGN_SYSTEM.md and #923. Offending sites:\n'
+            '${offenders.join("\n")}',
+      );
+    },
+  );
+}

--- a/test/lint/no_raw_card_in_features_test.dart
+++ b/test/lint/no_raw_card_in_features_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#923 final): feature `presentation/
+/// screens/` files MUST use `SectionCard`
+/// (`lib/core/widgets/section_card.dart`) instead of the bare Material
+/// `Card(...)` constructor.
+///
+/// The design-system epic (#923) phases 3a–3t replaced inline `Card(...)`
+/// calls in feature screens with `SectionCard`, which gives consistent
+/// elevation, padding, and dark-mode tinting. Reaching for the raw
+/// `Card` constructor in `lib/features/**/presentation/screens/` trips
+/// this scan, sending the author back to `SectionCard`.
+///
+/// Scope is intentionally narrowed to `presentation/screens/`. Reusable
+/// card-widget primitives in `presentation/widgets/` (the dozens of
+/// files named `*_card.dart`) ARE cards by contract — wrapping them in
+/// SectionCard would be redundant or wrong. Those primitives stay on
+/// raw `Card` because they implement the visual card themselves; the
+/// rule applies to consumers (the screens), not the primitives.
+///
+/// Regex: `(?<![A-Za-z0-9_])Card\s*\(` — token-boundary before `Card`
+/// so subclass calls (`StationCard`, `_StatCard`, `SectionCard`,
+/// `ChargingCard`, …) are not matched. Adjacent identifier characters
+/// disqualify a match.
+///
+/// The allowlist below pins the closed set of pre-existing screen-level
+/// `Card(...)` uses that survived #923's migration. Each entry cites
+/// the file and reason. Adding a new file requires the same
+/// justification — adding an unexplained allowlist entry defeats the
+/// lint.
+void main() {
+  test(
+    'no raw `Card(...)` in lib/features/**/presentation/screens/*.dart '
+    '(#923 final)',
+    () {
+      // Pre-existing legitimate raw `Card` uses in feature screens. All
+      // are followups tracked under #923-followup; allowlisting locks
+      // in the post-3a–3t baseline so the rest of the codebase stays
+      // enforced.
+      //
+      // - gdpr_consent_screen.dart   : consent-step explanatory card.
+      // - consumption_screen.dart    : two charging-charts cards.
+      // - trip_detail_screen.dart    : trip-summary card.
+      // - trip_recording_screen.dart : recording-controls card.
+      // - ev/ev_station_detail_screen.dart : connectors/info card.
+      // - price_history_screen.dart  : per-fuel-type chart card.
+      // - profile_screen.dart        : profile header card.
+      // - theme_settings_screen.dart : theme-preview card.
+      // - search/ev_station_detail_screen.dart : rating tile card.
+      // - sync/auth_screen.dart      : account-mode card.
+      const allowlist = <String>{
+        'lib/features/consent/presentation/screens/gdpr_consent_screen.dart',
+        'lib/features/consumption/presentation/screens/consumption_screen.dart',
+        'lib/features/consumption/presentation/screens/trip_detail_screen.dart',
+        'lib/features/consumption/presentation/screens/trip_recording_screen.dart',
+        'lib/features/ev/presentation/screens/ev_station_detail_screen.dart',
+        'lib/features/price_history/presentation/screens/price_history_screen.dart',
+        'lib/features/profile/presentation/screens/profile_screen.dart',
+        'lib/features/profile/presentation/screens/theme_settings_screen.dart',
+        'lib/features/search/presentation/screens/ev_station_detail_screen.dart',
+        'lib/features/sync/presentation/screens/auth_screen.dart',
+      };
+
+      // Match the bare Material `Card(` constructor — any preceding
+      // identifier character disqualifies the match, so subclass calls
+      // (`StationCard(`, `SectionCard(`, …) are not flagged.
+      final re = RegExp(r'(?<![A-Za-z0-9_])Card\s*\(');
+
+      final offenders = <String>[];
+      for (final entity
+          in Directory('lib/features').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('.g.dart') ||
+            entity.path.endsWith('.freezed.dart')) {
+          continue;
+        }
+        final posix = entity.path.replaceAll('\\', '/');
+        if (!posix.contains('/presentation/screens/')) continue;
+        if (allowlist.any(posix.endsWith)) continue;
+
+        final src = entity.readAsStringSync();
+        for (final m in re.allMatches(src)) {
+          final line = src.substring(0, m.start).split('\n').length;
+          offenders.add('$posix:$line  ${m.group(0)}');
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'Raw Card() found. Use SectionCard '
+            '(lib/core/widgets/section_card.dart). See #923. '
+            'Offending sites:\n${offenders.join("\n")}',
+      );
+    },
+  );
+}

--- a/test/lint/tab_switcher_canonical_test.dart
+++ b/test/lint/tab_switcher_canonical_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#923 final): feature presentation files
+/// MUST use `TabSwitcher` (`lib/core/widgets/tab_switcher.dart`) or
+/// Material `SegmentedButton` instead of the raw Material `TabBar`
+/// constructor.
+///
+/// `TabSwitcher` enforces the canonical chip-style segmented selector
+/// the design system uses for in-page navigation. Reaching for the raw
+/// `TabBar` constructor reintroduces the underline-style tab the epic
+/// (#923) specifically deprecated.
+///
+/// Allowlist: `lib/features/carbon/presentation/screens/
+/// carbon_dashboard_screen.dart` keeps `TabBar` intentionally — the
+/// segmented-button pattern was inappropriate for that screen's tab
+/// semantics (Charts / Achievements pair with `TabBarView` content).
+/// Decision recorded in phase 3c of the epic.
+///
+/// The regex `(?<![A-Za-z0-9_])TabBar\s*\(` matches the constructor
+/// call only — `TabBarView(`, `TabBarTheme(`, and identifiers like
+/// `MyTabBar(` are excluded by the trailing `\s*\(` (which requires
+/// the next non-whitespace token to be `(`) and the leading negative
+/// look-behind.
+void main() {
+  test(
+    'no raw `TabBar(...)` in lib/features/**/presentation (#923 final)',
+    () {
+      // Carbon dashboard intentionally uses TabBar — phase 3c of #923
+      // reviewed and ratified this exception. The Charts /
+      // Achievements pair maps to a TabBarView and the underline
+      // affordance suits the screen better than TabSwitcher's chip
+      // pattern.
+      const allowlist = <String>{
+        'lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart',
+      };
+
+      // `TabBar(` only — TabBarView is excluded because the `View`
+      // characters force `\s*\(` to fail.
+      final re = RegExp(r'(?<![A-Za-z0-9_])TabBar\s*\(');
+
+      final offenders = <String>[];
+      for (final entity
+          in Directory('lib/features').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('.g.dart') ||
+            entity.path.endsWith('.freezed.dart')) {
+          continue;
+        }
+        final posix = entity.path.replaceAll('\\', '/');
+        final inScope = posix.contains('/presentation/screens/') ||
+            posix.contains('/presentation/widgets/');
+        if (!inScope) continue;
+        if (allowlist.any(posix.endsWith)) continue;
+
+        final src = entity.readAsStringSync();
+        for (final m in re.allMatches(src)) {
+          final line = src.substring(0, m.start).split('\n').length;
+          offenders.add('$posix:$line  ${m.group(0)}');
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'Raw TabBar found. Use TabSwitcher '
+            '(lib/core/widgets/tab_switcher.dart) or SegmentedButton. '
+            'See #923. Offending sites:\n${offenders.join("\n")}',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Final phase of the #923 design-system epic. Adds four static-scan lint
tests in `test/lint/` so future PRs can't reintroduce raw AppBar / Card /
inline `textTheme.title*` / raw TabBar in feature presentation code.

- `no_raw_appbar_in_features_test.dart` — bans `appBar: AppBar(...)`. Allowlists `station_detail_screen.dart` (deferred — needs PageScaffold `title: Widget` variant).
- `no_raw_card_in_features_test.dart` — bans bare `Card(...)` in feature screens. Reusable card-widget primitives (`presentation/widgets/*_card.dart`) intentionally stay on raw `Card`. Pre-existing 10 screen-level uses allowlisted.
- `no_inline_title_theme_test.dart` — bans `textTheme.titleMedium / titleLarge / headlineSmall` in feature screens. Pre-existing legitimate uses (value displays, empty-state heads, followups) allowlisted with per-file rationale.
- `tab_switcher_canonical_test.dart` — bans raw `TabBar(...)`. Allowlists `carbon_dashboard_screen.dart` (intentional — phase 3c).

Token-boundary regexes (`(?<![A-Za-z0-9_])`) keep subclass calls (`StationCard(`, `SectionCard(`, `TabBarView(`) unaffected.

## Why

Without these scans, future PRs silently reintroduce the patterns the epic spent phases 3a–3t replacing. The test/lint/ pattern is the project's canonical defense: see `no_silent_catch_test.dart` and `retry_tile_provider_call_site_test.dart` for prior art.

## Testing

- `flutter analyze` — no issues found.
- `flutter test test/lint/` — all 27 tests pass (4 new + 23 existing).
- `flutter test` — full suite green (6522 passed, 1 skipped).

## Issue closure

Closes #923 — design-system epic complete. Static scans now enforce canonical widget usage in feature presentation code.

Phases shipped: 1 (doc #925), 2 (canonical widgets #927), 3a–3t (every feature screen migrated), final (lint tests, this PR).

PageScaffold extensions shipped: toolbarHeight (#937), floatingActionButton (#941), titleTextStyle + titleSpacing (#943), leading (#958), bottom (#966).

Deferred: `station_detail_screen.dart` — needs PageScaffold `title: Widget` variant (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)