### PR TITLE
test(error-tracing): cover integration observers and interceptor (Refs #561)

### DIFF
--- a/test/core/error_tracing/integrations/dio_trace_interceptor_test.dart
+++ b/test/core/error_tracing/integrations/dio_trace_interceptor_test.dart
@@ -1,0 +1,192 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error_tracing/collectors/app_state_collector.dart';
+import 'package:tankstellen/core/error_tracing/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/error_tracing/integrations/dio_trace_interceptor.dart';
+import 'package:tankstellen/core/error_tracing/models/error_trace.dart';
+import 'package:tankstellen/core/error_tracing/trace_recorder.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+
+/// Fake recorder that captures (error, stackTrace) without touching storage,
+/// uploader, or the connectivity_plus method channel.
+class _FakeTraceRecorder implements TraceRecorder {
+  Object? capturedError;
+  StackTrace? capturedStack;
+  int recordCount = 0;
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    capturedError = error;
+    capturedStack = stackTrace;
+    recordCount++;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => null;
+}
+
+/// Captures the most recent `next(options)` invocation.
+class _CapturingRequestHandler extends RequestInterceptorHandler {
+  RequestOptions? lastOptions;
+  int nextCount = 0;
+
+  @override
+  void next(RequestOptions options) {
+    lastOptions = options;
+    nextCount++;
+  }
+}
+
+class _CapturingErrorHandler extends ErrorInterceptorHandler {
+  DioException? lastError;
+  int nextCount = 0;
+
+  @override
+  void next(DioException err) {
+    lastError = err;
+    nextCount++;
+  }
+}
+
+void main() {
+  // Sanity: there is no public reset on AppStateCollector / BreadcrumbCollector
+  // for static fields from other tests, so each test overwrites the values it
+  // cares about and asserts on what it just set.
+  setUp(() {
+    BreadcrumbCollector.clear();
+    // Overwrite the static endpoint slot so a previous test's value can't leak
+    // into the assertion below.
+    AppStateCollector.updateLastApi('');
+  });
+
+  group('DioTraceInterceptor', () {
+    test(
+      'onRequest updates AppStateCollector + emits api:request breadcrumb + forwards',
+      () async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        late Ref capturedRef;
+        final refCapture = Provider<int>((ref) {
+          capturedRef = ref;
+          return 0;
+        });
+        container.read(refCapture);
+
+        final interceptor = DioTraceInterceptor(capturedRef);
+        final handler = _CapturingRequestHandler();
+        final options = RequestOptions(
+          method: 'GET',
+          path: '/foo',
+        );
+
+        interceptor.onRequest(options, handler);
+
+        // forwarded exactly once with the same options
+        expect(handler.nextCount, 1);
+        expect(handler.lastOptions, same(options));
+
+        // last endpoint is recorded as "METHOD path"
+        // We need a Ref with storageRepositoryProvider overridden to read
+        // the snapshot, but only the lastApiEndpoint field is what we assert.
+        // Set up a fresh container that *can* read storage; but since the
+        // collector's slot is static, reading from any container suffices.
+        final readerContainer = ProviderContainer(overrides: [
+          storageRepositoryProvider.overrideWithValue(_NullStorage()),
+        ]);
+        addTearDown(readerContainer.dispose);
+        late Ref readerRef;
+        final readerCapture = Provider<int>((ref) {
+          readerRef = ref;
+          return 0;
+        });
+        readerContainer.read(readerCapture);
+
+        final snapshot = AppStateCollector.collect(readerRef);
+        expect(snapshot.lastApiEndpoint, 'GET /foo');
+
+        // breadcrumb recorded
+        final breadcrumbs = BreadcrumbCollector.snapshot();
+        expect(breadcrumbs, isNotEmpty);
+        final last = breadcrumbs.last;
+        expect(last.action, 'api:request');
+        expect(last.detail, 'GET /foo');
+      },
+    );
+
+    test('onError forwards (error, stackTrace) to TraceRecorder + handler', () {
+      final fakeRecorder = _FakeTraceRecorder();
+      final container = ProviderContainer(overrides: [
+        traceRecorderProvider.overrideWithValue(fakeRecorder),
+      ]);
+      addTearDown(container.dispose);
+
+      late Ref capturedRef;
+      final refCapture = Provider<int>((ref) {
+        capturedRef = ref;
+        return 0;
+      });
+      container.read(refCapture);
+
+      final interceptor = DioTraceInterceptor(capturedRef);
+      final handler = _CapturingErrorHandler();
+      final stack = StackTrace.current;
+      final dioErr = DioException(
+        requestOptions: RequestOptions(path: '/boom'),
+        type: DioExceptionType.connectionError,
+        error: 'connection refused',
+        stackTrace: stack,
+      );
+
+      interceptor.onError(dioErr, handler);
+
+      expect(fakeRecorder.recordCount, 1);
+      expect(fakeRecorder.capturedError, same(dioErr));
+      expect(fakeRecorder.capturedStack, same(stack));
+
+      expect(handler.nextCount, 1);
+      expect(handler.lastError, same(dioErr));
+    });
+
+    test('onRequest: empty path still produces "METHOD " endpoint', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      late Ref capturedRef;
+      final refCapture = Provider<int>((ref) {
+        capturedRef = ref;
+        return 0;
+      });
+      container.read(refCapture);
+
+      final interceptor = DioTraceInterceptor(capturedRef);
+      final handler = _CapturingRequestHandler();
+      final options = RequestOptions(method: 'POST', path: '/');
+
+      interceptor.onRequest(options, handler);
+
+      expect(handler.nextCount, 1);
+      final breadcrumbs = BreadcrumbCollector.snapshot();
+      expect(breadcrumbs.last.action, 'api:request');
+      expect(breadcrumbs.last.detail, startsWith('POST '));
+    });
+  });
+}
+
+/// Minimal NoSQL stub for storageRepositoryProvider — only the two methods
+/// `AppStateCollector.collect` reads need to return null/empty values.
+class _NullStorage implements StorageRepository {
+  @override
+  String? getActiveProfileId() => null;
+
+  @override
+  Map<String, dynamic>? getProfile(String id) => null;
+
+  @override
+  noSuchMethod(Invocation invocation) => null;
+}

