### PR TITLE
fix(ci): pin daily-beta to existing action versions

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -46,12 +46,12 @@ jobs:
           echo "build_number=$BN" >> "$GITHUB_OUTPUT"
           echo "Daily build number: $BN"
 
-      - uses: actions/setup-java@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
-      - uses: subosito/flutter-action@v3
+      - uses: subosito/flutter-action@v2
         with:
           channel: stable
           cache: true
@@ -82,7 +82,7 @@ jobs:
         if: always()
         run: rm -f "$ANDROID_KEYSTORE_PATH"
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Summary
- Replace `actions/setup-java@v6` → `@v5` (v6 doesn't exist).
- Replace `subosito/flutter-action@v3` → `@v2` (v3 doesn't exist).
- Replace `actions/setup-python@v6` → `@v5` (v6 doesn't exist).

These are the same versions `ci.yml` uses, so they're known-good. The previous run failed at "Set up job" with "unable to resolve action ... unable to find version".

## Test plan
- [ ] CI green (analyze + test).
- [ ] Re-trigger workflow_dispatch on master after merge → expect successful AAB build + open-testing upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)