### PR TITLE
docs(test): document @Tags(['network']) test set (closes #1114)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ docs/*
 !docs/design/
 !docs/security/
 docs/guides/*
+!docs/guides/NETWORK_TESTS.md
 !docs/guides/NEW_COUNTRY.md
 !docs/guides/ARB_FRAGMENTS.md
 !docs/guides/BLOCKER-IOS-PROVISIONING.md

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,6 +76,10 @@ dart run build_runner build --delete-conflicting-outputs
 - Target the testing pyramid: 70% unit, 20% widget, 10% integration.
 - Prefer fakes over mocks for service layer tests.
 - Use `pumpApp` from `test/helpers/pump_app.dart` for widget tests.
+- Tests that hit real third-party endpoints are isolated under
+  `@Tags(['network'])` and excluded from CI — see
+  [docs/guides/NETWORK_TESTS.md](guides/NETWORK_TESTS.md) for the
+  full inventory and re-run triggers.
 
 ```bash
 flutter test                # all tests

--- a/docs/guides/NETWORK_TESTS.md
+++ b/docs/guides/NETWORK_TESTS.md
@@ -1,0 +1,224 @@
+# Network-tagged tests
+
+This project keeps a small set of tests that hit **real, third-party**
+endpoints — country fuel APIs, the Play Store, public URL constants,
+and (when credentials are configured) a live Supabase project. They are
+isolated behind the `@Tags(['network'])` directive so the default
+`flutter test` invocation never runs them.
+
+This doc is the contract. Read it before adding, removing, or rerunning
+a network-tagged test.
+
+## Why a separate tag
+
+- **Upstream outages must not block PRs.** Italian MIMIT, Argentina
+  `datos.energia.gob.ar`, Spain MITECO and others intermittently
+  time out for hours at a stretch. A failing PR check on an upstream
+  outage trains contributors to ignore CI — exactly the wrong signal.
+- **Contributor onboarding stays fast.** A clean clone runs
+  `flutter test` and gets a green bar in under two minutes without
+  network egress. New contributors aren't forced to debug
+  geocoder timeouts on the first day.
+- **CI cost stays predictable.** Every PR run is offline-deterministic;
+  flake re-runs are cheap because they don't queue behind a 60-second
+  upstream timeout.
+
+## How to run
+
+```bash
+# Full set (every @Tags(['network']) file)
+flutter test --tags=network
+
+# A subdirectory only
+flutter test --tags=network test/security/
+
+# A single file
+flutter test --tags=network test/core/services/italy_search_live_test.dart
+```
+
+Some files require environment variables to do anything meaningful
+(see the per-file inventory below). Files that detect missing credentials
+print a skip notice and exit cleanly — they don't fail.
+
+## CI behavior
+
+The default CI test step **excludes** the tag, quoted from
+`.github/workflows/ci.yml`:
+
+```yaml
+# Excludes the `network` tag — those tests hit real third-party
+# APIs (Argentina, Italy MIMIT, etc.) that intermittently time out
+# and cannot block PRs. Run them on demand with
+# `flutter test --tags=network` from a workstation.
+- run: flutter test --coverage --exclude-tags=network
+```
+
+The tag is declared in `dart_test.yaml` so the runner doesn't warn
+about an unknown tag:
+
+```yaml
+tags:
+  network:
+    description: >
+      Tests that hit real third-party APIs over the network. Intermittent
+      upstream timeouts mean these cannot block PRs. Run on demand with
+      `flutter test --tags=network`.
+```
+
+A weekly scheduled CI run does pick them up — `ci.yml` declares:
+
+```yaml
+schedule:
+  - cron: '0 6 * * 0'
+```
+
+(Every Sunday at 06:00 UTC.) The `test` job in that scheduled run still
+uses `--exclude-tags=network` today; teams that want network tests
+gated on the schedule should either add a separate `network-tests` job
+or override the exclude flag for the `schedule` event. For now,
+network tests are a manual workstation responsibility — the schedule
+mainly catches **non-network** drift (stale lockfile resolutions,
+analyzer rule changes, etc.).
+
+Tag releases also do not currently trigger network tests automatically.
+The Supabase RLS test (see below) is the one that **should** ride a
+release: when staging credentials are wired into the release workflow,
+add a step `flutter test --tags=network test/security/supabase_rls_test.dart`.
+
+## Per-file inventory
+
+There are four files with a file-level `@Tags(['network'])` directive
+today, plus three offline files that **reference** the tag in comments
+(handoff notes for future work). The inventory covers both groups so
+the comment trail doesn't become orphaned context.
+
+### Tagged: hits the network
+
+#### `test/core/services/api_connectivity_test.dart`
+
+Country fuel-API reachability matrix. Probes Tankerkoenig (DE),
+Prix-Carburants (FR), E-Control (AT), MITECO (ES), MIMIT station +
+price CSVs (IT), OK + Shell APIs (DK), Argentina Energía CSV, and
+Nominatim city search for every supported country.
+
+- **Probes**: each country's upstream root endpoint with a small
+  query, asserts HTTP status + a handful of schema invariants
+  (field names, list lengths, parseable lat/lng).
+- **Expected runtime**: 30 – 90 s end-to-end. The Argentina CSV step
+  has a 90-second timeout; everything else is 15 – 30 s.
+- **Re-run trigger**: after touching any
+  `lib/core/services/impl/*_station_service.dart`, after a
+  Nominatim user-agent or rate-limit change, or as a sanity check
+  before tagging a release.
+
+#### `test/core/services/italy_search_live_test.dart`
+
+End-to-end live search against the Italian MISE provider. Asserts
+the full pipeline (CSV download → parse → bounding-box filter →
+distance calc) returns >0 stations for Rome and Milan.
+
+- **Probes**: `MiseStationService.searchStations()` against
+  `mimit.gov.it/images/exportCSV/anagrafica_impianti_attivi.csv`
+  + the price CSV.
+- **Expected runtime**: 30 – 60 s per test (60 s timeout). The CSV
+  is ~5 MB and the parser is purely client-side.
+- **Re-run trigger**: any change to `mise_station_service.dart`,
+  `mise_csv_parser.dart`, or the Italian bounding box. Also rerun
+  if a user reports "Italy returns no results" — that's the bug
+  this file was created for (#695).
+
+#### `test/security/external_urls_reachable_test.dart`
+
+Sanity-check that every user-facing URL constant in
+`AppConstants` returns a non-error status. A 404 here is a visible
+broken link from the Settings or About screens.
+
+- **Probes**: `HEAD` request against `privacyPolicyUrl`,
+  `githubRepoUrl`, `githubIssuesUrl`, `tankerkoenigRegistrationUrl`,
+  `paypalUrl`, and `revolutUrl` (each with a 15 s timeout).
+- **Expected runtime**: 5 – 15 s.
+- **Re-run trigger**: after editing
+  `lib/core/constants/app_constants.dart`, or when GitHub Pages
+  for the privacy policy is reconfigured (#539).
+
+#### `test/security/supabase_rls_test.dart`
+
+Live verification of the Supabase Row-Level-Security policy matrix.
+Calls the `public.audit_rls_policies()` SQL function (added by
+migration `20260426000001_rls_audit_function.sql`) and asserts
+every expected policy exists with the right command, no `public.*`
+table is RLS-enabled-with-zero-policies, and no live table is
+absent from the matrix.
+
+- **Probes**: `POST /rest/v1/rpc/audit_rls_policies` against the
+  Supabase project resolved from `SUPABASE_TEST_URL`, authenticated
+  with `SUPABASE_TEST_SERVICE_KEY`. Skips cleanly if either env
+  var is unset.
+- **Expected runtime**: 5 – 15 s once the audit function is
+  installed; the first call after a `supabase db push` may take
+  longer because Postgres rebuilds the function cache.
+- **Re-run trigger**: any migration under `supabase/migrations/`
+  that touches `CREATE POLICY`, `ALTER TABLE … ENABLE/DISABLE ROW
+  LEVEL SECURITY`, or adds a `public.*` table. Also rerun whenever
+  `docs/security/SUPABASE_RLS_MATRIX.md` is edited — the matrix
+  and the test must move together (#1110).
+
+### Offline files that reference the tag (no live probe today)
+
+These files don't carry the directive themselves — they document
+the live counterpart or reserve a follow-up slot for a future test.
+Listed here so the cross-reference doesn't bit-rot.
+
+#### `test/core/services/impl/mise_station_service_test.dart`
+
+Pure-parser tests for `MiseStationService`. The block comment near
+line 360 explicitly directs live `searchStations()` coverage to
+`italy_search_live_test.dart`. **Do not** add live probes here — the
+intent is to keep this file deterministic and fast.
+
+#### `test/core/sync/price_history_sync_test.dart`
+
+Shape-only smoke tests for `PriceHistorySync`. The dartdoc points
+the reader at `test/core/data/sync_repository_test.dart` for the
+network-tagged equivalent (which lives one step out at the
+repository layer). If that repository test is removed or moved,
+update this dartdoc in the same PR.
+
+#### `test/core/utils/payment_app_launcher_test.dart`
+
+Includes the helper `assertLivePlayStoreListing()` annotated
+`@visibleForTesting`. The catalog is empty today (#736) so no
+network-tagged test calls it. **When a payment-app brand is
+re-added**, add a `@Tags(['network'])` test in this file (or a
+sibling) that calls the helper for the brand — the comment near
+line 180 is the contract.
+
+## When to add a network test
+
+Add a network-tagged test only when **correctness depends on a
+real external endpoint that is impractical to fake faithfully**:
+
+- Live geocoder or country API contract drift (a CSV column gets
+  renamed, a JSON field becomes nullable, a new auth header is
+  required).
+- Endpoint reachability (DNS, TLS, CDN, HTTP method support).
+- Server-enforced authorization (Supabase RLS — the postures we
+  care about are silent-fail, not exception-throw).
+- Browser-visible URL aliveness (the user taps and lands on a 404).
+
+Do **not** use a network-tagged test for:
+
+- Schema parsing — model that with a checked-in fixture and a
+  pure-Dart parser test instead.
+- Anything that can be expressed with `Dio` interceptors and a
+  fake response — those belong in the offline suite.
+- "Make the green bar greener" coverage. Network tests are a
+  contract-drift alarm, not a coverage tool.
+
+When you add one, also:
+
+1. Add a top-of-file dartdoc (2 – 4 lines) describing the
+   upstream and the re-run trigger. Match the style above.
+2. Add an entry to the per-file inventory in this doc.
+3. If the test needs credentials, gate them on env vars and
+   `skip:` cleanly when absent (mirror `supabase_rls_test.dart`).

--- a/test/core/services/api_connectivity_test.dart
+++ b/test/core/services/api_connectivity_test.dart
@@ -5,15 +5,15 @@ import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Integration tests that verify each country's fuel price API is reachable
-/// and returns valid data. These tests hit real endpoints.
+/// and returns valid data. Probes Tankerkoenig (DE), Prix-Carburants (FR),
+/// E-Control (AT), MITECO (ES), MIMIT (IT), OK + Shell (DK), Argentina
+/// Energía, and Nominatim — real endpoints, hence the `network` tag.
 ///
-/// Tagged `network` so the main CI run excludes them — the upstream APIs
-/// (Argentina, Italy MIMIT, Spain MITECO) intermittently time out and
-/// must not block PRs. Run on demand with:
+/// Rerun after any change under `lib/core/services/impl/*_station_service.dart`
+/// or before tagging a release. CI excludes the tag (intermittent upstream
+/// timeouts cannot block PRs); see `docs/guides/NETWORK_TESTS.md`.
 ///
 ///   flutter test test/core/services/api_connectivity_test.dart --tags=network
-///
-/// or from a workstation via `flutter test --tags=network`.
 void main() {
   late Dio dio;
 

--- a/test/core/services/impl/mise_station_service_test.dart
+++ b/test/core/services/impl/mise_station_service_test.dart
@@ -5,6 +5,14 @@ import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 
+/// Pure-parser + interface-contract tests for [MiseStationService]. Runs
+/// fully offline against checked-in CSV fixtures — no upstream call.
+///
+/// Live `searchStations()` coverage lives in
+/// `test/core/services/italy_search_live_test.dart` under
+/// `@Tags(['network'])`; rerun that file (not this one) when the MISE
+/// CSV schema or the `mimit.gov.it` host changes. See
+/// `docs/guides/NETWORK_TESTS.md`.
 void main() {
   late MiseStationService service;
 

--- a/test/core/services/italy_search_live_test.dart
+++ b/test/core/services/italy_search_live_test.dart
@@ -6,13 +6,13 @@ import 'package:tankstellen/core/services/impl/mise_station_service.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
-/// #695 — live reachability + end-to-end search test for the Italian
-/// MISE provider. Guards against the bug the user reported ("search
-/// for Italy returns no results") by hitting the real upstream and
-/// asserting >0 stations for a known-busy location (Rome).
+/// #695 — live end-to-end search against the Italian MISE provider.
+/// Hits `mimit.gov.it/images/exportCSV/anagrafica_impianti_attivi.csv`
+/// + the price CSV, asserts >0 stations for Rome and Milan.
 ///
-/// Run with `flutter test --tags network` on demand; skipped by the
-/// default test runner (CI `flutter test` excludes tagged suites).
+/// Rerun after touching `mise_station_service.dart`, `mise_csv_parser.dart`,
+/// or the Italian bounding box — also when a user reports "Italy returns
+/// no results". CI excludes the tag; see `docs/guides/NETWORK_TESTS.md`.
 void main() {
   test(
     'MISE returns stations within 10km of Rome (Roma Centro)',

--- a/test/core/sync/price_history_sync_test.dart
+++ b/test/core/sync/price_history_sync_test.dart
@@ -1,18 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/sync/price_history_sync.dart';
 
-/// Shape-only smoke tests for [PriceHistorySync] (#727 extract).
+/// Shape-only smoke tests for [PriceHistorySync] (#727 extract). Runs
+/// fully offline — exercises the "TankSync client is null → return empty
+/// list" guard without touching Supabase.
 ///
-/// The method wraps a Supabase query; the ONLY behaviour this test
-/// can exercise without a live Supabase stack is the "client is
-/// null → return empty list" guard. That guard is the contract the
-/// rest of the codebase depends on (see
-/// `supabase_sync_repository_test.dart` for the same test at the
-/// repository layer) — any refactor that loses it is a regression.
-///
-/// Tests that require a real Supabase client live under
-/// `test/core/data/sync_repository_test.dart` with a `@Tags(['network'])`
-/// guard; we don't duplicate those here.
+/// Live counterpart sits at `test/core/data/sync_repository_test.dart`
+/// under `@Tags(['network'])`; rerun that file (not this one) when the
+/// `price_snapshots` table schema or the TankSync RPC contract changes.
+/// See `docs/guides/NETWORK_TESTS.md`.
 void main() {
   group('PriceHistorySync', () {
     test('returns empty list when TankSync client is not configured',

--- a/test/core/utils/payment_app_launcher_test.dart
+++ b/test/core/utils/payment_app_launcher_test.dart
@@ -4,6 +4,13 @@ import 'package:http/http.dart' as http;
 import 'package:tankstellen/core/utils/payment_app_launcher.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+/// Offline tests for [paymentAppForBrand] and [PaymentAppLauncher]. The
+/// brand catalog is empty today (#736 — every hard-coded Play Store id
+/// 404'd), so no live probe runs.
+///
+/// When a brand is re-added, wrap [assertLivePlayStoreListing] (below) in
+/// a `@Tags(['network'])` test so CI catches silent Play Store redirects
+/// before users tap the chip. See `docs/guides/NETWORK_TESTS.md`.
 void main() {
   group('paymentAppForBrand', () {
     test('returns null for unknown brand', () {

--- a/test/security/external_urls_reachable_test.dart
+++ b/test/security/external_urls_reachable_test.dart
@@ -5,14 +5,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:tankstellen/core/constants/app_constants.dart';
 
-/// Verifies that every user-facing URL constant in [AppConstants] is
-/// reachable (returns HTTP 2xx or 3xx). Tagged `network` so it only
-/// runs in CI jobs / manual invocations with network access:
+/// #539 — `HEAD`-probes every user-facing URL constant in [AppConstants]
+/// (privacy policy, GitHub repo + issues, Tankerkoenig registration,
+/// PayPal, Revolut). Catches the broken-link case after a domain change.
 ///
-///   flutter test --tags=network
-///
-/// The default CI step runs `--exclude-tags=network`, so this test
-/// does NOT block offline PR checks.
+/// Rerun after editing `lib/core/constants/app_constants.dart` or after
+/// reconfiguring GitHub Pages for the privacy policy. CI excludes the
+/// tag; see `docs/guides/NETWORK_TESTS.md`.
 void main() {
   group('External URLs reachable (#539)', () {
     /// URLs the app opens in the user's browser. A 404 on any of

--- a/test/security/supabase_rls_test.dart
+++ b/test/security/supabase_rls_test.dart
@@ -7,7 +7,11 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 
-/// #1110 — RLS policy verification test.
+/// #1110 — Supabase RLS policy verification. Rerun after any migration
+/// under `supabase/migrations/` that touches `CREATE POLICY` or
+/// `ENABLE/DISABLE ROW LEVEL SECURITY`, and whenever
+/// `docs/security/SUPABASE_RLS_MATRIX.md` is edited (matrix and test
+/// move together). See `docs/guides/NETWORK_TESTS.md`.
 ///
 /// Calls the `public.audit_rls_policies()` SQL function (added by
 /// migration `20260426000001_rls_audit_function.sql`) against a live


### PR DESCRIPTION
## Summary
- New tracked guide `docs/guides/NETWORK_TESTS.md` covering rationale, run commands, CI exclusion config (`dart_test.yaml` + `.github/workflows/ci.yml --exclude-tags=network`), and a per-file inventory of every test that hits real third-party endpoints.
- 2-4 line top-of-file dartdoc on each of the seven test files identifying the upstream and the re-run trigger.
- `.gitignore` allowlist line `!docs/guides/NETWORK_TESTS.md` so the new doc is tracked.
- One sentence in `docs/CONTRIBUTING.md` Testing section pointing readers at the new guide.

## Files touched
Test files updated with top-of-file dartdoc:
1. `test/core/services/api_connectivity_test.dart` (already tagged)
2. `test/core/services/italy_search_live_test.dart` (already tagged)
3. `test/security/external_urls_reachable_test.dart` (already tagged)
4. `test/security/supabase_rls_test.dart` (already tagged)
5. `test/core/services/impl/mise_station_service_test.dart` (offline; cross-references the network counterpart)
6. `test/core/sync/price_history_sync_test.dart` (offline; cross-references the network counterpart)
7. `test/core/utils/payment_app_launcher_test.dart` (offline; reserves the slot for re-add of #736)

## Why
Per audit B10 (#1114), the network-tagged test set was excluded from CI but undocumented — no contributor instructions, no run command, no list of upstreams. Without docs the suite bit-rots. This commit gives it a tracked home so the next maintainer can run it without spelunking through git history.

## Notes
- Issue body asked to update `CLAUDE.md`, but `CLAUDE.md` has been moved out of git as of 2026-04-26. Documentation lives in `docs/guides/` instead.
- During grep we found that only four of the seven files carry the `@Tags(['network'])` directive at file level today (the other three reference it in comments or stage handoff notes). The doc records this distinction explicitly so future readers don't chase phantom directives.

## Test plan
- [x] `flutter analyze` — zero issues
- [x] `flutter test test/lint/no_silent_catch_test.dart` — passes
- [x] `git ls-files docs/guides/NETWORK_TESTS.md` — file is tracked (allowlist works)
- [ ] Reviewer skims `docs/guides/NETWORK_TESTS.md` end-to-end and confirms the per-file inventory matches the live source

Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)