### PR TITLE
feat(vehicle): VehicleProfile auto-record config (Refs #1004 phase 1)

### DIFF
--- a/lib/features/vehicle/domain/entities/vehicle_profile.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.dart
@@ -184,6 +184,42 @@ abstract class VehicleProfile with _$VehicleProfile {
     @Default(VehicleCalibrationMode.rule)
     @VehicleCalibrationModeJsonConverter()
     VehicleCalibrationMode calibrationMode,
+
+    // Hands-free auto-record configuration (#1004 phase 1). All
+    // fields default to "off" or to safe values so pre-#1004 Hive
+    // profiles deserialize cleanly via freezed's `@Default`. Phases
+    // 2-6 layer the background service, movement-detection,
+    // disconnect-save, badge counter and UI on top of these fields
+    // — phase 1 ships the data layer only.
+    //
+    //   autoRecord: master toggle. Off by default — every user must
+    //     opt in explicitly from the vehicle edit screen.
+    //   pairedAdapterMac: MAC address of the ELM327 adapter that
+    //     belongs to this vehicle. Distinct from
+    //     [obd2AdapterMac] (the "currently connected" adapter from
+    //     #784 / #816); pairedAdapterMac is the long-lived "this
+    //     adapter belongs to this car" marker that the BLE auto-
+    //     connect listener watches for. Null when the user hasn't
+    //     paired one yet.
+    //   movementStartThresholdKmh: speed (OBD2 PID 0x0D OR phone
+    //     GPS, whichever fires first) above which auto-record fires
+    //     `startTrip()`. Default 5 km/h — low enough to catch
+    //     pulling out of a parking spot, high enough to ignore the
+    //     adapter waking up while the car is stationary.
+    //   disconnectSaveDelaySec: debounce window in seconds before a
+    //     BT disconnect triggers `stopAndSave`. Default 60 s — long
+    //     enough to absorb a tunnel or a parking-garage lift, short
+    //     enough that the user sees a saved trip when they walk
+    //     into the kitchen.
+    //   backgroundLocationConsent: separate from runtime location
+    //     permission — this is the user's stored answer to "may we
+    //     record GPS while the screen is off?" Without it, the
+    //     auto-flow runs BT-only and skips GPS-based trip metadata.
+    @Default(false) bool autoRecord,
+    String? pairedAdapterMac,
+    @Default(5.0) double movementStartThresholdKmh,
+    @Default(60) int disconnectSaveDelaySec,
+    @Default(false) bool backgroundLocationConsent,
   }) = _VehicleProfile;
 
   factory VehicleProfile.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
@@ -338,7 +338,37 @@ mixin _$VehicleProfile {
 // sample across all situations via [FuzzyClassifier]. Default
 // stays on `rule` so existing profiles deserialize without a
 // migration — users opt in from the vehicle edit screen.
-@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode get calibrationMode;
+@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode get calibrationMode;// Hands-free auto-record configuration (#1004 phase 1). All
+// fields default to "off" or to safe values so pre-#1004 Hive
+// profiles deserialize cleanly via freezed's `@Default`. Phases
+// 2-6 layer the background service, movement-detection,
+// disconnect-save, badge counter and UI on top of these fields
+// — phase 1 ships the data layer only.
+//
+//   autoRecord: master toggle. Off by default — every user must
+//     opt in explicitly from the vehicle edit screen.
+//   pairedAdapterMac: MAC address of the ELM327 adapter that
+//     belongs to this vehicle. Distinct from
+//     [obd2AdapterMac] (the "currently connected" adapter from
+//     #784 / #816); pairedAdapterMac is the long-lived "this
+//     adapter belongs to this car" marker that the BLE auto-
+//     connect listener watches for. Null when the user hasn't
+//     paired one yet.
+//   movementStartThresholdKmh: speed (OBD2 PID 0x0D OR phone
+//     GPS, whichever fires first) above which auto-record fires
+//     `startTrip()`. Default 5 km/h — low enough to catch
+//     pulling out of a parking spot, high enough to ignore the
+//     adapter waking up while the car is stationary.
+//   disconnectSaveDelaySec: debounce window in seconds before a
+//     BT disconnect triggers `stopAndSave`. Default 60 s — long
+//     enough to absorb a tunnel or a parking-garage lift, short
+//     enough that the user sees a saved trip when they walk
+//     into the kitchen.
+//   backgroundLocationConsent: separate from runtime location
+//     permission — this is the user's stored answer to "may we
+//     record GPS while the screen is off?" Without it, the
+//     auto-flow runs BT-only and skips GPS-based trip metadata.
+ bool get autoRecord; String? get pairedAdapterMac; double get movementStartThresholdKmh; int get disconnectSaveDelaySec; bool get backgroundLocationConsent;
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -351,16 +381,16 @@ $VehicleProfileCopyWith<VehicleProfile> get copyWith => _$VehicleProfileCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent]);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent)';
 }
 
 
