### PR TITLE
refactor(report): extract submit handler + backend availability (Refs #563)

### DIFF
--- a/lib/features/report/presentation/screens/report_backend_availability.dart
+++ b/lib/features/report/presentation/screens/report_backend_availability.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/country/country_provider.dart';
+import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/sync/supabase_client.dart';
+import '../../../../core/sync/sync_provider.dart';
+import '../../domain/entities/report_type.dart';
+
+/// Snapshot of which reporting backends are currently usable for the
+/// active country / config. Pulled out of `report_screen.dart` in #563
+/// to keep the screen file under the 300-LOC budget.
+///
+/// #484 — backend availability is computed up front so we can both
+/// (a) render the no-backend banner and (b) disable the submit button
+/// in the same condition. Keeping the UI consistent with what the
+/// submit handler actually does.
+class ReportBackendAvailability {
+  ReportBackendAvailability({
+    required this.canSubmitTankerkoenig,
+    required this.canSubmitTankSync,
+    required this.visibleTypes,
+  });
+
+  final bool canSubmitTankerkoenig;
+  final bool canSubmitTankSync;
+  final List<ReportType> visibleTypes;
+
+  bool get hasAnyBackend => canSubmitTankerkoenig || canSubmitTankSync;
+
+  bool get allVisibleRouteToGitHub =>
+      visibleTypes.every((t) => t.routesToGitHub);
+
+  /// #508 — GitHub-routed types (wrongName / wrongAddress) need no
+  /// backend at all — the reporter opens the consent dialog and hands
+  /// off to the browser. So the radio row and submit button are always
+  /// usable when such a type is selected, regardless of Tankerkoenig
+  /// or TankSync availability.
+  bool selectedIsGitHubRouted(ReportType? selected) =>
+      selected != null && selected.routesToGitHub;
+
+  static ReportBackendAvailability watch(WidgetRef ref) {
+    final country = ref.watch(activeCountryProvider);
+    final apiKey = ref.watch(apiKeyStorageProvider).getApiKey();
+    final syncConfig = ref.watch(syncStateProvider);
+    final canSubmitTankerkoenig =
+        country.code == 'DE' && apiKey != null && apiKey.isNotEmpty;
+    final canSubmitTankSync =
+        TankSyncClient.isConnected && syncConfig.userId != null;
+    return ReportBackendAvailability(
+      canSubmitTankerkoenig: canSubmitTankerkoenig,
+      canSubmitTankSync: canSubmitTankSync,
+      visibleTypes: ReportType.visibleForCountry(country.code),
+    );
+  }
+}

--- a/lib/features/report/presentation/screens/report_screen.dart
+++ b/lib/features/report/presentation/screens/report_screen.dart
@@ -1,24 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import '../../../../core/country/country_provider.dart';
-import '../../../../core/error/exceptions.dart';
-import '../../../../core/error_reporting/error_report_payload.dart';
 import '../../../../core/error_reporting/error_reporter.dart';
-import '../../../../core/error_reporting/error_reporter_context.dart';
-import '../../../../core/services/report_service.dart';
-import '../../../../core/storage/storage_providers.dart';
-import '../../../../core/sync/supabase_client.dart';
-import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/widgets/page_scaffold.dart';
-import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../data/community_report_service.dart';
 import '../../domain/entities/report_type.dart';
 import '../../providers/report_form_provider.dart';
 import '../widgets/no_backend_banner.dart';
 import '../widgets/report_input_section.dart';
 import '../widgets/report_type_list.dart';
+import 'report_backend_availability.dart';
+import 'report_submit_handler.dart';
 
 export '../../domain/entities/report_type.dart';
 
@@ -78,158 +70,15 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
     super.dispose();
   }
 
