### PR TITLE
fix(consumption): restore per-second samples in TripHistoryEntry (#1040)

### DIFF
--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -235,6 +235,31 @@ class TripRecordingController {
   /// real odometer.
   final List<VirtualOdometerSample> _speedSamples = <VirtualOdometerSample>[];
 
+  /// Per-tick sample buffer used by the trip-detail charts (#1040).
+  /// Decimated to ~1 Hz inside [_emit] — the user-facing charts don't
+  /// need the 4 Hz emit cadence, and 1 Hz × 8 fields keeps a 39-min
+  /// trip's payload well under 20 KB compressed. Capped at
+  /// [_capturedSampleCap] so a forgotten recording can't eat unbounded
+  /// memory; the cap covers a 33-hour drive at 1 Hz which is more
+  /// than enough headroom.
+  final List<TripSample> _capturedSamples = <TripSample>[];
+
+  /// Timestamp of the most recently *captured* (decimated) sample.
+  /// Distinct from [_lastSampleAt] which tracks the recorder feed at
+  /// the full 4 Hz emit cadence.
+  DateTime? _lastCapturedAt;
+
+  /// Cap on the captured-sample buffer (#1040). 120000 samples = 33 h
+  /// at 1 Hz — comfortably above any plausible single trip — so this
+  /// only kicks in if the user forgets to stop a recording overnight.
+  static const int _capturedSampleCap = 120000;
+
+  /// Read-only snapshot of the captured sample buffer (#1040). The
+  /// list is unmodifiable so callers can't accidentally mutate the
+  /// controller's state — the provider clones it into the persisted
+  /// [TripHistoryEntry] at stop time.
+  List<TripSample> get capturedSamples => List.unmodifiable(_capturedSamples);
+
   /// Latest parsed values, keyed by PID command. Written by scheduler
   /// callbacks, read by [_emit] when assembling [TripLiveReading]. Not
   /// using a typed struct because most fields are optional doubles
@@ -885,13 +910,15 @@ class TripRecordingController {
     // the pre-#814 1 Hz loop's behavior closely enough that the
     // distance/fuelLitersConsumed integration is unchanged.
     if (_latestSpeedKmh != null || _latestRpm != null) {
-      _recorder.onSample(TripSample(
+      final sample = TripSample(
         timestamp: nowTs,
         speedKmh: _latestSpeedKmh ?? 0,
         rpm: _latestRpm ?? 0,
         fuelRateLPerHour: fuelRate,
-      ));
+      );
+      _recorder.onSample(sample);
       _lastSampleAt = nowTs;
+      _maybeCaptureSample(sample);
     }
     if (fuelRate != null) {
       _fuelRateSeen = true;
@@ -973,6 +1000,42 @@ class TripRecordingController {
     final ltft = _latestLtft;
     if (stft == null || ltft == null) return raw;
     return Obd2Service.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
+  }
+
+  /// Append [sample] to the captured-samples buffer when at least
+  /// 1 second has elapsed since the previous capture. The 4 Hz emit
+  /// loop drops 3 of every 4 candidate samples — the chart layer
+  /// renders at 1 Hz and the storage budget is sized for that
+  /// cadence (#1040).
+  void _maybeCaptureSample(TripSample sample) {
+    final last = _lastCapturedAt;
+    if (last != null) {
+      // Use 950 ms as the gate so a 1 Hz scheduler that's slightly
+      // jittered (998 ms / 1003 ms) still captures every tick. Without
+      // the slack a 998 ms gap would slip through the >=1000 check
+      // and we'd silently halve the captured rate.
+      if (sample.timestamp.difference(last).inMilliseconds < 950) return;
+    }
+    _capturedSamples.add(sample);
+    _lastCapturedAt = sample.timestamp;
+    if (_capturedSamples.length > _capturedSampleCap) {
+      // Drop the oldest slice — losing the early stretch is preferable
+      // to letting a forgotten overnight recording eat unbounded memory.
+      _capturedSamples.removeRange(
+        0,
+        _capturedSamples.length - _capturedSampleCap,
+      );
+    }
+  }
+
+  /// Exposed for tests: append a sample to the captured-samples buffer
+  /// without going through the scheduler / debounced emit timer
+  /// (#1040). Tests use this to populate a deterministic buffer + then
+  /// drive [TripRecording.stop] end-to-end.
+  @visibleForTesting
+  void debugCaptureSample(TripSample sample) {
+    _capturedSamples.add(sample);
+    _lastCapturedAt = sample.timestamp;
   }
 
   /// Exposed for tests: force an emit immediately instead of waiting

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -25,11 +25,27 @@ class TripHistoryEntry {
   /// pre-#1004 entries deserialise as manual.
   final bool automatic;
 
+  /// Per-tick recording profile used by the trip-detail charts (#1040).
+  ///
+  /// Captured by [TripRecordingController] at ~1 Hz throughout the
+  /// recording — the speed / RPM / fuel-rate fields render the
+  /// speed / fuel-rate / RPM line charts in the trip-detail screen.
+  /// Empty for legacy trips written before #1040 landed: the charts
+  /// fall back to the shared "No samples recorded" caption in that
+  /// case, which is the honest answer for trips whose buffer was
+  /// never persisted.
+  ///
+  /// Storage budget: ~1 Hz × 8 fields, so a 39-min trip is roughly
+  /// 19 KB compressed. A year of daily commutes is around 7 MB —
+  /// well below the rolling-log cap.
+  final List<TripSample> samples;
+
   const TripHistoryEntry({
     required this.id,
     required this.vehicleId,
     required this.summary,
     this.automatic = false,
+    this.samples = const [],
   });
 
   Map<String, dynamic> toJson() => {
@@ -37,6 +53,8 @@ class TripHistoryEntry {
         'vehicleId': vehicleId,
         'summary': _summaryToJson(summary),
         if (automatic) 'automatic': true,
+        if (samples.isNotEmpty)
+          'samples': samples.map(_sampleToJson).toList(growable: false),
       };
 
   static TripHistoryEntry fromJson(Map<String, dynamic> json) =>
@@ -47,8 +65,33 @@ class TripHistoryEntry {
           (json['summary'] as Map).cast<String, dynamic>(),
         ),
         automatic: (json['automatic'] as bool?) ?? false,
+        samples: (json['samples'] as List?)
+                ?.map(
+                    (e) => _sampleFromJson((e as Map).cast<String, dynamic>()))
+                .toList(growable: false) ??
+            const [],
       );
 }
+
+/// Serialise a single [TripSample]. Compact key names ('t','s','r','f')
+/// keep per-trip JSON small — a 39-min trip × 1 Hz lands around 19 KB
+/// compressed at this density. Use millisecondsSinceEpoch for the
+/// timestamp so the JSON parses fast and round-trips precisely.
+Map<String, dynamic> _sampleToJson(TripSample s) => {
+      't': s.timestamp.millisecondsSinceEpoch,
+      's': s.speedKmh,
+      'r': s.rpm,
+      if (s.fuelRateLPerHour != null) 'f': s.fuelRateLPerHour,
+    };
+
+TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
+      timestamp: DateTime.fromMillisecondsSinceEpoch(
+        (j['t'] as num).toInt(),
+      ),
+      speedKmh: (j['s'] as num).toDouble(),
+      rpm: (j['r'] as num).toDouble(),
+      fuelRateLPerHour: (j['f'] as num?)?.toDouble(),
+    );
 
 Map<String, dynamic> _summaryToJson(TripSummary s) => {
       'distanceKm': s.distanceKm,

--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/trip_history_repository.dart';
+import '../../domain/trip_recorder.dart';
 import '../../providers/trip_history_provider.dart';
 import '../widgets/trip_detail_body.dart';
 import '../widgets/trip_detail_charts.dart';
@@ -31,12 +32,15 @@ export '../widgets/trip_detail_share_payload.dart'
 /// * [TripHistoryEntry] is read from [tripHistoryListProvider] keyed
 ///   by the path id. A missing entry (stale deep link) falls back to
 ///   a friendly empty-state instead of crashing the route.
-/// * The per-sample time series is supplied via [samples]. The Hive
-///   schema today stores only the aggregated [TripSummary], so the
-///   production route passes an empty list and the charts render the
-///   shared empty-state caption. Future PRs will persist samples
-///   alongside the summary — tests inject them directly today so the
-///   detail screen's contract ships now.
+/// * The per-sample time series ships in two ways:
+///   1. The constructor's [samples] arg lets tests / future callers
+///      inject a hand-built profile directly.
+///   2. When [samples] is empty, the screen derives the chart input
+///      from [TripHistoryEntry.samples] (#1040) — so any trip recorded
+///      with the OBD2 buffer renders its full speed / fuel-rate / RPM
+///      profile. Legacy entries written before #1040 carry an empty
+///      list; the charts then fall back to the shared
+///      "No samples recorded" empty-state caption.
 ///
 /// ## AppBar actions
 /// * **Share** copies a JSON summary + CSV sample block to the
@@ -49,11 +53,10 @@ class TripDetailScreen extends ConsumerStatefulWidget {
 
   /// Optional per-sample profile used to populate the charts (#890).
   ///
-  /// Defaults to an empty list because the Hive schema doesn't yet
-  /// persist samples — every chart then renders its empty-state
-  /// caption, keeping the section layout honest. Tests and future
-  /// persisted-samples PRs pass a non-empty list to drive the
-  /// CustomPaint path.
+  /// Defaults to an empty list — the production route relies on the
+  /// per-trip samples persisted on [TripHistoryEntry.samples] (#1040)
+  /// instead. Tests inject a non-empty list here to drive the chart
+  /// CustomPaint path without needing Hive.
   final List<TripDetailSample> samples;
 
   const TripDetailScreen({
@@ -89,6 +92,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         : vehicles.where((v) => v.id == entry!.vehicleId).firstOrNull ??
             activeVehicle;
     final isEv = vehicle?.type == VehicleType.ev;
+
+    // Production callers pass widget.samples = const [] so the screen
+    // pulls the per-trip profile straight off the persisted entry
+    // (#1040). Tests pre-populate widget.samples; honour that input
+    // instead of overriding it. Legacy entries with no samples render
+    // the shared empty-state caption — same UX as a fresh install.
+    final List<TripDetailSample> samples = widget.samples.isNotEmpty
+        ? widget.samples
+        : (entry?.samples.map(_toDetailSample).toList(growable: false) ??
+            const []);
 
     return PageScaffold(
       title: l?.tripHistoryTitle ?? 'Trip history',
@@ -127,7 +140,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
           : TripDetailBody(
               entry: entry,
               vehicle: vehicle,
-              samples: widget.samples,
+              samples: samples,
               isEv: isEv,
             ),
     );
@@ -157,10 +170,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     TripHistoryEntry entry,
     VehicleProfile? vehicle,
   ) async {
+    final shareSamples = widget.samples.isNotEmpty
+        ? widget.samples
+        : entry.samples.map(_toDetailSample).toList(growable: false);
     final payload = tripDetailSharePayload(
       entry: entry,
       vehicle: vehicle,
-      samples: widget.samples,
+      samples: shareSamples,
     );
     await Clipboard.setData(ClipboardData(text: payload));
     if (!context.mounted) return;
@@ -206,3 +222,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     context.pop();
   }
 }
+
+/// Convert a domain-layer [TripSample] (persisted on
+/// [TripHistoryEntry]) into the presentation-layer [TripDetailSample]
+/// the trip-detail charts consume (#1040). The two types carry the
+/// same fields but live in different layers — keeping the converter
+/// at the screen boundary stops the chart widgets from depending on
+/// the consumption-domain package.
+TripDetailSample _toDetailSample(TripSample s) => TripDetailSample(
+      timestamp: s.timestamp,
+      speedKmh: s.speedKmh,
+      rpm: s.rpm,
+      fuelRateLPerHour: s.fuelRateLPerHour,
+    );

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -71,6 +71,13 @@ class TripRecording extends _$TripRecording {
   @visibleForTesting
   int hapticMediumCount = 0;
 
+  /// Exposed for tests: the underlying [TripRecordingController] while
+  /// a trip is active. Lets the #1040 sample-persistence test inject a
+  /// deterministic buffer through [TripRecordingController.debugCaptureSample]
+  /// without spinning up a real polling clock. Null between trips.
+  @visibleForTesting
+  TripRecordingController? get debugController => _controller;
+
   /// Snapshot of the vehicle the last [startTrip] call was scoped to.
   /// Exposed so the save-as-fill-up path can figure out which
   /// trajets to auto-link (#888). Null before the first call, or
@@ -406,6 +413,10 @@ class TripRecording extends _$TripRecording {
     } catch (e) {
       debugPrint('TripRecording.stop: refreshOdometer failed: $e');
     }
+    // Snapshot the captured-samples buffer BEFORE stop() tears down
+    // the controller — without this the trip-detail charts render the
+    // "No samples recorded" empty state on every saved trip (#1040).
+    final capturedSamples = List<TripSample>.unmodifiable(ctl.capturedSamples);
     final summary = await ctl.stop();
     final odometerStartKm = ctl.odometerStartKm;
     final odometerLatestKm = ctl.odometerLatestKm;
@@ -418,7 +429,7 @@ class TripRecording extends _$TripRecording {
     // (including discarded ones) is logged; the fill-up flow is a
     // *separate* decision. Best-effort: a Hive write failure here
     // shouldn't block service teardown.
-    await _saveToHistory(summary);
+    await _saveToHistory(summary, samples: capturedSamples);
     // #769 — flush learned baselines before releasing the service so
     // the next trip starts from the updated values. Best-effort: a
     // Hive write failure here shouldn't block teardown.
@@ -569,6 +580,7 @@ class TripRecording extends _$TripRecording {
   Future<void> _saveToHistory(
     TripSummary summary, {
     bool automatic = false,
+    List<TripSample> samples = const [],
   }) async {
     // Skip empty trips — the user tapped Stop without any usable
     // sample, or the service disconnected immediately. No signal, no
@@ -584,6 +596,7 @@ class TripRecording extends _$TripRecording {
         vehicleId: _vehicleId,
         summary: summary,
         automatic: automatic,
+        samples: samples,
       ));
       ref.read(tripHistoryListProvider.notifier).refresh();
       // Phase 5 (#1004): bump the launcher-icon badge so the user sees

--- a/test/features/consumption/providers/trip_recording_samples_persistence_test.dart
+++ b/test/features/consumption/providers/trip_recording_samples_persistence_test.dart
@@ -1,0 +1,162 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+
+/// Regression test for #1040 — the per-second OBD2 sample buffer must
+/// land in the persisted [TripHistoryEntry] so the trip-detail charts
+/// have data to plot.
+///
+/// Without this path the user sees aggregates (distance / duration /
+/// avg consumption) but the speed and fuel-rate charts render the
+/// "No samples recorded" empty state on every recorded trip.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('trip_samples_test_');
+    Hive.init(tmpDir.path);
+    await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2TripHistory).deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  test('TripHistoryEntry persists per-tick samples through save+load', () {
+    final start = DateTime(2026, 4, 24, 12);
+    final samples = <TripSample>[
+      for (int i = 0; i < 5; i++)
+        TripSample(
+          timestamp: start.add(Duration(seconds: i)),
+          speedKmh: 50 + i.toDouble(),
+          rpm: 2000 + i * 10,
+          fuelRateLPerHour: 6.0 + i * 0.1,
+        ),
+    ];
+    final entry = TripHistoryEntry(
+      id: start.toIso8601String(),
+      vehicleId: 'veh-1',
+      summary: TripSummary(
+        distanceKm: 0.5,
+        maxRpm: 2040,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        startedAt: start,
+        endedAt: start.add(const Duration(seconds: 5)),
+      ),
+      samples: samples,
+    );
+
+    final json = entry.toJson();
+    final restored = TripHistoryEntry.fromJson(json);
+
+    expect(restored.samples, hasLength(5));
+    expect(restored.samples.first.speedKmh, 50);
+    expect(restored.samples.last.speedKmh, 54);
+    expect(restored.samples[2].rpm, 2020);
+    expect(restored.samples[2].fuelRateLPerHour, closeTo(6.2, 1e-9));
+    expect(restored.samples.first.timestamp, start);
+  });
+
+  test('TripHistoryEntry samples default to empty for legacy payloads', () {
+    // Pre-#1040 payloads carry no `samples` key — make sure the
+    // rolling-log loader still deserialises them as empty rather than
+    // throwing.
+    final legacy = {
+      'id': 'legacy-1',
+      'vehicleId': 'veh-1',
+      'summary': {
+        'distanceKm': 12.0,
+        'maxRpm': 3000.0,
+        'highRpmSeconds': 0.0,
+        'idleSeconds': 0.0,
+        'harshBrakes': 0,
+        'harshAccelerations': 0,
+        'distanceSource': 'virtual',
+      },
+    };
+    final restored = TripHistoryEntry.fromJson(legacy);
+    expect(restored.samples, isEmpty);
+  });
+
+  test(
+    'TripRecording.stop() persists the controller sample buffer onto '
+    'the saved TripHistoryEntry — the charts read this back',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+      // Inject a deterministic sample buffer through the live stream
+      // path. The controller is owned by the provider; we drive its
+      // recorder via the visible-for-testing hook so we don't depend
+      // on real-clock timing of the 4 Hz emit loop.
+      final ctl = notifier.debugController;
+      expect(ctl, isNotNull,
+          reason: 'provider must own a controller while recording');
+      final start = DateTime.now();
+      for (int i = 0; i < 6; i++) {
+        final sample = TripSample(
+          timestamp: start.add(Duration(seconds: i)),
+          speedKmh: 40 + i.toDouble(),
+          rpm: 1800 + i * 5,
+          fuelRateLPerHour: 5.5,
+        );
+        // Feed the recorder so the resulting summary has a startedAt
+        // and a non-zero distance — without this _saveToHistory
+        // short-circuits as an "empty" trip.
+        ctl!.debugInjectSample(
+          speedKmh: sample.speedKmh,
+          rpm: sample.rpm,
+          at: sample.timestamp,
+          fuelRateLPerHour: sample.fuelRateLPerHour,
+        );
+        // Capture the same sample into the per-tick buffer that the
+        // chart layer reads back at display time.
+        ctl.debugCaptureSample(sample);
+      }
+      await notifier.stop();
+
+      final repo = container.read(tripHistoryRepositoryProvider);
+      expect(repo, isNotNull);
+      final history = repo!.loadAll();
+      expect(history, isNotEmpty,
+          reason: 'stop() must persist a TripHistoryEntry');
+      final saved = history.first;
+      expect(saved.samples, hasLength(6),
+          reason: 'every captured sample must round-trip into Hive — '
+              'without this the trip detail screen renders '
+              '"No samples recorded"');
+      expect(saved.samples.first.speedKmh, 40);
+      expect(saved.samples.last.speedKmh, 45);
+    },
+  );
+}
+
+Map<String, String> _elmOk() => const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '01A6': '41 A6 00 01 6A 2C>',
+    };


### PR DESCRIPTION
## What

Persists the OBD2 per-tick recording profile (speed / RPM / fuel rate) onto the saved trip and reads it back on the trip detail screen, so the speed and fuel-rate charts stop rendering "No samples recorded" on every recorded trip.

## Why

User report on build 5.0.0+5102: 39-min trip, OBD2 connected, charts empty. Investigation showed the chain was scaffolded (the screen constructor takes `samples`, the chart widgets are wired) but the persistence + read-back half was a TODO since #890 landed — comments in `trip_detail_charts.dart` and `trip_detail_screen.dart` explicitly flag "Future PRs will persist samples". Recent refactors (#929, #934, #1006, #1026) did not drop the field — there was nothing to drop.

## Producer-to-persistence chain after the fix

1. **Controller** — `TripRecordingController._emit()` decimates the 4 Hz emit cadence to ~1 Hz (`>= 950 ms` since the previous capture) and appends each survivor to a new `_capturedSamples` buffer. Capped at 120 k samples (33 h at 1 Hz) so a forgotten overnight recording can't eat unbounded memory.
2. **Provider** — `TripRecording.stop()` snapshots `ctl.capturedSamples` BEFORE `ctl.stop()` releases the controller, then passes the list to `_saveToHistory(summary, samples: capturedSamples)`.
3. **Entity** — `TripHistoryEntry` gains a `samples: List<TripSample>` field with compact JSON keys (`t`, `s`, `r`, `f`) so a 39-min × 1 Hz × 8-field trip lands around 19 KB compressed. Legacy entries deserialise as `samples: const []` so the rolling-log loader stays backwards-compatible.
4. **Screen** — `TripDetailScreen` now derives chart samples from `entry.samples` when the constructor's `widget.samples` is empty (the production path) and converts `TripSample` → `TripDetailSample` at the screen boundary so the chart widgets stay decoupled from the consumption-domain package.

## Storage budget

1 Hz × 8 fields × 39 min ≈ 19 KB compressed (matches the issue's sanity check). Year of daily commutes ≈ 7 MB — well under the 100-trip rolling cap.

## Testing

- New `test/features/consumption/providers/trip_recording_samples_persistence_test.dart`:
  - JSON round-trip preserves every sample's speed / RPM / fuel-rate / timestamp.
  - Legacy entries (no `samples` key) deserialise as empty list — no crash.
  - End-to-end: provider `stop()` → Hive save → `repo.loadAll()` returns the captured buffer.
- `flutter analyze` — zero issues.
- `flutter test` — 7047 pass, 1 pre-existing skip, no regressions.

## Test plan

- [x] New regression test fails before fix, passes after
- [x] Full suite green
- [x] Static analysis clean
- [ ] Device verification: > 1 minute trip on real hardware shows populated speed / fuel-rate charts and avg/max speed (deferred to next build)

## Out of scope

- New UI for the missing samples on legacy entries — see #1041 if/when filed.
- Sample-rate change — kept at 1 Hz per the storage-budget reminder in the issue.

Closes #1040