@@ -371,7 +401,7 @@ abstract mixin class $VehicleProfileCopyWith<$Res>  {
   factory $VehicleProfileCopyWith(VehicleProfile value, $Res Function(VehicleProfile) _then) = _$VehicleProfileCopyWithImpl;
 @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent
 });
 
 
@@ -388,7 +418,7 @@ class _$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -408,7 +438,12 @@ as int?,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2A
 as String?,obd2AdapterName: freezed == obd2AdapterName ? _self.obd2AdapterName : obd2AdapterName // ignore: cast_nullable_to_non_nullable
 as String?,vin: freezed == vin ? _self.vin : vin // ignore: cast_nullable_to_non_nullable
 as String?,calibrationMode: null == calibrationMode ? _self.calibrationMode : calibrationMode // ignore: cast_nullable_to_non_nullable
-as VehicleCalibrationMode,
+as VehicleCalibrationMode,autoRecord: null == autoRecord ? _self.autoRecord : autoRecord // ignore: cast_nullable_to_non_nullable
+as bool,pairedAdapterMac: freezed == pairedAdapterMac ? _self.pairedAdapterMac : pairedAdapterMac // ignore: cast_nullable_to_non_nullable
+as String?,movementStartThresholdKmh: null == movementStartThresholdKmh ? _self.movementStartThresholdKmh : movementStartThresholdKmh // ignore: cast_nullable_to_non_nullable
+as double,disconnectSaveDelaySec: null == disconnectSaveDelaySec ? _self.disconnectSaveDelaySec : disconnectSaveDelaySec // ignore: cast_nullable_to_non_nullable
+as int,backgroundLocationConsent: null == backgroundLocationConsent ? _self.backgroundLocationConsent : backgroundLocationConsent // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 /// Create a copy of VehicleProfile
@@ -502,10 +537,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent);case _:
   return orElse();
 
 }
@@ -523,10 +558,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent)  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile():
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -543,10 +578,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent)?  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent);case _:
   return null;
 
 }
@@ -558,7 +593,7 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 @JsonSerializable()
 
 class _VehicleProfile extends VehicleProfile {
-  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.volumetricEfficiencySamples = 0, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName, this.vin, @VehicleCalibrationModeJsonConverter() this.calibrationMode = VehicleCalibrationMode.rule}): _supportedConnectors = supportedConnectors,super._();
+  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.volumetricEfficiencySamples = 0, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName, this.vin, @VehicleCalibrationModeJsonConverter() this.calibrationMode = VehicleCalibrationMode.rule, this.autoRecord = false, this.pairedAdapterMac, this.movementStartThresholdKmh = 5.0, this.disconnectSaveDelaySec = 60, this.backgroundLocationConsent = false}): _supportedConnectors = supportedConnectors,super._();
   factory _VehicleProfile.fromJson(Map<String, dynamic> json) => _$VehicleProfileFromJson(json);
 
 @override final  String id;
