### PR TITLE
fix(map+conso): restore tab-flip map teardown; drop forced back arrow on Conso tab

### DIFF
--- a/lib/app/current_shell_branch_provider.dart
+++ b/lib/app/current_shell_branch_provider.dart
@@ -3,14 +3,17 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'current_shell_branch_provider.g.dart';
 
 /// Exposes the currently-visible bottom-nav branch (0 = Search, 1 = Map,
-/// 2 = Favorites, 3 = Settings). Updated by [ShellScreen] on every
-/// `goBranch` so observers can react to tab visibility changes without
-/// reaching into the shell's private state (#696).
+/// 2 = Favorites, 3 = Consumption, 4 = Settings). Updated by [ShellScreen]
+/// on every `goBranch` so observers can react to tab visibility changes
+/// without reaching into the shell's private state (#696).
 ///
-/// MapScreen listens to this to trigger a tile-viewport recompute every
-/// time the Map tab becomes visible — the IndexedStack pre-mounts every
-/// branch with degenerate constraints, so without this hook the map
-/// stays blank until the user manually pans or zooms.
+/// MapScreen listens to this to trigger a full FlutterMap + TileLayer
+/// teardown every time the Map tab becomes visible — the IndexedStack
+/// pre-mounts every branch with degenerate constraints, so without this
+/// hook the map stays gray until the user manually pans or zooms (#473,
+/// #498, #709). The [RetryNetworkTileProvider] (#757) does NOT subsume
+/// this — it retries failed HTTP requests, but the offstage-mount bug
+/// is a fetch that's never issued in the first place.
 @Riverpod(keepAlive: true)
 class CurrentShellBranch extends _$CurrentShellBranch {
   @override

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -163,11 +163,6 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     return PageScaffold(
       title: l?.consumptionLogTitle ?? 'Fuel consumption',
       bodyPadding: EdgeInsets.zero,
-      leading: IconButton(
-        icon: const Icon(Icons.arrow_back),
-        tooltip: l?.tooltipBack ?? 'Back',
-        onPressed: () => context.pop(),
-      ),
       bottom: TabSwitcher(
         controller: tabController,
         tabs: [

--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../app/current_shell_branch_provider.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../driving/presentation/widgets/driving_mode_fab.dart';
@@ -15,14 +16,28 @@ import '../widgets/route_map_view.dart';
 /// Top-level map screen that delegates to [RouteMapView] when route search
 /// results are available, or [NearbyMapView] for nearby station results.
 ///
-/// Previously this screen hosted a complex subtree-rebuild counter plus
-/// a `searchStateProvider` listener that nudged the controller on fresh
-/// search results (#529, #709). Both were symptom-level workarounds for
-/// `TileLayer` caching failed fetches — now addressed at the root by
-/// [RetryNetworkTileProvider] and `evictErrorTileStrategy:
-/// notVisibleRespectMargin` on every `TileLayer` in the app (#757).
-/// Keeping the workarounds after the root-cause fix added complexity
-/// and cancelled in-flight tile requests when price-refreshes landed.
+/// ## Tab-flip teardown ([_mapIncarnation])
+///
+/// `StatefulShellRoute.indexedStack` pre-mounts every tab with degenerate
+/// (zero-sized) constraints. `flutter_map`'s [TileLayer] captures its
+/// tile viewport on the first layout pass; when that pass happens
+/// offstage, the layer settles into a "no tiles to fetch" state and
+/// never re-issues requests when real constraints arrive. Result: gray
+/// background until the user manually pans or zooms (#473, #498, #709).
+///
+/// [RetryNetworkTileProvider] + `evictErrorTileStrategy` (#757) handle
+/// transient HTTP failures but cannot recover this state — the bug
+/// isn't a failed fetch, it's a fetch that's never issued. The only
+/// reliable cure is to tear down and rebuild the entire FlutterMap
+/// subtree when the Carte tab becomes visible, so it lays out against
+/// real post-mount constraints. That's what the [currentShellBranchProvider]
+/// listener + [_mapIncarnation] [ValueKey] do below.
+///
+/// We deliberately do NOT also listen to `searchStateProvider` —
+/// rebuilding on search-result change cancelled in-flight tile fetches
+/// when price-refreshes landed (#709 regression). Camera moves on
+/// search results are nudged inside [NearbyMapView] / [RouteMapView]
+/// instead.
 class MapScreen extends ConsumerStatefulWidget {
   const MapScreen({super.key});
 
@@ -31,7 +46,12 @@ class MapScreen extends ConsumerStatefulWidget {
 }
 
 class _MapScreenState extends ConsumerState<MapScreen> {
-  late final MapController _mapController;
+  late MapController _mapController;
+
+  /// Bumped every time the Carte tab becomes visible. Used as a
+  /// [ValueKey] on the map subtree so the FlutterMap + TileLayer is
+  /// destroyed and rebuilt with real post-layout constraints (#709).
+  int _mapIncarnation = 0;
 
   @override
   void initState() {
@@ -47,6 +67,32 @@ class _MapScreenState extends ConsumerState<MapScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<int>(currentShellBranchProvider, (_, next) {
+      const mapBranchIndex = 1;
+      if (next != mapBranchIndex) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final old = _mapController;
+        try {
+          setState(() {
+            _mapController = MapController();
+            _mapIncarnation++;
+          });
+        } catch (e) {
+          debugPrint('MapScreen rebuild on tab-flip: $e');
+        }
+        // Dispose the previous controller after the next frame so the
+        // old FlutterMap has fully detached from it.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          try {
+            old.dispose();
+          } catch (e) {
+            debugPrint('MapScreen old controller dispose: $e');
+          }
+        });
+      });
+    });
+
     final searchState = ref.watch(searchStateProvider);
     final selectedFuel = ref.watch(selectedFuelTypeProvider);
     final searchRadius = ref.watch(searchRadiusProvider);
@@ -56,18 +102,21 @@ class _MapScreenState extends ConsumerState<MapScreen> {
 
     final hasRouteResults = routeState.hasValue && routeState.value != null;
 
-    final body = hasRouteResults
-        ? RouteMapView(
-            routeResult: routeState.value!,
-            selectedFuel: selectedFuel,
-            mapController: _mapController,
-          )
-        : NearbyMapView(
-            searchState: searchState,
-            selectedFuel: selectedFuel,
-            searchRadiusKm: searchRadius,
-            mapController: _mapController,
-          );
+    final body = KeyedSubtree(
+      key: ValueKey<int>(_mapIncarnation),
+      child: hasRouteResults
+          ? RouteMapView(
+              routeResult: routeState.value!,
+              selectedFuel: selectedFuel,
+              mapController: _mapController,
+            )
+          : NearbyMapView(
+              searchState: searchState,
+              selectedFuel: selectedFuel,
+              searchRadiusKm: searchRadius,
+              mapController: _mapController,
+            ),
+    );
 
     return PageScaffold(
       title: l10n?.map ?? 'Map',

--- a/test/features/map/presentation/map_controller_lifecycle_test.dart
+++ b/test/features/map/presentation/map_controller_lifecycle_test.dart
@@ -15,13 +15,16 @@ void main() {
         reason:
             'MapScreen must dispose MapController to prevent stale references',
       );
-      // After #757 retired the `_mapIncarnation` subtree-rebuild hack,
-      // the controller is created once in initState and reused for the
-      // lifetime of the widget. The declaration is `late final` again.
+      // The controller is reassigned on every Carte tab-flip rebuild
+      // (see _mapIncarnation in the screen), so it cannot be `late
+      // final` — it's `late MapController _mapController` and the
+      // previous instance is disposed in the post-frame callback that
+      // bumps the incarnation.
       expect(
-        source.contains('late final MapController _mapController'),
+        source.contains('late MapController _mapController'),
         isTrue,
-        reason: 'MapController should be late final, created in initState',
+        reason: 'MapController should be `late MapController` (mutable), '
+            'created in initState and reassigned on tab-flip rebuild',
       );
     });
 
@@ -69,31 +72,47 @@ void main() {
     });
 
     test(
-      '#757: MapScreen no longer relies on `_mapIncarnation` subtree-rebuild '
-      'hack — retry+evict provider handles transient tile failures',
+      '#473 / #498 / #709: MapScreen keeps the `_mapIncarnation` + '
+      '`KeyedSubtree` tab-flip teardown — RetryNetworkTileProvider does '
+      'NOT subsume it',
       () {
         final source = File(
           'lib/features/map/presentation/screens/map_screen.dart',
         ).readAsStringSync();
 
-        // The `_mapIncarnation` counter + `ValueKey` KeyedSubtree wrapper
-        // from #709 were symptom-level workarounds for `TileLayer`
-        // caching failed fetches. They cancelled in-flight HTTP
-        // requests on every tab-flip, which itself caused the gray
-        // viewport some users reported (see #709 rollback history).
-        // Root cause is addressed by `RetryNetworkTileProvider` +
-        // `evictErrorTileStrategy` (#757), so these workarounds must
-        // be gone.
+        // Earlier reasoning (in the ddeace4 commit message) was that
+        // RetryNetworkTileProvider + evictErrorTileStrategy at the HTTP
+        // layer would make this workaround redundant. They don't:
+        //
+        //   * Retry handles failed HTTP fetches.
+        //   * The IndexedStack offstage-mount bug is a fetch that's
+        //     never *issued* — TileLayer captures a zero-sized
+        //     viewport on its first layout pass and settles into a
+        //     "no tiles to fetch" state.
+        //
+        // The only reliable fix is to tear down + rebuild the
+        // FlutterMap subtree when the Carte tab becomes visible so it
+        // lays out against real constraints. Removing this guard
+        // ships a gray map on first open (#473, #498, #709).
         expect(
           source.contains('_mapIncarnation'),
-          isFalse,
-          reason: '#757 — subtree-rebuild counter should have been '
-              'removed now that tile retries happen at the HTTP layer',
+          isTrue,
+          reason: 'subtree-rebuild counter is required to defeat the '
+              'IndexedStack offstage zero-viewport bug — see screen '
+              'docstring',
         );
         expect(
           source.contains('KeyedSubtree'),
-          isFalse,
-          reason: '#757 — KeyedSubtree wrapper no longer needed',
+          isTrue,
+          reason: 'KeyedSubtree(ValueKey<int>(_mapIncarnation)) is what '
+              'forces flutter_map teardown on tab-flip',
+        );
+        expect(
+          source.contains('currentShellBranchProvider'),
+          isTrue,
+          reason: 'tab-flip rebuild is driven by listening to '
+              'currentShellBranchProvider — the producer is in '
+              'ShellScreen and must have a consumer here',
         );
       },
     );

--- a/test/features/map/presentation/screens/map_screen_test.dart
+++ b/test/features/map/presentation/screens/map_screen_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/app/current_shell_branch_provider.dart';
 import 'package:tankstellen/core/widgets/page_scaffold.dart';
 import 'package:tankstellen/features/map/presentation/screens/map_screen.dart';
 
@@ -60,16 +62,81 @@ void main() {
       expect(find.byType(PageScaffold), findsOneWidget);
     });
 
