### PR TITLE
feat(feedback): auto-record badge service (Refs #1004 phase 5)

### DIFF
--- a/lib/core/feedback/auto_record_badge_provider.dart
+++ b/lib/core/feedback/auto_record_badge_provider.dart
@@ -1,0 +1,24 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'auto_record_badge_service.dart';
+
+part 'auto_record_badge_provider.g.dart';
+
+/// Process-wide singleton for the auto-record badge counter
+/// (#1004 phase 5).
+///
+/// `keepAlive` because the badge needs to stay coherent for the
+/// lifetime of the app — the trip-save path may call `increment`
+/// from a background isolate hand-off and the detail screen may
+/// `decrement` minutes later. Re-creating the service per-route
+/// would lose in-flight writes.
+///
+/// Returned as `AsyncValue<AutoRecordBadgeService>` because resolving
+/// `SharedPreferences` is asynchronous. Callers that need immediate
+/// access should await the future; UI consumers can `when` over it.
+@Riverpod(keepAlive: true)
+Future<AutoRecordBadgeService> autoRecordBadgeService(Ref ref) async {
+  final prefs = await SharedPreferences.getInstance();
+  return AutoRecordBadgeService(prefs: prefs);
+}

--- a/lib/core/feedback/auto_record_badge_provider.g.dart
+++ b/lib/core/feedback/auto_record_badge_provider.g.dart
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auto_record_badge_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Process-wide singleton for the auto-record badge counter
+/// (#1004 phase 5).
+///
+/// `keepAlive` because the badge needs to stay coherent for the
+/// lifetime of the app — the trip-save path may call `increment`
+/// from a background isolate hand-off and the detail screen may
+/// `decrement` minutes later. Re-creating the service per-route
+/// would lose in-flight writes.
+///
+/// Returned as `AsyncValue<AutoRecordBadgeService>` because resolving
+/// `SharedPreferences` is asynchronous. Callers that need immediate
+/// access should await the future; UI consumers can `when` over it.
+
+@ProviderFor(autoRecordBadgeService)
+final autoRecordBadgeServiceProvider = AutoRecordBadgeServiceProvider._();
+
+/// Process-wide singleton for the auto-record badge counter
+/// (#1004 phase 5).
+///
+/// `keepAlive` because the badge needs to stay coherent for the
+/// lifetime of the app — the trip-save path may call `increment`
+/// from a background isolate hand-off and the detail screen may
+/// `decrement` minutes later. Re-creating the service per-route
+/// would lose in-flight writes.
+///
+/// Returned as `AsyncValue<AutoRecordBadgeService>` because resolving
+/// `SharedPreferences` is asynchronous. Callers that need immediate
+/// access should await the future; UI consumers can `when` over it.
+
+final class AutoRecordBadgeServiceProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<AutoRecordBadgeService>,
+          AutoRecordBadgeService,
+          FutureOr<AutoRecordBadgeService>
+        >
+    with
+        $FutureModifier<AutoRecordBadgeService>,
+        $FutureProvider<AutoRecordBadgeService> {
+  /// Process-wide singleton for the auto-record badge counter
+  /// (#1004 phase 5).
+  ///
+  /// `keepAlive` because the badge needs to stay coherent for the
+  /// lifetime of the app — the trip-save path may call `increment`
+  /// from a background isolate hand-off and the detail screen may
+  /// `decrement` minutes later. Re-creating the service per-route
+  /// would lose in-flight writes.
+  ///
+  /// Returned as `AsyncValue<AutoRecordBadgeService>` because resolving
+  /// `SharedPreferences` is asynchronous. Callers that need immediate
+  /// access should await the future; UI consumers can `when` over it.
+  AutoRecordBadgeServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'autoRecordBadgeServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoRecordBadgeServiceHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<AutoRecordBadgeService> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<AutoRecordBadgeService> create(Ref ref) {
+    return autoRecordBadgeService(ref);
+  }
+}
+
+String _$autoRecordBadgeServiceHash() =>
+    r'3b635790f0a15f6020ccbc4dfe696ed021b76bf3';

