### PR TITLE
feat(refuel): Station + ChargingStation adapters (Refs #1116 phase 2)

### DIFF
--- a/lib/core/refuel/charging_station_as_refuel_option.dart
+++ b/lib/core/refuel/charging_station_as_refuel_option.dart
@@ -1,0 +1,90 @@
+import '../../features/ev/domain/entities/charging_station.dart';
+import 'refuel_availability.dart';
+import 'refuel_option.dart';
+import 'refuel_price.dart';
+import 'refuel_provider.dart';
+
+/// [RefuelOption] adapter that wraps an EV [ChargingStation].
+///
+/// Phase 2 of the fuel/EV unification (#1116). Mirrors
+/// [StationAsRefuelOption] for the EV side so the unified search list
+/// (phase 3) can render fuel pumps and EV chargers from one
+/// [RefuelOption] iterable.
+///
+/// ### Known phase-2 limitations
+///
+/// * [price] is **always `null`**. The upstream
+///   [ChargingStation.usageCost] is a free-form string ("0.49 EUR/kWh",
+///   "Free", "0.79 EUR/kWh after first 30 min", …). Parsing requires
+///   country-specific heuristics best owned by phase 3 alongside the
+///   pricing-display widgets.
+/// * The `limited` / `closed` reasons are literal English fallbacks.
+///   The adapter layer is locale-agnostic; the consumer (phase 3) will
+///   wrap the reason in `AppLocalizations` before showing it to the
+///   user.
+class ChargingStationAsRefuelOption extends RefuelOption {
+  /// Wrapped EV charging station.
+  final ChargingStation station;
+
+  const ChargingStationAsRefuelOption(this.station);
+
+  @override
+  ({double lat, double lng}) get coordinates =>
+      (lat: station.latitude, lng: station.longitude);
+
+  @override
+  String get id => 'ev:${station.id}';
+
+  @override
+  RefuelProvider get provider {
+    final op = station.operator;
+    if (op == null || op.isEmpty) {
+      return RefuelProvider.unknown;
+    }
+    return RefuelProvider(
+      name: op,
+      kind: RefuelProviderKind.ev,
+    );
+  }
+
+  @override
+  RefuelAvailability get availability {
+    // Operator-level shutdown trumps connector status.
+    if (station.isOperational == false) {
+      return RefuelAvailability.closed();
+    }
+
+    final connectors = station.connectors;
+    if (connectors.isEmpty) {
+      return RefuelAvailability.unknown;
+    }
+
+    final hasAvailable =
+        connectors.any((c) => c.status == ConnectorStatus.available);
+    if (hasAvailable) {
+      return RefuelAvailability.open;
+    }
+
+    final hasOccupied =
+        connectors.any((c) => c.status == ConnectorStatus.occupied);
+    if (hasOccupied) {
+      return RefuelAvailability.limited(
+        reason: 'All connectors occupied',
+      );
+    }
+
+    final hasOutOfOrder =
+        connectors.any((c) => c.status == ConnectorStatus.outOfOrder);
+    if (hasOutOfOrder) {
+      return RefuelAvailability.closed(
+        reason: 'All connectors out of order',
+      );
+    }
+
+    return RefuelAvailability.unknown;
+  }
+
+  /// Always `null` in phase 2. See class doc for rationale.
+  @override
+  RefuelPrice? get price => null;
+}

--- a/lib/core/refuel/station_as_refuel_option.dart
+++ b/lib/core/refuel/station_as_refuel_option.dart
@@ -1,0 +1,113 @@
+import '../../features/search/domain/entities/fuel_type.dart';
+import '../../features/search/domain/entities/station.dart';
+import 'refuel_availability.dart';
+import 'refuel_option.dart';
+import 'refuel_price.dart';
+import 'refuel_provider.dart';
+
+/// [RefuelOption] adapter that wraps a fuel-pump [Station].
+///
+/// Phase 2 of the fuel/EV unification (#1116). The abstract [RefuelOption]
+/// contract from phase 1 stays decoupled from the concrete station model;
+/// this adapter does the field-by-field mapping so the unified search list
+/// and downstream UI (phase 3) can treat fuel pumps and EV chargers
+/// uniformly.
+///
+/// The adapter is `const` whenever the underlying [Station] is `const`,
+/// so it adds no allocation overhead in hot paths.
+class StationAsRefuelOption extends RefuelOption {
+  /// Wrapped petrol station.
+  final Station station;
+
+  /// Which fuel field on [station] should drive [price]. Defaults to
+  /// [FuelType.e10] because it is the most widely available pump fuel
+  /// in EU markets (and the default the search providers ship with).
+  final FuelType fuelType;
+
+  const StationAsRefuelOption(this.station, [this.fuelType = FuelType.e10]);
+
+  @override
+  ({double lat, double lng}) get coordinates =>
+      (lat: station.lat, lng: station.lng);
+
+  @override
+  String get id => 'fuel:${station.id}';
+
+  @override
+  RefuelProvider get provider {
+    if (station.brand.isEmpty) {
+      return RefuelProvider.unknown;
+    }
+    return RefuelProvider(
+      name: station.brand,
+      kind: RefuelProviderKind.fuel,
+    );
+  }
+
+  @override
+  RefuelAvailability get availability {
+    if (station.is24h || station.isOpen) {
+      return RefuelAvailability.open;
+    }
+    // [Station.isOpen] is currently a non-null `bool`, so reaching
+    // here means the upstream API explicitly reported the station as
+    // closed. The unknown branch is intentionally absent today; if
+    // the model becomes nullable in a future migration the adapter
+    // tests will catch the resulting behavior change.
+    return RefuelAvailability.closed();
+  }
+
+  @override
+  RefuelPrice? get price {
+    final eur = _eurValueFor(fuelType);
+    if (eur == null) return null;
+    // Convert EUR/L (or EUR/kg for CNG; see note below) to cents.
+    // EU pumps display 0.1-cent precision (e.g. €1.749 → 174.9¢), so
+    // we round to one decimal to strip the IEEE-754 float drift
+    // (1.749 * 100 == 174.90000000000003) without losing the
+    // milli-cent the user actually sees on the totem.
+    final cents = double.parse((eur * 100).toStringAsFixed(1));
+    return RefuelPrice(
+      value: cents,
+      // NOTE: `FuelType.cng` advertises `unit: 'EUR/kg'`, but the
+      // upstream [Station.cng] field carries an EUR-per-pump-unit value
+      // consistent with the other fuel fields (i.e. the country API
+      // already returns cost-per-dispensed-unit). We therefore tag CNG
+      // as [centsPerLiter] here as well; phase 3 may introduce a
+      // dedicated `centsPerKg` unit if a UI consumer needs to
+      // distinguish them.
+      unit: RefuelPriceUnit.centsPerLiter,
+      lastUpdated: _lastUpdated,
+    );
+  }
+
+  /// Resolve the EUR/L (or EUR/kg) value for [fuel] from [station].
+  ///
+  /// Returns `null` for fuel types the [Station] model does not
+  /// represent ([FuelType.electric], [FuelType.hydrogen],
+  /// [FuelType.all]) and for cases where the chosen field is itself
+  /// `null` on this station.
+  double? _eurValueFor(FuelType fuel) {
+    return switch (fuel) {
+      FuelTypeE5() => station.e5,
+      FuelTypeE10() => station.e10,
+      FuelTypeE98() => station.e98,
+      FuelTypeDiesel() => station.diesel,
+      FuelTypeDieselPremium() => station.dieselPremium,
+      FuelTypeE85() => station.e85,
+      FuelTypeLpg() => station.lpg,
+      FuelTypeCng() => station.cng,
+      FuelTypeElectric() || FuelTypeHydrogen() || FuelTypeAll() => null,
+    };
+  }
+
+  /// Best-effort parse of [Station.updatedAt] (ISO-8601 string) into a
+  /// [DateTime]. Returns `null` when the field is absent or malformed
+  /// — the [RefuelPrice.lastUpdated] field accepts null and the UI
+  /// falls back to the surrounding `ServiceResult.fetchedAt`.
+  DateTime? get _lastUpdated {
+    final raw = station.updatedAt;
+    if (raw == null || raw.isEmpty) return null;
+    return DateTime.tryParse(raw);
+  }
+}

--- a/test/core/refuel/charging_station_as_refuel_option_test.dart
+++ b/test/core/refuel/charging_station_as_refuel_option_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/refuel/charging_station_as_refuel_option.dart';
+import 'package:tankstellen/core/refuel/refuel_availability.dart';
+import 'package:tankstellen/core/refuel/refuel_provider.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
+    show ConnectorType;
+
+EvConnector _connector(ConnectorStatus status) => EvConnector(
+      id: 'c-${status.key}',
+      type: ConnectorType.ccs,
+      maxPowerKw: 150,
+      status: status,
+    );
+
+ChargingStation _ev({
+  String id = 'ev-1',
+  String? operator = 'Ionity',
+  double latitude = 50.1109,
+  double longitude = 8.6821,
+  bool? isOperational,
+  List<EvConnector> connectors = const <EvConnector>[],
+  String? usageCost,
+}) =>
+    ChargingStation(
+      id: id,
+      name: 'Charger $id',
+      operator: operator,
+      latitude: latitude,
+      longitude: longitude,
+      isOperational: isOperational,
+      connectors: connectors,
+      usageCost: usageCost,
+    );
+
+void main() {
+  group('ChargingStationAsRefuelOption — identity & provider', () {
+    test('coordinates pass through latitude/longitude', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(latitude: 48.8566, longitude: 2.3522),
+      );
+      expect(adapter.coordinates.lat, 48.8566);
+      expect(adapter.coordinates.lng, 2.3522);
+    });
+
+    test('id uses the "ev:" type prefix', () {
+      final adapter = ChargingStationAsRefuelOption(_ev(id: 'abc-123'));
+      expect(adapter.id, 'ev:abc-123');
+    });
+
+    test('provider wraps the operator with kind=ev', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(operator: 'Tesla Supercharger'),
+      );
+      expect(
+        adapter.provider,
+        const RefuelProvider(
+          name: 'Tesla Supercharger',
+          kind: RefuelProviderKind.ev,
+        ),
+      );
+    });
+
+    test('null operator collapses to RefuelProvider.unknown', () {
+      final adapter = ChargingStationAsRefuelOption(_ev(operator: null));
+      expect(adapter.provider, RefuelProvider.unknown);
+    });
+
+    test('empty operator collapses to RefuelProvider.unknown', () {
+      final adapter = ChargingStationAsRefuelOption(_ev(operator: ''));
+      expect(adapter.provider, RefuelProvider.unknown);
+    });
+  });
+
+  group('ChargingStationAsRefuelOption — availability', () {
+    test('isOperational=false short-circuits to closed', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(
+          isOperational: false,
+          // Even an "available" connector is overridden by site-level
+          // outage flag.
+          connectors: [_connector(ConnectorStatus.available)],
+        ),
+      );
+      expect(adapter.availability, RefuelAvailability.closed());
+      expect(adapter.availability.isOperational, isFalse);
+    });
+
+    test('any available connector → open', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(connectors: [
+          _connector(ConnectorStatus.occupied),
+          _connector(ConnectorStatus.available),
+        ]),
+      );
+      expect(adapter.availability, RefuelAvailability.open);
+      expect(adapter.availability.isOperational, isTrue);
+    });
+
+    test('only-occupied connectors → limited with reason', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(connectors: [
+          _connector(ConnectorStatus.occupied),
+          _connector(ConnectorStatus.occupied),
+        ]),
+      );
+      expect(
+        adapter.availability,
+        RefuelAvailability.limited(reason: 'All connectors occupied'),
+      );
+      expect(adapter.availability.isOperational, isFalse);
+    });
+
+    test('only-out-of-order connectors → closed with reason', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(connectors: [
+          _connector(ConnectorStatus.outOfOrder),
+        ]),
+      );
+      expect(
+        adapter.availability,
+        RefuelAvailability.closed(reason: 'All connectors out of order'),
+      );
+    });
+
+    test('empty connector list → unknown', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(connectors: const []),
+      );
+      expect(adapter.availability, RefuelAvailability.unknown);
+    });
+
+    test('only-unknown-status connectors → unknown', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(connectors: [
+          _connector(ConnectorStatus.unknown),
+          _connector(ConnectorStatus.unknown),
+        ]),
+      );
+      expect(adapter.availability, RefuelAvailability.unknown);
+    });
+
+    test('isOperational=null does NOT trigger closed (only false does)', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(
+          // Default: isOperational is null
+          connectors: [_connector(ConnectorStatus.available)],
+        ),
+      );
+      expect(adapter.availability, RefuelAvailability.open);
+    });
+  });
+
+  group('ChargingStationAsRefuelOption — price (phase-2 limitation)', () {
+    test('price is always null in phase 2 even when usageCost is set', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(usageCost: '0.49 EUR/kWh'),
+      );
+      expect(adapter.price, isNull);
+    });
+
+    test('price is null when usageCost is null', () {
+      final adapter = ChargingStationAsRefuelOption(_ev(usageCost: null));
+      expect(adapter.price, isNull);
+    });
+  });
+}

