### PR TITLE
feat(vehicle): migrate user profiles to reference catalog (Refs #950 phase 4)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -20,6 +20,9 @@ import '../core/sync/community_config.dart';
 import '../core/sync/supabase_client.dart';
 import '../core/utils/edge_to_edge.dart';
 import '../features/profile/data/repositories/profile_repository.dart';
+import '../features/vehicle/data/reference_vehicle_catalog_provider.dart';
+import '../features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import '../features/vehicle/data/vehicle_profile_migrator.dart';
 import '../features/widget/data/home_widget_service.dart';
 import '../features/widget/providers/nearest_widget_refresh_provider.dart';
 
@@ -95,6 +98,28 @@ class AppInitializer {
         );
       } catch (e) {
         debugPrint('PackageInfo.fromPlatform failed (#570): $e');
+      }
+    });
+
+    // #950 phase 4 — backfill `referenceVehicleId` on existing
+    // VehicleProfile entries from the reference catalog. One-shot:
+    // gated on `vehicleCatalogMigrationDone` so subsequent launches
+    // skip the work. Runs after the first frame because reading the
+    // bundled JSON asset shouldn't block the landing UI.
+    _deferPostFirstFrame(() async {
+      try {
+        final migrator = VehicleProfileCatalogMigrator(
+          repository: VehicleProfileRepository(storage),
+          settings: storage,
+        );
+        if (migrator.hasRun) return;
+        final catalog =
+            await container.read(referenceVehicleCatalogProvider.future);
+        final matched = await migrator.run(catalog: catalog);
+        debugPrint(
+            'VehicleProfileCatalogMigrator: matched $matched profile(s)');
+      } catch (e) {
+        debugPrint('VehicleProfileCatalogMigrator: deferred run failed: $e');
       }
     });
 

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -41,4 +41,12 @@ class StorageKeys {
   /// false (off) so users who only want favourite sync aren't
   /// silently uploading driving data.
   static const String syncBaselinesEnabled = 'sync_baselines_enabled';
+
+  /// #950 phase 4 — flag set once the
+  /// [VehicleProfileCatalogMigrator] has run, so subsequent app
+  /// launches skip the migration. Stored in the settings box rather
+  /// than in shared_preferences to keep all app-state in one place
+  /// (matches how onboarding completion is tracked).
+  static const String vehicleCatalogMigrationDone =
+      'vehicle_catalog_migration_done';
 }