--- a/lib/core/feedback/auto_record_badge_service.dart
+++ b/lib/core/feedback/auto_record_badge_service.dart
@@ -1,0 +1,100 @@
+import 'package:app_badge_plus/app_badge_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persistent counter of unseen auto-recorded trips, surfaced as a
+/// launcher-icon badge (#1004 phase 5).
+///
+/// The number on the home-screen icon answers the user's question
+/// "did anything happen while I was driving?" without requiring the
+/// app to be opened. Each time the auto-record path saves a new trip
+/// (phase 4) [increment] is called; opening the corresponding trip
+/// detail screen calls [decrement]. When the counter reaches zero the
+/// badge disappears.
+///
+/// ## Why a Dart-side counter
+///
+/// `AppBadgePlus` is fire-and-forget — the launcher process owns the
+/// rendered badge and we have no way to query "what number is showing
+/// right now?". Persisting the count locally lets the service answer
+/// `count` synchronously, survive app restarts, and recover when the
+/// platform call fails (e.g. on a launcher that doesn't expose a
+/// badge API).
+///
+/// ## Why platform exceptions don't propagate
+///
+/// Some Android launchers (AOSP, certain custom skins) reject the
+/// shortcut-badger intent. Throwing back into the trip-save / detail-
+/// open path would either lose a saved trip or block navigation —
+/// both far worse than a missing badge. Instead the service logs via
+/// `debugPrint` and keeps the Dart-level state consistent.
+class AutoRecordBadgeService {
+  /// `SharedPreferences` key holding the int counter. Versioned so a
+  /// future schema change can ignore legacy values without colliding.
+  static const String storageKey = 'auto_record_badge_count_v1';
+
+  final Future<void> Function(int) _setBadge;
+  final SharedPreferences _prefs;
+
+  AutoRecordBadgeService({
+    Future<void> Function(int)? setBadge,
+    required SharedPreferences prefs,
+  })  : _setBadge = setBadge ?? _defaultSetBadge,
+        _prefs = prefs;
+
+  /// Read current count without side effects. Defaults to 0 when no
+  /// value has been persisted yet.
+  int get count => _prefs.getInt(storageKey) ?? 0;
+
+  /// Increment the unseen-trip counter by one and update the launcher
+  /// badge. Persists the new count before attempting the platform
+  /// call so a launcher-reject leaves the Dart state correct for the
+  /// next boot.
+  Future<void> increment() async {
+    final next = count + 1;
+    await _writeCount(next);
+    await _safeSetBadge(next);
+  }
+
+  /// Decrement the counter, clamped at 0. When the counter reaches 0
+  /// the launcher badge is removed.
+  Future<void> decrement() async {
+    final current = count;
+    final next = current > 0 ? current - 1 : 0;
+    await _writeCount(next);
+    await _safeSetBadge(next);
+  }
+
+  /// Reset the counter to 0 and clear the launcher badge. Reserved
+  /// for the "Mark all as read" affordance shipping in a later phase.
+  Future<void> markAllAsRead() async {
+    await _writeCount(0);
+    await _safeSetBadge(0);
+  }
+
+  Future<void> _writeCount(int value) async {
+    try {
+      await _prefs.setInt(storageKey, value);
+    } catch (e) {
+      debugPrint('AutoRecordBadgeService write failed: $e');
+    }
+  }
+
+  Future<void> _safeSetBadge(int value) async {
+    try {
+      await _setBadge(value);
+    } catch (e) {
+      // Launcher does not support badges, or the platform plugin
+      // raised. Don't propagate — the Dart-level counter is the
+      // source of truth and survives the next launch attempt.
+      debugPrint('AutoRecordBadgeService setBadge($value) failed: $e');
+    }
+  }
+
+  /// Default platform-side hook. `app_badge_plus` documents
+  /// `updateBadge(0)` as the cross-platform "remove badge" call, so
+  /// we don't need a separate clear path.
+  static Future<void> _defaultSetBadge(int count) {
+    return AppBadgePlus.updateBadge(count);
+  }
+}

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -18,16 +18,25 @@ class TripHistoryEntry {
   final String? vehicleId;
   final TripSummary summary;
 
+  /// Whether this trip was captured by the auto-record path
+  /// (#1004 phase 4). Drives the badge-decrement call when the user
+  /// opens the detail screen — manual trips don't decrement because
+  /// they were never counted as "unseen". Defaults to false so all
+  /// pre-#1004 entries deserialise as manual.
+  final bool automatic;
+
   const TripHistoryEntry({
     required this.id,
     required this.vehicleId,
     required this.summary,
+    this.automatic = false,
   });
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'vehicleId': vehicleId,
         'summary': _summaryToJson(summary),
+        if (automatic) 'automatic': true,
       };
 
   static TripHistoryEntry fromJson(Map<String, dynamic> json) =>