--- a/test/core/refuel/station_as_refuel_option_test.dart
+++ b/test/core/refuel/station_as_refuel_option_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/refuel/refuel_availability.dart';
+import 'package:tankstellen/core/refuel/refuel_price.dart';
+import 'package:tankstellen/core/refuel/refuel_provider.dart';
+import 'package:tankstellen/core/refuel/station_as_refuel_option.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+/// Build a [Station] with all required fields stubbed and only the
+/// fields each test cares about overridden. Keeps the test cases small
+/// and intent-focused.
+Station _station({
+  String id = '42',
+  String brand = 'Total',
+  double lat = 48.8566,
+  double lng = 2.3522,
+  double? e5,
+  double? e10,
+  double? e98,
+  double? diesel,
+  double? dieselPremium,
+  double? e85,
+  double? lpg,
+  double? cng,
+  bool isOpen = true,
+  bool is24h = false,
+  String? updatedAt,
+}) =>
+    Station(
+      id: id,
+      name: 'Station $id',
+      brand: brand,
+      street: 'rue de Test',
+      postCode: '75001',
+      place: 'Paris',
+      lat: lat,
+      lng: lng,
+      e5: e5,
+      e10: e10,
+      e98: e98,
+      diesel: diesel,
+      dieselPremium: dieselPremium,
+      e85: e85,
+      lpg: lpg,
+      cng: cng,
+      isOpen: isOpen,
+      is24h: is24h,
+      updatedAt: updatedAt,
+    );
+
+void main() {
+  group('StationAsRefuelOption — identity & provider', () {
+    test('coordinates pass through from station.lat/lng', () {
+      final adapter = StationAsRefuelOption(
+        _station(lat: 50.1109, lng: 8.6821),
+      );
+      expect(adapter.coordinates.lat, 50.1109);
+      expect(adapter.coordinates.lng, 8.6821);
+    });
+
+    test('id uses the "fuel:" type prefix', () {
+      final adapter = StationAsRefuelOption(_station(id: 'abc-123'));
+      expect(adapter.id, 'fuel:abc-123');
+    });
+
+    test('provider wraps the brand with kind=fuel', () {
+      final adapter = StationAsRefuelOption(_station(brand: 'Esso'));
+      expect(
+        adapter.provider,
+        const RefuelProvider(name: 'Esso', kind: RefuelProviderKind.fuel),
+      );
+    });
+
+    test('empty brand collapses to RefuelProvider.unknown', () {
+      final adapter = StationAsRefuelOption(_station(brand: ''));
+      expect(adapter.provider, RefuelProvider.unknown);
+    });
+  });
+
+  group('StationAsRefuelOption — price by fuel type', () {
+    test('FuelType.e5 reads station.e5, multiplies by 100, cents/L', () {
+      final adapter = StationAsRefuelOption(
+        _station(e5: 1.749),
+        FuelType.e5,
+      );
+      final price = adapter.price!;
+      expect(price.value, 174.9);
+      expect(price.unit, RefuelPriceUnit.centsPerLiter);
+    });
+
+    test('FuelType.e10 (default) reads station.e10', () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.699),
+      );
+      expect(adapter.price?.value, 169.9);
+    });
+
+    test('FuelType.e98 reads station.e98', () {
+      final adapter = StationAsRefuelOption(
+        _station(e98: 1.899),
+        FuelType.e98,
+      );
+      expect(adapter.price?.value, 189.9);
+    });
+
+    test('FuelType.diesel reads station.diesel', () {
+      final adapter = StationAsRefuelOption(
+        _station(diesel: 1.659),
+        FuelType.diesel,
+      );
+      expect(adapter.price?.value, 165.9);
+    });
+
+    test('FuelType.dieselPremium reads station.dieselPremium', () {
+      final adapter = StationAsRefuelOption(
+        _station(dieselPremium: 1.799),
+        FuelType.dieselPremium,
+      );
+      expect(adapter.price?.value, 179.9);
+    });
+
+    test('FuelType.e85 reads station.e85', () {
+      final adapter = StationAsRefuelOption(
+        _station(e85: 0.899),
+        FuelType.e85,
+      );
+      expect(adapter.price?.value, 89.9);
+    });
+
+    test('FuelType.lpg reads station.lpg', () {
+      final adapter = StationAsRefuelOption(
+        _station(lpg: 0.999),
+        FuelType.lpg,
+      );
+      expect(adapter.price?.value, 99.9);
+    });
+
+    test('FuelType.cng reads station.cng (tagged centsPerLiter — see doc)',
+        () {
+      final adapter = StationAsRefuelOption(
+        _station(cng: 1.299),
+        FuelType.cng,
+      );
+      final price = adapter.price!;
+      expect(price.value, 129.9);
+      // The CNG `Station` field is EUR-per-pump-unit — see adapter doc.
+      expect(price.unit, RefuelPriceUnit.centsPerLiter);
+    });
+
+    test('null fuel field on station → null price', () {
+      final adapter = StationAsRefuelOption(
+        _station(), // all fuel fields null
+        FuelType.e10,
+      );
+      expect(adapter.price, isNull);
+    });
+
+    test('FuelType.electric → null price (Station has no kWh field)', () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.699), // even when other fields are populated
+        FuelType.electric,
+      );
+      expect(adapter.price, isNull);
+    });
+
+    test('FuelType.hydrogen → null price (Station has no H2 field)', () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.699),
+        FuelType.hydrogen,
+      );
+      expect(adapter.price, isNull);
+    });
+
+    test('FuelType.all (meta wildcard) → null price', () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.699),
+        FuelType.all,
+      );
+      expect(adapter.price, isNull);
+    });
+
+    test('IEEE-754 float drift is stripped (0.1-cent precision)', () {
+      // 1.749 EUR/L * 100 == 174.90000000000003 in raw float math.
+      // The adapter strips that drift and exposes the displayed cents
+      // value (174.9) the user actually sees on the totem.
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.749),
+      );
+      expect(adapter.price?.value, 174.9);
+    });
+  });
+
+  group('StationAsRefuelOption — availability', () {
+    test('isOpen=true → open', () {
+      final adapter = StationAsRefuelOption(_station(isOpen: true));
+      expect(adapter.availability, RefuelAvailability.open);
+      expect(adapter.availability.isOperational, isTrue);
+    });
+
+    test('is24h=true → open even when isOpen=false', () {
+      final adapter = StationAsRefuelOption(
+        _station(isOpen: false, is24h: true),
+      );
+      expect(adapter.availability, RefuelAvailability.open);
+    });
+
+    test('isOpen=false and is24h=false → closed', () {
+      final adapter = StationAsRefuelOption(
+        _station(isOpen: false, is24h: false),
+      );
+      expect(adapter.availability, isA<RefuelAvailability>());
+      expect(adapter.availability.isOperational, isFalse);
+      expect(adapter.availability, RefuelAvailability.closed());
+    });
+  });
+
+  group('StationAsRefuelOption — lastUpdated parsing', () {
+    test('valid ISO-8601 updatedAt is parsed into DateTime', () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.699, updatedAt: '2026-04-26T10:15:30Z'),
+      );
+      expect(
+        adapter.price?.lastUpdated,
+        DateTime.parse('2026-04-26T10:15:30Z'),
+      );
+    });
+
+    test('null updatedAt → null lastUpdated', () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.699, updatedAt: null),
+      );
+      expect(adapter.price?.lastUpdated, isNull);
+    });
+
+    test('empty updatedAt → null lastUpdated', () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.699, updatedAt: ''),
+      );
+      expect(adapter.price?.lastUpdated, isNull);
+    });
+
+    test('garbage updatedAt → null lastUpdated (no throw)', () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.699, updatedAt: 'not-a-date'),
+      );
+      expect(adapter.price?.lastUpdated, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 of the fuel/EV unification (#1116). Phase 1 (#1155) introduced the abstract `RefuelOption` contract; this PR adds two concrete adapters that wrap the existing `Station` (fuel) and `ChargingStation` (EV) entities so phase 3 can render one unified search list without forking by category at the UI layer.

No existing call sites change yet — the adapters are pure additions and only the new tests exercise them.

## Files

- `lib/core/refuel/station_as_refuel_option.dart` — wraps `Station` + a chosen `FuelType`, mapping the eight price fields to `RefuelPrice` (cents/L, 0.1-cent precision to strip IEEE-754 float drift) and `is24h || isOpen` to `RefuelAvailability.open`.
- `lib/core/refuel/charging_station_as_refuel_option.dart` — wraps `ChargingStation`, deriving availability from connector status (any-available → open, all-occupied → limited, all-out-of-order → closed, empty/unknown → unknown) and short-circuiting to closed when the site-level `isOperational == false`.
- `test/core/refuel/station_as_refuel_option_test.dart` — 23 tests covering coordinate/provider/id mapping, every fuel-type branch (incl. electric/hydrogen/all → null), open/closed/24h availability, and `lastUpdated` parsing edge cases.
- `test/core/refuel/charging_station_as_refuel_option_test.dart` — 15 tests covering coordinate/provider/id mapping, the connector-status decision tree, the `isOperational=false` short-circuit, and the always-null `price` (phase-2 limitation).

## Phase boundary

EV `price` is intentionally `null` in phase 2: `ChargingStation.usageCost` is a free-form string ("0.49 EUR/kWh", "Free", "0.79 EUR/kWh after first 30 min") and country-specific parsing belongs alongside the phase-3 pricing widgets. EV `closed`/`limited` reasons are literal English fallbacks; the adapter layer stays locale-agnostic — consumers (phase 3) wrap the reason in `AppLocalizations` before display, which is why no ARB keys are added in this PR.

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test test/core/refuel/station_as_refuel_option_test.dart test/core/refuel/charging_station_as_refuel_option_test.dart` — 38/38 green locally
- [ ] Full CI suite green
- [ ] Reviewer sanity-check: phase-2 deliverables match #1116 scope, phases 3-4 still open

Refs #1116 phase 2 (phases 3-4 — UI consumer + EV-price parser — remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)