### PR TITLE
feat(ci): daily 18:00 Paris open-testing release

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -1,0 +1,122 @@
+name: Daily Open-Testing Build
+
+# Builds master at 18:00 Europe/Paris (CEST) and uploads to the open-testing track.
+# Cron is UTC: 16:00 UTC = 18:00 CEST (summer) / 17:00 CET (winter).
+# Adjust to '0 17 * * *' if you want 18:00 Paris during winter instead.
+#
+# Build numbers are date-based (YYYYMMDD) computed at build time, so there's no
+# commit pushed back to master. pubspec.yaml's +N keeps tracking manual releases.
+on:
+  schedule:
+    - cron: '0 16 * * *'
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Play track'
+        required: true
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+        default: beta
+      release_notes:
+        description: 'Release notes (overrides per-version changelog files)'
+        required: false
+        type: string
+
+concurrency:
+  group: daily-open-testing
+  cancel-in-progress: false
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+
+      - name: Compute date-based build number
+        id: bn
+        run: |
+          BN=$(TZ=Europe/Paris date +%Y%m%d)
+          echo "build_number=$BN" >> "$GITHUB_OUTPUT"
+          echo "Daily build number: $BN"
+
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: subosito/flutter-action@v3
+        with:
+          channel: stable
+          cache: true
+
+      - name: Decode signing keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ] || [ -z "$ANDROID_KEYSTORE_PASSWORD" ] || [ -z "$ANDROID_KEY_ALIAS" ]; then
+            echo "::error::Missing keystore secrets. Configure ANDROID_KEYSTORE_BASE64, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS." >&2
+            exit 1
+          fi
+          KEYSTORE_PATH="$RUNNER_TEMP/upload-keystore.jks"
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_PATH"
+          echo "ANDROID_KEYSTORE_PATH=$KEYSTORE_PATH" >> "$GITHUB_ENV"
+          echo "ANDROID_KEYSTORE_PASSWORD=$ANDROID_KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
+          echo "ANDROID_KEY_ALIAS=$ANDROID_KEY_ALIAS" >> "$GITHUB_ENV"
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Build AAB (play flavor, date-based build number)
+        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }}
+
+      - name: Clean up decoded keystore
+        if: always()
+        run: rm -f "$ANDROID_KEYSTORE_PATH"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Python deps
+        run: pip install --quiet google-api-python-client google-auth
+
+      - name: Decode service-account key
+        env:
+          SA_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "$SA_JSON" ]; then
+            echo "::error::PLAY_STORE_SERVICE_ACCOUNT_JSON secret is not set." >&2
+            exit 1
+          fi
+          echo "$SA_JSON" > "$RUNNER_TEMP/play-key.json"
+          echo "PLAY_KEY_PATH=$RUNNER_TEMP/play-key.json" >> "$GITHUB_ENV"
+
+      - name: Upload to Play Store
+        run: |
+          python tools/upload_to_play.py \
+            --aab build/app/outputs/bundle/playRelease/app-play-release.aab \
+            --key "$PLAY_KEY_PATH" \
+            --track "${{ github.event.inputs.track || 'beta' }}" \
+            ${{ github.event.inputs.release_notes && format('--release-notes "{0}"', github.event.inputs.release_notes) || '' }}
+
+      - name: Clean up service-account key
+        if: always()
+        run: rm -f "$PLAY_KEY_PATH"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Daily Open-Testing Release" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Build number:** ${{ steps.bn.outputs.build_number }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Track:** ${{ github.event.inputs.track || 'beta' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Trigger:** ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"

