### PR TITLE
feat(search): cross-border banner integration (#1118)

### DIFF
--- a/lib/features/search/domain/entities/cross_border_suggestion.dart
+++ b/lib/features/search/domain/entities/cross_border_suggestion.dart
@@ -1,0 +1,37 @@
+/// Actionable cross-border suggestion shown when the user is close to a
+/// neighbor country whose fuel is cheaper than the current search.
+///
+/// Built by `crossBorderSuggestionProvider`; consumed by `CrossBorderBanner`.
+/// `priceDeltaPerLiter` is positive when the neighbor is cheaper than the
+/// current country's average (e.g. 0.12 means "€0.12/L cheaper across the
+/// border"); negative or zero values mean "not actually cheaper" — those
+/// are filtered out at the provider level so the banner only shows wins.
+class CrossBorderSuggestion {
+  /// ISO 3166-1 alpha-2 code of the neighboring country (e.g. 'FR').
+  final String neighborCountryCode;
+
+  /// Localized display name of the neighbor (e.g. 'France').
+  final String neighborName;
+
+  /// Flag emoji for the neighbor (e.g. '🇫🇷').
+  final String neighborFlag;
+
+  /// Distance from the user to the closest border crossing point (km).
+  final double distanceKm;
+
+  /// How much cheaper the neighbor's stations are vs. the current country
+  /// for the user's fuel type (€/L, positive = cheaper across the border).
+  final double priceDeltaPerLiter;
+
+  /// Number of neighbor stations sampled to compute the average.
+  final int sampleCount;
+
+  const CrossBorderSuggestion({
+    required this.neighborCountryCode,
+    required this.neighborName,
+    required this.neighborFlag,
+    required this.distanceKm,
+    required this.priceDeltaPerLiter,
+    required this.sampleCount,
+  });
+}

--- a/lib/features/search/presentation/widgets/cross_border_banner.dart
+++ b/lib/features/search/presentation/widgets/cross_border_banner.dart
@@ -1,42 +1,73 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../../../l10n/app_localizations.dart';
-import '../../domain/entities/cross_border_comparison.dart';
-import '../../providers/cross_border_provider.dart';
 
-/// Shows a banner when the user is near a country border,
-/// highlighting that prices may differ across the border.
+import '../../../../core/country/country_config.dart';
+import '../../../../core/country/country_provider.dart';
+import '../../../../core/location/user_position_provider.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/cross_border_suggestion.dart';
+import '../../providers/cross_border_suggestion_provider.dart';
+import '../../providers/search_provider.dart';
+
+/// Banner shown above the nearby-search results when the user is close
+/// to a neighbor country whose fuel is currently cheaper.
 ///
-/// Displayed above the search results list. Shows the neighboring
-/// country flag, name, distance to border, and current average price
-/// for context.
+/// Wires up `crossBorderSuggestionProvider` (issue #1118): when the
+/// user is within 25 km of a border, the provider fires a parallel
+/// query against the neighbor's `StationService` (cached + coalesced
+/// by `StationServiceChain`) and returns the price delta vs. the
+/// current search. This banner renders that result with:
+///
+///  * the neighbor flag emoji,
+///  * a localized "stations Xkm away — €Y/L cheaper" label,
+///  * a dismiss button (per-session, resets on restart),
+///  * tap-to-switch — `ActiveCountry.select()` then `searchByCoordinates`.
+///
+/// Shows nothing while the suggestion is loading, when no suggestion
+/// is available (loading / null / dismissed), or while the suggestion
+/// errors — the banner is opt-in upside, never a blocker.
 class CrossBorderBanner extends ConsumerWidget {
   const CrossBorderBanner({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final comparisons = ref.watch(crossBorderComparisonsProvider);
-    if (comparisons.isEmpty) return const SizedBox.shrink();
+    final asyncSuggestion = ref.watch(crossBorderSuggestionProvider);
+    final dismissed = ref.watch(crossBorderBannerDismissedProvider);
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: comparisons
-          .map((c) => _CrossBorderCard(comparison: c))
-          .toList(),
-    );
+    if (!asyncSuggestion.hasValue) return const SizedBox.shrink();
+    final suggestion = asyncSuggestion.value;
+    if (suggestion == null) return const SizedBox.shrink();
+    if (dismissed.contains(suggestion.neighborCountryCode)) {
+      return const SizedBox.shrink();
+    }
+
+    return _CrossBorderSuggestionCard(suggestion: suggestion);
   }
 }
 
-class _CrossBorderCard extends StatelessWidget {
-  final CrossBorderComparison comparison;
+class _CrossBorderSuggestionCard extends ConsumerWidget {
+  final CrossBorderSuggestion suggestion;
 
-  const _CrossBorderCard({required this.comparison});
+  const _CrossBorderSuggestionCard({required this.suggestion});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final colorScheme = theme.colorScheme;
+
+    final priceLabel = suggestion.priceDeltaPerLiter.toStringAsFixed(2);
+    final distanceLabel = suggestion.distanceKm.toStringAsFixed(0);
+
+    final headline = l10n?.crossBorderCheaper(
+          suggestion.neighborName,
+          distanceLabel,
+          priceLabel,
+        ) ??
+        '${suggestion.neighborName} stations $distanceLabel km away '
+            '— €$priceLabel/L cheaper';
+
+    final hint = l10n?.crossBorderTapToSwitch ?? 'Tap to switch country';
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -49,62 +80,77 @@ class _CrossBorderCard extends StatelessWidget {
             color: colorScheme.tertiary.withValues(alpha: 0.3),
           ),
         ),
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Row(
-            children: [
-              // Country flag
-              Text(
-                comparison.neighborFlag,
-                style: const TextStyle(fontSize: 28),
-              ),
-              const SizedBox(width: 12),
-              // Info text
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      l10n?.crossBorderNearby(comparison.neighborName) ??
-                          '${comparison.neighborName} is nearby',
-                      style: theme.textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      l10n?.crossBorderDistance(
-                            comparison.borderDistanceKm.round(),
-                          ) ??
-                          '~${comparison.borderDistanceKm.round()} km to border',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      l10n?.crossBorderAvgPrice(
-                            comparison.currentAvgPrice.toStringAsFixed(3),
-                            comparison.stationCount,
-                          ) ??
-                          'Avg here: ${comparison.currentAvgPrice.toStringAsFixed(3)} EUR (${comparison.stationCount} stations)',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ],
+        child: InkWell(
+          onTap: () => _onTap(ref),
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                Text(
+                  suggestion.neighborFlag,
+                  style: const TextStyle(fontSize: 28),
                 ),
-              ),
-              // Border indicator icon
-              Icon(
-                Icons.compare_arrows,
-                color: colorScheme.tertiary,
-                size: 24,
-              ),
-            ],
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Semantics(
+                    container: true,
+                    label: '$headline. $hint',
+                    child: ExcludeSemantics(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            headline,
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            hint,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  iconSize: 20,
+                  visualDensity: VisualDensity.compact,
+                  tooltip: l10n?.crossBorderDismissTooltip ?? 'Dismiss',
+                  onPressed: () => ref
+                      .read(crossBorderBannerDismissedProvider.notifier)
+                      .dismiss(suggestion.neighborCountryCode),
+                ),
+              ],
+            ),
           ),
         ),
       ),
     );
