### PR TITLE
security(telemetry): add Sentry beforeSend PII scrubbing hook

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -18,6 +18,7 @@ import '../core/services/country_service_registry.dart';
 import '../core/storage/hive_storage.dart';
 import '../core/sync/community_config.dart';
 import '../core/sync/supabase_client.dart';
+import '../core/telemetry/pii_scrubber.dart';
 import '../core/utils/edge_to_edge.dart';
 import '../features/profile/data/repositories/profile_repository.dart';
 import '../features/vehicle/data/reference_vehicle_catalog_provider.dart';
@@ -139,6 +140,18 @@ class AppInitializer {
           options.tracesSampleRate = 0.2;
           options.environment = 'production';
           options.release = release;
+          // #1109 — strip PII (emails, lat/lng, tokens, user/request blocks,
+          // long breadcrumb payloads) from every event before it leaves the
+          // device. The scrubber is a pure function so it stays unit-tested
+          // and shared with `TraceUploader`.
+          options.beforeSend = (event, hint) {
+            try {
+              return PiiScrubber.scrubSentryEvent(event);
+            } catch (e) {
+              debugPrint('Sentry beforeSend scrub failed: $e');
+              return event;
+            }
+          };
         },
         appRunner: () => _launch(container, appBuilder),
       );

--- a/lib/core/error_tracing/upload/trace_uploader.dart
+++ b/lib/core/error_tracing/upload/trace_uploader.dart
@@ -4,6 +4,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../data/storage_repository.dart';
 import '../../services/dio_factory.dart';
 import '../../storage/storage_providers.dart';
+import '../../telemetry/pii_scrubber.dart';
 import '../models/error_trace.dart';
 import 'trace_upload_config.dart';
 
@@ -52,9 +53,14 @@ class TraceUploader {
         // immediately — opting out of the default rate limiter.
         rateLimit: null,
       );
