### PR TITLE
refactor(country): consolidate country registration via CountryServiceEntry (#1111)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -90,15 +90,21 @@ This is the most common type of contribution. See the full step-by-step guide:
 
 ### Quick Checklist
 
-When adding a new country, you must touch **all** of these files:
+Since #1111 the per-country touchpoints are consolidated onto a single
+`CountryServiceEntry` in the registry. When adding a new country you only
+touch these files:
 
 - [ ] `lib/core/services/impl/<country>_station_service.dart` -- new service
-- [ ] `lib/core/services/service_providers.dart` -- register in factory map
 - [ ] `lib/core/services/service_result.dart` -- add `ServiceSource` enum value
-- [ ] `lib/core/country/country_config.dart` -- add `CountryConfig` + add to `Countries.all`
-- [ ] `lib/core/country/country_bounding_box.dart` -- add bounding box
-- [ ] `lib/features/search/domain/entities/fuel_type.dart` -- add case in `fuelTypesForCountry`
+- [ ] `lib/core/services/country_service_registry.dart` -- append `CountryServiceEntry` (carries bounding box, fuel types, error source, factory)
+- [ ] `lib/core/country/country_config.dart` -- append `CountryConfig` + add to `Countries.all`
 - [ ] `test/` -- unit tests for the new service
+
+Pre-#1111 you also had to edit `lib/core/country/country_bounding_box.dart`,
+`lib/core/services/service_providers.dart`, and the per-country switch in
+`lib/features/search/domain/entities/fuel_type.dart` (`fuelTypesForCountry`).
+Those files now read from `CountryServiceRegistry.entries`, so they no
+longer require per-country edits.
 
 Optional but recommended:
 

--- a/docs/guides/NEW_COUNTRY.md
+++ b/docs/guides/NEW_COUNTRY.md
@@ -1,7 +1,11 @@
 # Adding a New Country to Tankstellen
 
-This guide walks through every file you need to create or modify when adding
-support for a new country's fuel price API.
+This guide walks through adding support for a new country's fuel price API.
+
+Since #1111 the per-country touchpoints are consolidated onto a single
+`CountryServiceEntry` in the registry, so adding a new country requires
+**one new file** plus **two small appends** (the registry entry and the
+`ServiceSource` enum value).
 
 ## Prerequisites
 
@@ -13,7 +17,7 @@ support for a new country's fuel price API.
 
 ### 1. Create the Station Service
 
-**File:** `lib/core/services/impl/<country>_station_service.dart`
+**File (NEW):** `lib/core/services/impl/<country>_station_service.dart`
 
 This is the core implementation. It must implement `StationService` and handle
 fetching + parsing station data from the country's API.
@@ -29,8 +33,6 @@ import '../service_result.dart';
 import '../station_service.dart';
 
 /// <Country> fuel prices from <API provider>.
-///
-/// <Brief description of API: free/paid, key required, data format.>
 class ExampleStationService
     with StationServiceHelpers
     implements StationService {
@@ -55,11 +57,11 @@ class ExampleStationService
         cancelToken: cancelToken,
       );
 
-      // Parse response into Station objects
+      // Parse response into Station objects (prefix ids with country code).
       final items = response.data as List<dynamic>? ?? [];
       final stations = items.map((item) {
         return Station(
-          id: 'xx-${item['id']}',       // prefix with country code
+          id: 'xx-${item['id']}',
           name: item['name'] ?? '',
           brand: item['brand'] ?? '',
           street: item['address'] ?? '',
@@ -67,14 +69,13 @@ class ExampleStationService
           place: item['city'] ?? '',
           lat: (item['lat'] as num).toDouble(),
           lng: (item['lng'] as num).toDouble(),
-          dist: 0,                        // calculated below
+          dist: 0,
           e5: (item['petrol'] as num?)?.toDouble(),
           diesel: (item['diesel'] as num?)?.toDouble(),
           isOpen: true,
         );
       }).toList();
 
-      // Calculate distances and filter by radius
       for (var i = 0; i < stations.length; i++) {
         stations[i] = stations[i].copyWith(
           dist: roundedDistance(
@@ -93,18 +94,12 @@ class ExampleStationService
   }
 
   @override
-  Future<ServiceResult<StationDetail>> getStationDetail(
-    String stationId,
-  ) async {
-    // Implement if the API supports detail queries, otherwise:
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) {
     throwDetailUnavailable('Example API');
   }
 
   @override
-  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
-    List<String> ids,
-  ) async {
-    // Implement if the API supports batch price queries, otherwise:
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(List<String> ids) async {
     return emptyPricesResult(ServiceSource.exampleApi);
   }
 }
@@ -112,168 +107,154 @@ class ExampleStationService
 
 **Key patterns:**
 
-- Use `DioFactory.create()` for HTTP -- never create raw `Dio()` instances.
-- Mix in `StationServiceHelpers` for `roundedDistance`, `filterByRadius`,
-  `sortStations`, `wrapStations`, `throwApiException`, etc.
-- For APIs that return all stations nationally (no radius query), also mix in
-  `CachedDatasetMixin` for in-memory caching with TTL. See
-  `denmark_station_service.dart` or `argentina_station_service.dart`.
+- Use `DioFactory.create()` for HTTP — never instantiate raw `Dio()`.
+- Mix in `StationServiceHelpers` for distance/filter/sort/wrap helpers.
+- For APIs that return all stations nationally, also mix in `CachedDatasetMixin`.
 - Prefix station IDs with the country code to avoid collisions across APIs.
 - Always handle `DioException` and call `throwApiException`.
 
-### 2. Add ServiceSource Enum Value
+### 2. Add the ServiceSource enum value
 
 **File:** `lib/core/services/service_result.dart`
-
-Add a new entry to the `ServiceSource` enum:
 
 ```dart
 enum ServiceSource {
   // ... existing entries ...
-  exampleApi('Example API'),        // <-- add this
+  exampleApi('Example API'),       // <-- add this
   // ...
 }
 ```
 
-### 3. Register in Service Providers
+### 3. Append the CountryServiceEntry
 
-**File:** `lib/core/services/service_providers.dart`
+**File:** `lib/core/services/country_service_registry.dart`
 
-Add an import for your new service and register it in the
-`_countryServiceFactories` map:
+This is the single registry edit that wires everything together — bounding
+box, fuel types, error source, API-key requirement, and the service factory
+all live on the entry. The registry uses `StationServiceChain` automatically
+to wrap the raw service.
 
 ```dart
 import 'impl/example_station_service.dart';
 
-final _countryServiceFactories = <String, StationService Function(Ref, CacheStrategy)>{
-  // ... existing entries ...
-  'XX': (ref, cache) => StationServiceChain(
-    ExampleStationService(), cache,
-    errorSource: ServiceSource.exampleApi, countryCode: 'XX',
+// ... in the entries list ...
+CountryServiceEntry(
+  countryCode: 'XX',
+  errorSource: ServiceSource.exampleApi,
+  // Generous 1-2 degree margin around the country's actual bounds. See
+  // ordering note on entries — tighter / island / coastal boxes go first.
+  boundingBox: CountryBoundingBox(
+    minLat: 40.0, maxLat: 50.0, minLng: -5.0, maxLng: 10.0,
   ),
-};
+  // Order matters — UI selectors render in this order. End every list
+  // with FuelType.electric followed by FuelType.all.
+  availableFuelTypes: [
+    FuelType.e5, FuelType.diesel, FuelType.electric, FuelType.all,
+  ],
+  requiresApiKey: false,
+  createService: _createExample,
+),
+
+// ... at the bottom of the file, alongside the other factories ...
+StationService _createExample(Ref ref) => ExampleStationService();
 ```
 
-If the API requires an API key, follow the `'DE'` pattern in the
-`stationService` provider (check `storage.hasApiKey()` first).
+If the API requires a user-supplied key, mirror the Tankerkönig pattern
+(`_createTankerkoenig` in the registry): fall back to `DemoStationService`
+when no key is configured.
 
-### 4. Add Country Configuration
+### 4. Append the CountryConfig
 
 **File:** `lib/core/country/country_config.dart`
 
-Add a new `CountryConfig` constant to the `Countries` class:
+`CountryConfig` carries the user-facing presentation data (display name,
+flag, currency, postal-code shape) consumed by every UI surface — this is
+why it stays separate from the service registry. Add a new constant and
+append it to `Countries.all`:
 
 ```dart
 static const example = CountryConfig(
   code: 'XX',
   name: 'Example Country',
-  flag: '\u{1F1FD}\u{1F1FD}',      // flag emoji (regional indicator symbols)
-  currency: 'EUR',                   // or 'GBP', 'USD', etc.
-  currencySymbol: '\u20ac',          // or '\u00a3', '\$', etc.
+  flag: '\u{1F1FD}\u{1F1FD}',
+  currency: 'EUR',
+  currencySymbol: '€',
   locale: 'xx_XX',
   postalCodeLength: 5,
   postalCodeRegex: r'^\d{5}$',
   postalCodeLabel: 'Postal code',
-  requiresApiKey: false,             // true if user must provide their own key
-  apiKeyRegistrationUrl: null,       // URL where user can register for an API key
   apiProvider: 'Example Data Provider',
   attribution: 'Data: example.com',
   fuelTypes: ['Petrol 95', 'Diesel'],
   examplePostalCode: '10000',
   exampleCity: 'Capital City',
 );
-```
 
-Then add it to `Countries.all`:
-
-```dart
+// Append to Countries.all:
 static const all = [
   // ... existing entries ...
-  example,    // <-- add here
+  example,
 ];
 ```
 
-### 5. Add Country Bounding Box
+The startup assertion `CountryServiceRegistry.assertAllCountriesRegistered()`
+verifies `Countries.all` and the registry stay in sync — drift fails fast
+on app launch in debug.
 
-**File:** `lib/core/country/country_bounding_box.dart`
+### 5. Bounding box & fuel types
 
-Add a bounding box for coordinate validation. Use generous margins (1-2 degrees)
-around the country's actual boundaries:
+These live on the `CountryServiceEntry` you appended in step 3 — there is
+no longer a separate `country_bounding_box.dart` map or a
+`fuelTypesForCountry` switch to edit (#1111). Both `countryBoundingBoxes`
+and `fuelTypesForCountry` continue to work as backwards-compatible
+top-level lookup helpers; they delegate to `CountryServiceRegistry`.
 
-```dart
-const countryBoundingBoxes = <String, CountryBoundingBox>{
-  // ... existing entries ...
-  'XX': CountryBoundingBox(minLat: 40.0, maxLat: 50.0, minLng: -5.0, maxLng: 10.0),
-};
-```
+### 6. Write tests
 
-Source bounding box coordinates from OpenStreetMap or Natural Earth data.
-
-### 6. Add Fuel Type Mapping
-
-**File:** `lib/features/search/domain/entities/fuel_type.dart`
-
-Add a case to the `fuelTypesForCountry` switch for your country code:
-
-```dart
-List<FuelType> fuelTypesForCountry(String countryCode) {
-  switch (countryCode) {
-    // ... existing cases ...
-    case 'XX':
-      return [FuelType.e5, FuelType.diesel, FuelType.electric, FuelType.all];
-    default:
-      return [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all];
-  }
-}
-```
-
-Map the country's local fuel names to the canonical `FuelType` values. If a
-country sells a fuel type not yet in the sealed class hierarchy, you will need to
-add a new `FuelType` subclass.
-
-### 7. Write Tests
-
-**Required:** Create `test/core/services/impl/<country>_station_service_test.dart`
+**Required:** `test/core/services/impl/<country>_station_service_test.dart`
 
 Test at minimum:
 
 - Parsing a valid API response into `Station` objects
 - Handling empty responses gracefully
-- Handling network errors (DioException)
+- Handling network errors (`DioException`)
 - Distance calculation and radius filtering
 - Station ID prefixing
 
-Use fakes, not mocks. See existing tests for patterns:
+Use fakes, not mocks. Follow patterns in existing tests under
+`test/core/services/impl/`.
+
+### 7. Run checks
 
 ```bash
-ls test/core/services/impl/
+flutter analyze    # must be zero warnings
+flutter test       # full suite must pass
 ```
 
-### 8. Run Checks
-
-```bash
-flutter analyze --no-fatal-infos   # must be zero warnings
-flutter test                        # must pass
-```
-
-## File Summary
+## File summary (post #1111)
 
 | File | Action | Required |
 |------|--------|----------|
 | `lib/core/services/impl/<country>_station_service.dart` | Create | Yes |
-| `lib/core/services/service_result.dart` | Add enum value | Yes |
-| `lib/core/services/service_providers.dart` | Add import + factory entry | Yes |
-| `lib/core/country/country_config.dart` | Add config + update `all` list | Yes |
-| `lib/core/country/country_bounding_box.dart` | Add bounding box | Yes |
-| `lib/features/search/domain/entities/fuel_type.dart` | Add `fuelTypesForCountry` case | Yes |
+| `lib/core/services/service_result.dart` | Add `ServiceSource` enum value | Yes |
+| `lib/core/services/country_service_registry.dart` | Append `CountryServiceEntry` + factory fn | Yes |
+| `lib/core/country/country_config.dart` | Append `CountryConfig` + update `Countries.all` list | Yes |
 | `test/core/services/impl/<country>_station_service_test.dart` | Create | Yes |
 | `lib/l10n/app_*.arb` | Localized strings | Optional |
+
+Compared to the pre-#1111 layout you no longer touch
+`lib/core/country/country_bounding_box.dart` or the per-country switch in
+`lib/features/search/domain/entities/fuel_type.dart` — both now read from
+`CountryServiceRegistry.entries`.
 
 ## Tips
 
 - Study `denmark_station_service.dart` for a "download all, filter locally" pattern.
 - Study `tankerkoenig_station_service.dart` for a "radius query with API key" pattern.
 - Study `portugal_station_service.dart` for a "dataset with CSV parsing" pattern.
-- The `StationServiceHelpers` mixin provides all distance, sorting, and wrapping utilities.
+- The `StationServiceHelpers` mixin provides distance, sorting, and wrapping utilities.
 - The `CachedDatasetMixin` provides in-memory TTL caching for national datasets.
 - Use the GitHub issue template `.github/ISSUE_TEMPLATE/new_country.yml` when proposing a new country.
+- Bounding-box ordering matters when a tight/island box sits inside a generous
+  neighbour's box. Insert your entry early in `CountryServiceRegistry.entries`
+  if your country could be shadowed by an existing one.

--- a/lib/core/country/country_bounding_box.dart
+++ b/lib/core/country/country_bounding_box.dart
@@ -1,11 +1,18 @@
-/// Geographic bounding boxes for all supported countries.
+import '../services/country_service_registry.dart';
+
+/// Geographic bounding box for a country.
 ///
 /// Used to validate that geocoded coordinates actually fall within the
-/// expected country. Prevents silently returning results for the wrong
-/// area when Nominatim returns inaccurate coordinates.
+/// expected country and to infer a station's origin country from its
+/// coordinates when the station id has no country prefix (#516).
 ///
-/// Boxes are intentionally generous (1-2 degree margin) to account for
+/// Boxes intentionally include a 1-2 degree margin to account for
 /// overseas territories, islands, and border regions.
+///
+/// Per-country boxes live on [CountryServiceEntry.boundingBox] in
+/// [CountryServiceRegistry.entries] — a single source of truth that
+/// also encapsulates fuel types, error source, and the service
+/// factory (#1111).
 class CountryBoundingBox {
   final double minLat;
   final double maxLat;
@@ -29,152 +36,31 @@ class CountryBoundingBox {
       'CountryBoundingBox(lat: $minLat..$maxLat, lng: $minLng..$maxLng)';
 }
 
-/// Bounding boxes for all supported countries, keyed by ISO 3166-1 alpha-2 code.
+/// Backwards-compatible map view of registered country bounding boxes,
+/// keyed by ISO 3166-1 alpha-2 code.
 ///
-/// Sources: OpenStreetMap / Natural Earth bounding boxes with generous margins.
-const countryBoundingBoxes = <String, CountryBoundingBox>{
-  // Germany: lat 47.27–55.06, lng 5.87–15.04 (with margin)
-  'DE': CountryBoundingBox(minLat: 47.0, maxLat: 55.5, minLng: 5.5, maxLng: 15.5),
+/// Reads from [CountryServiceRegistry.entries] — adding a new country
+/// only requires appending to the registry, never editing this file
+/// (#1111). Existing call sites that look up by code (e.g.
+/// `countryBoundingBoxes['DE']`) keep working unchanged.
+Map<String, CountryBoundingBox> get countryBoundingBoxes => {
+      for (final entry in CountryServiceRegistry.entries)
+        entry.countryCode: entry.boundingBox,
+    };
 
-  // France (mainland): lat 41.33–51.12, lng -5.14–9.56 (with margin)
-  // Excludes overseas territories (Réunion, Guadeloupe, etc.)
-  'FR': CountryBoundingBox(minLat: 41.0, maxLat: 51.5, minLng: -5.5, maxLng: 10.0),
-
-  // Austria: lat 46.37–49.02, lng 9.53–17.16 (with margin)
-  'AT': CountryBoundingBox(minLat: 46.0, maxLat: 49.5, minLng: 9.0, maxLng: 17.5),
-
-  // Spain (mainland + Balearic + Canary): lat 27.64–43.79, lng -18.17–4.33 (with margin)
-  'ES': CountryBoundingBox(minLat: 27.0, maxLat: 44.0, minLng: -19.0, maxLng: 5.0),
-
-  // Italy (mainland + Sicily + Sardinia): lat 35.49–47.09, lng 6.63–18.52 (with margin)
-  'IT': CountryBoundingBox(minLat: 35.0, maxLat: 47.5, minLng: 6.0, maxLng: 19.0),
-
-  // Denmark (mainland + Greenland excluded): lat 54.56–57.75, lng 8.07–15.20 (with margin)
-  'DK': CountryBoundingBox(minLat: 54.0, maxLat: 58.0, minLng: 7.5, maxLng: 15.5),
-
-  // Argentina: lat -55.06–-21.78, lng -73.56–-53.64 (with margin)
-  'AR': CountryBoundingBox(minLat: -56.0, maxLat: -21.0, minLng: -74.0, maxLng: -53.0),
-
-  // Portugal (mainland + Azores + Madeira): lat 32.40–42.15, lng -31.27–-6.19 (with margin)
-  'PT': CountryBoundingBox(minLat: 32.0, maxLat: 42.5, minLng: -32.0, maxLng: -6.0),
-
-  // United Kingdom: lat 49.86–60.86, lng -8.65–1.77 (with margin)
-  'GB': CountryBoundingBox(minLat: 49.5, maxLat: 61.0, minLng: -9.0, maxLng: 2.0),
-
-  // Australia: lat -43.64–-10.06, lng 112.92–153.64 (with margin)
-  'AU': CountryBoundingBox(minLat: -44.0, maxLat: -9.5, minLng: 112.5, maxLng: 154.0),
-
-  // Mexico: lat 14.39–32.72, lng -118.37–-86.71 (with margin)
-  'MX': CountryBoundingBox(minLat: 14.0, maxLat: 33.0, minLng: -119.0, maxLng: -86.0),
-
-  // Luxembourg: lat 49.45–50.18, lng 5.74–6.53 (with margin).
-  // Very tight box — LU is ~82 km north-south, ~57 km east-west; keeping
-  // the margin modest so BE/FR/DE neighbours don't bleed into LU matches.
-  'LU': CountryBoundingBox(minLat: 49.4, maxLat: 50.25, minLng: 5.7, maxLng: 6.55),
-
-  // Slovenia: lat 45.42–46.88, lng 13.38–16.61 (with margin). Tight
-  // box — Slovenia is small and surrounded by IT / AT / HR so an
-  // over-generous margin would shadow those neighbours. See #575.
-  'SI': CountryBoundingBox(minLat: 45.3, maxLat: 47.0, minLng: 13.3, maxLng: 16.7),
-
-  // South Korea (mainland + Jeju): lat 33.10–38.61, lng 124.61–131.87
-  // (with margin). No overlap with any other registered country. See #597.
-  'KR': CountryBoundingBox(minLat: 33.0, maxLat: 39.0, minLng: 124.0, maxLng: 131.0),
-
-  // Chile: lat -56.00 (Tierra del Fuego) – -17.50 (Arica), lng -75.80 –
-  // -66.40 (mainland, with a margin large enough for Isla de Chiloé and
-  // the Atacama coast but kept narrow on the east so Chile's tight west-
-  // coast strip does not shadow Argentina's much larger box. See #596.
-  'CL': CountryBoundingBox(minLat: -56.5, maxLat: -17.0, minLng: -77.0, maxLng: -66.0),
-
-  // Greece: lat 34.50 (southern Crete) – 41.80 (north Macedonia border),
-  // lng 19.00 (Corfu / Ionian) – 28.50 (eastern Dodecanese / Rhodes).
-  // The eastern edge is deliberately pulled in from the geographic
-  // limit (~29.6 for Kastellorizo) so Istanbul (41.01, 28.98) is
-  // NOT falsely attributed to GR. Kastellorizo (~500 residents) is
-  // the only Greek territory lost; every populated island including
-  // Rhodes (36.43, 28.22) and Kos stays inside the box. Turkey is
-  // not currently in the registry, so a point that falls between the
-  // bbox and the Turkish border simply returns `null` — the caller
-  // uses that as the signal to fall back to the active profile.
-  // See #576.
-  'GR': CountryBoundingBox(minLat: 34.5, maxLat: 41.8, minLng: 19.0, maxLng: 28.5),
-
-  // Romania: lat 43.50 (southern Danube border) – 48.50 (northern
-  // Maramureș), lng 20.00 (western Banat) – 29.80 (Dobrogea / Black
-  // Sea coast). No neighbour conflicts — HU, BG, UA, RS, and MD are
-  // not currently in the registry, so misattribution risk is zero at
-  // the bbox layer. See #577.
-  'RO': CountryBoundingBox(minLat: 43.5, maxLat: 48.5, minLng: 20.0, maxLng: 29.8),
-};
-
-/// Deterministic order used by [countryCodeFromLatLng] to walk
-/// [countryBoundingBoxes]. Small / island / coastal countries come
-/// first so their tight boxes are not shadowed by larger neighbours
-/// whose boxes incidentally overlap them (e.g. `PT`'s Iberian area
-/// is entirely inside `ES`'s box, so we must test `PT` first).
-///
-/// Cross-currency border cases (#516) were the primary motivation —
-/// getting a station misattributed between two euro-zone countries
-/// is invisible at the currency-symbol layer, but a UK/FR or DE/DK
-/// mix-up would flip the rendered symbol.
-///
-/// Ordering rationale:
-/// - `PT` first → its tight box is entirely inside `ES`'s generous
-///   one; Lisbon / Porto must not fall through to ES.
-/// - `GB` / island next → no continental overlap.
-/// - `DK` before `DE` → Copenhagen's lat sits inside DE's box.
-/// - `FR` before `DE` → Alsace (Strasbourg) sits inside both.
-/// - Continental EU countries last (DE) so stations outside every
-///   tighter box still get attributed to something European.
-/// - Non-EU countries last — they don't overlap anyone.
-const List<String> _bboxLookupOrder = [
-  'PT',
-  'GB',
-  'DK',
-  // LU sits inside the generous FR and DE boxes (49.6/6.1) — must be
-  // tested first so Luxembourg-Ville doesn't fall through to France.
-  'LU',
-  // SI first among Alpine neighbours — its tight box is entirely inside
-  // both AT and IT's generous boxes (#575). A Ljubljana station (lat
-  // 46.05 / lng 14.50) would otherwise fall through to AT.
-  'SI',
-  'AT',
-  'FR',
-  'IT',
-  'ES',
-  'DE',
-  'MX',
-  // CL before AR: Chile's narrow strip sits inside AR's generous
-  // longitude range along the cordillera. A Santiago station
-  // (-33.45 / -70.67) or a Punta Arenas station (-53.16 / -70.91)
-  // would otherwise fall through to AR. See #596.
-  'CL',
-  'AR',
-  'AU',
-  'KR',
-  // GR last — no overlap with any currently-registered country's box,
-  // so placement in the lookup order is inconsequential. #576
-  'GR',
-  // RO last — no overlap with any currently-registered country's box
-  // (HU / BG / UA / RS / MD are not registered). #577
-  'RO',
-];
-
-/// Returns the ISO country code whose bounding box contains the
-/// given point, or `null` when no box matches.
+/// Returns the ISO country code whose bounding box contains the given
+/// point, or `null` when no box matches.
 ///
 /// Used by `Countries.countryForStation` (#516) as a fallback when a
-/// station id has no country-specific prefix — every supported
-/// service still emits `lat` / `lng`, so the station can still be
-/// attributed to a country via its coordinates even if the id is a
-/// bare upstream identifier (FR Prix-Carburants, DE Tankerkoenig,
-/// AT E-Control, ES MITECO, IT MISE all fall into this case).
-String? countryCodeFromLatLng(double lat, double lng) {
-  for (final code in _bboxLookupOrder) {
-    final box = countryBoundingBoxes[code];
-    if (box == null) continue;
-    if (box.contains(lat, lng)) return code;
-  }
-  return null;
-}
+/// station id has no country-specific prefix — every supported service
+/// still emits `lat` / `lng`, so the station can still be attributed
+/// to a country via its coordinates even if the id is a bare upstream
+/// identifier (FR Prix-Carburants, DE Tankerkoenig, AT E-Control,
+/// ES MITECO, IT MISE all fall into this case).
+///
+/// Lookup-order matters: [CountryServiceRegistry.entries] is intentionally
+/// ordered so tighter / island / coastal boxes come first, before the
+/// larger boxes that incidentally overlap them. See the doc on
+/// [CountryServiceRegistry.entries] for the full rationale.
+String? countryCodeFromLatLng(double lat, double lng) =>
+    CountryServiceRegistry.entryByLatLng(lat, lng)?.countryCode;

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -2,8 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../cache/cache_manager.dart';
+import '../country/country_bounding_box.dart';
 import '../country/country_config.dart';
 import '../storage/storage_providers.dart';
+import '../../features/search/domain/entities/fuel_type.dart';
 import 'impl/argentina_station_service.dart';
 import 'impl/australia_station_service.dart';
 import 'impl/chile_station_service.dart';
@@ -28,21 +30,53 @@ import 'service_result.dart';
 import 'station_service.dart';
 import 'station_service_chain.dart';
 
-/// A single entry in the country service registry.
+/// A single entry in the country service registry — the **single source of
+/// truth** for everything we need to know about a supported country at the
+/// service layer.
 ///
-/// Encapsulates everything needed to create a [StationService] for one country:
-/// the country code, the [ServiceSource] for error reporting, and a factory
-/// that builds the raw (unwrapped) service instance.
+/// Encapsulates the country code, the [ServiceSource] used for error
+/// attribution in the fallback chain, the geographic [boundingBox] used to
+/// validate geocoded coordinates and infer the origin country of a station
+/// (#516), the ordered list of [availableFuelTypes] the upstream API
+/// publishes, the API-key requirement, and the factory that builds the raw
+/// [StationService].
 ///
-/// The factory receives a [Ref] for dependency injection (e.g. Dio, enrichers)
-/// and returns a raw [StationService] which will be wrapped in a
-/// [StationServiceChain] by the registry.
+/// Adding a 12th country now requires:
+///
+/// 1. One new file: `lib/core/services/impl/<country>_station_service.dart`
+/// 2. One [ServiceSource] enum value in `service_result.dart` (mechanical;
+///    enums naturally cluster on append)
+/// 3. One new entry appended to [CountryServiceRegistry.entries]
+///
+/// The country's [CountryConfig] (display name, flag, postal-code shape,
+/// currency formatting, etc.) is intentionally kept separate in
+/// `country_config.dart` because every UI surface depends on it; folding
+/// it into the entry would push the diff past 70 files for no real
+/// extensibility win. The registry composes the config by code, not by
+/// reference, via [Countries.byCode].
 class CountryServiceEntry {
   /// ISO 3166-1 alpha-2 country code (e.g. 'DE', 'FR').
   final String countryCode;
 
   /// The [ServiceSource] used for error attribution in the fallback chain.
   final ServiceSource errorSource;
+
+  /// Geographic bounding box used to:
+  ///
+  ///  - Validate geocoded coordinates land inside the expected country
+  ///    (`GeocodingChain`).
+  ///  - Infer the origin country of a station from its lat/lng when the
+  ///    station id has no country prefix (#516, `Countries.countryForStation`).
+  ///
+  /// Boxes intentionally include a 1-2 degree margin to account for
+  /// overseas territories, islands, and border regions.
+  final CountryBoundingBox boundingBox;
+
+  /// Ordered list of fuel types this country's UI fuel-type selector
+  /// shows (#1112). Order matters: the most common fuel sits first, and
+  /// every list ends with `FuelType.electric` followed by `FuelType.all`
+  /// (the search-time wildcard).
+  final List<FuelType> availableFuelTypes;
 
   /// Whether this country requires a user-provided API key.
   final bool requiresApiKey;
@@ -54,16 +88,31 @@ class CountryServiceEntry {
   const CountryServiceEntry({
     required this.countryCode,
     required this.errorSource,
+    required this.boundingBox,
+    required this.availableFuelTypes,
     this.requiresApiKey = false,
     required this.createService,
   });
 }
 
+/// Default ordered fuel-type list returned for any country not present in
+/// the registry. Mirrors the historical `default:` branch of the old
+/// `fuelTypesForCountry` switch — the minimal set every petrol/diesel
+/// station can be assumed to carry, plus EV and the "all" wildcard.
+const List<FuelType> _defaultFuelTypes = [
+  FuelType.e5,
+  FuelType.e10,
+  FuelType.diesel,
+  FuelType.electric,
+  FuelType.all,
+];
+
 /// Central registry of all country-specific station services.
 ///
 /// This is the **single source of truth** for which countries have API
-/// implementations. Adding a new country requires exactly one change:
-/// add a [CountryServiceEntry] to [entries].
+/// implementations. Adding a new country requires exactly one new file in
+/// `lib/core/services/impl/` plus one [CountryServiceEntry] appended to
+/// [entries].
 ///
 /// The registry provides compile-time safety through [assertAllCountriesRegistered],
 /// which is called at app startup in debug mode to verify every country in
@@ -73,105 +122,249 @@ class CountryServiceRegistry {
 
   /// All registered country service entries.
   ///
-  /// To add a new country:
-  /// 1. Create the service in `lib/core/services/impl/`
-  /// 2. Add a [ServiceSource] variant in `service_result.dart`
-  /// 3. Add a [CountryServiceEntry] here
-  /// 4. Add a [CountryConfig] in `country_config.dart`
+  /// Ordering note: the list is ordered for the bounding-box lookup
+  /// algorithm (see [_entryByLatLng] / [countryCodeFromLatLng]). Small
+  /// / island / coastal countries come first so their tight boxes are
+  /// not shadowed by larger neighbours whose generous boxes incidentally
+  /// overlap them — e.g. `PT`'s tight Iberian box sits entirely inside
+  /// `ES`'s generous box, so `PT` must be tested first. Cross-currency
+  /// border cases (#516) drove the ordering decisions:
   ///
-  /// The compile-time assertion ensures steps 3 and 4 stay in sync.
+  /// - `PT` first → its tight box is entirely inside `ES`'s.
+  /// - `GB` early → island, no continental overlap.
+  /// - `DK` before `DE` → Copenhagen's lat sits inside DE's box.
+  /// - `LU` before `FR` / `DE` → Luxembourg-Ville at (49.6, 6.1) sits
+  ///   inside both.
+  /// - `SI` before `AT` / `IT` → Ljubljana sits inside both.
+  /// - `CL` before `AR` → Santiago sits inside AR's generous box.
+  /// - Continental EU countries last so stations outside every tighter
+  ///   box still get attributed to something European.
   static const List<CountryServiceEntry> entries = [
-    CountryServiceEntry(
-      countryCode: 'DE',
-      errorSource: ServiceSource.tankerkoenigApi,
-      requiresApiKey: true,
-      createService: _createTankerkoenig,
-    ),
-    CountryServiceEntry(
-      countryCode: 'FR',
-      errorSource: ServiceSource.prixCarburantsApi,
-      createService: _createPrixCarburants,
-    ),
-    CountryServiceEntry(
-      countryCode: 'AT',
-      errorSource: ServiceSource.eControlApi,
-      createService: _createEControl,
-    ),
-    CountryServiceEntry(
-      countryCode: 'ES',
-      errorSource: ServiceSource.mitecoApi,
-      createService: _createMiteco,
-    ),
-    CountryServiceEntry(
-      countryCode: 'IT',
-      errorSource: ServiceSource.miseApi,
-      createService: _createMise,
-    ),
-    CountryServiceEntry(
-      countryCode: 'DK',
-      errorSource: ServiceSource.denmarkApi,
-      createService: _createDenmark,
-    ),
-    CountryServiceEntry(
-      countryCode: 'AR',
-      errorSource: ServiceSource.argentinaApi,
-      createService: _createArgentina,
-    ),
+    // ── Tight-box / island first (avoid shadowing) ─────────────────────
     CountryServiceEntry(
       countryCode: 'PT',
       errorSource: ServiceSource.portugalApi,
+      boundingBox: CountryBoundingBox(
+        minLat: 32.0, maxLat: 42.5, minLng: -32.0, maxLng: -6.0,
+      ),
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.lpg, FuelType.electric, FuelType.all,
+      ],
       createService: _createPortugal,
     ),
     CountryServiceEntry(
       countryCode: 'GB',
       errorSource: ServiceSource.ukApi,
+      boundingBox: CountryBoundingBox(
+        minLat: 49.5, maxLat: 61.0, minLng: -9.0, maxLng: 2.0,
+      ),
+      availableFuelTypes: _defaultFuelTypes,
       createService: _createUk,
     ),
     CountryServiceEntry(
-      countryCode: 'AU',
-      errorSource: ServiceSource.australiaApi,
-      createService: _createAustralia,
-    ),
-    CountryServiceEntry(
-      countryCode: 'MX',
-      errorSource: ServiceSource.mexicoApi,
-      createService: _createMexico,
+      countryCode: 'DK',
+      errorSource: ServiceSource.denmarkApi,
+      boundingBox: CountryBoundingBox(
+        minLat: 54.0, maxLat: 58.0, minLng: 7.5, maxLng: 15.5,
+      ),
+      availableFuelTypes: _defaultFuelTypes,
+      createService: _createDenmark,
     ),
     CountryServiceEntry(
       countryCode: 'LU',
       errorSource: ServiceSource.luxembourgApi,
+      // Tight box — LU is ~82 km north-south, ~57 km east-west; modest
+      // margin so BE/FR/DE neighbours don't bleed into LU matches.
+      boundingBox: CountryBoundingBox(
+        minLat: 49.4, maxLat: 50.25, minLng: 5.7, maxLng: 6.55,
+      ),
+      // Luxembourg regulated prices (#574): Sans Plomb 95 (E5/E10),
+      // Sans Plomb 98, Diesel, LPG.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+        FuelType.lpg, FuelType.electric, FuelType.all,
+      ],
       createService: _createLuxembourg,
     ),
     CountryServiceEntry(
       countryCode: 'SI',
       errorSource: ServiceSource.sloveniaApi,
+      // Tight box — Slovenia surrounded by IT / AT / HR; over-generous
+      // margin would shadow them. See #575.
+      boundingBox: CountryBoundingBox(
+        minLat: 45.3, maxLat: 47.0, minLng: 13.3, maxLng: 16.7,
+      ),
+      // Slovenia (#575): NMB-95 (e5), NMB-100 (e98), Dizel, Dizel
+      // Premium, LPG.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.dieselPremium, FuelType.lpg, FuelType.electric,
+        FuelType.all,
+      ],
       createService: _createSlovenia,
+    ),
+    // ── Continental EU (test order matters for shadow neighbours) ─────
+    CountryServiceEntry(
+      countryCode: 'AT',
+      errorSource: ServiceSource.eControlApi,
+      boundingBox: CountryBoundingBox(
+        minLat: 46.0, maxLat: 49.5, minLng: 9.0, maxLng: 17.5,
+      ),
+      availableFuelTypes: _defaultFuelTypes,
+      createService: _createEControl,
+    ),
+    CountryServiceEntry(
+      countryCode: 'FR',
+      errorSource: ServiceSource.prixCarburantsApi,
+      // France (mainland), excludes overseas territories.
+      boundingBox: CountryBoundingBox(
+        minLat: 41.0, maxLat: 51.5, minLng: -5.5, maxLng: 10.0,
+      ),
+      // FR: Prix Carburants — SP95-E10 first (most common), then
+      // SP95 / SP98, Gazole, E85 (Bioéthanol), GPL.
+      availableFuelTypes: [
+        FuelType.e10, FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.e85, FuelType.lpg, FuelType.electric, FuelType.all,
+      ],
+      createService: _createPrixCarburants,
+    ),
+    CountryServiceEntry(
+      countryCode: 'IT',
+      errorSource: ServiceSource.miseApi,
+      boundingBox: CountryBoundingBox(
+        minLat: 35.0, maxLat: 47.5, minLng: 6.0, maxLng: 19.0,
+      ),
+      // IT: MIMIT (osservaprezzi) — Benzina, Gasolio, GPL, Metano (CNG).
+      availableFuelTypes: [
+        FuelType.e5, FuelType.diesel, FuelType.lpg, FuelType.cng,
+        FuelType.electric, FuelType.all,
+      ],
+      createService: _createMise,
+    ),
+    CountryServiceEntry(
+      countryCode: 'ES',
+      errorSource: ServiceSource.mitecoApi,
+      // Spain (mainland + Balearic + Canary).
+      boundingBox: CountryBoundingBox(
+        minLat: 27.0, maxLat: 44.0, minLng: -19.0, maxLng: 5.0,
+      ),
+      // ES: Geoportal Gasolineras — 95/98, Diésel A/A+, GLP.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+        FuelType.dieselPremium, FuelType.lpg, FuelType.electric,
+        FuelType.all,
+      ],
+      createService: _createMiteco,
+    ),
+    CountryServiceEntry(
+      countryCode: 'DE',
+      errorSource: ServiceSource.tankerkoenigApi,
+      requiresApiKey: true,
+      boundingBox: CountryBoundingBox(
+        minLat: 47.0, maxLat: 55.5, minLng: 5.5, maxLng: 15.5,
+      ),
+      // DE: Tankerkönig publishes E5, E10, Diesel.
+      availableFuelTypes: _defaultFuelTypes,
+      createService: _createTankerkoenig,
+    ),
+    // ── Non-EU countries (no overlap concerns) ─────────────────────────
+    CountryServiceEntry(
+      countryCode: 'MX',
+      errorSource: ServiceSource.mexicoApi,
+      boundingBox: CountryBoundingBox(
+        minLat: 14.0, maxLat: 33.0, minLng: -119.0, maxLng: -86.0,
+      ),
+      availableFuelTypes: _defaultFuelTypes,
+      createService: _createMexico,
+    ),
+    // CL before AR: Chile's narrow strip sits inside AR's generous
+    // longitude range along the cordillera (#596).
+    CountryServiceEntry(
+      countryCode: 'CL',
+      errorSource: ServiceSource.chileApi,
+      requiresApiKey: true,
+      boundingBox: CountryBoundingBox(
+        minLat: -56.5, maxLat: -17.0, minLng: -77.0, maxLng: -66.0,
+      ),
+      // CL (#596): Gasolina 93/95 (e5), Gasolina 97 (e98), Diésel, LPG.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.lpg, FuelType.electric, FuelType.all,
+      ],
+      createService: _createChile,
+    ),
+    CountryServiceEntry(
+      countryCode: 'AR',
+      errorSource: ServiceSource.argentinaApi,
+      boundingBox: CountryBoundingBox(
+        minLat: -56.0, maxLat: -21.0, minLng: -74.0, maxLng: -53.0,
+      ),
+      availableFuelTypes: _defaultFuelTypes,
+      createService: _createArgentina,
+    ),
+    CountryServiceEntry(
+      countryCode: 'AU',
+      errorSource: ServiceSource.australiaApi,
+      boundingBox: CountryBoundingBox(
+        minLat: -44.0, maxLat: -9.5, minLng: 112.5, maxLng: 154.0,
+      ),
+      availableFuelTypes: _defaultFuelTypes,
+      createService: _createAustralia,
     ),
     CountryServiceEntry(
       countryCode: 'KR',
       errorSource: ServiceSource.openinetApi,
       requiresApiKey: true,
+      // South Korea mainland + Jeju. No overlap with any other
+      // registered country. See #597.
+      boundingBox: CountryBoundingBox(
+        minLat: 33.0, maxLat: 39.0, minLng: 124.0, maxLng: 131.0,
+      ),
+      // KR (#597): Gasoline (e5), Premium Gasoline (e98), Diesel, LPG.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.lpg, FuelType.electric, FuelType.all,
+      ],
       createService: _createSouthKorea,
-    ),
-    CountryServiceEntry(
-      countryCode: 'CL',
-      errorSource: ServiceSource.chileApi,
-      requiresApiKey: true,
-      createService: _createChile,
     ),
     CountryServiceEntry(
       countryCode: 'GR',
       errorSource: ServiceSource.greeceApi,
+      // Eastern edge deliberately pulled in from the geographic limit
+      // (~29.6) so Istanbul (41.01, 28.98) is NOT falsely attributed
+      // to GR. Kastellorizo is the only Greek territory lost. See #576.
+      boundingBox: CountryBoundingBox(
+        minLat: 34.5, maxLat: 41.8, minLng: 19.0, maxLng: 28.5,
+      ),
+      // GR (#576): Αμόλυβδη 95 (e5), Αμόλυβδη 100 (e98), Diesel, LPG.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.lpg, FuelType.electric, FuelType.all,
+      ],
       createService: _createGreece,
     ),
     CountryServiceEntry(
       countryCode: 'RO',
       errorSource: ServiceSource.romaniaApi,
+      // No neighbour conflicts — HU, BG, UA, RS, MD are not in the
+      // registry. See #577.
+      boundingBox: CountryBoundingBox(
+        minLat: 43.5, maxLat: 48.5, minLng: 20.0, maxLng: 29.8,
+      ),
+      // RO (#577): Benzină Standard (e5), Benzină Premium (e98),
+      // Motorină Standard (diesel), Motorină Premium (diesel premium),
+      // GPL (lpg).
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.dieselPremium, FuelType.lpg, FuelType.electric,
+        FuelType.all,
+      ],
       createService: _createRomania,
     ),
   ];
 