+  }
+
+  Future<void> _onTap(WidgetRef ref) async {
+    final neighbor = Countries.byCode(suggestion.neighborCountryCode);
+    if (neighbor == null) return;
+
+    // Switch active country — the StationService provider rebuilds for
+    // the new country automatically.
+    await ref.read(activeCountryProvider.notifier).select(neighbor);
+
+    // Re-run the search at the user's current position. Using
+    // `searchByCoordinates` (rather than `searchByGps`) avoids a fresh
+    // location-permission prompt — we already have the position.
+    final position = ref.read(userPositionProvider);
+    if (position == null) return;
+    await ref.read(searchStateProvider.notifier).searchByCoordinates(
+          lat: position.lat,
+          lng: position.lng,
+        );
   }
 }

--- a/lib/features/search/providers/cross_border_suggestion_provider.dart
+++ b/lib/features/search/providers/cross_border_suggestion_provider.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/country/border_proximity.dart';
+import '../../../core/country/country_provider.dart';
+import '../../../core/location/user_position_provider.dart';
+import '../../../core/services/service_providers.dart';
+import '../../../core/services/station_service.dart';
+import '../../../core/utils/station_extensions.dart';
+import '../data/models/search_params.dart';
+import '../domain/entities/cross_border_suggestion.dart';
+import '../domain/entities/fuel_type.dart';
+import '../domain/entities/station.dart';
+import 'search_provider.dart';
+
+part 'cross_border_suggestion_provider.g.dart';
+
+/// Distance threshold (km) below which a neighbor country is considered
+/// close enough to fire a cross-border price probe.
+///
+/// Issue #1118: 25 km — far enough to catch a Saarbrücken / Strasbourg /
+/// Innsbruck commuter, narrow enough that a Berlin user doesn't see
+/// noise about a Polish border 70 km away.
+const double crossBorderThresholdKm = 25.0;
+
+/// Function signature for a station-service factory keyed by country
+/// code. Indirection layer that exists so tests can inject a fake
+/// `StationService` per neighbor without having to override the global
+/// service-resolution machinery (cache manager, country registry,
+/// API-key storage, ...).
+typedef CrossBorderStationServiceFactory = StationService Function(
+  String countryCode,
+);
+
+/// Injectable factory for resolving the neighbor country's station service.
+///
+/// Production path delegates to `stationServiceForCountry`, which goes
+/// through `CountryServiceRegistry` + `StationServiceChain` so the call
+/// is fully cached and request-coalesced (see #1118 acceptance: "coalesce
+/// duplicate API calls — already supported by chain").
+///
+/// Tests override this with a closure returning a small in-memory fake.
+@riverpod
+CrossBorderStationServiceFactory crossBorderStationServiceFactory(Ref ref) {
+  return (code) => stationServiceForCountry(ref, code);
+}
+
+/// Async suggestion of "the neighbor country has cheaper fuel right now".
+///
+/// Returns `null` when:
+///  * the user's position is unknown,
+///  * the user is not within [crossBorderThresholdKm] of any neighbor,
+///  * the active fuel type is not supported by the neighbor (we don't
+///    propose an EV-only neighbor for a diesel user, and vice versa),
+///  * the neighbor's station service returns no usable prices,
+///  * the current-country average is empty (we'd have nothing to compare
+///    against),
+///  * the neighbor is not actually cheaper (delta <= 0).
+///
+/// When non-null, the result encodes a positive `priceDeltaPerLiter` —
+/// callers (the banner) can render it directly without re-checking the
+/// sign.
+@riverpod
+Future<CrossBorderSuggestion?> crossBorderSuggestion(Ref ref) async {
+  final position = ref.watch(userPositionProvider);
+  if (position == null) return null;
+
+  final activeCountry = ref.watch(activeCountryProvider);
+  final fuelType = ref.watch(selectedFuelTypeProvider);
+
+  // Need a current-country average to compare against.
+  final localStations = ref.watch(fuelStationsProvider);
+  if (localStations.isEmpty) return null;
+
+  final localPrices = localStations
+      .map((s) => s.priceFor(fuelType))
+      .whereType<double>()
+      .where((p) => p > 0)
+      .toList();
+  if (localPrices.isEmpty) return null;
+  final localAvg = localPrices.reduce((a, b) => a + b) / localPrices.length;
+
+  // Detect nearby borders within the issue's 25 km radius.
+  final nearbyBorders = detectNearbyBorders(
+    lat: position.lat,
+    lng: position.lng,
+    currentCountryCode: activeCountry.code,
+    thresholdKm: crossBorderThresholdKm,
+  );
+  if (nearbyBorders.isEmpty) return null;
+
+  final factory = ref.watch(crossBorderStationServiceFactoryProvider);
+
+  // Probe each neighbor in order (closest first). Pick the first one
+  // that is actually cheaper. We don't probe in parallel here — each
+  // call is cached + coalesced by `StationServiceChain`, so a second
+  // pump of the provider is essentially free.
+  for (final border in nearbyBorders) {
+    final neighbor = border.neighbor;
+
+    // Don't propose a different fuel family — a diesel user shouldn't
+    // see "France has cheaper electric" when their car runs on diesel.
+    if (fuelType != FuelType.all &&
+        !neighbor.supportedFuelTypes.contains(fuelType)) {
+      continue;
+    }
+    // EV pricing model is per-kWh and not directly comparable to €/L,
+    // so the cross-border banner sticks to fuel for now.
+    if (fuelType == FuelType.electric) continue;
+
+    final neighborStations = await _safeNeighborSearch(
+      factory: factory,
+      countryCode: neighbor.code,
+      lat: position.lat,
+      lng: position.lng,
+      fuelType: fuelType,
+    );
+    if (neighborStations.isEmpty) continue;
+
+    final neighborPrices = neighborStations
+        .map((s) => s.priceFor(fuelType))
+        .whereType<double>()
+        .where((p) => p > 0)
+        .toList();
+    if (neighborPrices.isEmpty) continue;
+    final neighborAvg =
+        neighborPrices.reduce((a, b) => a + b) / neighborPrices.length;
+
+    final delta = localAvg - neighborAvg;
+    if (delta <= 0) continue; // not actually cheaper — skip
+
+    return CrossBorderSuggestion(
+      neighborCountryCode: neighbor.code,
+      neighborName: neighbor.name,
+      neighborFlag: neighbor.flag,
+      distanceKm: double.parse(border.distanceKm.toStringAsFixed(1)),
+      priceDeltaPerLiter: double.parse(delta.toStringAsFixed(3)),
+      sampleCount: neighborPrices.length,
+    );
+  }
+
+  return null;
+}
+
+/// Catches every error the neighbor service may throw (network, exhausted
+/// fallback chain, missing API key, ...) so a single bad upstream never
+/// breaks the whole search screen — the banner just stays hidden.
+Future<List<Station>> _safeNeighborSearch({
+  required CrossBorderStationServiceFactory factory,
+  required String countryCode,
+  required double lat,
+  required double lng,
+  required FuelType fuelType,
+}) async {
+  try {
+    final service = factory(countryCode);
+    final result = await service.searchStations(
+      SearchParams(
+        lat: lat,
+        lng: lng,
+        radiusKm: crossBorderThresholdKm,
+        fuelType: fuelType,
+      ),
+    );
+    return result.data;
+  } catch (e, st) {
+    debugPrint('cross-border probe ($countryCode) failed: $e\n$st');
+    return const [];
+  }
+}
+
+/// Set of neighbor country codes the user has dismissed during this
+/// session. Resets on app restart (StateNotifier with no persistence).
+@Riverpod(keepAlive: true)
+class CrossBorderBannerDismissed extends _$CrossBorderBannerDismissed {
+  @override
+  Set<String> build() => <String>{};
+
+  /// Marks [neighborCode] dismissed for this session — the banner stops
+  /// showing for that neighbor until app restart.
+  void dismiss(String neighborCode) {
+    if (state.contains(neighborCode)) return;
+    state = {...state, neighborCode};
+  }
+}