+      // #1109 — same PII redaction policy as Sentry's `beforeSend`.
+      // Strips emails, lat/lng pairs, token-like strings, and caps long
+      // breadcrumb payloads so the user-configured trace endpoint sees
+      // the same scrubbed surface Sentry does.
+      final scrubbed = PiiScrubber.scrubErrorTrace(trace);
       await dio.post(
         config.serverUrl!,
-        data: trace.toJson(),
+        data: scrubbed.toJson(),
         options: Options(headers: {
           'Content-Type': 'application/json',
           if (config.authToken != null && config.authToken!.isNotEmpty)

--- a/lib/core/telemetry/pii_scrubber.dart
+++ b/lib/core/telemetry/pii_scrubber.dart
@@ -1,0 +1,195 @@
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import '../error_tracing/models/error_trace.dart' as et;
+
+/// Pure, side-effect-free PII redaction primitives shared between the
+/// Sentry `beforeSend` hook (#1109) and the local `TraceUploader` payload
+/// pipeline.
+///
+/// **Scope.** The user can disable telemetry entirely (consent gate in
+/// `AppInitializer`), but once they have opted in we still must not ship
+/// PII that an exception/breadcrumb might incidentally carry — emails,
+/// raw lat/lng pairs, API tokens, free-form route arguments, or the
+/// Sentry-injected `user` / `request` blocks.
+///
+/// **Design.** All public methods are pure functions of their input —
+/// no I/O, no globals, no Riverpod — so they can be unit-tested without
+/// any test harness and reused from both the Flutter UI isolate (Sentry
+/// `beforeSend`) and the background isolate (`TraceUploader.upload`).
+class PiiScrubber {
+  PiiScrubber._();
+
+  /// Replacement marker for any redacted email address.
+  static const String emailMarker = '[REDACTED_EMAIL]';
+
+  /// Replacement marker for any redacted lat/lng coordinate pair.
+  static const String coordMarker = '[REDACTED_COORD]';
+
+  /// Replacement marker for any redacted token-like opaque string.
+  static const String tokenMarker = '[REDACTED_TOKEN]';
+
+  /// Replacement marker for breadcrumb messages truncated for length.
+  static const String truncatedMarker = '[REDACTED_LONG]';
+
+  /// Maximum allowed length of a breadcrumb message before truncation.
+  /// Above this, the entire body is replaced with [truncatedMarker]
+  /// — better to lose context than to ship a paragraph of route args.
+  static const int maxBreadcrumbMessageLength = 500;
+
+  // --------------------------------------------------------------------------
+  // Regex catalog
+  // --------------------------------------------------------------------------
+
+  /// Standard email — local + `@` + domain. Avoids matching trailing
+  /// punctuation by anchoring the TLD to a word boundary.
+  static final RegExp _emailRegex = RegExp(
+    r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b',
+  );
+
+  /// Lat/lng pair — two signed decimals separated by a comma (with
+  /// optional whitespace). Each component must be a plausible coordinate
+  /// (latitude up to 90, longitude up to 180), so we tolerate -90..90
+  /// and -180..180 with up to 6 decimal places. We deliberately use a
+  /// loose numeric pattern (-?\d+\.\d+) and bound each side: it's
+  /// cheaper than a strict bounded regex and still rejects obvious
+  /// non-coordinates like timestamps.
+  static final RegExp _coordRegex = RegExp(
+    r'-?\d{1,3}\.\d{2,}\s*,\s*-?\d{1,3}\.\d{2,}',
+  );
+
+  /// Token-like string: at least 20 alphanumeric characters in a row,
+  /// no spaces. Catches API keys, JWT segments, anonymous Supabase
+  /// session ids, and station-id+coord composites. Anchored on word
+  /// boundaries so we don't redact half a sentence.
+  static final RegExp _tokenRegex = RegExp(r'\b[A-Za-z0-9_-]{20,}\b');
+
+  // --------------------------------------------------------------------------
+  // Public API
+  // --------------------------------------------------------------------------
+
+  /// Returns [text] with every email, coordinate pair, and token-like
+  /// substring replaced with a redaction marker. Order matters: emails
+  /// and coords are matched first because they have stricter patterns
+  /// than the generic token rule.
+  ///
+  /// Returns `null` if [text] is `null`. Returns the empty string for
+  /// an empty input. Never throws.
+  static String? scrubText(String? text) {
+    if (text == null) return null;
+    if (text.isEmpty) return text;
+    var out = text.replaceAll(_emailRegex, emailMarker);
+    out = out.replaceAll(_coordRegex, coordMarker);
+    out = out.replaceAll(_tokenRegex, tokenMarker);
+    return out;
+  }
+
+  /// Truncates [message] when it exceeds [maxBreadcrumbMessageLength]
+  /// AND additionally runs [scrubText] against the result.
+  ///
+  /// Breadcrumbs are the most common source of accidental PII (route
+  /// arguments, request paths, search queries) so we apply both rules
+  /// instead of just one.
+  static String? scrubBreadcrumbMessage(String? message) {
+    if (message == null) return null;
+    if (message.length > maxBreadcrumbMessageLength) {
+      return truncatedMarker;
+    }
+    return scrubText(message);
+  }
+
+  // --------------------------------------------------------------------------
+  // Sentry event mutation
+  // --------------------------------------------------------------------------
+
+  /// In-place scrub of a Sentry event before it leaves the device.
+  ///
+  /// Mutates the event so the SDK still has a valid object to ship —
+  /// returning `null` would cause Sentry to drop the event entirely,
+  /// which is *more* aggressive than we need (the operator still wants
+  /// to see scrubbed exceptions for triage).
+  ///
+  /// Strips:
+  /// * `event.user` — username/email/ip will leak through Sentry's
+  ///   automatic user enrichment; we never need that to triage.
+  /// * `event.request` — http path/query may carry station ids or
+  ///   user-typed search strings.
+  /// * `event.message.formatted` — runs through [scrubText].
+  /// * `event.exceptions[*].value` — runs through [scrubText].
+  /// * `event.breadcrumbs[*].message` — runs through
+  ///   [scrubBreadcrumbMessage] (length cap + regex).
+  ///
+  /// Returns the same [event] for chaining.
+  static SentryEvent scrubSentryEvent(SentryEvent event) {
+    event.user = null;
+    event.request = null;
+
+    final message = event.message;
+    if (message != null) {
+      final scrubbed = scrubText(message.formatted);
+      if (scrubbed != null && scrubbed != message.formatted) {
+        // SentryMessage.formatted is mutable; set in place so we don't
+        // need to clone the surrounding template/params metadata.
+        message.formatted = scrubbed;
+      }
+    }
+
+    final exceptions = event.exceptions;
+    if (exceptions != null) {
+      for (final exception in exceptions) {
+        exception.value = scrubText(exception.value);
+      }
+    }
+
+    final breadcrumbs = event.breadcrumbs;
+    if (breadcrumbs != null) {
+      for (final crumb in breadcrumbs) {
+        crumb.message = scrubBreadcrumbMessage(crumb.message);
+      }
+    }
+
+    return event;
+  }
+
+  // --------------------------------------------------------------------------
+  // ErrorTrace (TraceUploader) scrub
+  // --------------------------------------------------------------------------
+
+  /// Returns a copy of [trace] with the same redaction policy applied to
+  /// every free-form string field — `errorMessage`, the route + API +
+  /// search-params snapshot in `appState`, every breadcrumb action /
+  /// detail, and any `serviceChainState.attempts[*].errorMessage`.
+  ///
+  /// We deliberately do NOT touch `stackTrace`: it's structurally
+  /// formatted and dropping the regex on it tends to swallow real
+  /// frame paths. If a stack frame *does* leak PII the right answer is
+  /// to fix the throwing code, not to mangle the frame.
+  ///
+  /// Pure function — `ErrorTrace` is a freezed record, so we copy.
+  static et.ErrorTrace scrubErrorTrace(et.ErrorTrace trace) {
+    return trace.copyWith(
+      errorMessage: scrubText(trace.errorMessage) ?? trace.errorMessage,
+      appState: trace.appState.copyWith(
+        activeRoute: scrubText(trace.appState.activeRoute),
+        lastApiEndpoint: scrubText(trace.appState.lastApiEndpoint),
+        lastSearchParams: scrubText(trace.appState.lastSearchParams),
+      ),
+      serviceChainState: trace.serviceChainState == null
+          ? null
+          : trace.serviceChainState!.copyWith(
+              attempts: [
+                for (final attempt in trace.serviceChainState!.attempts)
+                  attempt.copyWith(
+                    errorMessage: scrubText(attempt.errorMessage),
+                  ),
+              ],
+            ),
+      breadcrumbs: [
+        for (final crumb in trace.breadcrumbs)
+          crumb.copyWith(
+            action: scrubBreadcrumbMessage(crumb.action) ?? crumb.action,
+            detail: scrubBreadcrumbMessage(crumb.detail),
+          ),
+      ],
+    );
+  }
+}

--- a/test/core/telemetry/pii_scrubber_test.dart
+++ b/test/core/telemetry/pii_scrubber_test.dart
@@ -1,0 +1,286 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:tankstellen/core/error_tracing/models/error_trace.dart' as et;
+import 'package:tankstellen/core/telemetry/pii_scrubber.dart';
+
+void main() {
+  group('PiiScrubber.scrubText', () {
+    test('returns null for null input', () {
+      expect(PiiScrubber.scrubText(null), isNull);
+    });
+
+    test('returns empty string unchanged', () {
+      expect(PiiScrubber.scrubText(''), '');
+    });
+
+    test('leaves typical exception messages intact', () {
+      const msg = 'Cache miss for key prices_de_44.5_8.2 — falling back';
+      // The coordinate-shaped substring 44.5_8.2 is underscore-separated, not
+      // comma-separated, so it is not a coordinate match. The trailing word
+      // "44.5_8.2" is too short for token redaction.
+      final out = PiiScrubber.scrubText(msg);
+      // Some scrubbing may still happen (token rule) but the human-readable
+      // English text must be preserved.
+      expect(out, contains('Cache miss for key'));
+      expect(out, contains('falling back'));
+    });
+
+    test('redacts a single email', () {
+      const msg = 'Failed to authenticate user foo.bar+baz@example.co.uk on /sync';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, contains(PiiScrubber.emailMarker));
+      expect(out, isNot(contains('foo.bar+baz@example.co.uk')));
+      expect(out, isNot(contains('foo.bar')));
+    });
+
+    test('redacts multiple emails in one string', () {
+      const msg = 'cc list: alice@a.com, bob@b.org, carol@c.io';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, isNot(contains('alice@a.com')));
+      expect(out, isNot(contains('bob@b.org')));
+      expect(out, isNot(contains('carol@c.io')));
+      // Three replacements expected.
+      expect(PiiScrubber.emailMarker.allMatches(out).length, 3);
+    });
+
+    test('redacts a lat/lng pair', () {
+      const msg = 'Last known location: 48.8566, 2.3522 (Paris)';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, contains(PiiScrubber.coordMarker));
+      expect(out, isNot(contains('48.8566')));
+      expect(out, isNot(contains('2.3522')));
+    });
+
+    test('redacts multiple coordinate pairs', () {
+      const msg = 'route: 48.8566, 2.3522 -> -33.8688, 151.2093 done';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(PiiScrubber.coordMarker.allMatches(out).length, 2);
+    });
+
+    test('redacts token-like alphanumeric strings (>=20 chars)', () {
+      const tok = 'AbCdEfGhIjKlMnOpQrStUv1234'; // 26 chars
+      final out = PiiScrubber.scrubText('Bearer $tok expired')!;
+      expect(out, contains(PiiScrubber.tokenMarker));
+      expect(out, isNot(contains(tok)));
+    });
+
+    test('does NOT redact short identifiers (<20 chars)', () {
+      const msg = 'station_id=DE-12345 missing';
+      final out = PiiScrubber.scrubText(msg);
+      expect(out, equals(msg));
+    });
+
+    test('combined: email + coord + token in one message', () {
+      const msg =
+          'user a@b.co at 48.8566, 2.3522 with token ZZZZZZZZZZZZZZZZZZZZZZZZZZ';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, contains(PiiScrubber.emailMarker));
+      expect(out, contains(PiiScrubber.coordMarker));
+      expect(out, contains(PiiScrubber.tokenMarker));
+      expect(out, isNot(contains('a@b.co')));
+      expect(out, isNot(contains('48.8566')));
+    });
+  });
+
+  group('PiiScrubber.scrubBreadcrumbMessage', () {
+    test('truncates messages longer than the cap', () {
+      final long = 'x' * (PiiScrubber.maxBreadcrumbMessageLength + 1);
+      expect(PiiScrubber.scrubBreadcrumbMessage(long),
+          equals(PiiScrubber.truncatedMarker));
+    });
+
+    test('keeps short messages but still scrubs them', () {
+      const msg = 'tap on user@example.com';
+      final out = PiiScrubber.scrubBreadcrumbMessage(msg)!;
+      expect(out, contains(PiiScrubber.emailMarker));
+      expect(out, isNot(contains('user@example.com')));
+    });
+
+    test('returns null for null input', () {
+      expect(PiiScrubber.scrubBreadcrumbMessage(null), isNull);
+    });
+  });
+
+  group('PiiScrubber.scrubSentryEvent', () {
+    test('strips event.user and event.request', () {
+      final event = SentryEvent()
+        ..user = SentryUser(
+          id: 'abc',
+          email: 'leak@example.com',
+          ipAddress: '203.0.113.7',
+        )
+        ..request = SentryRequest(
+          url: 'https://api.example.com/secret',
+          queryString: 'q=foo',
+        );
+
+      final scrubbed = PiiScrubber.scrubSentryEvent(event);
+      expect(scrubbed.user, isNull);
+      expect(scrubbed.request, isNull);
+    });
+
+    test('redacts email in exception value', () {
+      final event = SentryEvent(exceptions: [
+        SentryException(
+          type: 'StateError',
+          value: 'No profile for owner@gmail.com — re-auth needed',
+        ),
+      ]);
+
+      final scrubbed = PiiScrubber.scrubSentryEvent(event);
+      expect(scrubbed.exceptions, isNotEmpty);
+      final value = scrubbed.exceptions!.first.value!;
+      expect(value, contains(PiiScrubber.emailMarker));
+      expect(value, isNot(contains('owner@gmail.com')));
+    });
+
+    test('redacts coord in event.message', () {
+      final event = SentryEvent(
+        message: SentryMessage('crash near 48.8566, 2.3522'),
+      );
+
+      final scrubbed = PiiScrubber.scrubSentryEvent(event);
+      expect(scrubbed.message!.formatted, contains(PiiScrubber.coordMarker));
+      expect(scrubbed.message!.formatted, isNot(contains('48.8566')));
+    });
+
+    test('truncates long breadcrumb messages and scrubs short ones', () {
+      final long = 'route=${'a' * 600}';
+      final event = SentryEvent(breadcrumbs: [
+        Breadcrumb(message: long, timestamp: DateTime.now()),
+        Breadcrumb(
+          message: 'tap user@example.com',
+          timestamp: DateTime.now(),
+        ),
+      ]);
+
+      final scrubbed = PiiScrubber.scrubSentryEvent(event);
+      expect(scrubbed.breadcrumbs![0].message, PiiScrubber.truncatedMarker);
+      expect(scrubbed.breadcrumbs![1].message,
+          contains(PiiScrubber.emailMarker));
+    });
+
+    test('leaves typical exception untouched (no PII shape)', () {
+      final event = SentryEvent(exceptions: [
+        SentryException(type: 'FormatException', value: 'Unexpected token <'),
+      ]);
+      final scrubbed = PiiScrubber.scrubSentryEvent(event);
+      expect(scrubbed.exceptions!.first.value, 'Unexpected token <');
+    });
+  });
+
+  group('PiiScrubber.scrubErrorTrace', () {
+    test('redacts errorMessage, appState fields, attempts, breadcrumbs', () {
+      final trace = et.ErrorTrace(
+        id: 'id-1',
+        timestamp: DateTime.utc(2026, 1, 1),
+        timezoneOffset: '+00:00',
+        category: et.ErrorCategory.unknown,
+        errorType: 'Exception',
+        errorMessage: 'login failed for x@y.com',
+        stackTrace: '#0 main',
+        deviceInfo: const et.DeviceInfo(
+          os: 'test',
+          osVersion: '1',
+          platform: 'test',
+          locale: 'en',
+          screenWidth: 400,
+          screenHeight: 800,
+          appVersion: '1',
+        ),
+        appState: const et.AppStateSnapshot(
+          activeRoute: '/profile/owner@example.com',
+          lastApiEndpoint:
+              'https://api.example.com?token=ZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+          lastSearchParams: 'q=Paris @ 48.8566, 2.3522',
+        ),
+        serviceChainState: et.ServiceChainSnapshot(attempts: [
+          et.ServiceAttempt(
+            serviceName: 'tankerkoenig',
+            succeeded: false,
+            errorMessage: '401 for user a@b.co',
+            attemptedAt: DateTime.utc(2026, 1, 1),
+          ),
+        ]),
+        networkState: const et.NetworkSnapshot(isOnline: true),
+        breadcrumbs: [
+          et.Breadcrumb(
+            timestamp: DateTime.utc(2026, 1, 1),
+            action: 'tap',
+            detail: 'visited /map @ 48.8566, 2.3522',
+          ),
+        ],
+      );
+
+      final scrubbed = PiiScrubber.scrubErrorTrace(trace);
+
+      expect(scrubbed.errorMessage, contains(PiiScrubber.emailMarker));
+      expect(scrubbed.errorMessage, isNot(contains('x@y.com')));
+
+      expect(scrubbed.appState.activeRoute, contains(PiiScrubber.emailMarker));
+      expect(scrubbed.appState.lastApiEndpoint,
+          contains(PiiScrubber.tokenMarker));
+      expect(scrubbed.appState.lastSearchParams,
+          contains(PiiScrubber.coordMarker));
+
+      expect(scrubbed.serviceChainState!.attempts.first.errorMessage,
+          contains(PiiScrubber.emailMarker));
+
+      expect(scrubbed.breadcrumbs.first.detail,
+          contains(PiiScrubber.coordMarker));
+    });
+
+    test('preserves stackTrace verbatim', () {
+      final trace = et.ErrorTrace(
+        id: 'id-2',
+        timestamp: DateTime.utc(2026, 1, 1),
+        timezoneOffset: '+00:00',
+        category: et.ErrorCategory.unknown,
+        errorType: 'Exception',
+        errorMessage: 'plain',
+        stackTrace:
+            '#0 PathStuff (package:tankstellen/foo/bar/baz_handler.dart:123)',
+        deviceInfo: const et.DeviceInfo(
+          os: 'test',
+          osVersion: '1',
+          platform: 'test',
+          locale: 'en',
+          screenWidth: 400,
+          screenHeight: 800,
+          appVersion: '1',
+        ),
+        appState: const et.AppStateSnapshot(),
+        networkState: const et.NetworkSnapshot(isOnline: true),
+      );
+
+      final scrubbed = PiiScrubber.scrubErrorTrace(trace);
+      expect(scrubbed.stackTrace, trace.stackTrace);
+    });
+
+    test('handles null serviceChainState', () {
+      final trace = et.ErrorTrace(
+        id: 'id-3',
+        timestamp: DateTime.utc(2026, 1, 1),
+        timezoneOffset: '+00:00',
+        category: et.ErrorCategory.unknown,
+        errorType: 'Exception',
+        errorMessage: 'plain',
+        stackTrace: '#0 main',
+        deviceInfo: const et.DeviceInfo(
+          os: 'test',
+          osVersion: '1',
+          platform: 'test',
+          locale: 'en',
+          screenWidth: 400,
+          screenHeight: 800,
+          appVersion: '1',
+        ),
+        appState: const et.AppStateSnapshot(),
+        networkState: const et.NetworkSnapshot(isOnline: true),
+      );
+
+      final scrubbed = PiiScrubber.scrubErrorTrace(trace);
+      expect(scrubbed.serviceChainState, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What
Adds a pure `PiiScrubber` (lib/core/telemetry/pii_scrubber.dart) wired into both `SentryFlutter.init`'s `beforeSend` callback and the `TraceUploader` payload pipeline. Strips `event.user` / `event.request`, redacts emails / lat-lng pairs / 20+ char tokens, and truncates breadcrumb messages > 500 chars.

## Why
Sentry was initialised under the consent gate but with no scrubber, so any incidental PII in stack traces or breadcrumbs would ship verbatim. Same risk on the `TraceUploader` endpoint. Closes a real privacy hole required for v5.0 production beta (audit B6).

## Testing
- [x] 21 unit tests in `test/core/telemetry/pii_scrubber_test.dart` cover: typical exceptions intact, email redaction (single + multiple), lat/lng redaction, token redaction, short identifiers preserved, combined redaction, breadcrumb truncation, `event.user` + `event.request` strip, `SentryEvent` exception/message/breadcrumb mutation, `ErrorTrace` deep-copy scrub (errorMessage / appState / serviceChainState attempts / breadcrumbs), stackTrace preserved verbatim.
- [x] Re-ran `test/core/error_tracing/upload/trace_uploader_test.dart` (12 tests) — uploader still passes after wiring the scrubber in.
- [x] Re-ran `test/app/app_initializer*` (24 tests) — initializer wiring untouched.
- [x] `flutter analyze` clean.

Closes #1109