-  /// Lookup map built once from [entries] for O(1) access.
+  /// Lookup map built once from [entries] for O(1) access by code.
   static final Map<String, CountryServiceEntry> _byCode = {
     for (final entry in entries) entry.countryCode: entry,
   };
@@ -182,6 +375,27 @@ class CountryServiceRegistry {
   /// Get the registry entry for a country code, or null if not registered.
   static CountryServiceEntry? entryFor(String countryCode) =>
       _byCode[countryCode];
+
+  /// Returns the bounding box for [countryCode], or null when unregistered.
+  static CountryBoundingBox? boundingBoxFor(String countryCode) =>
+      _byCode[countryCode]?.boundingBox;
+
+  /// Ordered list of fuel types for [countryCode], or the default minimal
+  /// set when the code is unregistered. Mirrors the historical
+  /// `fuelTypesForCountry` switch's `default:` branch.
+  static List<FuelType> fuelTypesFor(String countryCode) =>
+      _byCode[countryCode]?.availableFuelTypes ?? _defaultFuelTypes;
+
+  /// Returns the entry whose bounding box contains the given point, or
+  /// null when no box matches. Walks [entries] in declared order — the
+  /// list is intentionally ordered so tighter boxes are tested before
+  /// the larger boxes that incidentally overlap them.
+  static CountryServiceEntry? entryByLatLng(double lat, double lng) {
+    for (final entry in entries) {
+      if (entry.boundingBox.contains(lat, lng)) return entry;
+    }
+    return null;
+  }
 
   /// Build a [StationService] for [countryCode], wrapped in [StationServiceChain].
   ///

--- a/lib/features/search/domain/entities/fuel_type.dart
+++ b/lib/features/search/domain/entities/fuel_type.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
 
+import '../../../../core/services/country_service_registry.dart';
+
 /// Canonical fuel types across all countries.
 ///
 /// Sealed class hierarchy enables exhaustive pattern matching while allowing
@@ -295,96 +297,12 @@ class FuelTypeJsonConverter implements JsonConverter<FuelType, String> {
 
 // ── Country mappings ────────────────────────────────────────────────────────
 
-/// Default fuel types for any country not present in [_countryFuels].
-///
-/// Mirrors the historical `default:` branch of `fuelTypesForCountry`: the
-/// minimal set every petrol/diesel station can be assumed to carry, plus
-/// the EV and "all" wildcard.
-const List<FuelType> _defaultCountryFuels = [
-  FuelType.e5,
-  FuelType.e10,
-  FuelType.diesel,
-  FuelType.electric,
-  FuelType.all,
-];
-
-/// Declarative per-country fuel-type catalogue.
-///
-/// Each entry is the exact ordered list returned for that ISO 3166-1
-/// alpha-2 country code. Order matters: the UI fuel-type selector renders
-/// the list in this order, so the most common fuel for each country sits
-/// first. Every list ends with [FuelType.electric] followed by
-/// [FuelType.all] (the search-time wildcard) — keep that tail when adding
-/// a new country.
-const Map<String, List<FuelType>> _countryFuels = {
-  // DE: Tankerkönig publishes E5, E10, Diesel.
-  'DE': [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all],
-  // FR: Prix Carburants — SP95-E10 first (most common at French pumps),
-  // then SP95 / SP98, Gazole, E85 (Bioéthanol), GPL.
-  'FR': [
-    FuelType.e10, FuelType.e5, FuelType.e98, FuelType.diesel,
-    FuelType.e85, FuelType.lpg, FuelType.electric, FuelType.all,
-  ],
-  // AT: Spritpreisrechner — Super 95 (E5/E10), Diesel.
-  'AT': [FuelType.e5, FuelType.e10, FuelType.diesel, FuelType.electric, FuelType.all],
-  // ES: Geoportal Gasolineras — Gasolina 95/98, Diésel A/A+, GLP.
-  'ES': [
-    FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
-    FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
-  ],
-  // IT: MIMIT (osservaprezzi) — Benzina, Gasolio, GPL, Metano (CNG).
-  'IT': [
-    FuelType.e5, FuelType.diesel, FuelType.lpg, FuelType.cng, FuelType.electric, FuelType.all,
-  ],
-  // LU: Luxembourg regulated prices (#574): Sans Plomb 95 (mapped to
-  // E5/E10), Sans Plomb 98 (E98), Diesel, LPG.
-  'LU': [
-    FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
-    FuelType.lpg, FuelType.electric, FuelType.all,
-  ],
-  // SI: Slovenia sells NMB-95 (→ e5), NMB-100 (premium, → e98), Dizel
-  // (→ diesel), Dizel Premium, and LPG. #575
-  'SI': [
-    FuelType.e5, FuelType.e98, FuelType.diesel,
-    FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
-  ],
-  // KR: South Korea (OPINET): Gasoline (→ e5), Premium Gasoline (→ e98),
-  // Diesel, LPG. Kerosene is published by OPINET but has no FuelType
-  // enum today — added in a follow-up. #597
-  'KR': [
-    FuelType.e5, FuelType.e98, FuelType.diesel,
-    FuelType.lpg, FuelType.electric, FuelType.all,
-  ],
-  // CL: Chile (CNE Bencina en Línea): Gasolina 93/95 (→ e5),
-  // Gasolina 97 (→ e98), Diésel, Gas licuado / LPG. Kerosene is
-  // published by CNE but has no FuelType enum today. #596
-  'CL': [
-    FuelType.e5, FuelType.e98, FuelType.diesel,
-    FuelType.lpg, FuelType.electric, FuelType.all,
-  ],
-  // GR: Greece (Paratiritirio Timon via fuelpricesgr community API):
-  // Αμόλυβδη 95 (→ e5), Αμόλυβδη 100 (→ e98), Diesel, Υγραέριο /
-  // LPG. Diesel heating is published but intentionally dropped
-  // (not a motoring fuel). #576
-  'GR': [
-    FuelType.e5, FuelType.e98, FuelType.diesel,
-    FuelType.lpg, FuelType.electric, FuelType.all,
-  ],
-  // RO: Romania (Monitorul Prețurilor — pretcarburant.ro): Benzină
-  // Standard (→ e5), Benzină Premium (→ e98), Motorină Standard
-  // (→ diesel), Motorină Premium (→ diesel premium), GPL
-  // (→ lpg). 15-minute government-mandated updates. #577
-  'RO': [
-    FuelType.e5, FuelType.e98, FuelType.diesel,
-    FuelType.dieselPremium, FuelType.lpg, FuelType.electric, FuelType.all,
-  ],
-};
-
 /// Returns fuel types available for a given country code.
 ///
-/// Looks up [countryCode] in [_countryFuels]; falls back to
-/// [_defaultCountryFuels] for unknown countries (the same minimal set the
-/// previous `switch` returned via its `default:` branch).
-List<FuelType> fuelTypesForCountry(String countryCode) {
-  return _countryFuels[countryCode] ?? _defaultCountryFuels;
-}
+/// Per-country fuel lists now live on [CountryServiceEntry.availableFuelTypes]
+/// in [CountryServiceRegistry.entries] (#1111) — adding a new country only
+/// requires appending one entry to the registry, never editing this file.
+/// Falls back to a default minimal set (E5, E10, Diesel, Electric, All) for
+/// unregistered countries.
+List<FuelType> fuelTypesForCountry(String countryCode) =>
+    CountryServiceRegistry.fuelTypesFor(countryCode);

--- a/test/core/services/country_service_registry_test.dart
+++ b/test/core/services/country_service_registry_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_bounding_box.dart';
 import 'package:tankstellen/core/country/country_config.dart';
 import 'package:tankstellen/core/services/country_service_registry.dart';
 import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
 void main() {
   group('CountryServiceRegistry', () {
@@ -205,6 +207,97 @@ void main() {
         final entry = CountryServiceRegistry.entryFor('RO');
         expect(entry, isNotNull);
         expect(entry!.errorSource, equals(ServiceSource.romaniaApi));
+      });
+    });
+
+    // ── Bounding box and fuel-type fields (#1111) ──────────────────────
+    group('boundingBox (#1111)', () {
+      test('every entry has a bounding box that is a CountryBoundingBox', () {
+        for (final entry in CountryServiceRegistry.entries) {
+          expect(entry.boundingBox, isA<CountryBoundingBox>(),
+              reason: '${entry.countryCode} entry must have a bounding box');
+        }
+      });
+
+      test('every bounding box has minLat < maxLat and minLng < maxLng', () {
+        for (final entry in CountryServiceRegistry.entries) {
+          final bbox = entry.boundingBox;
+          expect(bbox.minLat, lessThan(bbox.maxLat),
+              reason: '${entry.countryCode}: minLat must be < maxLat');
+          expect(bbox.minLng, lessThan(bbox.maxLng),
+              reason: '${entry.countryCode}: minLng must be < maxLng');
+        }
+      });
+
+      test('boundingBoxFor returns the entry box for a registered code', () {
+        final box = CountryServiceRegistry.boundingBoxFor('DE');
+        expect(box, isNotNull);
+        expect(box!.contains(52.52, 13.41), isTrue, // Berlin
+            reason: 'DE box must contain Berlin');
+      });
+
+      test('boundingBoxFor returns null for an unregistered code', () {
+        expect(CountryServiceRegistry.boundingBoxFor('ZZ'), isNull);
+      });
+
+      test('entryByLatLng resolves a Berlin point to DE', () {
+        final entry = CountryServiceRegistry.entryByLatLng(52.52, 13.41);
+        expect(entry, isNotNull);
+        expect(entry!.countryCode, equals('DE'));
+      });
+
+      test('entryByLatLng resolves a Lisbon point to PT (not ES)', () {
+        // Tight-box ordering invariant: PT must be tested before ES.
+        final entry = CountryServiceRegistry.entryByLatLng(38.72, -9.14);
+        expect(entry, isNotNull);
+        expect(entry!.countryCode, equals('PT'));
+      });
+
+      test('entryByLatLng returns null for the Atlantic', () {
+        expect(CountryServiceRegistry.entryByLatLng(0.0, -30.0), isNull);
+      });
+    });
+
+    group('availableFuelTypes (#1111)', () {
+      test('every entry exposes a non-empty fuel-type list', () {
+        for (final entry in CountryServiceRegistry.entries) {
+          expect(entry.availableFuelTypes, isNotEmpty,
+              reason:
+                  '${entry.countryCode} must publish at least one fuel type');
+        }
+      });
+
+      test('every fuel-type list ends with electric, all', () {
+        for (final entry in CountryServiceRegistry.entries) {
+          final list = entry.availableFuelTypes;
+          expect(list.length, greaterThanOrEqualTo(2),
+              reason: '${entry.countryCode}: list should be non-trivial');
+          expect(list[list.length - 2], FuelType.electric,
+              reason: '${entry.countryCode} must end with electric, all');
+          expect(list.last, FuelType.all,
+              reason: '${entry.countryCode} must end with electric, all');
+        }
+      });
+
+      test('fuelTypesFor returns the entry list for a registered code', () {
+        final list = CountryServiceRegistry.fuelTypesFor('FR');
+        // FR's first fuel is E10 (most common at French pumps).
+        expect(list.first, equals(FuelType.e10));
+      });
+
+      test('fuelTypesFor returns the default minimal set for unknown codes',
+          () {
+        final list = CountryServiceRegistry.fuelTypesFor('XX');
+        expect(
+          list,
+          equals(<FuelType>[
+            FuelType.e5,
+            FuelType.e10,
+            FuelType.diesel,
+            FuelType.electric,
+            FuelType.all,
+          ]),
+        );
       });
     });
   });

