### PR TITLE
test(profile): cover ProfileEditState + controller (Refs #561)

### DIFF
--- a/test/features/profile/providers/profile_edit_provider_test.dart
+++ b/test/features/profile/providers/profile_edit_provider_test.dart
@@ -5,6 +5,9 @@ import 'package:tankstellen/features/profile/providers/profile_edit_provider.dar
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
 void main() {
+  // Fully-populated fixture so every field has a non-default, distinguishable
+  // value. Tests that mutate one field can then assert the rest survived
+  // unchanged, catching future drift in copyWith / fromProfile.
   const profile = UserProfile(
     id: 'p1',
     name: 'Test',
@@ -18,7 +21,49 @@ void main() {
     showFuel: true,
     showElectric: false,
     ratingMode: 'local',
+    defaultVehicleId: 'veh-1',
   );
+
+  // Baseline state derived from the fixture profile, used as the
+  // "untouched" reference in copyWith per-field tests.
+  ProfileEditState baseState() => ProfileEditState.fromProfile(profile);
+
+  /// Asserts every ProfileEditState field other than [skip] equals the
+  /// matching field on [reference]. Catches accidental cross-field mutation
+  /// in copyWith.
+  void expectAllFieldsExcept(
+    ProfileEditState actual,
+    ProfileEditState reference, {
+    required String skip,
+  }) {
+    if (skip != 'fuelType') expect(actual.fuelType, reference.fuelType);
+    if (skip != 'radius') expect(actual.radius, reference.radius);
+    if (skip != 'landingScreen') {
+      expect(actual.landingScreen, reference.landingScreen);
+    }
+    if (skip != 'countryCode') {
+      expect(actual.countryCode, reference.countryCode);
+    }
+    if (skip != 'languageCode') {
+      expect(actual.languageCode, reference.languageCode);
+    }
+    if (skip != 'routeSegmentKm') {
+      expect(actual.routeSegmentKm, reference.routeSegmentKm);
+    }
+    if (skip != 'avoidHighways') {
+      expect(actual.avoidHighways, reference.avoidHighways);
+    }
+    if (skip != 'showFuel') expect(actual.showFuel, reference.showFuel);
+    if (skip != 'showElectric') {
+      expect(actual.showElectric, reference.showElectric);
+    }
+    if (skip != 'ratingMode') {
+      expect(actual.ratingMode, reference.ratingMode);
+    }
+    if (skip != 'defaultVehicleId') {
+      expect(actual.defaultVehicleId, reference.defaultVehicleId);
+    }
+  }
 
   ProviderContainer makeContainer() {
     final c = ProviderContainer();
@@ -26,61 +71,351 @@ void main() {
     return c;
   }
 
-  test('initial state matches profile', () {
-    final c = makeContainer();
-    final s = c.read(profileEditControllerProvider(profile));
+  group('ProfileEditState.fromProfile', () {
+    test('mirrors every field of the source profile', () {
+      final s = ProfileEditState.fromProfile(profile);
 
-    expect(s.fuelType, FuelType.e10);
-    expect(s.radius, 12);
-    expect(s.landingScreen, LandingScreen.favorites);
-    expect(s.countryCode, 'DE');
-    expect(s.languageCode, 'de');
-    expect(s.routeSegmentKm, 100);
-    expect(s.avoidHighways, isFalse);
-    expect(s.showFuel, isTrue);
-    expect(s.showElectric, isFalse);
-    expect(s.ratingMode, 'local');
+      expect(s.fuelType, profile.preferredFuelType);
+      expect(s.radius, profile.defaultSearchRadius);
+      expect(s.landingScreen, profile.landingScreen);
+      expect(s.countryCode, profile.countryCode);
+      expect(s.languageCode, profile.languageCode);
+      expect(s.routeSegmentKm, profile.routeSegmentKm);
+      expect(s.avoidHighways, profile.avoidHighways);
+      expect(s.showFuel, profile.showFuel);
+      expect(s.showElectric, profile.showElectric);
+      expect(s.ratingMode, profile.ratingMode);
+      expect(s.defaultVehicleId, profile.defaultVehicleId);
+    });
+
+    test('preserves null countryCode / languageCode / defaultVehicleId', () {
+      const minimal = UserProfile(id: 'p3', name: 'Minimal');
+      final s = ProfileEditState.fromProfile(minimal);
+
+      expect(s.countryCode, isNull);
+      expect(s.languageCode, isNull);
+      expect(s.defaultVehicleId, isNull);
+      // And defaults from UserProfile flow through.
+      expect(s.fuelType, FuelType.e10);
+      expect(s.radius, 10.0);
+      expect(s.landingScreen, LandingScreen.nearest);
+      expect(s.routeSegmentKm, 50.0);
+      expect(s.avoidHighways, isFalse);
+      expect(s.showFuel, isTrue);
+      expect(s.showElectric, isTrue);
+      expect(s.ratingMode, 'local');
+    });
   });
 
-  test('mutators update state', () {
-    final c = makeContainer();
-    final ctrl =
-        c.read(profileEditControllerProvider(profile).notifier);
+  group('ProfileEditState.copyWith', () {
+    test('no arguments returns a state equal in every field', () {
+      final base = baseState();
+      final copy = base.copyWith();
+      expectAllFieldsExcept(copy, base, skip: '__none__');
+    });
 
-    ctrl.setFuelType(FuelType.diesel);
-    ctrl.setRadius(20);
-    ctrl.setRouteSegmentKm(250);
-    ctrl.setAvoidHighways(true);
-    ctrl.setShowFuel(false);
-    ctrl.setShowElectric(true);
-    ctrl.setRatingMode('shared');
-    ctrl.setLandingScreen(LandingScreen.cheapest);
-    ctrl.setCountryCode('FR');
-    ctrl.setLanguageCode('fr');
+    test('fuelType only changes fuelType', () {
+      final base = baseState();
+      final copy = base.copyWith(fuelType: FuelType.diesel);
+      expect(copy.fuelType, FuelType.diesel);
+      expectAllFieldsExcept(copy, base, skip: 'fuelType');
+    });
 
-    final s = c.read(profileEditControllerProvider(profile));
-    expect(s.fuelType, FuelType.diesel);
-    expect(s.radius, 20);
-    expect(s.routeSegmentKm, 250);
-    expect(s.avoidHighways, isTrue);
-    expect(s.showFuel, isFalse);
-    expect(s.showElectric, isTrue);
-    expect(s.ratingMode, 'shared');
-    expect(s.landingScreen, LandingScreen.cheapest);
-    expect(s.countryCode, 'FR');
-    expect(s.languageCode, 'fr');
+    test('radius only changes radius', () {
+      final base = baseState();
+      final copy = base.copyWith(radius: 25);
+      expect(copy.radius, 25);
+      expectAllFieldsExcept(copy, base, skip: 'radius');
+    });
+
+    test('landingScreen only changes landingScreen', () {
+      final base = baseState();
+      final copy = base.copyWith(landingScreen: LandingScreen.map);
+      expect(copy.landingScreen, LandingScreen.map);
+      expectAllFieldsExcept(copy, base, skip: 'landingScreen');
+    });
+
+    test('countryCode only changes countryCode', () {
+      final base = baseState();
+      final copy = base.copyWith(countryCode: 'FR');
+      expect(copy.countryCode, 'FR');
+      expectAllFieldsExcept(copy, base, skip: 'countryCode');
+    });
+
+    test('clearCountry: true overrides any countryCode and nulls the field',
+        () {
+      final base = baseState();
+      // Even if a non-null value is also passed, clearCountry wins.
+      final copy = base.copyWith(countryCode: 'FR', clearCountry: true);
+      expect(copy.countryCode, isNull);
+      expectAllFieldsExcept(copy, base, skip: 'countryCode');
+    });
+
+    test('clearCountry: false with no countryCode keeps existing value', () {
+      final base = baseState();
+      final copy = base.copyWith();
+      expect(copy.countryCode, base.countryCode);
+    });
+
+    test('languageCode only changes languageCode', () {
+      final base = baseState();
+      final copy = base.copyWith(languageCode: 'fr');
+      expect(copy.languageCode, 'fr');
+      expectAllFieldsExcept(copy, base, skip: 'languageCode');
+    });
+
+    test('clearLanguage: true overrides any languageCode and nulls the field',
+        () {
+      final base = baseState();
+      final copy = base.copyWith(languageCode: 'fr', clearLanguage: true);
+      expect(copy.languageCode, isNull);
+      expectAllFieldsExcept(copy, base, skip: 'languageCode');
+    });
+
+    test('routeSegmentKm only changes routeSegmentKm', () {
+      final base = baseState();
+      final copy = base.copyWith(routeSegmentKm: 250);
+      expect(copy.routeSegmentKm, 250);
+      expectAllFieldsExcept(copy, base, skip: 'routeSegmentKm');
+    });
+
+    test('avoidHighways only changes avoidHighways', () {
+      final base = baseState();
+      final copy = base.copyWith(avoidHighways: true);
+      expect(copy.avoidHighways, isTrue);
+      expectAllFieldsExcept(copy, base, skip: 'avoidHighways');
+    });
+
+    test('showFuel only changes showFuel', () {
+      final base = baseState();
+      final copy = base.copyWith(showFuel: false);
+      expect(copy.showFuel, isFalse);
+      expectAllFieldsExcept(copy, base, skip: 'showFuel');
+    });
+
+    test('showElectric only changes showElectric', () {
+      final base = baseState();
+      final copy = base.copyWith(showElectric: true);
+      expect(copy.showElectric, isTrue);
+      expectAllFieldsExcept(copy, base, skip: 'showElectric');
+    });
+
+    test('ratingMode only changes ratingMode', () {
+      final base = baseState();
+      final copy = base.copyWith(ratingMode: 'shared');
+      expect(copy.ratingMode, 'shared');
+      expectAllFieldsExcept(copy, base, skip: 'ratingMode');
+    });
+
+    test('defaultVehicleId only changes defaultVehicleId', () {
+      final base = baseState();
+      final copy = base.copyWith(defaultVehicleId: 'veh-2');
+      expect(copy.defaultVehicleId, 'veh-2');
+      expectAllFieldsExcept(copy, base, skip: 'defaultVehicleId');
+    });
+
+    test(
+        'clearDefaultVehicle: true overrides any defaultVehicleId and nulls '
+        'the field', () {
+      final base = baseState();
+      final copy = base.copyWith(
+        defaultVehicleId: 'veh-2',
+        clearDefaultVehicle: true,
+      );
+      expect(copy.defaultVehicleId, isNull);
+      expectAllFieldsExcept(copy, base, skip: 'defaultVehicleId');
+    });
   });
 
-  test('each profile id scope is independent', () {
-    final c = makeContainer();
-    const other = UserProfile(id: 'p2', name: 'Other');
+  group('ProfileEditController', () {
+    test('build() returns state derived from the family-keyed profile', () {
+      final c = makeContainer();
+      final s = c.read(profileEditControllerProvider(profile));
 
-    c
-        .read(profileEditControllerProvider(profile).notifier)
-        .setRadius(22);
+      expect(s.fuelType, FuelType.e10);
+      expect(s.radius, 12);
+      expect(s.landingScreen, LandingScreen.favorites);
+      expect(s.countryCode, 'DE');
+      expect(s.languageCode, 'de');
+      expect(s.routeSegmentKm, 100);
+      expect(s.avoidHighways, isFalse);
+      expect(s.showFuel, isTrue);
+      expect(s.showElectric, isFalse);
+      expect(s.ratingMode, 'local');
+      expect(s.defaultVehicleId, 'veh-1');
+    });
 
-    final otherState = c.read(profileEditControllerProvider(other));
-    // Other scope is untouched and defaults to its own profile.
-    expect(otherState.radius, other.defaultSearchRadius);
+    test('setFuelType updates fuelType only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setFuelType(FuelType.diesel);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.fuelType, FuelType.diesel);
+      expectAllFieldsExcept(s, baseState(), skip: 'fuelType');
+    });
+
+    test('setRadius updates radius only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setRadius(20);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.radius, 20);
+      expectAllFieldsExcept(s, baseState(), skip: 'radius');
+    });
+
+    test('setRouteSegmentKm updates routeSegmentKm only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setRouteSegmentKm(250);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.routeSegmentKm, 250);
+      expectAllFieldsExcept(s, baseState(), skip: 'routeSegmentKm');
+    });
+
+    test('setAvoidHighways updates avoidHighways only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setAvoidHighways(true);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.avoidHighways, isTrue);
+      expectAllFieldsExcept(s, baseState(), skip: 'avoidHighways');
+    });
+
+    test('setShowFuel updates showFuel only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setShowFuel(false);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.showFuel, isFalse);
+      expectAllFieldsExcept(s, baseState(), skip: 'showFuel');
+    });
+
+    test('setShowElectric updates showElectric only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setShowElectric(true);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.showElectric, isTrue);
+      expectAllFieldsExcept(s, baseState(), skip: 'showElectric');
+    });
+
+    test('setRatingMode updates ratingMode only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setRatingMode('shared');
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.ratingMode, 'shared');
+      expectAllFieldsExcept(s, baseState(), skip: 'ratingMode');
+    });
+
+    test('setLandingScreen updates landingScreen only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setLandingScreen(LandingScreen.cheapest);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.landingScreen, LandingScreen.cheapest);
+      expectAllFieldsExcept(s, baseState(), skip: 'landingScreen');
+    });
+
+    test('setCountryCode with non-null value updates countryCode only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setCountryCode('FR');
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.countryCode, 'FR');
+      expectAllFieldsExcept(s, baseState(), skip: 'countryCode');
+    });
+
+    test('setCountryCode(null) clears countryCode', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setCountryCode(null);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.countryCode, isNull);
+      expectAllFieldsExcept(s, baseState(), skip: 'countryCode');
+    });
+
+    test('setLanguageCode with non-null value updates languageCode only', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setLanguageCode('fr');
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.languageCode, 'fr');
+      expectAllFieldsExcept(s, baseState(), skip: 'languageCode');
+    });
+
+    test('setLanguageCode(null) clears languageCode', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setLanguageCode(null);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.languageCode, isNull);
+      expectAllFieldsExcept(s, baseState(), skip: 'languageCode');
+    });
+
+    test('setDefaultVehicleId with non-null value updates the field only',
+        () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setDefaultVehicleId('veh-2');
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.defaultVehicleId, 'veh-2');
+      expectAllFieldsExcept(s, baseState(), skip: 'defaultVehicleId');
+    });
+
+    test('setDefaultVehicleId(null) clears defaultVehicleId', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+      ctrl.setDefaultVehicleId(null);
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.defaultVehicleId, isNull);
+      expectAllFieldsExcept(s, baseState(), skip: 'defaultVehicleId');
+    });
+
+    test('multiple mutators compose without dropping prior mutations', () {
+      final c = makeContainer();
+      final ctrl = c.read(profileEditControllerProvider(profile).notifier);
+
+      ctrl.setFuelType(FuelType.diesel);
+      ctrl.setRadius(20);
+      ctrl.setRouteSegmentKm(250);
+      ctrl.setAvoidHighways(true);
+      ctrl.setShowFuel(false);
+      ctrl.setShowElectric(true);
+      ctrl.setRatingMode('shared');
+      ctrl.setLandingScreen(LandingScreen.cheapest);
+      ctrl.setCountryCode('FR');
+      ctrl.setLanguageCode('fr');
+      ctrl.setDefaultVehicleId('veh-2');
+
+      final s = c.read(profileEditControllerProvider(profile));
+      expect(s.fuelType, FuelType.diesel);
+      expect(s.radius, 20);
+      expect(s.routeSegmentKm, 250);
+      expect(s.avoidHighways, isTrue);
+      expect(s.showFuel, isFalse);
+      expect(s.showElectric, isTrue);
+      expect(s.ratingMode, 'shared');
+      expect(s.landingScreen, LandingScreen.cheapest);
+      expect(s.countryCode, 'FR');
+      expect(s.languageCode, 'fr');
+      expect(s.defaultVehicleId, 'veh-2');
+    });
+
+    test(
+        'each profile id has its own state; mutating one does not affect '
+        'another', () {
+      final c = makeContainer();
+      const other = UserProfile(id: 'p2', name: 'Other');
+
+      c
+          .read(profileEditControllerProvider(profile).notifier)
+          .setRadius(22);
+
+      final otherState = c.read(profileEditControllerProvider(other));
+      expect(otherState.radius, other.defaultSearchRadius);
+      expect(otherState.fuelType, other.preferredFuelType);
+      expect(otherState.defaultVehicleId, other.defaultVehicleId);
+    });
   });
 }