-  Future<void> _submit() async {
-    final l10n = AppLocalizations.of(context);
-    final form = ref.read(reportFormControllerProvider);
-    final notifier = ref.read(reportFormControllerProvider.notifier);
-    final selectedType = form.selectedType;
-    if (selectedType == null) return;
-    if (selectedType.needsPrice && _priceController.text.isEmpty) {
-      SnackBarHelper.showError(
-        context,
-        l10n?.enterValidPrice ?? 'Please enter a valid price',
-      );
-      return;
-    }
-    if (selectedType.needsText && _textController.text.trim().isEmpty) {
-      SnackBarHelper.showError(
-        context,
-        l10n?.enterCorrection ?? 'Please enter the correction',
-      );
-      return;
-    }
-
-    notifier.setSubmitting(true);
-    try {
-      // #508 — name / address errors are implementation bugs, not
-      // community data corrections. Route them to a pre-filled GitHub
-      // issue instead of the Tankerkoenig / TankSync backends.
-      if (selectedType.routesToGitHub) {
-        final country = ref.read(activeCountryProvider);
-        final correction = _textController.text.trim();
-        final payload = ErrorReportPayload(
-          errorType: 'WrongMetadataReport',
-          errorMessage:
-              '${selectedType.fuelTypeColumnValue} reported wrong for '
-                  'station ${widget.stationId}: "$correction"',
-          sourceLabel: country.apiProvider ?? country.name,
-          countryCode: country.code,
-          appVersion: ErrorReporterContext.currentAppVersion(),
-          platform: ErrorReporterContext.currentPlatform(),
-          locale: ErrorReporterContext.currentLocale(context),
-          capturedAt: DateTime.now(),
-        );
-        final launched = await (widget.reporter ?? const ErrorReporter())
-            .reportError(context, payload);
-        if (mounted && launched) {
-          SnackBarHelper.showSuccess(
-            context,
-            l10n?.reportSent ?? 'Report sent. Thank you!',
-          );
-          // Use Navigator.maybePop so the path works both under the
-          // real GoRouter shell and under the plain MaterialApp that
-          // widget tests use — context.pop() would throw
-          // \`No GoRouter found in context\` in tests.
-          await Navigator.of(context).maybePop();
-        }
-        return;
-      }
-
-      final apiKeys = ref.read(apiKeyStorageProvider);
-      final apiKey = apiKeys.getApiKey();
-      final price = selectedType.needsPrice
-          ? double.tryParse(_priceController.text.replaceAll(',', '.'))
-          : null;
-      final correctionText =
-          selectedType.needsText ? _textController.text.trim() : null;
-
-      // #484 — resolve the reporting backends for the current country
-      // and config. Before this fix the screen always hit the
-      // Tankerkoenig complaint endpoint (which exists only for DE and
-      // requires an API key), so every non-DE user saw a silent failure.
-      // Now:
-      //   - Tankerkoenig: only when country == DE AND a key is set
-      //   - TankSync community reports: whenever TankSync is connected,
-      //     tagged with the user's ACTUAL country (not hardcoded 'DE')
-      //   - If neither backend is available, fail loudly with a
-      //     banner-style error so the user knows their report was not
-      //     sent anywhere.
-      final country = ref.read(activeCountryProvider);
-      final syncConfig = ref.read(syncStateProvider);
-      // #484 — Tankerkoenig only accepts the 5 original report types.
-      // Metadata and extended-fuel types (wrongE85, wrongName, etc.)
-      // route to TankSync only, even in Germany with a key set.
-      final canSubmitTankerkoenig = country.code == 'DE' &&
-          apiKey != null &&
-          apiKey.isNotEmpty &&
-          selectedType.isTankerkoenigSupported;
-      final canSubmitTankSync = TankSyncClient.isConnected &&
-          syncConfig.userId != null;
-
-      if (!canSubmitTankerkoenig && !canSubmitTankSync) {
-        if (mounted) {
-          SnackBarHelper.showError(
-            context,
-            l10n?.reportNoBackendAvailable ??
-                'The report could not be sent: no reporting service is '
-                    'configured for this country. Enable TankSync in Settings '
-                    'to send community reports.',
-          );
-        }
-        return;
-      }
-
-      if (canSubmitTankerkoenig) {
-        await ReportService().submitComplaint(
-          stationId: widget.stationId,
-          reportType: selectedType.apiValue,
-          apiKey: apiKey,
-          correction: price,
-        );
-      }
-
-      if (canSubmitTankSync) {
-        // #484 — dispatch by report shape. Price reports carry
-        // reportedPrice, metadata reports carry correctionText, status
-        // reports carry neither (they don't hit TankSync — the row
-        // would fail the check constraint, so we skip).
-        final hasPricePayload = selectedType.needsPrice && price != null;
-        final hasTextPayload =
-            selectedType.needsText && correctionText != null;
-        if (hasPricePayload || hasTextPayload) {
-          await CommunityReportService.submitReport(
-            stationId: widget.stationId,
-            fuelType: selectedType.fuelTypeColumnValue,
-            reportedPrice: hasPricePayload ? price : null,
-            correctionText: hasTextPayload ? correctionText : null,
-            // #484 — was hardcoded to 'DE', mislabelling every non-DE
-            // community report as German data.
-            countryCode: country.code,
-            supabaseUserId: syncConfig.userId,
-            supabaseClient: TankSyncClient.client,
-          );
-        }
-      }
-
-      if (mounted) {
-        SnackBarHelper.showSuccess(
-          context,
-          l10n?.reportSent ?? 'Report sent. Thank you!',
-        );
-        context.pop();
-      }
-    } on ApiException catch (e) {
-      if (mounted) {
-        SnackBarHelper.showError(
-          context,
-          '${l10n?.retry ?? "Error"}: ${e.message}',
-        );
-      }
-    } finally {
-      if (mounted) {
-        ref.read(reportFormControllerProvider.notifier).setSubmitting(false);
-      }
-    }
+  Future<void> _submit() {
+    return ReportSubmitHandler(
+      context: context,
+      ref: ref,
+      stationId: widget.stationId,
+      priceController: _priceController,
+      textController: _textController,
+      reporter: widget.reporter,
+    ).submit();
   }
 
   @override
@@ -237,31 +86,7 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
     final l10n = AppLocalizations.of(context);
     final form = ref.watch(reportFormControllerProvider);
     final selectedType = form.selectedType;
-
-    // #484 — compute the reporting-backends availability up front so
-    // we can both (a) render a banner when nothing is configured and
-    // (b) disable the submit button in the same condition. Keeps the
-    // UI consistent with what _submit() will actually do.
-    final country = ref.watch(activeCountryProvider);
-    final apiKey = ref.watch(apiKeyStorageProvider).getApiKey();
-    final syncConfig = ref.watch(syncStateProvider);
-    final canSubmitTankerkoenig = country.code == 'DE' &&
-        apiKey != null &&
-        apiKey.isNotEmpty;
-    final canSubmitTankSync =
-        TankSyncClient.isConnected && syncConfig.userId != null;
-    final hasAnyBackend = canSubmitTankerkoenig || canSubmitTankSync;
-
-    // #508 — GitHub-routed types (wrongName / wrongAddress) need no
-    // backend at all — the reporter opens the consent dialog and hands
-    // off to the browser. So the radio row and submit button are
-    // always usable when such a type is selected, regardless of
-    // Tankerkoenig / TankSync availability.
-    final visibleTypes = ReportType.visibleForCountry(country.code);
-    final allVisibleRouteToGitHub =
-        visibleTypes.every((t) => t.routesToGitHub);
-    final selectedIsGitHubRouted =
-        selectedType != null && selectedType.routesToGitHub;
+    final backends = ReportBackendAvailability.watch(ref);
 
     // #484 — was "Signaler un prix" but two of the existing options
     // (open/closed status) are not about prices and the rework will
@@ -284,41 +109,43 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
         onChanged: (v) =>
             ref.read(reportFormControllerProvider.notifier).selectType(v),
         child: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          if (!hasAnyBackend && !allVisibleRouteToGitHub) ...[
-            const NoBackendBanner(),
-            const SizedBox(height: 16),
+          padding: const EdgeInsets.all(16),
+          children: [
+            if (!backends.hasAnyBackend && !backends.allVisibleRouteToGitHub)
+              ...[
+                const NoBackendBanner(),
+                const SizedBox(height: 16),
+              ],
+            ...buildReportTypeList(
+              context,
+              ref,
+              visibleTypes: backends.visibleTypes,
+              hasAnyBackend: backends.hasAnyBackend,
+            ),
+            ReportInputSection(
+              selectedType: selectedType,
+              priceController: _priceController,
+              textController: _textController,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: selectedType != null &&
+                      !form.isSubmitting &&
+                      _hasRequiredInput(selectedType) &&
+                      (backends.selectedIsGitHubRouted(selectedType) ||
+                          backends.hasAnyBackend)
+                  ? _submit
+                  : null,
+              child: form.isSubmitting
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Text(l10n?.sendReport ?? 'Send report'),
+            ),
           ],
-          ...buildReportTypeList(
-            context,
-            ref,
-            visibleTypes: visibleTypes,
-            hasAnyBackend: hasAnyBackend,
-          ),
-          ReportInputSection(
-            selectedType: selectedType,
-            priceController: _priceController,
-            textController: _textController,
-          ),
-          const SizedBox(height: 24),
-          FilledButton(
-            onPressed: selectedType != null &&
-                    !form.isSubmitting &&
-                    _hasRequiredInput(selectedType) &&
-                    (selectedIsGitHubRouted || hasAnyBackend)
-                ? _submit
-                : null,
-            child: form.isSubmitting
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : Text(l10n?.sendReport ?? 'Send report'),
-          ),
-        ],
-      ),
+        ),
       ),
     );
   }

