### PR TITLE
refactor(uk-fuel-finder): split token + parser out of uk_fuel_finder_service (Refs #563)

### DIFF
--- a/lib/core/services/impl/uk_fuel_finder_response_parser.dart
+++ b/lib/core/services/impl/uk_fuel_finder_response_parser.dart
@@ -1,0 +1,133 @@
+/// Pure parsing helpers for the GOV.UK Fuel Finder JSON envelope
+/// (#573, #563 split). Lives separately from [UkFuelFinderService] so
+/// the JSON-shape contract — which is what the live endpoint typically
+/// breaks first — can be exercised with recorded fixtures, without
+/// touching Dio or any OAuth state. Adding network or storage imports
+/// here defeats the point of the split.
+///
+/// Public surface:
+///  - [UkFuelFinderResponseParser.extractStationList] — coerce the
+///    raw response body into a `List<dynamic>` of station records,
+///    tolerating list-at-root, `{stations: […]}`, `{data: […]}`,
+///    `{items: […]}`, or anything unrecognized (empty list).
+///  - [UkFuelFinderResponseParser.parseFuelFinderStations] — parse
+///    station records into [Station] entities, filter by radius,
+///    dedupe by `site_id`, sort by distance, cap at 50.
+///  - [UkFuelFinderResponseParser.parsePence] — UK pence-or-pound
+///    coercion: anything > 10 is treated as pence and divided by 100.
+library;
+
+import 'package:flutter/foundation.dart';
+
+import '../../../features/search/domain/entities/station.dart';
+import '../../utils/geo_utils.dart';
+
+/// Static helpers for turning Fuel Finder JSON into [Station] entities.
+class UkFuelFinderResponseParser {
+  UkFuelFinderResponseParser._();
+
+  /// Coerce the raw decoded response into the station-record list.
+  ///
+  /// Accepts a top-level list, or one of `{stations,data,items}: […]`.
+  /// Anything else degrades to an empty list rather than throwing — the
+  /// service layer prefers "no stations" over a hard error when the
+  /// envelope shape drifts.
+  static List<dynamic> extractStationList(dynamic data) {
+    if (data is List) return data;
+    if (data is Map<String, dynamic>) {
+      final list = data['stations'] as List<dynamic>? ??
+          data['data'] as List<dynamic>? ??
+          data['items'] as List<dynamic>? ??
+          const <dynamic>[];
+      return List<dynamic>.from(list);
+    }
+    return const <dynamic>[];
+  }
+
+  /// Parses Fuel Finder station records into [Station] entities, filters
+  /// by radius, dedupes by `site_id`, sorts by distance, caps at 50.
+  static List<Station> parseFuelFinderStations(
+    List<dynamic> items, {
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) {
+    final seenIds = <String>{};
+    final stations = <Station>[];
+
+    for (final item in items) {
+      if (item is! Map) continue;
+      try {
+        final loc = item['location'];
+        final locMap = loc is Map ? loc : null;
+        final itemLat = (locMap?['latitude'] as num?)?.toDouble() ??
+            (item['latitude'] as num?)?.toDouble() ??
+            (item['lat'] as num?)?.toDouble();
+        final itemLng = (locMap?['longitude'] as num?)?.toDouble() ??
+            (item['longitude'] as num?)?.toDouble() ??
+            (item['lng'] as num?)?.toDouble();
+        if (itemLat == null || itemLng == null) continue;
+
+        final dist = distanceKm(lat, lng, itemLat, itemLng);
+        if (dist > radiusKm) continue;
+
+        final rawId = item['site_id']?.toString() ??
+            item['id']?.toString() ??
+            '${itemLat.toStringAsFixed(5)}_${itemLng.toStringAsFixed(5)}';
+        final stationId = 'uk-$rawId';
+        if (!seenIds.add(stationId)) continue;
+
+        final prices = item['prices'] is Map
+            ? Map<String, dynamic>.from(item['prices'] as Map)
+            : <String, dynamic>{};
+
+        stations.add(Station(
+          id: stationId,
+          name: item['site_name']?.toString() ??
+              item['name']?.toString() ??
+              item['brand']?.toString() ??
+              '',
+          brand: item['brand']?.toString() ?? '',
+          street: item['address']?.toString() ?? '',
+          postCode: item['postcode']?.toString() ?? '',
+          place:
+              item['town']?.toString() ?? item['locality']?.toString() ?? '',
+          lat: itemLat,
+          lng: itemLng,
+          dist: dist,
+          // E5 → FuelType.e5 (Super Unleaded 95 octane)
+          e5: parsePence(prices['E5'] ?? prices['unleaded']),
+          // E10 → FuelType.e10 (95 octane, 10% ethanol)
+          e10: parsePence(prices['E10']),
+          // E98 / Super Unleaded → FuelType.e98 (97/98 octane premium petrol)
+          e98: parsePence(
+            prices['E98'] ?? prices['super_unleaded'] ?? prices['E5_97'],
+          ),
+          // B7 / Diesel → FuelType.diesel (7% biodiesel blend, standard UK spec)
+          diesel: parsePence(prices['B7'] ?? prices['diesel']),
+          // SDV / Premium Diesel → FuelType.dieselPremium
+          dieselPremium: parsePence(
+            prices['SDV'] ?? prices['premium_diesel'] ?? prices['B7_plus'],
+          ),
+          isOpen: true,
+        ));
+      } catch (e) {
+        debugPrint('UK Fuel Finder parse failed: $e');
+        continue;
+      }
+    }
+
+    stations.sort((a, b) => a.dist.compareTo(b.dist));
+    return stations.take(50).toList();
+  }
+
+  /// UK prices are published in pence per litre. Anything above 10
+  /// is treated as pence and divided by 100; anything at or below 10
+  /// is assumed to already be in pounds.
+  static double? parsePence(dynamic value) {
+    if (value == null) return null;
+    final price = double.tryParse(value.toString());
+    if (price == null) return null;
+    return price > 10 ? price / 100 : price;
+  }
+}

--- a/lib/core/services/impl/uk_fuel_finder_service.dart
+++ b/lib/core/services/impl/uk_fuel_finder_service.dart
@@ -5,11 +5,12 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../../../features/search/data/models/search_params.dart';
 import '../../../features/search/domain/entities/station.dart';
 import '../../error/exceptions.dart';
-import '../../utils/geo_utils.dart';
 import '../dio_factory.dart';
 import '../mixins/station_service_helpers.dart';
 import '../service_result.dart';
 import '../station_service.dart';
+import 'uk_fuel_finder_response_parser.dart';
+import 'uk_fuel_finder_token_manager.dart';
 
 /// GOV.UK Fuel Finder — new single-endpoint UK fuel price service (#573).
 ///
@@ -34,25 +35,14 @@ import '../station_service.dart';
 /// Keeping the gate inline (not in a central config) deliberately
 /// minimises the blast radius of this dormant code path.
 ///
-/// ### OAuth2 flow
+/// ### File split (#563)
 ///
-/// A `_TokenManager` fetches and caches an access token via the client
-/// credentials grant. The token is kept in memory with its `expires_in`
-/// and refreshed proactively one minute before expiry. A 401 from the
-/// token endpoint surfaces as an [ApiException] with "OAuth" in the
-/// message so the UI can differentiate credential problems from plain
-/// network errors.
-///
-/// ### Endpoints
-///
-/// The exact paths are hosted on
-/// `https://www.developer.fuel-finder.service.gov.uk` but the developer
-/// portal requires authentication to browse — the concrete token and
-/// data paths are therefore injectable via constructor so the user can
-/// confirm them against the GOV.UK spec once their application is
-/// approved and the docs become visible. Defaults match the published
-/// portal structure (`/oauth/token` for the OAuth2 step,
-/// `/api/v1/stations` for the data step).
+/// OAuth2 lifecycle lives in
+/// [`uk_fuel_finder_token_manager.dart`][UkFuelFinderTokenManager].
+/// JSON-to-[Station] parsing lives in
+/// [`uk_fuel_finder_response_parser.dart`][UkFuelFinderResponseParser].
+/// This shell wires them together and exposes the public test surface
+/// the existing test suite depends on.
 class UkFuelFinderService
     with StationServiceHelpers
     implements StationService {
@@ -88,7 +78,7 @@ class UkFuelFinderService
   final FlutterSecureStorage _secureStorage;
   final String _tokenUrl;
   final String _stationsUrl;
-  final _TokenManager _tokenManager;
+  final UkFuelFinderTokenManager _tokenManager;
 
   UkFuelFinderService({
     Dio? dio,
@@ -103,14 +93,21 @@ class UkFuelFinderService
         _secureStorage = secureStorage ?? const FlutterSecureStorage(),
         _tokenUrl = tokenUrl ?? defaultTokenUrl,
         _stationsUrl = stationsUrl ?? defaultStationsUrl,
-        _tokenManager = _TokenManager();
+        _tokenManager = UkFuelFinderTokenManager();
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(
     SearchParams params, {
     CancelToken? cancelToken,
   }) async {
-    final token = await _fetchAccessToken(cancelToken: cancelToken);
+    final token = await _tokenManager.fetchAccessToken(
+      dio: _dio,
+      secureStorage: _secureStorage,
+      tokenUrl: _tokenUrl,
+      clientIdStorageKey: kClientIdStorageKey,
+      clientSecretStorageKey: kClientSecretStorageKey,
+      cancelToken: cancelToken,
+    );
 
     final Response<dynamic> response;
     try {
@@ -128,8 +125,8 @@ class UkFuelFinderService
       throwApiException(e, defaultMessage: 'Fuel Finder request failed');
     }
 
-    final items = _extractStationList(response.data);
-    final stations = parseFuelFinderStations(
+    final items = UkFuelFinderResponseParser.extractStationList(response.data);
+    final stations = UkFuelFinderResponseParser.parseFuelFinderStations(
       items,
       lat: params.lat,
       lng: params.lng,
@@ -162,219 +159,33 @@ class UkFuelFinderService
     return emptyPricesResult(ServiceSource.ukApi);
   }
 
-  // ── OAuth2 ───────────────────────────────────────────────────────────────
+  // ── Test surface (stable — existing tests reach in here) ─────────────────
 
-  Future<String> _fetchAccessToken({CancelToken? cancelToken}) async {
-    final cached = _tokenManager.cachedToken;
-    if (cached != null) return cached;
-
-    final clientId = await _secureStorage.read(key: kClientIdStorageKey);
-    final clientSecret =
-        await _secureStorage.read(key: kClientSecretStorageKey);
-    if (clientId == null ||
-        clientId.isEmpty ||
-        clientSecret == null ||
-        clientSecret.isEmpty) {
-      throw const ApiException(
-        message:
-            'Fuel Finder OAuth credentials missing — set client id and '
-            'secret in secure storage before enabling.',
-      );
-    }
-
-    try {
-      final response = await _dio.post<Map<String, dynamic>>(
-        _tokenUrl,
-        data: {
-          'grant_type': 'client_credentials',
-          'client_id': clientId,
-          'client_secret': clientSecret,
-        },
-        cancelToken: cancelToken,
-        options: Options(
-          contentType: Headers.formUrlEncodedContentType,
-          responseType: ResponseType.json,
-          validateStatus: (status) => status != null && status < 400,
-        ),
-      );
-
-      final data = response.data;
-      if (data == null) {
-        throw const ApiException(
-          message: 'OAuth token response empty for Fuel Finder',
-        );
-      }
-      final accessToken = data['access_token']?.toString();
-      final expiresIn = (data['expires_in'] as num?)?.toInt() ?? 3600;
-      if (accessToken == null || accessToken.isEmpty) {
-        throw const ApiException(
-          message: 'OAuth token response missing access_token',
-        );
-      }
-
-      _tokenManager.store(accessToken, Duration(seconds: expiresIn));
-      return accessToken;
-    } on DioException catch (e) {
-      final status = e.response?.statusCode;
-      if (status == 401 || status == 403) {
-        throw ApiException(
-          message:
-              'OAuth authentication failed for Fuel Finder (HTTP $status) '
-              '— check client id and secret.',
-          statusCode: status,
-        );
-      }
-      throw ApiException(
-        message: 'OAuth token request failed: ${e.type.name}',
-        statusCode: status,
-      );
-    }
-  }
-
-  // ── Payload parsing ──────────────────────────────────────────────────────
-
-  List<dynamic> _extractStationList(dynamic data) {
-    if (data is List) return data;
-    if (data is Map<String, dynamic>) {
-      final list = data['stations'] as List<dynamic>? ??
-          data['data'] as List<dynamic>? ??
-          data['items'] as List<dynamic>? ??
-          const <dynamic>[];
-      return List<dynamic>.from(list);
-    }
-    return const <dynamic>[];
-  }
-
-  /// Parses Fuel Finder station records into [Station] entities, filters
-  /// by radius, dedupes by `site_id`, sorts by distance, caps at 50.
-  ///
-  /// Exposed for tests.
+  /// Static delegator preserved for tests — see
+  /// [UkFuelFinderResponseParser.parseFuelFinderStations].
   @visibleForTesting
   static List<Station> parseFuelFinderStations(
     List<dynamic> items, {
     required double lat,
     required double lng,
     required double radiusKm,
-  }) {
-    final seenIds = <String>{};
-    final stations = <Station>[];
+  }) =>
+      UkFuelFinderResponseParser.parseFuelFinderStations(
+        items,
+        lat: lat,
+        lng: lng,
+        radiusKm: radiusKm,
+      );
 
-    for (final item in items) {
-      if (item is! Map) continue;
-      try {
-        final loc = item['location'];
-        final locMap = loc is Map ? loc : null;
-        final itemLat = (locMap?['latitude'] as num?)?.toDouble() ??
-            (item['latitude'] as num?)?.toDouble() ??
-            (item['lat'] as num?)?.toDouble();
-        final itemLng = (locMap?['longitude'] as num?)?.toDouble() ??
-            (item['longitude'] as num?)?.toDouble() ??
-            (item['lng'] as num?)?.toDouble();
-        if (itemLat == null || itemLng == null) continue;
-
-        final dist = distanceKm(lat, lng, itemLat, itemLng);
-        if (dist > radiusKm) continue;
-
-        final rawId = item['site_id']?.toString() ??
-            item['id']?.toString() ??
-            '${itemLat.toStringAsFixed(5)}_${itemLng.toStringAsFixed(5)}';
-        final stationId = 'uk-$rawId';
-        if (!seenIds.add(stationId)) continue;
-
-        final prices = item['prices'] is Map
-            ? Map<String, dynamic>.from(item['prices'] as Map)
-            : <String, dynamic>{};
-
-        stations.add(Station(
-          id: stationId,
-          name: item['site_name']?.toString() ??
-              item['name']?.toString() ??
-              item['brand']?.toString() ??
-              '',
-          brand: item['brand']?.toString() ?? '',
-          street: item['address']?.toString() ?? '',
-          postCode: item['postcode']?.toString() ?? '',
-          place:
-              item['town']?.toString() ?? item['locality']?.toString() ?? '',
-          lat: itemLat,
-          lng: itemLng,
-          dist: dist,
-          // E5 → FuelType.e5 (Super Unleaded 95 octane)
-          e5: _parsePence(prices['E5'] ?? prices['unleaded']),
-          // E10 → FuelType.e10 (95 octane, 10% ethanol)
-          e10: _parsePence(prices['E10']),
-          // E98 / Super Unleaded → FuelType.e98 (97/98 octane premium petrol)
-          e98: _parsePence(
-            prices['E98'] ?? prices['super_unleaded'] ?? prices['E5_97'],
-          ),
-          // B7 / Diesel → FuelType.diesel (7% biodiesel blend, standard UK spec)
-          diesel: _parsePence(prices['B7'] ?? prices['diesel']),
-          // SDV / Premium Diesel → FuelType.dieselPremium
-          dieselPremium: _parsePence(
-            prices['SDV'] ?? prices['premium_diesel'] ?? prices['B7_plus'],
-          ),
-          isOpen: true,
-        ));
-      } catch (e) {
-        debugPrint('UK Fuel Finder parse failed: $e');
-        continue;
-      }
-    }
-
-    stations.sort((a, b) => a.dist.compareTo(b.dist));
-    return stations.take(50).toList();
-  }
-
-  /// UK prices are published in pence per litre. Anything above 10
-  /// is treated as pence and divided by 100; anything at or below 10 is
-  /// assumed to already be in pounds.
-  ///
-  /// Exposed for tests.
+  /// Static delegator preserved for tests — see
+  /// [UkFuelFinderResponseParser.parsePence].
   @visibleForTesting
-  static double? parsePenceForTest(dynamic value) => _parsePence(value);
+  static double? parsePenceForTest(dynamic value) =>
+      UkFuelFinderResponseParser.parsePence(value);
 
   /// Force the cached OAuth token to appear expired so the next
   /// [searchStations] call triggers a fresh `/oauth/token` request.
   /// Exposed for tests only.
   @visibleForTesting
   void expireTokenForTest() => _tokenManager.forceExpire();
-
-  static double? _parsePence(dynamic value) {
-    if (value == null) return null;
-    final price = double.tryParse(value.toString());
-    if (price == null) return null;
-    return price > 10 ? price / 100 : price;
-  }
-}
-
-/// Private OAuth2 token cache. One instance per service — keeps blast
-/// radius local instead of pushing a Dio-wide interceptor that would
-/// touch unrelated requests.
-class _TokenManager {
-  String? _accessToken;
-  DateTime? _expiresAt;
-
-  /// Returns the cached token if it is still valid for at least 60s,
-  /// otherwise `null` (caller must fetch a fresh one).
-  String? get cachedToken {
-    final token = _accessToken;
-    final expiry = _expiresAt;
-    if (token == null || expiry == null) return null;
-    // Refresh one minute before expiry to avoid racing a request against
-    // a token that expires mid-flight.
-    if (DateTime.now().isAfter(expiry.subtract(const Duration(seconds: 60)))) {
-      return null;
-    }
-    return token;
-  }
-
-  void store(String token, Duration ttl) {
-    _accessToken = token;
-    _expiresAt = DateTime.now().add(ttl);
-  }
-
-  @visibleForTesting
-  void forceExpire() {
-    _expiresAt = DateTime.now().subtract(const Duration(minutes: 1));
-  }
 }

--- a/lib/core/services/impl/uk_fuel_finder_token_manager.dart
+++ b/lib/core/services/impl/uk_fuel_finder_token_manager.dart
@@ -1,0 +1,140 @@
+/// OAuth2 client-credentials token lifecycle for the GOV.UK Fuel Finder
+/// service (#573, #563 split). Lives separately from
+/// [UkFuelFinderService] so the OAuth2 dance — token cache, proactive
+/// refresh, secure-storage credential lookup — can be exercised
+/// independently of the data-fetch + parse path.
+///
+/// One instance per service: keeps blast radius local instead of
+/// pushing a Dio-wide interceptor that would touch unrelated requests.
+///
+/// Public surface:
+///  - [UkFuelFinderTokenManager.cachedToken] — non-null when the
+///    in-memory token is still valid for ≥ 60s.
+///  - [UkFuelFinderTokenManager.store] — record a freshly fetched token
+///    and its TTL.
+///  - [UkFuelFinderTokenManager.forceExpire] — flip the cached expiry
+///    into the past so the next [fetchAccessToken] performs a real
+///    `/oauth/token` round trip. Test-only escape hatch.
+///  - [UkFuelFinderTokenManager.fetchAccessToken] — full
+///    cached-or-fetch entry point. Pulls credentials from
+///    [FlutterSecureStorage] under the configured keys, posts a
+///    `client_credentials` grant, and returns the access token.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../../error/exceptions.dart';
+
+/// OAuth2 client-credentials token lifecycle owner.
+class UkFuelFinderTokenManager {
+  String? _accessToken;
+  DateTime? _expiresAt;
+
+  /// Returns the cached token if it is still valid for at least 60s,
+  /// otherwise `null` (caller must fetch a fresh one).
+  String? get cachedToken {
+    final token = _accessToken;
+    final expiry = _expiresAt;
+    if (token == null || expiry == null) return null;
+    // Refresh one minute before expiry to avoid racing a request against
+    // a token that expires mid-flight.
+    if (DateTime.now().isAfter(expiry.subtract(const Duration(seconds: 60)))) {
+      return null;
+    }
+    return token;
+  }
+
+  /// Persist a freshly fetched token + TTL into the in-memory cache.
+  void store(String token, Duration ttl) {
+    _accessToken = token;
+    _expiresAt = DateTime.now().add(ttl);
+  }
+
+  /// Force the cached token to appear expired. Called by the service
+  /// shell's `expireTokenForTest()` (itself `@visibleForTesting`) so the
+  /// next [fetchAccessToken] call triggers a real token request.
+  void forceExpire() {
+    _expiresAt = DateTime.now().subtract(const Duration(minutes: 1));
+  }
+
+  /// Returns a valid access token — from the in-memory cache when fresh,
+  /// otherwise via a `client_credentials` grant against [tokenUrl].
+  ///
+  /// Reads credentials from [secureStorage] under
+  /// [clientIdStorageKey] / [clientSecretStorageKey]. Throws
+  /// [ApiException] when credentials are missing, the token endpoint
+  /// returns 401/403, or the response payload is malformed.
+  Future<String> fetchAccessToken({
+    required Dio dio,
+    required FlutterSecureStorage secureStorage,
+    required String tokenUrl,
+    required String clientIdStorageKey,
+    required String clientSecretStorageKey,
+    CancelToken? cancelToken,
+  }) async {
+    final cached = cachedToken;
+    if (cached != null) return cached;
+
+    final clientId = await secureStorage.read(key: clientIdStorageKey);
+    final clientSecret = await secureStorage.read(key: clientSecretStorageKey);
+    if (clientId == null ||
+        clientId.isEmpty ||
+        clientSecret == null ||
+        clientSecret.isEmpty) {
+      throw const ApiException(
+        message:
+            'Fuel Finder OAuth credentials missing — set client id and '
+            'secret in secure storage before enabling.',
+      );
+    }
+
+    try {
+      final response = await dio.post<Map<String, dynamic>>(
+        tokenUrl,
+        data: {
+          'grant_type': 'client_credentials',
+          'client_id': clientId,
+          'client_secret': clientSecret,
+        },
+        cancelToken: cancelToken,
+        options: Options(
+          contentType: Headers.formUrlEncodedContentType,
+          responseType: ResponseType.json,
+          validateStatus: (status) => status != null && status < 400,
+        ),
+      );
+
+      final data = response.data;
+      if (data == null) {
+        throw const ApiException(
+          message: 'OAuth token response empty for Fuel Finder',
+        );
+      }
+      final accessToken = data['access_token']?.toString();
+      final expiresIn = (data['expires_in'] as num?)?.toInt() ?? 3600;
+      if (accessToken == null || accessToken.isEmpty) {
+        throw const ApiException(
+          message: 'OAuth token response missing access_token',
+        );
+      }
+
+      store(accessToken, Duration(seconds: expiresIn));
+      return accessToken;
+    } on DioException catch (e) {
+      final status = e.response?.statusCode;
+      if (status == 401 || status == 403) {
+        throw ApiException(
+          message:
+              'OAuth authentication failed for Fuel Finder (HTTP $status) '
+              '— check client id and secret.',
+          statusCode: status,
+        );
+      }
+      throw ApiException(
+        message: 'OAuth token request failed: ${e.type.name}',
+        statusCode: status,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## What

Split `lib/core/services/impl/uk_fuel_finder_service.dart` (380 LOC) into a slim shell + two sibling helpers, mirroring the pattern shipped this session for chile (#1027), greece (#1030), south_korea (#1035).

**Moved out of the service file:**
- `lib/core/services/impl/uk_fuel_finder_token_manager.dart` (new, 139 LOC) — OAuth2 client-credentials token lifecycle. Owns the in-memory token cache, proactive refresh, secure-storage credential lookup, and the `client_credentials` grant POST.
- `lib/core/services/impl/uk_fuel_finder_response_parser.dart` (new, 133 LOC) — JSON-to-`Station` parsing, station-list extraction (`{stations|data|items}` envelope), pence-to-pound coercion.

**Stays on `UkFuelFinderService`:**
- Service shell (`searchStations`, `getStationDetail`, `getPrices`).
- Activation gate (`_useFuelFinder`).
- Public test surface, unchanged: `kClientIdStorageKey`, `kClientSecretStorageKey`, `parsePenceForTest`, `parseFuelFinderStations` (static delegator to the parser file), `expireTokenForTest` (delegates to the token manager's `forceExpire`).

## Why

Issue #563 epic — drop oversized service files under 300 LOC so the JSON-shape contract and OAuth2 lifecycle can be exercised independently of each other and of Dio.

## LOC delta

- `uk_fuel_finder_service.dart`: 380 → 191 LOC.
- Net new code in helpers: 272 LOC (extracted, not duplicated).

## Testing

- `flutter analyze` — zero warnings.
- `flutter test test/core/services/impl/uk_fuel_finder_service_test.dart` — all 14 tests pass, **without modifying the test file**.
- `flutter test test/lint/no_silent_catch_test.dart` — green.

Refs #563 (do not close — epic has more files).