### PR TITLE
refactor(chile): split CSV parser out of chile_station_service (Refs #563)

### DIFF
--- a/lib/core/services/impl/chile_response_parser.dart
+++ b/lib/core/services/impl/chile_response_parser.dart
@@ -1,0 +1,254 @@
+/// Pure parsing helpers for the CNE "Bencina en Línea" envelope (#596,
+/// #563 split). Lives separately from `ChileStationService` so the
+/// JSON-shape contract — which is what the live endpoint typically
+/// breaks first — can be exercised with recorded fixtures, without
+/// touching Dio, Hive, or any network state. Adding network or storage
+/// imports here defeats the point of the split.
+///
+/// Public surface:
+///  - [parseChileStationsResponse]: top-level envelope → list of
+///    [Station]. Drops entries with missing/zero coordinates.
+///  - [fuelForChileProductKey]: the canonical CNE product-key →
+///    [FuelType] mapping (case-insensitive).
+///  - [chileDroppedProductKeys]: keys we deliberately ignore until
+///    matching enums land (e.g. `kerosene`).
+library;
+
+import '../../../features/search/domain/entities/fuel_type.dart';
+import '../../../features/search/domain/entities/station.dart';
+import '../../error/exceptions.dart';
+import '../../utils/geo_utils.dart';
+
+/// CNE product keys → our canonical [FuelType].
+///
+/// Five products ship today; kerosene has no enum yet and is
+/// intentionally omitted so the parser skips it silently.
+///
+/// Gasolina 93 and Gasolina 95 both map to [FuelType.e5]. Chilean
+/// petrol cars fill with either octane grade; 95 is the closer
+/// benchmark to the European E5 RON-95 and wins when both prices are
+/// quoted for the same station (see [_parsePrices]).
+const Map<String, FuelType> _chileProductKeyToFuel = {
+  'gasolina_93': FuelType.e5,
+  'gasolina_95': FuelType.e5,
+  'gasolina_97': FuelType.e98,
+  'diesel': FuelType.diesel,
+  'glp': FuelType.lpg,
+  // Some deployments use `gas_licuado` instead of `glp`; accept both.
+  'gas_licuado': FuelType.lpg,
+};
+
+/// Product keys we deliberately drop because no [FuelType] exists yet.
+/// Exposed so tests can pin the MVP policy.
+const Set<String> chileDroppedProductKeys = {'kerosene', 'parafina'};
+
+/// CNE product key → [FuelType] (case-insensitive). Returns `null`
+/// when the key has no matching slot today (kerosene / parafina /
+/// unknown).
+FuelType? fuelForChileProductKey(String productKey) =>
+    _chileProductKeyToFuel[productKey.toLowerCase()];
+
+/// Parse the CNE "estaciones" envelope into [Station] instances.
+///
+/// The CNE envelope shape we depend on is:
+/// ```json
+/// { "data": [ { "codigo": ..., "ubicacion": {...}, "precios": {...} }, ... ] }
+/// ```
+/// Anything else (a top-level non-map, an `{error: "..."}` with no `data`)
+/// raises [ApiException]; an empty / missing `data` array yields an
+/// empty list.
+List<Station> parseChileStationsResponse(
+  dynamic data, {
+  required double fromLat,
+  required double fromLng,
+}) {
+  final parsed = _coerceMap(data);
+  if (parsed == null) {
+    throw const ApiException(message: 'CNE returned unparseable body');
+  }
+
+  // Propagate a CNE-level error. When auth fails the API usually
+  // returns a JSON body with `error` or `message` set and an HTTP
+  // 401/403 (caught in the service shell), but some proxies return
+  // 200 + error.
+  final errField = parsed['error'] ?? parsed['message'];
+  if (errField != null && parsed['data'] == null) {
+    throw ApiException(message: 'CNE error: $errField');
+  }
+
+  final list = parsed['data'];
+  if (list is! List) return const [];
+
+  final stations = <Station>[];
+  for (final raw in list) {
+    if (raw is! Map) continue;
+    final s = _parseOneStation(raw, fromLat: fromLat, fromLng: fromLng);
+    if (s != null) stations.add(s);
+  }
+  return stations;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Internals
+// ──────────────────────────────────────────────────────────────────────
+
+Station? _parseOneStation(
+  Map raw, {
+  required double fromLat,
+  required double fromLng,
+}) {
+  final idRaw = (raw['codigo'] ?? raw['id'] ?? raw['id_estacion'])?.toString();
+  if (idRaw == null || idRaw.isEmpty) return null;
+
+  // CNE `ubicacion` holds `latitud` / `longitud`. Some mirrored feeds
+  // use flat `latitud` / `longitud` on the station — accept both.
+  final ubi = raw['ubicacion'];
+  final lat = _parseDouble(ubi is Map ? ubi['latitud'] : raw['latitud']);
+  final lng = _parseDouble(ubi is Map ? ubi['longitud'] : raw['longitud']);
+  if (lat == null || lng == null) return null;
+  if (lat == 0 && lng == 0) return null;
+
+  final brand = _parseBrand(raw);
+  final nameRaw =
+      (raw['nombre_fantasia'] ?? raw['nombre'])?.toString().trim();
+  final name = (nameRaw != null && nameRaw.isNotEmpty) ? nameRaw : brand;
+
+  final street = _joinStreet(raw);
+  final comuna = raw['nombre_comuna']?.toString().trim() ?? '';
+
+  final prices = _parsePrices(raw);
+
+  final distKm = _roundedDistance(fromLat, fromLng, lat, lng);
+
+  // Stable 'cl-' prefix so the favorites currency lookup finds CL.
+  final id = idRaw.startsWith('cl-') ? idRaw : 'cl-$idRaw';
+
+  return Station(
+    id: id,
+    name: name,
+    brand: brand,
+    street: street,
+    postCode: '',
+    place: comuna,
+    lat: lat,
+    lng: lng,
+    dist: distKm,
+    e5: prices[FuelType.e5],
+    e98: prices[FuelType.e98],
+    diesel: prices[FuelType.diesel],
+    lpg: prices[FuelType.lpg],
+    isOpen: _isOpen(raw),
+  );
+}
+
+Map<FuelType, double> _parsePrices(Map raw) {
+  final out = <FuelType, double>{};
+  final precios = raw['precios'];
+  if (precios is! Map) return out;
+
+  // Walk every quoted product, mapping known keys to a [FuelType].
+  // Unknown keys are silently ignored so upstream additions (EV at
+  // CNE? future biofuels?) don't break the parser.
+  precios.forEach((key, value) {
+    final k = key.toString().toLowerCase();
+    final price = _parsePesoPerLitre(value);
+    if (price == null) return;
+
+    final fuel = _chileProductKeyToFuel[k];
+    if (fuel == null) return; // kerosene / parafina / unknown → drop
+
+    // Merge 93 + 95 into e5. When both are quoted we prefer 95
+    // (closer to the European E5 RON-95 benchmark).
+    if (fuel == FuelType.e5) {
+      final existing = out[FuelType.e5];
+      if (existing == null) {
+        out[FuelType.e5] = price;
+      } else if (k == 'gasolina_95') {
+        // 95 wins over a previously-inserted 93.
+        out[FuelType.e5] = price;
+      }
+      return;
+    }
+
+    out[fuel] = price;
+  });
+  return out;
+}
+
+/// CNE prices are pesos per litre (e.g. `1290.0` CLP/L). Chilean
+/// pesos have no decimals in daily use; keep the raw numeric value
+/// as the local-currency unit the forecourt sign shows. No scaling.
+double? _parsePesoPerLitre(dynamic raw) {
+  if (raw == null) return null;
+  if (raw is num) {
+    if (raw <= 0) return null;
+    return raw.toDouble();
+  }
+  if (raw is String) {
+    final t = raw.trim();
+    if (t.isEmpty) return null;
+    final v = double.tryParse(t);
+    if (v == null || v <= 0) return null;
+    return v;
+  }
+  return null;
+}
+
+double? _parseDouble(dynamic raw) {
+  if (raw == null) return null;
+  if (raw is num) return raw.toDouble();
+  if (raw is String) {
+    final t = raw.trim();
+    if (t.isEmpty) return null;
+    return double.tryParse(t);
+  }
+  return null;
+}
+
+Map? _coerceMap(dynamic data) {
+  if (data is Map) return data;
+  return null;
+}
+
+/// CNE nests the distributor under `distribuidor.nombre`; older
+/// payloads use a flat `distribuidor` string. Accept both.
+String _parseBrand(Map raw) {
+  final dist = raw['distribuidor'];
+  if (dist is Map) {
+    final n = dist['nombre']?.toString().trim();
+    if (n != null && n.isNotEmpty) return n;
+  } else if (dist is String && dist.trim().isNotEmpty) {
+    return dist.trim();
+  }
+  final marca = raw['marca']?.toString().trim();
+  if (marca != null && marca.isNotEmpty) return marca;
+  return 'Independent';
+}
+
+String _joinStreet(Map raw) {
+  final calle = raw['direccion_calle']?.toString().trim() ?? '';
+  final numero = raw['direccion_numero']?.toString().trim() ?? '';
+  if (calle.isEmpty && numero.isEmpty) return '';
+  if (numero.isEmpty) return calle;
+  if (calle.isEmpty) return numero;
+  return '$calle $numero';
+}
+
+/// CNE does not expose a reliable open/closed flag per station — the
+/// `horario_atencion` field often reads `"24_horas"` or a free-text
+/// schedule. We treat stations as open by default and fall back to
+/// `false` only when the field explicitly says `cerrado`.
+bool _isOpen(Map raw) {
+  final h = raw['horario_atencion']?.toString().toLowerCase().trim();
+  if (h == null || h.isEmpty) return true;
+  if (h.contains('cerrado')) return false;
+  return true;
+}
+
+/// Haversine distance in km, rounded to one decimal — mirrors
+/// `StationServiceHelpers.roundedDistance` so the parser stays free of
+/// the mixin's HTTP/result-wrapping baggage.
+double _roundedDistance(double lat1, double lng1, double lat2, double lng2) {
+  final d = distanceKm(lat1, lng1, lat2, lng2);
+  return double.parse(d.toStringAsFixed(1));
+}

--- a/lib/core/services/impl/chile_station_service.dart
+++ b/lib/core/services/impl/chile_station_service.dart
@@ -9,6 +9,7 @@ import '../dio_factory.dart';
 import '../mixins/station_service_helpers.dart';
 import '../service_result.dart';
 import '../station_service.dart';
+import 'chile_response_parser.dart' as parser;
 
 /// Chile fuel prices from the **CNE Bencina en Línea** developer API
 /// (#596).
@@ -86,6 +87,12 @@ import '../station_service.dart';
 /// the API settles on. If a path change breaks the live call, the bug
 /// is a one-line URL constant — the rest of the service remains
 /// correct against the JSON contract captured above.
+///
+/// **Split (#563)**: the JSON parsing + per-row → [Station] mapping
+/// lives in `chile_response_parser.dart` so it can be tested as a pure
+/// function without Dio. This shell keeps only the [StationService]
+/// implementation: HTTP via Dio, [ServiceResult] plumbing, error
+/// classification, and radius filtering.
 class ChileStationService
     with StationServiceHelpers
     implements StationService {
@@ -99,28 +106,10 @@ class ChileStationService
   static const String defaultBaseUrl =
       'https://api.cne.cl/api/v4/combustibles/estaciones';
 
-  /// CNE product keys → our canonical [FuelType].
-  ///
-  /// Five products ship today; kerosene has no enum yet and is
-  /// intentionally omitted so the parser skips it silently.
-  ///
-  /// Gasolina 93 and Gasolina 95 both map to [FuelType.e5]. Chilean
-  /// petrol cars fill with either octane grade; 95 is the closer
-  /// benchmark to the European E5 RON-95 and wins when both prices
-  /// are quoted for the same station.
-  static const Map<String, FuelType> _productKeyToFuel = {
-    'gasolina_93': FuelType.e5,
-    'gasolina_95': FuelType.e5,
-    'gasolina_97': FuelType.e98,
-    'diesel': FuelType.diesel,
-    'glp': FuelType.lpg,
-    // Some deployments use `gas_licuado` instead of `glp`; accept both.
-    'gas_licuado': FuelType.lpg,
-  };
-
   /// Product keys we deliberately drop because no [FuelType] exists
-  /// yet. Exposed for tests to pin the MVP policy.
-  static const Set<String> droppedProductKeys = {'kerosene', 'parafina'};
+  /// yet. Re-exported from the parser for tests that pin the MVP
+  /// policy without crossing into the parser's namespace.
+  static const Set<String> droppedProductKeys = parser.chileDroppedProductKeys;
 
   final Dio _dio;
   final String _apiKey;
@@ -188,45 +177,27 @@ class ChileStationService
 
   /// Parse the CNE "estaciones" envelope into [Station] instances.
   ///
-  /// Exposed for tests — the parser is the contract the live endpoint
-  /// changes tend to break first, so unit tests drive it against
-  /// recorded fixtures independent of any Dio mock.
+  /// Thin delegate over [parser.parseChileStationsResponse]; kept on
+  /// the service so existing tests + any external callers continue to
+  /// work after the #563 split.
   @visibleForTesting
   List<Station> parseStationsResponse(
     dynamic data, {
     required double fromLat,
     required double fromLng,
-  }) {
-    final parsed = _coerceMap(data);
-    if (parsed == null) {
-      throw const ApiException(message: 'CNE returned unparseable body');
-    }
+  }) =>
+      parser.parseChileStationsResponse(
+        data,
+        fromLat: fromLat,
+        fromLng: fromLng,
+      );
 
-    // Propagate a CNE-level error. When auth fails the API usually
-    // returns a JSON body with `error` or `message` set and an HTTP
-    // 401/403 (caught above), but some proxies return 200 + error.
-    final errField = parsed['error'] ?? parsed['message'];
-    if (errField != null && parsed['data'] == null) {
-      throw ApiException(message: 'CNE error: $errField');
-    }
-
-    final list = parsed['data'];
-    if (list is! List) return const [];
-
-    final stations = <Station>[];
-    for (final raw in list) {
-      if (raw is! Map) continue;
-      final s = _parseOneStation(raw, fromLat: fromLat, fromLng: fromLng);
-      if (s != null) stations.add(s);
-    }
-    return stations;
-  }
-
-  /// Exposed for tests — single source of truth for the CNE-key
-  /// → [FuelType] mapping.
+  /// Single source of truth for the CNE-key → [FuelType] mapping.
+  /// Delegates to the parser; kept on the service for legacy callers
+  /// that import [ChileStationService] directly.
   @visibleForTesting
   static FuelType? fuelForProductKey(String productKey) =>
-      _productKeyToFuel[productKey.toLowerCase()];
+      parser.fuelForChileProductKey(productKey);
 
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(
@@ -240,165 +211,5 @@ class ChileStationService
     List<String> ids,
   ) async {
     return emptyPricesResult(ServiceSource.chileApi);
-  }
-
-  // ──────────────────────────────────────────────────────────────────────
-  // Helpers
-  // ──────────────────────────────────────────────────────────────────────
-
-  Station? _parseOneStation(
-    Map raw, {
-    required double fromLat,
-    required double fromLng,
-  }) {
-    final idRaw = (raw['codigo'] ?? raw['id'] ?? raw['id_estacion'])?.toString();
-    if (idRaw == null || idRaw.isEmpty) return null;
-
-    // CNE `ubicacion` holds `latitud` / `longitud`. Some mirrored feeds
-    // use flat `latitud` / `longitud` on the station — accept both.
-    final ubi = raw['ubicacion'];
-    final lat = _parseDouble(
-      ubi is Map ? ubi['latitud'] : raw['latitud'],
-    );
-    final lng = _parseDouble(
-      ubi is Map ? ubi['longitud'] : raw['longitud'],
-    );
-    if (lat == null || lng == null) return null;
-    if (lat == 0 && lng == 0) return null;
-
-    final brand = _parseBrand(raw);
-    final nameRaw = (raw['nombre_fantasia'] ?? raw['nombre'])?.toString().trim();
-    final name = (nameRaw != null && nameRaw.isNotEmpty) ? nameRaw : brand;
-
-    final street = _joinStreet(raw);
-    final comuna = raw['nombre_comuna']?.toString().trim() ?? '';
-
-    final prices = _parsePrices(raw);
-
-    final distKm = roundedDistance(fromLat, fromLng, lat, lng);
-
-    // Stable 'cl-' prefix so the favorites currency lookup finds CL.
-    final id = idRaw.startsWith('cl-') ? idRaw : 'cl-$idRaw';
-
-    return Station(
-      id: id,
-      name: name,
-      brand: brand,
-      street: street,
-      postCode: '',
-      place: comuna,
-      lat: lat,
-      lng: lng,
-      dist: distKm,
-      e5: prices[FuelType.e5],
-      e98: prices[FuelType.e98],
-      diesel: prices[FuelType.diesel],
-      lpg: prices[FuelType.lpg],
-      isOpen: _isOpen(raw),
-    );
-  }
-
-  Map<FuelType, double> _parsePrices(Map raw) {
-    final out = <FuelType, double>{};
-    final precios = raw['precios'];
-    if (precios is! Map) return out;
-
-    // Walk every quoted product, mapping known keys to a [FuelType].
-    // Unknown keys are silently ignored so upstream additions (EV at
-    // CNE? future biofuels?) don't break the parser.
-    precios.forEach((key, value) {
-      final k = key.toString().toLowerCase();
-      final price = _parsePesoPerLitre(value);
-      if (price == null) return;
-
-      final fuel = _productKeyToFuel[k];
-      if (fuel == null) return; // kerosene / parafina / unknown → drop
-
-      // Merge 93 + 95 into e5. When both are quoted we prefer 95
-      // (closer to the European E5 RON-95 benchmark).
-      if (fuel == FuelType.e5) {
-        final existing = out[FuelType.e5];
-        if (existing == null) {
-          out[FuelType.e5] = price;
-        } else if (k == 'gasolina_95') {
-          // 95 wins over a previously-inserted 93.
-          out[FuelType.e5] = price;
-        }
-        return;
-      }
-
-      out[fuel] = price;
-    });
-    return out;
-  }
-
-  /// CNE prices are pesos per litre (e.g. `1290.0` CLP/L). Chilean
-  /// pesos have no decimals in daily use; keep the raw numeric value
-  /// as the local-currency unit the forecourt sign shows. No scaling.
-  double? _parsePesoPerLitre(dynamic raw) {
-    if (raw == null) return null;
-    if (raw is num) {
-      if (raw <= 0) return null;
-      return raw.toDouble();
-    }
-    if (raw is String) {
-      final t = raw.trim();
-      if (t.isEmpty) return null;
-      final v = double.tryParse(t);
-      if (v == null || v <= 0) return null;
-      return v;
-    }
-    return null;
-  }
-
-  static double? _parseDouble(dynamic raw) {
-    if (raw == null) return null;
-    if (raw is num) return raw.toDouble();
-    if (raw is String) {
-      final t = raw.trim();
-      if (t.isEmpty) return null;
-      return double.tryParse(t);
-    }
-    return null;
-  }
-
-  Map? _coerceMap(dynamic data) {
-    if (data is Map) return data;
-    return null;
-  }
-
-  /// CNE nests the distributor under `distribuidor.nombre`; older
-  /// payloads use a flat `distribuidor` string. Accept both.
-  String _parseBrand(Map raw) {
-    final dist = raw['distribuidor'];
-    if (dist is Map) {
-      final n = dist['nombre']?.toString().trim();
-      if (n != null && n.isNotEmpty) return n;
-    } else if (dist is String && dist.trim().isNotEmpty) {
-      return dist.trim();
-    }
-    final marca = raw['marca']?.toString().trim();
-    if (marca != null && marca.isNotEmpty) return marca;
-    return 'Independent';
-  }
-
-  String _joinStreet(Map raw) {
-    final calle = raw['direccion_calle']?.toString().trim() ?? '';
-    final numero = raw['direccion_numero']?.toString().trim() ?? '';
-    if (calle.isEmpty && numero.isEmpty) return '';
-    if (numero.isEmpty) return calle;
-    if (calle.isEmpty) return numero;
-    return '$calle $numero';
-  }
-
-  /// CNE does not expose a reliable open/closed flag per station — the
-  /// "horario_atencion" field often reads `"24_horas"` or a free-text
-  /// schedule. We treat stations as open by default and fall back to
-  /// false only when the field explicitly says `cerrado`.
-  bool _isOpen(Map raw) {
-    final h = raw['horario_atencion']?.toString().toLowerCase().trim();
-    if (h == null || h.isEmpty) return true;
-    if (h.contains('cerrado')) return false;
-    return true;
   }
 }