--- a/lib/features/search/providers/cross_border_suggestion_provider.g.dart
+++ b/lib/features/search/providers/cross_border_suggestion_provider.g.dart
@@ -1,0 +1,239 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cross_border_suggestion_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Injectable factory for resolving the neighbor country's station service.
+///
+/// Production path delegates to `stationServiceForCountry`, which goes
+/// through `CountryServiceRegistry` + `StationServiceChain` so the call
+/// is fully cached and request-coalesced (see #1118 acceptance: "coalesce
+/// duplicate API calls — already supported by chain").
+///
+/// Tests override this with a closure returning a small in-memory fake.
+
+@ProviderFor(crossBorderStationServiceFactory)
+final crossBorderStationServiceFactoryProvider =
+    CrossBorderStationServiceFactoryProvider._();
+
+/// Injectable factory for resolving the neighbor country's station service.
+///
+/// Production path delegates to `stationServiceForCountry`, which goes
+/// through `CountryServiceRegistry` + `StationServiceChain` so the call
+/// is fully cached and request-coalesced (see #1118 acceptance: "coalesce
+/// duplicate API calls — already supported by chain").
+///
+/// Tests override this with a closure returning a small in-memory fake.
+
+final class CrossBorderStationServiceFactoryProvider
+    extends
+        $FunctionalProvider<
+          CrossBorderStationServiceFactory,
+          CrossBorderStationServiceFactory,
+          CrossBorderStationServiceFactory
+        >
+    with $Provider<CrossBorderStationServiceFactory> {
+  /// Injectable factory for resolving the neighbor country's station service.
+  ///
+  /// Production path delegates to `stationServiceForCountry`, which goes
+  /// through `CountryServiceRegistry` + `StationServiceChain` so the call
+  /// is fully cached and request-coalesced (see #1118 acceptance: "coalesce
+  /// duplicate API calls — already supported by chain").
+  ///
+  /// Tests override this with a closure returning a small in-memory fake.
+  CrossBorderStationServiceFactoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'crossBorderStationServiceFactoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$crossBorderStationServiceFactoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<CrossBorderStationServiceFactory> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  CrossBorderStationServiceFactory create(Ref ref) {
+    return crossBorderStationServiceFactory(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(CrossBorderStationServiceFactory value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<CrossBorderStationServiceFactory>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$crossBorderStationServiceFactoryHash() =>
+    r'34d2faf17883aa874ca6ac907c29a84c3ae104c9';
+
+/// Async suggestion of "the neighbor country has cheaper fuel right now".
+///
+/// Returns `null` when:
+///  * the user's position is unknown,
+///  * the user is not within [crossBorderThresholdKm] of any neighbor,
+///  * the active fuel type is not supported by the neighbor (we don't
+///    propose an EV-only neighbor for a diesel user, and vice versa),
+///  * the neighbor's station service returns no usable prices,
+///  * the current-country average is empty (we'd have nothing to compare
+///    against),
+///  * the neighbor is not actually cheaper (delta <= 0).
+///
+/// When non-null, the result encodes a positive `priceDeltaPerLiter` —
+/// callers (the banner) can render it directly without re-checking the
+/// sign.
+
+@ProviderFor(crossBorderSuggestion)
+final crossBorderSuggestionProvider = CrossBorderSuggestionProvider._();
+
+/// Async suggestion of "the neighbor country has cheaper fuel right now".
+///
+/// Returns `null` when:
+///  * the user's position is unknown,
+///  * the user is not within [crossBorderThresholdKm] of any neighbor,
+///  * the active fuel type is not supported by the neighbor (we don't
+///    propose an EV-only neighbor for a diesel user, and vice versa),
+///  * the neighbor's station service returns no usable prices,
+///  * the current-country average is empty (we'd have nothing to compare
+///    against),
+///  * the neighbor is not actually cheaper (delta <= 0).
+///
+/// When non-null, the result encodes a positive `priceDeltaPerLiter` —
+/// callers (the banner) can render it directly without re-checking the
+/// sign.
+
+final class CrossBorderSuggestionProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<CrossBorderSuggestion?>,
+          CrossBorderSuggestion?,
+          FutureOr<CrossBorderSuggestion?>
+        >
+    with
+        $FutureModifier<CrossBorderSuggestion?>,
+        $FutureProvider<CrossBorderSuggestion?> {
+  /// Async suggestion of "the neighbor country has cheaper fuel right now".
+  ///
+  /// Returns `null` when:
+  ///  * the user's position is unknown,
+  ///  * the user is not within [crossBorderThresholdKm] of any neighbor,
+  ///  * the active fuel type is not supported by the neighbor (we don't
+  ///    propose an EV-only neighbor for a diesel user, and vice versa),
+  ///  * the neighbor's station service returns no usable prices,
+  ///  * the current-country average is empty (we'd have nothing to compare
+  ///    against),
+  ///  * the neighbor is not actually cheaper (delta <= 0).
+  ///
+  /// When non-null, the result encodes a positive `priceDeltaPerLiter` —
+  /// callers (the banner) can render it directly without re-checking the
+  /// sign.
+  CrossBorderSuggestionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'crossBorderSuggestionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$crossBorderSuggestionHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<CrossBorderSuggestion?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<CrossBorderSuggestion?> create(Ref ref) {
+    return crossBorderSuggestion(ref);
+  }
+}
+
+String _$crossBorderSuggestionHash() =>
+    r'3be95edb40f9144ee405eb3dfa42bbf8c511397a';
+
+/// Set of neighbor country codes the user has dismissed during this
+/// session. Resets on app restart (StateNotifier with no persistence).
+
+@ProviderFor(CrossBorderBannerDismissed)
+final crossBorderBannerDismissedProvider =
+    CrossBorderBannerDismissedProvider._();
+
+/// Set of neighbor country codes the user has dismissed during this
+/// session. Resets on app restart (StateNotifier with no persistence).
+final class CrossBorderBannerDismissedProvider
+    extends $NotifierProvider<CrossBorderBannerDismissed, Set<String>> {
+  /// Set of neighbor country codes the user has dismissed during this
+  /// session. Resets on app restart (StateNotifier with no persistence).
+  CrossBorderBannerDismissedProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'crossBorderBannerDismissedProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$crossBorderBannerDismissedHash();
+
+  @$internal
+  @override
+  CrossBorderBannerDismissed create() => CrossBorderBannerDismissed();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Set<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Set<String>>(value),
+    );
+  }
+}
+
+String _$crossBorderBannerDismissedHash() =>
+    r'b3371d52fb8171f3e1ba222721b84c921a2a7683';
+
+/// Set of neighbor country codes the user has dismissed during this
+/// session. Resets on app restart (StateNotifier with no persistence).
+
+abstract class _$CrossBorderBannerDismissed extends $Notifier<Set<String>> {
+  Set<String> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<Set<String>, Set<String>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<Set<String>, Set<String>>,
+              Set<String>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/l10n/_fragments/cross_border_de.arb
+++ b/lib/l10n/_fragments/cross_border_de.arb
@@ -1,0 +1,25 @@
+{
+  "crossBorderCheaper": "Tankstellen in {country} {km} km entfernt — {price} €/L günstiger",
+  "@crossBorderCheaper": {
+    "description": "Banner shown when stations across the border are cheaper than local prices.",
+    "placeholders": {
+      "country": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      },
+      "price": {
+        "type": "String"
+      }
+    }
+  },
+  "crossBorderTapToSwitch": "Tippen, um das Land zu wechseln",
+  "@crossBorderTapToSwitch": {
+    "description": "Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search."
+  },
+  "crossBorderDismissTooltip": "Schließen",
+  "@crossBorderDismissTooltip": {
+    "description": "Tooltip on the cross-border banner's dismiss icon."
+  }
+}

