### PR TITLE
feat(consumption): driving-insights cost-line analyzer (Refs #1041 phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ docs/guides/*
 !docs/guides/PLAY-STORE-LISTING-REFRESH.md
 !docs/guides/obd2-adapters.md
 !docs/guides/vehicle-catalog.md
+!docs/guides/driving-insights.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/driving-insights.md
+++ b/docs/guides/driving-insights.md
@@ -1,0 +1,100 @@
+# Driving insights — counterfactual model
+
+Phase 1 of #1041 introduces an analytical layer that turns a trip's raw OBD2
+samples into "Top-3 cost lines" — quantified bullets such as
+"12% of trip above 3000 RPM: +0.6 L wasted". This file documents the
+model so future contributors can refine the formulas without spelunking
+through the analyzer.
+
+## Inputs
+
+The analyzer (`lib/features/consumption/data/driving_insights_analyzer.dart`)
+is a pure function that consumes a `List<TripSample>` produced by
+`TripRecorder` (`lib/features/consumption/domain/trip_recorder.dart`).
+
+Each `TripSample` exposes:
+
+- `timestamp` — sample wall-clock time
+- `speedKmh`
+- `rpm`
+- `fuelRateLPerHour` (nullable — many cars don't expose PID 5E)
+
+Phase 1 deliberately ignores throttle, MAF, coolant temp, and elevation
+even when present. Those feed Cards C/D/E in later phases (#1041 phase 3).
+
+## Categories
+
+### High-RPM cost (`labelKey: insightHighRpm`)
+
+Waste accumulates whenever a sample's RPM exceeds 3 000. Per interval:
+
+```
+wastedLiters += (measuredRate − counterfactualRate) × Δt / 3600
+counterfactualRate = measuredRate × 0.6
+```
+
+The 0.6 ratio approximates "the same speed at moderate RPM would have
+used ~60% of the fuel". When no `fuelRateLPerHour` samples are
+available during the high-RPM windows, the analyzer falls back to a
+synthetic 6 L/h baseline so the cost line still surfaces — flagged in
+metadata so phase 2 UI can label it as an estimate.
+
+### Hard-acceleration cost (`labelKey: insightHardAccel`)
+
+Counts intervals where Δspeed/Δt ≥ 3.0 m/s². Each event adds a
+documented constant of **0.05 L** (≈ 50 mL) of wasted fuel — the
+order-of-magnitude figure cited in fleet-telematics literature for
+"punching the throttle vs smooth acceleration to the same target
+speed". Phase 3 will refine this with throttle-position data.
+
+### Idling cost (`labelKey: insightIdling`)
+
+Counts intervals where `speedKmh <= 0.5` AND `rpm > 0`. Idle is
+attributed 100% wasteful — every drop is avoidable by switching the
+engine off. Wasted liters = idle_time × idle_fuel_rate. The rate
+defaults to **0.6 L/h** (typical petrol passenger-car warm idle at
+700-900 RPM) when measured fuel-rate samples are unavailable.
+
+## Noise floor
+
+Categories below **0.05 L** are dropped — they're indistinguishable
+from sensor noise and would clutter the UI without coaching value.
+
+## Top-N
+
+The analyzer sorts candidates by `litersWasted` descending and returns
+at most **3** entries. This is the focused list the UI renders as the
+"Top-3 cost lines" card (#1041 phase 2 — not yet implemented).
+
+## Output shape
+
+Each cost line is a `DrivingInsight`
+(`lib/features/consumption/domain/driving_insight.dart`):
+
+| Field | Meaning |
+| --- | --- |
+| `labelKey` | Stable l10n key — phase 2 maps to the user's locale |
+| `litersWasted` | Estimated litres above the counterfactual |
+| `percentOfTrip` | Time/distance share relevant to this category |
+| `metadata` | Per-category supporting numbers (e.g. `aboveRpm: 3000`, `eventCount: 4`) |
+
+## What's deferred
+
+Phase 1 is the **pure analytical layer only**. The following are
+explicitly out of scope and tracked under #1041 phases 2-5:
+
+- **Phase 2** — Trip-detail Insights tab UI consuming `DrivingInsight`
+  values, ARB strings for each label key, and integration with the
+  existing baseline store.
+- **Phase 3** — Card A (driving score), Card C (throttle/RPM
+  histograms), Card D (cold-start cost), Card E (elevation-adjusted
+  score).
+- **Phase 4** — Aggregates surface ("this month vs last month") on the
+  consumption tab landing screen.
+- **Phase 5** — Achievement hooks (`smoothDriver`, `coldStartAware`,
+  `highwayMaster`) tied into #781.
+
+When refining the model, please add a test fixture that captures the
+behaviour you're correcting before changing the formula — the analyzer
+is plain Dart, fully unit-testable, and the existing tests live in
+`test/features/consumption/data/driving_insights_analyzer_test.dart`.

--- a/lib/features/consumption/data/driving_insights_analyzer.dart
+++ b/lib/features/consumption/data/driving_insights_analyzer.dart
@@ -1,0 +1,207 @@
+/// Pure analyzer that turns a stream of [TripSample]s into "cost
+/// lines" for the trip Insights tab (#1041 phase 1).
+///
+/// Phase 1 covers three behaviour-driven categories — high RPM,
+/// hard acceleration, and idling. Each yields a [DrivingInsight] when
+/// it accumulates at least [_noiseFloorLiters] of estimated waste.
+/// Results are sorted by `litersWasted` descending and capped at
+/// [_topN] entries so the UI shows a focused list.
+///
+/// The counterfactual model is documented in
+/// `docs/guides/driving-insights.md`. Numbers here are intentionally
+/// rough — the goal is *coaching*, not telematics-grade accounting.
+/// Future phases (cards C/D/E in #1041) will refine the model with
+/// throttle, coolant temp, and elevation data.
+library;
+
+import '../domain/driving_insight.dart';
+import '../domain/trip_recorder.dart';
+
+/// RPM above which a sample counts as "high RPM".
+const double _highRpmThreshold = 3000;
+
+/// Acceleration (m/s²) above which an interval counts as "hard accel".
+const double _hardAccelThresholdMps2 = 3.0;
+
+/// Liters wasted per hard-accel event. Documented constant — see
+/// `docs/guides/driving-insights.md`. Order-of-magnitude estimate
+/// from "punching the throttle costs ~50 mL extra over a smooth
+/// counterfactual" telematics literature.
+const double _wastedLitersPerHardAccelEvent = 0.05;
+
+/// Counterfactual fuel rate for high-RPM segments expressed as a
+/// fraction of the measured rate. 0.6 ≈ "the same trip at moderate
+/// RPM would have burned ~60% of the fuel you actually burned during
+/// those high-RPM windows".
+const double _highRpmCounterfactualRatio = 0.6;
+
+/// Default fuel rate (L/h) assumed for idling when no measured
+/// fuel-rate samples are available. 0.6 L/h is a common figure for
+/// petrol passenger cars at warm idle (~700-900 RPM).
+const double _idleFuelRateAssumptionLPerHour = 0.6;
+
+/// Categories below this many liters are dropped — they're indistinguishable
+/// from sensor noise.
+const double _noiseFloorLiters = 0.05;
+
+/// Maximum cost lines returned by [analyzeTrip].
+const int _topN = 3;
+
+/// Analyze a trip's samples and return the top-3 cost lines, sorted by
+/// estimated litres wasted (descending). Empty input → empty list.
+///
+/// The function is pure and synchronous — safe to call from a UI
+/// thread for trip durations the app realistically records (a 60-min
+/// trip at 1 Hz is 3 600 samples; the loop is O(n)).
+List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
+  if (samples.length < 2) return const [];
+
+  // Sort by timestamp so out-of-order persistence (#1040 race
+  // conditions) doesn't blow up the integration. Copy first so we
+  // don't mutate the caller's list.
+  final sorted = [...samples]
+    ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+  // Total trip duration — used to compute percentages.
+  final totalDt = sorted.last.timestamp
+          .difference(sorted.first.timestamp)
+          .inMicroseconds /
+      Duration.microsecondsPerSecond;
+  if (totalDt <= 0) return const [];
+
+  // Accumulators.
+  double highRpmSeconds = 0;
+  double highRpmWastedLiters = 0;
+  bool sawFuelRateInHighRpm = false;
+
+  int hardAccelEvents = 0;
+  double hardAccelTotalDt = 0;
+
+  double idleSeconds = 0;
+  double idleWastedLiters = 0;
+
+  for (var i = 1; i < sorted.length; i++) {
+    final prev = sorted[i - 1];
+    final cur = sorted[i];
+    final dt =
+        cur.timestamp.difference(prev.timestamp).inMicroseconds /
+            Duration.microsecondsPerSecond;
+    if (dt <= 0) continue;
+
+    // High-RPM cost: time fraction above the threshold weighted by
+    // measured-vs-counterfactual fuel rate. Mirrors TripRecorder's
+    // convention of attributing the whole interval to the start
+    // sample's RPM (the ~1 Hz cadence is short relative to gear
+    // shifts).
+    if (prev.rpm > _highRpmThreshold) {
+      highRpmSeconds += dt;
+      final measuredRate = prev.fuelRateLPerHour;
+      if (measuredRate != null && measuredRate > 0) {
+        sawFuelRateInHighRpm = true;
+        // Counterfactual = same speed at lower RPM ≈
+        // _highRpmCounterfactualRatio × measured. Wasted = (measured −
+        // counterfactual) × dt.
+        final counterfactualRate = measuredRate * _highRpmCounterfactualRatio;
+        final wastedLPerHour = measuredRate - counterfactualRate;
+        highRpmWastedLiters += wastedLPerHour * dt / 3600.0;
+      }
+    }
+
+    // Hard-acceleration: derivative of speed across the interval.
+    // Convert km/h → m/s by / 3.6.
+    final dvMps = (cur.speedKmh - prev.speedKmh) / 3.6;
+    final accelMps2 = dvMps / dt;
+    if (accelMps2 >= _hardAccelThresholdMps2) {
+      hardAccelEvents++;
+      hardAccelTotalDt += dt;
+    }
+
+    // Idling: engine on (rpm > 0), car stationary (speed == 0) for
+    // the whole interval. Use a small tolerance on speed to absorb
+    // the OBD2 noise floor.
+    if (prev.speedKmh <= 0.5 && prev.rpm > 0) {
+      idleSeconds += dt;
+      final measuredRate = prev.fuelRateLPerHour;
+      // Idle wastes 100% of the fuel — there's no counterfactual,
+      // every drop is avoidable (turn the engine off).
+      final rate = (measuredRate != null && measuredRate > 0)
+          ? measuredRate
+          : _idleFuelRateAssumptionLPerHour;
+      idleWastedLiters += rate * dt / 3600.0;
+    }
+  }
+
+  final candidates = <DrivingInsight>[];
+
+  // High-RPM cost line.
+  if (highRpmSeconds > 0) {
+    // If no fuel-rate samples were available we can't quantify the
+    // waste — fall back to "60% of the measured rate" using a
+    // synthetic 6 L/h baseline so the cost line still surfaces.
+    // Documented in docs/guides/driving-insights.md.
+    final liters = sawFuelRateInHighRpm
+        ? highRpmWastedLiters
+        : _fallbackHighRpmWaste(highRpmSeconds);
+    final pctTime = highRpmSeconds / totalDt * 100.0;
+    if (liters >= _noiseFloorLiters) {
+      candidates.add(DrivingInsight(
+        labelKey: 'insightHighRpm',
+        litersWasted: liters,
+        percentOfTrip: pctTime,
+        metadata: {
+          'aboveRpm': _highRpmThreshold,
+          'highRpmSeconds': highRpmSeconds,
+          'pctTime': pctTime,
+        },
+      ));
+    }
+  }
+
+  // Hard-acceleration cost line.
+  if (hardAccelEvents > 0) {
+    final liters = hardAccelEvents * _wastedLitersPerHardAccelEvent;
+    final pctTime = hardAccelTotalDt / totalDt * 100.0;
+    if (liters >= _noiseFloorLiters) {
+      candidates.add(DrivingInsight(
+        labelKey: 'insightHardAccel',
+        litersWasted: liters,
+        percentOfTrip: pctTime,
+        metadata: {
+          'eventCount': hardAccelEvents,
+          'thresholdMps2': _hardAccelThresholdMps2,
+          'pctTime': pctTime,
+        },
+      ));
+    }
+  }
+
+  // Idling cost line.
+  if (idleSeconds > 0 && idleWastedLiters >= _noiseFloorLiters) {
+    final pctTime = idleSeconds / totalDt * 100.0;
+    candidates.add(DrivingInsight(
+      labelKey: 'insightIdling',
+      litersWasted: idleWastedLiters,
+      percentOfTrip: pctTime,
+      metadata: {
+        'idleSeconds': idleSeconds,
+        'pctTime': pctTime,
+      },
+    ));
+  }
+
+  // Sort by wasted litres descending and cap at [_topN].
+  candidates.sort((a, b) => b.litersWasted.compareTo(a.litersWasted));
+  if (candidates.length <= _topN) return candidates;
+  return candidates.sublist(0, _topN);
+}
+
+/// Fallback when no fuel-rate samples are available during the
+/// high-RPM window. Assumes a 6 L/h synthetic baseline at high RPM
+/// and applies the same counterfactual ratio. Documented in
+/// `docs/guides/driving-insights.md`.
+double _fallbackHighRpmWaste(double highRpmSeconds) {
+  const syntheticRateLPerHour = 6.0;
+  const wastedLPerHour =
+      syntheticRateLPerHour * (1 - _highRpmCounterfactualRatio);
+  return wastedLPerHour * highRpmSeconds / 3600.0;
+}

--- a/lib/features/consumption/domain/driving_insight.dart
+++ b/lib/features/consumption/domain/driving_insight.dart
@@ -1,0 +1,82 @@
+/// One "cost line" surfaced in the trip Insights tab (#1041 phase 1).
+///
+/// Each insight quantifies a single behaviour-driven fuel cost so the
+/// driver can see *how* the trip burned more fuel than it had to. The
+/// presentation layer (#1041 phase 2) maps [labelKey] to a localized
+/// string and renders [litersWasted] / [percentOfTrip] alongside it.
+///
+/// The class is intentionally UI-agnostic — no `BuildContext`, no
+/// `AppLocalizations`. The analyzer in
+/// `driving_insights_analyzer.dart` produces these from raw
+/// [TripSample]s; the same value-object can be persisted, replayed,
+/// or aggregated across trips later (phase 4) without touching UI
+/// code.
+class DrivingInsight {
+  /// l10n key (e.g. `'insightHighRpm'`, `'insightHardAccel'`,
+  /// `'insightIdling'`). The key is stable; phase 2 will add ARB
+  /// entries that consume it. Kept as a plain `String` rather than an
+  /// enum so future categories don't need a domain-layer change.
+  final String labelKey;
+
+  /// Estimated wasted fuel attributed to this cost line, in litres.
+  /// Always >= the noise floor in the analyzer (0.05 L by default).
+  final double litersWasted;
+
+  /// Share of the trip relevant to this cost line, in percent (0..100).
+  /// Semantics differ per category — for high-RPM it's the share of
+  /// time above threshold, for idling it's the share of time idling,
+  /// for hard-acceleration it's the share of distance during the
+  /// counted events. The label key communicates the meaning.
+  final double percentOfTrip;
+
+  /// Free-form supporting numbers for the UI (e.g. `aboveRpm: 3000`,
+  /// `eventCount: 4`). Use `num` so int and double both fit; phase 2
+  /// will pull values out by key.
+  final Map<String, num> metadata;
+
+  const DrivingInsight({
+    required this.labelKey,
+    required this.litersWasted,
+    required this.percentOfTrip,
+    this.metadata = const {},
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DrivingInsight &&
+        other.labelKey == labelKey &&
+        other.litersWasted == litersWasted &&
+        other.percentOfTrip == percentOfTrip &&
+        _mapEquals(other.metadata, metadata);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        labelKey,
+        litersWasted,
+        percentOfTrip,
+        // Hash the sorted entries so two equal maps with different
+        // insertion order still hash the same.
+        Object.hashAllUnordered(
+          metadata.entries.map((e) => Object.hash(e.key, e.value)),
+        ),
+      );
+
+  @override
+  String toString() => 'DrivingInsight('
+      'labelKey: $labelKey, '
+      'litersWasted: ${litersWasted.toStringAsFixed(3)}, '
+      'percentOfTrip: ${percentOfTrip.toStringAsFixed(1)}, '
+      'metadata: $metadata)';
+
+  static bool _mapEquals(Map<String, num> a, Map<String, num> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (final entry in a.entries) {
+      if (!b.containsKey(entry.key)) return false;
+      if (b[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+}

--- a/test/features/consumption/data/driving_insights_analyzer_test.dart
+++ b/test/features/consumption/data/driving_insights_analyzer_test.dart
@@ -1,0 +1,313 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/driving_insights_analyzer.dart';
+import 'package:tankstellen/features/consumption/domain/driving_insight.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// Pure-logic tests for the driving-insights analyzer (#1041 phase 1).
+///
+/// The analyzer turns a stream of [TripSample]s into the "Top-3 cost
+/// lines" surfaced on the trip Insights tab. Tests cover the noise
+/// floor, sort order, top-N cap, and the three phase-1 categories
+/// (high RPM, hard accel, idling).
+void main() {
+  group('analyzeTrip (#1041 phase 1)', () {
+    final start = DateTime.utc(2026);
+
+    test('empty samples → empty list', () {
+      expect(analyzeTrip(const []), isEmpty);
+    });
+
+    test('single sample → empty list (no Δt to integrate)', () {
+      final samples = [
+        TripSample(timestamp: start, speedKmh: 0, rpm: 800),
+      ];
+      expect(analyzeTrip(samples), isEmpty);
+    });
+
+    test('pure idle trip → idling insight only', () {
+      // 20 minutes idling: speed=0, rpm=800 throughout. At the default
+      // 0.6 L/h idle rate that's 0.2 L wasted, well above the 0.05 L
+      // noise floor.
+      final samples = <TripSample>[];
+      for (var i = 0; i <= 20; i++) {
+        samples.add(TripSample(
+          timestamp: start.add(Duration(minutes: i)),
+          speedKmh: 0,
+          rpm: 800,
+        ));
+      }
+
+      final insights = analyzeTrip(samples);
+      expect(insights, hasLength(1));
+      expect(insights.single.labelKey, 'insightIdling');
+      expect(insights.single.litersWasted, closeTo(0.2, 0.01));
+      expect(insights.single.percentOfTrip, closeTo(100.0, 0.5));
+      expect(insights.single.metadata['idleSeconds'], closeTo(1200, 1));
+    });
+
+    test(
+        'mixed trip with high-RPM segment → high-rpm insight ranked first, '
+        'idling second', () {
+      // Build a trip:
+      //   0-300s: cruising at 80 km/h, rpm=4000, fuelRate=12 L/h
+      //           (high-rpm window).
+      //   300-1200s: idling — speed=0, rpm=800 (15 minutes).
+      //
+      // Each interval attributes the whole Δt to the START sample
+      // (matches TripRecorder convention). So:
+      //   i=1: prev = (0s, rpm=4000)        → 300s of high-RPM
+      //                                       waste = (12 − 12*0.6) × 300/3600 = 0.4 L
+      //   i=2: prev = (300s, rpm=4000)      → 900s of high-RPM
+      //                                       no fuelRate on either side this step,
+      //                                       but cur sample at 1200s has none
+      //                                       either, and prev (300s) has 12 L/h
+      //                                       → adds (12−12*0.6) × 900/3600 = 1.2 L
+      //   i=3: prev = (1200s, speed=0)      → idle 0..0 (no-op)
+      // Wait — i=2 prev is the SECOND sample (still rpm=4000,
+      // fuelRate=12). High-RPM accumulator runs for 900 more seconds.
+      // Total high-RPM = 0.4 + 1.2 = 1.6 L over 1200s.
+      // Idle:
+      //   i=3: prev = (1200s, speed=0, rpm=800) → idle for 0s (no
+      //                                            following sample)
+      // We need an extra idle sample so the integrator sees a non-zero
+      // dt with prev=idle.
+      final samples = <TripSample>[
+        TripSample(
+          timestamp: start,
+          speedKmh: 80,
+          rpm: 4000,
+          fuelRateLPerHour: 12,
+        ),
+        TripSample(
+          timestamp: start.add(const Duration(seconds: 300)),
+          speedKmh: 80,
+          rpm: 4000,
+          fuelRateLPerHour: 12,
+        ),
+        TripSample(
+          timestamp: start.add(const Duration(seconds: 1200)),
+          speedKmh: 0,
+          rpm: 800,
+        ),
+        TripSample(
+          timestamp: start.add(const Duration(seconds: 2400)),
+          speedKmh: 0,
+          rpm: 800,
+        ),
+      ];
+
+      final insights = analyzeTrip(samples);
+      expect(insights.length, greaterThanOrEqualTo(2));
+      // High-RPM waste dominates (~1.6 L), idle is ~0.2 L (1200s ×
+      // 0.6 L/h ÷ 3600). Insights are sorted descending.
+      expect(insights.first.labelKey, 'insightHighRpm');
+      expect(insights.first.litersWasted, greaterThan(0.5));
+      // Idle insight is ranked after high-RPM; verify it's present.
+      final keys = insights.map((i) => i.labelKey).toList();
+      expect(keys.indexOf('insightIdling'),
+          greaterThan(keys.indexOf('insightHighRpm')));
+      // Confirm descending order.
+      for (var i = 1; i < insights.length; i++) {
+        expect(
+          insights[i - 1].litersWasted,
+          greaterThanOrEqualTo(insights[i].litersWasted),
+        );
+      }
+    });
+
+    test('5 hard-accel events → hard-accel insight present', () {
+      // 5 strong accelerations: 0 → 50 km/h in 2 s each (≈ 6.94 m/s²,
+      // well above the 3.0 m/s² threshold). Separated by 10 s of
+      // cruising at 50 km/h to avoid retriggering. Each event adds
+      // 0.05 L → 0.25 L total, above the 0.05 L noise floor.
+      var t = start;
+      final samples = <TripSample>[];
+      for (var i = 0; i < 5; i++) {
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 1000));
+        t = t.add(const Duration(seconds: 2));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 3000));
+        t = t.add(const Duration(seconds: 10));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2000));
+        t = t.add(const Duration(seconds: 1));
+      }
+
+      final insights = analyzeTrip(samples);
+      final hardAccel = insights.firstWhere(
+        (i) => i.labelKey == 'insightHardAccel',
+        orElse: () => throw StateError('expected hardAccel insight'),
+      );
+      expect(hardAccel.metadata['eventCount'], 5);
+      expect(hardAccel.litersWasted, closeTo(0.25, 0.001));
+    });
+
+    test('all-below-noise-floor trip → empty list', () {
+      // 10s of low-RPM, gentle cruising — nothing trips a category.
+      final samples = <TripSample>[
+        TripSample(
+          timestamp: start,
+          speedKmh: 50,
+          rpm: 2000,
+          fuelRateLPerHour: 5,
+        ),
+        TripSample(
+          timestamp: start.add(const Duration(seconds: 5)),
+          speedKmh: 51,
+          rpm: 2000,
+          fuelRateLPerHour: 5,
+        ),
+        TripSample(
+          timestamp: start.add(const Duration(seconds: 10)),
+          speedKmh: 50,
+          rpm: 2000,
+          fuelRateLPerHour: 5,
+        ),
+      ];
+      expect(analyzeTrip(samples), isEmpty);
+    });
+
+    test('top-3 cap respected when all 3 categories trigger', () {
+      // Construct a trip that triggers all three categories above the
+      // noise floor. The top-3 cap means the result is exactly the 3
+      // categories — but if more were ever added, the cap stays at 3.
+      //
+      // Segment A — 0..600s: 80 km/h, rpm=4000, fuelRate=12 L/h
+      //   → high-RPM waste = 0.8 L
+      // Segment B — 600..602s: 0 → 50 km/h (hard accel event #1)
+      // Segment C — 602..612s: 50 km/h, rpm=2500
+      // Segment D — 612..614s: 0 → 50 km/h (hard accel event #2 — needs
+      //   a fresh "stopped" sample to retrigger).
+      // Segment E — 1200..1500s: idling (300s × 0.6 L/h = 0.05 L).
+      final t = start;
+      final samples = <TripSample>[
+        TripSample(
+          timestamp: t,
+          speedKmh: 80,
+          rpm: 4000,
+          fuelRateLPerHour: 12,
+        ),
+        TripSample(
+          timestamp: t.add(const Duration(seconds: 600)),
+          speedKmh: 80,
+          rpm: 4000,
+          fuelRateLPerHour: 12,
+        ),
+        // Hard accel #1.
+        TripSample(
+          timestamp: t.add(const Duration(seconds: 600)),
+          speedKmh: 0,
+          rpm: 1000,
+        ),
+        TripSample(
+          timestamp: t.add(const Duration(seconds: 602)),
+          speedKmh: 50,
+          rpm: 3000,
+        ),
+        // Stopped again.
+        TripSample(
+          timestamp: t.add(const Duration(seconds: 612)),
+          speedKmh: 0,
+          rpm: 1000,
+        ),
+        // Hard accel #2.
+        TripSample(
+          timestamp: t.add(const Duration(seconds: 614)),
+          speedKmh: 50,
+          rpm: 3000,
+        ),
+        // Idling segment — 1200s at 0 km/h, rpm=800
+        // → 1200s × 0.6 L/h ÷ 3600 = 0.2 L well above noise floor.
+        TripSample(
+          timestamp: t.add(const Duration(seconds: 1200)),
+          speedKmh: 0,
+          rpm: 800,
+        ),
+        TripSample(
+          timestamp: t.add(const Duration(seconds: 2400)),
+          speedKmh: 0,
+          rpm: 800,
+        ),
+      ];
+
+      final insights = analyzeTrip(samples);
+      expect(insights.length, lessThanOrEqualTo(3));
+      final keys = insights.map((i) => i.labelKey).toSet();
+      expect(keys, containsAll(<String>{
+        'insightHighRpm',
+        'insightHardAccel',
+        'insightIdling',
+      }));
+      // High-RPM should rank first (largest waste).
+      expect(insights.first.labelKey, 'insightHighRpm');
+      // Sorted descending.
+      for (var i = 1; i < insights.length; i++) {
+        expect(
+          insights[i - 1].litersWasted,
+          greaterThanOrEqualTo(insights[i].litersWasted),
+        );
+      }
+    });
+
+    test('out-of-order samples are sorted before integration', () {
+      // Same as the pure-idle case but with the middle sample shoved
+      // to the end of the list. The analyzer must still produce the
+      // idling insight.
+      final samples = <TripSample>[
+        TripSample(timestamp: start, speedKmh: 0, rpm: 800),
+        TripSample(
+          timestamp: start.add(const Duration(minutes: 20)),
+          speedKmh: 0,
+          rpm: 800,
+        ),
+        TripSample(
+          timestamp: start.add(const Duration(minutes: 10)),
+          speedKmh: 0,
+          rpm: 800,
+        ),
+      ];
+      final insights = analyzeTrip(samples);
+      expect(insights, hasLength(1));
+      expect(insights.single.labelKey, 'insightIdling');
+    });
+
+    test('high-RPM with no fuel-rate samples falls back to synthetic baseline',
+        () {
+      // 600s above 3000 RPM but no fuelRateLPerHour readings.
+      // Synthetic baseline: 6 L/h × (1 - 0.6) × 600/3600 = 0.4 L.
+      final samples = <TripSample>[
+        TripSample(timestamp: start, speedKmh: 80, rpm: 4000),
+        TripSample(
+          timestamp: start.add(const Duration(seconds: 600)),
+          speedKmh: 80,
+          rpm: 4000,
+        ),
+      ];
+      final insights = analyzeTrip(samples);
+      expect(insights, hasLength(1));
+      expect(insights.single.labelKey, 'insightHighRpm');
+      expect(insights.single.litersWasted, closeTo(0.4, 0.05));
+    });
+
+    test('DrivingInsight equality and hashCode work as value-objects', () {
+      const a = DrivingInsight(
+        labelKey: 'insightIdling',
+        litersWasted: 0.2,
+        percentOfTrip: 100.0,
+        metadata: {'idleSeconds': 1200, 'pctTime': 100.0},
+      );
+      const b = DrivingInsight(
+        labelKey: 'insightIdling',
+        litersWasted: 0.2,
+        percentOfTrip: 100.0,
+        metadata: {'idleSeconds': 1200, 'pctTime': 100.0},
+      );
+      const c = DrivingInsight(
+        labelKey: 'insightIdling',
+        litersWasted: 0.3,
+        percentOfTrip: 100.0,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+  });
+}


### PR DESCRIPTION
## What

Phase 1 of #1041 — pure analytical layer for the per-trip "Top-3 cost lines" coaching feature. Ships:

- `lib/features/consumption/domain/driving_insight.dart` — immutable `DrivingInsight` value-object with `labelKey`, `litersWasted`, `percentOfTrip`, `metadata`, plus `==` / `hashCode` / `toString`.
- `lib/features/consumption/data/driving_insights_analyzer.dart` — `analyzeTrip(List<TripSample>) → List<DrivingInsight>` covering three behaviour categories (high RPM, hard acceleration, idling). Top-3 sorted by liters wasted.
- `docs/guides/driving-insights.md` — counterfactual-model documentation so future contributors can refine the formulas.
- `test/features/consumption/data/driving_insights_analyzer_test.dart` — 10 unit tests covering empty/single-sample/idle/mixed/hard-accel/noise-floor/top-3-cap/out-of-order/fallback/equality cases.

## Why

The second savings lens (burn less behind the wheel) needs **coaching**, not raw graphs. Each cost line tells the driver *how* the trip burned more fuel than necessary — quantified against an "if you had driven smoother" baseline. This phase isolates the math so the next PR can drop the UI on top with no surprises.

### Counterfactual model

- **High RPM (>3000)** — waste = (measuredRate − 0.6 × measuredRate) × Δt. Falls back to a synthetic 6 L/h baseline when no fuel-rate samples are available.
- **Hard acceleration (≥3.0 m/s²)** — 0.05 L per event (documented constant from fleet-telematics literature).
- **Idling (speed=0, rpm>0)** — waste = idle_time × idle_rate. Defaults to 0.6 L/h when not measured.
- Noise floor: 0.05 L. Top-N: 3. Sorted by litersWasted descending.

### What's deferred

Refs #1041 phase 1; phases 2-5 pending. Specifically:

- Phase 2 — Trip-detail Insights tab UI consuming `DrivingInsight`, ARB strings for label keys.
- Phase 3 — Driving score (Card A), histograms (C), cold-start (D), elevation (E).
- Phase 4 — Monthly aggregates surface.
- Phase 5 — Achievement hooks (smoothDriver, coldStartAware, highwayMaster).

## Testing

- [x] `flutter analyze` — zero issues.
- [x] `flutter test test/features/consumption/data/driving_insights_analyzer_test.dart` — 10 tests pass.
- [ ] Full suite — runs in CI.

## Leitmotiv check

Behind-the-wheel savings — squarely the second lens. Fits.