--- a/lib/features/vehicle/data/vehicle_profile_catalog_matcher.dart
+++ b/lib/features/vehicle/data/vehicle_profile_catalog_matcher.dart
@@ -1,0 +1,101 @@
+import '../domain/entities/reference_vehicle.dart';
+import '../domain/entities/vehicle_profile.dart';
+
+/// Pure utility for matching a [VehicleProfile] against the
+/// [ReferenceVehicle] catalog (#950 phase 4).
+///
+/// The match is best-effort and tiered so a partial profile (e.g. a
+/// VIN-decoded entry that knows the make + model but the year is wrong
+/// or out of range) can still benefit from catalog-driven defaults.
+///
+/// Tiers, in priority order:
+///
+///   1. **Exact** — make, model, AND year all match. The catalog entry's
+///      production window covers the profile year.
+///   2. **Make + model** — same make + model regardless of year. Returns
+///      the first catalog row that matches.
+///   3. **Make only** — same make, any model. Returns the first catalog
+///      row for the brand. Better than nothing for OBD-II PID strategy
+///      dispatch since most quirks (e.g. PSA UDS, VAG UDS) are make-wide.
+///
+/// Returns `null` when no tier matches — the migrator persists the null
+/// `referenceVehicleId` and the OBD-II layer falls back to its generic
+/// behaviour.
+class VehicleProfileCatalogMatcher {
+  const VehicleProfileCatalogMatcher._();
+
+  /// Returns the best [ReferenceVehicle] for [profile] using the catalog
+  /// in [catalog], or `null` when nothing matches.
+  ///
+  /// Match is case-insensitive on `make` and `model`. A profile without
+  /// a `make` field (e.g. an EV-only profile that never went through
+  /// the VIN flow) returns `null` immediately — there's nothing to
+  /// match on.
+  static ReferenceVehicle? bestMatch({
+    required VehicleProfile profile,
+    required List<ReferenceVehicle> catalog,
+  }) {
+    final make = profile.make?.trim();
+    if (make == null || make.isEmpty) return null;
+
+    final model = profile.model?.trim();
+    final year = profile.year;
+    final lcMake = make.toLowerCase();
+    final lcModel = model?.toLowerCase();
+
+    // Tier 1 — exact make + model + year (when both model and year are
+    // populated).
+    if (lcModel != null && lcModel.isNotEmpty && year != null) {
+      for (final entry in catalog) {
+        if (entry.make.toLowerCase() == lcMake &&
+            entry.model.toLowerCase() == lcModel &&
+            entry.coversYear(year)) {
+          return entry;
+        }
+      }
+    }
+
+    // Tier 2 — make + model, any year. Falls through when the year is
+    // outside the production window or the user didn't enter one.
+    if (lcModel != null && lcModel.isNotEmpty) {
+      for (final entry in catalog) {
+        if (entry.make.toLowerCase() == lcMake &&
+            entry.model.toLowerCase() == lcModel) {
+          return entry;
+        }
+      }
+    }
+
+    // Tier 3 — make only. The OBD-II layer dispatches by
+    // `odometerPidStrategy`, which is brand-wide for the families we
+    // ship (PSA, VAG, BMW, Toyota etc.), so a make-only fallback still
+    // gives the consumer a useful strategy.
+    for (final entry in catalog) {
+      if (entry.make.toLowerCase() == lcMake) return entry;
+    }
+
+    return null;
+  }
+
+  /// Builds the persistent slug for a catalog entry. Stored on the
+  /// profile as [VehicleProfile.referenceVehicleId] so subsequent app
+  /// launches can resolve the same row without re-running the matcher.
+  ///
+  /// Format: `<make>-<model>-<generation>` lowercased, with every
+  /// non-alphanumeric character collapsed to a single dash, edges
+  /// trimmed. Stable across app launches because the inputs come from
+  /// the bundled JSON asset, not from user-typed strings.
+  ///
+  /// Examples:
+  ///   - Peugeot 208 II (2019-)        → `peugeot-208-ii-2019`
+  ///   - Volkswagen Golf VIII (2019-)  → `volkswagen-golf-viii-2019`
+  ///   - Citroen C5 Aircross I (2018-) → `citroen-c5-aircross-i-2018`
+  static String slugFor(ReferenceVehicle entry) {
+    final raw = '${entry.make}-${entry.model}-${entry.generation}';
+    final lowered = raw.toLowerCase();
+    final dashed = lowered.replaceAll(RegExp(r'[^a-z0-9]+'), '-');
+    // Collapse runs of dashes and trim leading/trailing dashes.
+    final collapsed = dashed.replaceAll(RegExp(r'-+'), '-');
+    return collapsed.replaceAll(RegExp(r'^-|-$'), '');
+  }
+}

--- a/lib/features/vehicle/data/vehicle_profile_migrator.dart
+++ b/lib/features/vehicle/data/vehicle_profile_migrator.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../core/data/storage_repository.dart';
+import '../../../core/storage/storage_keys.dart';
+import '../domain/entities/reference_vehicle.dart';
+import '../domain/entities/vehicle_profile.dart';
+import 'repositories/vehicle_profile_repository.dart';
+import 'vehicle_profile_catalog_matcher.dart';
+
+/// One-shot migrator that backfills [VehicleProfile.referenceVehicleId]
+/// for profiles created before the catalog existed (#950 phase 4).
+///
+/// Runs at app startup, after Hive opens and the reference catalog
+/// asset is loaded. Once successful, the [StorageKeys.vehicleCatalogMigrationDone]
+/// flag is flipped so subsequent launches skip straight through.
+///
+/// Failure modes are swallowed and `debugPrint`ed: this migrator must
+/// never block startup. A profile that fails to match is left with a
+/// `null` `referenceVehicleId` and the OBD-II layer falls back to its
+/// generic behaviour — exactly the pre-#950 path.
+class VehicleProfileCatalogMigrator {
+  final VehicleProfileRepository _repository;
+  final SettingsStorage _settings;
+
+  VehicleProfileCatalogMigrator({
+    required VehicleProfileRepository repository,
+    required SettingsStorage settings,
+  })  : _repository = repository,
+        _settings = settings;
+
+  /// True when the migration flag has been persisted in settings.
+  bool get hasRun =>
+      (_settings.getSetting(StorageKeys.vehicleCatalogMigrationDone)
+              as bool?) ==
+          true;
+
+  /// Run the migration once and mark it as done.
+  ///
+  /// Returns the number of profiles that received a non-null
+  /// `referenceVehicleId`. Profiles that already had a value (e.g.
+  /// from a prior run, a sync, or a user edit) are left alone.
+  Future<int> run({required List<ReferenceVehicle> catalog}) async {
+    if (hasRun) {
+      return 0;
+    }
+
+    var matched = 0;
+    try {
+      final profiles = _repository.getAll();
+      for (final profile in profiles) {
+        // Already pinned to a catalog entry — nothing to do.
+        if (profile.referenceVehicleId != null &&
+            profile.referenceVehicleId!.isNotEmpty) {
+          continue;
+        }
+
+        final match = VehicleProfileCatalogMatcher.bestMatch(
+          profile: profile,
+          catalog: catalog,
+        );
+        if (match == null) continue;
+
+        final slug = VehicleProfileCatalogMatcher.slugFor(match);
+        final updated = profile.copyWith(referenceVehicleId: slug);
+        await _repository.save(updated);
+        matched++;
+      }
+    } catch (e, st) {
+      // Don't bubble — startup must keep going.
+      debugPrint('VehicleProfileCatalogMigrator: run failed: $e\n$st');
+    }
+
+    // Always mark done, even if we matched zero. A user who has only
+    // EV-only profiles (no make set) doesn't need to re-run this every
+    // launch hoping they suddenly populate make/model.
+    try {
+      await _settings.putSetting(
+        StorageKeys.vehicleCatalogMigrationDone,
+        true,
+      );
+    } catch (e) {
+      debugPrint(
+          'VehicleProfileCatalogMigrator: failed to set done flag: $e');
+    }
+
+    return matched;
+  }
+}

