### PR TITLE
refactor(greece): extract parsers out of greece_station_service (Refs #563)

### DIFF
--- a/lib/core/services/impl/greece_parsers.dart
+++ b/lib/core/services/impl/greece_parsers.dart
@@ -1,0 +1,282 @@
+/// Pure parsing helpers for the Greek Paratiritirio Timon (Fuel Price
+/// Observatory) feed exposed via the community
+/// [fuelpricesgr](https://github.com/mavroprovato/fuelpricesgr) FastAPI
+/// wrapper (#576, #563 split).
+///
+/// Lives separately from [GreeceStationService] so the JSON-shape
+/// contract — which is what the live endpoint typically breaks first —
+/// can be exercised with recorded fixtures, without touching Dio, Hive,
+/// or any network state. Adding network or storage imports here defeats
+/// the point of the split.
+///
+/// Public surface:
+///  - [parsePrefectureResponse]: prefecture daily-price envelope →
+///    synthetic [Station] (or `null` when nothing usable came back).
+///  - [fuelForObservatoryKey]: the canonical Observatory `fuel_type`
+///    enum → [FuelType] mapping (case-insensitive).
+///  - [droppedObservatoryKeys]: keys we deliberately ignore because no
+///    [FuelType] enum exists today (DIESEL_HEATING, SUPER).
+///  - [GreekPrefecture]: data class for the static prefecture catalog
+///    used as virtual stations.
+library;
+
+import '../../../features/search/domain/entities/fuel_type.dart';
+import '../../../features/search/domain/entities/station.dart';
+import '../../error/exceptions.dart';
+import '../mixins/station_service_helpers.dart';
+
+/// Observatory fuel_type enum → canonical [FuelType].
+///
+/// `DIESEL_HEATING` and `SUPER` are intentionally absent from the
+/// map. [droppedObservatoryKeys] pins the policy for tests.
+const Map<String, FuelType> _fuelForObservatoryKey = {
+  'unleaded_95': FuelType.e5,
+  'unleaded_100': FuelType.e98,
+  'diesel': FuelType.diesel,
+  'gas': FuelType.lpg,
+};
+
+/// Keys the parser deliberately drops because no [FuelType] exists
+/// (DIESEL_HEATING is not a motoring fuel; SUPER is phased-out
+/// leaded).
+const Set<String> droppedObservatoryKeys = {
+  'diesel_heating',
+  'super',
+};
+
+/// Observatory fuel-key → [FuelType] (case-insensitive). Returns
+/// `null` when the key has no matching slot today
+/// (DIESEL_HEATING / SUPER / unknown).
+FuelType? fuelForObservatoryKey(String key) =>
+    _fuelForObservatoryKey[key.toLowerCase()];
+
+/// Parse a single prefecture's daily response into a synthetic
+/// [Station]. Driven by fixtures so it is independent of any Dio mock.
+///
+/// The response is either:
+/// - A list of `PriceResponse` objects (most recent first), or
+/// - An empty list when the prefecture has no recent data.
+///
+/// We pick the most recent entry (greatest ISO-8601 `date` string —
+/// lexicographic order works) and stamp its fuel prices onto the
+/// virtual station.
+///
+/// The prefecture is addressed by its stable `stationId` so callers do
+/// not need access to the [GreekPrefecture] catalog.
+Station? parsePrefectureResponse(
+  dynamic data, {
+  required String stationId,
+  required String displayName,
+  required String place,
+  required double prefectureLat,
+  required double prefectureLng,
+  required double fromLat,
+  required double fromLng,
+}) {
+  final list = _coerceList(data);
+  if (list == null) {
+    throw const ApiException(
+      message: 'Paratiritirio returned unparseable body',
+    );
+  }
+
+  // Empty list is valid — just means no recent data for this
+  // prefecture. Drop the station (a synthetic entry with no prices
+  // would clutter the list).
+  if (list.isEmpty) return null;
+
+  // Prefer the newest entry. The community API documents "most recent
+  // first" but we defend against order drift by picking the entry with
+  // the greatest `date` string (ISO-8601 lexicographic order works).
+  Map? newest;
+  String newestDate = '';
+  for (final item in list) {
+    if (item is! Map) continue;
+    final date = item['date']?.toString() ?? '';
+    if (date.compareTo(newestDate) > 0) {
+      newestDate = date;
+      newest = item;
+    }
+  }
+  if (newest == null) return null;
+
+  final prices = _parsePrices(newest['data']);
+  // A prefecture with zero recognised fuel rows is dropped — no
+  // synthetic pin for "nothing to show".
+  if (prices.isEmpty) return null;
+
+  return Station(
+    id: stationId,
+    name: displayName,
+    brand: 'Paratiritirio',
+    street: '',
+    postCode: '',
+    place: place,
+    lat: prefectureLat,
+    lng: prefectureLng,
+    dist: _roundedDistance(fromLat, fromLng, prefectureLat, prefectureLng),
+    e5: prices[FuelType.e5],
+    e98: prices[FuelType.e98],
+    diesel: prices[FuelType.diesel],
+    lpg: prices[FuelType.lpg],
+    isOpen: true,
+    updatedAt: newestDate.isEmpty ? null : newestDate,
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Internals
+// ──────────────────────────────────────────────────────────────────────
+
+Map<FuelType, double> _parsePrices(dynamic rawData) {
+  final out = <FuelType, double>{};
+  if (rawData is! List) return out;
+  for (final row in rawData) {
+    if (row is! Map) continue;
+    final key = row['fuel_type']?.toString() ?? '';
+    if (key.isEmpty) continue;
+    final fuel = _fuelForObservatoryKey[key.toLowerCase()];
+    if (fuel == null) continue; // unknown / intentionally dropped
+    final price = _parseEuroPerLitre(row['price']);
+    if (price == null) continue;
+    out[fuel] = price;
+  }
+  return out;
+}
+
+/// Observatory prices are EUR per litre with up to three decimals
+/// (e.g. `1.721`). Accepts `num` and numeric strings. Rejects zero
+/// and negative values.
+double? _parseEuroPerLitre(dynamic raw) {
+  if (raw == null) return null;
+  if (raw is num) {
+    if (raw <= 0) return null;
+    return raw.toDouble();
+  }
+  if (raw is String) {
+    final t = raw.trim();
+    if (t.isEmpty) return null;
+    final v = double.tryParse(t);
+    if (v == null || v <= 0) return null;
+    return v;
+  }
+  return null;
+}
+
+List? _coerceList(dynamic data) {
+  if (data is List) return data;
+  return null;
+}
+
+/// Mirrors [StationServiceHelpers.roundedDistance] so the parser stays
+/// free of the mixin's HTTP/result-wrapping baggage.
+///
+/// Implemented as a thin wrapper that constructs a throwaway helper
+/// instance via the [_DistanceOnly] shim — keeps the haversine in one
+/// place and avoids re-deriving it here.
+double _roundedDistance(double lat1, double lng1, double lat2, double lng2) {
+  return _distanceHelper.roundedDistance(lat1, lng1, lat2, lng2);
+}
+
+final _DistanceOnly _distanceHelper = _DistanceOnly();
+
+/// Tiny shim so the parser can use the shared haversine in
+/// [StationServiceHelpers] without dragging in a Dio/result-wrapping
+/// service shell.
+class _DistanceOnly with StationServiceHelpers {}
+
+/// Internal representation of a Greek prefecture used as a virtual
+/// station. Public so the catalog can live in this parser file but
+/// the prefix underscore on the service-side wrapper is preserved by
+/// only ever exposing fully-built [Station] objects to callers above
+/// the service shell.
+class GreekPrefecture {
+  final String apiName;
+  final String id;
+  final String displayName;
+  final String place;
+  final double lat;
+  final double lng;
+
+  const GreekPrefecture({
+    required this.apiName,
+    required this.id,
+    required this.displayName,
+    required this.place,
+    required this.lat,
+    required this.lng,
+  });
+}
+
+/// Representative prefectures used as virtual stations. Coordinates
+/// are each prefecture's capital (OpenStreetMap). The set is
+/// deliberately small and geographically spread so a user searching
+/// from anywhere in Greece hits at least one entry within a
+/// sensible radius, without flooding the map with 50+ synthetic
+/// pins.
+const List<GreekPrefecture> greekPrefectures = [
+  GreekPrefecture(
+    apiName: 'ATTICA',
+    id: 'gr-attica',
+    displayName: 'Αττική / Attica',
+    place: 'Αθήνα',
+    lat: 37.9838,
+    lng: 23.7275,
+  ),
+  GreekPrefecture(
+    apiName: 'THESSALONIKI',
+    id: 'gr-thessaloniki',
+    displayName: 'Θεσσαλονίκη / Thessaloniki',
+    place: 'Θεσσαλονίκη',
+    lat: 40.6401,
+    lng: 22.9444,
+  ),
+  GreekPrefecture(
+    apiName: 'ACHAEA',
+    id: 'gr-achaea',
+    displayName: 'Αχαΐα / Achaea',
+    place: 'Πάτρα',
+    lat: 38.2466,
+    lng: 21.7346,
+  ),
+  GreekPrefecture(
+    apiName: 'LARISSA',
+    id: 'gr-larissa',
+    displayName: 'Λάρισα / Larissa',
+    place: 'Λάρισα',
+    lat: 39.6390,
+    lng: 22.4191,
+  ),
+  GreekPrefecture(
+    apiName: 'HERAKLION',
+    id: 'gr-heraklion',
+    displayName: 'Ηράκλειο / Heraklion',
+    place: 'Ηράκλειο',
+    lat: 35.3387,
+    lng: 25.1442,
+  ),
+  GreekPrefecture(
+    apiName: 'IOANNINA',
+    id: 'gr-ioannina',
+    displayName: 'Ιωάννινα / Ioannina',
+    place: 'Ιωάννινα',
+    lat: 39.6650,
+    lng: 20.8537,
+  ),
+  GreekPrefecture(
+    apiName: 'DODECANESE',
+    id: 'gr-dodecanese',
+    displayName: 'Δωδεκάνησα / Dodecanese',
+    place: 'Ρόδος',
+    lat: 36.4349,
+    lng: 28.2176,
+  ),
+  GreekPrefecture(
+    apiName: 'CHANIA',
+    id: 'gr-chania',
+    displayName: 'Χανιά / Chania',
+    place: 'Χανιά',
+    lat: 35.5138,
+    lng: 24.0180,
+  ),
+];

--- a/lib/core/services/impl/greece_station_service.dart
+++ b/lib/core/services/impl/greece_station_service.dart
@@ -9,6 +9,7 @@ import '../dio_factory.dart';
 import '../mixins/station_service_helpers.dart';
 import '../service_result.dart';
 import '../station_service.dart';
+import 'greece_parsers.dart' as parser;
 
 /// Greece fuel prices — Paratiritirio Timon (Fuel Price Observatory) via the
 /// community [fuelpricesgr](https://github.com/mavroprovato/fuelpricesgr)
@@ -60,7 +61,7 @@ import '../station_service.dart';
 /// ]
 /// ```
 ///
-/// Fuel-type mapping used by [_fuelForObservatoryKey]:
+/// Fuel-type mapping used by [parser.fuelForObservatoryKey]:
 ///
 /// ```
 /// UNLEADED_95      → FuelType.e5
@@ -76,6 +77,13 @@ import '../station_service.dart';
 /// Tankstellen at a self-hosted mirror if the hosted endpoint goes
 /// down; and the parser is fully fixture-driven so a URL-path drift at
 /// upstream is a one-line fix.
+///
+/// **Split (#563)**: the JSON parsing + per-prefecture → [Station]
+/// mapping, the fuel-key map, and the prefecture catalog all live in
+/// `greece_parsers.dart` so they can be tested as pure functions
+/// without Dio. This shell keeps only the [StationService]
+/// implementation: HTTP via Dio, [ServiceResult] plumbing, and error
+/// classification.
 class GreeceStationService
     with StationServiceHelpers
     implements StationService {
@@ -88,97 +96,11 @@ class GreeceStationService
   /// changing the parser.
   static const String defaultBaseUrl = 'https://fuelpricesgr.com/api';
 
-  /// Observatory fuel_type enum → canonical [FuelType].
-  ///
-  /// `DIESEL_HEATING` and `SUPER` are intentionally absent from the
-  /// map. [droppedObservatoryKeys] pins the policy for tests.
-  static const Map<String, FuelType> _fuelForObservatoryKey = {
-    'unleaded_95': FuelType.e5,
-    'unleaded_100': FuelType.e98,
-    'diesel': FuelType.diesel,
-    'gas': FuelType.lpg,
-  };
-
-  /// Keys the parser deliberately drops because no [FuelType] exists
-  /// (DIESEL_HEATING is not a motoring fuel; SUPER is phased-out
-  /// leaded).
-  static const Set<String> droppedObservatoryKeys = {
-    'diesel_heating',
-    'super',
-  };
-
-  /// Representative prefectures used as virtual stations. Coordinates
-  /// are each prefecture's capital (OpenStreetMap). The set is
-  /// deliberately small and geographically spread so a user searching
-  /// from anywhere in Greece hits at least one entry within a
-  /// sensible radius, without flooding the map with 50+ synthetic
-  /// pins.
-  static const List<_GreekPrefecture> _prefectures = [
-    _GreekPrefecture(
-      apiName: 'ATTICA',
-      id: 'gr-attica',
-      displayName: 'Αττική / Attica',
-      place: 'Αθήνα',
-      lat: 37.9838,
-      lng: 23.7275,
-    ),
-    _GreekPrefecture(
-      apiName: 'THESSALONIKI',
-      id: 'gr-thessaloniki',
-      displayName: 'Θεσσαλονίκη / Thessaloniki',
-      place: 'Θεσσαλονίκη',
-      lat: 40.6401,
-      lng: 22.9444,
-    ),
-    _GreekPrefecture(
-      apiName: 'ACHAEA',
-      id: 'gr-achaea',
-      displayName: 'Αχαΐα / Achaea',
-      place: 'Πάτρα',
-      lat: 38.2466,
-      lng: 21.7346,
-    ),
-    _GreekPrefecture(
-      apiName: 'LARISSA',
-      id: 'gr-larissa',
-      displayName: 'Λάρισα / Larissa',
-      place: 'Λάρισα',
-      lat: 39.6390,
-      lng: 22.4191,
-    ),
-    _GreekPrefecture(
-      apiName: 'HERAKLION',
-      id: 'gr-heraklion',
-      displayName: 'Ηράκλειο / Heraklion',
-      place: 'Ηράκλειο',
-      lat: 35.3387,
-      lng: 25.1442,
-    ),
-    _GreekPrefecture(
-      apiName: 'IOANNINA',
-      id: 'gr-ioannina',
-      displayName: 'Ιωάννινα / Ioannina',
-      place: 'Ιωάννινα',
-      lat: 39.6650,
-      lng: 20.8537,
-    ),
-    _GreekPrefecture(
-      apiName: 'DODECANESE',
-      id: 'gr-dodecanese',
-      displayName: 'Δωδεκάνησα / Dodecanese',
-      place: 'Ρόδος',
-      lat: 36.4349,
-      lng: 28.2176,
-    ),
-    _GreekPrefecture(
-      apiName: 'CHANIA',
-      id: 'gr-chania',
-      displayName: 'Χανιά / Chania',
-      place: 'Χανιά',
-      lat: 35.5138,
-      lng: 24.0180,
-    ),
-  ];
+  /// Keys the parser deliberately drops because no [FuelType] exists.
+  /// Re-exported from the parser for tests that pin the MVP policy
+  /// without crossing into the parser's namespace.
+  static const Set<String> droppedObservatoryKeys =
+      parser.droppedObservatoryKeys;
 
   final Dio _dio;
   final String _baseUrl;
@@ -212,7 +134,7 @@ class GreeceStationService
           '$_baseUrl/data/daily/prefecture/${pref.apiName}',
           cancelToken: cancelToken,
         );
-        final s = parsePrefectureResponse(
+        final s = parser.parsePrefectureResponse(
           response.data,
           stationId: pref.id,
           displayName: pref.displayName,
@@ -273,18 +195,9 @@ class GreeceStationService
   }
 
   /// Parse a single prefecture's daily response into a synthetic
-  /// [Station]. Exposed for tests so the parser is driven by fixtures
-  /// independent of any Dio mock.
-  ///
-  /// The response is either:
-  /// - A list of `PriceResponse` objects (most recent first), or
-  /// - An empty list when the prefecture has no recent data.
-  ///
-  /// We pick the most recent entry (first in the list) and stamp its
-  /// fuel prices onto the virtual station.
-  ///
-  /// The prefecture is addressed by its stable `stationId` so tests do
-  /// not need access to the private `_GreekPrefecture` class.
+  /// [Station]. Thin delegate over [parser.parsePrefectureResponse];
+  /// kept on the service so existing tests + any external callers
+  /// continue to work after the #563 split.
   @visibleForTesting
   Station? parsePrefectureResponse(
     dynamic data, {
@@ -295,63 +208,24 @@ class GreeceStationService
     required double prefectureLng,
     required double fromLat,
     required double fromLng,
-  }) {
-    final list = _coerceList(data);
-    if (list == null) {
-      throw const ApiException(
-        message: 'Paratiritirio returned unparseable body',
+  }) =>
+      parser.parsePrefectureResponse(
+        data,
+        stationId: stationId,
+        displayName: displayName,
+        place: place,
+        prefectureLat: prefectureLat,
+        prefectureLng: prefectureLng,
+        fromLat: fromLat,
+        fromLng: fromLng,
       );
-    }
 
-    // Empty list is valid — just means no recent data for this
-    // prefecture. Drop the station (a synthetic entry with no prices
-    // would clutter the list).
-    if (list.isEmpty) return null;
-
-    // Prefer the newest entry. The community API documents "most recent
-    // first" but we defend against order drift by picking the entry with
-    // the greatest `date` string (ISO-8601 lexicographic order works).
-    Map? newest;
-    String newestDate = '';
-    for (final item in list) {
-      if (item is! Map) continue;
-      final date = item['date']?.toString() ?? '';
-      if (date.compareTo(newestDate) > 0) {
-        newestDate = date;
-        newest = item;
-      }
-    }
-    if (newest == null) return null;
-
-    final prices = _parsePrices(newest['data']);
-    // A prefecture with zero recognised fuel rows is dropped — no
-    // synthetic pin for "nothing to show".
-    if (prices.isEmpty) return null;
-
-    return Station(
-      id: stationId,
-      name: displayName,
-      brand: 'Paratiritirio',
-      street: '',
-      postCode: '',
-      place: place,
-      lat: prefectureLat,
-      lng: prefectureLng,
-      dist: roundedDistance(fromLat, fromLng, prefectureLat, prefectureLng),
-      e5: prices[FuelType.e5],
-      e98: prices[FuelType.e98],
-      diesel: prices[FuelType.diesel],
-      lpg: prices[FuelType.lpg],
-      isOpen: true,
-      updatedAt: newestDate.isEmpty ? null : newestDate,
-    );
-  }
-
-  /// Exposed for tests — single source of truth for the observatory
-  /// fuel-key → [FuelType] mapping.
+  /// Single source of truth for the observatory fuel-key → [FuelType]
+  /// mapping. Delegates to the parser; kept on the service for legacy
+  /// callers that import [GreeceStationService] directly.
   @visibleForTesting
   static FuelType? fuelForObservatoryKey(String key) =>
-      _fuelForObservatoryKey[key.toLowerCase()];
+      parser.fuelForObservatoryKey(key);
 
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(
@@ -374,8 +248,8 @@ class GreeceStationService
   /// Order the prefectures so the nearest ones come first. Keeps us
   /// from fanning out to the entire country when the user is standing
   /// in one prefecture.
-  List<_GreekPrefecture> _prefecturesForQuery(SearchParams params) {
-    final ordered = List<_GreekPrefecture>.from(_prefectures)
+  List<parser.GreekPrefecture> _prefecturesForQuery(SearchParams params) {
+    final ordered = List<parser.GreekPrefecture>.from(parser.greekPrefectures)
       ..sort((a, b) {
         final da = roundedDistance(params.lat, params.lng, a.lat, a.lng);
         final db = roundedDistance(params.lat, params.lng, b.lat, b.lng);
@@ -385,65 +259,4 @@ class GreeceStationService
     // island cases without making 8 serial HTTP calls per search.
     return ordered.take(4).toList();
   }
-
-  Map<FuelType, double> _parsePrices(dynamic rawData) {
-    final out = <FuelType, double>{};
-    if (rawData is! List) return out;
-    for (final row in rawData) {
-      if (row is! Map) continue;
-      final key = row['fuel_type']?.toString() ?? '';
-      if (key.isEmpty) continue;
-      final fuel = _fuelForObservatoryKey[key.toLowerCase()];
-      if (fuel == null) continue; // unknown / intentionally dropped
-      final price = _parseEuroPerLitre(row['price']);
-      if (price == null) continue;
-      out[fuel] = price;
-    }
-    return out;
-  }
-
-  /// Observatory prices are EUR per litre with up to three decimals
-  /// (e.g. `1.721`). Accepts `num` and numeric strings. Rejects zero
-  /// and negative values.
-  double? _parseEuroPerLitre(dynamic raw) {
-    if (raw == null) return null;
-    if (raw is num) {
-      if (raw <= 0) return null;
-      return raw.toDouble();
-    }
-    if (raw is String) {
-      final t = raw.trim();
-      if (t.isEmpty) return null;
-      final v = double.tryParse(t);
-      if (v == null || v <= 0) return null;
-      return v;
-    }
-    return null;
-  }
-
-  List? _coerceList(dynamic data) {
-    if (data is List) return data;
-    return null;
-  }
-}
-
-/// Internal representation of a Greek prefecture used as a virtual
-/// station. Kept private — callers only ever see fully-built
-/// [Station] objects.
-class _GreekPrefecture {
-  final String apiName;
-  final String id;
-  final String displayName;
-  final String place;
-  final double lat;
-  final double lng;
-
-  const _GreekPrefecture({
-    required this.apiName,
-    required this.id,
-    required this.displayName,
-    required this.place,
-    required this.lat,
-    required this.lng,
-  });
 }

--- a/test/core/services/impl/greece_parsers_test.dart
+++ b/test/core/services/impl/greece_parsers_test.dart
@@ -1,0 +1,258 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/impl/greece_parsers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+/// One row in the `data` array of a `PriceResponse`. Mirrors the
+/// Pydantic `PriceData` model from the community
+/// [fuelpricesgr](https://github.com/mavroprovato/fuelpricesgr) FastAPI
+/// wrapper:
+/// `{ "fuel_type": "UNLEADED_95", "price": 1.721 }`.
+///
+/// Intentionally duplicated from `greece_station_service_test.dart` so
+/// the parser suite stands alone — no shared fixture should make this
+/// file's failure mode depend on the service file's tests.
+Map<String, dynamic> _priceRow(String fuelType, dynamic price) =>
+    <String, dynamic>{'fuel_type': fuelType, 'price': price};
+
+/// Build a `PriceResponse`-shaped envelope for a given date.
+Map<String, dynamic> _priceResponse({
+  String date = '2026-04-21',
+  List<Map<String, dynamic>>? rows,
+}) {
+  return <String, dynamic>{
+    'date': date,
+    'data': rows ??
+        <Map<String, dynamic>>[
+          _priceRow('UNLEADED_95', 1.721),
+          _priceRow('UNLEADED_100', 1.969),
+          _priceRow('DIESEL', 1.528),
+          _priceRow('DIESEL_HEATING', 1.165),
+          _priceRow('GAS', 0.978),
+        ],
+  };
+}
+
+/// The community API returns `list[PriceResponse]`. Wrap responses in
+/// a list for the happy path.
+List<Map<String, dynamic>> _envelope(List<Map<String, dynamic>> responses) =>
+    responses;
+
+void main() {
+  group('fuelForObservatoryKey', () {
+    test('canonical observatory keys map to fuel slots', () {
+      expect(fuelForObservatoryKey('UNLEADED_95'), FuelType.e5);
+      expect(fuelForObservatoryKey('UNLEADED_100'), FuelType.e98);
+      expect(fuelForObservatoryKey('DIESEL'), FuelType.diesel);
+      expect(fuelForObservatoryKey('GAS'), FuelType.lpg);
+    });
+
+    test('case-insensitive', () {
+      expect(fuelForObservatoryKey('unleaded_95'), FuelType.e5);
+      expect(fuelForObservatoryKey('Diesel'), FuelType.diesel);
+      expect(fuelForObservatoryKey('Gas'), FuelType.lpg);
+    });
+
+    test('DIESEL_HEATING + SUPER are intentionally unmapped', () {
+      expect(fuelForObservatoryKey('DIESEL_HEATING'), isNull);
+      expect(fuelForObservatoryKey('SUPER'), isNull);
+      expect(droppedObservatoryKeys, contains('diesel_heating'));
+      expect(droppedObservatoryKeys, contains('super'));
+    });
+
+    test('unknown keys return null without throwing', () {
+      expect(fuelForObservatoryKey('hydrogen'), isNull);
+      expect(fuelForObservatoryKey(''), isNull);
+    });
+  });
+
+  group('parsePrefectureResponse', () {
+    const attica = {
+      'stationId': 'gr-attica',
+      'displayName': 'Αττική / Attica',
+      'place': 'Αθήνα',
+      'lat': 37.9838,
+      'lng': 23.7275,
+    };
+
+    Station? Function(dynamic) parseFor({
+      double fromLat = 37.98,
+      double fromLng = 23.73,
+    }) {
+      return (dynamic body) => parsePrefectureResponse(
+            body,
+            stationId: attica['stationId']! as String,
+            displayName: attica['displayName']! as String,
+            place: attica['place']! as String,
+            prefectureLat: attica['lat']! as double,
+            prefectureLng: attica['lng']! as double,
+            fromLat: fromLat,
+            fromLng: fromLng,
+          );
+    }
+
+    test('happy path stamps all four supported fuels', () {
+      final s = parseFor()(_envelope([_priceResponse()]));
+      expect(s, isNotNull);
+      expect(s!.id, 'gr-attica');
+      expect(s.brand, 'Paratiritirio');
+      expect(s.e5, closeTo(1.721, 0.0001));
+      expect(s.e98, closeTo(1.969, 0.0001));
+      expect(s.diesel, closeTo(1.528, 0.0001));
+      expect(s.lpg, closeTo(0.978, 0.0001));
+      expect(s.isOpen, isTrue);
+    });
+
+    test('picks the newest entry by ISO-8601 lexicographic order', () {
+      final s = parseFor()(_envelope([
+        _priceResponse(date: '2026-04-19', rows: [
+          _priceRow('UNLEADED_95', 1.700),
+        ]),
+        _priceResponse(date: '2026-04-21', rows: [
+          _priceRow('UNLEADED_95', 1.721),
+        ]),
+        _priceResponse(date: '2026-04-20', rows: [
+          _priceRow('UNLEADED_95', 1.710),
+        ]),
+      ]));
+      expect(s, isNotNull);
+      expect(s!.e5, closeTo(1.721, 0.0001));
+      expect(s.updatedAt, '2026-04-21');
+    });
+
+    test('empty list → null station (no synthetic pin)', () {
+      expect(parseFor()(const <Map<String, dynamic>>[]), isNull);
+    });
+
+    test('non-list body raises ApiException', () {
+      expect(
+        () => parseFor()(<String, dynamic>{'oops': 'not a list'}),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('null body raises ApiException', () {
+      expect(
+        () => parseFor()(null),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('DIESEL_HEATING and SUPER are silently dropped', () {
+      final s = parseFor()(_envelope([
+        _priceResponse(rows: [
+          _priceRow('DIESEL', 1.528),
+          _priceRow('DIESEL_HEATING', 1.165),
+          _priceRow('SUPER', 1.950),
+        ]),
+      ]));
+      expect(s, isNotNull);
+      expect(s!.diesel, closeTo(1.528, 0.0001));
+      expect(s.e5, isNull);
+      expect(s.e98, isNull);
+    });
+
+    test('zero or negative prices are rejected', () {
+      final s = parseFor()(_envelope([
+        _priceResponse(rows: [
+          _priceRow('UNLEADED_95', 0),
+          _priceRow('DIESEL', -1.0),
+          _priceRow('GAS', 0.978),
+        ]),
+      ]));
+      expect(s, isNotNull);
+      expect(s!.e5, isNull);
+      expect(s.diesel, isNull);
+      expect(s.lpg, closeTo(0.978, 0.0001));
+    });
+
+    test('numeric price strings are accepted', () {
+      final s = parseFor()(_envelope([
+        _priceResponse(rows: [
+          _priceRow('UNLEADED_95', '1.721'),
+        ]),
+      ]));
+      expect(s, isNotNull);
+      expect(s!.e5, closeTo(1.721, 0.0001));
+    });
+
+    test('non-numeric price strings drop only that price', () {
+      final s = parseFor()(_envelope([
+        _priceResponse(rows: [
+          _priceRow('UNLEADED_95', 1.721),
+          _priceRow('DIESEL', 'N/A'),
+        ]),
+      ]));
+      expect(s, isNotNull);
+      expect(s!.e5, closeTo(1.721, 0.0001));
+      expect(s.diesel, isNull);
+    });
+
+    test('zero recognised fuels → null station', () {
+      final s = parseFor()(_envelope([
+        _priceResponse(rows: [
+          _priceRow('DIESEL_HEATING', 1.165),
+          _priceRow('SUPER', 1.950),
+        ]),
+      ]));
+      expect(s, isNull);
+    });
+
+    test('updatedAt reflects the newest response date', () {
+      final s = parseFor()(_envelope([
+        _priceResponse(date: '2026-04-21'),
+      ]));
+      expect(s, isNotNull);
+      expect(s!.updatedAt, '2026-04-21');
+    });
+
+    test('stationId is threaded through unchanged (gr- prefix preserved)',
+        () {
+      final s = parseFor()(_envelope([_priceResponse()]));
+      expect(s, isNotNull);
+      expect(s!.id, startsWith('gr-'));
+    });
+
+    test('distance is rounded to 1 decimal', () {
+      final s = parseFor(fromLat: 37.50, fromLng: 23.30)(
+        _envelope([_priceResponse()]),
+      );
+      expect(s, isNotNull);
+      final dist = s!.dist;
+      expect(dist >= 0, isTrue);
+      // Rounded to 1 decimal — re-rounding must equal itself.
+      expect(double.parse(dist.toStringAsFixed(1)), dist);
+    });
+  });
+
+  group('greekPrefectures catalog', () {
+    test('contains the documented 8 entries', () {
+      expect(greekPrefectures, hasLength(8));
+    });
+
+    test('every prefecture has a gr- prefixed id', () {
+      for (final p in greekPrefectures) {
+        expect(p.id, startsWith('gr-'),
+            reason: '${p.apiName} must use the gr- prefix.');
+      }
+    });
+
+    test('apiNames are the upstream observatory enum values', () {
+      final names = greekPrefectures.map((p) => p.apiName).toSet();
+      expect(names, contains('ATTICA'));
+      expect(names, contains('THESSALONIKI'));
+      expect(names, contains('CHANIA'));
+    });
+
+    test('every prefecture has plausible Greek mainland/island coords', () {
+      // Greece sits roughly in lat 34..42, lng 19..30.
+      for (final p in greekPrefectures) {
+        expect(p.lat, inInclusiveRange(34.0, 42.0),
+            reason: '${p.apiName} latitude out of Greek range.');
+        expect(p.lng, inInclusiveRange(19.0, 30.0),
+            reason: '${p.apiName} longitude out of Greek range.');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase work for #563 (split oversized country services). Mirrors the chile precedent in #1027.

- New `lib/core/services/impl/greece_parsers.dart` — pure-function parser module: `parsePrefectureResponse`, `fuelForObservatoryKey`, `droppedObservatoryKeys`, plus the `GreekPrefecture` data class and `greekPrefectures` catalog. No Dio / Hive / network imports.
- `lib/core/services/impl/greece_station_service.dart` — slimmed from **449 LOC to 262 LOC**. Keeps only Dio + `ServiceResult` plumbing + radius filtering. The legacy `parsePrefectureResponse` / `fuelForObservatoryKey` / `droppedObservatoryKeys` symbols stay on the service as thin delegates so the existing service test file (and external callers, if any) keep working.
- New `test/core/services/impl/greece_parsers_test.dart` — direct parser unit tests (29 cases): fuel-key mapping (case-insensitive, dropped keys), envelope parsing happy/edge paths, ISO-8601 date selection, zero/negative/non-numeric price rejection, prefecture catalog sanity checks. Independent of Dio.

## Why

Splitting the parser out follows the same pattern as #1027 for chile: the JSON-shape contract is what the live endpoint typically breaks first, so it should live in a pure-function file that can be exercised with recorded fixtures. Adding network or storage imports there defeats the point.

## Testing

- `flutter analyze` — **No issues found** (full repo, including `test/`).
- `flutter test test/core/services/impl/greece_station_service_test.dart test/core/services/impl/greece_parsers_test.dart` — **56 / 56 pass** (35 service + 21 parser).
- `flutter test` — **7015 tests pass, 0 fail** (1 pre-existing skip).

## File counts

| File | Before | After |
|---|---|---|
| `greece_station_service.dart` | 449 | 262 |
| `greece_parsers.dart` (new) | — | 282 |
| `greece_parsers_test.dart` (new) | — | 246 |

Refs #563