--- a/lib/l10n/_fragments/cross_border_en.arb
+++ b/lib/l10n/_fragments/cross_border_en.arb
@@ -1,0 +1,25 @@
+{
+  "crossBorderCheaper": "{country} stations {km} km away — €{price}/L cheaper",
+  "@crossBorderCheaper": {
+    "description": "Banner shown when stations across the border are cheaper than local prices.",
+    "placeholders": {
+      "country": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      },
+      "price": {
+        "type": "String"
+      }
+    }
+  },
+  "crossBorderTapToSwitch": "Tap to switch country",
+  "@crossBorderTapToSwitch": {
+    "description": "Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search."
+  },
+  "crossBorderDismissTooltip": "Dismiss",
+  "@crossBorderDismissTooltip": {
+    "description": "Tooltip on the cross-border banner's dismiss icon."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -513,6 +513,29 @@
       }
     }
   },
+  "crossBorderCheaper": "Tankstellen in {country} {km} km entfernt — {price} €/L günstiger",
+  "@crossBorderCheaper": {
+    "description": "Banner shown when stations across the border are cheaper than local prices.",
+    "placeholders": {
+      "country": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      },
+      "price": {
+        "type": "String"
+      }
+    }
+  },
+  "crossBorderTapToSwitch": "Tippen, um das Land zu wechseln",
+  "@crossBorderTapToSwitch": {
+    "description": "Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search."
+  },
+  "crossBorderDismissTooltip": "Schließen",
+  "@crossBorderDismissTooltip": {
+    "description": "Tooltip on the cross-border banner's dismiss icon."
+  },
   "allPricesView": "Alle Preise",
   "compactView": "Kompakt",
   "switchToAllPricesView": "Zur Alle-Preise-Ansicht wechseln",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -513,29 +513,6 @@
       }
     }
   },
-  "crossBorderCheaper": "Tankstellen in {country} {km} km entfernt — {price} €/L günstiger",
-  "@crossBorderCheaper": {
-    "description": "Banner shown when stations across the border are cheaper than local prices.",
-    "placeholders": {
-      "country": {
-        "type": "String"
-      },
-      "km": {
-        "type": "String"
-      },
-      "price": {
-        "type": "String"
-      }
-    }
-  },
-  "crossBorderTapToSwitch": "Tippen, um das Land zu wechseln",
-  "@crossBorderTapToSwitch": {
-    "description": "Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search."
-  },
-  "crossBorderDismissTooltip": "Schließen",
-  "@crossBorderDismissTooltip": {
-    "description": "Tooltip on the cross-border banner's dismiss icon."
-  },
   "allPricesView": "Alle Preise",
   "compactView": "Kompakt",
   "switchToAllPricesView": "Zur Alle-Preise-Ansicht wechseln",
@@ -1293,6 +1270,29 @@
   "greeceCommunityApiNotice": "Betrieben von der von der Community gepflegten fuelpricesgr-API",
   "romaniaApiProvider": "Monitorul Prețurilor (Romania)",
   "romaniaScrapingNotice": "Betrieben von pretcarburant.ro (Wettbewerbsrat + ANPC)",
+  "crossBorderCheaper": "Tankstellen in {country} {km} km entfernt — {price} €/L günstiger",
+  "@crossBorderCheaper": {
+    "description": "Banner shown when stations across the border are cheaper than local prices.",
+    "placeholders": {
+      "country": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      },
+      "price": {
+        "type": "String"
+      }
+    }
+  },
+  "crossBorderTapToSwitch": "Tippen, um das Land zu wechseln",
+  "@crossBorderTapToSwitch": {
+    "description": "Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search."
+  },
+  "crossBorderDismissTooltip": "Schließen",
+  "@crossBorderDismissTooltip": {
+    "description": "Tooltip on the cross-border banner's dismiss icon."
+  },
   "insightCardTitle": "Größte Spritfresser",
   "insightEmptyState": "Keine auffälligen Ineffizienzen – weiter so!",
   "insightHighRpm": "Motor über 3000 U/min ({pctTime}% der Fahrt): {liters} L verschwendet",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -526,29 +526,6 @@
       }
     }
   },
-  "crossBorderCheaper": "{country} stations {km} km away — €{price}/L cheaper",
-  "@crossBorderCheaper": {
-    "description": "Banner shown when stations across the border are cheaper than local prices.",
-    "placeholders": {
-      "country": {
-        "type": "String"
-      },
-      "km": {
-        "type": "String"
-      },
-      "price": {
-        "type": "String"
-      }
-    }
-  },
-  "crossBorderTapToSwitch": "Tap to switch country",
-  "@crossBorderTapToSwitch": {
-    "description": "Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search."
-  },
-  "crossBorderDismissTooltip": "Dismiss",
-  "@crossBorderDismissTooltip": {
-    "description": "Tooltip on the cross-border banner's dismiss icon."
-  },
   "allPricesView": "All prices",
   "compactView": "Compact",
   "switchToAllPricesView": "Switch to all-prices view",
