### PR TITLE
test(core): add SafeJsonAccessors tests (refs #561)

### DIFF
--- a/test/core/utils/json_extensions_test.dart
+++ b/test/core/utils/json_extensions_test.dart
@@ -4,26 +4,38 @@ import 'package:tankstellen/core/utils/json_extensions.dart';
 void main() {
   group('SafeJsonAccessors', () {
     group('getString', () {
-      test('returns string value', () {
+      test('returns string value as-is', () {
         expect({'k': 'hello'}.getString('k'), 'hello');
       });
 
-      test('converts num to string', () {
+      test('returns empty string as-is', () {
+        expect({'k': ''}.getString('k'), '');
+      });
+
+      test('converts int to string', () {
         expect({'k': 42}.getString('k'), '42');
+      });
+
+      test('converts double to string', () {
         expect({'k': 3.14}.getString('k'), '3.14');
+      });
+
+      test('converts bool to string', () {
+        expect({'k': true}.getString('k'), 'true');
+        expect({'k': false}.getString('k'), 'false');
       });
 
       test('returns null for missing key', () {
         expect(<String, dynamic>{}.getString('k'), isNull);
       });
 
-      test('returns null for null value', () {
+      test('returns null for explicit null value', () {
         expect({'k': null}.getString('k'), isNull);
       });
     });
 
     group('getDouble', () {
-      test('returns double value', () {
+      test('returns double value as-is', () {
         expect({'k': 3.14}.getDouble('k'), 3.14);
       });
 
@@ -31,94 +43,229 @@ void main() {
         expect({'k': 42}.getDouble('k'), 42.0);
       });
 
-      test('parses string to double', () {
+      test('handles negative values', () {
+        expect({'k': -1.5}.getDouble('k'), -1.5);
+        expect({'k': -7}.getDouble('k'), -7.0);
+      });
+
+      test('parses numeric string', () {
         expect({'k': '3.14'}.getDouble('k'), 3.14);
+        expect({'k': '42'}.getDouble('k'), 42.0);
+        expect({'k': '-2.5'}.getDouble('k'), -2.5);
       });
 
       test('returns null for non-numeric string', () {
         expect({'k': 'abc'}.getDouble('k'), isNull);
       });
 
+      test('returns null for empty string', () {
+        expect({'k': ''}.getDouble('k'), isNull);
+      });
+
+      test('returns null for bool value', () {
+        expect({'k': true}.getDouble('k'), isNull);
+        expect({'k': false}.getDouble('k'), isNull);
+      });
+
       test('returns null for missing key', () {
         expect(<String, dynamic>{}.getDouble('k'), isNull);
+      });
+
+      test('returns null for explicit null value', () {
+        expect({'k': null}.getDouble('k'), isNull);
       });
     });
 
     group('getInt', () {
-      test('returns int value', () {
+      test('returns int value as-is', () {
         expect({'k': 42}.getInt('k'), 42);
       });
 
-      test('truncates double to int', () {
+      test('truncates positive double to int', () {
         expect({'k': 3.9}.getInt('k'), 3);
       });
 
-      test('parses string to int', () {
-        expect({'k': '42'}.getInt('k'), 42);
+      test('truncates negative double toward zero', () {
+        // Dart double.toInt() truncates toward zero, so -3.9 -> -3.
+        expect({'k': -3.9}.getInt('k'), -3);
       });
 
-      test('returns null for non-numeric', () {
+      test('parses numeric string to int', () {
+        expect({'k': '42'}.getInt('k'), 42);
+        expect({'k': '-7'}.getInt('k'), -7);
+      });
+
+      test('returns null for non-numeric string', () {
         expect({'k': 'abc'}.getInt('k'), isNull);
+      });
+
+      test('returns null for decimal-formatted string', () {
+        // int.tryParse rejects '3.14', unlike double.tryParse.
+        expect({'k': '3.14'}.getInt('k'), isNull);
+      });
+
+      test('returns null for bool value', () {
+        expect({'k': true}.getInt('k'), isNull);
+        expect({'k': false}.getInt('k'), isNull);
+      });
+
+      test('returns null for missing key', () {
+        expect(<String, dynamic>{}.getInt('k'), isNull);
+      });
+
+      test('returns null for explicit null value', () {
+        expect({'k': null}.getInt('k'), isNull);
       });
     });
 
     group('getBool', () {
-      test('returns bool value', () {
+      test('returns true bool as-is', () {
         expect({'k': true}.getBool('k'), isTrue);
+      });
+
+      test('returns false bool as-is', () {
         expect({'k': false}.getBool('k'), isFalse);
       });
 
-      test('converts int to bool', () {
+      test('maps int 1 to true', () {
         expect({'k': 1}.getBool('k'), isTrue);
+      });
+
+      test('maps int 0 to false', () {
         expect({'k': 0}.getBool('k'), isFalse);
       });
 
-      test('parses string to bool', () {
-        expect({'k': 'true'}.getBool('k'), isTrue);
-        expect({'k': 'false'}.getBool('k'), isFalse);
-        expect({'k': 'TRUE'}.getBool('k'), isTrue);
+      test('maps non-zero int to true', () {
+        expect({'k': 42}.getBool('k'), isTrue);
+        expect({'k': -1}.getBool('k'), isTrue);
       });
 
-      test('returns null for non-bool string', () {
+      test('parses lowercase string', () {
+        expect({'k': 'true'}.getBool('k'), isTrue);
+        expect({'k': 'false'}.getBool('k'), isFalse);
+      });
+
+      test('parses uppercase string', () {
+        expect({'k': 'TRUE'}.getBool('k'), isTrue);
+        expect({'k': 'FALSE'}.getBool('k'), isFalse);
+      });
+
+      test('parses mixed-case string', () {
+        expect({'k': 'True'}.getBool('k'), isTrue);
+        expect({'k': 'False'}.getBool('k'), isFalse);
+      });
+
+      test('returns null for unrecognised string', () {
         expect({'k': 'yes'}.getBool('k'), isNull);
+        expect({'k': 'no'}.getBool('k'), isNull);
+        expect({'k': '1'}.getBool('k'), isNull);
+        expect({'k': ''}.getBool('k'), isNull);
+      });
+
+      test('returns null for double value', () {
+        // Only bool/int/String are handled — doubles fall through.
+        expect({'k': 1.0}.getBool('k'), isNull);
+      });
+
+      test('returns null for missing key', () {
+        expect(<String, dynamic>{}.getBool('k'), isNull);
+      });
+
+      test('returns null for explicit null value', () {
+        expect({'k': null}.getBool('k'), isNull);
       });
     });
 
     group('getList', () {
-      test('returns typed list', () {
-        expect({'k': ['a', 'b']}.getList<String>('k'), ['a', 'b']);
+      test('returns list of T when all elements match', () {
+        expect(<String, dynamic>{
+          'k': <dynamic>['a', 'b', 'c'],
+        }.getList<String>('k'), ['a', 'b', 'c']);
       });
 
-      test('filters mismatched types', () {
-        expect({'k': ['a', 1, 'b']}.getList<String>('k'), ['a', 'b']);
+      test('filters mixed-type list to T only', () {
+        expect(<String, dynamic>{
+          'k': <dynamic>['a', 1, 'b', null, true, 'c'],
+        }.getList<String>('k'), ['a', 'b', 'c']);
+      });
+
+      test('returns empty list when no element matches T', () {
+        expect(<String, dynamic>{
+          'k': <dynamic>[1, 2, 3],
+        }.getList<String>('k'), isEmpty);
+      });
+
+      test('works for List<int>', () {
+        expect(<String, dynamic>{
+          'k': <dynamic>[1, 'two', 3, 4.5],
+        }.getList<int>('k'), [1, 3]);
       });
 
       test('returns empty list for missing key', () {
         expect(<String, dynamic>{}.getList<String>('k'), isEmpty);
       });
 
-      test('returns empty list for non-list value', () {
+      test('returns empty list for explicit null value', () {
+        expect({'k': null}.getList<String>('k'), isEmpty);
+      });
+
+      test('returns empty list for non-list value (string)', () {
         expect({'k': 'not a list'}.getList<String>('k'), isEmpty);
+      });
+
+      test('returns empty list for non-list value (map)', () {
+        expect({'k': <String, dynamic>{'a': 1}}.getList<String>('k'), isEmpty);
+      });
+
+      test('returns empty list for non-list value (int)', () {
+        expect({'k': 42}.getList<String>('k'), isEmpty);
+      });
+
+      test('preserves original element order', () {
+        expect(<String, dynamic>{
+          'k': <dynamic>['x', 1, 'a', 2, 'm'],
+        }.getList<String>('k'), ['x', 'a', 'm']);
       });
     });
 
     group('getMap', () {
-      test('returns map value', () {
-        final inner = {'nested': 'value'};
+      test('returns Map<String, dynamic> as-is', () {
+        final inner = <String, dynamic>{'nested': 'value', 'count': 3};
         expect({'k': inner}.getMap('k'), inner);
       });
 
-      test('converts raw Map to typed Map', () {
-        final raw = <dynamic, dynamic>{'nested': 'value'};
-        expect({'k': raw}.getMap('k'), {'nested': 'value'});
+      test('converts Map<dynamic, dynamic> via Map<String, dynamic>.from', () {
+        final raw = <dynamic, dynamic>{'nested': 'value', 'count': 3};
+        final result = {'k': raw}.getMap('k');
+        expect(result, isA<Map<String, dynamic>>());
+        expect(result, {'nested': 'value', 'count': 3});
+      });
+
+      test('converts Map<String, String> to Map<String, dynamic>', () {
+        final raw = <String, String>{'a': 'b'};
+        final result = {'k': raw}.getMap('k');
+        expect(result, isA<Map<String, dynamic>>());
+        expect(result, {'a': 'b'});
       });
 
       test('returns null for missing key', () {
         expect(<String, dynamic>{}.getMap('k'), isNull);
       });
 
-      test('returns null for non-map value', () {
-        expect({'k': 'string'}.getMap('k'), isNull);
+      test('returns null for explicit null value', () {
+        expect({'k': null}.getMap('k'), isNull);
+      });
+
+      test('returns null for non-map string value', () {
+        expect({'k': 'not a map'}.getMap('k'), isNull);
+      });
+
+      test('returns null for list value', () {
+        expect({'k': <dynamic>[1, 2, 3]}.getMap('k'), isNull);
+      });
+
+      test('returns null for numeric value', () {
+        expect({'k': 42}.getMap('k'), isNull);
       });
     });
   });


### PR DESCRIPTION
## What

Expand `test/core/utils/json_extensions_test.dart` from a few happy-path cases to a full matrix exercising every branch of `SafeJsonAccessors` on `Map<String, dynamic>` (lib/core/utils/json_extensions.dart, 73 LOC, previously underspecified at the contract level).

55 unit tests across six accessors:

- `getString` — String passthrough, int/double/bool `.toString()` fallback, empty string, missing key, null value.
- `getDouble` — double/int/num passthrough, numeric String (incl. negative), empty/non-numeric String, bool rejection, missing/null.
- `getInt` — int passthrough, double truncation toward zero (positive and negative), numeric String, decimal-formatted String rejection (since `int.tryParse('3.14') == null`), bool rejection, missing/null.
- `getBool` — bool passthrough, int 0/1/non-zero, case-insensitive String (`true`, `TRUE`, `True`, `false`, `FALSE`, `False`), unrecognised String (incl. `'1'`, `''`, `'yes'`), double rejection, missing/null.
- `getList<T>` — pure `List<T>`, mixed-type filtering via `whereType<T>`, ordering preservation, empty when no element matches `T`, generic over `List<int>`, missing/null/non-list (String, Map, int) all return empty list.
- `getMap` — `Map<String, dynamic>` passthrough, `Map<dynamic, dynamic>` and `Map<String, String>` conversion via `Map<String, dynamic>.from`, missing/null/non-map (String, List, num) all return null.

## Why

Refs #561 — zero-coverage cleanup. `json_extensions.dart` is a leaf utility used across country API parsers; an exhaustive contract suite hardens future refactors against silent regressions in JSON parsing edge cases (negative doubles, decimal-formatted ints, mixed-case bools, etc.) and pushes the file's branch coverage to ~100%.

## Testing

- `flutter test test/core/utils/json_extensions_test.dart` → 55 tests pass.
- `flutter analyze` (plain, covers `test/`) → No issues found.

Refs #561