### PR TITLE
feat(ui): PageScaffold titleWidget + StationDetailScreen migration (Refs #923)

### DIFF
--- a/docs/design/DESIGN_SYSTEM.md
+++ b/docs/design/DESIGN_SYSTEM.md
@@ -216,8 +216,15 @@ screen is about" identified in the #923 audit.
 
 **Props:**
 
-- **required** `title: String` — `pageTitle` role. Renders in the
-  `AppBar`.
+- `title: String?` — `pageTitle` role. Renders in the `AppBar` wrapped
+  in `Semantics(header: true, …)`. Mutually exclusive with
+  `titleWidget`: pass exactly one. The `bannerIcon` slot also requires
+  this string variant since the banner shows the title text.
+- `titleWidget: Widget?` — escape hatch for screens whose title cannot
+  be expressed as plain text (e.g. `StationDetailScreen`'s
+  Hero-flighted brand-header composition). Mutually exclusive with
+  `title`. The caller owns the title's semantics (header role,
+  ellipsis, etc.) when this slot is used.
 - `subtitle: String?` — optional second line under the app-bar title.
 - `bannerIcon: IconData?` — when non-null, renders a primary-tinted
   banner strip below the app bar carrying the icon + `title` +

--- a/lib/core/widgets/page_scaffold.dart
+++ b/lib/core/widgets/page_scaffold.dart
@@ -10,9 +10,19 @@ import '../theme/spacing.dart';
 /// strip à la `ThemeSettingsScreen`, ad-hoc hero row). See
 /// `docs/design/DESIGN_SYSTEM.md` §"PageScaffold" for the contract.
 class PageScaffold extends StatelessWidget {
-  /// App-bar title. Required — every page has a title in the
-  /// `pageTitle` role.
-  final String title;
+  /// App-bar title. Used unless [titleWidget] is provided. Mutually
+  /// exclusive with [titleWidget] — exactly one of the two must be
+  /// non-null. Renders in the `pageTitle` role wrapped in
+  /// `Semantics(header: true, …)`.
+  final String? title;
+
+  /// Custom title widget — escape hatch for screens whose title cannot
+  /// be expressed as plain text (e.g. `StationDetailScreen`'s
+  /// Hero-flighted brand-header composition). Mutually exclusive with
+  /// [title]: pass exactly one. The caller is responsible for the
+  /// title's semantics (header role, ellipsis, etc.) when this slot is
+  /// used.
+  final Widget? titleWidget;
 
   /// Optional subtitle — rendered inside the banner (if [bannerIcon]
   /// is set). When [bannerIcon] is null the subtitle is ignored
@@ -90,7 +100,8 @@ class PageScaffold extends StatelessWidget {
 
   const PageScaffold({
     super.key,
-    required this.title,
+    this.title,
+    this.titleWidget,
     required this.body,
     this.subtitle,
     this.bannerIcon,
@@ -105,14 +116,23 @@ class PageScaffold extends StatelessWidget {
     this.titleSpacing,
     this.bottomNavigationBar,
     this.bottom,
-  });
+  })  : assert(
+          title != null || titleWidget != null,
+          'PageScaffold requires either `title` or `titleWidget` to be '
+          'non-null.',
+        ),
+        assert(
+          bannerIcon == null || title != null,
+          'PageScaffold(bannerIcon: …) requires `title` (the banner '
+          'shows the title text). Drop the banner or pass `title`.',
+        );
 
   @override
   Widget build(BuildContext context) {
     final effectivePadding = bodyPadding ?? Spacing.screenPadding;
     return Scaffold(
       appBar: AppBar(
-        title: Semantics(header: true, child: Text(title)),
+        title: titleWidget ?? Semantics(header: true, child: Text(title!)),
         actions: actions,
         leading: leading,
         automaticallyImplyLeading: automaticallyImplyLeading,
@@ -126,7 +146,7 @@ class PageScaffold extends StatelessWidget {
           if (bannerIcon != null)
             _PageBanner(
               icon: bannerIcon!,
-              title: title,
+              title: title!,
               subtitle: subtitle,
             ),
           Expanded(

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/station.dart';
@@ -33,51 +34,49 @@ class StationDetailScreen extends ConsumerWidget {
         ? (hasRealBrand(station) ? station.brand : station.street)
         : (AppLocalizations.of(context)?.search ?? 'Station');
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Semantics(
-          header: true,
-          child: Hero(
-            tag: 'station-name-$stationId',
-            flightShuttleBuilder:
-                (ctx, animation, direction, fromCtx, toCtx) {
-              final theme = Theme.of(ctx);
-              return Material(
-                type: MaterialType.transparency,
-                child: DefaultTextStyle(
-                  style: theme.appBarTheme.titleTextStyle ??
-                      theme.textTheme.titleLarge ??
-                      const TextStyle(fontWeight: FontWeight.bold),
-                  child: Text(
-                    appBarTitle,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              );
-            },
-            child: Material(
+    return PageScaffold(
+      titleWidget: Semantics(
+        header: true,
+        child: Hero(
+          tag: 'station-name-$stationId',
+          flightShuttleBuilder: (ctx, animation, direction, fromCtx, toCtx) {
+            final theme = Theme.of(ctx);
+            return Material(
               type: MaterialType.transparency,
-              child: Text(
-                appBarTitle,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+              child: DefaultTextStyle(
+                style: theme.appBarTheme.titleTextStyle ??
+                    theme.textTheme.titleLarge ??
+                    const TextStyle(fontWeight: FontWeight.bold),
+                child: Text(
+                  appBarTitle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
+            );
+          },
+          child: Material(
+            type: MaterialType.transparency,
+            child: Text(
+              appBarTitle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
           ),
         ),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
-          tooltip: AppLocalizations.of(context)?.tooltipBack ?? 'Back',
-        ),
-        actions: [
-          StationDetailAppBarActions(
-            stationId: stationId,
-            station: station,
-          ),
-        ],
       ),
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        onPressed: () => context.pop(),
+        tooltip: AppLocalizations.of(context)?.tooltipBack ?? 'Back',
+      ),
+      actions: [
+        StationDetailAppBarActions(
+          stationId: stationId,
+          station: station,
+        ),
+      ],
+      bodyPadding: EdgeInsets.zero,
       body: detailAsync.when(
         data: (result) => Column(
           children: [

--- a/test/core/widgets/page_scaffold_test.dart
+++ b/test/core/widgets/page_scaffold_test.dart
@@ -234,6 +234,62 @@ void main() {
       expect(tapped, isTrue);
     });
 
+    testWidgets('renders titleWidget when provided', (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          titleWidget: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.local_gas_station, key: Key('brand_icon')),
+              SizedBox(width: 8),
+              Text('Custom Brand Title'),
+            ],
+          ),
+          body: SizedBox.shrink(),
+        ),
+      );
+      // The custom title widget renders inside the AppBar.
+      final appBarFinder = find.byType(AppBar);
+      expect(appBarFinder, findsOneWidget);
+      expect(
+        find.descendant(
+          of: appBarFinder,
+          matching: find.byKey(const Key('brand_icon')),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: appBarFinder,
+          matching: find.text('Custom Brand Title'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('titleWidget wins when both title and titleWidget are passed',
+        (tester) async {
+      await pump(
+        tester,
+        const PageScaffold(
+          title: 'Plain title',
+          titleWidget: Text('Widget title', key: Key('title_widget')),
+          body: SizedBox.shrink(),
+        ),
+      );
+      // titleWidget takes precedence; the plain `title` is not rendered.
+      expect(find.byKey(const Key('title_widget')), findsOneWidget);
+      expect(find.text('Plain title'), findsNothing);
+    });
+
+    test('assertion fires when both title and titleWidget are null', () {
+      expect(
+        () => PageScaffold(body: const SizedBox.shrink()),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
     testWidgets('title has header semantics', (tester) async {
       final handle = tester.ensureSemantics();
       await pump(

--- a/test/lint/no_raw_appbar_in_features_test.dart
+++ b/test/lint/no_raw_appbar_in_features_test.dart
@@ -13,23 +13,18 @@ import 'package:flutter_test/flutter_test.dart';
 /// onto `PageScaffold` (which already centralises title/leading/actions
 /// styling, system-nav padding, and bottom-sheet helpers).
 ///
-/// Allowlist: `lib/features/station_detail/presentation/screens/
-/// station_detail_screen.dart` is the one screen still on raw `AppBar`.
-/// It uses a `Hero`-flighted custom title widget, which `PageScaffold`
-/// cannot express until the `title: Widget` variant lands (deferred,
-/// tracked separately under #923-deferred). When that variant ships,
-/// remove the entry below.
+/// Allowlist: empty. The deferred `station_detail_screen.dart` migration
+/// landed once `PageScaffold` gained the `titleWidget:` variant — every
+/// feature presentation file now flows through `PageScaffold`.
 void main() {
   test(
     'no raw `appBar: AppBar(...)` in lib/features/**/presentation '
     '(#923 final)',
     () {
-      // Posix paths so the allowlist matches on every host OS.
-      // Deferred — needs PageScaffold `title: Widget` variant for the
-      // Hero-flighted station-name title. See #923-deferred.
-      const allowlist = <String>{
-        'lib/features/station_detail/presentation/screens/station_detail_screen.dart',
-      };
+      // Posix paths so the allowlist matches on every host OS. Empty
+      // since the station_detail migration landed alongside the
+      // PageScaffold `titleWidget:` variant.
+      const allowlist = <String>{};
 
       // Match `appBar: AppBar(` with optional whitespace. Paired
       // constructor-name boundary: an identifier char before `AppBar`


### PR DESCRIPTION
## Summary

Refs #923 (epic closed by #982); finishes the deferred station_detail migration.

- Adds optional `titleWidget:` slot to `PageScaffold` (mutually exclusive with `title`; assertion fires when both are null).
- Migrates `lib/features/station_detail/presentation/screens/station_detail_screen.dart` onto `PageScaffold` via the new prop, preserving the Hero flight + leading/actions.
- Empties the `no_raw_appbar_in_features_test.dart` allowlist — every feature presentation file now flows through `PageScaffold`.
- Documents `titleWidget` in `docs/design/DESIGN_SYSTEM.md`.

## Test plan
- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — full suite green (6547 tests)
- [x] New PageScaffold tests: `renders titleWidget when provided`, `titleWidget wins when both passed`, `assertion fires when both null`
- [x] `no_raw_appbar_in_features_test.dart` passes with empty allowlist