--- a/test/core/services/impl/chile_response_parser_test.dart
+++ b/test/core/services/impl/chile_response_parser_test.dart
@@ -1,0 +1,332 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/impl/chile_response_parser.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// One `data[]` entry from the CNE Bencina en Línea envelope. Mirrors
+/// the documented shape on `ChileStationService` and is intentionally
+/// duplicated from `chile_station_service_test.dart` so the parser
+/// suite stands alone — no shared fixture should make this file's
+/// failure mode depend on the service file's tests.
+Map<String, dynamic> _cneStation({
+  String codigo = '123456',
+  String distribuidor = 'Copec',
+  String name = 'Copec Providencia',
+  String calle = 'Av. Providencia',
+  String numero = '1234',
+  String comuna = 'Providencia',
+  double lat = -33.4254,
+  double lng = -70.6115,
+  Map<String, dynamic>? precios,
+  String horario = '24_horas',
+}) {
+  return <String, dynamic>{
+    'codigo': codigo,
+    'distribuidor': <String, dynamic>{'nombre': distribuidor},
+    'nombre_fantasia': name,
+    'direccion_calle': calle,
+    'direccion_numero': numero,
+    'nombre_comuna': comuna,
+    'ubicacion': <String, dynamic>{'latitud': lat, 'longitud': lng},
+    'precios': precios ??
+        <String, dynamic>{
+          'gasolina_93': 1290.0,
+          'gasolina_95': 1310.0,
+          'gasolina_97': 1340.0,
+          'diesel': 1150.0,
+          'glp': 820.0,
+          'kerosene': 1050.0,
+        },
+    'horario_atencion': horario,
+  };
+}
+
+Map<String, dynamic> _envelope(List<Map<String, dynamic>> data) =>
+    <String, dynamic>{'data': data};
+
+void main() {
+  group('fuelForChileProductKey', () {
+    test('canonical product keys map to fuel slots', () {
+      expect(fuelForChileProductKey('gasolina_93'), FuelType.e5);
+      expect(fuelForChileProductKey('gasolina_95'), FuelType.e5);
+      expect(fuelForChileProductKey('gasolina_97'), FuelType.e98);
+      expect(fuelForChileProductKey('diesel'), FuelType.diesel);
+      expect(fuelForChileProductKey('glp'), FuelType.lpg);
+      expect(fuelForChileProductKey('gas_licuado'), FuelType.lpg);
+    });
+
+    test('case-insensitive', () {
+      expect(fuelForChileProductKey('GASOLINA_93'), FuelType.e5);
+      expect(fuelForChileProductKey('Diesel'), FuelType.diesel);
+    });
+
+    test('kerosene + parafina are intentionally unmapped', () {
+      expect(fuelForChileProductKey('kerosene'), isNull);
+      expect(fuelForChileProductKey('parafina'), isNull);
+      expect(chileDroppedProductKeys, contains('kerosene'));
+      expect(chileDroppedProductKeys, contains('parafina'));
+    });
+
+    test('unknown product keys return null', () {
+      expect(fuelForChileProductKey('hidrogeno'), isNull);
+      expect(fuelForChileProductKey(''), isNull);
+    });
+  });
+
+  group('parseChileStationsResponse', () {
+    test('maps a typical CNE envelope into a Station with cl- prefix', () {
+      final stations = parseChileStationsResponse(
+        _envelope([_cneStation()]),
+        fromLat: -33.4254,
+        fromLng: -70.6115,
+      );
+      expect(stations, hasLength(1));
+      final s = stations.single;
+      expect(s.id, 'cl-123456');
+      expect(s.brand, 'Copec');
+      expect(s.name, 'Copec Providencia');
+      expect(s.street, contains('Providencia'));
+      expect(s.place, 'Providencia');
+      expect(s.lat, closeTo(-33.4254, 0.0001));
+      expect(s.lng, closeTo(-70.6115, 0.0001));
+      // 95 should win over 93 for the e5 slot.
+      expect(s.e5, closeTo(1310.0, 0.001));
+      expect(s.e98, closeTo(1340.0, 0.001));
+      expect(s.diesel, closeTo(1150.0, 0.001));
+      expect(s.lpg, closeTo(820.0, 0.001));
+      // Kerosene is dropped, so no assertion changes other slots.
+    });
+
+    test('codigo already prefixed `cl-` is not double-prefixed', () {
+      final stations = parseChileStationsResponse(
+        _envelope([_cneStation(codigo: 'cl-987654')]),
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations.single.id, 'cl-987654');
+    });
+
+    test('drops kerosene silently while keeping other slots', () {
+      final stations = parseChileStationsResponse(
+        _envelope([
+          _cneStation(precios: <String, dynamic>{
+            'diesel': 1150.0,
+            'kerosene': 1050.0,
+          }),
+        ]),
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations.single.diesel, closeTo(1150.0, 0.001));
+      expect(stations.single.e5, isNull);
+      expect(stations.single.e98, isNull);
+      expect(stations.single.lpg, isNull);
+    });
+
+    test('93 alone fills e5; 95 wins over 93 when both are quoted', () {
+      final only93 = parseChileStationsResponse(
+        _envelope([
+          _cneStation(precios: <String, dynamic>{'gasolina_93': 1250.0}),
+        ]),
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(only93.single.e5, closeTo(1250.0, 0.001));
+
+      final both = parseChileStationsResponse(
+        _envelope([
+          _cneStation(precios: <String, dynamic>{
+            'gasolina_93': 1250.0,
+            'gasolina_95': 1299.0,
+          }),
+        ]),
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(both.single.e5, closeTo(1299.0, 0.001));
+    });
+
+    test('skips entries with missing or 0/0 coords', () {
+      final stations = parseChileStationsResponse(
+        <String, dynamic>{
+          'data': [
+            <String, dynamic>{
+              'codigo': 'X01',
+              // no ubicacion
+              'precios': <String, dynamic>{'diesel': 1100.0},
+            },
+            _cneStation(codigo: 'Z01', lat: 0, lng: 0),
+            _cneStation(codigo: 'OK1'),
+          ],
+        },
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations, hasLength(1));
+      expect(stations.single.id, 'cl-OK1');
+    });
+
+    test('flat latitud/longitud on the station is accepted', () {
+      final stations = parseChileStationsResponse(
+        <String, dynamic>{
+          'data': [
+            <String, dynamic>{
+              'codigo': 'A2',
+              'latitud': -33.40,
+              'longitud': -70.55,
+              'precios': <String, dynamic>{'diesel': 1160.0},
+            },
+          ],
+        },
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations.single.lat, closeTo(-33.40, 0.0001));
+    });
+
+    test('distribuidor can be a flat string (older payloads)', () {
+      final stations = parseChileStationsResponse(
+        <String, dynamic>{
+          'data': [
+            <String, dynamic>{
+              'codigo': 'A1',
+              'distribuidor': 'Petrobras',
+              'nombre_fantasia': 'Petrobras Las Condes',
+              'ubicacion': <String, dynamic>{
+                'latitud': -33.40,
+                'longitud': -70.55,
+              },
+              'precios': <String, dynamic>{'diesel': 1160.0},
+            },
+          ],
+        },
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations.single.brand, 'Petrobras');
+    });
+
+    test('falls back to "Independent" when no brand info is present', () {
+      final stations = parseChileStationsResponse(
+        <String, dynamic>{
+          'data': [
+            <String, dynamic>{
+              'codigo': 'NB1',
+              'ubicacion': <String, dynamic>{
+                'latitud': -33.40,
+                'longitud': -70.55,
+              },
+              'precios': <String, dynamic>{'diesel': 1100.0},
+            },
+          ],
+        },
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations.single.brand, 'Independent');
+    });
+
+    test('non-numeric price strings drop only that price', () {
+      final stations = parseChileStationsResponse(
+        _envelope([
+          _cneStation(precios: <String, dynamic>{
+            'diesel': 'N/A',
+            'gasolina_95': 1299.0,
+          }),
+        ]),
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations.single.diesel, isNull);
+      expect(stations.single.e5, closeTo(1299.0, 0.001));
+    });
+
+    test('empty / missing data array yields empty list', () {
+      expect(
+        parseChileStationsResponse(
+          _envelope([]),
+          fromLat: -33.45,
+          fromLng: -70.67,
+        ),
+        isEmpty,
+      );
+      expect(
+        parseChileStationsResponse(
+          <String, dynamic>{},
+          fromLat: -33.45,
+          fromLng: -70.67,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('horario containing "cerrado" marks station as closed', () {
+      final stations = parseChileStationsResponse(
+        _envelope([
+          _cneStation(horario: 'Temporalmente CERRADO por mantenimiento'),
+        ]),
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations.single.isOpen, isFalse);
+    });
+
+    test('default horario "24_horas" is treated as open', () {
+      final stations = parseChileStationsResponse(
+        _envelope([_cneStation()]),
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations.single.isOpen, isTrue);
+    });
+
+    test('unparseable top-level body raises ApiException', () {
+      expect(
+        () => parseChileStationsResponse(
+          'garbage',
+          fromLat: -33.45,
+          fromLng: -70.67,
+        ),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('CNE error field without data raises ApiException', () {
+      expect(
+        () => parseChileStationsResponse(
+          <String, dynamic>{'error': 'invalid token'},
+          fromLat: -33.45,
+          fromLng: -70.67,
+        ),
+        throwsA(isA<ApiException>().having(
+          (e) => e.message,
+          'message',
+          contains('CNE'),
+        )),
+      );
+    });
+
+    test('joins direccion_calle + direccion_numero into a single street', () {
+      final stations = parseChileStationsResponse(
+        _envelope([
+          _cneStation(calle: 'Av. Apoquindo', numero: '4500'),
+        ]),
+        fromLat: -33.45,
+        fromLng: -70.67,
+      );
+      expect(stations.single.street, 'Av. Apoquindo 4500');
+    });
+
+    test('distance is rounded to 1 decimal', () {
+      final stations = parseChileStationsResponse(
+        _envelope([_cneStation()]),
+        fromLat: -33.50,
+        fromLng: -70.70,
+      );
+      final dist = stations.single.dist;
+      expect(dist >= 0, isTrue);
+      // Rounded to 1 decimal: re-rounding must equal itself.
+      expect(double.parse(dist.toStringAsFixed(1)), dist);
+    });
+  });
+}


### PR DESCRIPTION
## What

Extracts the CNE envelope parser (JSON envelope -> `List<Station>`, fuel-key mapping, dropped-key set, per-row helpers) out of `chile_station_service.dart` into a new pure-Dart helper at `lib/core/services/impl/chile_response_parser.dart`. The service shell now only owns the `StationService` interface, the Dio call, error classification, and `ServiceResult` plumbing. Public API (`ChileStationService.parseStationsResponse`, `fuelForProductKey`, `droppedProductKeys`) is preserved via thin delegates so existing tests and any external callers stay green.

## Why

Part of the #563 epic to bring oversized service files under the 300-LOC guideline. The parser is also the contract the live CNE endpoint breaks first, so isolating it as a pure function lets us exercise it against recorded fixtures with no Dio mock.

## LOC

- `chile_station_service.dart`: **404 -> 215 LOC** (under the 300 guideline).
- `chile_response_parser.dart`: 254 LOC (pure functions, no Dio/Hive/I/O imports).
- New parser-only test: `test/core/services/impl/chile_response_parser_test.dart`.

## Testing

- `flutter analyze` clean (zero issues).
- `flutter test test/core/services/impl/` -> 619 tests passing, including the unchanged `chile_station_service_test.dart` and the new parser test (covers fuel mapping, kerosene drop, 93/95 e5 priority, flat coords, missing brand, cerrado horario, error envelopes).

`Refs #563` (epic stays open — many more files remain).