@@ -633,6 +668,41 @@ class _VehicleProfile extends VehicleProfile {
 // stays on `rule` so existing profiles deserialize without a
 // migration — users opt in from the vehicle edit screen.
 @override@JsonKey()@VehicleCalibrationModeJsonConverter() final  VehicleCalibrationMode calibrationMode;
+// Hands-free auto-record configuration (#1004 phase 1). All
+// fields default to "off" or to safe values so pre-#1004 Hive
+// profiles deserialize cleanly via freezed's `@Default`. Phases
+// 2-6 layer the background service, movement-detection,
+// disconnect-save, badge counter and UI on top of these fields
+// — phase 1 ships the data layer only.
+//
+//   autoRecord: master toggle. Off by default — every user must
+//     opt in explicitly from the vehicle edit screen.
+//   pairedAdapterMac: MAC address of the ELM327 adapter that
+//     belongs to this vehicle. Distinct from
+//     [obd2AdapterMac] (the "currently connected" adapter from
+//     #784 / #816); pairedAdapterMac is the long-lived "this
+//     adapter belongs to this car" marker that the BLE auto-
+//     connect listener watches for. Null when the user hasn't
+//     paired one yet.
+//   movementStartThresholdKmh: speed (OBD2 PID 0x0D OR phone
+//     GPS, whichever fires first) above which auto-record fires
+//     `startTrip()`. Default 5 km/h — low enough to catch
+//     pulling out of a parking spot, high enough to ignore the
+//     adapter waking up while the car is stationary.
+//   disconnectSaveDelaySec: debounce window in seconds before a
+//     BT disconnect triggers `stopAndSave`. Default 60 s — long
+//     enough to absorb a tunnel or a parking-garage lift, short
+//     enough that the user sees a saved trip when they walk
+//     into the kitchen.
+//   backgroundLocationConsent: separate from runtime location
+//     permission — this is the user's stored answer to "may we
+//     record GPS while the screen is off?" Without it, the
+//     auto-flow runs BT-only and skips GPS-based trip metadata.
+@override@JsonKey() final  bool autoRecord;
+@override final  String? pairedAdapterMac;
+@override@JsonKey() final  double movementStartThresholdKmh;
+@override@JsonKey() final  int disconnectSaveDelaySec;
+@override@JsonKey() final  bool backgroundLocationConsent;
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
@@ -647,16 +717,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent]);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent)';
 }
 
 
@@ -667,7 +737,7 @@ abstract mixin class _$VehicleProfileCopyWith<$Res> implements $VehicleProfileCo
   factory _$VehicleProfileCopyWith(_VehicleProfile value, $Res Function(_VehicleProfile) _then) = __$VehicleProfileCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent
 });
 
 
@@ -684,7 +754,7 @@ class __$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,}) {
   return _then(_VehicleProfile(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -704,7 +774,12 @@ as int?,obd2AdapterMac: freezed == obd2AdapterMac ? _self.obd2AdapterMac : obd2A
 as String?,obd2AdapterName: freezed == obd2AdapterName ? _self.obd2AdapterName : obd2AdapterName // ignore: cast_nullable_to_non_nullable
 as String?,vin: freezed == vin ? _self.vin : vin // ignore: cast_nullable_to_non_nullable
 as String?,calibrationMode: null == calibrationMode ? _self.calibrationMode : calibrationMode // ignore: cast_nullable_to_non_nullable
-as VehicleCalibrationMode,
+as VehicleCalibrationMode,autoRecord: null == autoRecord ? _self.autoRecord : autoRecord // ignore: cast_nullable_to_non_nullable
+as bool,pairedAdapterMac: freezed == pairedAdapterMac ? _self.pairedAdapterMac : pairedAdapterMac // ignore: cast_nullable_to_non_nullable
+as String?,movementStartThresholdKmh: null == movementStartThresholdKmh ? _self.movementStartThresholdKmh : movementStartThresholdKmh // ignore: cast_nullable_to_non_nullable
+as double,disconnectSaveDelaySec: null == disconnectSaveDelaySec ? _self.disconnectSaveDelaySec : disconnectSaveDelaySec // ignore: cast_nullable_to_non_nullable
+as int,backgroundLocationConsent: null == backgroundLocationConsent ? _self.backgroundLocationConsent : backgroundLocationConsent // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
@@ -61,6 +61,14 @@ _VehicleProfile _$VehicleProfileFromJson(Map<String, dynamic> json) =>
           : const VehicleCalibrationModeJsonConverter().fromJson(
               json['calibrationMode'] as String?,
             ),
+      autoRecord: json['autoRecord'] as bool? ?? false,
+      pairedAdapterMac: json['pairedAdapterMac'] as String?,
+      movementStartThresholdKmh:
+          (json['movementStartThresholdKmh'] as num?)?.toDouble() ?? 5.0,
+      disconnectSaveDelaySec:
+          (json['disconnectSaveDelaySec'] as num?)?.toInt() ?? 60,
+      backgroundLocationConsent:
+          json['backgroundLocationConsent'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
@@ -89,4 +97,9 @@ Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
       'calibrationMode': const VehicleCalibrationModeJsonConverter().toJson(
         instance.calibrationMode,
       ),
+      'autoRecord': instance.autoRecord,
+      'pairedAdapterMac': instance.pairedAdapterMac,
+      'movementStartThresholdKmh': instance.movementStartThresholdKmh,
+      'disconnectSaveDelaySec': instance.disconnectSaveDelaySec,
+      'backgroundLocationConsent': instance.backgroundLocationConsent,
     };

--- a/test/features/vehicle/domain/vehicle_profile_test.dart
+++ b/test/features/vehicle/domain/vehicle_profile_test.dart
@@ -133,6 +133,91 @@ void main() {
       });
     });
 