--- a/lib/features/vehicle/domain/entities/vehicle_profile.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.dart
@@ -220,6 +220,26 @@ abstract class VehicleProfile with _$VehicleProfile {
     @Default(5.0) double movementStartThresholdKmh,
     @Default(60) int disconnectSaveDelaySec,
     @Default(false) bool backgroundLocationConsent,
+
+    // Reference catalog identification (#950 phase 4). Optional fields
+    // populated during onboarding (VIN decoder pre-fill or manual user
+    // entry) so the migrator and the OBD-II layer can resolve the
+    // vehicle to a [ReferenceVehicle]. All three default to null so
+    // pre-#950 profiles deserialize without losing data — the migrator
+    // fills them in on first launch.
+    //
+    //   make: marketing brand name, e.g. "Peugeot", "Renault".
+    //   model: model name as marketed in Europe, e.g. "208", "Clio".
+    //   year: model year (4-digit), used to disambiguate generations.
+    //   referenceVehicleId: slug of the matching catalog entry, e.g.
+    //     "peugeot-208-ii-2019-". Format is `<make>-<model>-<generation>`
+    //     lowercased with non-alphanumerics collapsed to dashes. The
+    //     consumer side (obd2_service) resolves the slug back to a
+    //     [ReferenceVehicle] via the catalog provider.
+    String? make,
+    String? model,
+    int? year,
+    String? referenceVehicleId,
   }) = _VehicleProfile;
 
   factory VehicleProfile.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
@@ -368,7 +368,22 @@ mixin _$VehicleProfile {
 //     permission — this is the user's stored answer to "may we
 //     record GPS while the screen is off?" Without it, the
 //     auto-flow runs BT-only and skips GPS-based trip metadata.
- bool get autoRecord; String? get pairedAdapterMac; double get movementStartThresholdKmh; int get disconnectSaveDelaySec; bool get backgroundLocationConsent;
+ bool get autoRecord; String? get pairedAdapterMac; double get movementStartThresholdKmh; int get disconnectSaveDelaySec; bool get backgroundLocationConsent;// Reference catalog identification (#950 phase 4). Optional fields
+// populated during onboarding (VIN decoder pre-fill or manual user
+// entry) so the migrator and the OBD-II layer can resolve the
+// vehicle to a [ReferenceVehicle]. All three default to null so
+// pre-#950 profiles deserialize without losing data — the migrator
+// fills them in on first launch.
+//
+//   make: marketing brand name, e.g. "Peugeot", "Renault".
+//   model: model name as marketed in Europe, e.g. "208", "Clio".
+//   year: model year (4-digit), used to disambiguate generations.
+//   referenceVehicleId: slug of the matching catalog entry, e.g.
+//     "peugeot-208-ii-2019-". Format is `<make>-<model>-<generation>`
+//     lowercased with non-alphanumerics collapsed to dashes. The
+//     consumer side (obd2_service) resolves the slug back to a
+//     [ReferenceVehicle] via the catalog provider.
+ String? get make; String? get model; int? get year; String? get referenceVehicleId;
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -381,16 +396,16 @@ $VehicleProfileCopyWith<VehicleProfile> get copyWith => _$VehicleProfileCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent)&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.year, year) || other.year == year)&&(identical(other.referenceVehicleId, referenceVehicleId) || other.referenceVehicleId == referenceVehicleId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent,make,model,year,referenceVehicleId]);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent, make: $make, model: $model, year: $year, referenceVehicleId: $referenceVehicleId)';
 }
 
 
