### PR TITLE
test(search): add LocationInputController tests (refs #561)

### DIFF
--- a/test/features/search/providers/location_input_provider_test.dart
+++ b/test/features/search/providers/location_input_provider_test.dart
@@ -22,8 +22,117 @@ void main() {
     lng: 4.35,
     postcode: '30000',
   );
+  const city3 = ResolvedLocation(
+    name: 'Sete',
+    lat: 43.4,
+    lng: 3.7,
+    postcode: '34200',
+  );
+
+  group('LocationInputState', () {
+    test('default constructor yields GPS type, empty suggestions, no city, '
+        'not searching', () {
+      const s = LocationInputState();
+      expect(s.inputType, LocationInputType.gps);
+      expect(s.suggestions, isEmpty);
+      expect(s.selectedCity, isNull);
+      expect(s.isSearching, isFalse);
+    });
+
+    test('copyWith(inputType:) overrides only inputType', () {
+      const base = LocationInputState(
+        suggestions: [city1],
+        selectedCity: city2,
+        isSearching: true,
+      );
+      final next = base.copyWith(inputType: LocationInputType.zip);
+      expect(next.inputType, LocationInputType.zip);
+      expect(next.suggestions, base.suggestions);
+      expect(next.selectedCity, city2);
+      expect(next.isSearching, isTrue);
+    });
+
+    test('copyWith(suggestions:) overrides only suggestions', () {
+      const base = LocationInputState(
+        inputType: LocationInputType.city,
+        suggestions: [city1],
+        selectedCity: city2,
+        isSearching: true,
+      );
+      final next = base.copyWith(suggestions: const [city3]);
+      expect(next.suggestions, const [city3]);
+      expect(next.inputType, LocationInputType.city);
+      expect(next.selectedCity, city2);
+      expect(next.isSearching, isTrue);
+    });
+
+    test('copyWith(selectedCity:) overrides only selectedCity', () {
+      const base = LocationInputState(
+        inputType: LocationInputType.city,
+        suggestions: [city1],
+        isSearching: true,
+      );
+      final next = base.copyWith(selectedCity: city2);
+      expect(next.selectedCity, city2);
+      expect(next.inputType, LocationInputType.city);
+      expect(next.suggestions, const [city1]);
+      expect(next.isSearching, isTrue);
+    });
+
+    test('copyWith(isSearching:) overrides only isSearching', () {
+      const base = LocationInputState(
+        inputType: LocationInputType.city,
+        suggestions: [city1],
+        selectedCity: city2,
+      );
+      final next = base.copyWith(isSearching: true);
+      expect(next.isSearching, isTrue);
+      expect(next.inputType, LocationInputType.city);
+      expect(next.suggestions, const [city1]);
+      expect(next.selectedCity, city2);
+    });
+
+    test('copyWith() with no args returns equal-by-value snapshot', () {
+      const base = LocationInputState(
+        inputType: LocationInputType.city,
+        suggestions: [city1, city2],
+        selectedCity: city2,
+        isSearching: true,
+      );
+      final next = base.copyWith();
+      expect(next.inputType, base.inputType);
+      expect(next.suggestions, base.suggestions);
+      expect(next.selectedCity, base.selectedCity);
+      expect(next.isSearching, base.isSearching);
+    });
+
+    test('copyWith(clearSelectedCity: true) nulls out a non-null city', () {
+      const base = LocationInputState(selectedCity: city1);
+      final next = base.copyWith(clearSelectedCity: true);
+      expect(next.selectedCity, isNull);
+    });
+
+    test('copyWith(clearSelectedCity: true) wins over a passed selectedCity',
+        () {
+      const base = LocationInputState(selectedCity: city1);
+      final next = base.copyWith(
+        clearSelectedCity: true,
+        selectedCity: city2,
+      );
+      expect(next.selectedCity, isNull);
+    });
+  });
 
   group('LocationInputController', () {
+    test('build() returns default LocationInputState', () {
+      final c = makeContainer();
+      final s = c.read(locationInputControllerProvider);
+      expect(s.inputType, LocationInputType.gps);
+      expect(s.suggestions, isEmpty);
+      expect(s.selectedCity, isNull);
+      expect(s.isSearching, isFalse);
+    });
+
     test('initial state: GPS type, empty suggestions', () {
       final c = makeContainer();
       final s = c.read(locationInputControllerProvider);
@@ -33,7 +142,22 @@ void main() {
       expect(s.isSearching, isFalse);
     });
 
-    test('setInputType(zip) clears suggestions and selected city', () {
+    test('setInputType(city) keeps suggestions and clears selectedCity', () {
+      final c = makeContainer();
+      final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setSuggestions(const [city1, city2]);
+      ctrl.selectCity(city1);
+      // selectCity also clears suggestions, so re-seed before flipping type.
+      ctrl.setSuggestions(const [city1, city2]);
+      ctrl.setInputType(LocationInputType.city);
+
+      final s = c.read(locationInputControllerProvider);
+      expect(s.inputType, LocationInputType.city);
+      expect(s.suggestions, hasLength(2));
+      expect(s.selectedCity, isNull);
+    });
+
+    test('setInputType(zip) clears suggestions and selectedCity', () {
       final c = makeContainer();
       final ctrl = c.read(locationInputControllerProvider.notifier);
       ctrl.setSuggestions(const [city1, city2]);
@@ -46,19 +170,66 @@ void main() {
       expect(s.selectedCity, isNull);
     });
 
-    test('setInputType(city) keeps existing suggestions', () {
+    test('setInputType(gps) clears suggestions and selectedCity', () {
+      final c = makeContainer();
+      final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setSuggestions(const [city1, city2]);
+      ctrl.selectCity(city1);
+      ctrl.setInputType(LocationInputType.gps);
+
+      final s = c.read(locationInputControllerProvider);
+      expect(s.inputType, LocationInputType.gps);
+      expect(s.suggestions, isEmpty);
+      expect(s.selectedCity, isNull);
+    });
+
+    test('setSearching(true) sets the flag and leaves other fields intact', () {
       final c = makeContainer();
       final ctrl = c.read(locationInputControllerProvider.notifier);
       ctrl.setSuggestions(const [city1]);
       ctrl.setInputType(LocationInputType.city);
+      // setInputType(city) preserves suggestions but clears selectedCity, so
+      // re-seed selectedCity afterwards to test that setSearching leaves it
+      // untouched.
+      ctrl.selectCity(city1);
+      // selectCity wipes suggestions, restore them so we can verify they
+      // survive setSearching.
+      ctrl.setSuggestions(const [city1]);
+      ctrl.setSearching(true);
 
-      expect(
-        c.read(locationInputControllerProvider).suggestions,
-        hasLength(1),
-      );
+      final s = c.read(locationInputControllerProvider);
+      expect(s.isSearching, isTrue);
+      expect(s.inputType, LocationInputType.city);
+      expect(s.suggestions, hasLength(1));
+      expect(s.selectedCity, city1);
     });
 
-    test('selectCity stores city and clears suggestions', () {
+    test('setSearching(false) clears the flag and leaves other fields intact',
+        () {
+      final c = makeContainer();
+      final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setInputType(LocationInputType.city);
+      ctrl.setSuggestions(const [city1, city2]);
+      ctrl.setSearching(true);
+      ctrl.setSearching(false);
+
+      final s = c.read(locationInputControllerProvider);
+      expect(s.isSearching, isFalse);
+      expect(s.inputType, LocationInputType.city);
+      expect(s.suggestions, hasLength(2));
+    });
+
+    test('setSuggestions replaces the suggestions list', () {
+      final c = makeContainer();
+      final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setSuggestions(const [city1]);
+      ctrl.setSuggestions(const [city2, city3]);
+
+      final s = c.read(locationInputControllerProvider);
+      expect(s.suggestions, const [city2, city3]);
+    });
+
+    test('selectCity sets selectedCity and clears suggestions', () {
       final c = makeContainer();
       final ctrl = c.read(locationInputControllerProvider.notifier);
       ctrl.setSuggestions(const [city1, city2]);
@@ -81,6 +252,7 @@ void main() {
     test('clear resets everything to defaults', () {
       final c = makeContainer();
       final ctrl = c.read(locationInputControllerProvider.notifier);
+      ctrl.setInputType(LocationInputType.city);
       ctrl.setSuggestions(const [city1]);
       ctrl.selectCity(city1);
       ctrl.setSearching(true);


### PR DESCRIPTION
## What
Expands unit-test coverage for `lib/features/search/providers/location_input_provider.dart` (the `LocationInputState` value class and the `LocationInputController` Riverpod controller) so all 9 scope items from the #561 audit checklist are now exercised.

## Why
The file was previously partially covered (6 controller-level cases). Audit issue #561 calls for explicit coverage of every state-mutating path, including the value-class `copyWith` semantics and the `clearSelectedCity:true` flag — none of which had a dedicated test. With this change, every public method on the controller and every `copyWith` permutation is exercised, eliminating untested branches in this 69-LOC provider.

## Scope covered
1. `LocationInputState` defaults (no args)
2. `copyWith` per-field overrides (inputType, suggestions, selectedCity, isSearching) + `copyWith()` no-arg + `clearSelectedCity:true` (nulling and winning over a passed `selectedCity`)
3. `LocationInputController.build()` returns default state
4. `setInputType(city)` keeps suggestions, clears selectedCity
5. `setInputType(zip)` and `setInputType(gps)` both clear suggestions AND selectedCity
6. `setSearching(true)` and `setSearching(false)` flip the flag, leave other fields intact
7. `setSuggestions([list])` replaces the list
8. `selectCity(city)` sets selectedCity AND clears suggestions
9. `clear()` resets to default

## Testing
- `flutter analyze` — No issues found
- `flutter test test/features/search/providers/location_input_provider_test.dart` — 19/19 passing
- No `.g.dart` / `.freezed.dart` drift; no production code changed

Refs #561