### PR TITLE
feat(obd2): consume ReferenceVehicle catalog in obd2_service (Refs #950 phase 2)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import 'elm327_protocol.dart';
 import 'fuel_rate_estimator.dart' as estimator;
@@ -181,14 +182,26 @@ class Obd2Service {
 
   /// Read the odometer value in km.
   ///
-  /// Fallback chain (#719):
+  /// Fallback chain (#719, refactored in #950 phase 2):
   ///   1. PID A6 (standard, only on cars from ~2018+)
   ///   2. PID 31 (distance since DTC cleared) — proxy, resets on DTC
-  ///   3. Manufacturer Mode 22 PID resolved from the car's VIN
+  ///   3. Manufacturer Mode 22 PID — resolution depends on
+  ///      [referenceVehicle]:
+  ///        * When [referenceVehicle] is non-null (#950 path), dispatch
+  ///          on its `odometerPidStrategy` (`stdA6` / `psaUds` /
+  ///          `bmwCan` / `vwUds` / `unknown`). `stdA6` and `unknown`
+  ///          short-circuit to null after the standard PIDs fail; the
+  ///          others walk only the matching catalog entry.
+  ///        * When [referenceVehicle] is null (legacy path), identify
+  ///          brand from the VIN and iterate every catalog entry for
+  ///          that brand. Preserves pre-#950 behaviour for callers that
+  ///          haven't been migrated yet.
   ///
   /// Returns null when every layer fails, so callers can surface
   /// "odometer not readable for your car" instead of a zero.
-  Future<double?> readOdometerKm() async {
+  Future<double?> readOdometerKm({
+    ReferenceVehicle? referenceVehicle,
+  }) async {
     if (!_transport.isConnected) return null;
 
     try {
@@ -204,45 +217,81 @@ class Obd2Service {
       final distance = Elm327Protocol.parseDistanceSinceDtcCleared(pid31);
       if (distance != null) return distance.toDouble();
 
-      // 3. Manufacturer Mode 22 fallback. Identify brand from VIN and
-      //    iterate every catalog entry for that brand. Silent failure
-      //    on unknown-brand is intentional — we'd rather return null
-      //    than spam the car with commands it rejects.
+      // 3. Manufacturer Mode 22 fallback.
+      if (referenceVehicle != null) {
+        return _readOdometerByStrategy(referenceVehicle.odometerPidStrategy);
+      }
+
+      // Legacy path: identify brand from VIN and iterate catalog.
+      // Silent failure on unknown-brand is intentional — we'd rather
+      // return null than spam the car with commands it rejects.
       final vinResponse =
           await _transport.sendCommand(Elm327Protocol.vinCommand);
       final vin = Elm327Protocol.parseVin(vinResponse);
       final brand = vehicleBrandFromVin(vin);
       if (brand == VehicleBrand.unknown) return null;
-
-      for (final entry in Elm327Protocol.mfgOdometerCatalog) {
-        if (entry.brand != brand) continue;
-        final response = await _transport.sendCommand(entry.command);
-        final value = switch (entry.kind) {
-          MfgOdometerKind.threeBytesKm =>
-            Elm327Protocol.parseMfgOdometer3Byte(
-              response,
-              expectedPidHi: entry.pidHi,
-              expectedPidLo: entry.pidLo,
-            ),
-          MfgOdometerKind.twoBytesKm => Elm327Protocol.parseMfgOdometer2Byte(
-              response,
-              expectedPidHi: entry.pidHi,
-              expectedPidLo: entry.pidLo,
-            ),
-          MfgOdometerKind.twoBytesMilesTimes10 =>
-            Elm327Protocol.parseMfgOdometerMilesTimes10(
-              response,
-              expectedPidHi: entry.pidHi,
-              expectedPidLo: entry.pidLo,
-            ),
-        };
-        if (value != null) return value;
-      }
-      return null;
+      return _readOdometerFromCatalogByBrand(brand);
     } catch (e) {
       debugPrint('OBD2 readOdometer failed: $e');
       return null;
     }
+  }
+
+  /// Resolve a [ReferenceVehicle.odometerPidStrategy] code to the
+  /// corresponding manufacturer-catalog brand and walk that brand's
+  /// entries. `stdA6` / `unknown` return null without sending any
+  /// further commands — the standard PIDs already exhausted that path.
+  /// `bmwCan` / `vwUds` route to the existing catalog rows; raw-CAN
+  /// support beyond Mode 22 is a separate issue.
+  Future<double?> _readOdometerByStrategy(String strategy) async {
+    switch (strategy) {
+      case 'psaUds':
+        return _readOdometerFromCatalogByBrand(VehicleBrand.psa);
+      case 'vwUds':
+        return _readOdometerFromCatalogByBrand(VehicleBrand.vwGroup);
+      case 'bmwCan':
+        // Catalog ships a Mode 22 fallback for BMW; raw-CAN broadcast
+        // (the literal "bmwCan" name) is a separate issue. Walk the
+        // catalog entry — better than returning null for cars that
+        // would otherwise answer 22 30 16.
+        return _readOdometerFromCatalogByBrand(VehicleBrand.bmw);
+      case 'stdA6':
+      case 'unknown':
+        return null;
+      default:
+        debugPrint(
+            'OBD2 readOdometer: unrecognised strategy "$strategy" — '
+            'falling back to null');
+        return null;
+    }
+  }
+
+  Future<double?> _readOdometerFromCatalogByBrand(VehicleBrand brand) async {
+    for (final entry in Elm327Protocol.mfgOdometerCatalog) {
+      if (entry.brand != brand) continue;
+      final response = await _transport.sendCommand(entry.command);
+      final value = switch (entry.kind) {
+        MfgOdometerKind.threeBytesKm =>
+          Elm327Protocol.parseMfgOdometer3Byte(
+            response,
+            expectedPidHi: entry.pidHi,
+            expectedPidLo: entry.pidLo,
+          ),
+        MfgOdometerKind.twoBytesKm => Elm327Protocol.parseMfgOdometer2Byte(
+            response,
+            expectedPidHi: entry.pidHi,
+            expectedPidLo: entry.pidLo,
+          ),
+        MfgOdometerKind.twoBytesMilesTimes10 =>
+          Elm327Protocol.parseMfgOdometerMilesTimes10(
+            response,
+            expectedPidHi: entry.pidHi,
+            expectedPidLo: entry.pidLo,
+          ),
+      };
+      if (value != null) return value;
+    }
+    return null;
   }
 
   /// Read current vehicle speed in km/h.
@@ -376,15 +425,31 @@ class Obd2Service {
   /// density ~745 g/L. When the profile is absent or the fuel type is
   /// unrecognised we default to petrol — that's the class of car
   /// (Peugeot 107 / Aygo / C1) that motivated this fallback.
-  Future<double?> readFuelRateLPerHour({VehicleProfile? vehicle}) async {
+  Future<double?> readFuelRateLPerHour({
+    VehicleProfile? vehicle,
+    ReferenceVehicle? referenceVehicle,
+  }) async {
+    // Precedence (#950 phase 2):
+    //   1. VehicleProfile field (user-set, may be tuned to override
+    //      the catalog defaults).
+    //   2. ReferenceVehicle catalog entry (data-driven defaults).
+    //   3. Generic estimator constants (last-resort 1500 cc / 0.85
+    //      VE — bumped from the legacy 1000 cc when a catalog entry
+    //      is missing AND the user hasn't filled in the engine spec).
     final engineDisplacementCc = vehicle?.engineDisplacementCc ??
+        referenceVehicle?.displacementCc ??
         estimator.kDefaultEngineDisplacementCc;
     // VE on VehicleProfile is a non-nullable double with its own
     // default (0.85). Using it directly here is equivalent to the
-    // service-level fallback for that field.
-    final volumetricEfficiency =
-        vehicle?.volumetricEfficiency ?? estimator.kDefaultVolumetricEfficiency;
-    final isDiesel = estimator.isDieselProfile(vehicle);
+    // service-level fallback for that field. When vehicle is null the
+    // ReferenceVehicle catalog VE wins; absent both, the estimator's
+    // 0.85 default is the final fallback.
+    final volumetricEfficiency = vehicle?.volumetricEfficiency ??
+        referenceVehicle?.volumetricEfficiency ??
+        estimator.kDefaultVolumetricEfficiency;
+    final isDiesel = vehicle != null
+        ? estimator.isDieselProfile(vehicle)
+        : referenceVehicle?.fuelType.toLowerCase() == 'diesel';
     final afr = isDiesel ? estimator.kDieselAfr : estimator.kPetrolAfr;
     final fuelDensityGPerL =
         isDiesel ? estimator.kDieselDensityGPerL : estimator.kPetrolDensityGPerL;

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/reference_vehicle.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 
 // Shared AT-init boilerplate for the FakeObd2Transport.
@@ -706,6 +707,271 @@ void main() {
 
       await service.disconnect();
       expect(service.isConnected, isFalse);
+    });
+  });
+
+  group('Obd2Service ReferenceVehicle catalog consumer (#950 phase 2)', () {
+    // PSA UDS-style fixture: PID A6 missing, PID 31 missing, but the
+    // PSA mfg odometer command 22D101 returns a 2-byte km value. This
+    // is the in-catalog Peugeot 208 path the user runs today.
+    const peugeot208 = ReferenceVehicle(
+      make: 'Peugeot',
+      model: '208',
+      generation: 'II (2019-)',
+      yearStart: 2019,
+      displacementCc: 1199,
+      fuelType: 'petrol',
+      transmission: 'manual',
+      odometerPidStrategy: 'psaUds',
+    );
+
+    // VW Golf VIII — 1498 cc, vwUds. The VW odometer command is
+    // 222203 returning a 3-byte km value.
+    const vwGolf = ReferenceVehicle(
+      make: 'Volkswagen',
+      model: 'Golf',
+      generation: 'VIII (2019-)',
+      yearStart: 2019,
+      displacementCc: 1498,
+      fuelType: 'petrol',
+      transmission: 'automatic',
+      volumetricEfficiency: 0.87,
+      odometerPidStrategy: 'vwUds',
+    );
+
+    // Fictional vehicle the catalog does not cover. Phase 2 callers
+    // are expected to pass `null` when the lookup misses; the service
+    // then falls back to the pre-#950 generic behaviour.
+    const unknownStrategy = ReferenceVehicle(
+      make: 'Acme',
+      model: 'XYZ',
+      generation: 'I',
+      yearStart: 2020,
+      displacementCc: 1500,
+      fuelType: 'petrol',
+      transmission: 'manual',
+      odometerPidStrategy: 'unknown',
+    );
+
+    test(
+        'readOdometerKm with Peugeot 208 ReferenceVehicle (psaUds) reads '
+        'the PSA mfg odometer command — preserves pre-#950 behaviour',
+        () async {
+      // VIN-free fixture: only the PSA-specific 22D101 command answers,
+      // proving the service dispatched on `odometerPidStrategy` rather
+      // than walking the brand catalog blindly.
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '01A6': 'NO DATA>',
+        '0131': 'NO DATA>',
+        // 0xD1 0x01 prefix + 2 bytes (0x4E 0x20) → 20000 km.
+        '22D101': '62 D1 01 4E 20>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final km = await service.readOdometerKm(referenceVehicle: peugeot208);
+      expect(km, 20000.0);
+    });
+
+    test(
+        'readFuelRateLPerHour without VehicleProfile uses ReferenceVehicle '
+        'displacement + VE in the speed-density branch (Peugeot 208: 1199 cc, '
+        '0.85 VE)', () async {
+      // Speed-density-only fixture (no 5E, no MAF, no trims).
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 41>', // MAP raw 0x41 = 65 kPa
+        '010F': '41 0F 46>', // IAT raw 0x46 → 30 °C
+        '010C': '41 0C 27 10>', // RPM 2500
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final rate = await service.readFuelRateLPerHour(
+        referenceVehicle: peugeot208,
+      );
+      final expected = Obd2Service.estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1199,
+        volumetricEfficiency: 0.85,
+      );
+      expect(rate, isNotNull);
+      expect(expected, isNotNull);
+      expect(rate, closeTo(expected!, 1e-3));
+    });
+
+    test(
+        'readOdometerKm with VW Golf ReferenceVehicle (vwUds) reads the VW '
+        'mfg odometer command (222203 → 3-byte km)', () async {
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '01A6': 'NO DATA>',
+        '0131': 'NO DATA>',
+        // 0x22 0x03 prefix + 3 bytes → 0x01 0xE2 0x40 = 123456 km.
+        '222203': '62 22 03 01 E2 40>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final km = await service.readOdometerKm(referenceVehicle: vwGolf);
+      expect(km, 123456.0);
+    });
+
+    test(
+        'readFuelRateLPerHour with VW Golf ReferenceVehicle uses 1498 cc + '
+        '0.87 VE (catalog values, not 1000 cc / 0.85 default)', () async {
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 41>',
+        '010F': '41 0F 46>',
+        '010C': '41 0C 27 10>',
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final rate = await service.readFuelRateLPerHour(
+        referenceVehicle: vwGolf,
+      );
+      final expected = Obd2Service.estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1498,
+        volumetricEfficiency: 0.87,
+      );
+      expect(rate, isNotNull);
+      expect(expected, isNotNull);
+      expect(rate, closeTo(expected!, 1e-3));
+
+      // Sanity: 1498 cc / 0.87 VE must produce a clearly different
+      // rate from the 1000 cc / 0.85 generic default.
+      final defaultRate = Obd2Service.estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1000,
+        volumetricEfficiency: 0.85,
+      )!;
+      expect((rate! - defaultRate).abs(), greaterThan(1e-2));
+    });
+
+    test(
+        'readOdometerKm with unknown-strategy ReferenceVehicle returns null '
+        'gracefully when standard PIDs miss — no mfg fallback attempted',
+        () async {
+      // No PSA / VW / BMW / Renault commands are mocked. If the
+      // service tried any of them, FakeObd2Transport throws. The
+      // strategy switch must short-circuit to null after PID 31.
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '01A6': 'NO DATA>',
+        '0131': 'NO DATA>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final km = await service.readOdometerKm(
+        referenceVehicle: unknownStrategy,
+      );
+      expect(km, isNull);
+    });
+
+    test(
+        'readFuelRateLPerHour with unknown-make ReferenceVehicle still uses '
+        'its 1500 cc displacement (data-driven default beats the legacy '
+        '1000 cc constant)', () async {
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 41>',
+        '010F': '41 0F 46>',
+        '010C': '41 0C 27 10>',
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final rate = await service.readFuelRateLPerHour(
+        referenceVehicle: unknownStrategy,
+      );
+      final expected = Obd2Service.estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1500,
+        volumetricEfficiency: 0.85,
+      );
+      expect(rate, isNotNull);
+      expect(expected, isNotNull);
+      expect(rate, closeTo(expected!, 1e-3));
+    });
+
+    test(
+        'VehicleProfile still wins over ReferenceVehicle when both supplied '
+        '— the user can override catalog defaults', () async {
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 41>',
+        '010F': '41 0F 46>',
+        '010C': '41 0C 27 10>',
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      const profile = VehicleProfile(
+        id: 'override',
+        name: 'tuned',
+        engineDisplacementCc: 1800,
+        volumetricEfficiency: 0.92,
+      );
+      final rate = await service.readFuelRateLPerHour(
+        vehicle: profile,
+        referenceVehicle: vwGolf,
+      );
+      final expected = Obd2Service.estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1800,
+        volumetricEfficiency: 0.92,
+      );
+      expect(rate, isNotNull);
+      expect(expected, isNotNull);
+      expect(rate, closeTo(expected!, 1e-3));
+    });
+
+    test(
+        'readOdometerKm with no ReferenceVehicle still walks the VIN→brand '
+        'fallback (pre-#950 behaviour preserved when callers do not opt in)',
+        () async {
+      // Same fixture as the existing "PID A6 returns odometer" test —
+      // proves we did not break call sites that pass nothing.
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '01A6': '41 A6 00 12 D6 87>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final km = await service.readOdometerKm();
+      expect(km, closeTo(123456.7, 0.1));
     });
   });
 }


