### PR TITLE
refactor(error): unify logging behind errorLogger.log() (#1104)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -13,6 +13,7 @@ import '../core/cache/cache_manager.dart';
 import '../core/error_tracing/storage/isolate_error_spool.dart';
 import '../core/error_tracing/storage/trace_storage.dart';
 import '../core/error_tracing/trace_recorder.dart';
+import '../core/logging/error_logger.dart';
 import '../core/notifications/local_notification_service.dart';
 import '../core/perf/startup_timer.dart';
 import '../core/services/country_service_registry.dart';
@@ -378,17 +379,29 @@ class AppInitializer {
     ProviderContainer container,
     Widget Function(ProviderContainer container) appBuilder,
   ) {
+    // #1104 — bind the unified errorLogger to this container so every
+    // call to `errorLogger.log(layer, e, st)` from the foreground
+    // isolate routes through TraceRecorder + Sentry. Background-isolate
+    // callsites never reach this path; they fall through to the Hive
+    // ring buffer (IsolateErrorSpool) and are replayed below.
+    errorLogger.bind(container);
+
     // Capture Flutter framework errors (build, layout, paint).
     FlutterError.onError = (details) {
       FlutterError.presentError(details);
-      container.read(traceRecorderProvider).record(
-            details.exception,
-            details.stack ?? StackTrace.current,
-          );
+      errorLogger.log(
+        ErrorLayer.ui,
+        details.exception,
+        details.stack ?? StackTrace.current,
+        context: <String, Object?>{
+          'library': details.library,
+          'context': details.context?.toString(),
+        },
+      );
     };
     // Capture async / platform errors that escape the framework.
     PlatformDispatcher.instance.onError = (error, stack) {
-      container.read(traceRecorderProvider).record(error, stack);
+      errorLogger.log(ErrorLayer.other, error, stack);
       return true;
     };
 

--- a/lib/core/error_tracing/integrations/dio_trace_interceptor.dart
+++ b/lib/core/error_tracing/integrations/dio_trace_interceptor.dart
@@ -1,12 +1,15 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../logging/error_logger.dart';
 import '../collectors/app_state_collector.dart';
 import '../collectors/breadcrumb_collector.dart';
-import '../trace_recorder.dart';
 
 class DioTraceInterceptor extends Interceptor {
-  final Ref _ref;
-  DioTraceInterceptor(this._ref);
+  /// Constructor parameter is intentionally accepted-and-ignored to
+  /// preserve the public signature; the unified [errorLogger] holds
+  /// the bound `ProviderContainer` and resolves `traceRecorderProvider`
+  /// from there.
+  DioTraceInterceptor(Ref _);
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
@@ -18,10 +21,20 @@ class DioTraceInterceptor extends Interceptor {
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
-    _ref.read(traceRecorderProvider).record(
-          err,
-          err.stackTrace,
-        );
+    // #1104 — route through the unified logger so service-layer Dio
+    // failures land in the same pipeline as foreground / background
+    // errors. Fire-and-forget: the interceptor contract is sync.
+    errorLogger.log(
+      ErrorLayer.services,
+      err,
+      err.stackTrace,
+      context: <String, Object?>{
+        'method': err.requestOptions.method,
+        'path': err.requestOptions.uri.path,
+        'statusCode': err.response?.statusCode,
+        'dioType': err.type.name,
+      },
+    );
     handler.next(err);
   }
 }

--- a/lib/core/error_tracing/integrations/riverpod_trace_observer.dart
+++ b/lib/core/error_tracing/integrations/riverpod_trace_observer.dart
@@ -1,9 +1,16 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../trace_recorder.dart';
+import '../../logging/error_logger.dart';
 
+/// Bridges Riverpod provider failures into the unified [errorLogger]
+/// pipeline (#1104). The constructor still accepts a [ProviderContainer]
+/// so existing callsites continue to compile, but the observer no
+/// longer reads from it directly — `errorLogger.log` resolves the
+/// recorder through the bound container under the hood.
 final class RiverpodTraceObserver extends ProviderObserver {
-  final ProviderContainer _container;
-  RiverpodTraceObserver(this._container);
+  /// Constructor parameter is intentionally accepted-and-ignored to
+  /// preserve the public signature; the unified logger holds the
+  /// bound container.
+  RiverpodTraceObserver(ProviderContainer _);
 
   @override
   void providerDidFail(
@@ -11,6 +18,8 @@ final class RiverpodTraceObserver extends ProviderObserver {
     Object error,
     StackTrace stackTrace,
   ) {
-    _container.read(traceRecorderProvider).record(error, stackTrace);
+    // Fire-and-forget: the observer's contract is synchronous. Dropping
+    // the future is fine because `errorLogger.log` never throws.
+    errorLogger.log(ErrorLayer.providers, error, stackTrace);
   }
 }

--- a/lib/core/logging/error_logger.dart
+++ b/lib/core/logging/error_logger.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../error_tracing/storage/isolate_error_spool.dart';
+import '../error_tracing/trace_recorder.dart';
+
+/// Layer / area of the codebase where an error originated. Used as a
+/// single grep target for cross-cutting analytics ("how many service
+/// errors did we see in the last 7 days?") and as routing metadata
+/// when the error eventually lands in Sentry / Glitchtip.
+enum ErrorLayer {
+  /// User-facing screens, widgets, route guards, navigation observers.
+  ui,
+
+  /// Riverpod providers — async notifiers, derived providers, observers.
+  providers,
+
+  /// Service layer (HTTP / API clients, country fetchers, geocoding).
+  services,
+
+  /// Local persistence (Hive boxes, secure storage, file IO).
+  storage,
+
+  /// TankSync / Supabase / cloud sync flows.
+  sync,
+
+  /// Background tasks running inside the foreground isolate
+  /// (Timers, post-frame callbacks, foreground-service runners).
+  background,
+
+  /// Code that may run inside the WorkManager / `dart:isolate` worker
+  /// where Riverpod is unavailable. Routes to [IsolateErrorSpool] for
+  /// later replay.
+  isolate,
+
+  /// Anything else / not yet classified.
+  other,
+}
+
+/// Single error-logging API for the app (#1104).
+///
+/// Replaces the four divergent channels (`debugPrint(e)`,
+/// `TraceRecorder.record`, `Sentry.captureException`, silent swallow)
+/// with one entry point. Foreground callsites are routed to
+/// [TraceRecorder] (which already feeds Sentry via the configured
+/// uploader); background-isolate callsites — where Riverpod is
+/// unavailable — are spooled to [IsolateErrorSpool] for replay through
+/// the same pipeline once the foreground app drains the ring buffer
+/// (see `lib/app/app_initializer.dart`).
+///
+/// ## Routing
+/// 1. If a `ProviderContainer` has been bound via [bind], we are in the
+///    foreground isolate → delegate to `TraceRecorder.record`.
+/// 2. Otherwise → write to [IsolateErrorSpool] (Hive ring buffer).
+///
+/// ## Why a singleton + bind, not a Riverpod provider
+/// The whole point is to make the API callable from background
+/// isolates that have no Riverpod container. A Riverpod-based logger
+/// would need a different shape per isolate; the singleton lets every
+/// callsite use the same `errorLogger.log(...)` regardless of context.
+///
+/// ## Contract
+/// - `log` never throws — observability must not derail the caller.
+/// - Stack trace is forwarded to TraceRecorder / spool unchanged; if
+///   the caller passes `null`, `StackTrace.current` is captured at the
+///   call site so the trace is still useful.
+/// - `context` is a free-form map of Hive-safe primitives (string,
+///   num, bool, null, List, Map). Non-primitives are coerced via
+///   `toString()` by the spool; for the foreground path the wrapper
+///   error preserves them in its `toString()`.
+class ErrorLogger {
+  ErrorLogger._();
+
+  /// The bound foreground container, set once by `AppInitializer` after
+  /// it builds the root `ProviderContainer`. Workers (background
+  /// isolates) never call [bind] so their `_container` stays null and
+  /// `log` falls through to the spool.
+  ProviderContainer? _container;
+
+  /// Test seam: an in-memory recorder that bypasses Riverpod. When set,
+  /// `log` calls it instead of resolving `traceRecorderProvider` from
+  /// the bound container. Useful for unit tests that don't want to
+  /// stand up a full Hive + provider stack.
+  @visibleForTesting
+  TraceRecorder? testRecorderOverride;
+
+  /// Test seam: replace the spool enqueue function. Defaults to
+  /// [IsolateErrorSpool.enqueue]. Tests inject a captor to assert what
+  /// was written without touching real Hive boxes.
+  @visibleForTesting
+  Future<void> Function({
+    required String isolateTaskName,
+    required Object error,
+    StackTrace? stack,
+    Map<String, dynamic>? contextMap,
+    DateTime? timestamp,
+  }) spoolEnqueueOverride = IsolateErrorSpool.enqueue;
+
+  /// Bind the root foreground [ProviderContainer]. Called exactly
+  /// once from `AppInitializer` after the container is built. After
+  /// this call, foreground `log` invocations are routed through
+  /// `TraceRecorder`; before it (or in a background isolate that
+  /// never calls bind) they are spooled.
+  void bind(ProviderContainer container) {
+    _container = container;
+  }
+
+  /// Reset the foreground binding. Used in tests; not expected in
+  /// production code (containers live for the lifetime of the app).
+  @visibleForTesting
+  void resetForTest() {
+    _container = null;
+    testRecorderOverride = null;
+    spoolEnqueueOverride = IsolateErrorSpool.enqueue;
+  }
+
+  /// `true` when running inside the foreground isolate with a bound
+  /// container or an explicit test recorder.
+  bool get isForegroundBound =>
+      _container != null || testRecorderOverride != null;
+
+  /// Log [error] under [layer]. Routes to [TraceRecorder] in the
+  /// foreground and to [IsolateErrorSpool] in background isolates.
+  ///
+  /// Never throws. Logs internal failures via [debugPrint] so the
+  /// caller is never derailed by an observability fault.
+  Future<void> log(
+    ErrorLayer layer,
+    Object error,
+    StackTrace? stack, {
+    Map<String, Object?>? context,
+  }) async {
+    final stackTrace = stack ?? StackTrace.current;
+    try {
+      if (testRecorderOverride != null) {
+        await testRecorderOverride!.record(
+          _ContextualError(layer: layer, error: error, context: context),
+          stackTrace,
+        );
+        return;
+      }
+      final container = _container;
+      if (container != null) {
+        // Foreground path: TraceRecorder pipeline + Sentry uploader.
+        // Wrap in a contextual error so the layer + context map land
+        // in `error.toString()` (which TraceRecorder serialises to
+        // `errorMessage`) without requiring a TraceRecorder API
+        // change.
+        final recorder = container.read(traceRecorderProvider);
+        await recorder.record(
+          _ContextualError(layer: layer, error: error, context: context),
+          stackTrace,
+        );
+        return;
+      }
+      // Background isolate path: spool through Hive ring buffer.
+      await spoolEnqueueOverride(
+        isolateTaskName: layer.name,
+        error: error,
+        stack: stackTrace,
+        contextMap: _toHiveContext(layer, context),
+      );
+    } catch (e, st) {
+      // Never re-throw from the logger. Observability MUST NOT break
+      // the calling task; #1105 spool follows the same contract.
+      debugPrint('ErrorLogger: log failed (${layer.name}): $e\n$st');
+    }
+  }
+
+  /// Convert a `Map<String, Object?>` (the public, type-safe context
+  /// map) into the `Map<String, dynamic>` shape the spool expects.
+  /// Adds the layer name under a reserved key so background-origin
+  /// errors carry the layer through replay.
+  static Map<String, dynamic> _toHiveContext(
+    ErrorLayer layer,
+    Map<String, Object?>? context,
+  ) {
+    final out = <String, dynamic>{
+      'errorLayer': layer.name,
+    };
+    if (context == null || context.isEmpty) {
+      return out;
+    }
+    for (final entry in context.entries) {
+      out[entry.key] = entry.value;
+    }
+    return out;
+  }
+}
+
+/// Wrapper error that carries the [ErrorLayer] and context map through
+/// [TraceRecorder]'s `errorMessage` field (which is built from
+/// `error.toString()`). This avoids a breaking change to
+/// `TraceRecorder.record` — the recorder still gets a single `Object`
+/// + `StackTrace`, but the rendered message includes the structured
+/// metadata for grep / log triage.
+class _ContextualError implements Exception {
+  final ErrorLayer layer;
+  final Object error;
+  final Map<String, Object?>? context;
+
+  _ContextualError({
+    required this.layer,
+    required this.error,
+    required this.context,
+  });
+
+  /// Expose the wrapped error for callers that want to inspect the
+  /// original type without parsing `toString()`.
+  Object get inner => error;
+
+  @override
+  String toString() {
+    final ctx = context;
+    if (ctx == null || ctx.isEmpty) {
+      return '[${layer.name}] $error';
+    }
+    return '[${layer.name}] $error [context=$ctx]';
+  }
+}
+
+/// Process-wide singleton. Safe to call from any isolate; routing is
+/// decided per call based on whether [ErrorLogger.bind] has been
+/// invoked in the current isolate.
+final ErrorLogger errorLogger = ErrorLogger._();

--- a/test/core/error_tracing/integrations/dio_trace_interceptor_test.dart
+++ b/test/core/error_tracing/integrations/dio_trace_interceptor_test.dart
@@ -6,6 +6,7 @@ import 'package:tankstellen/core/error_tracing/collectors/breadcrumb_collector.d
 import 'package:tankstellen/core/error_tracing/integrations/dio_trace_interceptor.dart';
 import 'package:tankstellen/core/error_tracing/models/error_trace.dart';
 import 'package:tankstellen/core/error_tracing/trace_recorder.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 
@@ -120,11 +121,16 @@ void main() {
       },
     );
 
-    test('onError forwards (error, stackTrace) to TraceRecorder + handler', () {
+    test('onError forwards (error, stackTrace) to errorLogger + handler',
+        () async {
+      // After #1104, DioTraceInterceptor routes errors through
+      // `errorLogger.log` instead of reading `traceRecorderProvider`
+      // directly. The test recorder seam captures the wrapped error.
       final fakeRecorder = _FakeTraceRecorder();
-      final container = ProviderContainer(overrides: [
-        traceRecorderProvider.overrideWithValue(fakeRecorder),
-      ]);
+      errorLogger.testRecorderOverride = fakeRecorder;
+      addTearDown(errorLogger.resetForTest);
+
+      final container = ProviderContainer();
       addTearDown(container.dispose);
 
       late Ref capturedRef;
@@ -138,7 +144,7 @@ void main() {
       final handler = _CapturingErrorHandler();
       final stack = StackTrace.current;
       final dioErr = DioException(
-        requestOptions: RequestOptions(path: '/boom'),
+        requestOptions: RequestOptions(method: 'GET', path: '/boom'),
         type: DioExceptionType.connectionError,
         error: 'connection refused',
         stackTrace: stack,
@@ -146,8 +152,16 @@ void main() {
 
       interceptor.onError(dioErr, handler);
 
+      // The interceptor fires-and-forgets; pump microtasks so the
+      // async log lands.
+      await Future<void>.delayed(Duration.zero);
+
       expect(fakeRecorder.recordCount, 1);
-      expect(fakeRecorder.capturedError, same(dioErr));
+      // Wrapped error renders the original DioException via toString();
+      // the layer prefix lets log triage filter by ErrorLayer.services.
+      expect(fakeRecorder.capturedError.toString(), contains('services'));
+      expect(fakeRecorder.capturedError.toString(),
+          contains('DioException'));
       expect(fakeRecorder.capturedStack, same(stack));
 
       expect(handler.nextCount, 1);

--- a/test/core/error_tracing/integrations/riverpod_trace_observer_test.dart
+++ b/test/core/error_tracing/integrations/riverpod_trace_observer_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error_tracing/integrations/riverpod_trace_observer.dart';
 import 'package:tankstellen/core/error_tracing/models/error_trace.dart';
 import 'package:tankstellen/core/error_tracing/trace_recorder.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 
 class _FakeTraceRecorder implements TraceRecorder {
   Object? capturedError;
@@ -34,23 +35,22 @@ final _exploding = Provider<int>((ref) {
 
 void main() {
   group('RiverpodTraceObserver', () {
-    test(
-      'providerDidFail forwards (error, stackTrace) to traceRecorderProvider',
-      () {
-        final fakeRecorder = _FakeTraceRecorder();
+    setUp(() => errorLogger.resetForTest());
+    tearDown(() => errorLogger.resetForTest());
 
-        // Build the container *first*, then attach the observer using the
-        // explicit constructor argument — RiverpodTraceObserver(_container)
-        // breaks the chicken-and-egg by storing the container reference.
+    test(
+      'providerDidFail forwards (error, stackTrace) to errorLogger',
+      () async {
+        final fakeRecorder = _FakeTraceRecorder();
+        // After #1104 the observer routes through `errorLogger.log`,
+        // which is bound here directly via the test seam so we skip
+        // standing up a full Riverpod TraceRecorder.
+        errorLogger.testRecorderOverride = fakeRecorder;
+
         late ProviderContainer container;
         final observer =
             _DeferredObserver((c) => RiverpodTraceObserver(c));
-        container = ProviderContainer(
-          observers: [observer],
-          overrides: [
-            traceRecorderProvider.overrideWithValue(fakeRecorder),
-          ],
-        );
+        container = ProviderContainer(observers: [observer]);
         observer.attach(container);
         addTearDown(container.dispose);
 
@@ -60,26 +60,27 @@ void main() {
         // receives the original StateError.)
         expect(() => container.read(_exploding), throwsA(isA<Object>()));
 
+        // The observer fires-and-forgets the future; pump microtasks so
+        // the async `record` call lands before assertions run.
+        await Future<void>.delayed(Duration.zero);
+
         expect(fakeRecorder.recordCount, 1);
-        expect(fakeRecorder.capturedError, isA<StateError>());
-        expect(
-          (fakeRecorder.capturedError as StateError).message,
-          'boom',
-        );
+        // Wrapped error preserves the original StateError in its
+        // toString() so log triage can still see the message.
+        expect(fakeRecorder.capturedError, isNotNull);
+        expect(fakeRecorder.capturedError.toString(), contains('boom'));
+        expect(fakeRecorder.capturedError.toString(), contains('providers'));
         expect(fakeRecorder.capturedStack, isNotNull);
       },
     );
 
-    test('multiple failing reads each forward to the recorder', () {
+    test('multiple failing reads each forward to the logger', () async {
       final fakeRecorder = _FakeTraceRecorder();
+      errorLogger.testRecorderOverride = fakeRecorder;
+
       late ProviderContainer container;
       final observer = _DeferredObserver((c) => RiverpodTraceObserver(c));
-      container = ProviderContainer(
-        observers: [observer],
-        overrides: [
-          traceRecorderProvider.overrideWithValue(fakeRecorder),
-        ],
-      );
+      container = ProviderContainer(observers: [observer]);
       observer.attach(container);
       addTearDown(container.dispose);
 
@@ -88,6 +89,7 @@ void main() {
       container.invalidate(_exploding);
       expect(() => container.read(_exploding), throwsA(isA<Object>()));
 
+      await Future<void>.delayed(Duration.zero);
       expect(fakeRecorder.recordCount, 2);
     });
   });

--- a/test/core/logging/error_logger_test.dart
+++ b/test/core/logging/error_logger_test.dart
@@ -1,0 +1,264 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error_tracing/models/error_trace.dart';
+import 'package:tankstellen/core/error_tracing/trace_recorder.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+
+/// Captures every `record` call without standing up a real
+/// TraceStorage / TraceUploader / Riverpod stack. Mirrors the fake
+/// used by `test/core/error_tracing/storage/isolate_error_spool_test.dart`.
+class _FakeTraceRecorder implements TraceRecorder {
+  final calls = <_RecordedCall>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(_RecordedCall(error, stackTrace, serviceChainState));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+class _RecordedCall {
+  final Object error;
+  final StackTrace stackTrace;
+  final ServiceChainSnapshot? snapshot;
+  _RecordedCall(this.error, this.stackTrace, this.snapshot);
+}
+
+class _SpoolCall {
+  final String isolateTaskName;
+  final Object error;
+  final StackTrace? stack;
+  final Map<String, dynamic>? contextMap;
+  _SpoolCall(this.isolateTaskName, this.error, this.stack, this.contextMap);
+}
+
+void main() {
+  group('ErrorLogger foreground path (TraceRecorder)', () {
+    late _FakeTraceRecorder recorder;
+
+    setUp(() {
+      errorLogger.resetForTest();
+      recorder = _FakeTraceRecorder();
+      errorLogger.testRecorderOverride = recorder;
+    });
+
+    tearDown(() {
+      errorLogger.resetForTest();
+    });
+
+    test('delegates a basic error + stack to the recorder', () async {
+      final stack = StackTrace.fromString('#0 unit_test (file.dart:1)');
+      await errorLogger.log(
+        ErrorLayer.services,
+        Exception('api boom'),
+        stack,
+      );
+
+      expect(recorder.calls, hasLength(1));
+      final call = recorder.calls.single;
+      expect(call.stackTrace, same(stack));
+      // Wrapped error renders the layer prefix so log triage can grep
+      // by layer in the recorder's `errorMessage` field.
+      expect(call.error.toString(), contains('[services]'));
+      expect(call.error.toString(), contains('api boom'));
+    });
+
+    test('captures StackTrace.current when stack is null', () async {
+      await errorLogger.log(
+        ErrorLayer.providers,
+        StateError('unbound provider'),
+        null,
+      );
+
+      expect(recorder.calls, hasLength(1));
+      // We can't compare to a synthesised stack, but it must not be
+      // empty and must not be the literal "null" string.
+      expect(recorder.calls.single.stackTrace.toString(), isNotEmpty);
+    });
+
+    test('layer prefix is part of the toString for grep targets',
+        () async {
+      for (final layer in ErrorLayer.values) {
+        recorder.calls.clear();
+        await errorLogger.log(layer, 'boom', StackTrace.empty);
+        expect(
+          recorder.calls.single.error.toString(),
+          contains('[${layer.name}]'),
+          reason: 'layer ${layer.name} must surface in errorMessage',
+        );
+      }
+    });
+
+    test('context map is rendered into the wrapper error toString',
+        () async {
+      await errorLogger.log(
+        ErrorLayer.services,
+        Exception('rate limit'),
+        StackTrace.empty,
+        context: <String, Object?>{
+          'station_id': 'abc-123',
+          'country': 'fr',
+          'attempt': 2,
+        },
+      );
+
+      final rendered = recorder.calls.single.error.toString();
+      expect(rendered, contains('station_id'));
+      expect(rendered, contains('abc-123'));
+      expect(rendered, contains('country'));
+      expect(rendered, contains('attempt'));
+    });
+
+    test('null context renders without a context= clause', () async {
+      await errorLogger.log(
+        ErrorLayer.ui,
+        Exception('layout failure'),
+        StackTrace.empty,
+      );
+      expect(
+        recorder.calls.single.error.toString(),
+        isNot(contains('context=')),
+      );
+    });
+
+    test('log never throws when the recorder throws', () async {
+      errorLogger.testRecorderOverride = _ThrowingRecorder();
+      // Must complete without re-raising.
+      await expectLater(
+        errorLogger.log(
+          ErrorLayer.other,
+          Exception('inner'),
+          StackTrace.empty,
+        ),
+        completes,
+      );
+    });
+  });
+
+  group('ErrorLogger background-isolate path (spool)', () {
+    final spoolCalls = <_SpoolCall>[];
+
+    setUp(() {
+      errorLogger.resetForTest();
+      spoolCalls.clear();
+      errorLogger.spoolEnqueueOverride = ({
+        required String isolateTaskName,
+        required Object error,
+        StackTrace? stack,
+        Map<String, dynamic>? contextMap,
+        DateTime? timestamp,
+      }) async {
+        spoolCalls
+            .add(_SpoolCall(isolateTaskName, error, stack, contextMap));
+      };
+    });
+
+    tearDown(() {
+      errorLogger.resetForTest();
+    });
+
+    test('writes to the spool when no container is bound', () async {
+      await errorLogger.log(
+        ErrorLayer.isolate,
+        Exception('bg task crashed'),
+        StackTrace.fromString('bg-stack'),
+        context: <String, Object?>{
+          'task': 'price_refresh',
+          'attempt': 1,
+        },
+      );
+
+      expect(spoolCalls, hasLength(1));
+      final call = spoolCalls.single;
+      // Layer name is propagated as the isolate task name so spool
+      // entries are filterable by layer through replay.
+      expect(call.isolateTaskName, 'isolate');
+      expect(call.error, isA<Exception>());
+      expect(call.stack.toString(), contains('bg-stack'));
+      // Context map carries the layer + caller-supplied keys.
+      expect(call.contextMap?['errorLayer'], 'isolate');
+      expect(call.contextMap?['task'], 'price_refresh');
+      expect(call.contextMap?['attempt'], 1);
+    });
+
+    test('passes original error object through to spool unchanged',
+        () async {
+      final original = StateError('original');
+      await errorLogger.log(
+        ErrorLayer.background,
+        original,
+        StackTrace.empty,
+      );
+      expect(spoolCalls.single.error, same(original));
+    });
+
+    test('captures StackTrace.current when stack is null in spool path',
+        () async {
+      await errorLogger.log(
+        ErrorLayer.background,
+        Exception('boom'),
+        null,
+      );
+      expect(spoolCalls.single.stack, isNotNull);
+      expect(spoolCalls.single.stack.toString(), isNotEmpty);
+    });
+
+    test('log never throws when the spool throws', () async {
+      errorLogger.spoolEnqueueOverride = ({
+        required String isolateTaskName,
+        required Object error,
+        StackTrace? stack,
+        Map<String, dynamic>? contextMap,
+        DateTime? timestamp,
+      }) async {
+        throw StateError('spool unavailable');
+      };
+
+      await expectLater(
+        errorLogger.log(
+          ErrorLayer.isolate,
+          Exception('inner'),
+          StackTrace.empty,
+        ),
+        completes,
+      );
+    });
+
+    test('isForegroundBound is false without a recorder or container',
+        () {
+      expect(errorLogger.isForegroundBound, isFalse);
+    });
+  });
+
+  group('ErrorLogger isForegroundBound flag', () {
+    setUp(() => errorLogger.resetForTest());
+    tearDown(() => errorLogger.resetForTest());
+
+    test('flips to true once a test recorder is set', () {
+      expect(errorLogger.isForegroundBound, isFalse);
+      errorLogger.testRecorderOverride = _FakeTraceRecorder();
+      expect(errorLogger.isForegroundBound, isTrue);
+    });
+  });
+}
+
+class _ThrowingRecorder implements TraceRecorder {
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    throw StateError('recorder broken');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}

--- a/test/lint/no_raw_debugprint_error_test.dart
+++ b/test/lint/no_raw_debugprint_error_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#1104): no raw `debugPrint(<exception>)`
+/// calls in `lib/`. Errors must go through `errorLogger.log(layer, e, st)`
+/// from `lib/core/logging/error_logger.dart` so we have a single PII
+/// scrub point, a single sample-rate control, and one place to swap
+/// Sentry → Glitchtip.
+///
+/// What is forbidden:
+///   debugPrint(e)
+///   debugPrint(error)
+///   debugPrint(err)
+///   debugPrint(exception)
+///   debugPrint(ex)
+///
+/// What is allowed:
+///   - String-interpolated forms like `debugPrint('context: $e')` —
+///     these already include surrounding context. They were migrated
+///     in #1137 and may be tightened up in a follow-up PR.
+///   - `lib/core/logging/` (this is the logger itself).
+///   - `tool/` (build scripts; lints don't apply to dev tooling).
+///   - Generated files (`.g.dart`, `.freezed.dart`).
+///   - A `// ignore: log_raw_debugprint: <reason>` opt-out on the same
+///     line or the line directly above the call.
+///
+/// Failure mode: list every `path:line  matched-text` and tell the
+/// caller to migrate to `errorLogger.log(layer, e, st)`.
+void main() {
+  test(
+      'no raw `debugPrint(<exception>)` calls outside lib/core/logging/ (#1104)',
+      () {
+    final offenders = <String>[];
+
+    // Match `debugPrint(<bare-name>)` where the bare name is one of
+    // the conventional exception variables. The trailing character
+    // must be `)` or `,` so we don't match `debugPrint(error.message)`
+    // or `debugPrint(error_count)`. Whitespace around the identifier
+    // is tolerated.
+    final raw = RegExp(
+      r'debugPrint\(\s*(e|error|err|exception|ex)\s*[\),]',
+    );
+
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+
+      // Skip generated files.
+      if (entity.path.endsWith('.g.dart') ||
+          entity.path.endsWith('.freezed.dart')) {
+        continue;
+      }
+
+      // Skip the logger module itself — it is allowed to fall back to
+      // `debugPrint` when its own dependencies (Hive, Riverpod
+      // container) are unavailable.
+      // Normalise path separators so the check works on Windows.
+      final normalisedPath = entity.path.replaceAll('\\', '/');
+      if (normalisedPath.contains('lib/core/logging/')) {
+        continue;
+      }
+
+      final src = entity.readAsStringSync();
+      final lines = src.split('\n');
+      for (final m in raw.allMatches(src)) {
+        final lineIdx = src.substring(0, m.start).split('\n').length - 1;
+        final thisLine =
+            lineIdx >= 0 && lineIdx < lines.length ? lines[lineIdx] : '';
+        final prevLine = lineIdx > 0 ? lines[lineIdx - 1] : '';
+        if (thisLine.contains('// ignore: log_raw_debugprint') ||
+            prevLine.trim().contains('// ignore: log_raw_debugprint')) {
+          continue;
+        }
+        offenders.add('${entity.path}:${lineIdx + 1}  ${m.group(0)}');
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'Raw `debugPrint(e)` bypasses the unified logging pipeline. '
+          'Use `errorLogger.log(ErrorLayer.<layer>, e, st)` from '
+          '`lib/core/logging/error_logger.dart` instead so Sentry / '
+          'Glitchtip / TraceRecorder all see the error. For the rare '
+          'case where this is genuinely correct, add '
+          '`// ignore: log_raw_debugprint: <reason>` on or above the '
+          'line.\nOffending sites:\n${offenders.join("\n")}',
+    );
+  });
+}


### PR DESCRIPTION
## Why
Single logging channel -> single PII scrub point, single sample-rate, one place to swap Sentry -> Glitchtip. Replaces the 4 divergent channels (`debugPrint`, `TraceRecorder`, `Sentry`, silent) with one API.

## What
- New `lib/core/logging/error_logger.dart` with foreground/background routing
  - `ErrorLayer` enum (ui, providers, services, storage, sync, background, isolate, other) — single grep target for cross-cutting analytics + context propagation
  - `errorLogger.bind(container)` called once from `AppInitializer`; foreground calls delegate to `TraceRecorder`, background-isolate calls fall through to `IsolateErrorSpool` for #1105 replay
  - Wraps the original error in a `_ContextualError` so the layer prefix + context map render in `error.toString()` (TraceRecorder's `errorMessage` field) without a TraceRecorder API change
  - Test seams: `testRecorderOverride` and `spoolEnqueueOverride` for unit tests that bypass the full Hive + Riverpod stack
  - Never throws (observability must not derail callers)
- Lint test `test/lint/no_raw_debugprint_error_test.dart` forbidding raw `debugPrint(e | error | err | exception | ex)` outside `lib/core/logging/`, with a `// ignore: log_raw_debugprint: <reason>` opt-out
- Migrated callsites:
  - `lib/app/app_initializer.dart` — `FlutterError.onError` + `PlatformDispatcher.onError` global handlers + `errorLogger.bind(container)` in `_launch`
  - `lib/core/error_tracing/integrations/riverpod_trace_observer.dart`
  - `lib/core/error_tracing/integrations/dio_trace_interceptor.dart` (with method/path/statusCode/dioType context map)
- Updated CLAUDE.md conventions section

## Out of scope
- String-interpolated `debugPrint('...: $e\n$st')` calls (added by #1137) — already context-rich, can be migrated in a follow-up PR
- Test files
- Sentry boundary handlers in `main.dart` (those are at the boundary by design)

## Test
- `flutter test test/core/logging/` — 12 new unit tests pass (foreground delegation, background spool, layer propagation, stack capture, context rendering, never-throws guarantees)
- `flutter test test/lint/` — all 28 existing + new lint tests pass
- `flutter test test/core/error_tracing/integrations/` — 13 tests pass (existing observer/interceptor tests updated for new logger seam)
- `flutter analyze` — zero warnings/errors
- CI full suite runs on push

Closes #1104