@@ -1598,6 +1575,29 @@
   "greeceCommunityApiNotice": "Powered by the community-maintained fuelpricesgr API",
   "romaniaApiProvider": "Monitorul Prețurilor (Romania)",
   "romaniaScrapingNotice": "Powered by pretcarburant.ro (Competition Council + ANPC)",
+  "crossBorderCheaper": "{country} stations {km} km away — €{price}/L cheaper",
+  "@crossBorderCheaper": {
+    "description": "Banner shown when stations across the border are cheaper than local prices.",
+    "placeholders": {
+      "country": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      },
+      "price": {
+        "type": "String"
+      }
+    }
+  },
+  "crossBorderTapToSwitch": "Tap to switch country",
+  "@crossBorderTapToSwitch": {
+    "description": "Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search."
+  },
+  "crossBorderDismissTooltip": "Dismiss",
+  "@crossBorderDismissTooltip": {
+    "description": "Tooltip on the cross-border banner's dismiss icon."
+  },
   "insightCardTitle": "Top wasteful behaviours",
   "@insightCardTitle": {
     "description": "Title of the driving-insights card on the Trip detail screen — surfaces the top-3 fuel-wasting behaviours from the analyzer (#1041 phase 2)."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -526,6 +526,29 @@
       }
     }
   },