### PR DESCRIPTION
Refs #950 phase 2; phases 3-4 follow.

## What
Plumb the phase-1 ReferenceVehicle catalog into `Obd2Service`:
- `readOdometerKm({ReferenceVehicle? referenceVehicle})` — when supplied, step 3 dispatches on `odometerPidStrategy` (`psaUds` / `vwUds` / `bmwCan` / `stdA6` / `unknown`). Without it, the legacy VIN→brand catalog walk runs unchanged.
- `readFuelRateLPerHour({VehicleProfile? vehicle, ReferenceVehicle? referenceVehicle})` — speed-density branch now uses `referenceVehicle.displacementCc` + `volumetricEfficiency` + `fuelType` when `VehicleProfile` lacks them. `VehicleProfile` still wins when both are passed.

## Why
Phase 1 shipped the catalog + provider. Phase 2 makes the OBD-II layer data-driven so adding a new car only edits JSON, not Dart. The legacy VIN-only path stays for callers that haven't been migrated yet — phase 4 will route the user's `VehicleProfile` through the catalog and remove the legacy branch.

## Testing
- 7 new tests in `obd2_service_test.dart` covering Peugeot 208 (psaUds, 1199cc), VW Golf (vwUds, 1498cc/0.87 VE), unknown-strategy fallback, `VehicleProfile` precedence, and pre-#950 behaviour preservation.
- `flutter analyze` — zero issues.
- `flutter test` — all 6807 tests pass.

## Out of scope
- Catalog additions (phase 1 closed).
- `VehicleProfile.makeModel` schema migration (phase 4).
- Catalog browser UI (separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)