### PR DESCRIPTION
Refs #561 phase profile-edit-provider — cover `ProfileEditState` (`fromProfile`, `copyWith` with `clearCountry` / `clearLanguage` / `clearDefaultVehicle` flags) + `ProfileEditController` `build()` + every public setter.

## What

Expanded the existing thin happy-path tests on `lib/features/profile/providers/profile_edit_provider.dart` (113 LOC) into a per-field copyWith / per-setter matrix that pins down the cross-field invariant: only the requested field moves, every other field equals the original.

## Methods covered

- `ProfileEditState.fromProfile(UserProfile)` — happy path + minimal-profile (null country/language/vehicle) path
- `ProfileEditState.copyWith(...)` — every field individually + all three clear-flags (`clearCountry`, `clearLanguage`, `clearDefaultVehicle`) + no-op call
- `ProfileEditController.build(UserProfile)` — initial state derived from family-keyed profile
- Every public mutator: `setFuelType`, `setRadius`, `setRouteSegmentKm`, `setAvoidHighways`, `setShowFuel`, `setShowElectric`, `setRatingMode`, `setLandingScreen`, `setCountryCode` (non-null + null clear), `setLanguageCode` (non-null + null clear), `setDefaultVehicleId` (non-null + null clear)
- Multi-mutator composition (no prior write dropped) + per-profile-id scope independence

## Test count

35 new tests in `test/features/profile/providers/profile_edit_provider_test.dart` (replaces 3 prior thin tests at the same path).

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test test/features/profile/providers/profile_edit_provider_test.dart test/lint/no_silent_catch_test.dart` — 36/36 pass
- [x] `flutter test` (full suite) — 7824 pass, 1 skipped, no regressions

## Anomalies

None. Lib file untouched.