### PR TITLE
chore(ci): paths-ignore for docs-only PRs (closes #1128)

### DIFF
--- a/.github/workflows/ci-docs-stub.yml
+++ b/.github/workflows/ci-docs-stub.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  pull_request:
+    branches: [master]
+    paths:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — analyze skipped (stub passes for branch protection)"
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — test skipped (stub passes for branch protection)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,18 @@ on:
   push:
     branches: [master]
     tags: ['v*']
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   schedule:
     - cron: '0 6 * * 0'
 


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` adds `paths-ignore` for `**/*.md`, `docs/**`, `LICENSE`, `.gitignore` on both `push` and `pull_request`. Docs-only changes no longer trigger the full ~8-min analyze + test pipeline.
- New `.github/workflows/ci-docs-stub.yml` runs on the same paths the main workflow ignores, with stub jobs named `analyze` and `test` that exit immediately. Branch protection's required checks see green status on docs-only PRs so they can still merge.

## Why

Last PR (#1129, the docs restructure) burned a full ~8 min CI cycle for a markdown move. This is the recurring cost #1128 calls out — cheap, compounding.

## Test plan

- [ ] Open a docs-only follow-up PR — only the stub `analyze` + `test` jobs run, both green, PR mergeable.
- [ ] Mixed (docs + code) PR triggers the real pipeline (paths-ignore needs ALL files to match to skip).
- [ ] Code-only PR unaffected.

Closes #1128.