### PR TITLE
feat(feedback): GithubIssueReporter service (Refs #952 phase 1)

### DIFF
--- a/lib/core/feedback/github_issue_reporter.dart
+++ b/lib/core/feedback/github_issue_reporter.dart
@@ -1,0 +1,313 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+/// What kind of scan produced the failing OCR output — determines the
+/// issue title.
+enum ScanKind {
+  receipt,
+  pumpDisplay,
+}
+
+extension ScanKindLabel on ScanKind {
+  String get title {
+    switch (this) {
+      case ScanKind.receipt:
+        return '[Scan] Receipt OCR failure';
+      case ScanKind.pumpDisplay:
+        return '[Scan] Pump display OCR failure';
+    }
+  }
+}
+
+/// Thrown when the GitHub REST API call fails in a way the caller needs
+/// to know about (auth error, rate limit, network, server error). The
+/// UI uses this to decide whether to fall back to SharePlus.
+class GithubReporterException implements Exception {
+  final String message;
+  final int? statusCode;
+
+  const GithubReporterException(this.message, {this.statusCode});
+
+  @override
+  String toString() => statusCode == null
+      ? 'GithubReporterException: $message'
+      : 'GithubReporterException($statusCode): $message';
+}
+
+/// Creates a GitHub issue from a failed OCR scan.
+///
+/// Phase 1 scope: the network service only. UI integration
+/// ([bad_scan_report_sheet] swap) ships in phase 2; EXIF stripping +
+/// consent dialog ship in phase 3.
+///
+/// The issue body bundles the raw OCR text, the parsed fields the app
+/// extracted, the corrections the user typed, and a base64-embedded
+/// screenshot/photo of the scan. GitHub renders `data:image/...` URIs
+/// in markdown so the photo appears inline.
+///
+/// Phase 1 notes called out in every issue body:
+///   - EXIF location is NOT stripped (lands in phase 3).
+///   - No user consent dialog yet (lands in phase 3).
+class GithubIssueReporter {
+  final http.Client _httpClient;
+  final String _token;
+  final String _repoOwner;
+  final String _repoName;
+
+  /// Absolute ceiling for the issue body. GitHub's own limit is
+  /// 65,536 chars — we keep a small safety margin.
+  static const int _maxBodyLength = 65000;
+
+  /// If `X-RateLimit-Remaining` drops below this threshold we refuse
+  /// to submit so the UI can fall back to SharePlus without burning
+  /// the last few calls on retries.
+  static const int _rateLimitFloor = 5;
+
+  GithubIssueReporter({
+    required http.Client httpClient,
+    required String token,
+    required String repoOwner,
+    required String repoName,
+  })  : _httpClient = httpClient,
+        _token = token,
+        _repoOwner = repoOwner,
+        _repoName = repoName;
+
+  /// Creates a GitHub issue and returns the `html_url` of the created
+  /// issue.
+  ///
+  /// Throws [GithubReporterException] on auth failures, rate-limit
+  /// exhaustion, network errors, or server errors.
+  ///
+  /// If the repo doesn't have one of the requested labels (422
+  /// Unprocessable Entity) the call is retried once without labels so
+  /// a missing `from-app` label doesn't block the submission.
+  Future<Uri> reportBadScan({
+    required ScanKind kind,
+    required String rawOcrText,
+    required Map<String, String?> parsedFields,
+    required Map<String, String?> userCorrections,
+    required Uint8List imageBytes,
+    String? userNote,
+  }) async {
+    final body = _buildBody(
+      kind: kind,
+      rawOcrText: rawOcrText,
+      parsedFields: parsedFields,
+      userCorrections: userCorrections,
+      imageBytes: imageBytes,
+      userNote: userNote,
+    );
+
+    final title = kind.title;
+    const labels = <String>['type/bug', 'area/scan', 'from-app'];
+
+    try {
+      final response = await _postIssue(title: title, body: body, labels: labels);
+
+      if (response.statusCode == 422) {
+        // Most likely cause: one of the labels isn't defined in the
+        // repo. Retry without labels so submission still succeeds.
+        final retry = await _postIssue(
+          title: title,
+          body: body,
+          labels: const [],
+        );
+        return _parseResponse(retry);
+      }
+
+      return _parseResponse(response);
+    } on GithubReporterException {
+      rethrow;
+    } catch (e) {
+      debugPrint('GithubIssueReporter network failure: $e');
+      throw GithubReporterException('network error: $e');
+    }
+  }
+
+  Future<http.Response> _postIssue({
+    required String title,
+    required String body,
+    required List<String> labels,
+  }) {
+    final uri = Uri.parse(
+      'https://api.github.com/repos/$_repoOwner/$_repoName/issues',
+    );
+    final payload = <String, Object?>{
+      'title': title,
+      'body': body,
+      if (labels.isNotEmpty) 'labels': labels,
+    };
+    return _httpClient.post(
+      uri,
+      headers: <String, String>{
+        'Accept': 'application/vnd.github+json',
+        'Authorization': 'Bearer $_token',
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: jsonEncode(payload),
+    );
+  }
+
+  Uri _parseResponse(http.Response response) {
+    _checkRateLimit(response);
+
+    if (response.statusCode == 401) {
+      throw const GithubReporterException(
+        'authentication failed (invalid token)',
+        statusCode: 401,
+      );
+    }
+    if (response.statusCode == 403) {
+      throw GithubReporterException(
+        'access forbidden: ${response.reasonPhrase ?? 'rate limited'}',
+        statusCode: 403,
+      );
+    }
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw GithubReporterException(
+        'unexpected status ${response.statusCode}: ${response.body}',
+        statusCode: response.statusCode,
+      );
+    }
+
+    final Map<String, dynamic> json =
+        jsonDecode(response.body) as Map<String, dynamic>;
+    final htmlUrl = json['html_url'] as String?;
+    if (htmlUrl == null || htmlUrl.isEmpty) {
+      throw const GithubReporterException(
+        'response missing html_url',
+      );
+    }
+    return Uri.parse(htmlUrl);
+  }
+
+  void _checkRateLimit(http.Response response) {
+    final remaining = response.headers['x-ratelimit-remaining'];
+    if (remaining == null) return;
+    final value = int.tryParse(remaining);
+    if (value == null) return;
+    if (value < _rateLimitFloor) {
+      throw GithubReporterException(
+        'rate limit nearly exhausted (remaining: $value)',
+        statusCode: response.statusCode,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Body construction
+
+  String _buildBody({
+    required ScanKind kind,
+    required String rawOcrText,
+    required Map<String, String?> parsedFields,
+    required Map<String, String?> userCorrections,
+    required Uint8List imageBytes,
+    String? userNote,
+  }) {
+    final buffer = StringBuffer();
+    buffer.writeln('## Scan kind');
+    buffer.writeln();
+    buffer.writeln('- ${_scanKindLabel(kind)}');
+    buffer.writeln();
+
+    if (userNote != null && userNote.trim().isNotEmpty) {
+      buffer.writeln('## User note');
+      buffer.writeln();
+      buffer.writeln(_sanitize(userNote.trim()));
+      buffer.writeln();
+    }
+
+    buffer.writeln('## Raw OCR text');
+    buffer.writeln();
+    buffer.writeln('```');
+    buffer.writeln(_sanitize(rawOcrText));
+    buffer.writeln('```');
+    buffer.writeln();
+
+    buffer.writeln('## Parsed fields');
+    buffer.writeln();
+    buffer.write(_fieldTable(parsedFields));
+    buffer.writeln();
+
+    buffer.writeln('## User corrections');
+    buffer.writeln();
+    buffer.write(_fieldTable(userCorrections));
+    buffer.writeln();
+
+    buffer.writeln('## Phase 1 notes');
+    buffer.writeln();
+    buffer.writeln(
+      '_EXIF metadata is NOT stripped from the attached image in phase 1 — '
+      'will land in phase 3._',
+    );
+    buffer.writeln();
+
+    buffer.writeln('## Scan image');
+    buffer.writeln();
+
+    final textSoFar = buffer.length;
+    final base64Image = base64Encode(imageBytes);
+    // ~30 chars of markdown wrapper around the base64 payload
+    // (`![scan](data:image/jpeg;base64,)`).
+    const wrapperLength = 32;
+    if (textSoFar + base64Image.length + wrapperLength > _maxBodyLength) {
+      buffer.writeln('_[image too large to embed]_');
+    } else {
+      buffer.writeln('![scan](data:image/jpeg;base64,$base64Image)');
+    }
+
+    return buffer.toString();
+  }
+
+  String _scanKindLabel(ScanKind kind) {
+    switch (kind) {
+      case ScanKind.receipt:
+        return 'Receipt';
+      case ScanKind.pumpDisplay:
+        return 'Pump display';
+    }
+  }
+
+  String _fieldTable(Map<String, String?> fields) {
+    if (fields.isEmpty) {
+      return '_(none)_\n';
+    }
+    final buffer = StringBuffer();
+    buffer.writeln('| Field | Value |');
+    buffer.writeln('| --- | --- |');
+    for (final entry in fields.entries) {
+      final key = _sanitizeCell(entry.key);
+      final value = entry.value == null || entry.value!.isEmpty
+          ? '_(empty)_'
+          : _sanitizeCell(entry.value!);
+      buffer.writeln('| $key | $value |');
+    }
+    return buffer.toString();
+  }
+
+  /// Strips ANSI escapes, control characters (except `\n` and `\t`),
+  /// and anything else that would break markdown rendering.
+  String _sanitize(String input) {
+    // Remove ANSI CSI sequences (ESC [ ... letter).
+    final withoutAnsi = input.replaceAll(
+      RegExp(r'\x1B\[[0-9;]*[A-Za-z]'),
+      '',
+    );
+    // Strip control chars except tab (\x09) and newline (\x0A).
+    return withoutAnsi.replaceAll(
+      RegExp(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]'),
+      '',
+    );
+  }
+
+  /// Like [_sanitize] but also escapes characters that break markdown
+  /// table cells (pipes and embedded newlines).
+  String _sanitizeCell(String input) {
+    return _sanitize(input).replaceAll('\n', ' ').replaceAll('|', r'\|');
+  }
+}

--- a/test/core/feedback/github_issue_reporter_test.dart
+++ b/test/core/feedback/github_issue_reporter_test.dart
@@ -1,0 +1,338 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:tankstellen/core/feedback/github_issue_reporter.dart';
+
+void main() {
+  group('GithubIssueReporter', () {
+    late _FakeClient client;
+    late GithubIssueReporter reporter;
+
+    setUp(() {
+      client = _FakeClient();
+      reporter = GithubIssueReporter(
+        httpClient: client,
+        token: 'test-token',
+        repoOwner: 'fdittgen-png',
+        repoName: 'tankstellen',
+      );
+    });
+
+    test('successful POST returns the html_url of the created issue',
+        () async {
+      client.responses.add(
+        _ok(
+          statusCode: 201,
+          body: {
+            'html_url':
+                'https://github.com/fdittgen-png/tankstellen/issues/123',
+            'number': 123,
+          },
+        ),
+      );
+
+      final url = await reporter.reportBadScan(
+        kind: ScanKind.receipt,
+        rawOcrText: 'ESSENCE 1.85 E/L',
+        parsedFields: const <String, String?>{'fuelType': 'E10'},
+        userCorrections: const <String, String?>{},
+        imageBytes: Uint8List.fromList(List<int>.filled(128, 0x42)),
+      );
+
+      expect(
+        url.toString(),
+        'https://github.com/fdittgen-png/tankstellen/issues/123',
+      );
+      expect(client.requests, hasLength(1));
+      final req = client.requests.single;
+      expect(req.method, 'POST');
+      expect(
+        req.url.toString(),
+        'https://api.github.com/repos/fdittgen-png/tankstellen/issues',
+      );
+      expect(req.headers['Authorization'], 'Bearer test-token');
+      expect(req.headers['Accept'], 'application/vnd.github+json');
+    });
+
+    test('401 unauthorized throws GithubReporterException with statusCode 401',
+        () async {
+      client.responses.add(
+        _ok(
+          statusCode: 401,
+          body: {'message': 'Bad credentials'},
+        ),
+      );
+
+      await expectLater(
+        reporter.reportBadScan(
+          kind: ScanKind.receipt,
+          rawOcrText: 'x',
+          parsedFields: const {},
+          userCorrections: const {},
+          imageBytes: Uint8List.fromList(const [1, 2, 3]),
+        ),
+        throwsA(isA<GithubReporterException>()
+            .having((e) => e.statusCode, 'statusCode', 401)),
+      );
+    });
+
+    test(
+        '403 with X-RateLimit-Remaining: 0 throws rate-limit exception',
+        () async {
+      client.responses.add(
+        _ok(
+          statusCode: 403,
+          body: {'message': 'API rate limit exceeded'},
+          headers: {'x-ratelimit-remaining': '0'},
+        ),
+      );
+
+      final future = reporter.reportBadScan(
+        kind: ScanKind.receipt,
+        rawOcrText: 'x',
+        parsedFields: const {},
+        userCorrections: const {},
+        imageBytes: Uint8List.fromList(const [1, 2, 3]),
+      );
+
+      await expectLater(
+        future,
+        throwsA(
+          isA<GithubReporterException>()
+              .having((e) => e.message, 'message',
+                  contains('rate limit')),
+        ),
+      );
+    });
+
+    test(
+        '422 validation error retries POST once without labels and succeeds',
+        () async {
+      client.responses
+        ..add(_ok(
+          statusCode: 422,
+          body: {'message': 'Validation Failed'},
+        ))
+        ..add(_ok(
+          statusCode: 201,
+          body: {
+            'html_url':
+                'https://github.com/fdittgen-png/tankstellen/issues/44',
+          },
+        ));
+
+      final url = await reporter.reportBadScan(
+        kind: ScanKind.pumpDisplay,
+        rawOcrText: 'x',
+        parsedFields: const {},
+        userCorrections: const {},
+        imageBytes: Uint8List.fromList(const [1, 2, 3]),
+      );
+
+      expect(url.path, endsWith('/44'));
+      expect(client.requests, hasLength(2));
+
+      final firstBody =
+          jsonDecode(client.requests[0].body) as Map<String, dynamic>;
+      final secondBody =
+          jsonDecode(client.requests[1].body) as Map<String, dynamic>;
+      expect(firstBody.containsKey('labels'), isTrue,
+          reason: 'first attempt sends labels');
+      expect(secondBody.containsKey('labels'), isFalse,
+          reason: 'retry omits labels');
+    });
+
+    test('image bytes are base64-embedded into the issue body as markdown',
+        () async {
+      client.responses.add(
+        _ok(
+          statusCode: 201,
+          body: {
+            'html_url':
+                'https://github.com/fdittgen-png/tankstellen/issues/1',
+          },
+        ),
+      );
+
+      final bytes = Uint8List.fromList(const [0xDE, 0xAD, 0xBE, 0xEF]);
+      await reporter.reportBadScan(
+        kind: ScanKind.receipt,
+        rawOcrText: 'raw',
+        parsedFields: const {'a': 'b'},
+        userCorrections: const {'a': 'c'},
+        imageBytes: bytes,
+      );
+
+      final payload =
+          jsonDecode(client.requests.single.body) as Map<String, dynamic>;
+      final body = payload['body'] as String;
+      expect(body, contains('## Raw OCR text'));
+      expect(body, contains('## Parsed fields'));
+      expect(body, contains('## User corrections'));
+      expect(
+        body,
+        contains('![scan](data:image/jpeg;base64,${base64Encode(bytes)})'),
+      );
+    });
+
+    test('100KB image body stays under 65,000 chars (truncates when needed)',
+        () async {
+      client.responses.add(
+        _ok(
+          statusCode: 201,
+          body: {
+            'html_url':
+                'https://github.com/fdittgen-png/tankstellen/issues/2',
+          },
+        ),
+      );
+
+      final bytes = Uint8List.fromList(List<int>.filled(100 * 1024, 0x41));
+      await reporter.reportBadScan(
+        kind: ScanKind.receipt,
+        rawOcrText: 'x',
+        parsedFields: const {},
+        userCorrections: const {},
+        imageBytes: bytes,
+      );
+
+      final payload =
+          jsonDecode(client.requests.single.body) as Map<String, dynamic>;
+      final body = payload['body'] as String;
+      expect(body.length, lessThan(65000));
+      expect(body, contains('[image too large to embed]'));
+      expect(body, isNot(contains('data:image/jpeg;base64,AAAA')));
+    });
+
+    test('scan kind drives the issue title', () async {
+      client.responses
+        ..add(_ok(
+          statusCode: 201,
+          body: {
+            'html_url':
+                'https://github.com/fdittgen-png/tankstellen/issues/1',
+          },
+        ))
+        ..add(_ok(
+          statusCode: 201,
+          body: {
+            'html_url':
+                'https://github.com/fdittgen-png/tankstellen/issues/2',
+          },
+        ));
+
+      await reporter.reportBadScan(
+        kind: ScanKind.receipt,
+        rawOcrText: 'x',
+        parsedFields: const {},
+        userCorrections: const {},
+        imageBytes: Uint8List.fromList(const [1]),
+      );
+      await reporter.reportBadScan(
+        kind: ScanKind.pumpDisplay,
+        rawOcrText: 'x',
+        parsedFields: const {},
+        userCorrections: const {},
+        imageBytes: Uint8List.fromList(const [1]),
+      );
+
+      final receipt =
+          jsonDecode(client.requests[0].body) as Map<String, dynamic>;
+      final pump =
+          jsonDecode(client.requests[1].body) as Map<String, dynamic>;
+      expect(receipt['title'], '[Scan] Receipt OCR failure');
+      expect(pump['title'], '[Scan] Pump display OCR failure');
+    });
+
+    test('sanitizes ANSI escape sequences and control chars from OCR text',
+        () async {
+      client.responses.add(
+        _ok(
+          statusCode: 201,
+          body: {
+            'html_url':
+                'https://github.com/fdittgen-png/tankstellen/issues/9',
+          },
+        ),
+      );
+
+      await reporter.reportBadScan(
+        kind: ScanKind.receipt,
+        rawOcrText: '\x1B[31mRED\x1B[0m\x00NUL\x07BEL',
+        parsedFields: const {},
+        userCorrections: const {},
+        imageBytes: Uint8List.fromList(const [1]),
+      );
+
+      final payload =
+          jsonDecode(client.requests.single.body) as Map<String, dynamic>;
+      final body = payload['body'] as String;
+      expect(body, contains('REDNULBEL'));
+      expect(body, isNot(contains('\x1B')));
+      expect(body, isNot(contains('\x00')));
+    });
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Test doubles
+
+http.Response _ok({
+  required int statusCode,
+  required Map<String, Object?> body,
+  Map<String, String>? headers,
+}) {
+  return http.Response(
+    jsonEncode(body),
+    statusCode,
+    headers: headers ?? const {},
+  );
+}
+
+class _CapturedRequest {
+  final String method;
+  final Uri url;
+  final Map<String, String> headers;
+  final String body;
+
+  _CapturedRequest({
+    required this.method,
+    required this.url,
+    required this.headers,
+    required this.body,
+  });
+}
+
+class _FakeClient extends http.BaseClient {
+  final List<http.Response> responses = <http.Response>[];
+  final List<_CapturedRequest> requests = <_CapturedRequest>[];
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    String body = '';
+    if (request is http.Request) {
+      body = request.body;
+    }
+    requests.add(_CapturedRequest(
+      method: request.method,
+      url: request.url,
+      headers: Map<String, String>.from(request.headers),
+      body: body,
+    ));
+
+    if (requests.length > responses.length) {
+      throw StateError(
+        'FakeClient: no response queued for request #${requests.length}',
+      );
+    }
+    final response = responses[requests.length - 1];
+    return http.StreamedResponse(
+      Stream<List<int>>.value(utf8.encode(response.body)),
+      response.statusCode,
+      headers: response.headers,
+      reasonPhrase: response.reasonPhrase,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- New `GithubIssueReporter` service in `lib/core/feedback/` — POSTs a markdown-bodied issue (raw OCR, parsed fields, user corrections, inline base64 scan image) to the GitHub REST API.
- Handles 401/403/422 paths: 422 retries once without labels so a missing `from-app` label never blocks submission; 403 with `X-RateLimit-Remaining < 5` throws so the UI can fall back to SharePlus.
- Body is capped at 65k chars; oversized images are replaced with a `[image too large to embed]` placeholder so we never post a body GitHub will reject.
- Tests: 8 new unit tests covering the happy path, auth failure, rate-limit, 422 retry, base64 embedding, body cap, scan-kind titles, and OCR sanitization.

Refs #952 phase 1; phase 2 (UI swap in `bad_scan_report_sheet` + token plumbing) and phase 3 (EXIF strip + consent dialog) follow in separate PRs.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — full suite green (6562 passing)
- [x] New tests in `test/core/feedback/github_issue_reporter_test.dart` all pass