### PR TITLE
refactor(fuel): replace fuelTypesForCountry switch with declarative map (closes #1112)

### DIFF
--- a/lib/features/search/domain/entities/fuel_type.dart
+++ b/lib/features/search/domain/entities/fuel_type.dart
@@ -295,76 +295,96 @@ class FuelTypeJsonConverter implements JsonConverter<FuelType, String> {
 
 // ── Country mappings ────────────────────────────────────────────────────────
 
+/// Default fuel types for any country not present in [_countryFuels].
+///
+/// Mirrors the historical `default:` branch of `fuelTypesForCountry`: the
+/// minimal set every petrol/diesel station can be assumed to carry, plus
+/// the EV and "all" wildcard.
+const List<FuelType> _defaultCountryFuels = [
+  FuelType.e5,
+  FuelType.e10,
+  FuelType.diesel,
+  FuelType.electric,
+  FuelType.all,
+];
+
+/// Declarative per-country fuel-type catalogue.
+///
+/// Each entry is the exact ordered list returned for that ISO 3166-1
+/// alpha-2 country code. Order matters: the UI fuel-type selector renders
+/// the list in this order, so the most common fuel for each country sits
+/// first. Every list ends with [FuelType.electric] followed by
+/// [FuelType.all] (the search-time wildcard) — keep that tail when adding
+/// a new country.
+const Map<String, List<FuelType>> _countryFuels = {
+  // DE: Tankerkönig publishes E5, E10, Diesel.
+  'DE': [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all],
+  // FR: Prix Carburants — SP95-E10 first (most common at French pumps),
+  // then SP95 / SP98, Gazole, E85 (Bioéthanol), GPL.
+  'FR': [
+    FuelType.e10, FuelType.e5, FuelType.e98, FuelType.diesel,
+    FuelType.e85, FuelType.lpg, FuelType.electric, FuelType.all,
+  ],
+  // AT: Spritpreisrechner — Super 95 (E5/E10), Diesel.
+  'AT': [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all],
+  // ES: Geoportal Gasolineras — Gasolina 95/98, Diésel A/A+, GLP.
+  'ES': [
+    FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+    FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
+  ],
+  // IT: MIMIT (osservaprezzi) — Benzina, Gasolio, GPL, Metano (CNG).
+  'IT': [
+    FuelType.e5, FuelType.diesel, FuelType.lpg, FuelType.cng, FuelType.electric, FuelType.all,
+  ],
+  // LU: Luxembourg regulated prices (#574): Sans Plomb 95 (mapped to
+  // E5/E10), Sans Plomb 98 (E98), Diesel, LPG.
+  'LU': [
+    FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+    FuelType.lpg, FuelType.electric, FuelType.all,
+  ],
+  // SI: Slovenia sells NMB-95 (→ e5), NMB-100 (premium, → e98), Dizel
+  // (→ diesel), Dizel Premium, and LPG. #575
+  'SI': [
+    FuelType.e5, FuelType.e98, FuelType.diesel,
+    FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
+  ],
+  // KR: South Korea (OPINET): Gasoline (→ e5), Premium Gasoline (→ e98),
+  // Diesel, LPG. Kerosene is published by OPINET but has no FuelType
+  // enum today — added in a follow-up. #597
+  'KR': [
+    FuelType.e5, FuelType.e98, FuelType.diesel,
+    FuelType.lpg, FuelType.electric, FuelType.all,
+  ],
+  // CL: Chile (CNE Bencina en Línea): Gasolina 93/95 (→ e5),
+  // Gasolina 97 (→ e98), Diésel, Gas licuado / LPG. Kerosene is
+  // published by CNE but has no FuelType enum today. #596
+  'CL': [
+    FuelType.e5, FuelType.e98, FuelType.diesel,
+    FuelType.lpg, FuelType.electric, FuelType.all,
+  ],
+  // GR: Greece (Paratiritirio Timon via fuelpricesgr community API):
+  // Αμόλυβδη 95 (→ e5), Αμόλυβδη 100 (→ e98), Diesel, Υγραέριο /
+  // LPG. Diesel heating is published but intentionally dropped
+  // (not a motoring fuel). #576
+  'GR': [
+    FuelType.e5, FuelType.e98, FuelType.diesel,
+    FuelType.lpg, FuelType.electric, FuelType.all,
+  ],
+  // RO: Romania (Monitorul Prețurilor — pretcarburant.ro): Benzină
+  // Standard (→ e5), Benzină Premium (→ e98), Motorină Standard
+  // (→ diesel), Motorină Premium (→ diesel premium), GPL
+  // (→ lpg). 15-minute government-mandated updates. #577
+  'RO': [
+    FuelType.e5, FuelType.e98, FuelType.diesel,
+    FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
+  ],
+};
+
 /// Returns fuel types available for a given country code.
+///
+/// Looks up [countryCode] in [_countryFuels]; falls back to
+/// [_defaultCountryFuels] for unknown countries (the same minimal set the
+/// previous `switch` returned via its `default:` branch).
 List<FuelType> fuelTypesForCountry(String countryCode) {
-  switch (countryCode) {
-    case 'DE':
-      return [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all];
-    case 'FR':
-      return [
-        FuelType.e10, FuelType.e5, FuelType.e98, FuelType.diesel,
-        FuelType.e85, FuelType.lpg, FuelType.electric, FuelType.all,
-      ];
-    case 'AT':
-      return [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all];
-    case 'ES':
-      return [
-        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
-        FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
-      ];
-    case 'IT':
-      return [
-        FuelType.e5, FuelType.diesel, FuelType.lpg, FuelType.cng, FuelType.electric, FuelType.all,
-      ];
-    case 'LU':
-      // Luxembourg regulated prices (#574): Sans Plomb 95 (mapped to
-      // E5/E10), Sans Plomb 98 (E98), Diesel, LPG.
-      return [
-        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
-        FuelType.lpg, FuelType.electric, FuelType.all,
-      ];
-    case 'SI':
-      // Slovenia sells NMB-95 (→ e5), NMB-100 (premium, → e98), Dizel
-      // (→ diesel), Dizel Premium, and LPG. #575
-      return [
-        FuelType.e5, FuelType.e98, FuelType.diesel,
-        FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
-      ];
-    case 'KR':
-      // South Korea (OPINET): Gasoline (→ e5), Premium Gasoline (→ e98),
-      // Diesel, LPG. Kerosene is published by OPINET but has no FuelType
-      // enum today — added in a follow-up. #597
-      return [
-        FuelType.e5, FuelType.e98, FuelType.diesel,
-        FuelType.lpg, FuelType.electric, FuelType.all,
-      ];
-    case 'CL':
-      // Chile (CNE Bencina en Línea): Gasolina 93/95 (→ e5),
-      // Gasolina 97 (→ e98), Diésel, Gas licuado / LPG. Kerosene is
-      // published by CNE but has no FuelType enum today. #596
-      return [
-        FuelType.e5, FuelType.e98, FuelType.diesel,
-        FuelType.lpg, FuelType.electric, FuelType.all,
-      ];
-    case 'GR':
-      // Greece (Paratiritirio Timon via fuelpricesgr community API):
-      // Αμόλυβδη 95 (→ e5), Αμόλυβδη 100 (→ e98), Diesel, Υγραέριο /
-      // LPG. Diesel heating is published but intentionally dropped
-      // (not a motoring fuel). #576
-      return [
-        FuelType.e5, FuelType.e98, FuelType.diesel,
-        FuelType.lpg, FuelType.electric, FuelType.all,
-      ];
-    case 'RO':
-      // Romania (Monitorul Prețurilor — pretcarburant.ro): Benzină
-      // Standard (→ e5), Benzină Premium (→ e98), Motorină Standard
-      // (→ diesel), Motorină Premium (→ diesel premium), GPL
-      // (→ lpg). 15-minute government-mandated updates. #577
-      return [
-        FuelType.e5, FuelType.e98, FuelType.diesel,
-        FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
-      ];
-    default:
-      return [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all];
-  }
+  return _countryFuels[countryCode] ?? _defaultCountryFuels;
 }

--- a/test/features/search/domain/entities/fuel_types_for_country_test.dart
+++ b/test/features/search/domain/entities/fuel_types_for_country_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Behaviour-preservation tests for the declarative `_countryFuels` map
+/// (closes #1112). Each expected list below is hard-coded from the
+/// pre-refactor `switch` in `fuel_type.dart` so that any drift from the
+/// historical mapping fails loudly here. Order matters: the UI fuel-type
+/// selector renders in the order returned, so we assert via `equals(...)`
+/// (exact list equality) rather than `contains(...)`.
+void main() {
+  group('fuelTypesForCountry — exact per-country lists (#1112)', () {
+    test('DE — E5, E10, Diesel, Electric, All', () {
+      expect(
+        fuelTypesForCountry('DE'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e10,
+          FuelType.diesel,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('FR — E10 first, then E5/E98/Diesel/E85/LPG', () {
+      expect(
+        fuelTypesForCountry('FR'),
+        equals(<FuelType>[
+          FuelType.e10,
+          FuelType.e5,
+          FuelType.e98,
+          FuelType.diesel,
+          FuelType.e85,
+          FuelType.lpg,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('AT — E5, E10, Diesel, Electric, All', () {
+      expect(
+        fuelTypesForCountry('AT'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e10,
+          FuelType.diesel,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('ES — includes Diesel Premium and LPG', () {
+      expect(
+        fuelTypesForCountry('ES'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e10,
+          FuelType.e98,
+          FuelType.diesel,
+          FuelType.dieselPremium,
+          FuelType.lpg,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('IT — Benzina, Diesel, LPG, CNG (Metano)', () {
+      expect(
+        fuelTypesForCountry('IT'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.diesel,
+          FuelType.lpg,
+          FuelType.cng,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('LU — E5, E10, E98, Diesel, LPG (#574)', () {
+      expect(
+        fuelTypesForCountry('LU'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e10,
+          FuelType.e98,
+          FuelType.diesel,
+          FuelType.lpg,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('SI — NMB-95/100, Diesel, Diesel Premium, LPG (#575)', () {
+      expect(
+        fuelTypesForCountry('SI'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e98,
+          FuelType.diesel,
+          FuelType.dieselPremium,
+          FuelType.lpg,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('KR — OPINET Gasoline / Premium / Diesel / LPG (#597)', () {
+      expect(
+        fuelTypesForCountry('KR'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e98,
+          FuelType.diesel,
+          FuelType.lpg,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('CL — CNE Gasolina 93/95/97, Diésel, LPG (#596)', () {
+      expect(
+        fuelTypesForCountry('CL'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e98,
+          FuelType.diesel,
+          FuelType.lpg,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('GR — Αμόλυβδη 95/100, Diesel, LPG (#576)', () {
+      expect(
+        fuelTypesForCountry('GR'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e98,
+          FuelType.diesel,
+          FuelType.lpg,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('RO — Benzină Standard/Premium, Motorină Standard/Premium, GPL (#577)',
+        () {
+      expect(
+        fuelTypesForCountry('RO'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e98,
+          FuelType.diesel,
+          FuelType.dieselPremium,
+          FuelType.lpg,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('XX (unknown) — falls back to default minimal set', () {
+      expect(
+        fuelTypesForCountry('XX'),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e10,
+          FuelType.diesel,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('empty country code falls back to default minimal set', () {
+      expect(
+        fuelTypesForCountry(''),
+        equals(<FuelType>[
+          FuelType.e5,
+          FuelType.e10,
+          FuelType.diesel,
+          FuelType.electric,
+          FuelType.all,
+        ]),
+      );
+    });
+
+    test('every country returns a list ending in electric, all', () {
+      const codes = [
+        'DE', 'FR', 'AT', 'ES', 'IT', 'LU', 'SI', 'KR', 'CL', 'GR', 'RO',
+      ];
+      for (final code in codes) {
+        final list = fuelTypesForCountry(code);
+        expect(list.length, greaterThanOrEqualTo(2),
+            reason: '$code list should be non-trivial');
+        expect(list[list.length - 2], FuelType.electric,
+            reason: '$code list should end with electric, all');
+        expect(list.last, FuelType.all,
+            reason: '$code list should end with electric, all');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Replace the per-country `switch` in `fuelTypesForCountry()` (lib/features/search/domain/entities/fuel_type.dart) with a declarative `_countryFuels` Map plus a one-line lookup. Behaviour is identical for every country code — same ordered list for DE/FR/AT/ES/IT/LU/SI/KR/CL/GR/RO and the same default `[E5, E10, Diesel, Electric, All]` for unknown codes (now named `_defaultCountryFuels` instead of buried in a `default:` branch).

## Why
- The 70-line switch did one job (return a list per country) but spent 11 `case` labels and 12 `return [...]` statements doing it.
- A map makes adding a new country a single entry edit, matches what `NEW_COUNTRY.md` already implies, and keeps the per-country block-comments (LU/SI/KR/CL/GR/RO with their issue refs) attached to their data.
- Function signature unchanged; the two callers (`fuel_type_selector.dart` and one test file) need no edits.

## What changed
- `lib/features/search/domain/entities/fuel_type.dart`: switch -> `Map<String, List<FuelType>>`. Every existing per-country comment is preserved on its map entry; DE/FR/AT/ES/IT picked up short one-line origin comments to match the rest.
- `test/features/search/domain/entities/fuel_types_for_country_test.dart` (new): asserts the EXACT pre-refactor list via `equals(...)` (not `contains(...)`) for every country code + XX + empty fallback, plus a structural check that every list ends with `electric, all`.
- Existing `fuel_type_test.dart` left untouched and still passes.

## Test plan
- [x] `flutter analyze` — zero issues
- [x] `flutter test test/features/search/domain/entities/` — 165 passed
- [x] `flutter test test/docs/new_country_guide_test.dart` — 23 passed (sanity-check that the new-country guide still references `fuelTypesForCountry`)
- [x] `git diff --stat` shows only the two intended files; no `.g.dart` / `.freezed.dart` drift

Closes #1112

Note: branch protection here squashes, so `Closes #1112` in the body may not auto-close on merge — coordinator will close manually if needed.