@@ -401,7 +416,7 @@ abstract mixin class $VehicleProfileCopyWith<$Res>  {
   factory $VehicleProfileCopyWith(VehicleProfile value, $Res Function(VehicleProfile) _then) = _$VehicleProfileCopyWithImpl;
 @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent, String? make, String? model, int? year, String? referenceVehicleId
 });
 
 
@@ -418,7 +433,7 @@ class _$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,Object? make = freezed,Object? model = freezed,Object? year = freezed,Object? referenceVehicleId = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -443,7 +458,11 @@ as bool,pairedAdapterMac: freezed == pairedAdapterMac ? _self.pairedAdapterMac :
 as String?,movementStartThresholdKmh: null == movementStartThresholdKmh ? _self.movementStartThresholdKmh : movementStartThresholdKmh // ignore: cast_nullable_to_non_nullable
 as double,disconnectSaveDelaySec: null == disconnectSaveDelaySec ? _self.disconnectSaveDelaySec : disconnectSaveDelaySec // ignore: cast_nullable_to_non_nullable
 as int,backgroundLocationConsent: null == backgroundLocationConsent ? _self.backgroundLocationConsent : backgroundLocationConsent // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,make: freezed == make ? _self.make : make // ignore: cast_nullable_to_non_nullable
+as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String?,year: freezed == year ? _self.year : year // ignore: cast_nullable_to_non_nullable
+as int?,referenceVehicleId: freezed == referenceVehicleId ? _self.referenceVehicleId : referenceVehicleId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 /// Create a copy of VehicleProfile
@@ -537,10 +556,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent,  String? make,  String? model,  int? year,  String? referenceVehicleId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent,_that.make,_that.model,_that.year,_that.referenceVehicleId);case _:
   return orElse();
 
 }
@@ -558,10 +577,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent,  String? make,  String? model,  int? year,  String? referenceVehicleId)  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile():
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent,_that.make,_that.model,_that.year,_that.referenceVehicleId);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -578,10 +597,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent,  String? make,  String? model,  int? year,  String? referenceVehicleId)?  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent,_that.make,_that.model,_that.year,_that.referenceVehicleId);case _:
   return null;
 
 }
@@ -593,7 +612,7 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 @JsonSerializable()
 
 class _VehicleProfile extends VehicleProfile {
-  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.volumetricEfficiencySamples = 0, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName, this.vin, @VehicleCalibrationModeJsonConverter() this.calibrationMode = VehicleCalibrationMode.rule, this.autoRecord = false, this.pairedAdapterMac, this.movementStartThresholdKmh = 5.0, this.disconnectSaveDelaySec = 60, this.backgroundLocationConsent = false}): _supportedConnectors = supportedConnectors,super._();
+  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.volumetricEfficiencySamples = 0, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName, this.vin, @VehicleCalibrationModeJsonConverter() this.calibrationMode = VehicleCalibrationMode.rule, this.autoRecord = false, this.pairedAdapterMac, this.movementStartThresholdKmh = 5.0, this.disconnectSaveDelaySec = 60, this.backgroundLocationConsent = false, this.make, this.model, this.year, this.referenceVehicleId}): _supportedConnectors = supportedConnectors,super._();
   factory _VehicleProfile.fromJson(Map<String, dynamic> json) => _$VehicleProfileFromJson(json);
 
 @override final  String id;
@@ -703,6 +722,25 @@ class _VehicleProfile extends VehicleProfile {
 @override@JsonKey() final  double movementStartThresholdKmh;
 @override@JsonKey() final  int disconnectSaveDelaySec;
 @override@JsonKey() final  bool backgroundLocationConsent;
+// Reference catalog identification (#950 phase 4). Optional fields
+// populated during onboarding (VIN decoder pre-fill or manual user
+// entry) so the migrator and the OBD-II layer can resolve the
+// vehicle to a [ReferenceVehicle]. All three default to null so
+// pre-#950 profiles deserialize without losing data — the migrator
+// fills them in on first launch.
+//
+//   make: marketing brand name, e.g. "Peugeot", "Renault".
+//   model: model name as marketed in Europe, e.g. "208", "Clio".
+//   year: model year (4-digit), used to disambiguate generations.
+//   referenceVehicleId: slug of the matching catalog entry, e.g.
+//     "peugeot-208-ii-2019-". Format is `<make>-<model>-<generation>`
+//     lowercased with non-alphanumerics collapsed to dashes. The
+//     consumer side (obd2_service) resolves the slug back to a
+//     [ReferenceVehicle] via the catalog provider.
+@override final  String? make;
+@override final  String? model;
+@override final  int? year;
+@override final  String? referenceVehicleId;
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
@@ -717,16 +755,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent)&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.year, year) || other.year == year)&&(identical(other.referenceVehicleId, referenceVehicleId) || other.referenceVehicleId == referenceVehicleId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent,make,model,year,referenceVehicleId]);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent, make: $make, model: $model, year: $year, referenceVehicleId: $referenceVehicleId)';
 }
 
 
