### PR TITLE
feat(alerts): grouped notification with top-N stations (Refs #1012 phase 2)

### DIFF
--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -581,26 +581,40 @@ Future<void> _runRadiusAlerts({
   debugPrint('BackgroundService: ${fired.length} radius alerts fired');
 }
 
-/// Build notification copy for a radius alert. The BG isolate can't
-/// resolve the full ARB bundle (no BuildContext), so we pick German
-/// vs English from [Platform.localeName] and interpolate placeholders
-/// the same way the main-isolate preview does.
-RadiusAlertCopy _buildRadiusAlertCopy(RadiusAlertNotification event) {
+/// Build notification copy for a radius alert (#1012 phase 2 grouped
+/// fire). The BG isolate can't resolve the full ARB bundle (no
+/// BuildContext), so we pick German vs English from
+/// [Platform.localeName] and interpolate placeholders the same way
+/// the main-isolate preview does.
+///
+/// Title summarises the alert as `<label>: N stations ≤ €X`. Body
+/// renders one line per top-N matching station (cheapest first) and
+/// appends `+ X more` when matches got truncated.
+RadiusAlertCopy _buildRadiusAlertCopy(RadiusAlertGroupedEvent event) {
   final threshold = event.alert.threshold.toStringAsFixed(3);
-  final price = event.price.toStringAsFixed(3);
-  final fuelLabel = event.alert.fuelType.toUpperCase();
   final label = event.alert.label;
   final isGerman = Platform.localeName.toLowerCase().startsWith('de');
+  // Total visible matches *plus* the truncated tail — the title number
+  // should reflect everything the user could see if they tapped in.
+  final total = event.matches.length + event.truncatedMoreCount;
+  final lines = event.matches
+      .map((m) => '${m.stationId} ${m.pricePerLiter.toStringAsFixed(3)} €')
+      .toList();
+  if (event.truncatedMoreCount > 0) {
+    lines.add(isGerman
+        ? '+ ${event.truncatedMoreCount} weitere'
+        : '+ ${event.truncatedMoreCount} more');
+  }
+  final body = lines.join('\n');
   if (isGerman) {
     return RadiusAlertCopy(
-      title: '$fuelLabel in der Nähe von $label',
-      body:
-          'Eine Tankstelle bietet $price € (Grenze: $threshold €)',
+      title: '$label: $total Tankstellen ≤ $threshold €',
+      body: body,
     );
   }
   return RadiusAlertCopy(
-    title: '$fuelLabel near $label',
-    body: 'A station is at $price € (target: $threshold €)',
+    title: '$label: $total stations ≤ $threshold €',
+    body: body,
   );
 }
 

--- a/lib/features/alerts/data/radius_alert_dedup.dart
+++ b/lib/features/alerts/data/radius_alert_dedup.dart
@@ -5,33 +5,50 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../../core/storage/hive_boxes.dart';
 
-/// Per-alert-per-station notification dedup state for [RadiusAlert]
-/// (#578 phase 3).
+/// Notification dedup state for [RadiusAlert].
+///
+/// Two dedup scopes coexist (#578 phase 3 + #1012 phase 2):
+///
+///  * Per-alert (used as the gating decision): the runner now fires
+///    one grouped notification per alert per cycle, so the dedup
+///    *decision* is keyed on the alert id alone. The store remembers
+///    the cheapest match price at the last fire so a deeper drop
+///    inside the dedup window still bypasses suppression.
+///  * Per-(alert, station): preserved for phase 3's per-station deep-
+///    link payload, which needs to know "when did we last tell the
+///    user about this station, and at what price?". The runner
+///    refreshes every per-station row that appeared in the grouped
+///    fire so the deep-link logic can read accurate timestamps.
 ///
 /// Without a rate limit the periodic background check would re-notify
 /// every cycle while a station is below the user's threshold — a 1 h
 /// WorkManager interval would dump 24 identical notifications per day
 /// until the price climbs back. The dedup store remembers the last
-/// (price, firedAt) per (alertId, stationId) and allows a new
-/// notification only when either:
-///   a) the new price dropped further (by at least [priceDropEpsilon])
-///      since the last fire — the user genuinely wants to know it's
-///      even cheaper, OR
+/// (price, firedAt) pair and allows a new notification only when:
+///   a) the cheapest current price dropped further (by at least
+///      [priceDropEpsilon]) since the last fire — the user genuinely
+///      wants to know it's even cheaper, OR
 ///   b) [dedupWindow] has elapsed since the last fire — the reminder
 ///      is fresh enough to surface again.
 ///
 /// Persists under the already-encrypted [HiveBoxes.alerts] box under
-/// the `radius_alert_dedup:<alertId>:<stationId>` key prefix so it
-/// lives alongside the per-station PriceAlerts and the RadiusAlert
+/// the `radius_alert_dedup:<alertId>:<stationId>` (per-station) and
+/// `radius_alert_dedup_alert:<alertId>` (per-alert) key prefixes so
+/// it lives alongside the per-station PriceAlerts and the RadiusAlert
 /// definitions themselves — one less box to open in the BG isolate.
 class RadiusAlertDedup {
-  /// Key prefix under [HiveBoxes.alerts]. Exposed so tests and
-  /// potential future migrations can iterate over dedup rows
-  /// without depending on this class's internals.
+  /// Key prefix for per-(alert, station) rows under [HiveBoxes.alerts].
+  /// Exposed so tests and potential future migrations can iterate
+  /// over dedup rows without depending on this class's internals.
   static const String keyPrefix = 'radius_alert_dedup:';
 
-  /// How long after a fire we suppress the same (alert, station)
-  /// unless the price drops further. 12 h matches the issue spec —
+  /// Key prefix for the alert-level dedup row (#1012 phase 2). The
+  /// runner gates fires off this row; per-station rows under
+  /// [keyPrefix] still exist as a side-record for phase 3 deep-links.
+  static const String alertKeyPrefix = 'radius_alert_dedup_alert:';
+
+  /// How long after a fire we suppress the same alert unless the
+  /// cheapest match drops further. 12 h matches the issue spec —
   /// short enough that a genuine dip the user missed resurfaces
   /// before the next commute, long enough that a flat "still below
   /// threshold" cycle stays quiet overnight.
@@ -55,11 +72,17 @@ class RadiusAlertDedup {
   String _key(String alertId, String stationId) =>
       '$keyPrefix$alertId:$stationId';
 
+  String _alertKey(String alertId) => '$alertKeyPrefix$alertId';
+
   /// Decide whether to notify for this (alert, station) pair.
   ///
   /// Returns `true` when the caller should fire a notification — i.e.
   /// either nothing has ever been recorded, or the price dropped
   /// further since the last fire, or the dedup window has expired.
+  ///
+  /// Retained from #578 phase 3 because the per-station ledger is
+  /// still useful for phase 3 deep-link payloads. Phase 2's runner
+  /// uses [shouldNotifyAlert] for the actual gating decision instead.
   Future<bool> shouldNotify({
     required String alertId,
     required String stationId,
@@ -73,8 +96,31 @@ class RadiusAlertDedup {
     return false;
   }
 
-  /// Stamp a fire — persist the (price, now) pair so the next
-  /// [shouldNotify] call can gate correctly.
+  /// Decide whether to notify for [alertId] given the cheapest match
+  /// in this cycle (#1012 phase 2). The runner now fires one grouped
+  /// notification per alert, so the gating decision lives at the
+  /// alert level rather than per-station.
+  ///
+  /// Returns `true` when:
+  ///   * no previous alert-level fire is recorded,
+  ///   * the cheapest match dropped at least [priceDropEpsilon] below
+  ///     the cheapest match at the last fire (further-drop override),
+  ///   * or the [dedupWindow] has elapsed since the last fire.
+  Future<bool> shouldNotifyAlert({
+    required String alertId,
+    required double cheapestPrice,
+    required DateTime now,
+  }) async {
+    final last = await _lastAlertFire(alertId);
+    if (last == null) return true;
+    if (cheapestPrice <= last.price - priceDropEpsilon) return true;
+    if (now.difference(last.firedAt) >= dedupWindow) return true;
+    return false;
+  }
+
+  /// Stamp a fire — persist the per-(alert, station) (price, now)
+  /// pair so the next [shouldNotify] / phase-3 deep-link lookup can
+  /// gate correctly.
   Future<void> recordFire({
     required String alertId,
     required String stationId,
@@ -96,16 +142,40 @@ class RadiusAlertDedup {
     );
   }
 
-  /// Drop every dedup row owned by [alertId]. Called when the user
-  /// deletes the RadiusAlert so stale (alertId, stationId) rows
-  /// don't leak into the box forever.
+  /// Stamp an alert-level fire (#1012 phase 2). Stores the cheapest
+  /// match price at fire time so [shouldNotifyAlert] can apply the
+  /// further-drop override on the next cycle.
+  Future<void> recordAlertFire({
+    required String alertId,
+    required double cheapestPrice,
+    required DateTime now,
+  }) async {
+    final box = _boxOrNull();
+    if (box == null) {
+      debugPrint(
+          'RadiusAlertDedup.recordAlertFire: alerts box closed, dropping $alertId');
+      return;
+    }
+    await box.put(
+      _alertKey(alertId),
+      jsonEncode({
+        'price': cheapestPrice,
+        'firedAt': now.toIso8601String(),
+      }),
+    );
+  }
+
+  /// Drop every dedup row owned by [alertId] (per-station + alert-
+  /// level). Called when the user deletes the RadiusAlert so stale
+  /// rows don't leak into the box forever.
   Future<void> clearForAlert(String alertId) async {
     final box = _boxOrNull();
     if (box == null) return;
-    final prefix = '$keyPrefix$alertId:';
+    final stationPrefix = '$keyPrefix$alertId:';
+    final alertKey = _alertKey(alertId);
     final keys = box.keys
         .whereType<String>()
-        .where((k) => k.startsWith(prefix))
+        .where((k) => k.startsWith(stationPrefix) || k == alertKey)
         .toList();
     if (keys.isEmpty) return;
     await box.deleteAll(keys);
@@ -119,7 +189,8 @@ class RadiusAlertDedup {
     if (box == null) return;
     final keys = box.keys
         .whereType<String>()
-        .where((k) => k.startsWith(keyPrefix))
+        .where((k) =>
+            k.startsWith(keyPrefix) || k.startsWith(alertKeyPrefix))
         .toList();
     if (keys.isEmpty) return;
     await box.deleteAll(keys);
@@ -131,7 +202,17 @@ class RadiusAlertDedup {
   }) async {
     final box = _boxOrNull();
     if (box == null) return null;
-    final raw = box.get(_key(alertId, stationId));
+    return _readRow(box.get(_key(alertId, stationId)),
+        context: '$alertId/$stationId');
+  }
+
+  Future<_LastFire?> _lastAlertFire(String alertId) async {
+    final box = _boxOrNull();
+    if (box == null) return null;
+    return _readRow(box.get(_alertKey(alertId)), context: 'alert:$alertId');
+  }
+
+  _LastFire? _readRow(Object? raw, {required String context}) {
     if (raw == null) return null;
     try {
       if (raw is String) {
@@ -140,8 +221,7 @@ class RadiusAlertDedup {
       }
       if (raw is Map) return _LastFire.fromJson(raw);
     } catch (e) {
-      debugPrint(
-          'RadiusAlertDedup: corrupt dedup row for $alertId/$stationId: $e');
+      debugPrint('RadiusAlertDedup: corrupt dedup row for $context: $e');
     }
     return null;
   }

--- a/lib/features/alerts/data/radius_alert_runner.dart
+++ b/lib/features/alerts/data/radius_alert_runner.dart
@@ -15,23 +15,38 @@ typedef SamplesForAlert = Future<List<StationPriceSample>> Function(
     RadiusAlert alert);
 
 /// Glue between the background price refresh cycle and the radius
-/// alert evaluator (#578 phase 3).
+/// alert evaluator (#578 phase 3 + #1012 phases 1–2).
 ///
 /// The background isolate calls [run] once per cycle. The runner:
 ///   1. loads every active [RadiusAlert] from [RadiusAlertStore],
-///   2. asks the [samplesFor] callback for stations currently in
+///   2. honours the per-alert frequencyPerDay throttle (#1012 phase 1)
+///      so a 1×/day alert only re-evaluates once per 24 h,
+///   3. asks the [samplesFor] callback for stations currently in
 ///      range of each alert (per-country StationService in the real
 ///      path, fake fixtures in tests),
-///   3. uses [RadiusAlertEvaluator] to pick the matching samples,
-///   4. runs each (alert, station) match past [RadiusAlertDedup]
-///      (12 h default window + further-drop override), and
-///   5. fires one local notification per surviving match through the
-///      injected [NotificationService].
+///   4. uses [RadiusAlertEvaluator] to pick every matching sample,
+///   5. sorts the matches by price ascending, caps at top-5,
+///   6. runs the *alert as a whole* past [RadiusAlertDedup] (12 h
+///      window, with a "cheaper than last fire" override), and
+///   7. fires **one** grouped local notification per alert per cycle
+///      with the top-N stations rolled up into one body.
+///
+/// The dedup record also stamps every per-station match in this cycle
+/// so phase 3's per-station deep-link payload can read the last-fired
+/// price for any station that appeared in a notification — even though
+/// the dedup *decision* is now made at the alert level.
 ///
 /// All collaborators are injected so the service-level integration
 /// test can seed an alert + a fake samples provider and assert that
 /// the notifier was called exactly once.
 class RadiusAlertRunner {
+  /// Maximum number of stations rendered in the grouped notification
+  /// body. Keeping this small (5) means the notification stays
+  /// glanceable on the Android lock screen — anything past five lines
+  /// gets truncated by the system anyway, and the "+ X more" suffix
+  /// tells the user to open the app for the full list.
+  static const int maxStationsInBody = 5;
+
   final RadiusAlertStore store;
   final RadiusAlertDedup dedup;
   final NotificationService notifier;
@@ -42,7 +57,7 @@ class RadiusAlertRunner {
   /// function that formats against the event payload. Keep the
   /// signature stable so the main-isolate preview and the BG runner
   /// emit identical strings.
-  final RadiusAlertCopy Function(RadiusAlertNotification event)
+  final RadiusAlertCopy Function(RadiusAlertGroupedEvent event)
       copyBuilder;
 
   RadiusAlertRunner({
@@ -53,13 +68,13 @@ class RadiusAlertRunner {
     RadiusAlertEvaluator? evaluator,
   }) : evaluator = evaluator ?? const RadiusAlertEvaluator();
 
-  /// Execute the whole pipeline. Returns the list of fired events
-  /// (may be empty) so callers can log / assert / update a widget
-  /// status line without re-walking state.
+  /// Execute the whole pipeline. Returns the list of fired grouped
+  /// events (may be empty) so callers can log / assert / update a
+  /// widget status line without re-walking state.
   ///
   /// Safe to call with no active alerts: the runner returns an empty
   /// list and never touches the notifier.
-  Future<List<RadiusAlertNotification>> run({
+  Future<List<RadiusAlertGroupedEvent>> run({
     required DateTime now,
     required SamplesForAlert samplesFor,
   }) async {
@@ -67,7 +82,7 @@ class RadiusAlertRunner {
     final active = alerts.where((a) => a.enabled).toList();
     if (active.isEmpty) return const [];
 
-    final fired = <RadiusAlertNotification>[];
+    final fired = <RadiusAlertGroupedEvent>[];
     for (final alert in active) {
       try {
         // #1012 phase 1 — per-alert frequency throttling. Skip the
@@ -92,34 +107,62 @@ class RadiusAlertRunner {
         if (samples.isEmpty) continue;
         final matches = evaluator.matches(alert, samples).toList();
         if (matches.isEmpty) continue;
-        for (final match in matches) {
-          final allow = await dedup.shouldNotify(
-            alertId: alert.id,
-            stationId: match.stationId,
-            currentPrice: match.pricePerLiter,
-            now: now,
-          );
-          if (!allow) continue;
 
-          final event = RadiusAlertNotification(
-            alert: alert,
-            stationId: match.stationId,
-            price: match.pricePerLiter,
-          );
-          final copy = copyBuilder(event);
-          await notifier.showPriceAlert(
-            id: _notificationId(alert.id, match.stationId),
-            title: copy.title,
-            body: copy.body,
-          );
+        // #1012 phase 2 — sort cheap-first and cap the rendered list
+        // at top-5. The full list still drives the dedup record so
+        // phase 3 can deep-link any station the user saw.
+        matches.sort(
+            (a, b) => a.pricePerLiter.compareTo(b.pricePerLiter));
+        final cheapest = matches.first.pricePerLiter;
+        final topMatches = matches.length > maxStationsInBody
+            ? matches.sublist(0, maxStationsInBody)
+            : List<StationPriceSample>.from(matches);
+        final truncatedMore = matches.length - topMatches.length;
+
+        // #1012 phase 2 — alert-level dedup. We notify once per alert
+        // per cycle, so the dedup decision is now per-alert, keyed off
+        // the cheapest current match. The "further drop" override
+        // still applies: if the cheapest price has dropped below the
+        // last-fired cheapest, surface again even inside the window.
+        final allow = await dedup.shouldNotifyAlert(
+          alertId: alert.id,
+          cheapestPrice: cheapest,
+          now: now,
+        );
+        if (!allow) continue;
+
+        final event = RadiusAlertGroupedEvent(
+          alert: alert,
+          matches: topMatches,
+          truncatedMoreCount: truncatedMore,
+        );
+        final copy = copyBuilder(event);
+        await notifier.showPriceAlert(
+          id: _notificationId(alert.id),
+          title: copy.title,
+          body: copy.body,
+        );
+        // Stamp the per-alert dedup row first — that's the source of
+        // truth for the next cycle's gating decision.
+        await dedup.recordAlertFire(
+          alertId: alert.id,
+          cheapestPrice: cheapest,
+          now: now,
+        );
+        // Also keep the per-(alert, station) fire records refreshed
+        // for every station in this cycle's match set. Phase 3's
+        // deep-link payload needs to know "what was the price when we
+        // told the user about this station last?" and that lookup
+        // would be impossible if we only stamped the cheapest one.
+        for (final match in matches) {
           await dedup.recordFire(
             alertId: alert.id,
             stationId: match.stationId,
             price: match.pricePerLiter,
             now: now,
           );
-          fired.add(event);
         }
+        fired.add(event);
       } catch (e) {
         // One bad alert (e.g. country API down) must not block the
         // rest — log and keep going.
@@ -129,26 +172,46 @@ class RadiusAlertRunner {
     return fired;
   }
 
-  /// Stable notification id per (alert, station) pair. Re-fires
-  /// overwrite the existing notification in place rather than
-  /// stacking a fresh banner for every periodic check.
-  static int _notificationId(String alertId, String stationId) =>
-      'radius:$alertId:$stationId'.hashCode;
+  /// Stable notification id per alert. Re-fires overwrite the
+  /// existing grouped notification in place rather than stacking a
+  /// fresh banner for every periodic check.
+  ///
+  /// Phase 1 / #578 keyed this by (alertId, stationId) because every
+  /// match produced its own banner; phase 2 collapses the whole alert
+  /// into one banner so the id is keyed on alertId alone.
+  static int _notificationId(String alertId) =>
+      'radius:$alertId'.hashCode;
 }
 
-/// Everything the notification-copy builder needs to format a single
-/// fired radius alert. Kept as a plain value object so the main-
-/// isolate preview and the BG runner produce identical strings.
-class RadiusAlertNotification {
+/// Everything the notification-copy builder needs to format one fired
+/// radius alert (#1012 phase 2). Carries the full top-N station list
+/// plus a `truncatedMoreCount` so the body renderer can append the
+/// "+ X more" suffix when matches got capped.
+///
+/// Kept as a plain value object so the main-isolate preview and the
+/// BG runner produce identical strings.
+class RadiusAlertGroupedEvent {
   final RadiusAlert alert;
-  final String stationId;
-  final double price;
 
-  const RadiusAlertNotification({
+  /// Matching stations, sorted cheapest first and capped to the
+  /// runner's [RadiusAlertRunner.maxStationsInBody] limit.
+  final List<StationPriceSample> matches;
+
+  /// Number of additional matching stations that were dropped from
+  /// [matches] because of the top-N cap. Zero when nothing was
+  /// truncated. Body renderers use this to print "+ X more".
+  final int truncatedMoreCount;
+
+  const RadiusAlertGroupedEvent({
     required this.alert,
-    required this.stationId,
-    required this.price,
+    required this.matches,
+    this.truncatedMoreCount = 0,
   });
+
+  /// Convenience accessor — first (cheapest) match. Body renderers
+  /// often need the headline price for the title before iterating
+  /// the rest for the body lines.
+  StationPriceSample get cheapest => matches.first;
 }
 
 /// User-facing copy for a radius alert notification.

--- a/test/features/alerts/data/radius_alert_dedup_test.dart
+++ b/test/features/alerts/data/radius_alert_dedup_test.dart
@@ -172,4 +172,183 @@ void main() {
       );
     });
   });
+
+  // #1012 phase 2 — the runner now fires one notification per alert
+  // per cycle, so the dedup *decision* moved from per-(alert, station)
+  // to per-alert. The per-station ledger still exists (phase 3 deep-
+  // links use it), but `shouldNotifyAlert` is the gate.
+  group('RadiusAlertDedup alert-level (#1012 phase 2)', () {
+    test('first alert-level notification is always allowed', () async {
+      final dedup = RadiusAlertDedup();
+      final allowed = await dedup.shouldNotifyAlert(
+        alertId: 'a1',
+        cheapestPrice: 1.550,
+        now: DateTime.utc(2026, 4, 22, 12),
+      );
+      expect(allowed, isTrue);
+    });
+
+    test(
+        'within 12 h with the cheapest unchanged → suppressed (per-alert window)',
+        () async {
+      final dedup = RadiusAlertDedup();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      await dedup.recordAlertFire(
+          alertId: 'a1', cheapestPrice: 1.550, now: t0);
+
+      final allowed = await dedup.shouldNotifyAlert(
+        alertId: 'a1',
+        cheapestPrice: 1.550,
+        now: t0.add(const Duration(hours: 11, minutes: 59)),
+      );
+      expect(allowed, isFalse);
+    });
+
+    test(
+        'within 12 h but cheapest dropped further → fires (further-drop override preserved)',
+        () async {
+      final dedup = RadiusAlertDedup();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      await dedup.recordAlertFire(
+          alertId: 'a1', cheapestPrice: 1.550, now: t0);
+
+      // 4 h later the cheapest match dropped another cent — the user
+      // wants to know the new floor even though the dedup window is
+      // still active.
+      final allowed = await dedup.shouldNotifyAlert(
+        alertId: 'a1',
+        cheapestPrice: 1.540,
+        now: t0.add(const Duration(hours: 4)),
+      );
+      expect(allowed, isTrue);
+    });
+
+    test('sub-epsilon wiggle on the cheapest is still suppressed',
+        () async {
+      final dedup = RadiusAlertDedup();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      await dedup.recordAlertFire(
+          alertId: 'a1', cheapestPrice: 1.550, now: t0);
+
+      final allowed = await dedup.shouldNotifyAlert(
+        alertId: 'a1',
+        cheapestPrice: 1.5495,
+        now: t0.add(const Duration(hours: 1)),
+      );
+      expect(allowed, isFalse);
+    });
+
+    test('alert-level notification re-fires once 12 h elapsed', () async {
+      final dedup = RadiusAlertDedup();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      await dedup.recordAlertFire(
+          alertId: 'a1', cheapestPrice: 1.550, now: t0);
+
+      final allowed = await dedup.shouldNotifyAlert(
+        alertId: 'a1',
+        cheapestPrice: 1.550,
+        now: t0.add(const Duration(hours: 12, minutes: 1)),
+      );
+      expect(allowed, isTrue);
+    });
+
+    test('alert-level dedup is scoped per alertId', () async {
+      final dedup = RadiusAlertDedup();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      await dedup.recordAlertFire(
+          alertId: 'a1', cheapestPrice: 1.550, now: t0);
+
+      // a2 hasn't been recorded — must fire.
+      expect(
+        await dedup.shouldNotifyAlert(
+          alertId: 'a2',
+          cheapestPrice: 1.550,
+          now: t0.add(const Duration(minutes: 5)),
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+        'per-station fire records remain readable after alert-level fire (phase 3 deep-link prereq)',
+        () async {
+      // Phase 3 will deep-link to the cheapest station shown in a
+      // grouped notification. Its tap handler reads the per-station
+      // ledger to know "what price did we tell the user about this
+      // station?". The runner stamps both ledgers in one cycle, so we
+      // pin here that they coexist and the per-station read still
+      // works after the alert-level row is written.
+      final dedup = RadiusAlertDedup();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      await dedup.recordAlertFire(
+          alertId: 'a1', cheapestPrice: 1.500, now: t0);
+      await dedup.recordFire(
+          alertId: 'a1', stationId: 's1', price: 1.500, now: t0);
+      await dedup.recordFire(
+          alertId: 'a1', stationId: 's2', price: 1.520, now: t0);
+
+      // Per-station gate still suppresses repeats within the window.
+      expect(
+        await dedup.shouldNotify(
+          alertId: 'a1',
+          stationId: 's1',
+          currentPrice: 1.500,
+          now: t0.add(const Duration(hours: 1)),
+        ),
+        isFalse,
+      );
+      expect(
+        await dedup.shouldNotify(
+          alertId: 'a1',
+          stationId: 's2',
+          currentPrice: 1.520,
+          now: t0.add(const Duration(hours: 1)),
+        ),
+        isFalse,
+      );
+      // And the per-station further-drop override still works.
+      expect(
+        await dedup.shouldNotify(
+          alertId: 'a1',
+          stationId: 's2',
+          currentPrice: 1.500,
+          now: t0.add(const Duration(hours: 1)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('clearForAlert wipes both alert-level and per-station rows',
+        () async {
+      final dedup = RadiusAlertDedup();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      await dedup.recordAlertFire(
+          alertId: 'a1', cheapestPrice: 1.550, now: t0);
+      await dedup.recordFire(
+          alertId: 'a1', stationId: 's1', price: 1.550, now: t0);
+      await dedup.recordAlertFire(
+          alertId: 'a2', cheapestPrice: 1.560, now: t0);
+
+      await dedup.clearForAlert('a1');
+
+      // a1 alert-level row gone — shouldNotifyAlert returns true.
+      expect(
+        await dedup.shouldNotifyAlert(
+          alertId: 'a1',
+          cheapestPrice: 1.550,
+          now: t0.add(const Duration(minutes: 1)),
+        ),
+        isTrue,
+      );
+      // a2 alert-level row preserved.
+      expect(
+        await dedup.shouldNotifyAlert(
+          alertId: 'a2',
+          cheapestPrice: 1.560,
+          now: t0.add(const Duration(minutes: 1)),
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/test/features/alerts/data/radius_alert_runner_test.dart
+++ b/test/features/alerts/data/radius_alert_runner_test.dart
@@ -42,10 +42,24 @@ class _FakeNotifier implements NotificationService {
   Future<void> cancelAll() async {}
 }
 
-RadiusAlertCopy _copy(RadiusAlertNotification event) => RadiusAlertCopy(
-      title: '${event.alert.fuelType.toUpperCase()} near ${event.alert.label}',
-      body: 'A station is at ${event.price.toStringAsFixed(3)}',
-    );
+/// Render the grouped event the same way the BG copy builder does:
+/// one line per top-N station, cheapest first, with a "+ X more"
+/// suffix when truncated. Matches the production format closely
+/// enough that body assertions test the real shape.
+RadiusAlertCopy _copy(RadiusAlertGroupedEvent event) {
+  final lines = event.matches
+      .map((m) => '${m.stationId} ${m.pricePerLiter.toStringAsFixed(3)}')
+      .toList();
+  if (event.truncatedMoreCount > 0) {
+    lines.add('+ ${event.truncatedMoreCount} more');
+  }
+  final total = event.matches.length + event.truncatedMoreCount;
+  return RadiusAlertCopy(
+    title:
+        '${event.alert.label}: $total stations <= ${event.alert.threshold.toStringAsFixed(3)}',
+    body: lines.join('\n'),
+  );
+}
 
 void main() {
   late Directory tempDir;
@@ -134,7 +148,6 @@ void main() {
 
       expect(fired, hasLength(1));
       expect(notifier.priceAlerts, hasLength(1));
-      expect(notifier.priceAlerts.single.title, contains('DIESEL'));
       expect(notifier.priceAlerts.single.title, contains('Home'));
       expect(notifier.priceAlerts.single.body, contains('1.540'));
     });
@@ -329,8 +342,11 @@ void main() {
       expect(notifier.priceAlerts, hasLength(2));
     });
 
-    test('multiple in-range stations each get their own notification',
+    test(
+        'multiple in-range stations roll up into a single grouped notification',
         () async {
+      // #1012 phase 2: one notification per alert per cycle (was: one
+      // notification per (alert, station) match).
       final store = RadiusAlertStore();
       final dedup = RadiusAlertDedup();
       final notifier = _FakeNotifier();
@@ -348,17 +364,78 @@ void main() {
         samplesFor: (a) async => [
           sample(stationId: 's1', price: 1.540),
           sample(stationId: 's2', price: 1.545, lat: 43.51, lng: 3.51),
+          sample(stationId: 's3', price: 1.520, lat: 43.49, lng: 3.49),
         ],
       );
 
-      expect(fired, hasLength(2));
-      expect(notifier.priceAlerts, hasLength(2));
-      expect(
-        notifier.priceAlerts.map((n) => n.id).toSet().length,
-        2,
-        reason:
-            'Each (alert, station) pair must resolve to a distinct notification id',
+      expect(fired, hasLength(1),
+          reason: 'Three matches must collapse into a single fired event');
+      expect(notifier.priceAlerts, hasLength(1));
+
+      final event = fired.single;
+      expect(event.matches.map((m) => m.stationId).toList(),
+          equals(['s3', 's1', 's2']),
+          reason: 'Matches must be sorted ascending by price');
+      expect(event.truncatedMoreCount, 0);
+      expect(notifier.priceAlerts.single.title, contains('3 stations'));
+    });
+
+    test(
+        'top-5 truncation: 7 matches render 5 sorted lines plus "+ 2 more"',
+        () async {
+      final store = RadiusAlertStore();
+      final dedup = RadiusAlertDedup();
+      final notifier = _FakeNotifier();
+      final runner = RadiusAlertRunner(
+        store: store,
+        dedup: dedup,
+        notifier: notifier,
+        copyBuilder: _copy,
       );
+
+      await store.upsert(makeAlert(id: 'r1'));
+
+      // Seven distinct in-range matches at increasing prices. Note
+      // they're inserted out of price order on purpose so the test
+      // pins the runner's sort behaviour, not the input ordering.
+      final samples = <StationPriceSample>[
+        sample(stationId: 's5', price: 1.530, lat: 43.51, lng: 3.51),
+        sample(stationId: 's2', price: 1.500, lat: 43.50, lng: 3.51),
+        sample(stationId: 's7', price: 1.540, lat: 43.49, lng: 3.50),
+        sample(stationId: 's1', price: 1.490, lat: 43.50, lng: 3.50),
+        sample(stationId: 's4', price: 1.520, lat: 43.50, lng: 3.49),
+        sample(stationId: 's3', price: 1.510, lat: 43.49, lng: 3.49),
+        sample(stationId: 's6', price: 1.535, lat: 43.51, lng: 3.49),
+      ];
+
+      final fired = await runner.run(
+        now: DateTime.utc(2026, 4, 22, 12),
+        samplesFor: (a) async => samples,
+      );
+
+      expect(fired, hasLength(1));
+      final event = fired.single;
+      expect(event.matches, hasLength(RadiusAlertRunner.maxStationsInBody),
+          reason:
+              'matches list must be capped to RadiusAlertRunner.maxStationsInBody');
+      expect(event.matches.map((m) => m.stationId).toList(),
+          equals(['s1', 's2', 's3', 's4', 's5']),
+          reason:
+              'Top-5 list must be the 5 cheapest matches, sorted ascending');
+      expect(event.truncatedMoreCount, 2,
+          reason:
+              '7 matches with a top-5 cap leaves 2 in the truncated tail');
+
+      final body = notifier.priceAlerts.single.body;
+      // Each top-5 line in cheap-first order plus the + 2 more suffix.
+      expect(body.split('\n'), hasLength(6));
+      expect(body, contains('s1 1.490'));
+      expect(body, contains('s5 1.530'));
+      expect(body, isNot(contains('s6')),
+          reason:
+              'Stations 6 and 7 are in the truncated tail, not the body');
+      expect(body, isNot(contains('s7')));
+      expect(body, contains('+ 2 more'));
     });
 
     test('one alert failing does not block the rest', () async {

--- a/test/features/alerts/data/radius_alert_runner_throttle_test.dart
+++ b/test/features/alerts/data/radius_alert_runner_throttle_test.dart
@@ -45,10 +45,19 @@ class _FakeNotifier implements NotificationService {
   Future<void> cancelAll() async {}
 }
 
-RadiusAlertCopy _copy(RadiusAlertNotification event) => RadiusAlertCopy(
-      title: '${event.alert.fuelType.toUpperCase()} near ${event.alert.label}',
-      body: 'A station is at ${event.price.toStringAsFixed(3)}',
-    );
+RadiusAlertCopy _copy(RadiusAlertGroupedEvent event) {
+  final lines = event.matches
+      .map((m) => '${m.stationId} ${m.pricePerLiter.toStringAsFixed(3)}')
+      .toList();
+  if (event.truncatedMoreCount > 0) {
+    lines.add('+ ${event.truncatedMoreCount} more');
+  }
+  return RadiusAlertCopy(
+    title:
+        '${event.alert.fuelType.toUpperCase()} near ${event.alert.label}',
+    body: lines.join('\n'),
+  );
+}
 
 void main() {
   late Directory tempDir;


### PR DESCRIPTION
## Summary

Refs #1012 phase 2. Collapse the per-(alert, station) notification loop into **one grouped notification per alert per cycle**.

- Sort matches cheapest-first, cap at top-5, append `+ X more` when truncated.
- Dedup decision moves to alert-level — the gating record now stores the cheapest match at last fire under `radius_alert_dedup_alert:<alertId>`.
- Further-drop override preserved at the alert level: cheapest dropping below the cheapest at last fire bypasses the 12 h window.
- Per-(alert, station) fire records are still written so phase 3's deep-link payload can read accurate per-station "last seen" timestamps.

## Why

Phase 1 (#1017) capped *how often* an alert evaluates. Phase 2 caps *how many banners* a single evaluation cycle produces — three matching stations was three notifications, now it's one stack-merged banner with the top-5 listed inside.

## Behaviour change

- **Before:** 1 notification per match → noisy lock screen on busy radii.
- **After:** 1 notification per alert per cycle, sorted cheapest first, top-5 listed, `+ X more` suffix on truncation.
- **Notification id:** keyed on `radius:<alertId>` (was `radius:<alertId>:<stationId>`) so re-fires replace the existing banner in place.

## Files

- `lib/features/alerts/data/radius_alert_runner.dart` — sort + top-N truncate + alert-level dedup + grouped fire. New `RadiusAlertGroupedEvent` replaces `RadiusAlertNotification`.
- `lib/features/alerts/data/radius_alert_dedup.dart` — adds `shouldNotifyAlert` / `recordAlertFire` keyed on alert id; per-station methods retained for phase 3.
- `lib/core/background/background_service.dart` — copy builder updated to render the grouped event (title `<label>: N stations ≤ €X`, body one line per match newline-separated).

## Test plan

- [x] `flutter analyze` — zero warnings.
- [x] `flutter test test/features/alerts/` — 205 tests pass.
- [x] New: top-5 truncation test (7 matches → 5 sorted ascending lines + `+ 2 more`).
- [x] New: alert-level dedup window suppresses re-fire when cheapest unchanged.
- [x] New: alert-level further-drop fires inside the 12 h window.
- [x] New: per-station fire records still readable after a grouped fire.
- [x] Existing dedup-window + further-drop runner tests adapted to the grouped event shape.

## Out of scope (phase 3)

- Notification payload / deep-link to station detail.
- Tap handler in `main.dart` / app router.
- Action buttons on the notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)