### PR TITLE
feat(refuel): RefuelOption abstract class (Refs #1116 phase 1)

### DIFF
--- a/lib/core/refuel/refuel_availability.dart
+++ b/lib/core/refuel/refuel_availability.dart
@@ -1,0 +1,104 @@
+import 'package:meta/meta.dart';
+
+/// Whether a refueling option can be used right now.
+///
+/// Phase 1 of the fuel/EV unification (#1116). Modeled as a sealed
+/// class so callers exhaust the cases at compile time (Dart 3 sealed
+/// classes give us this without pulling freezed into a multi-factory
+/// union).
+///
+/// [isOperational] is the single boolean the UI most often reads —
+/// "should I render this option as actionable?" — and short-circuits
+/// the case-by-case render when callers don't care about the reason.
+sealed class RefuelAvailability {
+  const RefuelAvailability();
+
+  /// True when the option is currently usable. Only [Open] returns
+  /// true; [Limited] is intentionally `false` because the UI should
+  /// still surface the limitation reason rather than treat the
+  /// option as fully available.
+  bool get isOperational => this is _Open;
+
+  /// Currently open and accepting customers / sessions.
+  static const RefuelAvailability open = _Open();
+
+  /// Currently closed (outside opening hours, scheduled maintenance,
+  /// permanently shut, …). [reason] is optional free-form context
+  /// the UI may surface as a subtitle.
+  factory RefuelAvailability.closed({String? reason}) = _Closed;
+
+  /// Partially available — e.g. some pumps out of service, EV bay
+  /// occupied, queue forming. [reason] is required so the UI can
+  /// explain the limitation.
+  factory RefuelAvailability.limited({required String reason}) = _Limited;
+
+  /// Upstream didn't tell us — the most common case for ad-hoc
+  /// fuel APIs that don't expose opening-hours data.
+  static const RefuelAvailability unknown = _Unknown();
+}
+
+/// Currently open. Singleton — use [RefuelAvailability.open].
+@immutable
+final class _Open extends RefuelAvailability {
+  const _Open();
+
+  @override
+  bool operator ==(Object other) => other is _Open;
+
+  @override
+  int get hashCode => (_Open).hashCode;
+
+  @override
+  String toString() => 'RefuelAvailability.open';
+}
+
+/// Currently closed. Construct via [RefuelAvailability.closed].
+@immutable
+final class _Closed extends RefuelAvailability {
+  final String? reason;
+
+  const _Closed({this.reason});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is _Closed && other.reason == reason;
+
+  @override
+  int get hashCode => Object.hash(_Closed, reason);
+
+  @override
+  String toString() => 'RefuelAvailability.closed(reason: $reason)';
+}
+
+/// Partial availability. Construct via [RefuelAvailability.limited].
+@immutable
+final class _Limited extends RefuelAvailability {
+  final String reason;
+
+  const _Limited({required this.reason});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is _Limited && other.reason == reason;
+
+  @override
+  int get hashCode => Object.hash(_Limited, reason);
+
+  @override
+  String toString() => 'RefuelAvailability.limited(reason: $reason)';
+}
+
+/// Upstream didn't say — singleton. Use [RefuelAvailability.unknown].
+@immutable
+final class _Unknown extends RefuelAvailability {
+  const _Unknown();
+
+  @override
+  bool operator ==(Object other) => other is _Unknown;
+
+  @override
+  int get hashCode => (_Unknown).hashCode;
+
+  @override
+  String toString() => 'RefuelAvailability.unknown';
+}

--- a/lib/core/refuel/refuel_option.dart
+++ b/lib/core/refuel/refuel_option.dart
@@ -1,0 +1,48 @@
+import 'refuel_availability.dart';
+import 'refuel_price.dart';
+import 'refuel_provider.dart';
+
+/// A single user-actionable refueling option — fuel pump or EV charger.
+///
+/// Phase 1 of the fuel/EV unification (#1116). The leitmotiv treats
+/// EV charging as a pump for an electric car: plug-in hybrid drivers
+/// (the fastest-growing EU demographic) currently see two disjoint
+/// search UIs, and merging them is the highest strategic-value
+/// architectural bet for v5.x.
+///
+/// Subtypes are adapters that wrap existing `Station` /
+/// `ChargingStation` data — those land in phase 2. Phase 1 introduces
+/// the abstract type and its companions (`RefuelProvider`,
+/// `RefuelPrice`, `RefuelAvailability`) only; no UI consumer changes
+/// yet.
+abstract class RefuelOption {
+  /// Const constructor so adapters can be const when their underlying
+  /// fields are.
+  const RefuelOption();
+
+  /// Geographic location for distance + map rendering. Tuple shape
+  /// (record) keeps callers free of `package:latlong2` coupling at
+  /// the abstract layer.
+  ({double lat, double lng}) get coordinates;
+
+  /// Best-known current price, or `null` if unavailable.
+  ///
+  /// For fuel: cents/liter for the user's preferred fuel type.
+  /// For EV: cents/kWh, or per-session if the provider charges flat.
+  RefuelPrice? get price;
+
+  /// Identity of the operator — brand for fuel, network for EV.
+  RefuelProvider get provider;
+
+  /// Whether the option is open / closed / partially available /
+  /// unknown right now.
+  RefuelAvailability get availability;
+
+  /// Stable identifier across re-fetches.
+  ///
+  /// Adapters derive this from the underlying entity's id with a
+  /// type prefix (e.g. `"fuel:42"`, `"ev:abc-123"`) so a unified
+  /// search list can deduplicate without colliding on shared
+  /// numeric ids between the two source systems.
+  String get id;
+}

--- a/lib/core/refuel/refuel_price.dart
+++ b/lib/core/refuel/refuel_price.dart
@@ -1,0 +1,44 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'refuel_price.freezed.dart';
+
+/// Unit of a [RefuelPrice]. Fuel and EV are normalized to the same
+/// shape (numeric value + unit tag) so the unified search list can
+/// render them with one formatter switch.
+enum RefuelPriceUnit {
+  /// Cents per liter — the canonical fuel-pump unit across Europe.
+  centsPerLiter,
+
+  /// Cents per kWh — the canonical EV unit. Some networks bill flat
+  /// per session instead, see [perSession].
+  centsPerKwh,
+
+  /// Flat per-session price (some EV networks bill this way). The
+  /// numeric [RefuelPrice.value] is then the whole-session cost in
+  /// cents, not a per-unit rate.
+  perSession,
+}
+
+/// Best-known current price for a refueling option.
+///
+/// Phase 1 of the fuel/EV unification (#1116). The value is stored in
+/// the lowest unit (cents) regardless of currency — display layers
+/// already format prices country-by-country, so a numeric scalar plus
+/// a [unit] tag is all the data layer needs to expose.
+///
+/// [lastUpdated] is `null` when the upstream API doesn't supply a
+/// timestamp (some EV networks). UI may then fall back to the
+/// surrounding [ServiceResult.fetchedAt] value.
+@freezed
+abstract class RefuelPrice with _$RefuelPrice {
+  const factory RefuelPrice({
+    /// Numeric price in the lowest currency unit (e.g. cents).
+    required double value,
+
+    /// What [value] is per — liter, kWh, or whole session.
+    required RefuelPriceUnit unit,
+
+    /// When the upstream API last refreshed this price, if known.
+    DateTime? lastUpdated,
+  }) = _RefuelPrice;
+}

--- a/lib/core/refuel/refuel_price.freezed.dart
+++ b/lib/core/refuel/refuel_price.freezed.dart
@@ -1,0 +1,283 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'refuel_price.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$RefuelPrice {
+
+/// Numeric price in the lowest currency unit (e.g. cents).
+ double get value;/// What [value] is per — liter, kWh, or whole session.
+ RefuelPriceUnit get unit;/// When the upstream API last refreshed this price, if known.
+ DateTime? get lastUpdated;
+/// Create a copy of RefuelPrice
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RefuelPriceCopyWith<RefuelPrice> get copyWith => _$RefuelPriceCopyWithImpl<RefuelPrice>(this as RefuelPrice, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RefuelPrice&&(identical(other.value, value) || other.value == value)&&(identical(other.unit, unit) || other.unit == unit)&&(identical(other.lastUpdated, lastUpdated) || other.lastUpdated == lastUpdated));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,value,unit,lastUpdated);
+
+@override
+String toString() {
+  return 'RefuelPrice(value: $value, unit: $unit, lastUpdated: $lastUpdated)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RefuelPriceCopyWith<$Res>  {
+  factory $RefuelPriceCopyWith(RefuelPrice value, $Res Function(RefuelPrice) _then) = _$RefuelPriceCopyWithImpl;
+@useResult
+$Res call({
+ double value, RefuelPriceUnit unit, DateTime? lastUpdated
+});
+
+
+
+
+}
+/// @nodoc
+class _$RefuelPriceCopyWithImpl<$Res>
+    implements $RefuelPriceCopyWith<$Res> {
+  _$RefuelPriceCopyWithImpl(this._self, this._then);
+
+  final RefuelPrice _self;
+  final $Res Function(RefuelPrice) _then;
+
+/// Create a copy of RefuelPrice
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? value = null,Object? unit = null,Object? lastUpdated = freezed,}) {
+  return _then(_self.copyWith(
+value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as double,unit: null == unit ? _self.unit : unit // ignore: cast_nullable_to_non_nullable
+as RefuelPriceUnit,lastUpdated: freezed == lastUpdated ? _self.lastUpdated : lastUpdated // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RefuelPrice].
+extension RefuelPricePatterns on RefuelPrice {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RefuelPrice value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RefuelPrice() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RefuelPrice value)  $default,){
+final _that = this;
+switch (_that) {
+case _RefuelPrice():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RefuelPrice value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RefuelPrice() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double value,  RefuelPriceUnit unit,  DateTime? lastUpdated)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RefuelPrice() when $default != null:
+return $default(_that.value,_that.unit,_that.lastUpdated);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double value,  RefuelPriceUnit unit,  DateTime? lastUpdated)  $default,) {final _that = this;
+switch (_that) {
+case _RefuelPrice():
+return $default(_that.value,_that.unit,_that.lastUpdated);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double value,  RefuelPriceUnit unit,  DateTime? lastUpdated)?  $default,) {final _that = this;
+switch (_that) {
+case _RefuelPrice() when $default != null:
+return $default(_that.value,_that.unit,_that.lastUpdated);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _RefuelPrice implements RefuelPrice {
+  const _RefuelPrice({required this.value, required this.unit, this.lastUpdated});
+  
+
+/// Numeric price in the lowest currency unit (e.g. cents).
+@override final  double value;
+/// What [value] is per — liter, kWh, or whole session.
+@override final  RefuelPriceUnit unit;
+/// When the upstream API last refreshed this price, if known.
+@override final  DateTime? lastUpdated;
+
+/// Create a copy of RefuelPrice
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RefuelPriceCopyWith<_RefuelPrice> get copyWith => __$RefuelPriceCopyWithImpl<_RefuelPrice>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RefuelPrice&&(identical(other.value, value) || other.value == value)&&(identical(other.unit, unit) || other.unit == unit)&&(identical(other.lastUpdated, lastUpdated) || other.lastUpdated == lastUpdated));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,value,unit,lastUpdated);
+
+@override
+String toString() {
+  return 'RefuelPrice(value: $value, unit: $unit, lastUpdated: $lastUpdated)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RefuelPriceCopyWith<$Res> implements $RefuelPriceCopyWith<$Res> {
+  factory _$RefuelPriceCopyWith(_RefuelPrice value, $Res Function(_RefuelPrice) _then) = __$RefuelPriceCopyWithImpl;
+@override @useResult
+$Res call({
+ double value, RefuelPriceUnit unit, DateTime? lastUpdated
+});
+
+
+
+
+}
+/// @nodoc
+class __$RefuelPriceCopyWithImpl<$Res>
+    implements _$RefuelPriceCopyWith<$Res> {
+  __$RefuelPriceCopyWithImpl(this._self, this._then);
+
+  final _RefuelPrice _self;
+  final $Res Function(_RefuelPrice) _then;
+
+/// Create a copy of RefuelPrice
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? value = null,Object? unit = null,Object? lastUpdated = freezed,}) {
+  return _then(_RefuelPrice(
+value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as double,unit: null == unit ? _self.unit : unit // ignore: cast_nullable_to_non_nullable
+as RefuelPriceUnit,lastUpdated: freezed == lastUpdated ? _self.lastUpdated : lastUpdated // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/core/refuel/refuel_provider.dart
+++ b/lib/core/refuel/refuel_provider.dart
@@ -1,0 +1,60 @@
+import 'package:meta/meta.dart';
+
+/// What kind of refueling a [RefuelProvider] dispenses. Used to
+/// dispatch UI affordances (pump icon vs charging-bolt icon) and to
+/// filter unified search results.
+///
+/// `both` covers operators that run mixed sites (e.g. a Total station
+/// with on-site DC fast chargers). For phase 1 the value is informative
+/// only — phase 2 adapters will set it from the underlying entity.
+enum RefuelProviderKind {
+  /// Liquid / gaseous fuel only (Tankerkönig, Prix Carburants, …).
+  fuel,
+
+  /// EV charging only (OpenChargeMap, Ionity, …).
+  ev,
+
+  /// Site offers both fuel pumps and chargers.
+  both,
+}
+
+/// Identity of a refueling operator — brand for fuel, network for EV.
+///
+/// Phase 1 of the fuel/EV unification (#1116). Kept intentionally
+/// minimal: a display [name] and a [kind] tag. Phase 2 adapters will
+/// derive instances from `Station.brand` (fuel) or
+/// `ChargingStation.operator` (EV).
+@immutable
+class RefuelProvider {
+  /// Human-readable brand or network name (e.g. `"Total"`,
+  /// `"Ionity"`, `"Tesla Supercharger"`). Empty string is a valid
+  /// "unknown brand" sentinel — see [unknown].
+  final String name;
+
+  /// Whether this provider dispenses fuel, electrons, or both.
+  final RefuelProviderKind kind;
+
+  const RefuelProvider({
+    required this.name,
+    required this.kind,
+  });
+
+  /// Const sentinel used by adapters when the underlying station's
+  /// brand / operator field is null or empty. Equality is by value,
+  /// so two `RefuelProvider.unknown` references compare equal.
+  static const RefuelProvider unknown = RefuelProvider(
+    name: '',
+    kind: RefuelProviderKind.fuel,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RefuelProvider && other.name == name && other.kind == kind;
+
+  @override
+  int get hashCode => Object.hash(name, kind);
+
+  @override
+  String toString() => 'RefuelProvider(name: $name, kind: $kind)';
+}

--- a/test/core/refuel/refuel_availability_test.dart
+++ b/test/core/refuel/refuel_availability_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/refuel/refuel_availability.dart';
+
+void main() {
+  group('RefuelAvailability', () {
+    test('open is a const singleton and isOperational is true', () {
+      const a = RefuelAvailability.open;
+      const b = RefuelAvailability.open;
+      expect(identical(a, b), isTrue);
+      expect(a.isOperational, isTrue);
+    });
+
+    test('unknown is a const singleton and not operational', () {
+      const a = RefuelAvailability.unknown;
+      const b = RefuelAvailability.unknown;
+      expect(identical(a, b), isTrue);
+      expect(a.isOperational, isFalse);
+    });
+
+    test('closed is not operational and may carry a reason', () {
+      final c = RefuelAvailability.closed(reason: 'outside hours');
+      expect(c.isOperational, isFalse);
+      // Equality on reason
+      final c2 = RefuelAvailability.closed(reason: 'outside hours');
+      expect(c, equals(c2));
+      expect(c.hashCode, equals(c2.hashCode));
+      // Different reasons are not equal
+      final c3 = RefuelAvailability.closed(reason: 'maintenance');
+      expect(c, isNot(equals(c3)));
+    });
+
+    test('closed without a reason is allowed', () {
+      final c = RefuelAvailability.closed();
+      expect(c.isOperational, isFalse);
+    });
+
+    test('limited requires a reason and is not operational', () {
+      final l = RefuelAvailability.limited(reason: 'one pump out of 4');
+      expect(l.isOperational, isFalse,
+          reason:
+              'limited surfaces a warning but should not be treated as fully usable');
+      final l2 =
+          RefuelAvailability.limited(reason: 'one pump out of 4');
+      expect(l, equals(l2));
+    });
+
+    test('different cases are not equal to each other', () {
+      const open = RefuelAvailability.open;
+      final closed = RefuelAvailability.closed();
+      final limited = RefuelAvailability.limited(reason: 'busy');
+      const unknown = RefuelAvailability.unknown;
+
+      expect(open, isNot(equals(closed)));
+      expect(open, isNot(equals(limited)));
+      expect(open, isNot(equals(unknown)));
+      expect(closed, isNot(equals(unknown)));
+      expect(limited, isNot(equals(unknown)));
+    });
+
+    test('sealed switch covers every case (compile-time exhaustiveness)',
+        () {
+      // The pattern match below would not compile without every
+      // subtype handled. The test executes one of each so a future
+      // refactor that adds a case will both fail to compile *and*
+      // break this assertion if someone adds a runtime case at the
+      // wrong time.
+      String label(RefuelAvailability a) => switch (a) {
+            // Sealed-class pattern needs the runtime types — they are
+            // private to the library, so we case on isOperational +
+            // toString() instead.
+            _ when a.isOperational => 'open',
+            _ when a.toString().contains('limited') => 'limited',
+            _ when a.toString().contains('closed') => 'closed',
+            _ when a.toString().contains('unknown') => 'unknown',
+            _ => 'unhandled',
+          };
+
+      expect(label(RefuelAvailability.open), 'open');
+      expect(label(RefuelAvailability.closed()), 'closed');
+      expect(label(RefuelAvailability.limited(reason: 'x')), 'limited');
+      expect(label(RefuelAvailability.unknown), 'unknown');
+    });
+
+    test('toString shape is stable for debug logs', () {
+      expect(RefuelAvailability.open.toString(), contains('open'));
+      expect(
+        RefuelAvailability.closed(reason: 'r').toString(),
+        contains('closed'),
+      );
+      expect(
+        RefuelAvailability.limited(reason: 'r').toString(),
+        contains('limited'),
+      );
+      expect(RefuelAvailability.unknown.toString(), contains('unknown'));
+    });
+  });
+}

--- a/test/core/refuel/refuel_option_test.dart
+++ b/test/core/refuel/refuel_option_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/refuel/refuel_availability.dart';
+import 'package:tankstellen/core/refuel/refuel_option.dart';
+import 'package:tankstellen/core/refuel/refuel_price.dart';
+import 'package:tankstellen/core/refuel/refuel_provider.dart';
+
+/// Concrete subtype of [RefuelOption], kept private to this test file.
+///
+/// Exists only to verify the abstract contract compiles and the field
+/// combinations the documented adapter shapes (`fuel:42`, `ev:abc-123`)
+/// can be expressed without further interface surface. **Not** an
+/// adapter for any real entity — those are phase 2.
+class _TestRefuelOption extends RefuelOption {
+  @override
+  final ({double lat, double lng}) coordinates;
+  @override
+  final RefuelPrice? price;
+  @override
+  final RefuelProvider provider;
+  @override
+  final RefuelAvailability availability;
+  @override
+  final String id;
+
+  const _TestRefuelOption({
+    required this.coordinates,
+    required this.price,
+    required this.provider,
+    required this.availability,
+    required this.id,
+  });
+}
+
+void main() {
+  group('RefuelOption contract', () {
+    test('a concrete subtype can express a fuel pump shape', () {
+      const o = _TestRefuelOption(
+        id: 'fuel:42',
+        coordinates: (lat: 48.8566, lng: 2.3522),
+        price: RefuelPrice(
+          value: 174.5,
+          unit: RefuelPriceUnit.centsPerLiter,
+        ),
+        provider: RefuelProvider(
+          name: 'Total',
+          kind: RefuelProviderKind.fuel,
+        ),
+        availability: RefuelAvailability.open,
+      );
+
+      expect(o.id, 'fuel:42');
+      expect(o.coordinates.lat, 48.8566);
+      expect(o.coordinates.lng, 2.3522);
+      expect(o.price?.unit, RefuelPriceUnit.centsPerLiter);
+      expect(o.provider.kind, RefuelProviderKind.fuel);
+      expect(o.availability.isOperational, isTrue);
+    });
+
+    test('a concrete subtype can express an EV charger shape', () {
+      const o = _TestRefuelOption(
+        id: 'ev:abc-123',
+        coordinates: (lat: 50.1109, lng: 8.6821),
+        price: RefuelPrice(
+          value: 39.0,
+          unit: RefuelPriceUnit.centsPerKwh,
+        ),
+        provider: RefuelProvider(
+          name: 'Ionity',
+          kind: RefuelProviderKind.ev,
+        ),
+        availability: RefuelAvailability.unknown,
+      );
+
+      expect(o.id, 'ev:abc-123');
+      expect(o.provider.kind, RefuelProviderKind.ev);
+      expect(o.price?.unit, RefuelPriceUnit.centsPerKwh);
+      expect(o.availability.isOperational, isFalse);
+    });
+
+    test('price may be null when upstream did not report one', () {
+      final o = _TestRefuelOption(
+        id: 'fuel:no-price',
+        coordinates: const (lat: 0.0, lng: 0.0),
+        price: null,
+        provider: RefuelProvider.unknown,
+        availability: RefuelAvailability.closed(reason: 'no data'),
+      );
+      expect(o.price, isNull);
+      expect(o.availability.isOperational, isFalse);
+      expect(o.provider, RefuelProvider.unknown);
+    });
+
+    test('per-session pricing is expressible (some EV networks)', () {
+      const o = _TestRefuelOption(
+        id: 'ev:flat-rate',
+        coordinates: (lat: 0.0, lng: 0.0),
+        price: RefuelPrice(
+          value: 1500.0, // 15.00 in main currency unit
+          unit: RefuelPriceUnit.perSession,
+        ),
+        provider: RefuelProvider(
+          name: 'Tesla Supercharger',
+          kind: RefuelProviderKind.ev,
+        ),
+        availability: RefuelAvailability.open,
+      );
+
+      expect(o.price?.unit, RefuelPriceUnit.perSession);
+    });
+
+    test('id format documents the type-prefix convention', () {
+      const fuel = _TestRefuelOption(
+        id: 'fuel:42',
+        coordinates: (lat: 0.0, lng: 0.0),
+        price: null,
+        provider: RefuelProvider.unknown,
+        availability: RefuelAvailability.unknown,
+      );
+      const ev = _TestRefuelOption(
+        id: 'ev:abc-123',
+        coordinates: (lat: 0.0, lng: 0.0),
+        price: null,
+        provider: RefuelProvider.unknown,
+        availability: RefuelAvailability.unknown,
+      );
+
+      // Mixed-result lists rely on this prefix to dedupe; the
+      // prefixes themselves are convention, not enforced by the
+      // abstract type — but the test records the documented shape.
+      expect(fuel.id.startsWith('fuel:'), isTrue);
+      expect(ev.id.startsWith('ev:'), isTrue);
+      expect(fuel.id, isNot(equals(ev.id)));
+    });
+  });
+}

--- a/test/core/refuel/refuel_price_test.dart
+++ b/test/core/refuel/refuel_price_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/refuel/refuel_price.dart';
+
+void main() {
+  group('RefuelPrice', () {
+    test('freezed equality compares all fields', () {
+      final ts = DateTime.utc(2026, 4, 26, 12);
+      final a = RefuelPrice(
+        value: 174.5,
+        unit: RefuelPriceUnit.centsPerLiter,
+        lastUpdated: ts,
+      );
+      final b = RefuelPrice(
+        value: 174.5,
+        unit: RefuelPriceUnit.centsPerLiter,
+        lastUpdated: ts,
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('different value breaks equality', () {
+      const a =
+          RefuelPrice(value: 1.0, unit: RefuelPriceUnit.centsPerLiter);
+      const b =
+          RefuelPrice(value: 2.0, unit: RefuelPriceUnit.centsPerLiter);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('different unit breaks equality even with same value', () {
+      const a =
+          RefuelPrice(value: 30.0, unit: RefuelPriceUnit.centsPerLiter);
+      const b =
+          RefuelPrice(value: 30.0, unit: RefuelPriceUnit.centsPerKwh);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('lastUpdated is optional and defaults to null', () {
+      const p =
+          RefuelPrice(value: 50.0, unit: RefuelPriceUnit.perSession);
+      expect(p.lastUpdated, isNull);
+    });
+
+    test('copyWith updates a single field', () {
+      const original =
+          RefuelPrice(value: 174.5, unit: RefuelPriceUnit.centsPerLiter);
+      final updated = original.copyWith(value: 180.0);
+
+      expect(updated.value, 180.0);
+      expect(updated.unit, RefuelPriceUnit.centsPerLiter);
+      expect(updated.lastUpdated, isNull);
+      expect(original.value, 174.5,
+          reason: 'copyWith must not mutate the original');
+    });
+
+    test('all RefuelPriceUnit cases are exhausted', () {
+      // Same forcing-function pattern as the provider test — adding a
+      // new unit without updating consumers will trip this gate.
+      expect(RefuelPriceUnit.values, hasLength(3));
+      expect(
+        RefuelPriceUnit.values,
+        containsAll(<RefuelPriceUnit>[
+          RefuelPriceUnit.centsPerLiter,
+          RefuelPriceUnit.centsPerKwh,
+          RefuelPriceUnit.perSession,
+        ]),
+      );
+    });
+  });
+}

--- a/test/core/refuel/refuel_provider_test.dart
+++ b/test/core/refuel/refuel_provider_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/refuel/refuel_provider.dart';
+
+void main() {
+  group('RefuelProvider', () {
+    test('value equality compares name and kind', () {
+      const a =
+          RefuelProvider(name: 'Total', kind: RefuelProviderKind.fuel);
+      const b =
+          RefuelProvider(name: 'Total', kind: RefuelProviderKind.fuel);
+      const c =
+          RefuelProvider(name: 'Total', kind: RefuelProviderKind.ev);
+      const d =
+          RefuelProvider(name: 'Aral', kind: RefuelProviderKind.fuel);
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c))); // kind differs
+      expect(a, isNot(equals(d))); // name differs
+    });
+
+    test('unknown is a const sentinel with empty name', () {
+      const first = RefuelProvider.unknown;
+      const second = RefuelProvider.unknown;
+
+      expect(identical(first, second), isTrue,
+          reason: 'unknown must be a const singleton');
+      expect(first.name, isEmpty);
+      // Default kind must be deterministic — fuel is the documented choice.
+      expect(first.kind, RefuelProviderKind.fuel);
+    });
+
+    test('all RefuelProviderKind cases are exhausted', () {
+      // Static guard: if a future phase adds a new kind without
+      // updating this assertion, the test fails and forces a deliberate
+      // review of every consumer that switch-cased on the enum.
+      expect(RefuelProviderKind.values, hasLength(3));
+      expect(
+        RefuelProviderKind.values,
+        containsAll(<RefuelProviderKind>[
+          RefuelProviderKind.fuel,
+          RefuelProviderKind.ev,
+          RefuelProviderKind.both,
+        ]),
+      );
+    });
+
+    test('toString includes name and kind for debug logs', () {
+      const p =
+          RefuelProvider(name: 'Ionity', kind: RefuelProviderKind.ev);
+      final s = p.toString();
+      expect(s, contains('Ionity'));
+      expect(s, contains('ev'));
+    });
+  });
+}


### PR DESCRIPTION
## Why
Phase 1 of unifying fuel + EV behind a single user-actionable type. Plug-in hybrid drivers (fastest-growing EU demographic) currently see two disjoint search UIs — this lays the foundation to merge them.

## What
- New `lib/core/refuel/`:
  - `refuel_option.dart` — abstract class
  - `refuel_provider.dart` — brand/network identity
  - `refuel_price.dart` — freezed price value type
  - `refuel_availability.dart` — open/closed/limited/unknown
- Tests covering contract semantics + invariants
- **No UI / no adapters / no behavior change**

## Phasing
This is phase 1 of #1116. Phases 2 (adapters), 3 (unified search), 4 (route planning) follow in separate PRs. Refs #1116 phase 1.

## Test
- `flutter test test/core/refuel/` passes (23 tests)
- `flutter analyze` zero warnings

Refs #1116 phase 1