--- a/tools/upload_to_play.py
+++ b/tools/upload_to_play.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Upload a Flutter-built AAB to a Google Play track via the Android Publisher API.
+
+Usage:
+    python tools/upload_to_play.py                          # uses all defaults
+    python tools/upload_to_play.py --track internal         # internal testing
+    python tools/upload_to_play.py --release-notes "Daily build"
+    python tools/upload_to_play.py --dry-run                # validate without committing
+
+Requires:
+    - google-api-python-client, google-auth (pip install)
+    - Service-account JSON key with Play Console "Release manager" access
+    - AAB at build/app/outputs/bundle/release/app-release.aab (or pass --aab)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaFileUpload
+
+DEFAULT_PACKAGE = "de.tankstellen.fuelprices"
+DEFAULT_TRACK = "beta"  # 'beta' = open testing, 'internal' = internal, 'alpha' = closed, 'production' = prod
+DEFAULT_AAB = "build/app/outputs/bundle/playRelease/app-play-release.aab"
+DEFAULT_KEY = os.path.expanduser("~/.play-console-key.json")
+DEFAULT_CHANGELOG_DIR = "fastlane/metadata/android"
+DEFAULT_LOCALES = ["de-DE", "en-US", "fr-FR"]
+SCOPES = ["https://www.googleapis.com/auth/androidpublisher"]
+
+
+def load_release_notes(
+    changelog_dir: Path,
+    locales: list[str],
+    version_code: int,
+    fallback: str,
+) -> list[dict]:
+    """Build the releaseNotes payload, one entry per locale.
+
+    For each locale, prefer fastlane/metadata/android/{locale}/changelogs/{versionCode}.txt;
+    fall back to the provided default text if the file is missing.
+    """
+    notes = []
+    for locale in locales:
+        path = changelog_dir / locale / "changelogs" / f"{version_code}.txt"
+        if path.is_file():
+            text = path.read_text(encoding="utf-8").strip()
+            print(f"  [{locale}] using {path}")
+        else:
+            text = fallback
+            print(f"  [{locale}] no per-version changelog, using fallback")
+        # Play Store caps release notes at 500 chars per locale
+        if len(text) > 500:
+            print(f"  [{locale}] WARNING: truncated from {len(text)} to 500 chars")
+            text = text[:497] + "..."
+        notes.append({"language": locale, "text": text})
+    return notes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--package", default=DEFAULT_PACKAGE, help=f"App package name (default: {DEFAULT_PACKAGE})")
+    parser.add_argument("--track", default=DEFAULT_TRACK, choices=["internal", "alpha", "beta", "production"],
+                        help=f"Play Store track (default: {DEFAULT_TRACK} = open testing)")
+    parser.add_argument("--aab", default=DEFAULT_AAB, help=f"Path to AAB (default: {DEFAULT_AAB})")
+    parser.add_argument("--key", default=DEFAULT_KEY, help=f"Service-account JSON key path (default: {DEFAULT_KEY})")
+    parser.add_argument("--changelog-dir", default=DEFAULT_CHANGELOG_DIR,
+                        help=f"Root of fastlane-style changelog metadata (default: {DEFAULT_CHANGELOG_DIR})")
+    parser.add_argument("--locales", nargs="+", default=DEFAULT_LOCALES,
+                        help=f"Locales to publish release notes for (default: {' '.join(DEFAULT_LOCALES)})")
+    parser.add_argument("--release-notes", default=None,
+                        help="Fallback release-notes text used when a per-version changelog file is missing. "
+                             "Defaults to 'Daily build YYYY-MM-DD'.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Validate the edit without committing (no testers receive the build)")
+    args = parser.parse_args()
+
+    aab = Path(args.aab).resolve()
+    key = Path(args.key).resolve()
+    changelog_dir = Path(args.changelog_dir).resolve()
+
+    if not aab.is_file():
+        print(f"ERROR: AAB not found at {aab}", file=sys.stderr)
+        print("       Run `flutter build appbundle --release` first.", file=sys.stderr)
+        return 2
+    if not key.is_file():
+        print(f"ERROR: service-account key not found at {key}", file=sys.stderr)
+        return 2
+
+    fallback_notes = args.release_notes or f"Daily build {date.today().isoformat()}"
+
+    print(f"Authenticating as service account from {key}")
+    creds = service_account.Credentials.from_service_account_file(str(key), scopes=SCOPES)
+    service = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
+    edits = service.edits()
+
+    print(f"Opening edit for {args.package}")
+    try:
+        edit = edits.insert(packageName=args.package, body={}).execute()
+    except HttpError as e:
+        print(f"ERROR: edits.insert failed: {e}", file=sys.stderr)
+        return 3
+    edit_id = edit["id"]
+    print(f"  edit id: {edit_id}")
+
+    print(f"Uploading {aab} ({aab.stat().st_size / 1_000_000:.2f} MB)")
+    media = MediaFileUpload(str(aab), mimetype="application/octet-stream", resumable=True)
+    try:
+        bundle = edits.bundles().upload(
+            packageName=args.package,
+            editId=edit_id,
+            media_body=media,
+        ).execute()
+    except HttpError as e:
+        print(f"ERROR: bundle upload failed: {e}", file=sys.stderr)
+        return 4
+    version_code = bundle["versionCode"]
+    print(f"  uploaded versionCode: {version_code}")
+
+    print(f"Resolving release notes for versionCode {version_code}")
+    release_notes = load_release_notes(changelog_dir, args.locales, version_code, fallback_notes)
+
+    print(f"Assigning to track '{args.track}'")
+    try:
+        edits.tracks().update(
+            packageName=args.package,
+            editId=edit_id,
+            track=args.track,
+            body={
+                "track": args.track,
+                "releases": [{
+                    "name": f"{version_code}",
+                    "versionCodes": [str(version_code)],
+                    "status": "completed",
+                    "releaseNotes": release_notes,
+                }],
+            },
+        ).execute()
+    except HttpError as e:
+        print(f"ERROR: track update failed: {e}", file=sys.stderr)
+        return 5
+
+    if args.dry_run:
+        print("Dry-run: validating edit (no commit)")
+        try:
+            edits.validate(packageName=args.package, editId=edit_id).execute()
+            print("Validation OK — edit will NOT be committed (dry-run).")
+        except HttpError as e:
+            print(f"ERROR: validation failed: {e}", file=sys.stderr)
+            return 6
+        return 0
+
+    print("Committing edit")
+    try:
+        edits.commit(packageName=args.package, editId=edit_id).execute()
+    except HttpError as e:
+        print(f"ERROR: edits.commit failed: {e}", file=sys.stderr)
+        return 7
+
+    print(f"\nSUCCESS: versionCode {version_code} published to track '{args.track}'")
+    print(f"https://play.google.com/console/u/0/developers/5325652654414690657/app/4973487066249778216/tracks/open-testing")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/daily-beta.yml` — cron-triggered workflow that builds master at 18:00 Europe/Paris (16:00 UTC) and uploads to the open-testing track.
- Adds `tools/upload_to_play.py` — small Python helper that uses the Google Play Developer API to upload a signed AAB to a chosen track. Reuses existing fastlane-style changelog metadata (`fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt`) when present, otherwise falls back to "Daily build YYYY-MM-DD".

## Why
Testers should automatically receive a fresh open-testing build every day without manual upload steps. The script can also be run locally for ad-hoc uploads (e.g. `python tools/upload_to_play.py --dry-run`).

## Build number strategy
Date-based (`YYYYMMDD`) computed at build time and passed via `flutter build appbundle --build-number=...`. No commit is pushed back to master, so this avoids the master-branch-protection rule. `pubspec.yaml`'s `+N` continues to track manual releases independently.

## Secrets
- Reuses existing `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS` (already configured for `ci.yml`).
- Adds dependency on `PLAY_STORE_SERVICE_ACCOUNT_JSON` (already configured before this PR was opened).

## DST behaviour
Cron is `0 16 * * *` UTC. Resolves to:
- 18:00 Paris during CEST (summer)
- 17:00 Paris during CET (winter)

If 18:00 Paris year-round matters, switch to the `0 17 * * *` cron during winter manually. (GitHub Actions cron is UTC-only — no native timezone support.)

## Validation
- `tools/upload_to_play.py --dry-run` was test-run end-to-end on 2026-04-25 against the open-testing track (versionCode 5102) — uploaded successfully.
- Workflow file syntax has not yet been validated by CI; recommend triggering `workflow_dispatch` after merge to confirm.

## Test plan
- [ ] Merge this PR.
- [ ] Trigger the workflow manually: Actions → "Daily Open-Testing Build" → Run workflow → track: beta.
- [ ] Verify a new release appears on the open-testing track in Play Console.
- [ ] Verify the cron fires the next day at 18:00 Paris.

🤖 Generated with [Claude Code](https://claude.com/claude-code)