--- a/lib/features/report/presentation/screens/report_submit_handler.dart
+++ b/lib/features/report/presentation/screens/report_submit_handler.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/country/country_provider.dart';
+import '../../../../core/error/exceptions.dart';
+import '../../../../core/error_reporting/error_report_payload.dart';
+import '../../../../core/error_reporting/error_reporter.dart';
+import '../../../../core/error_reporting/error_reporter_context.dart';
+import '../../../../core/services/report_service.dart';
+import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/sync/supabase_client.dart';
+import '../../../../core/sync/sync_provider.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../data/community_report_service.dart';
+import '../../domain/entities/report_type.dart';
+import '../../providers/report_form_provider.dart';
+
+/// Encapsulates the submit-flow for [ReportScreen]. Split out of the
+/// screen file in #563 so the screen stays under the 300-LOC budget and
+/// so the dispatching logic (GitHub vs Tankerkoenig vs TankSync) is
+/// reachable from a single place.
+class ReportSubmitHandler {
+  ReportSubmitHandler({
+    required this.context,
+    required this.ref,
+    required this.stationId,
+    required this.priceController,
+    required this.textController,
+    this.reporter,
+  });
+
+  final BuildContext context;
+  final WidgetRef ref;
+  final String stationId;
+  final TextEditingController priceController;
+  final TextEditingController textController;
+  final ErrorReporter? reporter;
+
+  Future<void> submit() async {
+    final l10n = AppLocalizations.of(context);
+    final form = ref.read(reportFormControllerProvider);
+    final notifier = ref.read(reportFormControllerProvider.notifier);
+    final selectedType = form.selectedType;
+    if (selectedType == null) return;
+    if (selectedType.needsPrice && priceController.text.isEmpty) {
+      SnackBarHelper.showError(
+        context,
+        l10n?.enterValidPrice ?? 'Please enter a valid price',
+      );
+      return;
+    }
+    if (selectedType.needsText && textController.text.trim().isEmpty) {
+      SnackBarHelper.showError(
+        context,
+        l10n?.enterCorrection ?? 'Please enter the correction',
+      );
+      return;
+    }
+
+    notifier.setSubmitting(true);
+    try {
+      // #508 — name / address errors are implementation bugs, not
+      // community data corrections. Route them to a pre-filled GitHub
+      // issue instead of the Tankerkoenig / TankSync backends.
+      if (selectedType.routesToGitHub) {
+        await _routeToGitHub(selectedType, l10n);
+        return;
+      }
+
+      final apiKeys = ref.read(apiKeyStorageProvider);
+      final apiKey = apiKeys.getApiKey();
+      final price = selectedType.needsPrice
+          ? double.tryParse(priceController.text.replaceAll(',', '.'))
+          : null;
+      final correctionText =
+          selectedType.needsText ? textController.text.trim() : null;
+
+      // #484 — resolve the reporting backends for the current country
+      // and config. Before this fix the screen always hit the
+      // Tankerkoenig complaint endpoint (which exists only for DE and
+      // requires an API key), so every non-DE user saw a silent failure.
+      // Now:
+      //   - Tankerkoenig: only when country == DE AND a key is set
+      //   - TankSync community reports: whenever TankSync is connected,
+      //     tagged with the user's ACTUAL country (not hardcoded 'DE')
+      //   - If neither backend is available, fail loudly with a
+      //     banner-style error so the user knows their report was not
+      //     sent anywhere.
+      final country = ref.read(activeCountryProvider);
+      final syncConfig = ref.read(syncStateProvider);
+      // #484 — Tankerkoenig only accepts the 5 original report types.
+      // Metadata and extended-fuel types (wrongE85, wrongName, etc.)
+      // route to TankSync only, even in Germany with a key set.
+      final canSubmitTankerkoenig = country.code == 'DE' &&
+          apiKey != null &&
+          apiKey.isNotEmpty &&
+          selectedType.isTankerkoenigSupported;
+      final canSubmitTankSync = TankSyncClient.isConnected &&
+          syncConfig.userId != null;
+
+      if (!canSubmitTankerkoenig && !canSubmitTankSync) {
+        if (context.mounted) {
+          SnackBarHelper.showError(
+            context,
+            l10n?.reportNoBackendAvailable ??
+                'The report could not be sent: no reporting service is '
+                    'configured for this country. Enable TankSync in Settings '
+                    'to send community reports.',
+          );
+        }
+        return;
+      }
+
+      if (canSubmitTankerkoenig) {
+        await ReportService().submitComplaint(
+          stationId: stationId,
+          reportType: selectedType.apiValue,
+          apiKey: apiKey,
+          correction: price,
+        );
+      }
+
+      if (canSubmitTankSync) {
+        // #484 — dispatch by report shape. Price reports carry
+        // reportedPrice, metadata reports carry correctionText, status
+        // reports carry neither (they don't hit TankSync — the row
+        // would fail the check constraint, so we skip).
+        final hasPricePayload = selectedType.needsPrice && price != null;
+        final hasTextPayload =
+            selectedType.needsText && correctionText != null;
+        if (hasPricePayload || hasTextPayload) {
+          await CommunityReportService.submitReport(
+            stationId: stationId,
+            fuelType: selectedType.fuelTypeColumnValue,
+            reportedPrice: hasPricePayload ? price : null,
+            correctionText: hasTextPayload ? correctionText : null,
+            // #484 — was hardcoded to 'DE', mislabelling every non-DE
+            // community report as German data.
+            countryCode: country.code,
+            supabaseUserId: syncConfig.userId,
+            supabaseClient: TankSyncClient.client,
+          );
+        }
+      }
+
+      if (context.mounted) {
+        SnackBarHelper.showSuccess(
+          context,
+          l10n?.reportSent ?? 'Report sent. Thank you!',
+        );
+        context.pop();
+      }
+    } on ApiException catch (e) {
+      if (context.mounted) {
+        SnackBarHelper.showError(
+          context,
+          '${l10n?.retry ?? "Error"}: ${e.message}',
+        );
+      }
+    } finally {
+      if (context.mounted) {
+        ref.read(reportFormControllerProvider.notifier).setSubmitting(false);
+      }
+    }
+  }
+
+  Future<void> _routeToGitHub(
+    ReportType selectedType,
+    AppLocalizations? l10n,
+  ) async {
+    final country = ref.read(activeCountryProvider);
+    final correction = textController.text.trim();
+    final payload = ErrorReportPayload(
+      errorType: 'WrongMetadataReport',
+      errorMessage:
+          '${selectedType.fuelTypeColumnValue} reported wrong for '
+              'station $stationId: "$correction"',
+      sourceLabel: country.apiProvider ?? country.name,
+      countryCode: country.code,
+      appVersion: ErrorReporterContext.currentAppVersion(),
+      platform: ErrorReporterContext.currentPlatform(),
+      locale: ErrorReporterContext.currentLocale(context),
+      capturedAt: DateTime.now(),
+    );
+    final launched =
+        await (reporter ?? const ErrorReporter()).reportError(context, payload);
+    if (context.mounted && launched) {
+      SnackBarHelper.showSuccess(
+        context,
+        l10n?.reportSent ?? 'Report sent. Thank you!',
+      );
+      // Use Navigator.maybePop so the path works both under the
+      // real GoRouter shell and under the plain MaterialApp that
+      // widget tests use — context.pop() would throw
+      // `No GoRouter found in context` in tests.
+      await Navigator.of(context).maybePop();
+    }
+  }
+}

