### PR TITLE
refactor(consumption): extract trip detail sections (Refs #563)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,7 +9,15 @@ import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/trip_history_repository.dart';
 import '../../providers/trip_history_provider.dart';
+import '../widgets/trip_detail_body.dart';
 import '../widgets/trip_detail_charts.dart';
+import '../widgets/trip_detail_share_payload.dart';
+
+// Re-export the visible-for-testing share payload builder so existing
+// importers (and tests) can keep using the screen file as the entry
+// point even though the implementation now lives in a sibling widget.
+export '../widgets/trip_detail_share_payload.dart'
+    show buildTripDetailSharePayload;
 
 /// Trip detail screen (#890).
 ///
@@ -68,9 +74,7 @@ class TripDetailScreen extends ConsumerWidget {
     // pre-dates the vehicleId tagging from #889.
     final vehicle = entry?.vehicleId == null
         ? activeVehicle
-        : vehicles
-                .where((v) => v.id == entry!.vehicleId)
-                .firstOrNull ??
+        : vehicles.where((v) => v.id == entry!.vehicleId).firstOrNull ??
             activeVehicle;
     final isEv = vehicle?.type == VehicleType.ev;
 
@@ -108,7 +112,7 @@ class TripDetailScreen extends ConsumerWidget {
                 ),
               ),
             )