--- a/test/core/error_tracing/integrations/navigation_trace_observer_test.dart
+++ b/test/core/error_tracing/integrations/navigation_trace_observer_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/error_tracing/collectors/app_state_collector.dart';
+import 'package:tankstellen/core/error_tracing/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/error_tracing/integrations/navigation_trace_observer.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+
+/// Minimal storage repo so AppStateCollector.collect doesn't fail when reading
+/// the active profile.
+class _NullStorage implements StorageRepository {
+  @override
+  String? getActiveProfileId() => null;
+
+  @override
+  Map<String, dynamic>? getProfile(String id) => null;
+
+  @override
+  noSuchMethod(Invocation invocation) => null;
+}
+
+Route<dynamic> _route(String? name) => MaterialPageRoute<dynamic>(
+      settings: RouteSettings(name: name),
+      builder: (_) => const SizedBox.shrink(),
+    );
+
+void main() {
+  late ProviderContainer container;
+  late Ref ref;
+
+  setUp(() {
+    BreadcrumbCollector.clear();
+    AppStateCollector.updateRoute('');
+
+    container = ProviderContainer(overrides: [
+      storageRepositoryProvider.overrideWithValue(_NullStorage()),
+    ]);
+    final refCapture = Provider<int>((r) {
+      ref = r;
+      return 0;
+    });
+    container.read(refCapture);
+  });
+
+  tearDown(() => container.dispose());
+
+  group('NavigationTraceObserver', () {
+    test('didPush updates active route + records navigate breadcrumb', () {
+      final observer = NavigationTraceObserver();
+
+      observer.didPush(_route('home'), null);
+
+      expect(AppStateCollector.collect(ref).activeRoute, 'home');
+      final breadcrumbs = BreadcrumbCollector.snapshot();
+      expect(breadcrumbs, hasLength(1));
+      expect(breadcrumbs.first.action, 'navigate:home');
+    });
+
+    test('didPush with null name defaults to "unknown"', () {
+      final observer = NavigationTraceObserver();
+
+      observer.didPush(_route(null), null);
+
+      expect(AppStateCollector.collect(ref).activeRoute, 'unknown');
+      expect(BreadcrumbCollector.snapshot().last.action, 'navigate:unknown');
+    });
+
+    test('didReplace tracks newRoute when present', () {
+      final observer = NavigationTraceObserver();
+
+      observer.didReplace(
+        newRoute: _route('settings'),
+        oldRoute: _route('home'),
+      );
+
+      expect(AppStateCollector.collect(ref).activeRoute, 'settings');
+      expect(BreadcrumbCollector.snapshot().last.action, 'navigate:settings');
+    });
+
+    test('didReplace with newRoute=null is a no-op', () {
+      final observer = NavigationTraceObserver();
+      // Seed a known route via didPush so we can detect a leak.
+      observer.didPush(_route('seeded'), null);
+      final breadcrumbCountAfterSeed = BreadcrumbCollector.snapshot().length;
+
+      observer.didReplace(newRoute: null, oldRoute: _route('home'));
+
+      // Active route unchanged; no new breadcrumb added.
+      expect(AppStateCollector.collect(ref).activeRoute, 'seeded');
+      expect(
+        BreadcrumbCollector.snapshot().length,
+        breadcrumbCountAfterSeed,
+      );
+    });
+
+    test('didPop tracks the previous route', () {
+      final observer = NavigationTraceObserver();
+
+      observer.didPop(_route('detail'), _route('list'));
+
+      expect(AppStateCollector.collect(ref).activeRoute, 'list');
+      expect(BreadcrumbCollector.snapshot().last.action, 'navigate:list');
+    });
+
+    test('didPop with previousRoute=null is a no-op', () {
+      final observer = NavigationTraceObserver();
+      observer.didPush(_route('seeded'), null);
+      final beforeLen = BreadcrumbCollector.snapshot().length;
+
+      observer.didPop(_route('detail'), null);
+
+      expect(AppStateCollector.collect(ref).activeRoute, 'seeded');
+      expect(BreadcrumbCollector.snapshot().length, beforeLen);
+    });
+
+    test('didPop with anonymous previousRoute defaults to "unknown"', () {
+      final observer = NavigationTraceObserver();
+
+      observer.didPop(_route('detail'), _route(null));
+
+      expect(AppStateCollector.collect(ref).activeRoute, 'unknown');
+      expect(BreadcrumbCollector.snapshot().last.action, 'navigate:unknown');
+    });
+  });
+}

