### PR TITLE
refactor(charging): extract form sections from add_charging_log_screen (Refs #563 phase: add_charging_log)

### DIFF
--- a/lib/features/consumption/domain/charging_log_readout.dart
+++ b/lib/features/consumption/domain/charging_log_readout.dart
@@ -1,0 +1,106 @@
+import '../../ev/domain/charging_cost_calculator.dart';
+import '../../ev/domain/entities/charging_log.dart';
+
+/// Shape of the EUR/100 km + kWh/100 km readout shown beneath the
+/// cost field on the Add-Charging-Log form. Pulled out of
+/// `add_charging_log_screen.dart` (#582 phase 2 follow-up) so the
+/// derivation rule is a pure function with its own unit tests
+/// instead of a private method on a stateful widget.
+///
+/// Three states the panel needs to render:
+///
+///  * `null` — inputs are incomplete or unparseable; hide the panel.
+///  * [ChargingLogReadout.empty] — inputs are complete but there's no
+///    prior log to anchor the distance. Render the helper text
+///    instead of numbers.
+///  * fully-populated — render the formatted EUR/kWh per-100-km line.
+class ChargingLogReadout {
+  final double? eurPer100km;
+  final double? kwhPer100km;
+
+  const ChargingLogReadout({
+    required this.eurPer100km,
+    required this.kwhPer100km,
+  });
+
+  const ChargingLogReadout.empty()
+      : eurPer100km = null,
+        kwhPer100km = null;
+
+  bool get hasValues => eurPer100km != null && kwhPer100km != null;
+}
+
+/// Compute the readout for a hypothetical log carrying the form's
+/// current inputs, comparing against the most-recent prior log for
+/// the selected vehicle.
+///
+/// Returns `null` when:
+///   * no vehicle is selected
+///   * any of [kWhText], [costText], [odometerText] is null,
+///     unparseable, or non-positive
+///   * the prior-logs list is null (still loading)
+///
+/// Returns [ChargingLogReadout.empty] when:
+///   * inputs parse cleanly but there's no prior log for this vehicle
+///   * the most-recent prior log has the same or higher odometer
+///     (i.e. zero distance driven since)
+///
+/// Otherwise returns a fully-populated [ChargingLogReadout].
+ChargingLogReadout? computeChargingLogReadout({
+  required String? vehicleId,
+  required String kWhText,
+  required String costText,
+  required String odometerText,
+  required DateTime date,
+  required List<ChargingLog>? allLogs,
+}) {
+  if (vehicleId == null) return null;
+  final kWh = double.tryParse(kWhText.replaceAll(',', '.'));
+  final cost = double.tryParse(costText.replaceAll(',', '.'));
+  final parsedOdo = int.tryParse(
+    odometerText.replaceAll(',', '.').split('.').first,
+  );
+  if (kWh == null || kWh <= 0) return null;
+  if (cost == null || cost <= 0) return null;
+  if (parsedOdo == null || parsedOdo <= 0) return null;
+  // Local non-nullable copy — Dart's flow analysis does not promote
+  // captured nullable locals inside closures like [firstWhere].
+  final int odo = parsedOdo;
+
+  if (allLogs == null) return null;
+  final prior = allLogs
+      .where((log) => log.vehicleId == vehicleId)
+      .toList(growable: false);
+  if (prior.isEmpty) return const ChargingLogReadout.empty();
+
+  // Prior logs are oldest-first; the anchor is the most recent one
+  // with odometer < odo (i.e. driven since then).
+  final candidate = prior.reversed.firstWhere(
+    (log) => log.odometerKm < odo,
+    orElse: () => prior.last,
+  );
+  final int kmDriven = odo - candidate.odometerKm;
+  if (kmDriven <= 0) return const ChargingLogReadout.empty();
+
+  final preview = ChargingLog(
+    id: 'preview',
+    vehicleId: vehicleId,
+    date: date,
+    kWh: kWh,
+    costEur: cost,
+    chargeTimeMin: 0,
+    odometerKm: odo,
+  );
+  final eurPer100 = ChargingCostCalculator.eurPer100km(
+    preview,
+    kmDriven: kmDriven,
+  );
+  final kwhPer100 = ChargingCostCalculator.kWhPer100km(
+    preview,
+    kmDriven: kmDriven,
+  );
+  return ChargingLogReadout(
+    eurPer100km: eurPer100,
+    kwhPer100km: kwhPer100,
+  );
+}

--- a/lib/features/consumption/domain/charging_log_validators.dart
+++ b/lib/features/consumption/domain/charging_log_validators.dart
@@ -1,0 +1,53 @@
+import '../../../l10n/app_localizations.dart';
+
+/// Pure validators / parsers shared by the Add-Charging-Log form
+/// (#582 phase 2). Pulled out of `add_charging_log_screen.dart` so the
+/// rules can be unit-tested without pumping a full widget tree.
+///
+/// All validators accept `null` localizations for tests / golden
+/// fallbacks and degrade to English defaults — the same pattern used
+/// elsewhere in the codebase (see `AppLocalizations.of(context)?.x ??
+/// 'Fallback'`).
+class ChargingLogValidators {
+  ChargingLogValidators._();
+
+  /// Validates that [value] parses to a strictly positive number. Used
+  /// for kWh, cost, and odometer fields — all three must be > 0 for a
+  /// charging log to make sense (you can't charge nothing, pay
+  /// nothing, or have a zero-km odometer).
+  static String? positiveNumber(String? value, AppLocalizations? l) {
+    if (value == null || value.trim().isEmpty) {
+      return l?.fieldRequired ?? 'Required';
+    }
+    final parsed = double.tryParse(value.replaceAll(',', '.'));
+    if (parsed == null || parsed <= 0) {
+      return l?.fieldInvalidNumber ?? 'Invalid number';
+    }
+    return null;
+  }
+
+  /// Validates that [value] parses to a non-negative integer. Used for
+  /// the charge-time-minutes field — 0 is allowed (slow chargers can
+  /// log a zero-minute session if the user hasn't measured it).
+  static String? nonNegativeInt(String? value, AppLocalizations? l) {
+    if (value == null || value.trim().isEmpty) {
+      return l?.fieldRequired ?? 'Required';
+    }
+    final parsed = int.tryParse(value.replaceAll(',', '.').split('.').first);
+    if (parsed == null || parsed < 0) {
+      return l?.fieldInvalidNumber ?? 'Invalid number';
+    }
+    return null;
+  }
+
+  /// Parses a double from a comma-or-dot decimal string. Throws if the
+  /// string is unparseable — call only after validation has passed.
+  static double parseDouble(String text) =>
+      double.parse(text.replaceAll(',', '.'));
+
+  /// Parses an int from a comma-or-dot decimal string (truncates the
+  /// fractional part). Throws if the leading numeric is unparseable —
+  /// call only after validation has passed.
+  static int parseInt(String text) =>
+      int.parse(text.replaceAll(',', '.').split('.').first);
+}

--- a/lib/features/consumption/presentation/screens/add_charging_log_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_charging_log_screen.dart
@@ -1,17 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../ev/domain/charging_cost_calculator.dart';
 import '../../../ev/domain/entities/charging_log.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
+import '../../domain/charging_log_readout.dart';
+import '../../domain/charging_log_validators.dart';
 import '../../providers/charging_logs_provider.dart';
-import '../widgets/fill_up_date_row.dart';
-import '../widgets/fill_up_numeric_field.dart';
-import '../widgets/fill_up_vehicle_dropdown.dart';
+import '../widgets/charging_log_form_fields.dart';
 
 /// Form to add a new [ChargingLog] entry (#582 phase 2).
 ///
@@ -28,6 +26,11 @@ import '../widgets/fill_up_vehicle_dropdown.dart';
 /// When there is no prior log, the readout hides and a small helper
 /// line explains why. Phase-3 will upgrade this to the vehicle's
 /// consumption baseline when odometer-only anchoring isn't enough.
+///
+/// **#563 refactor** — form layout, validators, and the derived
+/// readout were extracted to siblings under `presentation/widgets/`
+/// and `domain/`. The screen now owns lifecycle (controllers, state
+/// flags, vehicle init, submit) and delegates rendering.
 class AddChargingLogScreen extends ConsumerStatefulWidget {
   /// Optional pre-fill from a selected EV station. Phase 3 wires
   /// this up from the EV-station-detail screen (#691) — this phase
@@ -115,37 +118,6 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
     _vehicleInitialized = true;
   }
 
-  String? _positiveNumberValidator(String? value) {
-    final l = AppLocalizations.of(context);
-    if (value == null || value.trim().isEmpty) {
-      return l?.fieldRequired ?? 'Required';
-    }
-    final parsed = double.tryParse(value.replaceAll(',', '.'));
-    if (parsed == null || parsed <= 0) {
-      return l?.fieldInvalidNumber ?? 'Invalid number';
-    }
-    return null;
-  }
-
-  String? _nonNegativeIntValidator(String? value) {
-    final l = AppLocalizations.of(context);
-    if (value == null || value.trim().isEmpty) {
-      return l?.fieldRequired ?? 'Required';
-    }
-    final parsed = int.tryParse(value.replaceAll(',', '.').split('.').first);
-    if (parsed == null || parsed < 0) {
-      return l?.fieldInvalidNumber ?? 'Invalid number';
-    }
-    return null;
-  }
-
-  double _parseDouble(TextEditingController ctrl) =>
-      double.parse(ctrl.text.replaceAll(',', '.'));
-
-  int _parseInt(TextEditingController ctrl) => int.parse(
-        ctrl.text.replaceAll(',', '.').split('.').first,
-      );
-
   Future<void> _pickDate() async {
     final picked = await showDatePicker(
       context: context,
@@ -158,62 +130,12 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
     }
   }
 
-  /// Compute EUR/100 km for a hypothetical log carrying the form's
-  /// current inputs, comparing against the most-recent prior log for
-  /// the selected vehicle. Returns null when inputs are incomplete,
-  /// unparseable, or there's no prior log to anchor the distance.
-  _DerivedReadout? _deriveReadout() {
-    if (_vehicleId == null) return null;
-    final kWh = double.tryParse(_kwhCtrl.text.replaceAll(',', '.'));
-    final cost = double.tryParse(_costCtrl.text.replaceAll(',', '.'));
-    final parsedOdo = int.tryParse(
-      _odoCtrl.text.replaceAll(',', '.').split('.').first,
-    );
-    if (kWh == null || kWh <= 0) return null;
-    if (cost == null || cost <= 0) return null;
-    if (parsedOdo == null || parsedOdo <= 0) return null;
-    // Local non-nullable copy — Dart's flow analysis does not promote
-    // captured nullable locals inside closures like [firstWhere].
-    final int odo = parsedOdo;
-
+  /// Resolve the prior-logs list for the readout. Returns null while
+  /// the provider is still loading so the panel hides until data
+  /// arrives.
+  List<ChargingLog>? _allLogsOrNull() {
     final logsAsync = ref.watch(chargingLogsProvider);
-    final all = logsAsync.hasValue ? logsAsync.value : null;
-    if (all == null) return null;
-    final prior = all
-        .where((log) => log.vehicleId == _vehicleId)
-        .toList(growable: false);
-    if (prior.isEmpty) return const _DerivedReadout.empty();
-
-    // Prior logs are oldest-first; the anchor is the most recent one
-    // with odometer < odo (i.e. driven since then).
-    final candidate = prior.reversed.firstWhere(
-      (log) => log.odometerKm < odo,
-      orElse: () => prior.last,
-    );
-    final int kmDriven = odo - candidate.odometerKm;
-    if (kmDriven <= 0) return const _DerivedReadout.empty();
-
-    final preview = ChargingLog(
-      id: 'preview',
-      vehicleId: _vehicleId!,
-      date: _date,
-      kWh: kWh,
-      costEur: cost,
-      chargeTimeMin: 0,
-      odometerKm: odo,
-    );
-    final eurPer100 = ChargingCostCalculator.eurPer100km(
-      preview,
-      kmDriven: kmDriven,
-    );
-    final kwhPer100 = ChargingCostCalculator.kWhPer100km(
-      preview,
-      kmDriven: kmDriven,
-    );
-    return _DerivedReadout(
-      eurPer100km: eurPer100,
-      kwhPer100km: kwhPer100,
-    );
+    return logsAsync.hasValue ? logsAsync.value : null;
   }
 
   Future<void> _save() async {
@@ -225,10 +147,10 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
         id: DateTime.now().microsecondsSinceEpoch.toString(),
         vehicleId: _vehicleId!,
         date: _date,
-        kWh: _parseDouble(_kwhCtrl),
-        costEur: _parseDouble(_costCtrl),
-        chargeTimeMin: _parseInt(_timeMinCtrl),
-        odometerKm: _parseInt(_odoCtrl),
+        kWh: ChargingLogValidators.parseDouble(_kwhCtrl.text),
+        costEur: ChargingLogValidators.parseDouble(_costCtrl.text),
+        chargeTimeMin: ChargingLogValidators.parseInt(_timeMinCtrl.text),
+        odometerKm: ChargingLogValidators.parseInt(_odoCtrl.text),
         stationName:
             _stationCtrl.text.trim().isEmpty ? null : _stationCtrl.text.trim(),
         chargingStationId: widget.chargingStationId,
@@ -290,163 +212,40 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
 
     final dateStr =
         '${_date.year}-${_pad(_date.month)}-${_pad(_date.day)}';
-    final derived = _deriveReadout();
+    final derived = computeChargingLogReadout(
+      vehicleId: _vehicleId,
+      kWhText: _kwhCtrl.text,
+      costText: _costCtrl.text,
+      odometerText: _odoCtrl.text,
+      date: _date,
+      allLogs: _allLogsOrNull(),
+    );
 
     return PageScaffold(
       title: l?.addChargingLogTitle ?? 'Log charging session',
       bodyPadding: EdgeInsets.zero,
       body: Form(
         key: _formKey,
-        child: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            FillUpDateRow(dateLabel: dateStr, onTap: _pickDate),
-            const SizedBox(height: 8),
-            FillUpVehicleDropdown(
-              vehicleId: _vehicleId,
-              vehicles: vehicles,
-              onChanged: (id, _) {
-                setState(() => _vehicleId = id);
-              },
-            ),
-            const SizedBox(height: 12),
-            FillUpNumericField(
-              key: const Key('charging_kwh_field'),
-              controller: _kwhCtrl,
-              label: l?.chargingKwh ?? 'Energy (kWh)',
-              icon: Icons.bolt_outlined,
-              validator: _positiveNumberValidator,
-            ),
-            const SizedBox(height: 12),
-            FillUpNumericField(
-              key: const Key('charging_cost_field'),
-              controller: _costCtrl,
-              label: l?.chargingCost ?? 'Total cost',
-              icon: Icons.euro,
-              validator: _positiveNumberValidator,
-            ),
-            _DerivedReadoutPanel(readout: derived),
-            const SizedBox(height: 12),
-            FillUpNumericField(
-              key: const Key('charging_time_field'),
-              controller: _timeMinCtrl,
-              label: l?.chargingTimeMin ?? 'Charge time (min)',
-              icon: Icons.timer_outlined,
-              validator: _nonNegativeIntValidator,
-            ),
-            const SizedBox(height: 12),
-            FillUpNumericField(
-              key: const Key('charging_odo_field'),
-              controller: _odoCtrl,
-              label: l?.odometerKm ?? 'Odometer (km)',
-              icon: Icons.speed,
-              validator: _positiveNumberValidator,
-            ),
-            const SizedBox(height: 12),
-            TextFormField(
-              key: const Key('charging_station_field'),
-              controller: _stationCtrl,
-              textCapitalization: TextCapitalization.words,
-              inputFormatters: [
-                LengthLimitingTextInputFormatter(80),
-              ],
-              decoration: InputDecoration(
-                labelText: l?.chargingStationName ?? 'Station (optional)',
-                prefixIcon: const Icon(Icons.place_outlined),
-              ),
-            ),
-            const SizedBox(height: 24),
-            FilledButton.icon(
-              key: const Key('charging_save_button'),
-              onPressed: _saving ? null : _save,
-              icon: _saving
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.save),
-              label: Text(l?.save ?? 'Save'),
-            ),
-            SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
-          ],
+        child: ChargingLogFormFields(
+          dateLabel: dateStr,
+          onPickDate: _pickDate,
+          vehicleId: _vehicleId,
+          vehicles: vehicles,
+          onVehicleChanged: (id, _) {
+            setState(() => _vehicleId = id);
+          },
+          kwhCtrl: _kwhCtrl,
+          costCtrl: _costCtrl,
+          timeMinCtrl: _timeMinCtrl,
+          odoCtrl: _odoCtrl,
+          stationCtrl: _stationCtrl,
+          derived: derived,
+          saving: _saving,
+          onSave: _save,
         ),
       ),
     );
   }
 
   String _pad(int n) => n.toString().padLeft(2, '0');
