### PR TITLE
refactor(app): extract navigation/animation widgets out of shell_screen (Refs #563 phase: shell)

### DIFF
--- a/lib/app/shell/shell_bottom_bar.dart
+++ b/lib/app/shell/shell_bottom_bar.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+import 'shell_nav_item.dart';
+
+/// Compact-screen bottom navigation bar.
+///
+/// Sibling to [ShellNavRail]; the parent shell picks one based on
+/// screen size. Shrinks the icon and drops the label row in landscape
+/// to keep the bar from eating the body height on phones held
+/// sideways.
+class ShellBottomBar extends StatelessWidget {
+  final List<ShellNavItem> items;
+
+  /// Router-branch index for each visible slot (see rail comment, #893).
+  final List<int> branchForSlot;
+  final int currentIndex;
+  final List<AnimationController> iconControllers;
+  final bool isLandscape;
+  final ValueChanged<int> onTap;
+
+  const ShellBottomBar({
+    super.key,
+    required this.items,
+    required this.branchForSlot,
+    required this.currentIndex,
+    required this.iconControllers,
+    required this.isLandscape,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final iconSize = isLandscape ? 20.0 : 24.0;
+    // #528 — wrap the bar in `SafeArea(top: false)` rather than
+    // reading `MediaQuery.viewPadding.bottom` manually. SafeArea
+    // *consumes* the inset, so no ancestor or descendant can
+    // accidentally apply it a second time. Fixes the visible band
+    // of empty space between the bottom nav and the Android gesture
+    // bar on edge-to-edge devices (same class of bug as #520).
+    final barHeight = isLandscape ? 48.0 : 64.0;
+
+    return SafeArea(
+      top: false,
+      child: Container(
+        height: barHeight,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHighest,
+          boxShadow: [
+            BoxShadow(
+              color: Theme.of(context).brightness == Brightness.dark
+                  ? Colors.black.withValues(alpha: 0.3)
+                  : Colors.black.withValues(alpha: 0.08),
+              blurRadius: 8,
+              offset: const Offset(0, -2),
+            ),
+          ],
+        ),
+        child: Row(
+          children: List.generate(items.length, (i) {
+            final selected = i == currentIndex;
+            final item = items[i];
+            final controller = iconControllers[branchForSlot[i]];
+
+            return Expanded(
+              child: Semantics(
+                label: item.label,
+                button: true,
+                selected: selected,
+                excludeSemantics: true,
+                child: InkWell(
+                  onTap: () => onTap(i),
+                  splashColor:
+                      theme.colorScheme.primary.withValues(alpha: 0.1),
+                  highlightColor: Colors.transparent,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      ShellBounceIcon(
+                        controller: controller,
+                        selected: selected,
+                        icon: selected ? item.filledIcon : item.outlinedIcon,
+                        iconSize: iconSize,
+                        color: selected
+                            ? theme.colorScheme.primary
+                            : theme.colorScheme.onSurfaceVariant,
+                      ),
+                      if (!isLandscape) ...[
+                        const SizedBox(height: 2),
+                        AnimatedDefaultTextStyle(
+                          duration: const Duration(milliseconds: 200),
+                          style: TextStyle(
+                            fontSize: selected ? 11 : 10,
+                            fontWeight: selected
+                                ? FontWeight.w600
+                                : FontWeight.w400,
+                            color: selected
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.onSurfaceVariant,
+                          ),
+                          child: Text(
+                            item.label,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            );
+          }),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/shell/shell_destinations.dart
+++ b/lib/app/shell/shell_destinations.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/app_localizations.dart';
+import 'shell_nav_item.dart';
+
+/// Index of the Consumption branch in the StatefulShellRoute (see
+/// `router.dart`). Public so the shell's "snap selection back to
+/// Search when the last vehicle is removed" branch can refer to the
+/// hidden tab by name rather than a naked `3`.
+const int kConsumptionBranchIndex = 3;
+
+/// Resolved nav destinations for the current shell render.
+///
+/// [items] is the list the bottom-bar / rail should iterate over.
+/// [branchForSlot] maps each visible slot back to its router-branch
+/// index — when Conso is hidden (#893), Settings still routes to
+/// branch 4 even though it sits at display-slot 3.
+class ShellDestinations {
+  final List<ShellNavItem> items;
+  final List<int> branchForSlot;
+
+  const ShellDestinations({
+    required this.items,
+    required this.branchForSlot,
+  });
+}
+
+/// Build the canonical 5-item nav list, then strip the Conso slot
+/// when no vehicle is configured. Pure function — no Flutter state,
+/// no Riverpod — the shell decides _when_ to call it (every build)
+/// and what `hasVehicle` evaluates to.
+ShellDestinations resolveShellDestinations({
+  required AppLocalizations? l10n,
+  required bool hasVehicle,
+}) {
+  // Kept in router-branch order so the index handed to
+  // `navigationShell.goBranch()` still lines up: Search=0, Map=1,
+  // Favorites=2, Consumption=3, Settings=4.
+  final allDestinations = <ShellNavItem>[
+    ShellNavItem(
+      Icons.search_outlined,
+      Icons.search,
+      l10n?.search ?? 'Search',
+    ),
+    ShellNavItem(Icons.map_outlined, Icons.map, l10n?.map ?? 'Map'),
+    ShellNavItem(
+      Icons.star_outline,
+      Icons.star,
+      l10n?.favorites ?? 'Favorites',
+    ),
+    ShellNavItem(
+      Icons.local_gas_station_outlined,
+      Icons.local_gas_station,
+      l10n?.navConsumption ?? 'Consumption',
+    ),
+    ShellNavItem(
+      Icons.settings_outlined,
+      Icons.settings,
+      l10n?.settings ?? 'Settings',
+    ),
+  ];
+
+  // Visible items + the router-branch index each one maps to. When
+  // Conso is hidden, Settings still routes to branch 4 even though
+  // it renders at display-slot 3.
+  final visibleDestinations = <ShellNavItem>[];
+  final branchForSlot = <int>[];
+  for (var i = 0; i < allDestinations.length; i++) {
+    if (i == kConsumptionBranchIndex && !hasVehicle) continue;
+    visibleDestinations.add(allDestinations[i]);
+    branchForSlot.add(i);
+  }
+  return ShellDestinations(
+    items: visibleDestinations,
+    branchForSlot: branchForSlot,
+  );
+}

--- a/lib/app/shell/shell_nav_item.dart
+++ b/lib/app/shell/shell_nav_item.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+/// A single bottom-nav / NavigationRail destination.
+///
+/// Holds the outlined + filled icon pair plus the user-facing label.
+/// Library-private to the `shell/` subtree — the parent [ShellScreen]
+/// builds the canonical 5-item list and passes the visible subset down
+/// to [ShellNavRail] / [ShellBottomBar].
+class ShellNavItem {
+  final IconData outlinedIcon;
+  final IconData filledIcon;
+  final String label;
+  const ShellNavItem(this.outlinedIcon, this.filledIcon, this.label);
+}
+
+/// A small icon that bounces (scale up → settle) when [controller]
+/// fires. Used by both the bottom nav and the NavigationRail so a tab
+/// switch animates identically in both layouts.
+///
+/// The [controller] is shared with the parent state so a single
+/// animation drives every place the icon is shown — keeping the
+/// state-of-truth at the shell level instead of forking it per nav
+/// surface.
+class ShellBounceIcon extends StatelessWidget {
+  final AnimationController controller;
+  final bool selected;
+  final IconData icon;
+  final double iconSize;
+  final Color color;
+
+  const ShellBounceIcon({
+    super.key,
+    required this.controller,
+    required this.selected,
+    required this.icon,
+    required this.iconSize,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scaleAnim = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 1.25)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 40,
+      ),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.25, end: 0.95)
+            .chain(CurveTween(curve: Curves.easeInOut)),
+        weight: 30,
+      ),
+      TweenSequenceItem(
+        tween: Tween(begin: 0.95, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 30,
+      ),
+    ]).animate(controller);
+
+    return AnimatedBuilder(
+      animation: scaleAnim,
+      builder: (context, child) {
+        return Transform.scale(
+          scale: scaleAnim.value,
+          child: child,
+        );
+      },
+      child: Icon(icon, size: iconSize, color: color),
+    );
+  }
+}

--- a/lib/app/shell/shell_nav_rail.dart
+++ b/lib/app/shell/shell_nav_rail.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+import 'shell_nav_item.dart';
+
+/// NavigationRail for medium and expanded screen sizes.
+///
+/// Shows labels and a wider rail on expanded screens (>= 840dp).
+/// Shows an icons-only rail on medium screens (600-840dp).
+///
+/// Companion to [ShellBottomBar] — both consume the same
+/// `(items, branchForSlot, currentIndex, iconControllers)` quad so the
+/// parent shell can flip surfaces on resize without re-deriving any
+/// state.
+class ShellNavRail extends StatelessWidget {
+  final List<ShellNavItem> items;
+
+  /// Router-branch index for each visible slot. Used to index into the
+  /// 5-wide [iconControllers] list when the Conso branch is hidden
+  /// (#893) — the controllers stay aligned with the router branches,
+  /// not the visible-slot positions.
+  final List<int> branchForSlot;
+  final int currentIndex;
+  final List<AnimationController> iconControllers;
+  final bool extended;
+  final ValueChanged<int> onTap;
+
+  const ShellNavRail({
+    super.key,
+    required this.items,
+    required this.branchForSlot,
+    required this.currentIndex,
+    required this.iconControllers,
+    required this.extended,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return NavigationRail(
+      selectedIndex: currentIndex,
+      onDestinationSelected: onTap,
+      extended: extended,
+      minWidth: 56,
+      minExtendedWidth: 180,
+      labelType: extended
+          ? NavigationRailLabelType.none
+          : NavigationRailLabelType.selected,
+      selectedIconTheme: IconThemeData(color: theme.colorScheme.primary),
+      unselectedIconTheme: IconThemeData(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+      destinations: List.generate(items.length, (i) {
+        final item = items[i];
+        final selected = i == currentIndex;
+        final controller = iconControllers[branchForSlot[i]];
+        return NavigationRailDestination(
+          icon: ShellBounceIcon(
+            controller: controller,
+            selected: false,
+            icon: item.outlinedIcon,
+            iconSize: 24,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          selectedIcon: ShellBounceIcon(
+            controller: controller,
+            selected: true,
+            icon: item.filledIcon,
+            iconSize: 24,
+            color: theme.colorScheme.primary,
+          ),
+          label: Text(item.label),
+          padding: EdgeInsets.symmetric(vertical: selected ? 4 : 0),
+        );
+      }),
+    );
+  }
+}

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -6,6 +6,9 @@ import '../features/vehicle/providers/vehicle_providers.dart';
 import '../l10n/app_localizations.dart';
 import 'current_shell_branch_provider.dart';
 import 'responsive_search_layout.dart';
+import 'shell/shell_bottom_bar.dart';
+import 'shell/shell_destinations.dart';
+import 'shell/shell_nav_rail.dart';
 
 /// The main app shell with adaptive navigation.
 ///
@@ -31,7 +34,8 @@ class ShellScreen extends ConsumerStatefulWidget {
   ConsumerState<ShellScreen> createState() => _ShellScreenState();
 }
 
-class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderStateMixin {
+class _ShellScreenState extends ConsumerState<ShellScreen>
+    with TickerProviderStateMixin {
   late final List<AnimationController> _iconControllers;
   late AnimationController _transitionController;
   late Animation<Offset> _slideInAnim;
@@ -87,7 +91,8 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
     _slideInAnim = Tween<Offset>(
       begin: Offset(0.3 * direction, 0),
       end: Offset.zero,
-    ).animate(CurvedAnimation(parent: _transitionController, curve: Curves.easeOutCubic));
+    ).animate(CurvedAnimation(
+        parent: _transitionController, curve: Curves.easeOutCubic));
     _fadeAnim = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(parent: _transitionController, curve: Curves.easeOut),
     );
@@ -164,7 +169,8 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
 
     final l10n = AppLocalizations.of(context);
     final screenSize = screenSizeOf(context);
-    final isLandscape = MediaQuery.of(context).orientation == Orientation.landscape;
+    final isLandscape =
+        MediaQuery.of(context).orientation == Orientation.landscape;
 
     // #893 — Conso tab is only visible once the user has configured at
     // least one vehicle. A fresh install (no vehicles) shows the 4
@@ -175,48 +181,22 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
     // reactive — removing the last vehicle from Settings instantly
     // collapses the tab to 4, and adding the first vehicle grows it
     // back to 5.
-    final hasVehicle =
-        ref.watch(vehicleProfileListProvider).isNotEmpty;
+    final hasVehicle = ref.watch(vehicleProfileListProvider).isNotEmpty;
 
-    // Kept in router-branch order so the index we hand to
-    // `navigationShell.goBranch()` still lines up: Search=0, Map=1,
-    // Favorites=2, Consumption=3, Settings=4.
-    final allDestinations = <_NavItem>[
-      _NavItem(Icons.search_outlined, Icons.search, l10n?.search ?? 'Search'),
-      _NavItem(Icons.map_outlined, Icons.map, l10n?.map ?? 'Map'),
-      _NavItem(Icons.star_outline, Icons.star, l10n?.favorites ?? 'Favorites'),
-      _NavItem(
-        Icons.local_gas_station_outlined,
-        Icons.local_gas_station,
-        l10n?.navConsumption ?? 'Consumption',
-      ),
-      _NavItem(
-        Icons.settings_outlined,
-        Icons.settings,
-        l10n?.settings ?? 'Settings',
-      ),
-    ];
-
-    // Visible items + the router-branch index each one maps to. When
-    // Conso is hidden, Settings still routes to branch 4 even though
-    // it renders at display-slot 3.
-    final visibleDestinations = <_NavItem>[];
-    final branchForSlot = <int>[];
-    for (var i = 0; i < allDestinations.length; i++) {
-      if (i == _consumptionBranchIndex && !hasVehicle) continue;
-      visibleDestinations.add(allDestinations[i]);
-      branchForSlot.add(i);
-    }
+    final destinations =
+        resolveShellDestinations(l10n: l10n, hasVehicle: hasVehicle);
+    final visibleDestinations = destinations.items;
+    final branchForSlot = destinations.branchForSlot;
     _branchForSlot = branchForSlot;
 
     // If the user was on the Conso tab and just deleted their last
     // vehicle, snap the selection to Search (branch 0) — the Conso
     // slot has disappeared from the nav bar and leaving
     // `_currentIndex` pointing at it would leave no item highlighted.
-    if (!hasVehicle && _currentIndex == _consumptionBranchIndex) {
+    if (!hasVehicle && _currentIndex == kConsumptionBranchIndex) {
       safePostFrame(() {
         if (!mounted) return;
-        if (_currentIndex != _consumptionBranchIndex) return;
+        if (_currentIndex != kConsumptionBranchIndex) return;
         _goToPage(0);
       });
     }
@@ -228,9 +208,8 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
 
     final body = GestureDetector(
       behavior: HitTestBehavior.translucent,
-      onHorizontalDragEnd: screenSize == ScreenSize.compact
-          ? _onHorizontalDragEnd
-          : null,
+      onHorizontalDragEnd:
+          screenSize == ScreenSize.compact ? _onHorizontalDragEnd : null,
       child: AnimatedBuilder(
         animation: _transitionController,
         builder: (context, _) {
@@ -268,7 +247,7 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
         primary: false,
         body: Row(
           children: [
-            _AdaptiveNavigationRail(
+            ShellNavRail(
               items: visibleDestinations,
               branchForSlot: branchForSlot,
               currentIndex: selectedSlot < 0 ? 0 : selectedSlot,
@@ -289,7 +268,7 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
       // applied to the compact Scaffold that hosts the bottom nav.
       primary: false,
       body: body,
-      bottomNavigationBar: _AnimatedNavBar(
+      bottomNavigationBar: ShellBottomBar(
         items: visibleDestinations,
         branchForSlot: branchForSlot,
         currentIndex: selectedSlot < 0 ? 0 : selectedSlot,
@@ -297,230 +276,6 @@ class _ShellScreenState extends ConsumerState<ShellScreen> with TickerProviderSt
         isLandscape: isLandscape,
         onTap: onSlotTap,
       ),
-    );
-  }
-
-  /// Index of the Consumption branch in the StatefulShellRoute (see
-  /// `router.dart`). Exposed as a constant so hiding/showing logic can
-  /// refer to it by name rather than a naked `3`.
-  static const int _consumptionBranchIndex = 3;
-}
-
-class _NavItem {
-  final IconData outlinedIcon;
-  final IconData filledIcon;
-  final String label;
-  const _NavItem(this.outlinedIcon, this.filledIcon, this.label);
-}
-
-/// NavigationRail for medium and expanded screen sizes.
-///
-/// Shows labels and wider rail on expanded screens (> 840dp).
-/// Shows icons-only rail on medium screens (600-840dp).
-class _AdaptiveNavigationRail extends StatelessWidget {
-  final List<_NavItem> items;
-  /// Router-branch index for each visible slot. Used to index into the
-  /// 5-wide `iconControllers` list when Conso is hidden (#893).
-  final List<int> branchForSlot;
-  final int currentIndex;
-  final List<AnimationController> iconControllers;
-  final bool extended;
-  final ValueChanged<int> onTap;
-
-  const _AdaptiveNavigationRail({
-    required this.items,
-    required this.branchForSlot,
-    required this.currentIndex,
-    required this.iconControllers,
-    required this.extended,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return NavigationRail(
-      selectedIndex: currentIndex,
-      onDestinationSelected: onTap,
-      extended: extended,
-      minWidth: 56,
-      minExtendedWidth: 180,
-      labelType: extended
-          ? NavigationRailLabelType.none
-          : NavigationRailLabelType.selected,
-      selectedIconTheme: IconThemeData(color: theme.colorScheme.primary),
-      unselectedIconTheme: IconThemeData(
-        color: theme.colorScheme.onSurfaceVariant,
-      ),
-      destinations: List.generate(items.length, (i) {
-        final item = items[i];
-        final selected = i == currentIndex;
-        final controller = iconControllers[branchForSlot[i]];
-        return NavigationRailDestination(
-          icon: _BounceIcon(
-            controller: controller,
-            selected: false,
-            icon: item.outlinedIcon,
-            iconSize: 24,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          selectedIcon: _BounceIcon(
-            controller: controller,
-            selected: true,
-            icon: item.filledIcon,
-            iconSize: 24,
-            color: theme.colorScheme.primary,
-          ),
-          label: Text(item.label),
-          padding: EdgeInsets.symmetric(vertical: selected ? 4 : 0),
-        );
-      }),
-    );
-  }
-}
-
-class _AnimatedNavBar extends StatelessWidget {
-  final List<_NavItem> items;
-  /// Router-branch index for each visible slot (see rail comment, #893).
-  final List<int> branchForSlot;
-  final int currentIndex;
-  final List<AnimationController> iconControllers;
-  final bool isLandscape;
-  final ValueChanged<int> onTap;
-
-  const _AnimatedNavBar({
-    required this.items,
-    required this.branchForSlot,
-    required this.currentIndex,
-    required this.iconControllers,
-    required this.isLandscape,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final iconSize = isLandscape ? 20.0 : 24.0;
-    // #528 — wrap the bar in `SafeArea(top: false)` rather than
-    // reading `MediaQuery.viewPadding.bottom` manually. SafeArea
-    // *consumes* the inset, so no ancestor or descendant can
-    // accidentally apply it a second time. Fixes the visible band
-    // of empty space between the bottom nav and the Android gesture
-    // bar on edge-to-edge devices (same class of bug as #520).
-    final barHeight = isLandscape ? 48.0 : 64.0;
-
-    return SafeArea(
-      top: false,
-      child: Container(
-      height: barHeight,
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest,
-        boxShadow: [
-          BoxShadow(
-            color: Theme.of(context).brightness == Brightness.dark
-                ? Colors.black.withValues(alpha: 0.3)
-                : Colors.black.withValues(alpha: 0.08),
-            blurRadius: 8,
-            offset: const Offset(0, -2),
-          ),
-        ],
-      ),
-      child: Row(
-        children: List.generate(items.length, (i) {
-          final selected = i == currentIndex;
-          final item = items[i];
-          final controller = iconControllers[branchForSlot[i]];
-
-          return Expanded(
-            child: Semantics(
-              label: item.label,
-              button: true,
-              selected: selected,
-              excludeSemantics: true,
-              child: InkWell(
-              onTap: () => onTap(i),
-              splashColor: theme.colorScheme.primary.withValues(alpha: 0.1),
-              highlightColor: Colors.transparent,
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  _BounceIcon(
-                    controller: controller,
-                    selected: selected,
-                    icon: selected ? item.filledIcon : item.outlinedIcon,
-                    iconSize: iconSize,
-                    color: selected
-                        ? theme.colorScheme.primary
-                        : theme.colorScheme.onSurfaceVariant,
-                  ),
-                  if (!isLandscape) ...[
-                    const SizedBox(height: 2),
-                    AnimatedDefaultTextStyle(
-                      duration: const Duration(milliseconds: 200),
-                      style: TextStyle(
-                        fontSize: selected ? 11 : 10,
-                        fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
-                        color: selected
-                            ? theme.colorScheme.primary
-                            : theme.colorScheme.onSurfaceVariant,
-                      ),
-                      child: Text(item.label, maxLines: 1, overflow: TextOverflow.ellipsis),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-            ),
-          );
-        }),
-      ),
-      ),
-    );
-  }
-}
-
-class _BounceIcon extends StatelessWidget {
-  final AnimationController controller;
-  final bool selected;
-  final IconData icon;
-  final double iconSize;
-  final Color color;
-
-  const _BounceIcon({
-    required this.controller,
-    required this.selected,
-    required this.icon,
-    required this.iconSize,
-    required this.color,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final scaleAnim = TweenSequence<double>([
-      TweenSequenceItem(
-        tween: Tween(begin: 1.0, end: 1.25).chain(CurveTween(curve: Curves.easeOut)),
-        weight: 40,
-      ),
-      TweenSequenceItem(
-        tween: Tween(begin: 1.25, end: 0.95).chain(CurveTween(curve: Curves.easeInOut)),
-        weight: 30,
-      ),
-      TweenSequenceItem(
-        tween: Tween(begin: 0.95, end: 1.0).chain(CurveTween(curve: Curves.easeOut)),
-        weight: 30,
-      ),
-    ]).animate(controller);
-
-    return AnimatedBuilder(
-      animation: scaleAnim,
-      builder: (context, child) {
-        return Transform.scale(
-          scale: scaleAnim.value,
-          child: child,
-        );
-      },
-      child: Icon(icon, size: iconSize, color: color),
     );
   }
 }

--- a/test/app/shell/shell_destinations_test.dart
+++ b/test/app/shell/shell_destinations_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/shell/shell_destinations.dart';
+
+/// Pure-function tests for the destination-resolution helper extracted
+/// from `shell_screen.dart` during the #563 refactor. Verifies that:
+/// - The 5-item canonical order (Search, Map, Favorites, Conso,
+///   Settings) is preserved when a vehicle is configured.
+/// - The Conso slot is dropped (not stubbed, not reordered) when no
+///   vehicle is configured (#893) — and the remaining slots still map
+///   to their original router-branch indices so Settings still routes
+///   to branch 4.
+void main() {
+  group('resolveShellDestinations', () {
+    test('returns 5 destinations and identity slot mapping when vehicle '
+        'is configured', () {
+      final result =
+          resolveShellDestinations(l10n: null, hasVehicle: true);
+
+      expect(result.items, hasLength(5));
+      expect(result.branchForSlot, [0, 1, 2, 3, 4]);
+
+      // The Conso item carries the fuel-station icon — sanity-check
+      // ordering hasn't drifted.
+      expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
+      expect(result.items[3].filledIcon, Icons.local_gas_station);
+    });
+
+    test('drops the Conso slot when no vehicle is configured (#893)', () {
+      final result =
+          resolveShellDestinations(l10n: null, hasVehicle: false);
+
+      expect(result.items, hasLength(4));
+      // The Conso slot (router-branch 3) is gone, but branchForSlot
+      // still preserves the original branch indices so Settings (now
+      // at display-slot 3) routes to branch 4.
+      expect(result.branchForSlot, [0, 1, 2, 4]);
+
+      // No fuel-station icon should appear in the visible items list.
+      for (final item in result.items) {
+        expect(item.outlinedIcon, isNot(Icons.local_gas_station_outlined));
+        expect(item.filledIcon, isNot(Icons.local_gas_station));
+      }
+    });
+
+    test('falls back to English labels when l10n is null', () {
+      final result =
+          resolveShellDestinations(l10n: null, hasVehicle: true);
+
+      expect(result.items.map((i) => i.label).toList(), [
+        'Search',
+        'Map',
+        'Favorites',
+        'Consumption',
+        'Settings',
+      ]);
+    });
+
+    test('Settings always sits at the rightmost visible slot', () {
+      final withConso =
+          resolveShellDestinations(l10n: null, hasVehicle: true);
+      final withoutConso =
+          resolveShellDestinations(l10n: null, hasVehicle: false);
+
+      expect(withConso.items.last.label, 'Settings');
+      expect(withoutConso.items.last.label, 'Settings');
+    });
+
+    test('kConsumptionBranchIndex matches the position of the Conso '
+        'router branch in the canonical destination list', () {
+      // If router.dart ever reorders branches, this test fires before
+      // the gating logic silently goes wrong.
+      final result =
+          resolveShellDestinations(l10n: null, hasVehicle: true);
+      expect(
+        result.items[kConsumptionBranchIndex].outlinedIcon,
+        Icons.local_gas_station_outlined,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`lib/app/shell_screen.dart` was 526 LOC — well over the 300 LOC ceiling tracked by #563. This phase extracts the two presentation surfaces (NavigationRail, bottom bar) and the canonical destination-resolution helper into a sibling `lib/app/shell/` package, leaving the parent file responsible only for animation + navigation orchestration.

## Before / after

| File                                   | Before | After |
| -------------------------------------- | -----: | ----: |
| `lib/app/shell_screen.dart`            |    526 |   281 |
| `lib/app/shell/shell_bottom_bar.dart`  |      — |   118 |
| `lib/app/shell/shell_destinations.dart`|      — |    77 |
| `lib/app/shell/shell_nav_item.dart`    |      — |    71 |
| `lib/app/shell/shell_nav_rail.dart`    |      — |    79 |

Every file is ≤ 300 LOC.

## Extracted children

- **`shell_nav_item.dart`** — `ShellNavItem` data class + `ShellBounceIcon` widget. Both nav surfaces consume the same primitives, so the icon-bounce animation lives next to the data it animates.
- **`shell_nav_rail.dart`** — `ShellNavRail` (was `_AdaptiveNavigationRail`). Owns the medium/expanded layout.
- **`shell_bottom_bar.dart`** — `ShellBottomBar` (was `_AnimatedNavBar`). Owns the compact layout, including the #528 SafeArea fix.
- **`shell_destinations.dart`** — pure `resolveShellDestinations({l10n, hasVehicle})` function returning `(items, branchForSlot)` pair, plus `kConsumptionBranchIndex` constant. This is the #893 vehicle-gating rule, now covered by direct unit tests.

## Behavior unchanged

- **#893 (Conso vehicle gating)** — same `if (i == kConsumptionBranchIndex && !hasVehicle) continue` rule, same snap-to-Search post-frame side-effect when the last vehicle is removed.
- **#595 (Hero preservation)** — `StatefulNavigationShell.goBranch()` is still the only routing primitive used; nothing about the indexedStack / Hero handoff changed.
- **#520 / #528 (system inset bugs)** — `primary: false` and `SafeArea(top: false)` both preserved, with their explanatory comments.
- **#709 (initial-frame branch-publish)** — preserved in `initState`.

## Tests

- Added `test/app/shell/shell_destinations_test.dart` — 5 unit tests covering the pure resolver: 5-tab default, 4-tab gated layout, identity vs gapped `branchForSlot` mapping, Settings-rightmost invariant, and a guard that fires if `kConsumptionBranchIndex` ever drifts out of sync with the canonical destination list.
- All 4 existing shell tests still pass against the extracted code:
  - `test/app/shell_screen_test.dart`
  - `test/app/shell_screen_responsive_test.dart`
  - `test/app/shell_consumption_tab_test.dart`
  - `test/app/shell_nav_vehicle_gating_test.dart`

## Verification
- `flutter analyze` — `No issues found!` (plain, no `--no-fatal-infos`)
- `flutter test test/app/shell/... test/app/shell_*` — 26/26 passing

## Scope

This PR is one phase of the #563 epic — the epic remains open until all 12 oversized files are addressed. Refs #563 (not Closes).

## Test plan
- [ ] CI passes on `flutter analyze` + `flutter test`
- [ ] No visual / behavior change on the bottom nav (compact)
- [ ] No visual / behavior change on the NavigationRail (tablet / desktop)
- [ ] Vehicle-gated 4-tab → 5-tab transition still snaps correctly when the user adds / removes their last vehicle (#893)