### PR TITLE
chore(telemetry): document self-hosted Glitchtip swap (#1127)

### DIFF
--- a/docs/security/SELF_HOSTED_TELEMETRY.md
+++ b/docs/security/SELF_HOSTED_TELEMETRY.md
@@ -1,0 +1,179 @@
+# Self-Hosted Telemetry (Glitchtip)
+
+> Status: opt-in. Sentry is the default. Swap procedure is documented
+> below and exercised by `test/core/telemetry/glitchtip_compatibility_test.dart`.
+
+## Why
+
+Tankstellen's privacy-first leitmotiv says the user owns their data.
+Crash and performance telemetry are no exception: even with PII
+scrubbing (see `lib/core/telemetry/pii_scrubber.dart`) the operator
+ultimately decides which third party sees the scrubbed events.
+
+Sentry's free tier is generous and SaaS-managed, but the strongest
+privacy posture is one where **the events never leave a server you
+control**. Glitchtip exists for exactly that case.
+
+## What is Glitchtip
+
+[Glitchtip](https://glitchtip.com/) is an OSS error-monitoring backend
+that re-implements the Sentry ingest API (envelope endpoint) on top of
+Django + Postgres. The Sentry SDK doesn't know or care that it's
+talking to Glitchtip — it sees a DSN, it POSTs envelopes, it gets a
+200 back. Drop-in replacement.
+
+Practically that means:
+
+- **No code change in this app.** The `core/telemetry/` abstraction
+  and `SentryFlutter.init` in `lib/app/app_initializer.dart` already
+  treat the DSN as an opaque string. Point the DSN at a Glitchtip
+  endpoint and events flow there instead.
+- **Same SDK features used by this app keep working** — exception
+  capture, breadcrumbs, releases, environments, `beforeSend` PII
+  scrubbing. Glitchtip implements all of these.
+- **Some Sentry-only features are not implemented** — see Trade-offs
+  below.
+
+## Self-hosting
+
+Glitchtip publishes a canonical `docker-compose.yml` at
+<https://glitchtip.com/documentation/install>. The version below is
+the **shape** of a minimal production install; always cross-check the
+upstream docs for the latest images and required env vars before you
+deploy.
+
+```yaml
+# docker-compose.yml — minimal, single-VPS deployment.
+# Authoritative version: https://glitchtip.com/documentation/install
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: glitchtip
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    image: redis
+    restart: unless-stopped
+
+  web:
+    image: glitchtip/glitchtip
+    depends_on: [postgres, redis]
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/glitchtip
+      SECRET_KEY: ${SECRET_KEY}
+      PORT: 8000
+      EMAIL_URL: consolemail://
+      GLITCHTIP_DOMAIN: https://telemetry.example.org
+      DEFAULT_FROM_EMAIL: telemetry@example.org
+      CELERY_WORKER_AUTOSCALE: "1,3"
+    restart: unless-stopped
+
+  worker:
+    image: glitchtip/glitchtip
+    command: ./bin/run-celery-with-beat.sh
+    depends_on: [postgres, redis]
+    environment:
+      DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/glitchtip
+      SECRET_KEY: ${SECRET_KEY}
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+```
+
+### Sizing
+
+A €5/month single-core, 1 GB RAM VPS (Hetzner CX11, Scaleway STARDUST1-S,
+DigitalOcean basic, OVH Eco) handles a small alpha-tester crowd
+comfortably. Scale up to 2 GB RAM before opening to public traffic —
+the Celery worker and Postgres both want headroom under burst.
+
+### Persistence
+
+The `pgdata` named volume above is the only stateful piece. **Back it
+up.** Losing the Postgres volume loses every recorded event. A nightly
+`pg_dump` to off-host storage is enough.
+
+### Reverse proxy
+
+Front the `web` container with Caddy, nginx, or Traefik to terminate
+TLS and provide the `https://telemetry.example.org` Glitchtip needs.
+The DSN you hand to the app must use HTTPS.
+
+## Swap procedure
+
+The app reads its DSN from one of two places, in this order
+(see `AppInitializer.resolveSentryDsn` in `lib/app/app_initializer.dart`):
+
+1. **`sentry_dsn` Hive setting** — manually entered via
+   *Settings → Diagnostics* on a single device. Wins if non-empty.
+2. **`SENTRY_DSN` dart-define** — compile-time, applies to every
+   build of the resulting binary.
+
+To swap the entire fleet to Glitchtip, change the dart-define at
+build time:
+
+```bash
+flutter build apk --release \
+  --dart-define=SENTRY_DSN=https://<publicKey>@telemetry.example.org/<projectId>
+```
+
+To swap a single dev device to Glitchtip, paste the same DSN into
+*Settings → Diagnostics → Sentry DSN* and restart the app.
+
+That's it. **No code change. No new dependency. No rebuild flag
+beyond the DSN value.** The dart-define key stays `SENTRY_DSN`
+regardless of backend — the issue's acceptance criterion
+("config-only swap") is exactly this property and is pinned by
+`test/core/telemetry/glitchtip_compatibility_test.dart`.
+
+## Verification
+
+Three checks confirm events are landing on your Glitchtip instance:
+
+1. **App startup log** — when `consent_error_reporting` is true and
+   the DSN is non-empty, `SentryFlutter.init` runs in
+   `AppInitializer.run`. A failure to reach the endpoint shows up as
+   a Dio/HTTP error in `flutter logs`.
+2. **Glitchtip UI** — open `https://telemetry.example.org`, navigate
+   to your project, and watch *Issues*. The first uncaught exception
+   the app hits should appear within ~30 seconds (Celery flush
+   interval).
+3. **Manual test exception** — temporarily wire a button to
+   `errorLogger.log('manual', Exception('Glitchtip swap test'),
+   StackTrace.current)`. The single event lets you confirm scrubbing,
+   release tagging, and breadcrumb capture all work end-to-end.
+   Remove the button before merge.
+
+## Trade-offs
+
+Glitchtip implements the **error-monitoring** subset of the Sentry
+API. Features not implemented (or implemented partially) at the time
+of writing:
+
+| Feature | Sentry | Glitchtip |
+|--------|--------|-----------|
+| Exception + breadcrumb capture | yes | yes |
+| Releases + environments | yes | yes |
+| `beforeSend` / PII scrubbing | yes | yes (same SDK hook) |
+| Source maps for web/JS | yes | partial |
+| **Performance monitoring (transactions/spans)** | yes | **no** |
+| **Profiling** | yes | **no** |
+| Session replay | yes | no |
+| User feedback widget | yes | partial |
+| Native crash symbolication (Android NDK / iOS dSYM) | yes | partial |
+
+This app currently sets `tracesSampleRate = 0.2`. On Glitchtip those
+transaction events are silently dropped. If your operator workflow
+relies on Sentry's performance tab, stay on Sentry.
+
+For everything we use today — uncaught exceptions, breadcrumbs from
+Dio/Riverpod/navigation, releases tied to `pubspec` version, scrubbed
+`beforeSend` payloads — Glitchtip is a one-line config swap and a
+€5/month VPS away.

--- a/test/core/telemetry/glitchtip_compatibility_test.dart
+++ b/test/core/telemetry/glitchtip_compatibility_test.dart
@@ -1,0 +1,192 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// #1127 — Glitchtip is Sentry-API-compatible. The promise of the
+/// `core/telemetry/` abstraction is "config-only swap": pointing the
+/// Sentry SDK at a Glitchtip endpoint must work without any code change.
+///
+/// These tests are the static guarantee behind that promise. They verify:
+///
+/// 1. A Glitchtip-shaped DSN (the URI format Glitchtip exposes in its
+///    project settings) is structurally identical to a Sentry DSN — same
+///    `https://<publicKey>@<host>/<projectId>` shape, parses to the same
+///    `Uri` components.
+/// 2. The cold-start DSN resolver (`AppInitializer.resolveSentryDsn`) is
+///    backend-agnostic at the source level — no `sentry.io` host check,
+///    no `getsentry.com` host check, no allowlist that would reject a
+///    self-hosted endpoint.
+/// 3. The dart-define key is `SENTRY_DSN` regardless of which backend
+///    the user runs (this is the env var documented in
+///    `docs/security/SELF_HOSTED_TELEMETRY.md`).
+///
+/// If any of these break, the swap-procedure doc is no longer truthful
+/// and the issue's acceptance criterion ("No code change required to
+/// swap — just config") regresses.
+void main() {
+  group('Glitchtip DSN URI shape matches Sentry DSN', () {
+    // Sample Glitchtip DSN. Format mirrors what the Glitchtip UI prints
+    // on a project's "Settings → SDK Setup" page. The publicKey, host,
+    // and projectId are all examples.
+    const glitchtipDsn =
+        'https://abcdef0123456789abcdef0123456789@glitchtip.example.org/42';
+    const sentryDsn =
+        'https://abcdef0123456789abcdef0123456789@o1234567.ingest.sentry.io/42';
+
+    test('Glitchtip DSN parses as a valid HTTPS URI with userInfo + path',
+        () {
+      final uri = Uri.parse(glitchtipDsn);
+      expect(uri.scheme, 'https');
+      expect(uri.userInfo, isNotEmpty,
+          reason: 'publicKey lives in the userInfo segment');
+      expect(uri.host, 'glitchtip.example.org');
+      expect(uri.pathSegments, isNotEmpty,
+          reason: 'projectId is the last path segment');
+      expect(uri.pathSegments.last, '42');
+    });
+
+    test('Glitchtip and Sentry DSNs produce structurally identical Uris',
+        () {
+      final glitchtip = Uri.parse(glitchtipDsn);
+      final sentry = Uri.parse(sentryDsn);
+
+      // Both must expose the same set of fields the Sentry SDK pulls out
+      // of `Dsn.parse` — scheme, userInfo (publicKey:secretKey), host,
+      // and pathSegments (with projectId at the end).
+      expect(glitchtip.scheme, sentry.scheme);
+      expect(glitchtip.userInfo.split(':').first.length,
+          sentry.userInfo.split(':').first.length,
+          reason: 'public key portion is the same length on both backends');
+      expect(glitchtip.pathSegments.last, sentry.pathSegments.last,
+          reason: 'projectId in our fixture is the same so the test asserts '
+              'shape — host and key differ but layout is identical');
+      expect(glitchtip.hasEmptyPath, sentry.hasEmptyPath);
+    });
+
+    test('Glitchtip DSN with self-hosted port (e.g. 8000) still parses', () {
+      // VPS deploys often expose Glitchtip on a non-default port behind a
+      // reverse proxy; the SDK must still accept the DSN.
+      const dsn =
+          'https://abcdef0123456789abcdef0123456789@telemetry.example.org:8000/1';
+      final uri = Uri.parse(dsn);
+      expect(uri.port, 8000);
+      expect(uri.host, 'telemetry.example.org');
+      expect(uri.pathSegments.last, '1');
+    });
+  });
+
+  group('AppInitializer.resolveSentryDsn is backend-agnostic', () {
+    late String initSource;
+
+    setUpAll(() {
+      initSource = File('lib/app/app_initializer.dart').readAsStringSync();
+    });
+
+    test('source has no host allowlist that would reject Glitchtip', () {
+      // If a future patch adds a host check (e.g. `dsn.contains('sentry.io')`)
+      // it would silently break self-hosted deployments. Forbid the
+      // common offenders at the source level.
+      const forbidden = [
+        'sentry.io',
+        'getsentry.com',
+        'ingest.sentry',
+      ];
+      for (final needle in forbidden) {
+        expect(initSource, isNot(contains(needle)),
+            reason: 'AppInitializer must treat the DSN as an opaque string. '
+                "A host allowlist '$needle' would block Glitchtip.");
+      }
+    });
+
+    test('dart-define key is exactly SENTRY_DSN (matches doc + build flag)',
+        () {
+      // `docs/security/SELF_HOSTED_TELEMETRY.md` tells users to set
+      // `--dart-define=SENTRY_DSN=<glitchtip-url>` to swap backends.
+      // If the env-var key drifts, the doc lies and the swap silently
+      // fails to a no-op startup (DSN empty, telemetry disabled).
+      expect(initSource, contains("String.fromEnvironment('SENTRY_DSN')"),
+          reason: 'env var key must be exactly SENTRY_DSN — see '
+              'docs/security/SELF_HOSTED_TELEMETRY.md');
+    });
+
+    test('resolver returns the configured DSN unchanged (no rewriting)', () {
+      // Source-level invariant: the resolver returns either the stored
+      // setting or the dart-define, not a transformed value. Anything
+      // else (e.g. `if (dsn.contains('sentry.io')) dsn += ...`) would
+      // break self-hosted deployments.
+      final body = _extractMethodBody(initSource, 'static String resolveSentryDsn');
+      expect(body, isNotNull);
+      // No string concatenation or replacement on the DSN value.
+      expect(body, isNot(contains('.replaceAll(')));
+      expect(body, isNot(contains('.replaceFirst(')));
+      // The function returns either `stored` or `buildDsn` — both are the
+      // original opaque value.
+      expect(body, contains('return stored'));
+      expect(body, contains('return buildDsn'));
+    });
+  });
+
+  group('docs/security/SELF_HOSTED_TELEMETRY.md is present and truthful', () {
+    late String docSource;
+
+    setUpAll(() {
+      docSource =
+          File('docs/security/SELF_HOSTED_TELEMETRY.md').readAsStringSync();
+    });
+
+    test('doc references the SENTRY_DSN env var (the actual swap point)', () {
+      // If a contributor renames the env var without updating the doc,
+      // the swap procedure becomes wrong. Pin them together.
+      expect(docSource, contains('SENTRY_DSN'),
+          reason: 'doc must name the exact env var users set to swap '
+              'backends — that is SENTRY_DSN');
+    });
+
+    test('doc covers the required sections from the issue acceptance', () {
+      // The four sections #1127 expects readers to find quickly. Match on
+      // case-insensitive section anchors so a wording tweak doesn't break
+      // the test.
+      final lowered = docSource.toLowerCase();
+      expect(lowered, contains('glitchtip'));
+      expect(lowered, contains('self-host'));
+      expect(lowered, contains('verif'),
+          reason: 'doc must explain how to verify events land');
+      expect(lowered, contains('trade-off'),
+          reason: 'doc must list features Glitchtip lacks vs Sentry');
+    });
+  });
+}
+
+/// Extracts the body of the first method that starts with [signature].
+/// Mirrors the helper in `test/app/app_initializer_test.dart` so the
+/// two test files stay independent.
+String? _extractMethodBody(String source, String signature) {
+  final start = source.indexOf(signature);
+  if (start < 0) return null;
+  var i = source.indexOf('(', start);
+  if (i < 0) return null;
+  var parenDepth = 0;
+  for (; i < source.length; i++) {
+    final ch = source[i];
+    if (ch == '(') parenDepth++;
+    if (ch == ')') {
+      parenDepth--;
+      if (parenDepth == 0) {
+        i++;
+        break;
+      }
+    }
+  }
+  final braceStart = source.indexOf('{', i);
+  if (braceStart < 0) return null;
+  var depth = 0;
+  for (var j = braceStart; j < source.length; j++) {
+    final ch = source[j];
+    if (ch == '{') depth++;
+    if (ch == '}') {
+      depth--;
+      if (depth == 0) return source.substring(braceStart + 1, j);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #1127.

## Summary

- Adds `docs/security/SELF_HOSTED_TELEMETRY.md` (179 lines) — why self-host, minimal `docker-compose.yml` shape (links upstream canonical install), VPS sizing (€5/mo single-core 1GB is fine), swap procedure, three verification checks, and trade-offs vs Sentry (no performance monitoring, no profiling, partial NDK symbolication).
- Adds `test/core/telemetry/glitchtip_compatibility_test.dart` (192 lines, 8 cases) pinning the "config-only swap" guarantee at the source level — forbids any `sentry.io` / `getsentry.com` host allowlist in `resolveSentryDsn`, asserts the dart-define key is exactly `SENTRY_DSN`, verifies a Glitchtip-shaped DSN parses to the same URI components Sentry's SDK consumes.
- **Zero app code change.** The `core/telemetry/` abstraction (post-#1144 rename) and `SentryFlutter.init` already treat the DSN as an opaque string. The only `Sentry.` API references outside `lib/core/telemetry/` are the single `SentryFlutter.init` call in `lib/app/app_initializer.dart` (the documented swap point) — no leaks to abstract.
- Sentry stays the default; Glitchtip is opt-in via the existing `--dart-define=SENTRY_DSN=...` build flag or *Settings → Diagnostics* override. The issue accepted "build flag or settings" — both already exist.

## Why this matches the privacy-first leitmotiv

Even with the `PiiScrubber.beforeSend` hook stripping emails, coords, and tokens, the user still has to trust *some* operator. Self-hosted Glitchtip means that operator is them. The €5/mo VPS price tag keeps the option real for a hobby alpha tester, not just enterprises.

## Test plan

- [x] `flutter analyze` — zero issues.
- [x] `flutter test test/core/telemetry/glitchtip_compatibility_test.dart` — 8/8 pass locally (URI shape, no host allowlist, env var key pin, doc-content cross-checks).
- [ ] CI green on PR.
- [ ] Reviewer skim of the doc — aim is "practical, not marketing": one operator should be able to swap backends from this page alone.

## Out of scope

- No code defaults moved to Glitchtip (issue says keep Sentry default).
- No new runtime settings toggle — the existing dart-define + `sentry_dsn` Hive setting are enough; doc says so explicitly.
- No new dependencies.