### PR TITLE
test(security): RLS policy verification + matrix doc (#1110)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ docs/*
 !docs/guides/
 !docs/screenshots/
 !docs/design/
+!docs/security/
 docs/guides/*
 !docs/guides/NEW_COUNTRY.md
 !docs/guides/DEV-GIT-WORKTREES.md

--- a/docs/security/SUPABASE_RLS_MATRIX.md
+++ b/docs/security/SUPABASE_RLS_MATRIX.md
@@ -1,0 +1,167 @@
+# Supabase RLS Policy Matrix
+
+This document is the **authoritative inventory** of every Supabase
+table the TankSync backend depends on, plus the Row-Level-Security
+(RLS) policies expected on each. It exists because Supabase RLS is
+the only thing that prevents one user's anon-key request from reading
+another user's rows — if a future migration accidentally drops a
+policy or a `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`, the only
+thing standing between a curious anon-key holder and the entire
+`favorites` table is this matrix and its companion test
+(`test/security/supabase_rls_test.dart`).
+
+> Audit reference: B7 — "Supabase security relies entirely on RLS
+> policies set in the project dashboard. There is no test, no
+> migration assertion, no documented matrix."
+
+## Threat model
+
+The Tankstellen client ships with a Supabase **anon key**. The anon
+key is public by design; all data isolation MUST happen on the
+server, in Postgres, via RLS policies. There are three callers:
+
+| Role            | How it shows up                                 | Trust level |
+|-----------------|-------------------------------------------------|-------------|
+| `anon`          | Unauthenticated request from the app            | Untrusted — must fail closed |
+| `authenticated` | App after `signInAnonymously` / email sign-in   | Scoped to its own `auth.uid()` |
+| `service_role`  | Edge Functions only (`SUPABASE_SERVICE_ROLE_KEY`) | Trusted — bypasses RLS |
+
+Every `public.*` table MUST have RLS enabled and at least one policy.
+A table with RLS enabled but zero policies is read-locked for
+authenticated users — a soft-fail that breaks the app silently and
+is just as bad as the open-data alternative.
+
+## Matrix
+
+The columns capture what the **default request** (an `anon`-key
+request that has called `signInAnonymously()` and so carries an
+`authenticated` JWT) is allowed to do. Operations the `service_role`
+performs from Edge Functions are out of scope — that role bypasses
+RLS by design.
+
+Legend:
+
+- **own** — limited to rows where `user_id = auth.uid()` (or `id =
+  auth.uid()` for the `users` table itself).
+- **all** — any authenticated user can read every row.
+- **none** — denied at the policy layer (no matching policy or an
+  explicit `service_role` gate).
+- **(svc)** — service-role-only path; anon is denied.
+
+| Table              | SELECT       | INSERT          | UPDATE     | DELETE             | Notes |
+|--------------------|--------------|-----------------|------------|--------------------|-------|
+| `users`            | own          | own             | own        | own + owner-or-svc | Splits `users_own` into per-op policies. Delete is gated by `is_database_owner()` so a single compromised account can't wipe the user table. |
+| `favorites`        | own          | own             | own        | own                | Single `favorites_own` `FOR ALL`. Bulk-delete trigger caps each statement at 100 rows. |
+| `alerts`           | own          | own             | own        | own                | Single `alerts_own` `FOR ALL`. Bulk-delete trigger applies. |
+| `price_snapshots`  | all          | (svc)           | (svc)      | (svc)              | Aggregate prices visible to every authenticated client; only Edge Functions write. |
+| `price_reports`    | all          | own (`reporter_id = auth.uid()`) | (none) | own + owner-or-svc | Reports are crowdsourced; reads are public among authenticated users. There is no UPDATE policy on purpose — corrections are new reports, not edits. |
+| `push_tokens`      | own          | own             | own        | own                | Single `push_own` `FOR ALL`. ntfy.sh topics are device-scoped. |
+| `sync_settings`    | own          | own             | own        | own                | Single `sync_own` `FOR ALL`. |
+| `itineraries`      | own          | own             | own        | own                | Single `itineraries_own` `FOR ALL`. Bulk-delete trigger applies. |
+| `ignored_stations` | own          | own             | own        | own                | Single `ignored_own` `FOR ALL`. |
+| `station_ratings`  | own + shared (`is_shared = true OR user_id = auth.uid()`) | own | own | own | Two policies: `ratings_own FOR ALL` plus a SELECT-only `ratings_shared_read` that opens shared rows to other users. |
+| `database_owner`   | all          | (svc)           | (svc)      | (svc)              | The singleton "first user" tracker. Anyone can read it (so a client knows whether it's the owner); only `service_role` modifies it. |
+| `vehicles`         | own          | own             | own        | own                | Single `vehicles_own` `FOR ALL`. |
+| `fill_ups`         | own          | own             | own        | own                | Single `fill_ups_own` `FOR ALL`. |
+| `obd2_baselines`   | own          | own             | own        | own                | Single `obd2_baselines_own` `FOR ALL`. |
+
+The migration source-of-truth lives in `supabase/migrations/`:
+
+- `20260327000001_initial_schema.sql` — initial seven tables.
+- `20260327000002_rls_policies.sql` — initial RLS + policies.
+- `20260328000001_itineraries.sql` — `itineraries`.
+- `20260329000001_complete_schema.sql` — additive (`ignored_stations`,
+  `station_ratings`, `database_owner` placeholder), idempotent.
+- `20260401000001_owner_protection.sql` — splits `users_own` into per-op
+  policies, adds bulk-delete trigger, introduces `database_owner`
+  policies and helper `is_database_owner()`.
+- `20260414000001_report_metadata_fields.sql` — schema-only, no RLS
+  change.
+- `20260418000001_vehicles_and_fillups.sql` — `vehicles`, `fill_ups`.
+- `20260421000001_obd2_baselines.sql` — `obd2_baselines`.
+- `20260403000001_pg_cron_alert_schedules.sql` — schedules only,
+  service-role-driven, no public-table RLS change.
+
+If a migration not listed above is found in `supabase/migrations/`,
+this matrix is stale. See "How to update" below.
+
+## Verification
+
+The matrix is enforced by `test/security/supabase_rls_test.dart`. The
+test is `@Tags(['network'])`, so it only runs when explicitly invoked:
+
+```bash
+SUPABASE_TEST_URL='https://<project>.supabase.co' \
+SUPABASE_TEST_SERVICE_KEY='<service_role_key>' \
+flutter test --tags network test/security/supabase_rls_test.dart
+```
+
+If `SUPABASE_TEST_URL` or `SUPABASE_TEST_SERVICE_KEY` is missing, the
+test prints a clear message and skips — local development without
+Supabase credentials is not a hard failure. CI runs the test on
+release-tag builds against a staging project (see
+`.github/workflows/release.yml`).
+
+The test asserts two invariants:
+
+1. Every table in the matrix exists in `pg_policies` with at least
+   one policy — i.e. RLS is enabled AND a non-empty policy set
+   exists.
+2. No `public.*` table has zero policies. A table without policies
+   is either RLS-disabled (open data) or RLS-enabled-without-policies
+   (read-locked) — both are bugs.
+
+The test does NOT assert exact policy SQL — that's intentional. The
+shape is matched by name + `cmd` + table; the predicate text is
+allowed to evolve. If you change a policy's predicate, you do not
+need to update this matrix.
+
+## How to update
+
+Whenever a migration touches an `ALTER TABLE ... ENABLE ROW LEVEL
+SECURITY`, a `CREATE POLICY`, or a `DROP POLICY`:
+
+1. **Add the migration** under `supabase/migrations/` with an
+   `RLS confirmed` checkbox in its top-of-file comment block (see
+   "Migration template" below).
+2. **Update this matrix** — add or modify the row for the affected
+   table.
+3. **Update the expected-policy list** in
+   `test/security/supabase_rls_test.dart` — the `_expectedPolicies`
+   map keys are table names; the values are the policy names you
+   expect on each.
+4. **Re-run** `flutter test --tags network test/security/
+   supabase_rls_test.dart` against your staging Supabase project to
+   confirm the live policies match.
+
+If a migration drops a table, remove it from both the matrix and
+the test, and add a `git commit` message that calls out the removal
+explicitly so the audit trail is searchable.
+
+## Migration template
+
+Every new SQL migration under `supabase/migrations/` SHOULD start
+with this header. It is enforced by code review (no automated check
+yet — the security test catches the runtime symptom, but the
+checkbox is the human-facing reminder during PR review):
+
+```sql
+-- <NNN> — <one-line description>
+--
+-- Why: <link to issue / one paragraph rationale>
+--
+-- RLS impact:
+--   [ ] No public-table RLS change (schema-only, indexes, etc.)
+--   [ ] Adds new public table → MUST `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`
+--                              AND `CREATE POLICY` covering anon access.
+--   [ ] Modifies existing policy (DROP + CREATE).
+--   [ ] Drops a public table.
+--
+-- RLS confirmed: [ ]
+--   I have updated `docs/security/SUPABASE_RLS_MATRIX.md` and
+--   `test/security/supabase_rls_test.dart` to reflect the change
+--   above (or this migration has no public-table RLS impact).
+```
+
+The `RLS confirmed: [ ]` checkbox is the gate. When it is checked,
+the matrix and the test must already be in the same PR.

--- a/supabase/migrations/20260426000001_rls_audit_function.sql
+++ b/supabase/migrations/20260426000001_rls_audit_function.sql
@@ -1,0 +1,63 @@
+-- #1110 — RLS audit helper for `test/security/supabase_rls_test.dart`.
+--
+-- Why: Supabase RLS is the only thing that prevents one anon-key
+-- holder from reading another user's rows. Without a programmatic
+-- way to inventory live policies we have no automated guard against
+-- a future migration that accidentally drops one. This function is
+-- the read-only entry point the verification test calls; it returns
+-- one row per policy on every `public.*` table plus a row with NULL
+-- policy columns for tables that have RLS enabled but zero policies
+-- (the silent-fail case where a table is read-locked).
+--
+-- Security:
+--   - SECURITY INVOKER: the function runs with the caller's
+--     privileges. The test calls it with the service-role key, which
+--     can read `pg_policies` and `pg_class`. Anon callers get an
+--     empty result because they lack `SELECT` on those catalogs —
+--     which is the correct posture; we don't want to leak policy
+--     structure to anon clients.
+--   - REVOKE EXECUTE FROM anon, authenticated: belt-and-braces.
+--
+-- RLS impact:
+--   [x] No public-table RLS change (adds a helper function only).
+--
+-- RLS confirmed: [x]
+--   This migration adds verification machinery; the matrix in
+--   docs/security/SUPABASE_RLS_MATRIX.md is unchanged.
+
+CREATE OR REPLACE FUNCTION public.audit_rls_policies()
+RETURNS TABLE (
+  table_name TEXT,
+  rls_enabled BOOLEAN,
+  policy_name TEXT,
+  policy_cmd TEXT,
+  policy_roles TEXT[]
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+AS $$
+  SELECT
+    c.relname::TEXT AS table_name,
+    c.relrowsecurity AS rls_enabled,
+    p.policyname::TEXT AS policy_name,
+    p.cmd::TEXT AS policy_cmd,
+    p.roles::TEXT[] AS policy_roles
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  LEFT JOIN pg_policies p
+    ON p.schemaname = n.nspname
+   AND p.tablename = c.relname
+  WHERE n.nspname = 'public'
+    AND c.relkind = 'r'  -- ordinary tables only (skip views, sequences)
+  ORDER BY c.relname, p.policyname NULLS FIRST;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.audit_rls_policies() FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.audit_rls_policies() TO service_role;
+
+COMMENT ON FUNCTION public.audit_rls_policies() IS
+  'Read-only RLS policy inventory for verification tests (#1110). '
+  'Service-role only. Returns one row per (table, policy); tables '
+  'with RLS-enabled-but-zero-policies surface as a single row with '
+  'NULL policy_name. See docs/security/SUPABASE_RLS_MATRIX.md.';

--- a/test/security/supabase_rls_test.dart
+++ b/test/security/supabase_rls_test.dart
@@ -1,0 +1,317 @@
+@Tags(['network'])
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+/// #1110 — RLS policy verification test.
+///
+/// Calls the `public.audit_rls_policies()` SQL function (added by
+/// migration `20260426000001_rls_audit_function.sql`) against a live
+/// Supabase project and asserts:
+///
+///   1. Every table named in `_expectedPolicies` has every policy
+///      named there. The `cmd` (SELECT/INSERT/UPDATE/DELETE/ALL) on
+///      the policy is checked too.
+///   2. No `public.*` table is RLS-enabled-with-zero-policies.
+///      That state is the silent-fail Supabase posture — the table
+///      is effectively read-locked for `authenticated` users while
+///      remaining writable to `service_role`. Either RLS is wrong
+///      or a policy is missing.
+///   3. Every table found in the live schema is covered by the
+///      matrix. If a new table appears that the matrix doesn't know
+///      about, the test fails — forcing a doc + test update before
+///      the table can be merged.
+///
+/// Tagged `network` so the default `flutter test` run skips it. To
+/// invoke locally:
+///
+/// ```bash
+/// SUPABASE_TEST_URL='https://<project>.supabase.co' \
+/// SUPABASE_TEST_SERVICE_KEY='<service_role_key>' \
+/// flutter test --tags network test/security/supabase_rls_test.dart
+/// ```
+///
+/// If the env vars are absent the test prints a clear message and
+/// skips — local development without Supabase credentials is not a
+/// hard failure. CI runs this on tag releases against the staging
+/// project (see `.github/workflows/release.yml`).
+///
+/// See `docs/security/SUPABASE_RLS_MATRIX.md` for the human-readable
+/// policy matrix and the workflow for keeping it in sync with this
+/// test.
+void main() {
+  final supabaseUrl = Platform.environment['SUPABASE_TEST_URL'];
+  final serviceKey = Platform.environment['SUPABASE_TEST_SERVICE_KEY'];
+  final hasCredentials =
+      supabaseUrl != null &&
+      supabaseUrl.isNotEmpty &&
+      serviceKey != null &&
+      serviceKey.isNotEmpty;
+
+  // The matrix the test enforces. Keep in lock-step with
+  // `docs/security/SUPABASE_RLS_MATRIX.md` — when a migration adds,
+  // removes, or renames a policy, both files change in the same PR.
+  //
+  // Each entry maps a policy_name to its expected `cmd`. Postgres
+  // reports `cmd` as one of: SELECT, INSERT, UPDATE, DELETE, ALL.
+  const expectedPolicies = <String, Map<String, String>>{
+    'users': {
+      'users_own_select': 'SELECT',
+      'users_own_insert': 'INSERT',
+      'users_own_update': 'UPDATE',
+      'users_delete_owner_only': 'DELETE',
+    },
+    'favorites': {
+      'favorites_own': 'ALL',
+    },
+    'alerts': {
+      'alerts_own': 'ALL',
+    },
+    'price_snapshots': {
+      'snapshots_read': 'SELECT',
+      'snapshots_insert': 'INSERT',
+      'snapshots_delete': 'DELETE',
+    },
+    'price_reports': {
+      'reports_insert': 'INSERT',
+      'reports_read': 'SELECT',
+      'reports_delete': 'DELETE',
+    },
+    'push_tokens': {
+      'push_own': 'ALL',
+    },
+    'sync_settings': {
+      'sync_own': 'ALL',
+    },
+    'itineraries': {
+      'itineraries_own': 'ALL',
+    },
+    'ignored_stations': {
+      'ignored_own': 'ALL',
+    },
+    'station_ratings': {
+      'ratings_own': 'ALL',
+      'ratings_shared_read': 'SELECT',
+    },
+    'database_owner': {
+      'owner_read': 'SELECT',
+      'owner_manage': 'ALL',
+    },
+    'vehicles': {
+      'vehicles_own': 'ALL',
+    },
+    'fill_ups': {
+      'fill_ups_own': 'ALL',
+    },
+    'obd2_baselines': {
+      'obd2_baselines_own': 'ALL',
+    },
+  };
+
+  group('Supabase RLS matrix (#1110)', () {
+    if (!hasCredentials) {
+      test(
+        'skipped — set SUPABASE_TEST_URL + SUPABASE_TEST_SERVICE_KEY to run',
+        () {
+          // ignore: avoid_print
+          print(
+            'Skipping Supabase RLS verification: '
+            'SUPABASE_TEST_URL and/or SUPABASE_TEST_SERVICE_KEY env '
+            'vars are not set. This is expected on local dev machines '
+            'without staging credentials. CI sets them on tag releases.',
+          );
+        },
+        skip: 'Supabase test credentials not configured',
+      );
+      return;
+    }
+
+    late List<Map<String, dynamic>> auditRows;
+
+    setUpAll(() async {
+      auditRows = await _fetchPolicyAudit(
+        supabaseUrl: supabaseUrl,
+        serviceKey: serviceKey,
+      );
+    });
+
+    test('every expected policy is present with the right cmd', () {
+      final missing = <String>[];
+      final wrongCmd = <String>[];
+
+      for (final entry in expectedPolicies.entries) {
+        final tableName = entry.key;
+        for (final policy in entry.value.entries) {
+          final policyName = policy.key;
+          final expectedCmd = policy.value;
+          final match = auditRows.firstWhere(
+            (row) =>
+                row['table_name'] == tableName &&
+                row['policy_name'] == policyName,
+            orElse: () => <String, dynamic>{},
+          );
+          if (match.isEmpty) {
+            missing.add('$tableName.$policyName');
+            continue;
+          }
+          final actualCmd = (match['policy_cmd'] as String?)?.toUpperCase();
+          if (actualCmd != expectedCmd) {
+            wrongCmd.add(
+              '$tableName.$policyName expected cmd=$expectedCmd, '
+              'got cmd=$actualCmd',
+            );
+          }
+        }
+      }
+
+      expect(
+        missing,
+        isEmpty,
+        reason:
+            'Missing RLS policies (matrix vs. live schema):\n'
+            '  ${missing.join('\n  ')}\n'
+            'Either a migration dropped them or the matrix in '
+            'docs/security/SUPABASE_RLS_MATRIX.md is stale.',
+      );
+      expect(
+        wrongCmd,
+        isEmpty,
+        reason:
+            'RLS policies with wrong cmd:\n  ${wrongCmd.join('\n  ')}',
+      );
+    });
+
+    test('no public table is RLS-enabled-with-zero-policies', () {
+      // Group rows by table_name; a row with policy_name == null AND
+      // rls_enabled == true means the table has RLS on but no policies
+      // covering any caller — silent-fail posture.
+      final byTable = <String, List<Map<String, dynamic>>>{};
+      for (final row in auditRows) {
+        final t = row['table_name'] as String;
+        byTable.putIfAbsent(t, () => []).add(row);
+      }
+
+      final silentFails = <String>[];
+      for (final entry in byTable.entries) {
+        final tableName = entry.key;
+        final rows = entry.value;
+        final hasAnyPolicy = rows.any((r) => r['policy_name'] != null);
+        // The function returns a single row with NULL policy columns
+        // when a table has zero policies. If RLS is enabled and there
+        // are no policies, surface it.
+        final rlsEnabled = rows.any((r) => r['rls_enabled'] == true);
+        if (rlsEnabled && !hasAnyPolicy) {
+          silentFails.add(tableName);
+        }
+      }
+
+      expect(
+        silentFails,
+        isEmpty,
+        reason:
+            'These public tables have RLS enabled but zero policies, '
+            'which read-locks them for authenticated users: '
+            '${silentFails.join(', ')}. Either disable RLS (open data) '
+            'or add the missing policies. See docs/security/'
+            'SUPABASE_RLS_MATRIX.md.',
+      );
+    });
+
+    test('no public table is RLS-disabled', () {
+      // The audit function returns one row per (table, policy) — for
+      // tables with zero policies it returns a single row with NULL
+      // policy columns. Either way `rls_enabled` reflects the table,
+      // so we can collapse to one entry per table_name.
+      final byTable = <String, bool>{};
+      for (final row in auditRows) {
+        final t = row['table_name'] as String;
+        final enabled = row['rls_enabled'] == true;
+        byTable[t] = byTable[t] == true || enabled;
+      }
+
+      final disabled = <String>[];
+      for (final entry in byTable.entries) {
+        if (!entry.value) disabled.add(entry.key);
+      }
+
+      expect(
+        disabled,
+        isEmpty,
+        reason:
+            'These public tables have Row Level Security DISABLED — '
+            'the anon key can read every row: ${disabled.join(', ')}. '
+            'Add `ALTER TABLE public.<name> ENABLE ROW LEVEL SECURITY;` '
+            'in a migration.',
+      );
+    });
+
+    test('every live table is covered by the matrix', () {
+      final liveTables = auditRows
+          .map((r) => r['table_name'] as String)
+          .toSet();
+      final knownTables = expectedPolicies.keys.toSet();
+
+      final unknown = liveTables.difference(knownTables);
+
+      expect(
+        unknown,
+        isEmpty,
+        reason:
+            'These tables exist in the live schema but are not in '
+            'docs/security/SUPABASE_RLS_MATRIX.md: '
+            '${unknown.join(', ')}. Add them to the matrix and to '
+            '_expectedPolicies in this test.',
+      );
+    });
+  });
+}
+
+/// Calls the `public.audit_rls_policies()` SQL function via Supabase
+/// PostgREST and returns the rows as JSON-decoded maps.
+///
+/// Uses the service-role key because the function is locked down to
+/// `service_role` (anon callers get an empty result by design).
+Future<List<Map<String, dynamic>>> _fetchPolicyAudit({
+  required String supabaseUrl,
+  required String serviceKey,
+}) async {
+  final cleanUrl = supabaseUrl.replaceAll(RegExp(r'/+$'), '');
+  final endpoint = Uri.parse('$cleanUrl/rest/v1/rpc/audit_rls_policies');
+
+  final response = await http
+      .post(
+        endpoint,
+        headers: {
+          'apikey': serviceKey,
+          'Authorization': 'Bearer $serviceKey',
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: '{}',
+      )
+      .timeout(const Duration(seconds: 30));
+
+  if (response.statusCode != 200) {
+    fail(
+      'audit_rls_policies RPC failed: '
+      'HTTP ${response.statusCode} — ${response.body}\n'
+      'If the function is missing, apply migration '
+      '`supabase/migrations/20260426000001_rls_audit_function.sql` '
+      'against the test project first (`supabase db push`).',
+    );
+  }
+
+  final decoded = json.decode(response.body);
+  if (decoded is! List) {
+    fail(
+      'audit_rls_policies returned non-list payload: $decoded',
+    );
+  }
+  return decoded
+      .whereType<Map<String, dynamic>>()
+      .toList(growable: false);
+}


### PR DESCRIPTION
## Summary

- Adds `docs/security/SUPABASE_RLS_MATRIX.md` enumerating every public table and its expected anon / authenticated / service_role policies, plus a migration template with an "RLS confirmed" checkbox.
- Adds `test/security/supabase_rls_test.dart` (network-tagged) that queries the live policy set via a small SECURITY INVOKER audit helper and asserts the matrix, no RLS-disabled public table, no RLS-enabled-with-zero-policies table, and no live table missing from the matrix.
- Adds `supabase/migrations/20260426000001_rls_audit_function.sql` providing `audit_rls_policies()` (service-role only).

The default `flutter test` skips the network-tagged suite — local dev without staging credentials prints a clear skip reason and passes. Run on demand with:

```bash
SUPABASE_TEST_URL='https://<project>.supabase.co' \
SUPABASE_TEST_SERVICE_KEY='<service_role_key>' \
flutter test --tags network test/security/supabase_rls_test.dart
```

Audit B7 reference: closes the only path that can leak user data off-device. Required for Security grade A− → A.

## Test plan

- [x] `flutter analyze` — zero issues.
- [x] `flutter test test/security/supabase_rls_test.dart` — skips cleanly with explanatory message when env vars absent.
- [x] `flutter test --tags network test/security/supabase_rls_test.dart` — same skip behaviour without credentials.
- [x] `flutter test test/security/` — full security suite green (18 tests).
- [ ] Manual: apply migration to staging Supabase project + run with real `SUPABASE_TEST_URL` / `SUPABASE_TEST_SERVICE_KEY` to confirm it actually exercises `pg_policies`.

Closes #1110