+    group('hands-free auto-record config (#1004 phase 1)', () {
+      test('defaults: auto-record off, no paired adapter, 5 km/h / 60 s, '
+          'no background-location consent', () {
+        const v = VehicleProfile(id: 'abc', name: 'Car');
+        expect(v.autoRecord, isFalse);
+        expect(v.pairedAdapterMac, isNull);
+        expect(v.movementStartThresholdKmh, 5.0);
+        expect(v.disconnectSaveDelaySec, 60);
+        expect(v.backgroundLocationConsent, isFalse);
+      });
+
+      test('round-trips opted-in values through JSON', () {
+        const v = VehicleProfile(
+          id: 'auto-1',
+          name: 'Daily Driver',
+          type: VehicleType.combustion,
+          autoRecord: true,
+          pairedAdapterMac: 'AA:BB:CC:DD:EE:FF',
+          movementStartThresholdKmh: 7.5,
+          disconnectSaveDelaySec: 90,
+          backgroundLocationConsent: true,
+        );
+
+        final restored = VehicleProfile.fromJson(v.toJson());
+
+        expect(restored.autoRecord, isTrue);
+        expect(restored.pairedAdapterMac, 'AA:BB:CC:DD:EE:FF');
+        expect(restored.movementStartThresholdKmh, closeTo(7.5, 0.001));
+        expect(restored.disconnectSaveDelaySec, 90);
+        expect(restored.backgroundLocationConsent, isTrue);
+        expect(v, equals(restored));
+      });
+
+      test('legacy JSON without auto-record keys still decodes — '
+          'existing Hive profiles take safe defaults', () {
+        // Payload shape that pre-#1004 profiles wrote to Hive: no
+        // autoRecord / pairedAdapterMac / movementStartThresholdKmh
+        // / disconnectSaveDelaySec / backgroundLocationConsent
+        // keys at all. Must round-trip cleanly with defaults.
+        final json = <String, dynamic>{
+          'id': 'legacy',
+          'name': 'Legacy Car',
+          'type': 'combustion',
+          'tankCapacityL': 50.0,
+          'preferredFuelType': 'Diesel',
+        };
+
+        final v = VehicleProfile.fromJson(json);
+
+        expect(v.autoRecord, isFalse);
+        expect(v.pairedAdapterMac, isNull);
+        expect(v.movementStartThresholdKmh, 5.0);
+        expect(v.disconnectSaveDelaySec, 60);
+        expect(v.backgroundLocationConsent, isFalse);
+        // Pre-existing fields should still come through.
+        expect(v.tankCapacityL, 50.0);
+        expect(v.preferredFuelType, 'Diesel');
+      });
+
+      test('copyWith updates auto-record fields without disturbing '
+          'unrelated state', () {
+        const v = VehicleProfile(
+          id: 'cw',
+          name: 'CopyWith Car',
+          type: VehicleType.combustion,
+          tankCapacityL: 45,
+        );
+
+        final updated = v.copyWith(
+          autoRecord: true,
+          pairedAdapterMac: '11:22:33:44:55:66',
+          movementStartThresholdKmh: 3.0,
+          disconnectSaveDelaySec: 120,
+          backgroundLocationConsent: true,
+        );
+
+        expect(updated.tankCapacityL, 45);
+        expect(updated.autoRecord, isTrue);
+        expect(updated.pairedAdapterMac, '11:22:33:44:55:66');
+        expect(updated.movementStartThresholdKmh, 3.0);
+        expect(updated.disconnectSaveDelaySec, 120);
+        expect(updated.backgroundLocationConsent, isTrue);
+      });
+    });
+
     test('copyWith preserves unspecified fields', () {
       const v = VehicleProfile(
         id: 'a',


### PR DESCRIPTION
## What

Refs #1004 phase 1; phases 2-6 follow.

Extends the freezed `VehicleProfile` entity with the five auto-record fields the rest of the hands-free OBD2 stack will consume:

| Field | Default | Purpose |
| --- | --- | --- |
| `autoRecord: bool` | `false` | Master toggle. Off by default — every user opts in. |
| `pairedAdapterMac: String?` | `null` | MAC of the ELM327 paired to this car. Distinct from `obd2AdapterMac` (the "currently connected" adapter from #784/#816); this is the long-lived "this adapter belongs to this car" marker the BLE auto-connect listener watches for. |
| `movementStartThresholdKmh: double` | `5.0` | Speed (PID 0x0D or GPS) above which auto-start fires. |
| `disconnectSaveDelaySec: int` | `60` | BT-disconnect debounce window before auto-save. |
| `backgroundLocationConsent: bool` | `false` | Stored consent for `ACCESS_BACKGROUND_LOCATION` — separate from runtime permission so the auto-flow can fall back to BT-only. |

## Why

Phase 1 of #1004 ships only the data layer so phases 2-6 can be reviewed independently. No background service, no UI, no movement detector in this PR.

## Migration

`VehicleProfile` is persisted as JSON via `VehicleProfileRepository` (settings box, key `StorageKeys.vehicleProfiles`); there is **no hand-written Hive `TypeAdapter`** for the entity. Backward compatibility is therefore handled by freezed's `@Default(...)` — pre-#1004 payloads simply omit the new keys and `fromJson` fills in defaults. Verified by the `legacy JSON without auto-record keys still decodes` test.

## Testing

`test/features/vehicle/domain/vehicle_profile_test.dart` adds a `hands-free auto-record config (#1004 phase 1)` group covering:

1. Defaults — fresh profile takes off/null/5.0/60/false.
2. Round-trip — opted-in values (`autoRecord: true`, MAC `AA:BB:CC:DD:EE:FF`, threshold 7.5, delay 90 s, consent true) survive `toJson` -> `fromJson` and equality.
3. Migration — a legacy JSON map without the five new keys decodes successfully and gets the defaults; existing fields (`tankCapacityL`, `preferredFuelType`) still round-trip.
4. `copyWith` — auto-record fields update without disturbing unrelated state (`tankCapacityL` preserved).

- `flutter analyze` -> No issues found.
- `flutter test` -> 6738 passed, 1 skipped.

## Phases (separate PRs)

- 2. Foreground BLE auto-connect service (Android-only foreground service + MethodChannel).
- 3. `AutoTripCoordinator` — speed-threshold `startTrip(automatic: true)`.
- 4. Disconnect-debounce auto-save with WAL recovery (#797 reuse).
- 5. `AutoRecordBadgeService` — launcher icon counter via `flutter_app_badger` or `home_widget`.
- 6. Vehicle wizard / edit-screen UI for the new fields.

## Screenshots

N/A — data-layer-only PR, no UI.