### PR TITLE
refactor(logging): introduce errorLogger.log() unified API (Refs #1104 phase 1)

### DIFF
--- a/lib/core/logging/error_logger.dart
+++ b/lib/core/logging/error_logger.dart
@@ -1,0 +1,358 @@
+import 'package:flutter/foundation.dart';
+
+import '../error_tracing/storage/isolate_error_spool.dart';
+import '../error_tracing/trace_recorder.dart';
+
+/// Unified error logging API for the Tankstellen app (#1104 phase 1).
+///
+/// The codebase historically had four divergent logging channels —
+/// `debugPrint`, `TraceRecorder.record`, `Sentry.captureException`, and
+/// silent `catch (_) {}`. [ErrorLogger] is the single entrypoint that
+/// foreground (Riverpod-aware) and background isolates (no Riverpod)
+/// can both call: it routes to the right downstream pipeline based on
+/// where it was invoked from, so callers don't have to care.
+///
+/// **Routing:**
+/// - **Foreground** (after `AppInitializer._launch` has called
+///   [markForeground]) → forwards to [TraceRecorder.record] with the
+///   layer + context attached as a wrapping error so the foreground
+///   pipeline (TraceStorage + Sentry upload) sees the full picture.
+/// - **Background isolate** (default — no `markForeground` call) →
+///   forwards to [IsolateErrorSpool.enqueue] which writes to a Hive
+///   ring buffer that the foreground drains on the next cold start.
+///
+/// **Phase 1 scope** (this file): introduce the API + unit tests +
+/// CLAUDE.md doc. Existing call sites (~12 `TraceRecorder.record` and
+/// ~40 raw `debugPrint(e)`) are NOT migrated yet.
+///
+/// **Phase 2 scope** (separate PR): migrate every callsite, plus add
+/// the lint test forbidding raw `debugPrint(e)` outside `tools/` and
+/// `lib/core/logging/`.
+///
+/// Use it via the [errorLogger] singleton:
+///
+/// ```dart
+/// try {
+///   await stationService.fetch();
+/// } catch (e, st) {
+///   await errorLogger.log(
+///     'StationService',
+///     e,
+///     st,
+///     context: {'stationId': station.id},
+///   );
+/// }
+/// ```
+abstract class ErrorLogger {
+  /// Logs an error with optional stack trace and context. Routes to
+  /// [TraceRecorder] in foreground (Riverpod available) or
+  /// [IsolateErrorSpool] in background isolates (no Riverpod).
+  ///
+  /// [layer] is a short string identifying the origin (e.g.
+  /// `'StationService'`, `'background.refreshPrices'`,
+  /// `'BackgroundService'`). It surfaces in the error trace and the
+  /// isolate spool entry's `isolateTaskName` field.
+  ///
+  /// [stackTrace] is forwarded as-is to the background path. The
+  /// foreground path requires non-null, so the router substitutes
+  /// `StackTrace.current` rather than synthesizing a fake trace
+  /// downstream.
+  ///
+  /// [context] is a metadata map (strings, numbers, bools, lists,
+  /// maps). Non-Hive-serializable values are coerced via `toString()`
+  /// by the spool to keep the ring buffer durable across schema drift.
+  ///
+  /// [classification] is an optional override hint. By default the
+  /// downstream pipeline uses [ErrorClassifier.classify] on the error
+  /// itself; passing this lets a caller force a specific category
+  /// (e.g. for synthetic test exceptions whose runtime type doesn't
+  /// match a real bucket).
+  ///
+  /// **Never throws.** Any failure inside the underlying writer is
+  /// caught and logged via [debugPrint] with the exception message so
+  /// observability failures never break the calling code path. The
+  /// fallback message satisfies the "no silent catch" lint
+  /// (`test/lint/no_silent_catch_test.dart`).
+  Future<void> log(
+    String layer,
+    Object error,
+    StackTrace? stackTrace, {
+    Map<String, Object?>? context,
+    ErrorClassification? classification,
+  });
+}
+
+/// Caller-provided classification hint for [ErrorLogger.log]. The
+/// downstream pipeline still runs [ErrorClassifier.classify] on the
+/// error type by default — this enum exists so phase-2 callsites can
+/// override the bucket when the runtime type is too generic
+/// (e.g. plain `Exception` rethrown from an isolate, or a synthetic
+/// error in tests). Maps 1:1 to [ErrorCategory] for downstream use.
+enum ErrorClassification {
+  api,
+  network,
+  cache,
+  ui,
+  platform,
+  serviceChain,
+  provider,
+  unknown,
+}
+
+/// Production singleton. Test code may override via
+/// [debugSetErrorLoggerForTesting] in a `setUp` and reset it in
+/// `tearDown`.
+ErrorLogger errorLogger = _RoutingErrorLogger();
+
+/// Test-only override.
+@visibleForTesting
+void debugSetErrorLoggerForTesting(ErrorLogger logger) {
+  errorLogger = logger;
+}
+
+/// Test-only reset back to the production singleton.
+@visibleForTesting
+void debugResetErrorLoggerForTesting() {
+  errorLogger = _RoutingErrorLogger();
+}
+
+/// Foreground/background mode flag. `AppInitializer._launch` flips
+/// this to `true` once a Riverpod [ProviderContainer] is constructed
+/// and a [TraceRecorder] is available.
+///
+/// Background isolates (WorkManager) never call [markForeground], so
+/// they keep the default `false` value and route to the spool.
+bool _isForeground = false;
+
+/// Reference to the foreground [TraceRecorder]. Set by
+/// [markForeground]; consulted by [_RoutingErrorLogger] when the
+/// foreground flag is `true`.
+TraceRecorder? _foregroundRecorder;
+
+/// Called by `AppInitializer._launch` once Riverpod is up. After this
+/// call, [errorLogger.log] routes to [TraceRecorder.record].
+///
+/// Phase 1: nothing in `lib/` calls this yet — phase 2 wires it from
+/// `app_initializer.dart` alongside the FlutterError /
+/// PlatformDispatcher global handlers. Tests use
+/// [debugSetForegroundForTesting].
+void markForeground(TraceRecorder recorder) {
+  _isForeground = true;
+  _foregroundRecorder = recorder;
+}
+
+/// Test-only setter for the foreground flag + recorder reference.
+@visibleForTesting
+void debugSetForegroundForTesting({
+  required bool isForeground,
+  TraceRecorder? recorder,
+}) {
+  _isForeground = isForeground;
+  _foregroundRecorder = recorder;
+}
+
+/// Resets the foreground flag back to its background default.
+@visibleForTesting
+void debugResetForegroundForTesting() {
+  _isForeground = false;
+  _foregroundRecorder = null;
+}
+
+/// Foreground writer signature. Test code can swap this to capture
+/// arguments without spinning up Riverpod or Sentry.
+typedef ForegroundWriter = Future<void> Function(
+  TraceRecorder recorder,
+  Object error,
+  StackTrace stackTrace,
+  String layer,
+  Map<String, Object?>? context,
+  ErrorClassification? classification,
+);
+
+/// Background writer signature. Test code can swap this to capture
+/// arguments without touching Hive.
+typedef BackgroundWriter = Future<void> Function(
+  String layer,
+  Object error,
+  StackTrace? stackTrace,
+  Map<String, Object?>? context,
+  ErrorClassification? classification,
+);
+
+/// Active foreground writer. Production default forwards to
+/// [TraceRecorder.record].
+ForegroundWriter _foregroundWriter = _writeForeground;
+
+/// Active background writer. Production default forwards to
+/// [IsolateErrorSpool.enqueue].
+BackgroundWriter _backgroundWriter = _writeBackground;
+
+/// Test-only writer override. Pair with [debugResetWritersForTesting]
+/// in `tearDown` so other tests aren't affected.
+@visibleForTesting
+void debugSetForegroundWriterForTesting(ForegroundWriter writer) {
+  _foregroundWriter = writer;
+}
+
+/// Test-only writer override.
+@visibleForTesting
+void debugSetBackgroundWriterForTesting(BackgroundWriter writer) {
+  _backgroundWriter = writer;
+}
+
+/// Test-only reset of both writer seams.
+@visibleForTesting
+void debugResetWritersForTesting() {
+  _foregroundWriter = _writeForeground;
+  _backgroundWriter = _writeBackground;
+}
+
+/// Production [ErrorLogger] implementation. Inspects the foreground
+/// flag and dispatches to the right downstream sink.
+class _RoutingErrorLogger implements ErrorLogger {
+  @override
+  Future<void> log(
+    String layer,
+    Object error,
+    StackTrace? stackTrace, {
+    Map<String, Object?>? context,
+    ErrorClassification? classification,
+  }) async {
+    try {
+      if (_isForeground) {
+        final recorder = _foregroundRecorder;
+        if (recorder == null) {
+          // Foreground flag flipped but recorder missing — should not
+          // happen in production because [markForeground] sets both
+          // atomically, but stay defensive: fall through to the spool
+          // so the error doesn't disappear.
+          await _backgroundWriter(
+            layer,
+            error,
+            stackTrace,
+            context,
+            classification,
+          );
+          return;
+        }
+        await _foregroundWriter(
+          recorder,
+          error,
+          stackTrace ?? StackTrace.current,
+          layer,
+          context,
+          classification,
+        );
+        return;
+      }
+      await _backgroundWriter(
+        layer,
+        error,
+        stackTrace,
+        context,
+        classification,
+      );
+    } catch (e) {
+      // Never bubble — observability failures must not derail callers.
+      // Include the exception message so we don't violate the
+      // "no silent catch" rule (test/lint/no_silent_catch_test.dart).
+      debugPrint('errorLogger.log fallback: $e');
+    }
+  }
+}
+
+/// Default foreground writer — wraps the original error in a
+/// [LoggedError] so the layer + context surface in
+/// [TraceRecorder.record]'s downstream pipeline (TraceStorage +
+/// Sentry).
+Future<void> _writeForeground(
+  TraceRecorder recorder,
+  Object error,
+  StackTrace stackTrace,
+  String layer,
+  Map<String, Object?>? context,
+  ErrorClassification? classification,
+) async {
+  final wrapped = LoggedError(
+    layer: layer,
+    cause: error,
+    context: context,
+    classification: classification,
+  );
+  await recorder.record(wrapped, stackTrace);
+}
+
+/// Default background writer — appends to [IsolateErrorSpool].
+Future<void> _writeBackground(
+  String layer,
+  Object error,
+  StackTrace? stackTrace,
+  Map<String, Object?>? context,
+  ErrorClassification? classification,
+) async {
+  await IsolateErrorSpool.enqueue(
+    isolateTaskName: layer,
+    error: error,
+    stack: stackTrace,
+    contextMap: _coerceContextForSpool(context, classification),
+  );
+}
+
+/// Convert the public `Map<String, Object?>` shape that `errorLogger.log`
+/// accepts into the `Map<String, dynamic>` shape that the spool
+/// requires, and tack the optional classification on so it survives
+/// the Hive round-trip.
+Map<String, dynamic>? _coerceContextForSpool(
+  Map<String, Object?>? context,
+  ErrorClassification? classification,
+) {
+  if (context == null && classification == null) return null;
+  final out = <String, dynamic>{};
+  if (context != null) {
+    for (final entry in context.entries) {
+      out[entry.key] = entry.value;
+    }
+  }
+  if (classification != null) {
+    out['_classification'] = classification.name;
+  }
+  return out;
+}
+
+/// Wrapper exception used when forwarding to [TraceRecorder] in the
+/// foreground. Carries the [layer], optional [context] map, and
+/// optional [classification] hint alongside the original [cause] so
+/// the existing trace pipeline (which classifies by `runtimeType` and
+/// `error.toString()`) keeps working.
+///
+/// Mirrors the shape of `_IsolateBackgroundError` in the spool — both
+/// adapter wrappers exist so the trace pipeline doesn't need to know
+/// about layer / context as first-class fields. Phase 2 may promote
+/// them to first-class once every callsite is on the new API.
+class LoggedError implements Exception {
+  final String layer;
+  final Object cause;
+  final Map<String, Object?>? context;
+  final ErrorClassification? classification;
+
+  LoggedError({
+    required this.layer,
+    required this.cause,
+    this.context,
+    this.classification,
+  });
+
+  @override
+  String toString() {
+    final ctx = context;
+    final cls = classification;
+    final parts = <String>['LoggedError($layer): $cause'];
+    if (ctx != null && ctx.isNotEmpty) {
+      parts.add('[context=$ctx]');
+    }
+    if (cls != null) {
+      parts.add('[classification=${cls.name}]');
+    }
+    return parts.join(' ');
+  }
+}

--- a/test/core/logging/error_logger_test.dart
+++ b/test/core/logging/error_logger_test.dart
@@ -1,0 +1,426 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/error_tracing/storage/isolate_error_spool.dart';
+import 'package:tankstellen/core/error_tracing/storage/isolate_error_spool_entry.dart';
+import 'package:tankstellen/core/error_tracing/trace_recorder.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+
+/// Captured arguments for the foreground writer seam.
+class _ForegroundCall {
+  _ForegroundCall({
+    required this.recorder,
+    required this.error,
+    required this.stackTrace,
+    required this.layer,
+    required this.context,
+    required this.classification,
+  });
+
+  final TraceRecorder recorder;
+  final Object error;
+  final StackTrace stackTrace;
+  final String layer;
+  final Map<String, Object?>? context;
+  final ErrorClassification? classification;
+}
+
+/// Captured arguments for the background writer seam.
+class _BackgroundCall {
+  _BackgroundCall({
+    required this.layer,
+    required this.error,
+    required this.stackTrace,
+    required this.context,
+    required this.classification,
+  });
+
+  final String layer;
+  final Object error;
+  final StackTrace? stackTrace;
+  final Map<String, Object?>? context;
+  final ErrorClassification? classification;
+}
+
+/// Stand-in TraceRecorder. We never invoke `.record()` because the
+/// foreground writer seam is replaced with a captor in every test that
+/// enters the foreground path — but [_RoutingErrorLogger] still needs
+/// *some* recorder reference to satisfy the null check before
+/// dispatching.
+class _StubTraceRecorder implements TraceRecorder {
+  @override
+  noSuchMethod(Invocation invocation) {
+    throw StateError(
+      '_StubTraceRecorder.${invocation.memberName} called — the foreground '
+      'writer seam should have intercepted this call',
+    );
+  }
+}
+
+/// Minimal in-memory `Box<String>` substitute — only the surface that
+/// `IsolateErrorSpool.enqueue` exercises is implemented (`put`,
+/// `length`, `keys`, `delete`, `clear`, `get`). Keeps the integration
+/// test free of `Hive.initFlutter` / `path_provider` setup.
+class _FakeBox implements Box<String> {
+  final Map<String, String> store = <String, String>{};
+
+  @override
+  Future<void> put(dynamic key, String value) async {
+    store[key as String] = value;
+  }
+
+  @override
+  String? get(dynamic key, {String? defaultValue}) =>
+      store[key as String] ?? defaultValue;
+
+  @override
+  int get length => store.length;
+
+  @override
+  Iterable<dynamic> get keys => store.keys;
+
+  @override
+  Future<void> delete(dynamic key) async {
+    store.remove(key as String);
+  }
+
+  @override
+  Future<int> clear() async {
+    final n = store.length;
+    store.clear();
+    return n;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) {
+    throw UnimplementedError(
+      '_FakeBox.${invocation.memberName} is not implemented',
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<_ForegroundCall> fgCalls;
+  late List<_BackgroundCall> bgCalls;
+  late _StubTraceRecorder stubRecorder;
+
+  setUp(() {
+    fgCalls = [];
+    bgCalls = [];
+    stubRecorder = _StubTraceRecorder();
+
+    // Replace both writer seams with captors that record arguments
+    // verbatim so each test can assert exact forwarding without
+    // touching Hive or Riverpod.
+    debugSetForegroundWriterForTesting((
+      recorder,
+      error,
+      stackTrace,
+      layer,
+      context,
+      classification,
+    ) async {
+      fgCalls.add(_ForegroundCall(
+        recorder: recorder,
+        error: error,
+        stackTrace: stackTrace,
+        layer: layer,
+        context: context,
+        classification: classification,
+      ));
+    });
+    debugSetBackgroundWriterForTesting((
+      layer,
+      error,
+      stackTrace,
+      context,
+      classification,
+    ) async {
+      bgCalls.add(_BackgroundCall(
+        layer: layer,
+        error: error,
+        stackTrace: stackTrace,
+        context: context,
+        classification: classification,
+      ));
+    });
+  });
+
+  tearDown(() {
+    debugResetForegroundForTesting();
+    debugResetErrorLoggerForTesting();
+    debugResetWritersForTesting();
+    IsolateErrorSpool.resetBoxFactoryForTest();
+  });
+
+  group('errorLogger.log — mode detection', () {
+    test('default (no markForeground) routes to background spool', () async {
+      // No debugSetForegroundForTesting → flag stays false → background.
+      await errorLogger.log(
+        'BackgroundService',
+        Exception('boom'),
+        StackTrace.current,
+      );
+
+      expect(fgCalls, isEmpty);
+      expect(bgCalls, hasLength(1));
+      expect(bgCalls.single.layer, 'BackgroundService');
+    });
+
+    test('after debugSetForegroundForTesting → routes to TraceRecorder',
+        () async {
+      debugSetForegroundForTesting(
+        isForeground: true,
+        recorder: stubRecorder,
+      );
+
+      await errorLogger.log(
+        'StationService',
+        Exception('foreground boom'),
+        StackTrace.current,
+      );
+
+      expect(fgCalls, hasLength(1));
+      expect(bgCalls, isEmpty);
+      expect(fgCalls.single.layer, 'StationService');
+      expect(fgCalls.single.recorder, same(stubRecorder));
+    });
+
+    test(
+      'foreground flag set but recorder null → falls through to background',
+      () async {
+        debugSetForegroundForTesting(isForeground: true, recorder: null);
+
+        await errorLogger.log(
+          'StationService',
+          Exception('boom'),
+          StackTrace.current,
+        );
+
+        expect(fgCalls, isEmpty);
+        expect(bgCalls, hasLength(1),
+            reason: 'null recorder must not silently drop the error');
+      },
+    );
+  });
+
+  group('errorLogger.log — foreground forwarding', () {
+    setUp(() {
+      debugSetForegroundForTesting(
+        isForeground: true,
+        recorder: stubRecorder,
+      );
+    });
+
+    test('forwards every arg verbatim (layer, error, stack, context, class)',
+        () async {
+      final stack = StackTrace.fromString('fake-stack-1');
+      final err = Exception('foreground-arg-test');
+      final ctx = <String, Object?>{
+        'stationId': 'st-42',
+        'attempt': 3,
+        'isStale': true,
+      };
+
+      await errorLogger.log(
+        'StationServiceChain',
+        err,
+        stack,
+        context: ctx,
+        classification: ErrorClassification.network,
+      );
+
+      expect(fgCalls, hasLength(1));
+      final call = fgCalls.single;
+      expect(call.layer, 'StationServiceChain');
+      expect(call.error, same(err));
+      expect(call.stackTrace, same(stack));
+      expect(call.context, ctx);
+      expect(call.classification, ErrorClassification.network);
+    });
+
+    test('null stackTrace is replaced with a real StackTrace.current', () async {
+      // The foreground pipeline (`TraceRecorder.record`) requires a
+      // non-null StackTrace, so the router substitutes
+      // `StackTrace.current` rather than passing null. We verify the
+      // substitution happens but don't assert on the trace's content
+      // (which depends on the Dart runtime's frame layout).
+      await errorLogger.log(
+        'Layer',
+        Exception('e'),
+        null,
+      );
+
+      expect(fgCalls, hasLength(1));
+      expect(fgCalls.single.stackTrace, isNotNull);
+      expect(fgCalls.single.stackTrace, isA<StackTrace>());
+    });
+
+    test('null context and null classification forward as null', () async {
+      await errorLogger.log(
+        'Layer',
+        Exception('e'),
+        StackTrace.fromString('s'),
+      );
+
+      expect(fgCalls, hasLength(1));
+      expect(fgCalls.single.context, isNull);
+      expect(fgCalls.single.classification, isNull);
+    });
+  });
+
+  group('errorLogger.log — background forwarding', () {
+    test('forwards layer/error/stack/context/classification verbatim',
+        () async {
+      final stack = StackTrace.fromString('bg-stack-1');
+      final err = Exception('bg-arg-test');
+      final ctx = <String, Object?>{
+        'taskName': 'refreshPrices',
+        'alertId': 'alert-7',
+      };
+
+      await errorLogger.log(
+        'background.refreshPrices',
+        err,
+        stack,
+        context: ctx,
+        classification: ErrorClassification.api,
+      );
+
+      expect(bgCalls, hasLength(1));
+      final call = bgCalls.single;
+      expect(call.layer, 'background.refreshPrices');
+      expect(call.error, same(err));
+      expect(call.stackTrace, same(stack));
+      expect(call.context, ctx);
+      expect(call.classification, ErrorClassification.api);
+    });
+
+    test('null stackTrace forwards null (no synthesized trace)', () async {
+      // For the background path we DO forward null — the spool's
+      // `enqueue` synthesizes `StackTrace.current` itself if needed.
+      // The router must not invent a fake trace because that would
+      // hide the async-gap context the spool wants to capture.
+      await errorLogger.log(
+        'Layer',
+        Exception('e'),
+        null,
+      );
+
+      expect(bgCalls, hasLength(1));
+      expect(bgCalls.single.stackTrace, isNull);
+    });
+
+    test('null context and null classification forward as null', () async {
+      await errorLogger.log(
+        'Layer',
+        Exception('e'),
+        StackTrace.fromString('s'),
+      );
+
+      expect(bgCalls, hasLength(1));
+      expect(bgCalls.single.context, isNull);
+      expect(bgCalls.single.classification, isNull);
+    });
+  });
+
+  group('errorLogger.log — defensive contract', () {
+    test('a throwing background writer is swallowed (no rethrow)', () async {
+      debugSetBackgroundWriterForTesting((
+        layer,
+        error,
+        stackTrace,
+        context,
+        classification,
+      ) async {
+        throw StateError('downstream Hive failure');
+      });
+
+      // Must not throw — observability failures cannot derail callers.
+      await expectLater(
+        errorLogger.log(
+          'BackgroundService',
+          Exception('boom'),
+          StackTrace.current,
+        ),
+        completes,
+      );
+    });
+
+    test('a throwing foreground writer is swallowed (no rethrow)', () async {
+      debugSetForegroundForTesting(
+        isForeground: true,
+        recorder: stubRecorder,
+      );
+      debugSetForegroundWriterForTesting((
+        recorder,
+        error,
+        stackTrace,
+        layer,
+        context,
+        classification,
+      ) async {
+        throw StateError('downstream TraceRecorder failure');
+      });
+
+      await expectLater(
+        errorLogger.log(
+          'StationService',
+          Exception('boom'),
+          StackTrace.current,
+        ),
+        completes,
+      );
+    });
+  });
+
+  group('errorLogger.log — production background path → spool', () {
+    // Integration-ish: hand the production `_writeBackground` a fake
+    // Hive box and assert the spool sees the right entry shape. The
+    // captor tests above prove the router forwards args; this proves
+    // the production writer maps them onto `IsolateErrorSpool.enqueue`.
+    setUp(() {
+      debugResetWritersForTesting();
+    });
+
+    test(
+      'production writer maps layer→isolateTaskName and merges classification',
+      () async {
+        // Mock path_provider so Hive's plugin probe doesn't fail when
+        // the production writer reaches into IsolateErrorSpool. We
+        // fully replace the box factory below so this is belt-and-
+        // suspenders, but `Hive.initFlutter` isn't required because
+        // boxFactory short-circuits the open path.
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => '.',
+        );
+
+        final fake = _FakeBox();
+        IsolateErrorSpool.boxFactory = () async => fake;
+
+        await errorLogger.log(
+          'background.refreshPrices',
+          Exception('integration-boom'),
+          StackTrace.fromString('integration-stack'),
+          context: {'alertId': 'a-7'},
+          classification: ErrorClassification.api,
+        );
+
+        expect(fake.store, hasLength(1));
+        final raw = fake.store.values.single;
+        final json = jsonDecode(raw) as Map<String, dynamic>;
+        final entry = IsolateErrorSpoolEntry.fromJson(json);
+        expect(entry.isolateTaskName, 'background.refreshPrices');
+        expect(entry.errorMessage, contains('integration-boom'));
+        expect(entry.contextMap['alertId'], 'a-7');
+        expect(entry.contextMap['_classification'], 'api');
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

First slice of #1104 — introduce the unified `errorLogger.log()` API that wraps the existing `TraceRecorder` (foreground) and `IsolateErrorSpool` (background isolate) pipelines behind a single entrypoint. **No call sites are migrated in this PR.** Phase 2 is the migration + lint.

Refs #1104 phase 1.

## In scope (this PR)

1. **`lib/core/logging/error_logger.dart`** — new file, ~360 LOC.
   - Abstract `ErrorLogger` with `log(layer, error, stackTrace, {context, classification})`.
   - `errorLogger` singleton routes to `TraceRecorder.record` in foreground or `IsolateErrorSpool.enqueue` in background isolates.
   - Foreground/background mode detection via a static flag; `markForeground(TraceRecorder)` is the production setter (phase 2 wires it from `AppInitializer._launch`).
   - Foreground path wraps the original error in a `LoggedError` adapter so `layer` + `context` + `classification` survive into the existing trace pipeline.
   - Background path translates `Map<String, Object?>` → `Map<String, dynamic>` for the spool, and tacks the optional classification on as `_classification` so it survives the Hive round-trip.
   - Never throws — any failure inside the underlying writer is caught and surfaced via `debugPrint('errorLogger.log fallback: $e')` so the "no silent catch" lint stays happy.

2. **`test/core/logging/error_logger_test.dart`** — new file, 12 tests, all green.
   - Mode detection: default → background spool; after `debugSetForegroundForTesting` → TraceRecorder; flag set + recorder null → falls back to spool (no silent drop).
   - Foreground forwarding: every arg verbatim; `null` stack → `StackTrace.current` substituted; null context + null classification forward as null.
   - Background forwarding: every arg verbatim; `null` stack forwards `null` (the spool synthesizes its own); null context + null classification forward as null.
   - Defensive contract: a throwing foreground or background writer is swallowed and `debugPrint`-logged with the exception message — caller awaits a completed future.
   - End-to-end production-writer test confirms `layer → isolateTaskName` and `classification → _classification` mapping into a fake Hive box.

3. **CLAUDE.md** — new "Unified logging" sub-section under "Error Handling" pointing at `lib/core/logging/error_logger.dart` as the single entrypoint and noting phase 2 will migrate the existing callsites + add the lint.
   - Note: `CLAUDE.md` is gitignored in this repo (`.gitignore:60`), so the doc update is applied locally only — it cannot be committed in this PR. The text I added is included verbatim in the test plan below for reviewer reference.

## Out of scope (phase 2, separate PR)

- Lint test forbidding `debugPrint(e)` outside `tools/` and `lib/core/logging/`.
- Migration of the ~12 existing `TraceRecorder.record` callsites.
- Migration of the ~40 raw `debugPrint(e)` callsites.
- Wiring `markForeground(...)` from `AppInitializer._launch` (currently nothing in `lib/` calls it; tests use `debugSetForegroundForTesting`).
- Phase 2 will close #1104 when shipped.

## Test plan

- [x] `flutter analyze` — zero issues (plain, no `--no-fatal-infos`).
- [x] `flutter test test/core/logging/error_logger_test.dart` — 12/12 passing.
- [x] No `.g.dart` drift; only the two new files in this commit.
- [x] No `catch (_) {}` in the new code; the one `catch (e)` in `_RoutingErrorLogger.log` includes `$e` in the `debugPrint`.

## CLAUDE.md text added (for reviewers — gitignored, applied locally)

> #### Unified logging — `errorLogger.log()` (#1104)
> - **The single error-logging entrypoint is `lib/core/logging/error_logger.dart`** — `errorLogger.log(layer, error, stackTrace, {context, classification})`. It routes to `TraceRecorder.record` in foreground (after `markForeground` is called by `AppInitializer._launch`) or `IsolateErrorSpool.enqueue` in background isolates, so callers don't have to care which side they're on.
> - **Phase 1 (this PR)** introduces the API + tests + this doc. Phase 2 will migrate the ~12 existing `TraceRecorder.record` callsites and ~40 raw `debugPrint(e)` callsites and add a lint test forbidding raw `debugPrint(e)` outside `tools/` and `lib/core/logging/`.
> - Use it in new code today; existing callsites stay as-is until phase 2 lands.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>