--- a/test/core/services/report_service_test.dart
+++ b/test/core/services/report_service_test.dart
@@ -148,30 +148,42 @@ void main() {
     });
 
     group('source-level regression', () {
-      test('report_screen does not instantiate Dio directly', () {
-        final source = File(
-          'lib/features/report/presentation/screens/report_screen.dart',
-        ).readAsStringSync();
+      // #563 — submit-flow extracted to sibling report_submit_handler.dart so
+      // report_screen.dart stays under the 300-LOC budget. The screen file
+      // and the handler file together must keep the original invariants
+      // (no direct Dio, ReportService.submitComplaint is the entry point).
+      const reportScreenPath =
+          'lib/features/report/presentation/screens/report_screen.dart';
+      const submitHandlerPath =
+          'lib/features/report/presentation/screens/report_submit_handler.dart';
 
-        expect(
-          source.contains('Dio('),
-          isFalse,
-          reason: 'ReportScreen should use ReportService, not create Dio directly',
-        );
-        expect(
-          source.contains("import 'package:dio/dio.dart'"),
-          isFalse,
-          reason: 'ReportScreen should not import Dio',
-        );
+      test('report_screen does not instantiate Dio directly', () {
+        final screenSource = File(reportScreenPath).readAsStringSync();
+        final handlerSource = File(submitHandlerPath).readAsStringSync();
+
+        for (final entry in {
+          reportScreenPath: screenSource,
+          submitHandlerPath: handlerSource,
+        }.entries) {
+          expect(
+            entry.value.contains('Dio('),
+            isFalse,
+            reason:
+                '${entry.key} should use ReportService, not create Dio directly',
+          );
+          expect(
+            entry.value.contains("import 'package:dio/dio.dart'"),
+            isFalse,
+            reason: '${entry.key} should not import Dio',
+          );
+        }
       });
 
       test('report_screen uses ReportService', () {
-        final source = File(
-          'lib/features/report/presentation/screens/report_screen.dart',
-        ).readAsStringSync();
+        final handlerSource = File(submitHandlerPath).readAsStringSync();
 
-        expect(source, contains('ReportService'));
-        expect(source, contains('submitComplaint'));
+        expect(handlerSource, contains('ReportService'));
+        expect(handlerSource, contains('submitComplaint'));
       });
     });
   });