--- a/test/docs/new_country_guide_test.dart
+++ b/test/docs/new_country_guide_test.dart
@@ -4,6 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 /// Verifies that the new-country documentation references all required
 /// touchpoints for adding a country. If a developer adds a new required
 /// file but forgets to update the guide, this test will fail.
+///
+/// Updated post-#1111: the per-country touchpoints are now consolidated
+/// onto a single `CountryServiceEntry` in `country_service_registry.dart`.
+/// Bounding boxes and per-country fuel-type lists no longer have their
+/// own dedicated edit files — they live on the registry entry.
 void main() {
   group('New-country guide completeness', () {
     late String guideContent;
@@ -24,12 +29,10 @@ void main() {
     group('NEW_COUNTRY.md references all required files', () {
       final requiredPaths = <String, String>{
         'lib/core/services/impl/': 'station service implementation directory',
-        'lib/core/services/service_providers.dart': 'service registry',
+        'lib/core/services/country_service_registry.dart':
+            'country service registry (entries for bounding box / fuel types / factory)',
         'lib/core/services/service_result.dart': 'ServiceSource enum',
         'lib/core/country/country_config.dart': 'country configuration',
-        'lib/core/country/country_bounding_box.dart': 'bounding box',
-        'lib/features/search/domain/entities/fuel_type.dart':
-            'fuel type mapping',
       };
 
       for (final entry in requiredPaths.entries) {
@@ -46,10 +49,11 @@ void main() {
         'StationService': 'the abstract service interface',
         'StationServiceHelpers': 'the helpers mixin',
         'ServiceSource': 'the service source enum',
+        'CountryServiceEntry': 'the registry entry class (#1111)',
+        'CountryServiceRegistry': 'the registry singleton (#1111)',
         'CountryConfig': 'the country config class',
-        'CountryBoundingBox': 'the bounding box class',
-        'fuelTypesForCountry': 'the fuel type mapping function',
-        'StationServiceChain': 'the service chain wrapper',
+        'CountryBoundingBox': 'the bounding box value class',
+        'availableFuelTypes': 'the per-entry fuel type list (#1111)',
         'DioFactory': 'the Dio factory',
         'Countries.all': 'the all-countries list',
       };
@@ -87,14 +91,12 @@ void main() {
       });
 
       test('contains new-country checklist', () {
-        // Every required file must appear in the checklist
+        // Every required file must appear in the checklist.
         final requiredChecklist = [
           'station_service.dart',
-          'service_providers.dart',
           'service_result.dart',
+          'country_service_registry.dart',
           'country_config.dart',
-          'country_bounding_box.dart',
-          'fuel_type.dart',
         ];
 
         for (final item in requiredChecklist) {
@@ -139,7 +141,7 @@ void main() {
         for (final file in serviceFiles) {
           final fileName = file.uri.pathSegments.last;
 
-          // Check that the file is imported in service_providers.dart or registry
+          // The file must be imported in service_providers.dart or registry.
           expect(
             serviceProviders.contains(fileName) ||
                 registryContent.contains(fileName),


### PR DESCRIPTION
## Why

Adding a 12th country currently touches 5 hot files. Consolidating per-country attributes onto `CountryServiceEntry` reduces this to **1 new service file + 1 entry append + 1 ServiceSource enum value**.

## What

- Extended `CountryServiceEntry` with `boundingBox` (`CountryBoundingBox`) and `availableFuelTypes` (`List<FuelType>`) fields.
- Migrated all 11 live countries (DE, FR, AT, ES, IT, DK, AR, PT, GB, AU, MX, LU, SI, KR, CL, GR, RO — 17 entries total) onto the new shape, preserving every bounding box, lookup-order invariant, and per-country fuel list.
- **Composed**, not folded, `CountryConfig` (display name, flag, postal-code shape, currency formatting). Folding it would touch 70+ UI surfaces for no real extensibility win — the registry composes the config by code via `Countries.byCode`.
- Reduced `lib/core/country/country_bounding_box.dart` to the `CountryBoundingBox` value class plus a backwards-compatible top-level shim that derives `countryBoundingBoxes` and `countryCodeFromLatLng` from the registry. No more standalone bbox map or `_bboxLookupOrder` list.
- Reduced `fuelTypesForCountry()` in `fuel_type.dart` to a thin shim over `CountryServiceRegistry.fuelTypesFor`. Removed the `_countryFuels` declarative map.
- Tests cover the new fields: bounding-box validity, lookup-order invariants (PT inside ES, CL inside AR, LU inside FR/DE, SI inside AT/IT), and that every fuel-type list ends with electric/all.
- Updated `docs/guides/NEW_COUNTRY.md` and `docs/CONTRIBUTING.md` with the new "1 service file + 1 entry append" recipe.

## Hot files killed

- `lib/core/country/country_bounding_box.dart` no longer carries the bbox data (just the value class + shim).
- `lib/features/search/domain/entities/fuel_type.dart` no longer carries the per-country fuel lists.
- `lib/core/services/service_providers.dart` was already off the per-country path (the registry took it over earlier).
- The new touchpoint for a 12th country is `country_service_registry.dart` only.

`country_config.dart` and `service_result.dart` (`ServiceSource` enum) remain by design — both are accept-only-on-append and aren't really hot in conflict-frequency terms.

## Test

- Behaviour-preservation: existing `fuel_types_for_country_test.dart`, `country_bounding_box_test.dart`, `country_supported_fuels_test.dart`, `country_service_registry_test.dart` all pass without modification.
- New: registry tests for boundingBox-per-entry, availableFuelTypes-per-entry, `boundingBoxFor`, `fuelTypesFor`, `entryByLatLng` (including PT-before-ES tight-box ordering).
- New: doc-completeness test (`test/docs/new_country_guide_test.dart`) updated for the post-#1111 file list.
- `flutter analyze` zero warnings.
- Local: `flutter test test/core/ test/features/search/ test/features/profile/ test/docs/ test/lint/ test/accessibility/` → 4200 tests pass.

Closes #1111