@@ -37,6 +46,7 @@ class TripHistoryEntry {
         summary: _summaryFromJson(
           (json['summary'] as Map).cast<String, dynamic>(),
         ),
+        automatic: (json['automatic'] as bool?) ?? false,
       );
 }
 

--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
@@ -43,7 +44,7 @@ export '../widgets/trip_detail_share_payload.dart'
 ///   tool without needing any backend.
 /// * **Delete** confirms and then calls
 ///   [TripHistoryList.delete] before popping back to the Trajets tab.
-class TripDetailScreen extends ConsumerWidget {
+class TripDetailScreen extends ConsumerStatefulWidget {
   final String tripId;
 
   /// Optional per-sample profile used to populate the charts (#890).
@@ -62,10 +63,21 @@ class TripDetailScreen extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<TripDetailScreen> createState() => _TripDetailScreenState();
+}
+
+class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
+  /// Latches the badge-decrement to the first frame after the trip
+  /// detail mounts, so a `setState` rebuild can't trigger a second
+  /// decrement and over-clear the launcher counter.
+  bool _badgeDecremented = false;
+
+  @override
+  Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final trips = ref.watch(tripHistoryListProvider);
-    final entry = trips.where((t) => t.id == tripId).firstOrNull;
+    final entry = trips.where((t) => t.id == widget.tripId).firstOrNull;
+    _maybeDecrementBadge(entry);
     final activeVehicle = ref.watch(activeVehicleProfileProvider);
     final vehicles = ref.watch(vehicleProfileListProvider);
 
@@ -115,10 +127,28 @@ class TripDetailScreen extends ConsumerWidget {
           : TripDetailBody(
               entry: entry,
               vehicle: vehicle,
-              samples: samples,
+              samples: widget.samples,
               isEv: isEv,
             ),
     );
+  }
+
+  /// Decrement the launcher-icon badge once on the first build that
+  /// resolves an auto-recorded entry (#1004 phase 5). Scheduled
+  /// post-frame so we don't mutate provider state during a build.
+  void _maybeDecrementBadge(TripHistoryEntry? entry) {
+    if (_badgeDecremented) return;
+    if (entry == null || !entry.automatic) return;
+    _badgeDecremented = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      try {
+        final badge =
+            await ref.read(autoRecordBadgeServiceProvider.future);
+        await badge.decrement();
+      } catch (e) {
+        debugPrint('TripDetailScreen badge decrement: $e');
+      }
+    });
   }
 
   Future<void> _onShare(
@@ -130,7 +160,7 @@ class TripDetailScreen extends ConsumerWidget {
     final payload = tripDetailSharePayload(
       entry: entry,
       vehicle: vehicle,
-      samples: samples,
+      samples: widget.samples,
     );
     await Clipboard.setData(ClipboardData(text: payload));
     if (!context.mounted) return;
@@ -171,7 +201,7 @@ class TripDetailScreen extends ConsumerWidget {
       ),
     );
     if (confirmed != true || !context.mounted) return;
-    await ref.read(tripHistoryListProvider.notifier).delete(tripId);
+    await ref.read(tripHistoryListProvider.notifier).delete(widget.tripId);
     if (!context.mounted) return;
     context.pop();
   }

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../core/storage/hive_boxes.dart';
 import '../../../core/storage/storage_keys.dart';
 import '../../../core/storage/storage_providers.dart';