### PR DESCRIPTION
Refs #563. Last file from the issue listing now under 300 LOC.

## What

Split `lib/features/report/presentation/screens/report_screen.dart` (325 LOC -> 152 LOC) by extracting two siblings into the same directory:

- `report_submit_handler.dart` (201 LOC) — the submit-flow controller covering the three dispatch paths (GitHub-routed metadata reports per #508, Tankerkoenig complaint endpoint, TankSync community reports per #484).
- `report_backend_availability.dart` (55 LOC) — Riverpod-watching snapshot of which backends are usable, with helpers (`hasAnyBackend`, `allVisibleRouteToGitHub`, `selectedIsGitHubRouted`).

## Why

Per #563, screen files should stay under 300 LOC. The submit logic is also a clean cohesive boundary — the screen just renders state and delegates the action.

Public `ReportScreen` API is unchanged.

## Testing

- `flutter analyze` — zero warnings.
- `flutter test` — 6827 passed, 1 skipped.
- The source-level regression test in `test/core/services/report_service_test.dart` was updated to check the screen + handler pair so the "no direct Dio in the report flow" invariant keeps holding after the split.

## LOC

| File | Before | After |
|---|---|---|
| report_screen.dart | 325 | 152 |
| report_submit_handler.dart | — | 201 (new) |
| report_backend_availability.dart | — | 55 (new) |