-    // #529 / #709 regression tests retired by #757. Previously
-    // MapScreen listened to `searchStateProvider` and
-    // `currentShellBranchProvider` to nudge the map controller and
-    // rebuild the FlutterMap subtree on every tab-flip — both were
-    // symptom-level workarounds for `TileLayer` caching failed
-    // fetches. They cancelled in-flight HTTP requests and caused
-    // regressions of their own. The root cause is addressed at the
-    // tile-provider layer by `RetryNetworkTileProvider` +
-    // `evictErrorTileStrategy` (see
-    // `lib/features/map/data/retry_network_tile_provider.dart` and
-    // `test/features/map/tile_layer_eviction_strategy_test.dart`).
+    testWidgets(
+      'rebuilds FlutterMap subtree when shell branch flips TO Map tab '
+      '(#473 / #498 / #709 — IndexedStack offstage-mount workaround)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const MapScreen(),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+          ],
+        );
+
+        // The outermost KeyedSubtree under MapScreen carries the
+        // ValueKey<int>(_mapIncarnation). Pre-order traversal returns
+        // the highest match first, so .first is ours; flutter_map
+        // internal KeyedSubtrees sit deeper in the tree.
+        int currentIncarnation() {
+          final subtree = tester
+              .widgetList<KeyedSubtree>(
+                find.descendant(
+                  of: find.byType(MapScreen),
+                  matching: find.byType(KeyedSubtree),
+                ),
+              )
+              .firstWhere((w) => w.key is ValueKey<int>);
+          return (subtree.key as ValueKey<int>).value;
+        }
+
+        final initial = currentIncarnation();
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MapScreen)),
+        );
+
+        // Simulate ShellScreen publishing "Map tab is now visible" (branch 1).
+        // _mapIncarnation increments via a post-frame callback then setState,
+        // so two pumps are needed to settle.
+        container.read(currentShellBranchProvider.notifier).set(1);
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          currentIncarnation(),
+          greaterThan(initial),
+          reason:
+              'MapScreen must rebuild the FlutterMap subtree when the Map '
+              'branch becomes visible. Without the rebuild, TileLayer keeps '
+              'the offstage zero-sized viewport it captured at app start '
+              'and the map stays gray until manual pan/zoom (#709). The '
+              'RetryNetworkTileProvider added in #757 cannot fix this — it '
+              'retries failed HTTP fetches, but here the fetch is never '
+              'issued.',
+        );
+
+        final afterMapEntry = currentIncarnation();
+
+        // Flipping AWAY from the Map tab must NOT bump the incarnation —
+        // only entering the Map tab does. Otherwise we'd cancel in-flight
+        // tile fetches whenever the user navigates away (the #709
+        // regression that originally killed the search-state listener).
+        container.read(currentShellBranchProvider.notifier).set(0);
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          currentIncarnation(),
+          equals(afterMapEntry),
+          reason:
+              'Branch changes that leave the Map tab must not rebuild — '
+              'rebuilding cancels in-flight tile HTTP requests (#709).',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- **Map gray-tile fix (#473 / #498 / #709 redux):** restores the `_mapIncarnation` + `KeyedSubtree` + `currentShellBranchProvider` listener removed in ddeace4. `RetryNetworkTileProvider` (#757) does NOT subsume it — retry handles failed HTTP fetches, but the IndexedStack offstage-mount bug is a fetch that's never *issued* (TileLayer captures a zero-sized viewport on first layout). The only fix is to tear down + rebuild the FlutterMap subtree when the Carte tab becomes visible.
- **Conso AppBar polish:** drop the explicit `leading: IconButton(arrow_back, context.pop)` on `ConsumptionScreen`. It was non-functional at the top-level branch root (`/consumption-tab` has nothing to pop) and looked out-of-place vs Search/Favorites/Settings. `PageScaffold`'s `automaticallyImplyLeading` now derives correctly: hidden on the tab root, shown when reached via `/consumption` deep-link from station detail.

## Test plan
- [x] `flutter analyze` zero issues across all 5 touched files
- [x] `test/features/map/presentation/screens/map_screen_test.dart` — new regression test drives `currentShellBranchProvider.notifier.set(1)` and asserts the outermost `KeyedSubtree`'s `ValueKey<int>(_mapIncarnation)` increments. Leaving the Map tab (`set(0)`) must NOT bump the counter (the symmetric guard against the #709 in-flight-cancel regression).
- [x] `test/features/map/presentation/map_controller_lifecycle_test.dart` — static assertions inverted from ddeace4: now requires `_mapIncarnation`, `KeyedSubtree`, `currentShellBranchProvider` to be present in the source.
- [x] All 1211 consumption tests still green
- [ ] Device test on real Android: open app → Map tab → verify tiles load on first switch (was gray before fix)
- [ ] Device test: open Consumption tab → verify no back arrow at the top level; navigate from a station detail → Consumption history → verify back arrow appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)