@@ -737,7 +775,7 @@ abstract mixin class _$VehicleProfileCopyWith<$Res> implements $VehicleProfileCo
   factory _$VehicleProfileCopyWith(_VehicleProfile value, $Res Function(_VehicleProfile) _then) = __$VehicleProfileCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent, String? make, String? model, int? year, String? referenceVehicleId
 });
 
 
@@ -754,7 +792,7 @@ class __$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,Object? make = freezed,Object? model = freezed,Object? year = freezed,Object? referenceVehicleId = freezed,}) {
   return _then(_VehicleProfile(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -779,7 +817,11 @@ as bool,pairedAdapterMac: freezed == pairedAdapterMac ? _self.pairedAdapterMac :
 as String?,movementStartThresholdKmh: null == movementStartThresholdKmh ? _self.movementStartThresholdKmh : movementStartThresholdKmh // ignore: cast_nullable_to_non_nullable
 as double,disconnectSaveDelaySec: null == disconnectSaveDelaySec ? _self.disconnectSaveDelaySec : disconnectSaveDelaySec // ignore: cast_nullable_to_non_nullable
 as int,backgroundLocationConsent: null == backgroundLocationConsent ? _self.backgroundLocationConsent : backgroundLocationConsent // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,make: freezed == make ? _self.make : make // ignore: cast_nullable_to_non_nullable
+as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String?,year: freezed == year ? _self.year : year // ignore: cast_nullable_to_non_nullable
+as int?,referenceVehicleId: freezed == referenceVehicleId ? _self.referenceVehicleId : referenceVehicleId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
@@ -69,6 +69,10 @@ _VehicleProfile _$VehicleProfileFromJson(Map<String, dynamic> json) =>
           (json['disconnectSaveDelaySec'] as num?)?.toInt() ?? 60,
       backgroundLocationConsent:
           json['backgroundLocationConsent'] as bool? ?? false,
+      make: json['make'] as String?,
+      model: json['model'] as String?,
+      year: (json['year'] as num?)?.toInt(),
+      referenceVehicleId: json['referenceVehicleId'] as String?,
     );
 
 Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
@@ -102,4 +106,8 @@ Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
       'movementStartThresholdKmh': instance.movementStartThresholdKmh,
       'disconnectSaveDelaySec': instance.disconnectSaveDelaySec,
       'backgroundLocationConsent': instance.backgroundLocationConsent,
+      'make': instance.make,
+      'model': instance.model,
+      'year': instance.year,
+      'referenceVehicleId': instance.referenceVehicleId,
     };

--- a/test/features/vehicle/data/vehicle_profile_catalog_matcher_test.dart
+++ b/test/features/vehicle/data/vehicle_profile_catalog_matcher_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/data/vehicle_profile_catalog_matcher.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/reference_vehicle.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+/// Unit tests for [VehicleProfileCatalogMatcher] (#950 phase 4).
+///
+/// The matcher is pure — no Hive, no network, no Riverpod. We feed it
+/// hand-built [ReferenceVehicle] catalogs that mirror the asset shape
+/// without depending on the bundled JSON, so the tests don't drift if
+/// the canonical catalog is reordered.
+void main() {
+  // The first Peugeot row in the canonical catalog. Matches by year
+  // window via Tier 1.
+  const peugeot208II = ReferenceVehicle(
+    make: 'Peugeot',
+    model: '208',
+    generation: 'II (2019-)',
+    yearStart: 2019,
+    displacementCc: 1199,
+    fuelType: 'petrol',
+    transmission: 'manual',
+    odometerPidStrategy: 'psaUds',
+  );
+
+  // A second Peugeot model so the make-only fallback has somewhere to
+  // land when the model name is unknown.
+  const peugeot308 = ReferenceVehicle(
+    make: 'Peugeot',
+    model: '308',
+    generation: 'III (2021-)',
+    yearStart: 2021,
+    displacementCc: 1199,
+    fuelType: 'petrol',
+    transmission: 'automatic',
+    odometerPidStrategy: 'psaUds',
+  );
+
+  // A Renault row so we can prove cross-make queries don't accidentally
+  // return Peugeot.
+  const renaultClio = ReferenceVehicle(
+    make: 'Renault',
+    model: 'Clio',
+    generation: 'V (2019-)',
+    yearStart: 2019,
+    displacementCc: 999,
+    fuelType: 'petrol',
+    transmission: 'manual',
+    odometerPidStrategy: 'stdA6',
+  );
+
+  const catalog = <ReferenceVehicle>[peugeot208II, peugeot308, renaultClio];
+
+  group('VehicleProfileCatalogMatcher.bestMatch', () {
+    test('Tier 1: exact make + model + year matches catalog entry', () {
+      const profile = VehicleProfile(
+        id: 'p1',
+        name: 'My 208',
+        make: 'Peugeot',
+        model: '208',
+        year: 2020,
+      );
+      final match = VehicleProfileCatalogMatcher.bestMatch(
+        profile: profile,
+        catalog: catalog,
+      );
+      expect(match, peugeot208II);
+    });
+
+    test('Tier 1 is case-insensitive on make and model', () {
+      const profile = VehicleProfile(
+        id: 'p2',
+        name: 'My 208',
+        make: 'peugeot',
+        model: '208',
+        year: 2020,
+      );
+      final match = VehicleProfileCatalogMatcher.bestMatch(
+        profile: profile,
+        catalog: catalog,
+      );
+      expect(match, peugeot208II);
+    });
+
+    test(
+        'Tier 2: out-of-window year falls back to make + model match',
+        () {
+      // Peugeot 208 with a year far before any catalog generation.
+      const profile = VehicleProfile(
+        id: 'p3',
+        name: 'Old 208',
+        make: 'Peugeot',
+        model: '208',
+        year: 1955,
+      );
+      final match = VehicleProfileCatalogMatcher.bestMatch(
+        profile: profile,
+        catalog: catalog,
+      );
+      expect(match, peugeot208II,
+          reason:
+              'Make + model wins when year is outside the catalog window');
+    });
+
+    test('Tier 2: missing year still produces make + model match', () {
+      const profile = VehicleProfile(
+        id: 'p4',
+        name: 'My 208',
+        make: 'Peugeot',
+        model: '208',
+      );
+      final match = VehicleProfileCatalogMatcher.bestMatch(
+        profile: profile,
+        catalog: catalog,
+      );
+      expect(match, peugeot208II);
+    });
+
+    test(
+        'Tier 3: unknown model with known make returns first '
+        'matching make entry', () {
+      const profile = VehicleProfile(
+        id: 'p5',
+        name: 'My Peugeot',
+        make: 'Peugeot',
+        model: 'Bar',
+        year: 2020,
+      );
+      final match = VehicleProfileCatalogMatcher.bestMatch(
+        profile: profile,
+        catalog: catalog,
+      );
+      expect(match, peugeot208II,
+          reason:
+              'Make-only fallback returns the first catalog row for the brand');
+    });
+
+    test('returns null when make is unknown', () {
+      const profile = VehicleProfile(
+        id: 'p6',
+        name: 'Acme',
+        make: 'Acme',
+        model: 'Foo',
+        year: 2020,
+      );
+      final match = VehicleProfileCatalogMatcher.bestMatch(
+        profile: profile,
+        catalog: catalog,
+      );
+      expect(match, isNull);
+    });
+
+    test('returns null when make is empty or null', () {
+      const profileNoMake = VehicleProfile(id: 'p7', name: 'X');
+      expect(
+        VehicleProfileCatalogMatcher.bestMatch(
+          profile: profileNoMake,
+          catalog: catalog,
+        ),
+        isNull,
+      );
+
+      const profileBlankMake =
+          VehicleProfile(id: 'p8', name: 'X', make: '   ');
+      expect(
+        VehicleProfileCatalogMatcher.bestMatch(
+          profile: profileBlankMake,
+          catalog: catalog,
+        ),
+        isNull,
+      );
+    });
+
+    test('cross-make queries do not leak between brands', () {
+      const profile = VehicleProfile(
+        id: 'p9',
+        name: 'Clio',
+        make: 'Renault',
+        model: 'Clio',
+        year: 2020,
+      );
+      final match = VehicleProfileCatalogMatcher.bestMatch(
+        profile: profile,
+        catalog: catalog,
+      );
+      expect(match, renaultClio);
+    });
+  });
+
+  group('VehicleProfileCatalogMatcher.slugFor', () {
+    test('produces lowercase dashed slugs for catalog entries', () {
+      expect(
+        VehicleProfileCatalogMatcher.slugFor(peugeot208II),
+        'peugeot-208-ii-2019',
+      );
+    });
+
+    test('collapses spaces and punctuation to single dashes', () {
+      const c5Aircross = ReferenceVehicle(
+        make: 'Citroen',
+        model: 'C5 Aircross',
+        generation: 'I (2018-)',
+        yearStart: 2018,
+        displacementCc: 1499,
+        fuelType: 'diesel',
+        transmission: 'automatic',
+        odometerPidStrategy: 'psaUds',
+      );
+      expect(
+        VehicleProfileCatalogMatcher.slugFor(c5Aircross),
+        'citroen-c5-aircross-i-2018',
+      );
+    });
+  });
+}

--- a/test/features/vehicle/data/vehicle_profile_migrator_test.dart
+++ b/test/features/vehicle/data/vehicle_profile_migrator_test.dart
@@ -1,0 +1,230 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/data/vehicle_profile_catalog_matcher.dart';
+import 'package:tankstellen/features/vehicle/data/vehicle_profile_migrator.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/reference_vehicle.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+/// Unit tests for the [VehicleProfileCatalogMigrator] (#950 phase 4).
+///
+/// We feed an in-memory [SettingsStorage] fake and a hand-built
+/// catalog so the test is fully synchronous and doesn't depend on the
+/// bundled JSON asset.
+void main() {
+  const peugeot208II = ReferenceVehicle(
+    make: 'Peugeot',
+    model: '208',
+    generation: 'II (2019-)',
+    yearStart: 2019,
+    displacementCc: 1199,
+    fuelType: 'petrol',
+    transmission: 'manual',
+    odometerPidStrategy: 'psaUds',
+  );
+
+  const renaultClio = ReferenceVehicle(
+    make: 'Renault',
+    model: 'Clio',
+    generation: 'V (2019-)',
+    yearStart: 2019,
+    displacementCc: 999,
+    fuelType: 'petrol',
+    transmission: 'manual',
+    odometerPidStrategy: 'stdA6',
+  );
+
+  const catalog = <ReferenceVehicle>[peugeot208II, renaultClio];
+  final peugeot208IISlug =
+      VehicleProfileCatalogMatcher.slugFor(peugeot208II);
+
+  late _FakeSettings settings;
+  late VehicleProfileRepository repository;
+  late VehicleProfileCatalogMigrator migrator;
+
+  setUp(() {
+    settings = _FakeSettings();
+    repository = VehicleProfileRepository(settings);
+    migrator = VehicleProfileCatalogMigrator(
+      repository: repository,
+      settings: settings,
+    );
+  });
+
+  group('VehicleProfileCatalogMigrator.run', () {
+    test('runs once when migration flag is unset', () async {
+      const profile = VehicleProfile(
+        id: 'p1',
+        name: 'My 208',
+        make: 'Peugeot',
+        model: '208',
+        year: 2020,
+      );
+      await repository.save(profile);
+
+      expect(migrator.hasRun, isFalse);
+      final matched = await migrator.run(catalog: catalog);
+
+      expect(matched, 1);
+      expect(migrator.hasRun, isTrue);
+      expect(
+        settings.getSetting(StorageKeys.vehicleCatalogMigrationDone),
+        isTrue,
+      );
+    });
+
+    test('skips when flag is already set', () async {
+      const profile = VehicleProfile(
+        id: 'p1',
+        name: 'My 208',
+        make: 'Peugeot',
+        model: '208',
+        year: 2020,
+      );
+      await repository.save(profile);
+      await settings.putSetting(
+          StorageKeys.vehicleCatalogMigrationDone, true);
+
+      final matched = await migrator.run(catalog: catalog);
+
+      expect(matched, 0,
+          reason: 'Migrator must not touch profiles when flag is set');
+      // Profile remains untouched.
+      expect(repository.getById('p1')?.referenceVehicleId, isNull);
+    });
+
+    test(
+        'updates referenceVehicleId for known make+model entries '
+        'and persists to repo', () async {
+      const peugeot = VehicleProfile(
+        id: 'p1',
+        name: 'My 208',
+        make: 'Peugeot',
+        model: '208',
+        year: 2020,
+      );
+      const renault = VehicleProfile(
+        id: 'r1',
+        name: 'My Clio',
+        make: 'Renault',
+        model: 'Clio',
+        year: 2021,
+      );
+      await repository.save(peugeot);
+      await repository.save(renault);
+
+      final matched = await migrator.run(catalog: catalog);
+
+      expect(matched, 2);
+      // Verify by re-reading from the repo (proves Hive persistence).
+      final stored208 = repository.getById('p1')!;
+      final storedClio = repository.getById('r1')!;
+      expect(stored208.referenceVehicleId, peugeot208IISlug);
+      expect(
+        storedClio.referenceVehicleId,
+        VehicleProfileCatalogMatcher.slugFor(renaultClio),
+      );
+      // Round-trip: existing fields untouched.
+      expect(stored208.make, 'Peugeot');
+      expect(stored208.model, '208');
+      expect(stored208.year, 2020);
+    });
+
+    test('leaves referenceVehicleId null for unmatched entries', () async {
+      const profile = VehicleProfile(
+        id: 'unknown',
+        name: 'Acme Foo',
+        make: 'Acme',
+        model: 'Foo',
+        year: 2020,
+      );
+      await repository.save(profile);
+
+      final matched = await migrator.run(catalog: catalog);
+
+      expect(matched, 0);
+      expect(repository.getById('unknown')?.referenceVehicleId, isNull);
+      // Flag flipped even with zero matches.
+      expect(migrator.hasRun, isTrue);
+    });
+
+    test('skips profiles that already have a referenceVehicleId', () async {
+      const existing = VehicleProfile(
+        id: 'p1',
+        name: 'My 208',
+        make: 'Peugeot',
+        model: '208',
+        year: 2020,
+        referenceVehicleId: 'pre-existing-slug',
+      );
+      await repository.save(existing);
+
+      final matched = await migrator.run(catalog: catalog);
+
+      expect(matched, 0,
+          reason: 'Migrator must not overwrite existing slugs');
+      expect(
+        repository.getById('p1')?.referenceVehicleId,
+        'pre-existing-slug',
+      );
+    });
+
+    test('handles empty profile list without errors', () async {
+      final matched = await migrator.run(catalog: catalog);
+      expect(matched, 0);
+      expect(migrator.hasRun, isTrue);
+    });
+
+    test('legacy profile JSON without phase-4 fields decodes cleanly',
+        () async {
+      // Simulate a pre-#950 profile that was stored before make/model/
+      // year/referenceVehicleId existed. Round-trip through the
+      // repository to prove fromJson supplies defaults.
+      const legacy = VehicleProfile(id: 'legacy', name: 'Legacy car');
+      await repository.save(legacy);
+
+      final loaded = repository.getById('legacy');
+      expect(loaded, isNotNull);
+      expect(loaded!.make, isNull);
+      expect(loaded.model, isNull);
+      expect(loaded.year, isNull);
+      expect(loaded.referenceVehicleId, isNull);
+
+      // Migrator should leave the legacy profile alone (no make to
+      // match on) and still mark the migration done.
+      final matched = await migrator.run(catalog: catalog);
+      expect(matched, 0);
+      expect(migrator.hasRun, isTrue);
+      expect(repository.getById('legacy')?.referenceVehicleId, isNull);
+    });
+  });
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}


### PR DESCRIPTION
## Summary

- Adds `VehicleProfileCatalogMatcher` — pure utility with 3-tier matching (exact make+model+year, make+model, make-only).
- Adds `VehicleProfileCatalogMigrator` — one-shot startup task that backfills `referenceVehicleId` for existing profiles, gated by a settings flag so it never runs twice.
- Extends `VehicleProfile` with `make`, `model`, `year`, `referenceVehicleId` (all nullable, freezed `@Default` so pre-#950 JSON round-trips cleanly).
- Wires the migrator into `AppInitializer._deferPostFirstFrame` so it runs after the first paint without blocking startup.

## Why

Closes #950. Database-driven vehicle catalog complete: phase 1 (catalog #1003), phase 2 (obd2_service consumer #1009), phase 3 (docs + parse test #1015), phase 4 (this PR — migrate existing user profiles + wire matcher into startup).

The Peugeot speed-density hardcoding in obd2_service is now fully replaced by catalog-driven configuration. Adding a new EU car is a JSON edit + one matcher test.

## Testing

- `flutter analyze` — zero warnings.
- `flutter test` — 6886 passed, 1 skipped (full suite green).
- 17 new unit tests cover all match tiers, slug generation, migration flag gating, persistence to repo, legacy JSON round-trip, and unmatched fallthrough.

## Migration safety

- `VehicleProfile` JSON shape is additive: legacy profiles deserialize via `@Default` to null/null/null for the new fields.
- Migrator skips profiles that already have a `referenceVehicleId` (sync-safe).
- Migrator marks done even when zero matches happen — no thrash for users with EV-only profiles that have no `make`.

## Screenshots

N/A — data-layer + startup wiring, no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)