--- a/test/core/error_tracing/integrations/riverpod_trace_observer_test.dart
+++ b/test/core/error_tracing/integrations/riverpod_trace_observer_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error_tracing/integrations/riverpod_trace_observer.dart';
+import 'package:tankstellen/core/error_tracing/models/error_trace.dart';
+import 'package:tankstellen/core/error_tracing/trace_recorder.dart';
+
+class _FakeTraceRecorder implements TraceRecorder {
+  Object? capturedError;
+  StackTrace? capturedStack;
+  int recordCount = 0;
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    capturedError = error;
+    capturedStack = stackTrace;
+    recordCount++;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => null;
+}
+
+/// A provider whose build throws — used to drive the natural
+/// `providerDidFail` path inside the Riverpod runtime so the test
+/// exercises the observer end-to-end (no internal-API construction
+/// of `ProviderObserverContext`).
+final _exploding = Provider<int>((ref) {
+  throw StateError('boom');
+});
+
+void main() {
+  group('RiverpodTraceObserver', () {
+    test(
+      'providerDidFail forwards (error, stackTrace) to traceRecorderProvider',
+      () {
+        final fakeRecorder = _FakeTraceRecorder();
+
+        // Build the container *first*, then attach the observer using the
+        // explicit constructor argument — RiverpodTraceObserver(_container)
+        // breaks the chicken-and-egg by storing the container reference.
+        late ProviderContainer container;
+        final observer =
+            _DeferredObserver((c) => RiverpodTraceObserver(c));
+        container = ProviderContainer(
+          observers: [observer],
+          overrides: [
+            traceRecorderProvider.overrideWithValue(fakeRecorder),
+          ],
+        );
+        observer.attach(container);
+        addTearDown(container.dispose);
+
+        // Trigger a build error → Riverpod will invoke providerDidFail on
+        // every observer with the original error + stackTrace.
+        // (Riverpod 3.x re-throws as ProviderException; the observer still
+        // receives the original StateError.)
+        expect(() => container.read(_exploding), throwsA(isA<Object>()));
+
+        expect(fakeRecorder.recordCount, 1);
+        expect(fakeRecorder.capturedError, isA<StateError>());
+        expect(
+          (fakeRecorder.capturedError as StateError).message,
+          'boom',
+        );
+        expect(fakeRecorder.capturedStack, isNotNull);
+      },
+    );
+
+    test('multiple failing reads each forward to the recorder', () {
+      final fakeRecorder = _FakeTraceRecorder();
+      late ProviderContainer container;
+      final observer = _DeferredObserver((c) => RiverpodTraceObserver(c));
+      container = ProviderContainer(
+        observers: [observer],
+        overrides: [
+          traceRecorderProvider.overrideWithValue(fakeRecorder),
+        ],
+      );
+      observer.attach(container);
+      addTearDown(container.dispose);
+
+      expect(() => container.read(_exploding), throwsA(isA<Object>()));
+      // Invalidate so the build runs again on the next read.
+      container.invalidate(_exploding);
+      expect(() => container.read(_exploding), throwsA(isA<Object>()));
+
+      expect(fakeRecorder.recordCount, 2);
+    });
+  });
+}
+
+/// Wrapper that lets us pass an observer to `ProviderContainer` and then
+/// inject the container reference (resolves the chicken-and-egg without
+/// touching `@internal` Riverpod APIs).
+final class _DeferredObserver extends ProviderObserver {
+  _DeferredObserver(this._build);
+  final RiverpodTraceObserver Function(ProviderContainer) _build;
+  RiverpodTraceObserver? _delegate;
+
+  void attach(ProviderContainer container) {
+    _delegate = _build(container);
+  }
+
+  @override
+  void providerDidFail(
+    ProviderObserverContext context,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    _delegate?.providerDidFail(context, error, stackTrace);
+  }
+}


