### PR TITLE
test(report): extend ReportFormController tests (refs #561)

### DIFF
--- a/test/features/report/providers/report_form_provider_test.dart
+++ b/test/features/report/providers/report_form_provider_test.dart
@@ -4,11 +4,93 @@ import 'package:tankstellen/features/report/providers/report_form_provider.dart'
 import 'package:tankstellen/features/report/presentation/screens/report_screen.dart';
 
 void main() {
+  group('ReportFormState', () {
+    test('default constructor has null selectedType and isSubmitting=false',
+        () {
+      const state = ReportFormState();
+      expect(state.selectedType, isNull);
+      expect(state.isSubmitting, isFalse);
+    });
+
+    test('constructor accepts explicit values', () {
+      const state = ReportFormState(
+        selectedType: ReportType.wrongE5,
+        isSubmitting: true,
+      );
+      expect(state.selectedType, ReportType.wrongE5);
+      expect(state.isSubmitting, isTrue);
+    });
+
+    group('copyWith', () {
+      test('returns identical state when called with no arguments', () {
+        const state = ReportFormState(
+          selectedType: ReportType.wrongDiesel,
+          isSubmitting: true,
+        );
+        final copy = state.copyWith();
+        expect(copy.selectedType, ReportType.wrongDiesel);
+        expect(copy.isSubmitting, isTrue);
+      });
+
+      test('selectedType param updates only that field', () {
+        const state = ReportFormState(isSubmitting: true);
+        final copy = state.copyWith(selectedType: ReportType.wrongName);
+        expect(copy.selectedType, ReportType.wrongName);
+        expect(copy.isSubmitting, isTrue);
+      });
+
+      test('isSubmitting param updates only that field', () {
+        const state = ReportFormState(selectedType: ReportType.wrongAddress);
+        final copy = state.copyWith(isSubmitting: true);
+        expect(copy.selectedType, ReportType.wrongAddress);
+        expect(copy.isSubmitting, isTrue);
+      });
+
+      test(
+          'clearSelectedType=true clears non-null selection (no selectedType '
+          'arg)', () {
+        const state = ReportFormState(selectedType: ReportType.wrongE10);
+        final copy = state.copyWith(clearSelectedType: true);
+        expect(copy.selectedType, isNull);
+      });
+
+      test(
+          'clearSelectedType=true wins over a non-null selectedType arg '
+          '(clearSelectedType branch precedence)', () {
+        const state = ReportFormState(selectedType: ReportType.wrongE10);
+        final copy = state.copyWith(
+          selectedType: ReportType.wrongDiesel,
+          clearSelectedType: true,
+        );
+        expect(copy.selectedType, isNull);
+      });
+
+      test('clearSelectedType=true preserves isSubmitting flag', () {
+        const state = ReportFormState(
+          selectedType: ReportType.wrongE10,
+          isSubmitting: true,
+        );
+        final copy = state.copyWith(clearSelectedType: true);
+        expect(copy.selectedType, isNull);
+        expect(copy.isSubmitting, isTrue);
+      });
+    });
+  });
+
   group('ReportFormController', () {
     test('initial state has no selection and is not submitting', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final state = container.read(reportFormControllerProvider);
+      expect(state.selectedType, isNull);
+      expect(state.isSubmitting, isFalse);
+    });
+
+    test('build() returns the const default ReportFormState', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final state = container.read(reportFormControllerProvider);
+      // The default state has both fields at their zero values.
       expect(state.selectedType, isNull);
       expect(state.isSubmitting, isFalse);
     });
@@ -22,6 +104,38 @@ void main() {
       expect(
         container.read(reportFormControllerProvider).selectedType,
         ReportType.wrongE10,
+      );
+
+      notifier.selectType(null);
+      expect(
+        container.read(reportFormControllerProvider).selectedType,
+        isNull,
+      );
+    });
+
+    test('selectType with a non-null value sets selectedType', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(reportFormControllerProvider.notifier);
+
+      notifier.selectType(ReportType.wrongE5);
+      expect(
+        container.read(reportFormControllerProvider).selectedType,
+        ReportType.wrongE5,
+      );
+    });
+
+    test(
+        'selectType(null) clears a previously-set selection via the '
+        'clearSelectedType branch', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(reportFormControllerProvider.notifier);
+
+      notifier.selectType(ReportType.wrongDiesel);
+      expect(
+        container.read(reportFormControllerProvider).selectedType,
+        ReportType.wrongDiesel,
       );
 
       notifier.selectType(null);
@@ -46,6 +160,72 @@ void main() {
       expect(
         container.read(reportFormControllerProvider).isSubmitting,
         isFalse,
+      );
+    });
+
+    test('setSubmitting does not affect selectedType', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(reportFormControllerProvider.notifier);
+
+      notifier.selectType(ReportType.wrongName);
+      notifier.setSubmitting(true);
+      expect(
+        container.read(reportFormControllerProvider).selectedType,
+        ReportType.wrongName,
+      );
+      expect(
+        container.read(reportFormControllerProvider).isSubmitting,
+        isTrue,
+      );
+
+      notifier.setSubmitting(false);
+      expect(
+        container.read(reportFormControllerProvider).selectedType,
+        ReportType.wrongName,
+      );
+      expect(
+        container.read(reportFormControllerProvider).isSubmitting,
+        isFalse,
+      );
+    });
+
+    test(
+        'sequence: selectType then setSubmitting then selectType(null) '
+        'combines correctly', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(reportFormControllerProvider.notifier);
+
+      notifier.selectType(ReportType.wrongAddress);
+      expect(
+        container.read(reportFormControllerProvider).selectedType,
+        ReportType.wrongAddress,
+      );
+      expect(
+        container.read(reportFormControllerProvider).isSubmitting,
+        isFalse,
+      );
+
+      notifier.setSubmitting(true);
+      expect(
+        container.read(reportFormControllerProvider).selectedType,
+        ReportType.wrongAddress,
+      );
+      expect(
+        container.read(reportFormControllerProvider).isSubmitting,
+        isTrue,
+      );
+
+      notifier.selectType(null);
+      expect(
+        container.read(reportFormControllerProvider).selectedType,
+        isNull,
+      );
+      // setSubmitting flag survives a clear.
+      expect(
+        container.read(reportFormControllerProvider).isSubmitting,
+        isTrue,
       );
     });
   });


### PR DESCRIPTION
## What
Extend the existing unit-test suite for `ReportFormController` and `ReportFormState` (`lib/features/report/providers/report_form_provider.dart`) to cover all branches: defaults, every `copyWith` parameter, the `clearSelectedType` precedence rule, `build()` default state, `selectType` for both non-null and null inputs, `setSubmitting` independence from `selectedType`, and a combined sequence.

## Why
Improve unit-test coverage on a small pure-Riverpod controller to chip away at the coverage backlog tracked in #561. No production code changes — tests only.

## Testing
- `flutter analyze` — zero issues
- `flutter test test/features/report/providers/report_form_provider_test.dart` — 16/16 passing (3 prior + 13 new)

Refs #561