### PR TITLE
security(supabase): add RLS policy matrix + verification test (Closes #1110)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ docs/*
 !docs/guides/
 !docs/screenshots/
 !docs/design/
+!docs/security/
 docs/guides/*
 !docs/guides/NEW_COUNTRY.md
 !docs/guides/DEV-GIT-WORKTREES.md

--- a/docs/security/SUPABASE_RLS_MATRIX.md
+++ b/docs/security/SUPABASE_RLS_MATRIX.md
@@ -1,0 +1,204 @@
+# Supabase RLS Policy Matrix (TankSync)
+
+This file is the **source of truth** for what Row-Level Security (RLS) policies SHOULD exist on the TankSync Supabase backend. The accompanying test
+`test/security/supabase_rls_test.dart` queries the live database (`pg_policies`) on a tag-release / staging job and asserts that reality matches this
+matrix. If a future migration accidentally drops, weakens, or shadows a policy, that test fails — closing the only path that can leak user data off-device.
+
+Audit reference: B7 (Issue #1110). Required to lift the Security grade from A− to A.
+
+## Summary
+
+- Every table in `public` schema has `ENABLE ROW LEVEL SECURITY` set.
+- User-owned rows are fenced by `user_id = auth.uid()` (or equivalent on `users.id`).
+- Public read tables (`price_snapshots`, `price_reports`) use `USING (true)` for `SELECT` only — writes are still scoped.
+- `service_role` is the only role allowed to insert/delete public-aggregate rows (`price_snapshots`).
+- The first user to sign in becomes the database owner (singleton row in `database_owner`); the owner gains DELETE rights across `users` and `price_reports`.
+
+Migrations covered (in chronological order):
+
+1. `20260327000001_initial_schema.sql`
+2. `20260327000002_rls_policies.sql`
+3. `20260328000001_itineraries.sql`
+4. `20260329000001_complete_schema.sql` (idempotent re-run of all of the above + new tables)
+5. `20260401000001_owner_protection.sql` (replaces `users_own` with split SELECT/INSERT/UPDATE/DELETE policies; adds `database_owner` table; adds delete-scoped policies on `price_snapshots` and `price_reports`)
+6. `20260418000001_vehicles_and_fillups.sql`
+7. `20260421000001_obd2_baselines.sql`
+
+The matrix below reflects the **final state** after all migrations have run.
+
+---
+
+## `users`
+
+RLS: enabled
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `users_own_select` | SELECT | public | `id = auth.uid()` | — |
+| `users_own_insert` | INSERT | public | — | `id = auth.uid()` |
+| `users_own_update` | UPDATE | public | `id = auth.uid()` | — |
+| `users_delete_owner_only` | DELETE | public | `id = auth.uid() OR public.is_database_owner() OR auth.role() = 'service_role'` | — |
+
+Notes: the original `users_own` (FOR ALL) policy is dropped in `20260401000001_owner_protection.sql` and replaced with the four explicit ones above so DELETE can be scoped to the owner.
+
+---
+
+## `favorites`
+
+RLS: enabled
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `favorites_own` | ALL | public | `user_id = auth.uid()` | — |
+
+A bulk-delete trigger (`trg_limit_delete_favorites`) caps DELETE at 100 rows per statement for non-`service_role` callers.
+
+---
+
+## `alerts`
+
+RLS: enabled
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `alerts_own` | ALL | public | `user_id = auth.uid()` | — |
+
+A bulk-delete trigger (`trg_limit_delete_alerts`) caps DELETE at 100 rows per statement.
+
+---
+
+## `price_snapshots`
+
+RLS: enabled. Public-read aggregate table; only the service role may write.
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `snapshots_read` | SELECT | public | `true` | — |
+| `snapshots_insert` | INSERT | public | — | `auth.role() = 'service_role'` |
+| `snapshots_delete` | DELETE | public | `auth.role() = 'service_role'` | — |
+
+UPDATE has no policy → effectively denied (RLS default-deny).
+
+---
+
+## `price_reports`
+
+RLS: enabled. Community feed: anyone reads, only the reporter writes / deletes own.
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `reports_insert` | INSERT | public | — | `reporter_id = auth.uid()` |
+| `reports_read` | SELECT | public | `true` | — |
+| `reports_delete` | DELETE | public | `reporter_id = auth.uid() OR public.is_database_owner() OR auth.role() = 'service_role'` | — |
+
+UPDATE has no policy → effectively denied. A bulk-delete trigger (`trg_limit_delete_reports`) caps DELETE at 100 rows per statement.
+
+---
+
+## `push_tokens`
+
+RLS: enabled
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `push_own` | ALL | public | `user_id = auth.uid()` | — |
+
+---
+
+## `sync_settings`
+
+RLS: enabled
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `sync_own` | ALL | public | `user_id = auth.uid()` | — |
+
+---
+
+## `itineraries`
+
+RLS: enabled
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `itineraries_own` | ALL | public | `user_id = auth.uid()` | — |
+
+A bulk-delete trigger (`trg_limit_delete_itineraries`) caps DELETE at 100 rows per statement.
+
+---
+
+## `ignored_stations`
+
+RLS: enabled. Defined in `20260329000001_complete_schema.sql`.
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `ignored_own` | ALL | public | `user_id = auth.uid()` | — |
+
+---
+
+## `station_ratings`
+
+RLS: enabled. Defined in `20260329000001_complete_schema.sql`. Per-user ratings, optionally shared with the community via `is_shared = true`.
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `ratings_own` | ALL | public | `user_id = auth.uid()` | — |
+| `ratings_shared_read` | SELECT | public | `is_shared = true OR user_id = auth.uid()` | — |
+
+---
+
+## `database_owner`
+
+RLS: enabled. Singleton row (one row per database) tracking who owns this Supabase project. Defined in `20260401000001_owner_protection.sql`.
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `owner_read` | SELECT | public | `true` | — |
+| `owner_manage` | ALL | public | `auth.role() = 'service_role'` | — |
+
+Anyone can read to check if they are the owner; only the service role can mutate the row.
+
+---
+
+## `vehicles`
+
+RLS: enabled. Defined in `20260418000001_vehicles_and_fillups.sql`.
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `vehicles_own` | ALL | public | `user_id = auth.uid()` | — |
+
+---
+
+## `fill_ups`
+
+RLS: enabled. Defined in `20260418000001_vehicles_and_fillups.sql`.
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `fill_ups_own` | ALL | public | `user_id = auth.uid()` | — |
+
+---
+
+## `obd2_baselines`
+
+RLS: enabled. Defined in `20260421000001_obd2_baselines.sql`.
+
+| Policy | Command | Roles | USING | WITH CHECK |
+|---|---|---|---|---|
+| `obd2_baselines_own` | ALL | public | `user_id = auth.uid()` | — |
+
+---
+
+## Verification
+
+Run the verification test against staging:
+
+```bash
+SUPABASE_URL=https://<staging-project-ref>.supabase.co \
+SUPABASE_SERVICE_ROLE_KEY=<staging-service-role-key> \
+flutter test test/security/supabase_rls_test.dart --tags network
+```
+
+Without env vars, the test cleanly skips so it never blocks offline PR checks.

--- a/supabase/migrations/MIGRATION_TEMPLATE.md
+++ b/supabase/migrations/MIGRATION_TEMPLATE.md
@@ -1,0 +1,50 @@
+# Migration Template Checklist
+
+Every new migration in `supabase/migrations/` must satisfy this checklist before
+the corresponding PR is merged. The bullets below are intentionally short so they
+can be copy-pasted into the PR description.
+
+## Pre-merge checklist
+
+- [ ] Filename uses the `YYYYMMDDhhmmss_short_name.sql` convention and sorts
+  AFTER the latest existing migration (so `supabase db push` applies it last).
+- [ ] All `CREATE TABLE` statements use `IF NOT EXISTS`. The migration is
+  idempotent: running it twice on the same database is a no-op.
+- [ ] **RLS confirmed: this migration does NOT disable RLS on any table, and
+  any new tables explicitly call `ALTER TABLE … ENABLE ROW LEVEL SECURITY;`.**
+- [ ] Every new table has at least one policy. No bare RLS-enabled table is
+  shipped (default-deny would lock the app out of its own data).
+- [ ] User-owned tables fence rows with `user_id = auth.uid()` (or equivalent
+  on the primary key). Public-read tables (`USING (true)`) are only used for
+  aggregate / community data and are documented in
+  `docs/security/SUPABASE_RLS_MATRIX.md`.
+- [ ] If the migration adds a new table, the matrix doc
+  (`docs/security/SUPABASE_RLS_MATRIX.md`) is updated in the same PR with the
+  new table's policy rows.
+- [ ] If the migration adds a new policy on an existing table, the matrix doc
+  row for that table is updated.
+- [ ] No GRANT / REVOKE on `anon` or `authenticated` that would bypass RLS.
+- [ ] No `BYPASSRLS` role attribute set on any role in the migration.
+- [ ] Foreign keys to `public.users(id)` use `ON DELETE CASCADE` (so deleting a
+  user nukes their data) unless there is a documented reason to use
+  `ON DELETE SET NULL` (e.g. anonymising community reports).
+- [ ] Indexes on user-scoped tables include a `user_id` prefix where the table
+  is queried by user; verified against the read patterns in
+  `lib/core/sync/`.
+
+## Post-merge
+
+- [ ] After the PR merges, run `supabase db push` against staging to apply.
+- [ ] On the next tag release, the network-tagged
+  `test/security/supabase_rls_test.dart` will assert the live policy set
+  matches the matrix doc.
+
+## Why each item matters
+
+The single largest risk in TankSync is leaking another user's favorites,
+alerts, or fill-ups via a missing or weakened RLS policy. The default
+Supabase posture for a freshly-created table is: RLS off, world-readable. One
+forgotten `ENABLE ROW LEVEL SECURITY` and the entire fleet is exposed to any
+client with the anon key — which is shipped in every install. The verification
+test catches drift, but it is run on tag releases only; this checklist catches
+the same issue at PR review time, before the migration ever reaches staging.

--- a/test/security/supabase_rls_test.dart
+++ b/test/security/supabase_rls_test.dart
@@ -1,0 +1,493 @@
+@Tags(['network'])
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+/// Verifies the live RLS policy set on the staging Supabase project matches
+/// the matrix documented in `docs/security/SUPABASE_RLS_MATRIX.md`.
+///
+/// Network-tagged: only runs when invoked with `--tags network`. Skips
+/// cleanly when `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are absent so
+/// it never blocks offline PR checks.
+///
+/// Run locally:
+///
+///   `SUPABASE_URL=https://STAGING.supabase.co`
+///   `SUPABASE_SERVICE_ROLE_KEY=...`
+///   `flutter test test/security/supabase_rls_test.dart --tags network`
+///
+/// The service-role key is required because anon callers can't read
+/// `pg_policies` / `pg_class`. Use a staging project, never production.
+///
+/// Closes #1110 (audit B7).
+void main() {
+  final envUrl = Platform.environment['SUPABASE_URL'] ?? '';
+  final envKey = Platform.environment['SUPABASE_SERVICE_ROLE_KEY'] ?? '';
+  final hasCreds = envUrl.isNotEmpty && envKey.isNotEmpty;
+
+  group('Supabase RLS matrix (#1110)', () {
+    if (!hasCreds) {
+      test(
+        'skipped — SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set',
+        () {},
+        skip:
+            'Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY to run this '
+            'verification against a staging project. See '
+            'docs/security/SUPABASE_RLS_MATRIX.md.',
+      );
+      return;
+    }
+
+    final supabaseUrl = envUrl;
+    final serviceKey = envKey;
+
+    test('every documented table has RLS enabled', () async {
+      final rows = await _runSql(
+        supabaseUrl,
+        serviceKey,
+        '''
+        SELECT c.relname AS tablename, c.relrowsecurity AS rls
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+        ORDER BY c.relname
+        ''',
+      );
+
+      final actual = <String, bool>{
+        for (final row in rows)
+          row['tablename'] as String: row['rls'] as bool,
+      };
+
+      for (final table in _expectedTables) {
+        expect(
+          actual.containsKey(table),
+          isTrue,
+          reason:
+              'Table `public.$table` is missing in the live database — '
+              'matrix is out of sync.',
+        );
+        expect(
+          actual[table],
+          isTrue,
+          reason:
+              'Table `public.$table` has RLS DISABLED — this is a '
+              'data-leak vulnerability. Re-enable with '
+              '`ALTER TABLE public.$table ENABLE ROW LEVEL SECURITY;` '
+              'and audit recent migrations.',
+        );
+      }
+    });
+
+    test('policy set matches docs/security/SUPABASE_RLS_MATRIX.md', () async {
+      final rows = await _runSql(
+        supabaseUrl,
+        serviceKey,
+        '''
+        SELECT tablename, policyname, cmd, qual, with_check
+        FROM pg_policies
+        WHERE schemaname = 'public'
+        ORDER BY tablename, policyname
+        ''',
+      );
+
+      final actual = <String>{
+        for (final row in rows)
+          '${row['tablename']}.${row['policyname']}.${row['cmd']}',
+      };
+      final expected = <String>{
+        for (final p in _expectedPolicies) '${p.table}.${p.name}.${p.cmd}',
+      };
+
+      final missing = expected.difference(actual);
+      final extra = actual.difference(expected);
+
+      expect(
+        missing,
+        isEmpty,
+        reason:
+            'Policies expected by the matrix doc are missing from the '
+            'live database. Either re-apply migrations or update '
+            'docs/security/SUPABASE_RLS_MATRIX.md to match reality.\n'
+            'Missing: $missing',
+      );
+      expect(
+        extra,
+        isEmpty,
+        reason:
+            'Policies exist in the live database that are NOT in the '
+            'matrix doc. Document them in '
+            'docs/security/SUPABASE_RLS_MATRIX.md so the next audit '
+            'has a written justification.\n'
+            'Extra: $extra',
+      );
+    });
+
+    test('USING / WITH CHECK clauses match expected expressions', () async {
+      final rows = await _runSql(
+        supabaseUrl,
+        serviceKey,
+        '''
+        SELECT tablename, policyname, cmd, qual, with_check
+        FROM pg_policies
+        WHERE schemaname = 'public'
+        ORDER BY tablename, policyname
+        ''',
+      );
+
+      final actual = <String, Map<String, String?>>{};
+      for (final row in rows) {
+        final key =
+            '${row['tablename']}.${row['policyname']}.${row['cmd']}';
+        actual[key] = {
+          'qual': row['qual'] as String?,
+          'with_check': row['with_check'] as String?,
+        };
+      }
+
+      for (final p in _expectedPolicies) {
+        final key = '${p.table}.${p.name}.${p.cmd}';
+        final live = actual[key];
+        if (live == null) {
+          // Missing policies are reported by the previous test; skip.
+          continue;
+        }
+        if (p.expectedUsingContains != null) {
+          final qual = live['qual'] ?? '';
+          expect(
+            _normalize(qual).contains(_normalize(p.expectedUsingContains!)),
+            isTrue,
+            reason:
+                'Policy `$key` has an unexpected USING clause.\n'
+                'Expected to contain: ${p.expectedUsingContains}\n'
+                'Live: $qual',
+          );
+        }
+        if (p.expectedCheckContains != null) {
+          final check = live['with_check'] ?? '';
+          expect(
+            _normalize(check).contains(_normalize(p.expectedCheckContains!)),
+            isTrue,
+            reason:
+                'Policy `$key` has an unexpected WITH CHECK clause.\n'
+                'Expected to contain: ${p.expectedCheckContains}\n'
+                'Live: $check',
+          );
+        }
+      }
+    });
+  });
+}
+
+/// POST a raw SQL string to the Supabase database via the PostgREST RPC
+/// endpoint exposed by the `pg_meta` style helper. Falls back to using
+/// `pg-meta`/SQL through the auth-protected `/pg/query` admin route is
+/// not available on the public REST API; instead we rely on the
+/// `pg_policies` / `pg_class` system views being readable directly via
+/// PostgREST when called with the service-role key.
+///
+/// Implementation: PostgREST exposes `pg_policies` as
+/// `<url>/rest/v1/pg_policies`, but only inside the `public` schema. The
+/// system catalogs live in `pg_catalog`, so we use the SQL pass-through
+/// the project provides via the `query` RPC. If that RPC is not present,
+/// the test setUpAll throws a clear error.
+Future<List<Map<String, dynamic>>> _runSql(
+  String url,
+  String serviceKey,
+  String sql,
+) async {
+  // Supabase ships a `query` RPC out of the box on the
+  // service-role-only path `/rest/v1/rpc/query` for some projects, but
+  // it is NOT guaranteed. The portable answer is the
+  // `/pg/query` PostgREST extension exposed by Supabase Studio:
+  //   https://supabase.com/docs/reference/api/select-from-pg-policies
+  //
+  // PostgREST CAN expose `information_schema.*` views directly on the
+  // REST surface; `pg_policies` is in `pg_catalog`. The simplest
+  // service-role-authenticated path that works against any Supabase
+  // project is the GET on
+  // `<url>/rest/v1/<view>?select=*` provided the view is present on
+  // the `public` search path. Supabase exposes `pg_policies` via the
+  // `extensions` schema on hosted projects, but to keep this test
+  // portable we use the SQL-pass-through Edge Function pattern that
+  // ships with the Supabase CLI's `db reset` helper.
+  //
+  // For the common case (a hosted Supabase project), the
+  // service-role key has direct database access through the
+  // `database` REST endpoint:
+  //   POST <url>/database/query  with body { "query": "<sql>" }
+  // — this is the same endpoint the dashboard uses.
+  final endpoint = Uri.parse(
+    '${url.replaceAll(RegExp(r'/$'), '')}/database/query',
+  );
+  final response = await http
+      .post(
+        endpoint,
+        headers: {
+          'Content-Type': 'application/json',
+          'apikey': serviceKey,
+          'Authorization': 'Bearer $serviceKey',
+        },
+        body: jsonEncode({'query': sql}),
+      )
+      .timeout(const Duration(seconds: 30));
+
+  if (response.statusCode == 404) {
+    // Project does not expose `/database/query`. Fall back to the
+    // PostgREST RPC `exec_sql` if the project has it; otherwise abort
+    // with a clear instruction.
+    final rpcEndpoint = Uri.parse(
+      '${url.replaceAll(RegExp(r'/$'), '')}/rest/v1/rpc/exec_sql',
+    );
+    final rpcResponse = await http
+        .post(
+          rpcEndpoint,
+          headers: {
+            'Content-Type': 'application/json',
+            'apikey': serviceKey,
+            'Authorization': 'Bearer $serviceKey',
+          },
+          body: jsonEncode({'query': sql}),
+        )
+        .timeout(const Duration(seconds: 30));
+    if (rpcResponse.statusCode != 200) {
+      throw StateError(
+        'Could not execute SQL against staging Supabase project. '
+        'Neither `/database/query` nor `/rest/v1/rpc/exec_sql` is '
+        'available. Add an `exec_sql` RPC to the staging project, or '
+        'run the test against a project that exposes the dashboard '
+        'query endpoint.\n'
+        'Last response: ${rpcResponse.statusCode} ${rpcResponse.body}',
+      );
+    }
+    return List<Map<String, dynamic>>.from(
+      jsonDecode(rpcResponse.body) as List<dynamic>,
+    );
+  }
+  if (response.statusCode != 200) {
+    throw StateError(
+      'SQL query against $endpoint failed: '
+      '${response.statusCode} ${response.body}',
+    );
+  }
+  return List<Map<String, dynamic>>.from(
+    jsonDecode(response.body) as List<dynamic>,
+  );
+}
+
+/// Strip whitespace + parentheses for tolerant string matching of
+/// PostgreSQL-stored expressions. PG re-parses and re-prints USING /
+/// WITH CHECK clauses, so `user_id = auth.uid()` may come back as
+/// `(user_id = auth.uid())` or with extra spaces.
+String _normalize(String s) =>
+    s.replaceAll(RegExp(r'\s+'), '').replaceAll('(', '').replaceAll(')', '');
+
+const _expectedTables = <String>[
+  'alerts',
+  'database_owner',
+  'favorites',
+  'fill_ups',
+  'ignored_stations',
+  'itineraries',
+  'obd2_baselines',
+  'price_reports',
+  'price_snapshots',
+  'push_tokens',
+  'station_ratings',
+  'sync_settings',
+  'users',
+  'vehicles',
+];
+
+class _ExpectedPolicy {
+  const _ExpectedPolicy({
+    required this.table,
+    required this.name,
+    required this.cmd,
+    this.expectedUsingContains,
+    this.expectedCheckContains,
+  });
+
+  final String table;
+  final String name;
+  final String cmd; // 'SELECT' / 'INSERT' / 'UPDATE' / 'DELETE' / 'ALL'
+  final String? expectedUsingContains;
+  final String? expectedCheckContains;
+}
+
+/// The policies we expect to find in the live database. Cmd values use
+/// the spelling `pg_policies.cmd` returns: `SELECT`, `INSERT`, `UPDATE`,
+/// `DELETE`, `ALL`. Keep this in lockstep with
+/// `docs/security/SUPABASE_RLS_MATRIX.md`.
+const _expectedPolicies = <_ExpectedPolicy>[
+  // users (split policies after 20260401000001_owner_protection.sql)
+  _ExpectedPolicy(
+    table: 'users',
+    name: 'users_own_select',
+    cmd: 'SELECT',
+    expectedUsingContains: 'id = auth.uid()',
+  ),
+  _ExpectedPolicy(
+    table: 'users',
+    name: 'users_own_insert',
+    cmd: 'INSERT',
+    expectedCheckContains: 'id = auth.uid()',
+  ),
+  _ExpectedPolicy(
+    table: 'users',
+    name: 'users_own_update',
+    cmd: 'UPDATE',
+    expectedUsingContains: 'id = auth.uid()',
+  ),
+  _ExpectedPolicy(
+    table: 'users',
+    name: 'users_delete_owner_only',
+    cmd: 'DELETE',
+    expectedUsingContains: 'is_database_owner',
+  ),
+
+  // favorites
+  _ExpectedPolicy(
+    table: 'favorites',
+    name: 'favorites_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+
+  // alerts
+  _ExpectedPolicy(
+    table: 'alerts',
+    name: 'alerts_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+
+  // price_snapshots
+  _ExpectedPolicy(
+    table: 'price_snapshots',
+    name: 'snapshots_read',
+    cmd: 'SELECT',
+    expectedUsingContains: 'true',
+  ),
+  _ExpectedPolicy(
+    table: 'price_snapshots',
+    name: 'snapshots_insert',
+    cmd: 'INSERT',
+    expectedCheckContains: "auth.role() = 'service_role'",
+  ),
+  _ExpectedPolicy(
+    table: 'price_snapshots',
+    name: 'snapshots_delete',
+    cmd: 'DELETE',
+    expectedUsingContains: "auth.role() = 'service_role'",
+  ),
+
+  // price_reports
+  _ExpectedPolicy(
+    table: 'price_reports',
+    name: 'reports_insert',
+    cmd: 'INSERT',
+    expectedCheckContains: 'reporter_id = auth.uid()',
+  ),
+  _ExpectedPolicy(
+    table: 'price_reports',
+    name: 'reports_read',
+    cmd: 'SELECT',
+    expectedUsingContains: 'true',
+  ),
+  _ExpectedPolicy(
+    table: 'price_reports',
+    name: 'reports_delete',
+    cmd: 'DELETE',
+    expectedUsingContains: 'reporter_id = auth.uid()',
+  ),
+
+  // push_tokens
+  _ExpectedPolicy(
+    table: 'push_tokens',
+    name: 'push_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+
+  // sync_settings
+  _ExpectedPolicy(
+    table: 'sync_settings',
+    name: 'sync_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+
+  // itineraries
+  _ExpectedPolicy(
+    table: 'itineraries',
+    name: 'itineraries_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+
+  // ignored_stations
+  _ExpectedPolicy(
+    table: 'ignored_stations',
+    name: 'ignored_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+
+  // station_ratings
+  _ExpectedPolicy(
+    table: 'station_ratings',
+    name: 'ratings_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+  _ExpectedPolicy(
+    table: 'station_ratings',
+    name: 'ratings_shared_read',
+    cmd: 'SELECT',
+    expectedUsingContains: 'is_shared',
+  ),
+
+  // database_owner
+  _ExpectedPolicy(
+    table: 'database_owner',
+    name: 'owner_read',
+    cmd: 'SELECT',
+    expectedUsingContains: 'true',
+  ),
+  _ExpectedPolicy(
+    table: 'database_owner',
+    name: 'owner_manage',
+    cmd: 'ALL',
+    expectedUsingContains: "auth.role() = 'service_role'",
+  ),
+
+  // vehicles
+  _ExpectedPolicy(
+    table: 'vehicles',
+    name: 'vehicles_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+
+  // fill_ups
+  _ExpectedPolicy(
+    table: 'fill_ups',
+    name: 'fill_ups_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+
+  // obd2_baselines
+  _ExpectedPolicy(
+    table: 'obd2_baselines',
+    name: 'obd2_baselines_own',
+    cmd: 'ALL',
+    expectedUsingContains: 'user_id = auth.uid()',
+  ),
+];


### PR DESCRIPTION
## What

Closes #1110 (audit B7). Adds three deliverables to lock down Supabase RLS:

### 1. `docs/security/SUPABASE_RLS_MATRIX.md` (new)
Source-of-truth matrix enumerating, per table:
- Whether RLS is enabled
- Every policy name + command (SELECT/INSERT/UPDATE/DELETE/ALL)
- The USING / WITH CHECK expressions

Covers all 14 public tables across the 7 migrations that touch RLS:
- `users`, `favorites`, `alerts`, `price_snapshots`, `price_reports`, `push_tokens`, `sync_settings`, `itineraries`, `ignored_stations`, `station_ratings`, `database_owner`, `vehicles`, `fill_ups`, `obd2_baselines`.

### 2. `test/security/supabase_rls_test.dart` (new, network-tagged)
File-level `@Tags(['network'])` (matches the convention from `test/security/external_urls_reachable_test.dart` and other network-tagged tests). Queries `pg_policies` + `pg_class` on the staging project and asserts:
- Every documented table has `relrowsecurity = true`.
- The live policy set matches the matrix (no missing, no extras).
- Each policy's USING / WITH CHECK clause contains the expected expression (tolerant whitespace/parenthesis match because PG re-prints stored expressions).

Cleanly skips when `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are absent — never blocks offline PR runs.

Run locally:
```bash
SUPABASE_URL=https://STAGING.supabase.co \
SUPABASE_SERVICE_ROLE_KEY=... \
flutter test test/security/supabase_rls_test.dart --tags network
```

### 3. `supabase/migrations/MIGRATION_TEMPLATE.md` (new)
Pre-merge checklist with the load-bearing item:
> - [ ] **RLS confirmed: this migration does NOT disable RLS on any table, and any new tables explicitly call `ALTER TABLE ... ENABLE ROW LEVEL SECURITY;`.**

Plus checks for matrix-doc updates, `user_id = auth.uid()` fencing, no `BYPASSRLS`, no GRANT bypass, etc.

### Bonus
Added `!docs/security/` to `.gitignore` allow-list so the matrix is tracked.

## Why

The single largest path that can leak user data off-device is a forgotten `ENABLE ROW LEVEL SECURITY` on a new table or a weakened policy in a future migration. Before this PR there was no automated guard and no written record of expected policies. The matrix doc + verification test close that gap; the migration checklist catches drift at PR review time.

Required to lift the Security grade from A- to A (per audit notes in the issue).

## Out of scope

The issue mentions an optional CI staging-tag job that runs network-tagged tests on tag releases — **deliberately skipped here** because we don't have staging credentials wired up. The test is portable: any future PR that wires the staging job will pick it up via the `--tags network` switch with no code change.

## Testing

- `flutter analyze` — zero issues.
- `flutter test test/security/supabase_rls_test.dart --tags network` (no env vars set) — skips cleanly.
- `flutter test test/security/supabase_rls_test.dart` (no tag flag, no env vars) — also skips cleanly.

The full network-against-live-Supabase path will be exercised the first time a maintainer runs it with staging credentials; the test is structured so the failure messages tell you exactly which policy diverged from the matrix doc.