@@ -565,7 +566,10 @@ class TripRecording extends _$TripRecording {
     };
   }
 
-  Future<void> _saveToHistory(TripSummary summary) async {
+  Future<void> _saveToHistory(
+    TripSummary summary, {
+    bool automatic = false,
+  }) async {
     // Skip empty trips — the user tapped Stop without any usable
     // sample, or the service disconnected immediately. No signal, no
     // history clutter.
@@ -579,8 +583,21 @@ class TripRecording extends _$TripRecording {
         id: id,
         vehicleId: _vehicleId,
         summary: summary,
+        automatic: automatic,
       ));
       ref.read(tripHistoryListProvider.notifier).refresh();
+      // Phase 5 (#1004): bump the launcher-icon badge so the user sees
+      // "something happened while I was driving" without opening the
+      // app. The decrement fires when the user lands on the trip
+      // detail screen for this auto-recorded trip.
+      if (automatic) {
+        try {
+          final badge = await ref.read(autoRecordBadgeServiceProvider.future);
+          await badge.increment();
+        } catch (e) {
+          debugPrint('TripRecording auto-record badge increment: $e');
+        }
+      }
     } catch (e) {
       debugPrint('TripRecording._saveToHistory: $e');
     }

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'0fad8abf73331569d18957cf11ccc55e95166909';
+String _$tripRecordingHash() => r'0528613a6195194c4132ddb6a88edd837025d42d';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.4"
+  app_badge_plus:
+    dependency: "direct main"
+    description:
+      name: app_badge_plus
+      sha256: dab607342bbf73b33a532e384117ccb13efbaabadb6058c40fd74d743b0ef1ab
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.9"
   app_links:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,7 @@ dependencies:
   flutter_local_notifications: ^21.0.0
   supabase_flutter: ^2.12.4
   wakelock_plus: ^1.2.8
+  app_badge_plus: ^1.2.9
 
 dev_dependencies:
   flutter_test:

