### PR TITLE
refactor(feedback): split body formatter out of github_issue_reporter (Refs #563)

### DIFF
--- a/lib/core/feedback/github_issue_body_formatter.dart
+++ b/lib/core/feedback/github_issue_body_formatter.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+
+import 'github_issue_reporter.dart' show ScanKind;
+
+/// Pure string-formatting helpers used by [GithubIssueReporter] to
+/// build the markdown body of a bad-scan issue. Split out of
+/// `github_issue_reporter.dart` so the reporter shell stays focused on
+/// HTTP + rate-limit handling.
+///
+/// All members are static — the formatter is stateless. Callers pass
+/// in the scan payload and get back a markdown string ready to POST.
+class GithubIssueBodyFormatter {
+  GithubIssueBodyFormatter._();
+
+  /// Absolute ceiling for the issue body. GitHub's own limit is
+  /// 65,536 chars — we keep a small safety margin.
+  static const int maxBodyLength = 65000;
+
+  /// Builds the markdown body for a bad-scan issue. Embeds the OCR
+  /// text, parsed fields, user corrections, and a base64-encoded image
+  /// (with EXIF stripped on a best-effort basis).
+  static String buildBody({
+    required ScanKind kind,
+    required String rawOcrText,
+    required Map<String, String?> parsedFields,
+    required Map<String, String?> userCorrections,
+    required Uint8List imageBytes,
+    String? userNote,
+  }) {
+    final buffer = StringBuffer();
+    buffer.writeln('## Scan kind');
+    buffer.writeln();
+    buffer.writeln('- ${scanKindLabel(kind)}');
+    buffer.writeln();
+
+    if (userNote != null && userNote.trim().isNotEmpty) {
+      buffer.writeln('## User note');
+      buffer.writeln();
+      buffer.writeln(sanitize(userNote.trim()));
+      buffer.writeln();
+    }
+
+    buffer.writeln('## Raw OCR text');
+    buffer.writeln();
+    buffer.writeln('```');
+    buffer.writeln(sanitize(rawOcrText));
+    buffer.writeln('```');
+    buffer.writeln();
+
+    buffer.writeln('## Parsed fields');
+    buffer.writeln();
+    buffer.write(fieldTable(parsedFields));
+    buffer.writeln();
+
+    buffer.writeln('## User corrections');
+    buffer.writeln();
+    buffer.write(fieldTable(userCorrections));
+    buffer.writeln();
+
+    final stripResult = _stripExif(imageBytes);
+    if (!stripResult.stripped) {
+      buffer.writeln('## Notes');
+      buffer.writeln();
+      buffer.writeln(
+        '_[note: EXIF strip failed, raw bytes uploaded]_',
+      );
+      buffer.writeln();
+    }
+
+    buffer.writeln('## Scan image');
+    buffer.writeln();
+
+    final textSoFar = buffer.length;
+    final base64Image = base64Encode(stripResult.bytes);
+    // ~30 chars of markdown wrapper around the base64 payload
+    // (`![scan](data:image/jpeg;base64,)`).
+    const wrapperLength = 32;
+    if (textSoFar + base64Image.length + wrapperLength > maxBodyLength) {
+      buffer.writeln('_[image too large to embed]_');
+    } else {
+      buffer.writeln('![scan](data:image/jpeg;base64,$base64Image)');
+    }
+
+    return buffer.toString();
+  }
+
+  /// Decodes the input, drops the EXIF block (location, timestamps,
+  /// device id), and re-encodes as JPEG. On any failure the original
+  /// bytes are returned with `stripped == false` so the caller can
+  /// annotate the issue body but still ship the image.
+  static _ExifStripResult _stripExif(Uint8List bytes) {
+    if (bytes.isEmpty) {
+      return _ExifStripResult(bytes: bytes, stripped: false);
+    }
+    try {
+      final decoded = img.decodeImage(bytes);
+      if (decoded == null) {
+        return _ExifStripResult(bytes: bytes, stripped: false);
+      }
+      // Replace any populated ExifData with an empty one — drops GPS,
+      // timestamps, camera model, and any maker notes.
+      decoded.exif = img.ExifData();
+      final encoded = img.encodeJpg(decoded, quality: 85);
+      return _ExifStripResult(bytes: encoded, stripped: true);
+    } catch (e) {
+      debugPrint('GithubIssueReporter EXIF strip failed: $e');
+      return _ExifStripResult(bytes: bytes, stripped: false);
+    }
+  }
+
+  static String scanKindLabel(ScanKind kind) {
+    switch (kind) {
+      case ScanKind.receipt:
+        return 'Receipt';
+      case ScanKind.pumpDisplay:
+        return 'Pump display';
+    }
+  }
+
+  static String fieldTable(Map<String, String?> fields) {
+    if (fields.isEmpty) {
+      return '_(none)_\n';
+    }
+    final buffer = StringBuffer();
+    buffer.writeln('| Field | Value |');
+    buffer.writeln('| --- | --- |');
+    for (final entry in fields.entries) {
+      final key = sanitizeCell(entry.key);
+      final value = entry.value == null || entry.value!.isEmpty
+          ? '_(empty)_'
+          : sanitizeCell(entry.value!);
+      buffer.writeln('| $key | $value |');
+    }
+    return buffer.toString();
+  }
+
+  /// Strips ANSI escapes, control characters (except `\n` and `\t`),
+  /// and anything else that would break markdown rendering.
+  static String sanitize(String input) {
+    // Remove ANSI CSI sequences (ESC [ ... letter).
+    final withoutAnsi = input.replaceAll(
+      RegExp(r'\x1B\[[0-9;]*[A-Za-z]'),
+      '',
+    );
+    // Strip control chars except tab (\x09) and newline (\x0A).
+    return withoutAnsi.replaceAll(
+      RegExp(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]'),
+      '',
+    );
+  }
+
+  /// Like [sanitize] but also escapes characters that break markdown
+  /// table cells (pipes and embedded newlines).
+  static String sanitizeCell(String input) {
+    return sanitize(input).replaceAll('\n', ' ').replaceAll('|', r'\|');
+  }
+}
+
+/// Internal carrier for [GithubIssueBodyFormatter._stripExif].
+/// `stripped == true` means the bytes have been re-encoded with an
+/// empty EXIF block; `false` means decoding/encoding failed and the
+/// original bytes are returned.
+@immutable
+class _ExifStripResult {
+  final Uint8List bytes;
+  final bool stripped;
+
+  const _ExifStripResult({required this.bytes, required this.stripped});
+}

--- a/lib/core/feedback/github_issue_reporter.dart
+++ b/lib/core/feedback/github_issue_reporter.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'package:image/image.dart' as img;
+
+import 'github_issue_body_formatter.dart';
 
 /// What kind of scan produced the failing OCR output — determines the
 /// issue title.
@@ -48,19 +49,14 @@ class GithubReporterException implements Exception {
 /// screenshot/photo of the scan. GitHub renders `data:image/...` URIs
 /// in markdown so the photo appears inline.
 ///
-/// Phase 3 (#952) — EXIF location tags are stripped before encoding.
-/// If decoding fails (corrupt input, unsupported format) we fall back
-/// to passing raw bytes through and add a marker in the issue body so
-/// triage knows the image may carry metadata.
+/// Body construction (markdown layout, sanitization, EXIF strip) lives
+/// in [GithubIssueBodyFormatter]; this class is the HTTP + rate-limit
+/// shell only.
 class GithubIssueReporter {
   final http.Client _httpClient;
   final String _token;
   final String _repoOwner;
   final String _repoName;
-
-  /// Absolute ceiling for the issue body. GitHub's own limit is
-  /// 65,536 chars — we keep a small safety margin.
-  static const int _maxBodyLength = 65000;
 
   /// If `X-RateLimit-Remaining` drops below this threshold we refuse
   /// to submit so the UI can fall back to SharePlus without burning
@@ -94,7 +90,7 @@ class GithubIssueReporter {
     required Uint8List imageBytes,
     String? userNote,
   }) async {
-    final body = _buildBody(
+    final body = GithubIssueBodyFormatter.buildBody(
       kind: kind,
       rawOcrText: rawOcrText,
       parsedFields: parsedFields,
@@ -199,154 +195,4 @@ class GithubIssueReporter {
       );
     }
   }
-
-  // ---------------------------------------------------------------------------
-  // Body construction
-
-  String _buildBody({
-    required ScanKind kind,
-    required String rawOcrText,
-    required Map<String, String?> parsedFields,
-    required Map<String, String?> userCorrections,
-    required Uint8List imageBytes,
-    String? userNote,
-  }) {
-    final buffer = StringBuffer();
-    buffer.writeln('## Scan kind');
-    buffer.writeln();
-    buffer.writeln('- ${_scanKindLabel(kind)}');
-    buffer.writeln();
-
-    if (userNote != null && userNote.trim().isNotEmpty) {
-      buffer.writeln('## User note');
-      buffer.writeln();
-      buffer.writeln(_sanitize(userNote.trim()));
-      buffer.writeln();
-    }
-
-    buffer.writeln('## Raw OCR text');
-    buffer.writeln();
-    buffer.writeln('```');
-    buffer.writeln(_sanitize(rawOcrText));
-    buffer.writeln('```');
-    buffer.writeln();
-
-    buffer.writeln('## Parsed fields');
-    buffer.writeln();
-    buffer.write(_fieldTable(parsedFields));
-    buffer.writeln();
-
-    buffer.writeln('## User corrections');
-    buffer.writeln();
-    buffer.write(_fieldTable(userCorrections));
-    buffer.writeln();
-
-    final stripResult = _stripExif(imageBytes);
-    if (!stripResult.stripped) {
-      buffer.writeln('## Notes');
-      buffer.writeln();
-      buffer.writeln(
-        '_[note: EXIF strip failed, raw bytes uploaded]_',
-      );
-      buffer.writeln();
-    }
-
-    buffer.writeln('## Scan image');
-    buffer.writeln();
-
-    final textSoFar = buffer.length;
-    final base64Image = base64Encode(stripResult.bytes);
-    // ~30 chars of markdown wrapper around the base64 payload
-    // (`![scan](data:image/jpeg;base64,)`).
-    const wrapperLength = 32;
-    if (textSoFar + base64Image.length + wrapperLength > _maxBodyLength) {
-      buffer.writeln('_[image too large to embed]_');
-    } else {
-      buffer.writeln('![scan](data:image/jpeg;base64,$base64Image)');
-    }
-
-    return buffer.toString();
-  }
-
-  /// Decodes the input, drops the EXIF block (location, timestamps,
-  /// device id), and re-encodes as JPEG. On any failure the original
-  /// bytes are returned with `stripped == false` so the caller can
-  /// annotate the issue body but still ship the image.
-  _ExifStripResult _stripExif(Uint8List bytes) {
-    if (bytes.isEmpty) {
-      return _ExifStripResult(bytes: bytes, stripped: false);
-    }
-    try {
-      final decoded = img.decodeImage(bytes);
-      if (decoded == null) {
-        return _ExifStripResult(bytes: bytes, stripped: false);
-      }
-      // Replace any populated ExifData with an empty one — drops GPS,
-      // timestamps, camera model, and any maker notes.
-      decoded.exif = img.ExifData();
-      final encoded = img.encodeJpg(decoded, quality: 85);
-      return _ExifStripResult(bytes: encoded, stripped: true);
-    } catch (e) {
-      debugPrint('GithubIssueReporter EXIF strip failed: $e');
-      return _ExifStripResult(bytes: bytes, stripped: false);
-    }
-  }
-
-  String _scanKindLabel(ScanKind kind) {
-    switch (kind) {
-      case ScanKind.receipt:
-        return 'Receipt';
-      case ScanKind.pumpDisplay:
-        return 'Pump display';
-    }
-  }
-
-  String _fieldTable(Map<String, String?> fields) {
-    if (fields.isEmpty) {
-      return '_(none)_\n';
-    }
-    final buffer = StringBuffer();
-    buffer.writeln('| Field | Value |');
-    buffer.writeln('| --- | --- |');
-    for (final entry in fields.entries) {
-      final key = _sanitizeCell(entry.key);
-      final value = entry.value == null || entry.value!.isEmpty
-          ? '_(empty)_'
-          : _sanitizeCell(entry.value!);
-      buffer.writeln('| $key | $value |');
-    }
-    return buffer.toString();
-  }
-
-  /// Strips ANSI escapes, control characters (except `\n` and `\t`),
-  /// and anything else that would break markdown rendering.
-  String _sanitize(String input) {
-    // Remove ANSI CSI sequences (ESC [ ... letter).
-    final withoutAnsi = input.replaceAll(
-      RegExp(r'\x1B\[[0-9;]*[A-Za-z]'),
-      '',
-    );
-    // Strip control chars except tab (\x09) and newline (\x0A).
-    return withoutAnsi.replaceAll(
-      RegExp(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]'),
-      '',
-    );
-  }
-
-  /// Like [_sanitize] but also escapes characters that break markdown
-  /// table cells (pipes and embedded newlines).
-  String _sanitizeCell(String input) {
-    return _sanitize(input).replaceAll('\n', ' ').replaceAll('|', r'\|');
-  }
-}
-
-/// Internal carrier returned by [_stripExif]. `stripped == true` means
-/// the bytes have been re-encoded with an empty EXIF block; `false`
-/// means decoding/encoding failed and the original bytes are returned.
-@immutable
-class _ExifStripResult {
-  final Uint8List bytes;
-  final bool stripped;
-
-  const _ExifStripResult({required this.bytes, required this.stripped});
 }


### PR DESCRIPTION
## What

Split `lib/core/feedback/github_issue_reporter.dart` (352 LOC) into:

- `lib/core/feedback/github_issue_reporter.dart` — HTTP + rate-limit shell only (~198 LOC).
- `lib/core/feedback/github_issue_body_formatter.dart` (new) — markdown body construction, field-table rendering, ANSI/control-char sanitization, scan-kind label, EXIF strip helper (~172 LOC).

## Why

Part of #563 (extract oversized files). Drops the reporter under the 300-LOC ceiling and isolates pure string-formatting logic from network plumbing — easier to test each side in isolation, easier to reason about EXIF/sanitization without scrolling past HTTP code.

## What stayed

- `enum ScanKind` + `ScanKindLabel` extension (test surface).
- `class GithubReporterException`.
- `class GithubIssueReporter` public API: `reportBadScan(...)` unchanged.
- Private network helpers `_postIssue`, `_parseResponse`, `_checkRateLimit`.

## What moved

- `_buildBody` -> `GithubIssueBodyFormatter.buildBody`.
- `_scanKindLabel` -> `GithubIssueBodyFormatter.scanKindLabel`.
- `_fieldTable` -> `GithubIssueBodyFormatter.fieldTable`.
- `_sanitize` / `_sanitizeCell` -> `GithubIssueBodyFormatter.sanitize` / `sanitizeCell`.
- `_stripExif` + `_ExifStripResult` carrier (called from `buildBody`) moved alongside.
- `_maxBodyLength` constant -> `GithubIssueBodyFormatter.maxBodyLength`.

## Testing

- `flutter analyze` -> 0 issues.
- `flutter test test/core/feedback/github_issue_reporter_test.dart` -> 9/9 pass with **zero edits** to the test file. Public API preserved.

## LOC delta

- `github_issue_reporter.dart`: 352 -> 198.
- `github_issue_body_formatter.dart`: 0 -> 172 (new).

Refs #563 (do not close — epic has more files).