-          : _TripDetailBody(
+          : TripDetailBody(
               entry: entry,
               vehicle: vehicle,
               samples: samples,
@@ -123,7 +127,11 @@ class TripDetailScreen extends ConsumerWidget {
     TripHistoryEntry entry,
     VehicleProfile? vehicle,
   ) async {
-    final payload = _buildSharePayload(entry, vehicle, samples);
+    final payload = tripDetailSharePayload(
+      entry: entry,
+      vehicle: vehicle,
+      samples: samples,
+    );
     await Clipboard.setData(ClipboardData(text: payload));
     if (!context.mounted) return;
     final msg = l?.trajetDetailShareCopied ?? 'Copied to clipboard';
@@ -166,307 +174,5 @@ class TripDetailScreen extends ConsumerWidget {
     await ref.read(tripHistoryListProvider.notifier).delete(tripId);
     if (!context.mounted) return;
     context.pop();
-  }
-}
-
-/// Structured clipboard payload: JSON header summarising the trip,
-/// followed by a CSV block of every sample. This keeps the share
-/// action useful for both machines (paste into a diff tool) and
-/// humans (skim in a text editor). Exposed so tests can assert on
-/// the exact text written to [Clipboard].
-@visibleForTesting
-String buildTripDetailSharePayload({
-  required TripHistoryEntry entry,
-  required VehicleProfile? vehicle,
-  required List<TripDetailSample> samples,
-}) =>
-    _buildSharePayload(entry, vehicle, samples);
-
-String _buildSharePayload(
-  TripHistoryEntry entry,
-  VehicleProfile? vehicle,
-  List<TripDetailSample> samples,
-) {
-  final s = entry.summary;
-  final summary = <String, dynamic>{
-    'id': entry.id,
-    if (vehicle != null) 'vehicle': vehicle.name,
-    if (entry.vehicleId != null) 'vehicleId': entry.vehicleId,
-    if (s.startedAt != null) 'startedAt': s.startedAt!.toIso8601String(),
-    if (s.endedAt != null) 'endedAt': s.endedAt!.toIso8601String(),
-    'distanceKm': s.distanceKm,
-    'distanceSource': s.distanceSource,
-    if (s.avgLPer100Km != null) 'avgLPer100Km': s.avgLPer100Km,
-    if (s.fuelLitersConsumed != null)
-      'fuelLitersConsumed': s.fuelLitersConsumed,
-    'maxRpm': s.maxRpm,
-    'highRpmSeconds': s.highRpmSeconds,
-    'idleSeconds': s.idleSeconds,
-    'harshBrakes': s.harshBrakes,
-    'harshAccelerations': s.harshAccelerations,
-    'sampleCount': samples.length,
-  };
-  const encoder = JsonEncoder.withIndent('  ');
-  final csvBuffer = StringBuffer()
-    ..writeln('timestamp,speedKmh,rpm,fuelRateLPerHour');
-  for (final sample in samples) {
-    csvBuffer
-      ..write(sample.timestamp.toIso8601String())
-      ..write(',')
-      ..write(sample.speedKmh.toStringAsFixed(2))
-      ..write(',')
-      ..write(sample.rpm?.toStringAsFixed(0) ?? '')
-      ..write(',')
-      ..writeln(sample.fuelRateLPerHour?.toStringAsFixed(3) ?? '');
-  }
-  return '${encoder.convert(summary)}\n\n${csvBuffer.toString()}';
-}
-
-class _TripDetailBody extends StatelessWidget {
-  final TripHistoryEntry entry;
-  final VehicleProfile? vehicle;
-  final List<TripDetailSample> samples;
-  final bool isEv;
-
-  const _TripDetailBody({
-    required this.entry,
-    required this.vehicle,
-    required this.samples,
-    required this.isEv,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-
-    // RPM section is hidden when every sample reports null (the car's
-    // PID cache flagged RPM as unsupported). The summary card still
-    // shows max-RPM for the trip because that's part of the stored
-    // summary regardless of per-sample availability.
-    final hasRpmSamples = samples.any((s) => s.rpm != null);
-
-    // Use SingleChildScrollView + Column (not ListView) so every
-    // section stays in the widget tree — simplifies widget tests that
-    // assert on the presence / absence of the RPM chart below the
-    // fold, and keeps the screen compatible with `scrollUntilVisible`
-    // when the profile is long enough to require actual scrolling.
-    return SingleChildScrollView(
-      key: const Key('trip_detail_scroll'),
-      padding: EdgeInsets.only(
-        top: 8,
-        bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          _TripSummaryCard(
-            entry: entry,
-            vehicle: vehicle,
-            samples: samples,
-            isEv: isEv,
-          ),
-          const SizedBox(height: 8),
-          _ChartSection(
-            title: l?.trajetDetailChartSpeed ?? 'Speed (km/h)',
-            chart: TripDetailSpeedChart(samples: samples),
-          ),
-          _ChartSection(
-            title: l?.trajetDetailChartFuelRate ?? 'Fuel rate (L/h)',
-            chart: TripDetailFuelRateChart(samples: samples),
-          ),
-          if (hasRpmSamples)
-            _ChartSection(
-              title: l?.trajetDetailChartRpm ?? 'RPM',
-              chart: TripDetailRpmChart(samples: samples),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ChartSection extends StatelessWidget {
-  final String title;
-  final Widget chart;
-
-  const _ChartSection({required this.title, required this.chart});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(title, style: theme.textTheme.titleSmall),
-          const SizedBox(height: 4),
-          chart,
-        ],
-      ),
-    );
-  }
-}
-
-class _TripSummaryCard extends StatelessWidget {
-  final TripHistoryEntry entry;
-  final VehicleProfile? vehicle;
-  final List<TripDetailSample> samples;
-  final bool isEv;
-
-  const _TripSummaryCard({
-    required this.entry,
-    required this.vehicle,
-    required this.samples,
-    required this.isEv,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    final s = entry.summary;
-    final unknown = l?.trajetDetailFieldValueUnknown ?? '—';
-    final avgUnit = isEv ? 'kWh/100 km' : 'L/100 km';
-
-    final date = s.startedAt == null ? unknown : _fmtDate(s.startedAt!);
-    final vehicleName = vehicle?.name ?? unknown;
-    final distance = '${s.distanceKm.toStringAsFixed(1)} km';
-    final duration =
-        s.startedAt != null && s.endedAt != null && s.endedAt!.isAfter(s.startedAt!)
-            ? _fmtDuration(s.endedAt!.difference(s.startedAt!))
-            : unknown;
-    final avgConsumption = s.avgLPer100Km == null
-        ? unknown
-        : '${s.avgLPer100Km!.toStringAsFixed(1)} $avgUnit';
-    final fuelUsed = s.fuelLitersConsumed == null
-        ? unknown
-        : '${s.fuelLitersConsumed!.toStringAsFixed(2)} L';
-    final avgSpeed = _avgSpeedLabel(samples, unknown);
-    final maxSpeed = _maxSpeedLabel(samples, unknown);
-
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              l?.trajetDetailSummaryTitle ?? 'Summary',
-              style: theme.textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-            _SummaryRow(
-              label: l?.trajetDetailFieldDate ?? 'Date',
-              value: date,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldVehicle ?? 'Vehicle',
-              value: vehicleName,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldDistance ?? 'Distance',
-              value: distance,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldDuration ?? 'Duration',
-              value: duration,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldAvgConsumption ?? 'Avg consumption',
-              value: avgConsumption,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldFuelUsed ?? 'Fuel used',
-              value: fuelUsed,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldAvgSpeed ?? 'Avg speed',
-              value: avgSpeed,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldMaxSpeed ?? 'Max speed',
-              value: maxSpeed,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  static String _avgSpeedLabel(
-    List<TripDetailSample> samples,
-    String unknown,
-  ) {
-    if (samples.isEmpty) return unknown;
-    var sum = 0.0;
-    for (final s in samples) {
-      sum += s.speedKmh;
-    }
-    final avg = sum / samples.length;
-    return '${avg.toStringAsFixed(1)} km/h';
-  }
-
-  static String _maxSpeedLabel(
-    List<TripDetailSample> samples,
-    String unknown,
-  ) {
-    if (samples.isEmpty) return unknown;
-    var maxV = samples.first.speedKmh;
-    for (final s in samples) {
-      if (s.speedKmh > maxV) maxV = s.speedKmh;
-    }
-    return '${maxV.toStringAsFixed(1)} km/h';
-  }
-
-  static String _fmtDate(DateTime d) {
-    final y = d.year.toString();
-    final m = d.month.toString().padLeft(2, '0');
-    final day = d.day.toString().padLeft(2, '0');
-    final h = d.hour.toString().padLeft(2, '0');
-    final min = d.minute.toString().padLeft(2, '0');
-    return '$y-$m-$day $h:$min';
-  }
-
-  static String _fmtDuration(Duration d) {
-    final h = d.inHours;
-    final m = d.inMinutes % 60;
-    final s = d.inSeconds % 60;
-    if (h == 0 && m == 0) return '${s}s';
-    if (h == 0) return '${m}m ${s}s';
-    return '${h}h ${m}m';
-  }
-}
-
-class _SummaryRow extends StatelessWidget {
-  final String label;
-  final String value;
-
-  const _SummaryRow({required this.label, required this.value});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(
-            child: Text(
-              label,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ),
-          Text(
-            value,
-            style: theme.textTheme.bodyMedium,
-          ),
-        ],
-      ),
-    );
   }
 }

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../data/trip_history_repository.dart';
+import 'trip_detail_charts.dart';
+import 'trip_summary_card.dart';
+
+/// Scrollable body of the trip detail screen (#890): summary card
+/// followed by speed / fuel-rate / RPM line charts.
+///
+/// Uses [SingleChildScrollView] + [Column] (not a [ListView]) so every
+/// section stays in the widget tree — simplifies widget tests that
+/// assert on the presence / absence of the RPM chart below the fold,
+/// and keeps the screen compatible with [scrollUntilVisible] when the
+/// profile is long enough to require actual scrolling.
+class TripDetailBody extends StatelessWidget {
+  final TripHistoryEntry entry;
+  final VehicleProfile? vehicle;
+  final List<TripDetailSample> samples;
+  final bool isEv;
+
+  const TripDetailBody({
+    super.key,
+    required this.entry,
+    required this.vehicle,
+    required this.samples,
+    required this.isEv,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+
+    // RPM section is hidden when every sample reports null (the car's
+    // PID cache flagged RPM as unsupported). The summary card still
+    // shows max-RPM for the trip because that's part of the stored
+    // summary regardless of per-sample availability.
+    final hasRpmSamples = samples.any((s) => s.rpm != null);
+
+    return SingleChildScrollView(
+      key: const Key('trip_detail_scroll'),
+      padding: EdgeInsets.only(
+        top: 8,
+        bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TripSummaryCard(
+            entry: entry,
+            vehicle: vehicle,
+            samples: samples,
+            isEv: isEv,
+          ),
+          const SizedBox(height: 8),
+          _ChartSection(
+            title: l?.trajetDetailChartSpeed ?? 'Speed (km/h)',
+            chart: TripDetailSpeedChart(samples: samples),
+          ),
+          _ChartSection(
+            title: l?.trajetDetailChartFuelRate ?? 'Fuel rate (L/h)',
+            chart: TripDetailFuelRateChart(samples: samples),
+          ),
+          if (hasRpmSamples)
+            _ChartSection(
+              title: l?.trajetDetailChartRpm ?? 'RPM',
+              chart: TripDetailRpmChart(samples: samples),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChartSection extends StatelessWidget {
+  final String title;
+  final Widget chart;
+
+  const _ChartSection({required this.title, required this.chart});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: theme.textTheme.titleSmall),
+          const SizedBox(height: 4),
+          chart,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/trip_detail_share_payload.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_share_payload.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../data/trip_history_repository.dart';
+import 'trip_detail_charts.dart';
+
+/// Structured clipboard payload for the Share action on the trip
+/// detail screen (#890): JSON header summarising the trip, followed
+/// by a CSV block of every sample. This keeps the action useful for
+/// both machines (paste into a diff tool) and humans (skim in a text
+/// editor).
+///
+/// The implementation is shared with [buildTripDetailSharePayload],
+/// which re-exposes the same function under a `@visibleForTesting`
+/// name so tests can assert on the exact text written to the
+/// clipboard while production code keeps using the unrestricted
+/// helper.
+String tripDetailSharePayload({
+  required TripHistoryEntry entry,
+  required VehicleProfile? vehicle,
+  required List<TripDetailSample> samples,
+}) {
+  final s = entry.summary;
+  final summary = <String, dynamic>{
+    'id': entry.id,
+    if (vehicle != null) 'vehicle': vehicle.name,
+    if (entry.vehicleId != null) 'vehicleId': entry.vehicleId,
+    if (s.startedAt != null) 'startedAt': s.startedAt!.toIso8601String(),
+    if (s.endedAt != null) 'endedAt': s.endedAt!.toIso8601String(),
+    'distanceKm': s.distanceKm,
+    'distanceSource': s.distanceSource,
+    if (s.avgLPer100Km != null) 'avgLPer100Km': s.avgLPer100Km,
+    if (s.fuelLitersConsumed != null)
+      'fuelLitersConsumed': s.fuelLitersConsumed,
+    'maxRpm': s.maxRpm,
+    'highRpmSeconds': s.highRpmSeconds,
+    'idleSeconds': s.idleSeconds,
+    'harshBrakes': s.harshBrakes,
+    'harshAccelerations': s.harshAccelerations,
+    'sampleCount': samples.length,
+  };
+  const encoder = JsonEncoder.withIndent('  ');
+  final csvBuffer = StringBuffer()
+    ..writeln('timestamp,speedKmh,rpm,fuelRateLPerHour');
+  for (final sample in samples) {
+    csvBuffer
+      ..write(sample.timestamp.toIso8601String())
+      ..write(',')
+      ..write(sample.speedKmh.toStringAsFixed(2))
+      ..write(',')
+      ..write(sample.rpm?.toStringAsFixed(0) ?? '')
+      ..write(',')
+      ..writeln(sample.fuelRateLPerHour?.toStringAsFixed(3) ?? '');
+  }
+  return '${encoder.convert(summary)}\n\n${csvBuffer.toString()}';
+}
+
+/// Test-only alias of [tripDetailSharePayload].
+///
+/// Exposed under the historical `@visibleForTesting` name so existing
+/// tests (which assert on the exact text copied to the clipboard) can
+/// keep importing the same symbol after the share-payload helper was
+/// extracted out of `trip_detail_screen.dart`.
+@visibleForTesting
+String buildTripDetailSharePayload({
+  required TripHistoryEntry entry,
+  required VehicleProfile? vehicle,
+  required List<TripDetailSample> samples,
+}) =>
+    tripDetailSharePayload(
+      entry: entry,
+      vehicle: vehicle,
+      samples: samples,
+    );

--- a/lib/features/consumption/presentation/widgets/trip_summary_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_summary_card.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../data/trip_history_repository.dart';
+import 'trip_detail_charts.dart';
+
+/// Headline summary card on the trip detail screen (#890).
+///
+/// Shows date, vehicle, distance, duration, average + max speed and —
+/// for fuel vehicles — average consumption (L/100 km) and total fuel
+/// used. EV trips swap the consumption unit to kWh/100 km.
+///
+/// Per-sample fields (avg/max speed) come from [samples]; the rest is
+/// read straight off [TripSummary]. Missing values fall back to the
+/// localised "unknown" placeholder so the layout stays stable.
+class TripSummaryCard extends StatelessWidget {
+  final TripHistoryEntry entry;
+  final VehicleProfile? vehicle;
+  final List<TripDetailSample> samples;
+  final bool isEv;
+
+  const TripSummaryCard({
+    super.key,
+    required this.entry,
+    required this.vehicle,
+    required this.samples,
+    required this.isEv,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final s = entry.summary;
+    final unknown = l?.trajetDetailFieldValueUnknown ?? '—';
+    final avgUnit = isEv ? 'kWh/100 km' : 'L/100 km';
+
+    final date = s.startedAt == null ? unknown : _fmtDate(s.startedAt!);
+    final vehicleName = vehicle?.name ?? unknown;
+    final distance = '${s.distanceKm.toStringAsFixed(1)} km';
+    final duration = s.startedAt != null &&
+            s.endedAt != null &&
+            s.endedAt!.isAfter(s.startedAt!)
+        ? _fmtDuration(s.endedAt!.difference(s.startedAt!))
+        : unknown;
+    final avgConsumption = s.avgLPer100Km == null
+        ? unknown
+        : '${s.avgLPer100Km!.toStringAsFixed(1)} $avgUnit';
+    final fuelUsed = s.fuelLitersConsumed == null
+        ? unknown
+        : '${s.fuelLitersConsumed!.toStringAsFixed(2)} L';
+    final avgSpeed = _avgSpeedLabel(samples, unknown);
+    final maxSpeed = _maxSpeedLabel(samples, unknown);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l?.trajetDetailSummaryTitle ?? 'Summary',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            _SummaryRow(
+              label: l?.trajetDetailFieldDate ?? 'Date',
+              value: date,
+            ),
+            _SummaryRow(
+              label: l?.trajetDetailFieldVehicle ?? 'Vehicle',
+              value: vehicleName,
+            ),
+            _SummaryRow(
+              label: l?.trajetDetailFieldDistance ?? 'Distance',
+              value: distance,
+            ),
+            _SummaryRow(
+              label: l?.trajetDetailFieldDuration ?? 'Duration',
+              value: duration,
+            ),
+            _SummaryRow(
+              label: l?.trajetDetailFieldAvgConsumption ?? 'Avg consumption',
+              value: avgConsumption,
+            ),
+            _SummaryRow(
+              label: l?.trajetDetailFieldFuelUsed ?? 'Fuel used',
+              value: fuelUsed,
+            ),
+            _SummaryRow(
+              label: l?.trajetDetailFieldAvgSpeed ?? 'Avg speed',
+              value: avgSpeed,
+            ),
+            _SummaryRow(
+              label: l?.trajetDetailFieldMaxSpeed ?? 'Max speed',
+              value: maxSpeed,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _avgSpeedLabel(
+    List<TripDetailSample> samples,
+    String unknown,
+  ) {
+    if (samples.isEmpty) return unknown;
+    var sum = 0.0;
+    for (final s in samples) {
+      sum += s.speedKmh;
+    }
+    final avg = sum / samples.length;
+    return '${avg.toStringAsFixed(1)} km/h';
+  }
+
+  static String _maxSpeedLabel(
+    List<TripDetailSample> samples,
+    String unknown,
+  ) {
+    if (samples.isEmpty) return unknown;
+    var maxV = samples.first.speedKmh;
+    for (final s in samples) {
+      if (s.speedKmh > maxV) maxV = s.speedKmh;
+    }
+    return '${maxV.toStringAsFixed(1)} km/h';
+  }
+
+  static String _fmtDate(DateTime d) {
+    final y = d.year.toString();
+    final m = d.month.toString().padLeft(2, '0');
+    final day = d.day.toString().padLeft(2, '0');
+    final h = d.hour.toString().padLeft(2, '0');
+    final min = d.minute.toString().padLeft(2, '0');
+    return '$y-$m-$day $h:$min';
+  }
+
+  static String _fmtDuration(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes % 60;
+    final s = d.inSeconds % 60;
+    if (h == 0 && m == 0) return '${s}s';
+    if (h == 0) return '${m}m ${s}s';
+    return '${h}h ${m}m';
+  }
+}
+
+class _SummaryRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _SummaryRow({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          Text(
+            value,
+            style: theme.textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## What
Extract three focused widgets out of `trip_detail_screen.dart` (472 LOC) so the screen file lands at 178 LOC, well under the 300-LOC ceiling tracked by epic #563.

- `widgets/trip_summary_card.dart` (180 LOC) — `TripSummaryCard` + `_SummaryRow` + the `_fmtDate` / `_fmtDuration` / `_avgSpeedLabel` / `_maxSpeedLabel` formatters that fed it.
- `widgets/trip_detail_body.dart` (97 LOC) — `TripDetailBody` (the `SingleChildScrollView` + summary + chart sections) and the `_ChartSection` titled-chart wrapper.
- `widgets/trip_detail_share_payload.dart` (74 LOC) — `tripDetailSharePayload` (production callable) + `buildTripDetailSharePayload` (`@visibleForTesting` alias preserving the existing test entry point).

The screen now only owns the route-level concerns: routing/scaffold, vehicle resolution, share/delete handlers, and the empty-state.

## Why
Refs #563 phase: `trip_detail_screen.dart` was on the oversized-files list. Smaller files are easier to navigate, the extracted widgets are individually testable, and `TripSummaryCard` is now reusable from any future "preview a trip" surfaces (recap sheet, share preview).

## Testing
- `flutter analyze` — zero issues.
- `flutter test` — full suite (6836 tests) passes; the 7-case `trip_detail_screen_test.dart` is unchanged and still green.
- LOC delta on the screen: 472 → 178.

## Scope
Refs #563 — one of multiple files in the epic. Other phases stay open.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>