--- a/test/core/feedback/auto_record_badge_service_test.dart
+++ b/test/core/feedback/auto_record_badge_service_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tankstellen/core/feedback/auto_record_badge_service.dart';
+
+/// Unit tests for [AutoRecordBadgeService] (#1004 phase 5).
+///
+/// The launcher-side `AppBadgePlus.updateBadge` call is replaced with
+/// an in-test recorder so we can assert exact call sequences without
+/// reaching for a platform channel mock — that level of indirection
+/// belongs in the integration suite, not here.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const {});
+  });
+
+  Future<({AutoRecordBadgeService service, List<int> calls})> build({
+    Future<void> Function(int)? overrideSetBadge,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final calls = <int>[];
+    final service = AutoRecordBadgeService(
+      prefs: prefs,
+      setBadge: overrideSetBadge ??
+          (count) async {
+            calls.add(count);
+          },
+    );
+    return (service: service, calls: calls);
+  }
+
+  group('AutoRecordBadgeService', () {
+    test('initial count is 0', () async {
+      final fixture = await build();
+      expect(fixture.service.count, 0);
+    });
+
+    test('increment from 0 sets count to 1 and badge to 1', () async {
+      final fixture = await build();
+      await fixture.service.increment();
+      expect(fixture.service.count, 1);
+      expect(fixture.calls, [1]);
+    });
+
+    test('three increments push the badge to 1, 2, 3 in order', () async {
+      final fixture = await build();
+      await fixture.service.increment();
+      await fixture.service.increment();
+      await fixture.service.increment();
+      expect(fixture.service.count, 3);
+      expect(fixture.calls, [1, 2, 3]);
+    });
+
+    test('decrement from 2 drops to 1 and pushes 1 to the badge', () async {
+      final fixture = await build();
+      await fixture.service.increment();
+      await fixture.service.increment();
+      fixture.calls.clear();
+      await fixture.service.decrement();
+      expect(fixture.service.count, 1);
+      expect(fixture.calls, [1]);
+    });
+
+    test('decrement from 0 clamps at 0 and pushes 0 to clear the badge',
+        () async {
+      final fixture = await build();
+      await fixture.service.decrement();
+      expect(fixture.service.count, 0);
+      expect(fixture.calls, [0]);
+    });
+
+    test('markAllAsRead resets to 0 and clears the badge', () async {
+      final fixture = await build();
+      for (var i = 0; i < 5; i++) {
+        await fixture.service.increment();
+      }
+      fixture.calls.clear();
+      await fixture.service.markAllAsRead();
+      expect(fixture.service.count, 0);
+      expect(fixture.calls, [0]);
+    });
+
+    test('platform exception in setBadge does not propagate, state persists',
+        () async {
+      final fixture = await build(
+        overrideSetBadge: (_) async {
+          throw StateError('launcher does not support badges');
+        },
+      );
+      await fixture.service.increment(); // must not throw
+      expect(fixture.service.count, 1);
+
+      // The next service instance reading the same prefs sees the
+      // persisted count — proving the Dart-level state survives the
+      // platform-side failure.
+      final prefs = await SharedPreferences.getInstance();
+      final reread = AutoRecordBadgeService(prefs: prefs);
+      expect(reread.count, 1);
+    });
+
+    test('count survives across instances backed by the same prefs',
+        () async {
+      final fixture = await build();
+      await fixture.service.increment();
+      await fixture.service.increment();
+      final prefs = await SharedPreferences.getInstance();
+      final reread = AutoRecordBadgeService(prefs: prefs);
+      expect(reread.count, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Refs #1004 phase 5; phases 2, 3, 4, 6 still pending.
- New `AutoRecordBadgeService` (lib/core/feedback) persists an unseen-trip counter in `SharedPreferences` and pushes the value to the launcher via `app_badge_plus: ^1.2.9`. Platform errors are caught + `debugPrint`-logged so a launcher that doesn't support badges never blocks the trip-save / detail-open path.
- `TripHistoryEntry` gains an optional `automatic` flag (defaulting to `false`, so legacy entries stay manual). `_saveToHistory(automatic: true)` increments; `TripDetailScreen` decrements once on first build when the entry is auto-recorded.
- Self-contained: no dependency on the foreground BG service, BLE listener, or movement-start trigger from phases 2-4. Phase 4 will land the production caller that flips `automatic: true`.

## Why
Phase 5 closes the "did anything happen while I was driving?" UX loop without forcing the user to open the app to find out. The Dart-side counter is the source of truth so the badge survives app restarts and platform-side rejections.

## Testing
- [x] `flutter analyze` — clean (no issues)
- [x] `flutter test` — 6937 tests pass
- [x] New unit tests in `test/core/feedback/auto_record_badge_service_test.dart` cover increment, multi-increment ordering, decrement, decrement-clamp at zero, `markAllAsRead`, platform-exception swallowing, and cross-instance persistence

## Phases still pending
- #1004 phase 2 — foreground BG service + BLE auto-connect listener
- #1004 phase 3 — movement-start trigger
- #1004 phase 4 — disconnect-save trigger (will be the production caller of `_saveToHistory(automatic: true)`)
- #1004 phase 6 — "Mark all as read" UI