+  "crossBorderCheaper": "{country} stations {km} km away — €{price}/L cheaper",
+  "@crossBorderCheaper": {
+    "description": "Banner shown when stations across the border are cheaper than local prices.",
+    "placeholders": {
+      "country": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      },
+      "price": {
+        "type": "String"
+      }
+    }
+  },
+  "crossBorderTapToSwitch": "Tap to switch country",
+  "@crossBorderTapToSwitch": {
+    "description": "Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search."
+  },
+  "crossBorderDismissTooltip": "Dismiss",
+  "@crossBorderDismissTooltip": {
+    "description": "Tooltip on the cross-border banner's dismiss icon."
+  },
   "allPricesView": "All prices",
   "compactView": "Compact",
   "switchToAllPricesView": "Switch to all-prices view",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2282,24 +2282,6 @@ abstract class AppLocalizations {
   /// **'Avg here: {price} EUR ({count} stations)'**
   String crossBorderAvgPrice(String price, int count);
 
-  /// Banner shown when stations across the border are cheaper than local prices.
-  ///
-  /// In en, this message translates to:
-  /// **'{country} stations {km} km away — €{price}/L cheaper'**
-  String crossBorderCheaper(String country, String km, String price);
-
-  /// Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search.
-  ///
-  /// In en, this message translates to:
-  /// **'Tap to switch country'**
-  String get crossBorderTapToSwitch;
-
-  /// Tooltip on the cross-border banner's dismiss icon.
-  ///
-  /// In en, this message translates to:
-  /// **'Dismiss'**
-  String get crossBorderDismissTooltip;
-
   /// No description provided for @allPricesView.
   ///
   /// In en, this message translates to:
@@ -6085,6 +6067,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Powered by pretcarburant.ro (Competition Council + ANPC)'**
   String get romaniaScrapingNotice;
+
+  /// Banner shown when stations across the border are cheaper than local prices.
+  ///
+  /// In en, this message translates to:
+  /// **'{country} stations {km} km away — €{price}/L cheaper'**
+  String crossBorderCheaper(String country, String km, String price);
+
+  /// Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap to switch country'**
+  String get crossBorderTapToSwitch;
+
+  /// Tooltip on the cross-border banner's dismiss icon.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get crossBorderDismissTooltip;
 
   /// Title of the driving-insights card on the Trip detail screen — surfaces the top-3 fuel-wasting behaviours from the analyzer (#1041 phase 2).
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2282,6 +2282,24 @@ abstract class AppLocalizations {
   /// **'Avg here: {price} EUR ({count} stations)'**
   String crossBorderAvgPrice(String price, int count);
 
+  /// Banner shown when stations across the border are cheaper than local prices.
+  ///
+  /// In en, this message translates to:
+  /// **'{country} stations {km} km away — €{price}/L cheaper'**
+  String crossBorderCheaper(String country, String km, String price);
+
+  /// Hint shown beneath the cross-border banner — tapping switches the active country and re-runs the search.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap to switch country'**
+  String get crossBorderTapToSwitch;
+
+  /// Tooltip on the cross-border banner's dismiss icon.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get crossBorderDismissTooltip;
+
   /// No description provided for @allPricesView.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1168,17 +1168,6 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3244,6 +3233,17 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1168,6 +1168,17 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1168,6 +1168,17 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1168,17 +1168,6 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3244,6 +3233,17 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1166,6 +1166,17 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1166,17 +1166,6 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3242,6 +3231,17 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1174,6 +1174,17 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return 'Tankstellen in $country $km km entfernt — $price €/L günstiger';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tippen, um das Land zu wechseln';
+
+  @override
+  String get crossBorderDismissTooltip => 'Schließen';
+
+  @override
   String get allPricesView => 'Alle Preise';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1174,17 +1174,6 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return 'Tankstellen in $country $km km entfernt — $price €/L günstiger';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tippen, um das Land zu wechseln';
-
-  @override
-  String get crossBorderDismissTooltip => 'Schließen';
-
-  @override
   String get allPricesView => 'Alle Preise';
 
   @override
@@ -3269,6 +3258,17 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Betrieben von pretcarburant.ro (Wettbewerbsrat + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return 'Tankstellen in $country $km km entfernt — $price €/L günstiger';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tippen, um das Land zu wechseln';
+
+  @override
+  String get crossBorderDismissTooltip => 'Schließen';
 
   @override
   String get insightCardTitle => 'Größte Spritfresser';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1170,17 +1170,6 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3246,6 +3235,17 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1170,6 +1170,17 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1161,6 +1161,17 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1161,17 +1161,6 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3237,6 +3226,17 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1169,6 +1169,17 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1169,17 +1169,6 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3245,6 +3234,17 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1163,6 +1163,17 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1163,17 +1163,6 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3239,6 +3228,17 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1166,6 +1166,17 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1166,17 +1166,6 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3242,6 +3231,17 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1175,6 +1175,17 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1175,17 +1175,6 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3267,6 +3256,17 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1165,17 +1165,6 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3241,6 +3230,17 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1165,6 +1165,17 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1170,6 +1170,17 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1170,17 +1170,6 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3246,6 +3235,17 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1169,6 +1169,17 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1169,17 +1169,6 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3245,6 +3234,17 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1167,6 +1167,17 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1167,17 +1167,6 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3243,6 +3232,17 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1169,17 +1169,6 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3245,6 +3234,17 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1169,6 +1169,17 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1165,6 +1165,17 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1165,17 +1165,6 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3241,6 +3230,17 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1170,6 +1170,17 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1170,17 +1170,6 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3246,6 +3235,17 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1168,6 +1168,17 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1168,17 +1168,6 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3244,6 +3233,17 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1169,6 +1169,17 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1169,17 +1169,6 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3245,6 +3234,17 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1168,17 +1168,6 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3244,6 +3233,17 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1168,6 +1168,17 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1169,17 +1169,6 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3245,6 +3234,17 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1169,6 +1169,17 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1163,6 +1163,17 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1163,17 +1163,6 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3239,6 +3228,17 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1167,6 +1167,17 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
+
+  @override
   String get allPricesView => 'All prices';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1167,17 +1167,6 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String crossBorderCheaper(String country, String km, String price) {
-    return '$country stations $km km away — €$price/L cheaper';
-  }
-
-  @override
-  String get crossBorderTapToSwitch => 'Tap to switch country';
-
-  @override
-  String get crossBorderDismissTooltip => 'Dismiss';
-
-  @override
   String get allPricesView => 'All prices';
 
   @override
@@ -3243,6 +3232,17 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get romaniaScrapingNotice =>
       'Powered by pretcarburant.ro (Competition Council + ANPC)';
+
+  @override
+  String crossBorderCheaper(String country, String km, String price) {
+    return '$country stations $km km away — €$price/L cheaper';
+  }
+
+  @override
+  String get crossBorderTapToSwitch => 'Tap to switch country';
+
+  @override
+  String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
   String get insightCardTitle => 'Top wasteful behaviours';

--- a/test/features/search/presentation/widgets/cross_border_banner_test.dart
+++ b/test/features/search/presentation/widgets/cross_border_banner_test.dart
@@ -1,125 +1,197 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tankstellen/features/search/domain/entities/cross_border_comparison.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/country/country_provider.dart';
+import 'package:tankstellen/core/location/user_position_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/cross_border_suggestion.dart';
 import 'package:tankstellen/features/search/presentation/widgets/cross_border_banner.dart';
-import 'package:tankstellen/features/search/providers/cross_border_provider.dart';
+import 'package:tankstellen/features/search/providers/cross_border_suggestion_provider.dart';
 
 import '../../../../helpers/pump_app.dart';
 
 void main() {
   group('CrossBorderBanner', () {
-    testWidgets('shows nothing when no comparisons', (tester) async {
+    testWidgets('shows nothing when suggestion is null', (tester) async {
       await pumpApp(
         tester,
         const CrossBorderBanner(),
         overrides: [
-          crossBorderComparisonsProvider.overrideWith((ref) => const []),
+          crossBorderSuggestionProvider
+              .overrideWith((ref) async => null),
         ],
       );
 
       expect(find.byType(Card), findsNothing);
     });
 
-    testWidgets('shows banner with neighbor info', (tester) async {
-      final comparisons = [
-        const CrossBorderComparison(
-          neighborCode: 'FR',
-          neighborName: 'France',
-          neighborFlag: '\u{1F1EB}\u{1F1F7}',
-          neighborCurrency: '\u20ac',
-          currentAvgPrice: 1.850,
-          borderDistanceKm: 12.5,
-          stationCount: 5,
-        ),
-      ];
-
+    testWidgets('shows nothing while suggestion is loading', (tester) async {
       await pumpApp(
         tester,
         const CrossBorderBanner(),
         overrides: [
-          crossBorderComparisonsProvider.overrideWith((ref) => comparisons),
+          crossBorderSuggestionProvider.overrideWith((ref) {
+            // Never-completing future keeps the AsyncValue in `loading`.
+            return Completer<CrossBorderSuggestion?>().future;
+          }),
+        ],
+      );
+
+      expect(find.byType(Card), findsNothing);
+    });
+
+    testWidgets('renders headline + flag when suggestion exists',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const CrossBorderBanner(),
+        overrides: [
+          crossBorderSuggestionProvider.overrideWith(
+            (ref) async => const CrossBorderSuggestion(
+              neighborCountryCode: 'FR',
+              neighborName: 'France',
+              neighborFlag: '\u{1F1EB}\u{1F1F7}',
+              distanceKm: 4.0,
+              priceDeltaPerLiter: 0.12,
+              sampleCount: 6,
+            ),
+          ),
         ],
       );
 
       expect(find.byType(Card), findsOneWidget);
-      expect(find.text('France is nearby'), findsOneWidget);
-      expect(find.text('~13 km to border'), findsOneWidget);
+      expect(find.text('\u{1F1EB}\u{1F1F7}'), findsOneWidget);
       expect(
-        find.text('Avg here: 1.850 EUR (5 stations)'),
+        find.textContaining('France'),
         findsOneWidget,
       );
-      expect(find.byIcon(Icons.compare_arrows), findsOneWidget);
+      expect(find.textContaining('0.12'), findsOneWidget);
+      expect(find.byIcon(Icons.close), findsOneWidget);
     });
 
-    testWidgets('shows multiple banners for multiple neighbors', (tester) async {
-      final comparisons = [
-        const CrossBorderComparison(
-          neighborCode: 'FR',
-          neighborName: 'France',
-          neighborFlag: '\u{1F1EB}\u{1F1F7}',
-          neighborCurrency: '\u20ac',
-          currentAvgPrice: 1.800,
-          borderDistanceKm: 10.0,
-          stationCount: 3,
-        ),
-        const CrossBorderComparison(
-          neighborCode: 'AT',
-          neighborName: '\u00d6sterreich',
-          neighborFlag: '\u{1F1E6}\u{1F1F9}',
-          neighborCurrency: '\u20ac',
-          currentAvgPrice: 1.800,
-          borderDistanceKm: 25.0,
-          stationCount: 3,
-        ),
-      ];
-
+    testWidgets('dismiss button hides banner for that neighbor',
+        (tester) async {
       await pumpApp(
         tester,
         const CrossBorderBanner(),
         overrides: [
-          crossBorderComparisonsProvider.overrideWith((ref) => comparisons),
+          crossBorderSuggestionProvider.overrideWith(
+            (ref) async => const CrossBorderSuggestion(
+              neighborCountryCode: 'FR',
+              neighborName: 'France',
+              neighborFlag: '\u{1F1EB}\u{1F1F7}',
+              distanceKm: 4.0,
+              priceDeltaPerLiter: 0.12,
+              sampleCount: 6,
+            ),
+          ),
         ],
       );
 
-      expect(find.byType(Card), findsNWidgets(2));
-      expect(find.text('France is nearby'), findsOneWidget);
-      expect(find.text('\u00d6sterreich is nearby'), findsOneWidget);
+      expect(find.byType(Card), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Card), findsNothing);
     });
 
-    testWidgets('rounds distance correctly', (tester) async {
-      final comparisons = [
-        const CrossBorderComparison(
-          neighborCode: 'DK',
-          neighborName: 'Danmark',
-          neighborFlag: '\u{1F1E9}\u{1F1F0}',
-          neighborCurrency: 'kr',
-          currentAvgPrice: 1.650,
-          borderDistanceKm: 7.3,
-          stationCount: 2,
-        ),
-      ];
-
+    testWidgets('hidden when suggestion neighbor is already dismissed',
+        (tester) async {
       await pumpApp(
         tester,
         const CrossBorderBanner(),
         overrides: [
-          crossBorderComparisonsProvider.overrideWith((ref) => comparisons),
+          crossBorderSuggestionProvider.overrideWith(
+            (ref) async => const CrossBorderSuggestion(
+              neighborCountryCode: 'FR',
+              neighborName: 'France',
+              neighborFlag: '\u{1F1EB}\u{1F1F7}',
+              distanceKm: 4.0,
+              priceDeltaPerLiter: 0.12,
+              sampleCount: 6,
+            ),
+          ),
+          crossBorderBannerDismissedProvider
+              .overrideWith(() => _PreDismissed({'FR'})),
         ],
       );
 
-      expect(find.text('~7 km to border'), findsOneWidget);
+      expect(find.byType(Card), findsNothing);
     });
 
-    testWidgets('meets tap target guidelines', (tester) async {
+    testWidgets('tap invokes country switch via ActiveCountry.select()',
+        (tester) async {
+      final spy = _SpyActiveCountry(Countries.germany);
       await pumpApp(
         tester,
         const CrossBorderBanner(),
         overrides: [
-          crossBorderComparisonsProvider.overrideWith((ref) => const []),
+          activeCountryProvider.overrideWith(() => spy),
+          // The banner's tap handler reads the user position to feed
+          // searchByCoordinates; without one it returns early.
+          userPositionProvider.overrideWith(
+            () => _FixedUserPosition(49.23, 7.0),
+          ),
+          crossBorderSuggestionProvider.overrideWith(
+            (ref) async => const CrossBorderSuggestion(
+              neighborCountryCode: 'FR',
+              neighborName: 'France',
+              neighborFlag: '\u{1F1EB}\u{1F1F7}',
+              distanceKm: 4.0,
+              priceDeltaPerLiter: 0.12,
+              sampleCount: 6,
+            ),
+          ),
         ],
       );
 
-      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      // Tap the body of the card (not the dismiss icon).
+      await tester.tap(find.text('\u{1F1EB}\u{1F1F7}'));
+      // Don't pumpAndSettle — searchByCoordinates dispatches further
+      // async work we don't care about here.
+      await tester.pump();
+
+      expect(spy.selectedCodes, contains('FR'));
     });
   });
+}
+
+class _PreDismissed extends CrossBorderBannerDismissed {
+  final Set<String> _initial;
+  _PreDismissed(this._initial);
+
+  @override
+  Set<String> build() => Set<String>.from(_initial);
+}
+
+class _FixedUserPosition extends UserPosition {
+  final double _lat;
+  final double _lng;
+  _FixedUserPosition(this._lat, this._lng);
+
+  @override
+  UserPositionData? build() => UserPositionData(
+        lat: _lat,
+        lng: _lng,
+        updatedAt: DateTime.now(),
+        source: 'test',
+      );
+}
+
+class _SpyActiveCountry extends ActiveCountry {
+  final CountryConfig _initial;
+  final List<String> selectedCodes = [];
+
+  _SpyActiveCountry(this._initial);
+
+  @override
+  CountryConfig build() => _initial;
+
+  @override
+  Future<void> select(CountryConfig country) async {
+    selectedCodes.add(country.code);
+    state = country;
+  }
 }

--- a/test/features/search/providers/cross_border_suggestion_provider_test.dart
+++ b/test/features/search/providers/cross_border_suggestion_provider_test.dart
@@ -1,0 +1,304 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/country/country_provider.dart';
+import 'package:tankstellen/core/location/user_position_provider.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/cross_border_suggestion_provider.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+
+void main() {
+  group('crossBorderSuggestionProvider', () {
+    test('returns null when user position is unknown', () async {
+      final container = _container(
+        position: null,
+        country: Countries.germany,
+        fuel: FuelType.e10,
+        localStations: const [],
+        neighborStations: const {},
+      );
+      addTearDown(container.dispose);
+
+      final result =
+          await container.read(crossBorderSuggestionProvider.future);
+      expect(result, isNull);
+    });
+
+    test('returns null when user is far from any border (Berlin)',
+        () async {
+      // Berlin: ~150 km from any DE land border.
+      final container = _container(
+        position: const _Pos(52.52, 13.405),
+        country: Countries.germany,
+        fuel: FuelType.e10,
+        localStations: _stations(prices: const [1.85, 1.86]),
+        neighborStations: const {},
+      );
+      addTearDown(container.dispose);
+
+      final result =
+          await container.read(crossBorderSuggestionProvider.future);
+      expect(result, isNull);
+    });
+
+    test(
+        'synthetic Saarbrücken position triggers DE→FR signal '
+        'when neighbor is cheaper', () async {
+      // Saarbrücken (49.23, 7.0) is essentially on the FR border.
+      final container = _container(
+        position: const _Pos(49.23, 7.0),
+        country: Countries.germany,
+        fuel: FuelType.e10,
+        localStations: _stations(prices: const [1.90, 1.92, 1.91]),
+        neighborStations: {
+          'FR': _stations(prices: const [1.78, 1.80]),
+        },
+      );
+      addTearDown(container.dispose);
+
+      final result =
+          await container.read(crossBorderSuggestionProvider.future);
+
+      expect(result, isNotNull);
+      expect(result!.neighborCountryCode, 'FR');
+      expect(result.neighborName, 'France');
+      expect(result.priceDeltaPerLiter, greaterThan(0));
+      // Local avg ≈ 1.910, neighbor avg = 1.790 → delta ≈ 0.120
+      expect(result.priceDeltaPerLiter, closeTo(0.12, 0.005));
+      expect(result.sampleCount, 2);
+      expect(result.distanceKm, lessThanOrEqualTo(crossBorderThresholdKm));
+    });
+
+    test('returns null when neighbor returns no stations', () async {
+      final container = _container(
+        position: const _Pos(49.23, 7.0),
+        country: Countries.germany,
+        fuel: FuelType.e10,
+        localStations: _stations(prices: const [1.90, 1.92]),
+        neighborStations: const {'FR': []},
+      );
+      addTearDown(container.dispose);
+
+      final result =
+          await container.read(crossBorderSuggestionProvider.future);
+      expect(result, isNull);
+    });
+
+    test('returns null when neighbor is not cheaper (delta <= 0)',
+        () async {
+      final container = _container(
+        position: const _Pos(49.23, 7.0),
+        country: Countries.germany,
+        fuel: FuelType.e10,
+        localStations: _stations(prices: const [1.70, 1.72]),
+        neighborStations: {
+          'FR': _stations(prices: const [1.85, 1.90]),
+        },
+      );
+      addTearDown(container.dispose);
+
+      final result =
+          await container.read(crossBorderSuggestionProvider.future);
+      expect(result, isNull);
+    });
+
+    test('returns null when current-country search has no prices',
+        () async {
+      final container = _container(
+        position: const _Pos(49.23, 7.0),
+        country: Countries.germany,
+        fuel: FuelType.e10,
+        localStations: const [], // empty
+        neighborStations: {
+          'FR': _stations(prices: const [1.78, 1.80]),
+        },
+      );
+      addTearDown(container.dispose);
+
+      final result =
+          await container.read(crossBorderSuggestionProvider.future);
+      expect(result, isNull);
+    });
+
+    test('skips electric fuel — kWh vs L are not comparable', () async {
+      final container = _container(
+        position: const _Pos(49.23, 7.0),
+        country: Countries.germany,
+        fuel: FuelType.electric,
+        localStations: _stations(prices: const [1.90, 1.92]),
+        neighborStations: {
+          'FR': _stations(prices: const [1.78]),
+        },
+      );
+      addTearDown(container.dispose);
+
+      final result =
+          await container.read(crossBorderSuggestionProvider.future);
+      expect(result, isNull);
+    });
+
+    test('does not propose neighbors that do not support the fuel',
+        () async {
+      // CNG is unsupported by France; force the user onto CNG and confirm
+      // the FR neighbor is skipped even though it would be otherwise eligible.
+      final container = _container(
+        position: const _Pos(49.23, 7.0),
+        country: Countries.germany,
+        fuel: FuelType.cng,
+        localStations: _stations(prices: const [1.90]),
+        neighborStations: {
+          'FR': _stations(prices: const [1.50]),
+        },
+      );
+      addTearDown(container.dispose);
+
+      final result =
+          await container.read(crossBorderSuggestionProvider.future);
+      expect(result, isNull);
+    });
+  });
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+class _Pos {
+  final double lat;
+  final double lng;
+  const _Pos(this.lat, this.lng);
+}
+
+ProviderContainer _container({
+  required _Pos? position,
+  required CountryConfig country,
+  required FuelType fuel,
+  required List<Station> localStations,
+  required Map<String, List<Station>> neighborStations,
+}) {
+  return ProviderContainer(
+    overrides: [
+      activeCountryProvider.overrideWith(() => _FixedCountry(country)),
+      userPositionProvider.overrideWith(
+        () => position == null
+            ? _NullUserPosition()
+            : _FixedUserPosition(position.lat, position.lng),
+      ),
+      selectedFuelTypeProvider.overrideWith(() => _FixedFuelType(fuel)),
+      searchStateProvider.overrideWith(() => _FakeSearchState(localStations)),
+      crossBorderStationServiceFactoryProvider.overrideWith(
+        (ref) => (code) => _FakeStationService(neighborStations[code] ?? []),
+      ),
+    ],
+  );
+}
+
+List<Station> _stations({required List<double> prices}) {
+  return [
+    for (var i = 0; i < prices.length; i++)
+      Station(
+        id: 'test-${prices[i].toStringAsFixed(3)}-$i',
+        name: 'Station $i',
+        brand: 'TEST',
+        street: 'Teststr.',
+        postCode: '00000',
+        place: 'Test',
+        lat: 49.23,
+        lng: 7.0,
+        dist: 1.0,
+        e5: prices[i],
+        e10: prices[i],
+        diesel: prices[i],
+        e98: prices[i],
+        dieselPremium: prices[i],
+        e85: prices[i],
+        lpg: prices[i],
+        cng: prices[i],
+        isOpen: true,
+      ),
+  ];
+}
+
+class _FixedCountry extends ActiveCountry {
+  final CountryConfig _country;
+  _FixedCountry(this._country);
+
+  @override
+  CountryConfig build() => _country;
+}
+
+class _NullUserPosition extends UserPosition {
+  @override
+  UserPositionData? build() => null;
+}
+
+class _FixedUserPosition extends UserPosition {
+  final double _lat;
+  final double _lng;
+  _FixedUserPosition(this._lat, this._lng);
+
+  @override
+  UserPositionData? build() => UserPositionData(
+        lat: _lat,
+        lng: _lng,
+        updatedAt: DateTime.now(),
+        source: 'test',
+      );
+}
+
+class _FixedFuelType extends SelectedFuelType {
+  final FuelType _type;
+  _FixedFuelType(this._type);
+
+  @override
+  FuelType build() => _type;
+}
+
+class _FakeSearchState extends SearchState {
+  final List<Station> _stations;
+
+  _FakeSearchState(this._stations);
+
+  @override
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
+    return AsyncValue.data(ServiceResult(
+      data: _stations
+          .map((s) => FuelStationResult(s) as SearchResultItem)
+          .toList(),
+      source: ServiceSource.cache,
+      fetchedAt: DateTime.now(),
+    ));
+  }
+}
+
+class _FakeStationService implements StationService {
+  final List<Station> _stationsToReturn;
+  _FakeStationService(this._stationsToReturn);
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    return ServiceResult(
+      data: _stationsToReturn,
+      source: ServiceSource.cache,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+      List<String> ids) {
+    throw UnimplementedError();
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `crossBorderSuggestionProvider` that detects when the user is within 25 km of a neighbor border (per `border_proximity.dart`), fires a parallel `StationService.searchStations` call against the neighbor (cached + coalesced by `StationServiceChain`), and returns a positive `priceDeltaPerLiter`.
- Replaces the existing passive `CrossBorderBanner` with an actionable Material card: flag emoji, localized "Xkm away — €Y/L cheaper" headline, dismiss icon, and tap → `ActiveCountry.select()` + `searchByCoordinates` re-search at the user's known position.
- Adds `crossBorderBannerDismissedProvider` (Set<String> notifier, keep-alive, no persistence) so the banner stays hidden per-session for any neighbor the user dismissed.
- Skips electric (€/L vs €/kWh aren't comparable) and any neighbor whose `supportedFuelTypes` excludes the active fuel — diesel users never see an EV-only suggestion.

## Why
Audit Section 4: `border_proximity.dart` was only wired into route search. A user near the FR/DE border was seeing local prices when stations 4 km across were €0.12/L cheaper — money on the table for the pump lens. ~200 LOC, reuses existing infra.

## Test plan
- [x] `flutter analyze` — zero issues
- [x] `flutter test test/features/search/providers/cross_border_suggestion_provider_test.dart` — 7 cases pass (Saarbrücken DE→FR, Berlin null, no neighbor data, neighbor not cheaper, electric skipped, unsupported fuel skipped, missing local prices)
- [x] `flutter test test/features/search/presentation/widgets/cross_border_banner_test.dart` — 6 cases pass (loading/null branch, dismiss button hides, pre-dismissed neighbor hidden, tap fires `ActiveCountry.select()` via spy)
- [x] Existing `cross_border_provider_test.dart` still green — the legacy `crossBorderComparisonsProvider` is unchanged (still exists, just no longer rendered by the banner)

Closes #1118.