### PR DESCRIPTION
Refs #561 phase X — cover `DioTraceInterceptor`, `NavigationTraceObserver`, `RiverpodTraceObserver`

## What

Three new test files cover the previously zero-coverage glue layer in `lib/core/error_tracing/integrations/`:

| File under test | LOC | New test file | Tests |
|---|---|---|---|
| `dio_trace_interceptor.dart` | 27 | `dio_trace_interceptor_test.dart` | 3 |
| `navigation_trace_observer.dart` | 27 | `navigation_trace_observer_test.dart` | 7 |
| `riverpod_trace_observer.dart` | 16 | `riverpod_trace_observer_test.dart` | 2 |
| **Total** | **70** | | **12** |

### Methods covered

**`DioTraceInterceptor`**
- `onRequest`: writes `AppStateCollector.lastApiEndpoint = "GET /foo"`, emits `BreadcrumbCollector` entry `api:request` with detail, calls `handler.next(options)` exactly once with the same options.
- `onError`: forwards `(error, stackTrace)` to the `traceRecorderProvider` (overridden with a fake recorder) and re-emits to `handler.next(err)`.
- Edge case: empty/`/` path still produces a `METHOD ` endpoint and a breadcrumb.

**`NavigationTraceObserver`**
- `didPush(route, prev)` updates `activeRoute` + records `navigate:<name>` breadcrumb.
- `didPush` with `route.settings.name == null` defaults to `"unknown"`.
- `didReplace(newRoute, oldRoute)` tracks new route when present.
- `didReplace(newRoute: null, …)` is a no-op (active route + breadcrumb count unchanged).
- `didPop(route, previousRoute)` tracks the previous route's name.
- `didPop(_, null)` is a no-op.
- `didPop` with anonymous previousRoute defaults to `"unknown"`.

**`RiverpodTraceObserver`**
- Drives the natural `providerDidFail` path by `container.read(...)`-ing a provider whose `build` throws `StateError('boom')` — observer receives the original `StateError` (not the Riverpod 3.x `ProviderException` wrapper) and forwards it to the recorder.
- Multiple failing reads each invoke the recorder once.

## Why

These three files are integration glue between the Tankstellen error-tracing pipeline and Dio / Flutter Navigator / Riverpod runtime. Zero coverage today (verified via `grep -r '<ClassName>' test/`); a future regression in Dio's interceptor contract or Riverpod's observer signature would silently break all error reporting.

## Implementation notes

- **Static-state-reset gymnastics**: `AppStateCollector` and `BreadcrumbCollector` keep static fields, so `setUp` calls `BreadcrumbCollector.clear()` and `AppStateCollector.updateLastApi('') / updateRoute('')` to overwrite leakage from prior tests.
- **No `@internal` API touch**: `ProviderObserverContext`'s constructor is `@internal`. Instead of constructing one directly, the test reads a deliberately-throwing provider so Riverpod itself synthesizes the context and routes through `providerDidFail` — exercising the observer end-to-end. A thin `_DeferredObserver` wrapper resolves the chicken-and-egg between `ProviderContainer` construction and the `RiverpodTraceObserver(_container)` constructor argument.
- **Fake recorder via `implements TraceRecorder`**: avoids dragging Hive (`TraceStorage`), the `connectivity_plus` method channel (`NetworkStateCollector`), and `TraceUploader` into these tests.
- **No `lib/` edits**: only the 3 new test files.

## Testing

- `flutter analyze` — `No issues found! (ran in 45.2s)`
- `flutter test test/core/error_tracing/integrations/` — `+12: All tests passed!`
- `flutter test test/lint/no_silent_catch_test.dart` — passes
- `flutter test` (full suite) — `+7782 ~1: All tests passed!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)