-}
-
-/// Shape returned by [_AddChargingLogScreenState._deriveReadout].
-///
-/// A null instance means "inputs incomplete" — hide the panel
-/// entirely. A [_DerivedReadout.empty] instance means "inputs
-/// complete but no prior log to anchor the distance" — render the
-/// helper text instead of numbers so the user knows why the
-/// readout is blank.
-class _DerivedReadout {
-  final double? eurPer100km;
-  final double? kwhPer100km;
-
-  const _DerivedReadout({
-    required this.eurPer100km,
-    required this.kwhPer100km,
-  });
-
-  const _DerivedReadout.empty()
-      : eurPer100km = null,
-        kwhPer100km = null;
-
-  bool get hasValues => eurPer100km != null && kwhPer100km != null;
-}
-
-class _DerivedReadoutPanel extends StatelessWidget {
-  final _DerivedReadout? readout;
-
-  const _DerivedReadoutPanel({required this.readout});
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final r = readout;
-    if (r == null) return const SizedBox.shrink();
-    final theme = Theme.of(context);
-    final style = theme.textTheme.bodySmall?.copyWith(
-      color: theme.colorScheme.primary,
-    );
-    if (!r.hasValues) {
-      return Padding(
-        padding: const EdgeInsets.only(top: 6, left: 12),
-        child: Text(
-          l?.chargingDerivedHelper ?? 'Need a previous log to compare',
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          key: const Key('charging_derived_helper'),
-        ),
-      );
-    }
-    final eurStr = r.eurPer100km!.toStringAsFixed(2);
-    final kwhStr = r.kwhPer100km!.toStringAsFixed(1);
-    return Padding(
-      padding: const EdgeInsets.only(top: 6, left: 12),
-      child: Row(
-        key: const Key('charging_derived_readout'),
-        children: [
-          Icon(Icons.insights_outlined,
-              size: 16, color: theme.colorScheme.primary),
-          const SizedBox(width: 6),
-          Flexible(
-            child: Text(
-              '${l?.chargingEurPer100km(eurStr) ?? '$eurStr EUR / 100 km'}'
-              '  •  '
-              '${l?.chargingKwhPer100km(kwhStr) ?? '$kwhStr kWh / 100 km'}',
-              style: style,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
 }

--- a/lib/features/consumption/presentation/widgets/charging_log_derived_readout_panel.dart
+++ b/lib/features/consumption/presentation/widgets/charging_log_derived_readout_panel.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/charging_log_readout.dart';
+
+/// Renders the EUR/100 km + kWh/100 km line below the cost field on
+/// the Add-Charging-Log form (#582 phase 2). Pulled out of
+/// `add_charging_log_screen.dart` so the screen drops a private
+/// widget class and the rendering logic gets its own widget test.
+///
+/// Three states (see [ChargingLogReadout]):
+///
+///  * [readout] is `null` — render nothing (zero-height shrink).
+///  * [readout] is empty — render the "need a previous log to
+///    compare" helper line in the muted on-surface-variant colour.
+///  * [readout] has values — render the formatted EUR/kWh per-100-km
+///    row with the insights icon in the primary colour.
+class ChargingLogDerivedReadoutPanel extends StatelessWidget {
+  final ChargingLogReadout? readout;
+
+  const ChargingLogDerivedReadoutPanel({super.key, required this.readout});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final r = readout;
+    if (r == null) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    final style = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.primary,
+    );
+    if (!r.hasValues) {
+      return Padding(
+        padding: const EdgeInsets.only(top: 6, left: 12),
+        child: Text(
+          l?.chargingDerivedHelper ?? 'Need a previous log to compare',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          key: const Key('charging_derived_helper'),
+        ),
+      );
+    }
+    final eurStr = r.eurPer100km!.toStringAsFixed(2);
+    final kwhStr = r.kwhPer100km!.toStringAsFixed(1);
+    return Padding(
+      padding: const EdgeInsets.only(top: 6, left: 12),
+      child: Row(
+        key: const Key('charging_derived_readout'),
+        children: [
+          Icon(Icons.insights_outlined,
+              size: 16, color: theme.colorScheme.primary),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              '${l?.chargingEurPer100km(eurStr) ?? '$eurStr EUR / 100 km'}'
+              '  •  '
+              '${l?.chargingKwhPer100km(kwhStr) ?? '$kwhStr kWh / 100 km'}',
+              style: style,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/charging_log_form_fields.dart
+++ b/lib/features/consumption/presentation/widgets/charging_log_form_fields.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../domain/charging_log_readout.dart';
+import '../../domain/charging_log_validators.dart';
+import 'charging_log_derived_readout_panel.dart';
+import 'fill_up_date_row.dart';
+import 'fill_up_numeric_field.dart';
+import 'fill_up_vehicle_dropdown.dart';
+
+/// All the input rows on the Add-Charging-Log form, composed in the
+/// canonical order: date, vehicle, kWh, cost (+derived readout),
+/// charge-time, odometer, station name, save button. Pulled out of
+/// `add_charging_log_screen.dart` (#582 phase 2 follow-up, #563)
+/// so the screen file drops well below 300 LOC and the form layout
+/// can be exercised as a single widget in tests.
+///
+/// All controllers, callbacks, and the form's parent `_formKey` are
+/// owned by the screen — this widget is a pure stateless layout.
+class ChargingLogFormFields extends StatelessWidget {
+  final String dateLabel;
+  final VoidCallback onPickDate;
+
+  final String? vehicleId;
+  final List<VehicleProfile> vehicles;
+  final void Function(String? id, VehicleProfile? selected) onVehicleChanged;
+
+  final TextEditingController kwhCtrl;
+  final TextEditingController costCtrl;
+  final TextEditingController timeMinCtrl;
+  final TextEditingController odoCtrl;
+  final TextEditingController stationCtrl;
+
+  final ChargingLogReadout? derived;
+
+  final bool saving;
+  final VoidCallback onSave;
+
+  const ChargingLogFormFields({
+    super.key,
+    required this.dateLabel,
+    required this.onPickDate,
+    required this.vehicleId,
+    required this.vehicles,
+    required this.onVehicleChanged,
+    required this.kwhCtrl,
+    required this.costCtrl,
+    required this.timeMinCtrl,
+    required this.odoCtrl,
+    required this.stationCtrl,
+    required this.derived,
+    required this.saving,
+    required this.onSave,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        FillUpDateRow(dateLabel: dateLabel, onTap: onPickDate),
+        const SizedBox(height: 8),
+        FillUpVehicleDropdown(
+          vehicleId: vehicleId,
+          vehicles: vehicles,
+          onChanged: onVehicleChanged,
+        ),
+        const SizedBox(height: 12),
+        FillUpNumericField(
+          key: const Key('charging_kwh_field'),
+          controller: kwhCtrl,
+          label: l?.chargingKwh ?? 'Energy (kWh)',
+          icon: Icons.bolt_outlined,
+          validator: (v) => ChargingLogValidators.positiveNumber(v, l),
+        ),
+        const SizedBox(height: 12),
+        FillUpNumericField(
+          key: const Key('charging_cost_field'),
+          controller: costCtrl,
+          label: l?.chargingCost ?? 'Total cost',
+          icon: Icons.euro,
+          validator: (v) => ChargingLogValidators.positiveNumber(v, l),
+        ),
+        ChargingLogDerivedReadoutPanel(readout: derived),
+        const SizedBox(height: 12),
+        FillUpNumericField(
+          key: const Key('charging_time_field'),
+          controller: timeMinCtrl,
+          label: l?.chargingTimeMin ?? 'Charge time (min)',
+          icon: Icons.timer_outlined,
+          validator: (v) => ChargingLogValidators.nonNegativeInt(v, l),
+        ),
+        const SizedBox(height: 12),
+        FillUpNumericField(
+          key: const Key('charging_odo_field'),
+          controller: odoCtrl,
+          label: l?.odometerKm ?? 'Odometer (km)',
+          icon: Icons.speed,
+          validator: (v) => ChargingLogValidators.positiveNumber(v, l),
+        ),
+        const SizedBox(height: 12),
+        TextFormField(
+          key: const Key('charging_station_field'),
+          controller: stationCtrl,
+          textCapitalization: TextCapitalization.words,
+          inputFormatters: [
+            LengthLimitingTextInputFormatter(80),
+          ],
+          decoration: InputDecoration(
+            labelText: l?.chargingStationName ?? 'Station (optional)',
+            prefixIcon: const Icon(Icons.place_outlined),
+          ),
+        ),
+        const SizedBox(height: 24),
+        FilledButton.icon(
+          key: const Key('charging_save_button'),
+          onPressed: saving ? null : onSave,
+          icon: saving
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.save),
+          label: Text(l?.save ?? 'Save'),
+        ),
+        SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
+      ],
+    );
+  }
+}

--- a/test/features/consumption/domain/charging_log_readout_test.dart
+++ b/test/features/consumption/domain/charging_log_readout_test.dart
@@ -1,0 +1,221 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/charging_log_readout.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
+
+/// Unit tests for [computeChargingLogReadout] — the pure derivation
+/// rule extracted from `add_charging_log_screen.dart` (#563 refactor).
+/// Three states must be distinguishable: incomplete (`null`), no
+/// anchor (`ChargingLogReadout.empty`), and fully-populated.
+ChargingLog _log({
+  String id = 'p1',
+  String vehicleId = 'ev-1',
+  double kWh = 40,
+  double costEur = 20,
+  int odometerKm = 10000,
+}) =>
+    ChargingLog(
+      id: id,
+      vehicleId: vehicleId,
+      date: DateTime.utc(2026, 4, 1),
+      kWh: kWh,
+      costEur: costEur,
+      chargeTimeMin: 30,
+      odometerKm: odometerKm,
+    );
+
+void main() {
+  final date = DateTime.utc(2026, 4, 26);
+
+  group('computeChargingLogReadout — incomplete inputs return null', () {
+    test('null vehicleId returns null', () {
+      expect(
+        computeChargingLogReadout(
+          vehicleId: null,
+          kWhText: '30',
+          costText: '12',
+          odometerText: '10500',
+          date: date,
+          allLogs: const [],
+        ),
+        isNull,
+      );
+    });
+
+    test('blank kWh returns null', () {
+      expect(
+        computeChargingLogReadout(
+          vehicleId: 'ev-1',
+          kWhText: '',
+          costText: '12',
+          odometerText: '10500',
+          date: date,
+          allLogs: const [],
+        ),
+        isNull,
+      );
+    });
+
+    test('zero kWh returns null', () {
+      expect(
+        computeChargingLogReadout(
+          vehicleId: 'ev-1',
+          kWhText: '0',
+          costText: '12',
+          odometerText: '10500',
+          date: date,
+          allLogs: const [],
+        ),
+        isNull,
+      );
+    });
+
+    test('negative cost returns null', () {
+      expect(
+        computeChargingLogReadout(
+          vehicleId: 'ev-1',
+          kWhText: '30',
+          costText: '-12',
+          odometerText: '10500',
+          date: date,
+          allLogs: const [],
+        ),
+        isNull,
+      );
+    });
+
+    test('zero odometer returns null', () {
+      expect(
+        computeChargingLogReadout(
+          vehicleId: 'ev-1',
+          kWhText: '30',
+          costText: '12',
+          odometerText: '0',
+          date: date,
+          allLogs: const [],
+        ),
+        isNull,
+      );
+    });
+
+    test('null allLogs (still loading) returns null', () {
+      expect(
+        computeChargingLogReadout(
+          vehicleId: 'ev-1',
+          kWhText: '30',
+          costText: '12',
+          odometerText: '10500',
+          date: date,
+          allLogs: null,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('computeChargingLogReadout — empty branch (no anchor)', () {
+    test('no prior logs at all returns empty readout', () {
+      final r = computeChargingLogReadout(
+        vehicleId: 'ev-1',
+        kWhText: '30',
+        costText: '12',
+        odometerText: '10500',
+        date: date,
+        allLogs: const [],
+      );
+      expect(r, isNotNull);
+      expect(r!.hasValues, isFalse);
+      expect(r.eurPer100km, isNull);
+      expect(r.kwhPer100km, isNull);
+    });
+
+    test('only prior logs for OTHER vehicles returns empty readout', () {
+      final r = computeChargingLogReadout(
+        vehicleId: 'ev-1',
+        kWhText: '30',
+        costText: '12',
+        odometerText: '10500',
+        date: date,
+        allLogs: [_log(vehicleId: 'ev-2', odometerKm: 5000)],
+      );
+      expect(r, isNotNull);
+      expect(r!.hasValues, isFalse);
+    });
+
+    test('prior log has same odometer (zero km driven) returns empty', () {
+      final r = computeChargingLogReadout(
+        vehicleId: 'ev-1',
+        kWhText: '30',
+        costText: '12',
+        odometerText: '10500',
+        date: date,
+        allLogs: [_log(odometerKm: 10500)],
+      );
+      expect(r, isNotNull);
+      expect(r!.hasValues, isFalse);
+    });
+  });
+
+  group('computeChargingLogReadout — happy path', () {
+    test('30 kWh / 12 EUR over 500 km yields 2.40 EUR/100 km, 6.0 kWh/100 km',
+        () {
+      final r = computeChargingLogReadout(
+        vehicleId: 'ev-1',
+        kWhText: '30',
+        costText: '12',
+        odometerText: '10500',
+        date: date,
+        allLogs: [_log(odometerKm: 10000)],
+      );
+      expect(r, isNotNull);
+      expect(r!.hasValues, isTrue);
+      expect(r.eurPer100km, closeTo(2.4, 1e-9));
+      expect(r.kwhPer100km, closeTo(6.0, 1e-9));
+    });
+
+    test('picks the most-recent prior log with odometer < current', () {
+      // Anchor candidate: 10000 (latest log with odo < 10500). The
+      // 10800 log is filtered out — you can't drive backwards.
+      final r = computeChargingLogReadout(
+        vehicleId: 'ev-1',
+        kWhText: '30',
+        costText: '12',
+        odometerText: '10500',
+        date: date,
+        allLogs: [
+          _log(id: 'a', odometerKm: 9000),
+          _log(id: 'b', odometerKm: 10000),
+          _log(id: 'c', odometerKm: 10800),
+        ],
+      );
+      expect(r, isNotNull);
+      expect(r!.eurPer100km, closeTo(2.4, 1e-9));
+    });
+
+    test('comma-decimal inputs parse identically to dot-decimal', () {
+      final r = computeChargingLogReadout(
+        vehicleId: 'ev-1',
+        kWhText: '30,0',
+        costText: '12,0',
+        odometerText: '10500',
+        date: date,
+        allLogs: [_log(odometerKm: 10000)],
+      );
+      expect(r, isNotNull);
+      expect(r!.eurPer100km, closeTo(2.4, 1e-9));
+    });
+  });
+
+  group('ChargingLogReadout', () {
+    test('empty constructor produces hasValues == false', () {
+      const r = ChargingLogReadout.empty();
+      expect(r.hasValues, isFalse);
+      expect(r.eurPer100km, isNull);
+      expect(r.kwhPer100km, isNull);
+    });
+
+    test('populated constructor produces hasValues == true', () {
+      const r = ChargingLogReadout(eurPer100km: 2.4, kwhPer100km: 6.0);
+      expect(r.hasValues, isTrue);
+    });
+  });
+}

--- a/test/features/consumption/domain/charging_log_validators_test.dart
+++ b/test/features/consumption/domain/charging_log_validators_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/charging_log_validators.dart';
+
+/// Unit tests for the pure validators / parsers extracted from
+/// `add_charging_log_screen.dart` (#563 refactor). Each rule is
+/// covered for: blank/null input, unparseable input, boundary
+/// values (zero, negative), and at least one happy-path case.
+///
+/// All tests pass `null` for [AppLocalizations] — the validators
+/// must degrade to English fallbacks ("Required", "Invalid number")
+/// when no localizations are in the tree, which is exactly the path
+/// they take in widget tests that don't pump a MaterialApp with
+/// AppLocalizations.delegate.
+void main() {
+  group('ChargingLogValidators.positiveNumber', () {
+    test('returns Required when value is null', () {
+      expect(
+        ChargingLogValidators.positiveNumber(null, null),
+        equals('Required'),
+      );
+    });
+
+    test('returns Required when value is empty', () {
+      expect(
+        ChargingLogValidators.positiveNumber('', null),
+        equals('Required'),
+      );
+    });
+
+    test('returns Required when value is whitespace only', () {
+      expect(
+        ChargingLogValidators.positiveNumber('   ', null),
+        equals('Required'),
+      );
+    });
+
+    test('returns Invalid number when value is not numeric', () {
+      expect(
+        ChargingLogValidators.positiveNumber('abc', null),
+        equals('Invalid number'),
+      );
+    });
+
+    test('returns Invalid number when value is zero', () {
+      expect(
+        ChargingLogValidators.positiveNumber('0', null),
+        equals('Invalid number'),
+      );
+    });
+
+    test('returns Invalid number when value is negative', () {
+      expect(
+        ChargingLogValidators.positiveNumber('-1.5', null),
+        equals('Invalid number'),
+      );
+    });
+
+    test('accepts a positive double with dot decimal', () {
+      expect(
+        ChargingLogValidators.positiveNumber('12.5', null),
+        isNull,
+      );
+    });
+
+    test('accepts a positive double with comma decimal', () {
+      expect(
+        ChargingLogValidators.positiveNumber('12,5', null),
+        isNull,
+      );
+    });
+
+    test('accepts a positive integer string', () {
+      expect(
+        ChargingLogValidators.positiveNumber('42', null),
+        isNull,
+      );
+    });
+  });
+
+  group('ChargingLogValidators.nonNegativeInt', () {
+    test('returns Required when value is null', () {
+      expect(
+        ChargingLogValidators.nonNegativeInt(null, null),
+        equals('Required'),
+      );
+    });
+
+    test('returns Required when value is empty', () {
+      expect(
+        ChargingLogValidators.nonNegativeInt('', null),
+        equals('Required'),
+      );
+    });
+
+    test('returns Invalid number when value is not numeric', () {
+      expect(
+        ChargingLogValidators.nonNegativeInt('xx', null),
+        equals('Invalid number'),
+      );
+    });
+
+    test('returns Invalid number when value is negative', () {
+      expect(
+        ChargingLogValidators.nonNegativeInt('-3', null),
+        equals('Invalid number'),
+      );
+    });
+
+    test('accepts zero (a 0-minute charge session is valid)', () {
+      expect(
+        ChargingLogValidators.nonNegativeInt('0', null),
+        isNull,
+      );
+    });
+
+    test('accepts a positive integer', () {
+      expect(
+        ChargingLogValidators.nonNegativeInt('30', null),
+        isNull,
+      );
+    });
+
+    test('accepts a decimal by truncating to its integer part', () {
+      // The validator parses the integer prefix only — "30.5" reads
+      // as 30 and passes. This mirrors the behaviour the UI relied
+      // on before the refactor.
+      expect(
+        ChargingLogValidators.nonNegativeInt('30.5', null),
+        isNull,
+      );
+    });
+  });
+
+  group('ChargingLogValidators.parseDouble', () {
+    test('parses dot decimal', () {
+      expect(ChargingLogValidators.parseDouble('12.5'), closeTo(12.5, 1e-9));
+    });
+
+    test('parses comma decimal', () {
+      expect(ChargingLogValidators.parseDouble('12,5'), closeTo(12.5, 1e-9));
+    });
+
+    test('parses an integer string', () {
+      expect(ChargingLogValidators.parseDouble('42'), closeTo(42.0, 1e-9));
+    });
+  });
+
+  group('ChargingLogValidators.parseInt', () {
+    test('parses an integer string', () {
+      expect(ChargingLogValidators.parseInt('42'), equals(42));
+    });
+
+    test('truncates a decimal value', () {
+      expect(ChargingLogValidators.parseInt('42.9'), equals(42));
+    });
+
+    test('truncates a comma-decimal value', () {
+      expect(ChargingLogValidators.parseInt('42,9'), equals(42));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Refs #563 epic phase: add_charging_log. Pure refactor — extracts the 452-LOC `AddChargingLogScreen` into four focused siblings so every file in the feature is now well below the 300-LOC guideline. **Behavior unchanged.**

## Before / after LOC

| File | Before | After |
|---|---:|---:|
| `presentation/screens/add_charging_log_screen.dart` | 452 | 251 |
| `presentation/widgets/charging_log_form_fields.dart` | new | 134 |
| `presentation/widgets/charging_log_derived_readout_panel.dart` | new | 66 |
| `domain/charging_log_validators.dart` | new | 54 |
| `domain/charging_log_readout.dart` | new | 106 |

The screen now owns lifecycle (controllers, vehicle init, submit) and delegates rendering / derivation.

## Extracted children

- **`domain/charging_log_validators.dart`** — `ChargingLogValidators.positiveNumber` / `.nonNegativeInt` + `parseDouble` / `parseInt` helpers. English fallbacks when `AppLocalizations` is null. Pure functions.
- **`domain/charging_log_readout.dart`** — `ChargingLogReadout` data class + `computeChargingLogReadout()` returning `null` (incomplete inputs) / `.empty` (no anchor) / populated. Pure function — no `BuildContext`, no Riverpod.
- **`presentation/widgets/charging_log_derived_readout_panel.dart`** — promoted private `_DerivedReadoutPanel` to a public widget.
- **`presentation/widgets/charging_log_form_fields.dart`** — composite `ListView` of date row, vehicle dropdown, four numeric fields (with the same `Key`s as before — keeps existing widget tests green), station field, and save button.

## Tests

- Added 22 unit tests for `ChargingLogValidators` (blank, whitespace, non-numeric, zero, negative, dot/comma decimal, integer truncation).
- Added 14 unit tests for `computeChargingLogReadout` (every null-branch, multi-vehicle filter, reverse-driving anchor, comma decimals, happy path).
- Existing 5 widget tests for `AddChargingLogScreen` (`add_charging_log_screen_test.dart`) pass unchanged — same widget keys, same rendering, same provider wiring.
- All 297 consumption widget tests still green.

## Behavior unchanged

- Field validation rules: identical (positive doubles for kWh / cost / odometer, non-negative int for charge time).
- Submit shape (`ChargingLog.id` from `microsecondsSinceEpoch`, optional `stationName` trimmed): identical.
- Empty-vehicle branch (`PageScaffold` + add-vehicle prompt): identical.
- Derived EUR/kWh per-100-km readout (anchor selection, `kmDriven` math, hide-when-incomplete, helper-text-when-empty): identical.

## Test plan

- [x] `flutter analyze` clean (no `--no-fatal-infos`)
- [x] Validator + readout unit tests green
- [x] Existing screen widget tests green
- [x] Every new file ≤ 300 LOC

## Out of scope

- Other oversized files in #563 epic (this PR is a single phase)
- ARB / i18n changes
- Behavior changes