### PR TITLE
refactor(consumption): extract form sections from add_fill_up_screen (Refs #563 phase: add_fill_up_screen)

### DIFF
--- a/lib/features/consumption/domain/add_fill_up_fuel_resolver.dart
+++ b/lib/features/consumption/domain/add_fill_up_fuel_resolver.dart
@@ -1,0 +1,71 @@
+import '../../search/domain/entities/fuel_type.dart';
+import '../../vehicle/domain/entities/vehicle_profile.dart';
+
+/// Pure helpers that map a [VehicleProfile] to its preferred [FuelType],
+/// pick the initial vehicle on the Add-Fill-up form, and resolve which
+/// fuel the form should land on by default. Pulled out of
+/// `add_fill_up_screen.dart` (#563 extraction) so the policy is
+/// unit-testable and a future change (e.g. a per-station preferred
+/// fuel) only touches the helper.
+///
+/// Mirrors `charging_log_readout.dart` / `charging_log_validators.dart`
+/// pattern PR #1156 set on master for the Add-Charging-Log form.
+class AddFillUpFuelResolver {
+  AddFillUpFuelResolver._();
+
+  /// Resolve the vehicle's fuel type (#698). EV → electric; combustion
+  /// → the stored preferredFuelType parsed back to the typed enum.
+  /// Returns `null` when the vehicle has no fuel configured.
+  static FuelType? fuelForVehicle(VehicleProfile v) {
+    if (v.type == VehicleType.ev) return FuelType.electric;
+    final raw = v.preferredFuelType;
+    if (raw == null || raw.trim().isEmpty) return null;
+    return FuelType.fromString(raw);
+  }
+
+  /// Default-fuel policy (#713):
+  ///   1. [preFill] (from receipt scan / station context) if it is
+  ///      compatible with the vehicle.
+  ///   2. [profilePreferred] if compatible — honours "suggest by
+  ///      default the one in the profile" for flex-fuel vehicles.
+  ///   3. The vehicle's own preferred fuel as the fallback.
+  ///   4. [FuelType.e10] as the global last-resort default (when the
+  ///      vehicle has nothing configured).
+  static FuelType resolveDefaultFuel({
+    required VehicleProfile vehicle,
+    FuelType? profilePreferred,
+    FuelType? preFill,
+  }) {
+    final vehicleFuel = fuelForVehicle(vehicle) ?? FuelType.e10;
+    final compatible = compatibleFuelsFor(vehicleFuel);
+    if (preFill != null && compatible.contains(preFill)) return preFill;
+    if (profilePreferred != null && compatible.contains(profilePreferred)) {
+      return profilePreferred;
+    }
+    return vehicleFuel;
+  }
+
+  /// Pick the initial vehicle id for the Add-Fill-up form (#713):
+  ///   1. The profile's `defaultVehicleId` if it exists in [vehicles].
+  ///   2. The currently-active vehicle's id if it exists in [vehicles].
+  ///   3. The first vehicle in the list (vehicle is mandatory).
+  ///
+  /// Returns `null` only when [vehicles] is empty — the screen reacts
+  /// to that by routing to the "Add a vehicle first" CTA.
+  static String? pickInitialVehicleId({
+    required List<VehicleProfile> vehicles,
+    String? profileDefaultId,
+    String? activeVehicleId,
+  }) {
+    if (vehicles.isEmpty) return null;
+    if (profileDefaultId != null &&
+        vehicles.any((v) => v.id == profileDefaultId)) {
+      return profileDefaultId;
+    }
+    if (activeVehicleId != null &&
+        vehicles.any((v) => v.id == activeVehicleId)) {
+      return activeVehicleId;
+    }
+    return vehicles.first.id;
+  }
+}

--- a/lib/features/consumption/domain/add_fill_up_validators.dart
+++ b/lib/features/consumption/domain/add_fill_up_validators.dart
@@ -1,0 +1,35 @@
+import '../../../l10n/app_localizations.dart';
+
+/// Pure validators / parsers shared by the Add-Fill-up form (#563
+/// extraction). Pulled out of `add_fill_up_screen.dart` so the rules
+/// can be unit-tested without pumping a full widget tree, mirroring
+/// the `charging_log_validators.dart` split landed for the Add-Charging
+/// form in PR #1156.
+///
+/// All validators accept `null` localizations for tests / golden
+/// fallbacks and degrade to English defaults — the same pattern used
+/// elsewhere in the codebase (see `AppLocalizations.of(context)?.x ??
+/// 'Fallback'`).
+class AddFillUpValidators {
+  AddFillUpValidators._();
+
+  /// Validates that [value] parses to a strictly positive number. Used
+  /// for liters, total cost, and odometer fields — all three must be
+  /// > 0 for a fill-up to make sense (you can't fill nothing, pay
+  /// nothing, or have a zero-km odometer reading).
+  static String? positiveNumber(String? value, AppLocalizations? l) {
+    if (value == null || value.trim().isEmpty) {
+      return l?.fieldRequired ?? 'Required';
+    }
+    final parsed = double.tryParse(value.replaceAll(',', '.'));
+    if (parsed == null || parsed <= 0) {
+      return l?.fieldInvalidNumber ?? 'Invalid number';
+    }
+    return null;
+  }
+
+  /// Parses a double from a comma-or-dot decimal string. Throws if the
+  /// string is unparseable — call only after validation has passed.
+  static double parseDouble(String text) =>
+      double.parse(text.replaceAll(',', '.'));
+}

--- a/lib/features/consumption/domain/fill_up_auto_cost_calculator.dart
+++ b/lib/features/consumption/domain/fill_up_auto_cost_calculator.dart
@@ -1,0 +1,51 @@
+/// Auto-fills the total-cost field on the Add-Fill-up form (#581)
+/// when the screen receives a non-null `preFilledPricePerLiter` from
+/// the station context.
+///
+/// Pulled out of `add_fill_up_screen.dart` (#563 extraction) so the
+/// "don't clobber a manually-typed cost" rule has its own unit tests
+/// and the calculator owns its `lastAutoCost` instead of leaking the
+/// field across the screen state.
+///
+/// Usage from the screen:
+///
+///     final calc = FillUpAutoCostCalculator(pricePerLiter: 1.859);
+///     // in the liters-controller listener:
+///     final next = calc.recompute(
+///       litersText: _litersCtrl.text,
+///       costText: _costCtrl.text,
+///     );
+///     if (next != null) _costCtrl.text = next;
+class FillUpAutoCostCalculator {
+  final double pricePerLiter;
+  double? _lastAutoCost;
+
+  FillUpAutoCostCalculator({required this.pricePerLiter});
+
+  /// Recompute the total cost from [litersText]. Returns the new cost
+  /// text to write into the cost field, or `null` when:
+  ///   * liters parses to a non-positive / unparseable value, OR
+  ///   * the user has typed a custom cost (cost field is non-empty
+  ///     and does not match the previous auto-fill).
+  ///
+  /// The caller is responsible for assigning the returned string to
+  /// the controller.
+  String? recompute({
+    required String litersText,
+    required String costText,
+  }) {
+    final liters = double.tryParse(litersText.replaceAll(',', '.'));
+    if (liters == null || liters <= 0) return null;
+    final current = double.tryParse(costText.replaceAll(',', '.'));
+    final autoCost = (liters * pricePerLiter).toStringAsFixed(2);
+    // Only overwrite if the user hasn't typed a custom cost. We detect
+    // "user-typed" by checking whether the current value matches a
+    // prior auto-fill: if the field is empty OR exactly matches the
+    // previous auto-computed value, we overwrite.
+    if (costText.isEmpty || current == _lastAutoCost) {
+      _lastAutoCost = double.tryParse(autoCost);
+      return autoCost;
+    }
+    return null;
+  }
+}

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -2,26 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../../core/constants/app_constants.dart';
-import '../../../../core/feedback/github_issue_reporter.dart';
-import '../../../../core/widgets/form_section_card.dart';
-import '../../../../core/widgets/fuel_type_dropdown.dart';
 import '../../../../core/widgets/page_scaffold.dart';
-import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/receipt_scan_service.dart';
+import '../../domain/add_fill_up_fuel_resolver.dart';
+import '../../domain/add_fill_up_validators.dart';
 import '../../domain/entities/fill_up.dart';
+import '../../domain/fill_up_auto_cost_calculator.dart';
 import '../../providers/consumption_providers.dart';
-import '../widgets/bad_scan_report_sheet.dart';
-import '../widgets/fill_up_notes_field.dart';
-import '../widgets/fill_up_numeric_field.dart';
-import '../widgets/fill_up_price_per_liter_readout.dart';
-import '../widgets/fill_up_vehicle_dropdown.dart';
-import '../widgets/pump_scan_failure_sheet.dart';
+import '../widgets/add_fill_up_form_fields.dart';
+import '../widgets/fill_up_no_vehicle_cta.dart';
+import '../widgets/fill_up_pinned_save_bar.dart';
+import '../widgets/fill_up_scan_handlers.dart';
 
 /// Form to add a new [FillUp] entry.
 class AddFillUpScreen extends ConsumerStatefulWidget {
@@ -74,12 +70,14 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
   String? _vehicleId;
   bool _vehicleInitialized = false;
   ReceiptScanOutcome? _lastScan;
+  FillUpAutoCostCalculator? _autoCostCalc;
 
   @override
   void initState() {
     super.initState();
     final price = widget.preFilledPricePerLiter;
     if (price != null) {
+      _autoCostCalc = FillUpAutoCostCalculator(pricePerLiter: price);
       _litersCtrl.addListener(_recomputeCost);
     }
     // #953 — accept an injected scan service so widget tests can drive
@@ -114,18 +112,16 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     } catch (e, st) {
       debugPrint('AddFillUp: active vehicle unavailable: $e\n$st');
     }
-    if (defaultId != null && vehicles.any((v) => v.id == defaultId)) {
-      _vehicleId = defaultId;
-    } else if (activeId != null && vehicles.any((v) => v.id == activeId)) {
-      _vehicleId = activeId;
-    } else {
-      _vehicleId = vehicles.first.id;
-    }
+    _vehicleId = AddFillUpFuelResolver.pickInitialVehicleId(
+      vehicles: vehicles,
+      profileDefaultId: defaultId,
+      activeVehicleId: activeId,
+    );
     final selected = vehicles.firstWhere(
       (v) => v.id == _vehicleId,
       orElse: () => vehicles.first,
     );
-    _fuelType = _resolveDefaultFuel(
+    _fuelType = AddFillUpFuelResolver.resolveDefaultFuel(
       vehicle: selected,
       profilePreferred: profilePreferred,
       preFill: widget.preFilledFuelType,
@@ -133,48 +129,15 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     _vehicleInitialized = true;
   }
 
-  /// Default-fuel policy (#713):
-  /// 1. preFilledFuelType (from receipt scan / station context) if it
-  ///    is compatible with the vehicle
-  /// 2. profile's preferredFuelType if compatible — honours "suggest
-  ///    by default the one in the profile" for flex-fuel vehicles
-  /// 3. vehicle's own preferred fuel as the fallback
-  /// 4. FuelType.e10 as the global last-resort default
-  FuelType _resolveDefaultFuel({
-    required VehicleProfile vehicle,
-    FuelType? profilePreferred,
-    FuelType? preFill,
-  }) {
-    final vehicleFuel = _fuelForVehicle(vehicle) ?? FuelType.e10;
-    final compatible = compatibleFuelsFor(vehicleFuel);
-    if (preFill != null && compatible.contains(preFill)) return preFill;
-    if (profilePreferred != null && compatible.contains(profilePreferred)) {
-      return profilePreferred;
-    }
-    return vehicleFuel;
-  }
-
-  /// Auto-fills the total cost based on the pre-filled price per liter
-  /// and the current liters input. Only runs when the user has not manually
-  /// typed a cost (empty field) — so we don't clobber a scanned receipt.
+  /// Listener bridging the liters controller to the auto-cost
+  /// calculator (extracted to `fill_up_auto_cost_calculator.dart`).
   void _recomputeCost() {
-    final price = widget.preFilledPricePerLiter;
-    if (price == null) return;
-    final liters = double.tryParse(_litersCtrl.text.replaceAll(',', '.'));
-    if (liters == null || liters <= 0) return;
-    final current = double.tryParse(_costCtrl.text.replaceAll(',', '.'));
-    // Only overwrite if the user hasn't typed a custom cost. We detect
-    // "user-typed" by checking whether the current value matches a prior
-    // auto-fill: if the field is empty OR exactly matches the previous
-    // auto-computed value, we overwrite.
-    final autoCost = (liters * price).toStringAsFixed(2);
-    if (_costCtrl.text.isEmpty || current == _lastAutoCost) {
-      _costCtrl.text = autoCost;
-      _lastAutoCost = double.tryParse(autoCost);
-    }
+    final next = _autoCostCalc?.recompute(
+      litersText: _litersCtrl.text,
+      costText: _costCtrl.text,
+    );
+    if (next != null) _costCtrl.text = next;
   }
-
-  double? _lastAutoCost;
 
   @override
   void dispose() {
@@ -191,66 +154,72 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     super.dispose();
   }
 
-  Future<void> _scanReceipt() async {
-    setState(() => _scanning = true);
-    final l = AppLocalizations.of(context);
-    try {
-      _scanService ??= ReceiptScanService();
-      final outcome = await _scanService!.scanReceipt();
-      if (outcome == null || !mounted) return;
-      final result = outcome.parse;
+  /// Bridge to the scan helpers in `fill_up_scan_handlers.dart`.
+  /// Bundles the controllers + per-field setters the helpers need so
+  /// the long async sequences live outside the screen file.
+  FillUpScanHostState _buildScanHostState() => FillUpScanHostState(
+        litersCtrl: _litersCtrl,
+        costCtrl: _costCtrl,
+        vehicleId: _vehicleId,
+        readService: () => _scanService,
+        writeService: (s) => _scanService = s,
+        setScanning: (v) => setState(() => _scanning = v),
+        setScanningPump: (v) => setState(() => _scanningPump = v),
+        setDate: (d) => setState(() => _date = d),
+        setFuelType: (f) => setState(() => _fuelType = f),
+        setLastScan: (o) => setState(() => _lastScan = o),
+        isMounted: () => mounted,
+      );
 
-      if (!result.hasData) {
-        SnackBarHelper.show(
-          context,
-          l?.scanReceiptNoData ?? 'No receipt data found — try again',
-        );
-        return;
-      }
+  Future<void> _scanReceipt() => runReceiptScan(context, _buildScanHostState());
 
-      setState(() {
-        if (result.liters != null) {
-          _litersCtrl.text = result.liters!.toStringAsFixed(2);
-        }
-        if (result.totalCost != null) {
-          _costCtrl.text = result.totalCost!.toStringAsFixed(2);
-        }
-        if (result.date != null) {
-          _date = result.date!;
-        }
-        // Only pre-select the fuel when there is no vehicle bound — the
-        // vehicle's configured fuel always wins (#698 single source of
-        // truth for fuel).
-        if (result.fuelType != null && _vehicleId == null) {
-          _fuelType = result.fuelType!;
-        }
-        _lastScan = outcome;
-      });
+  Future<void> _scanPumpDisplay() =>
+      runPumpDisplayScan(context, _buildScanHostState());
 
-      if (mounted) {
-        SnackBarHelper.show(
-          context,
-          l?.scanReceiptSuccess ??
-              'Receipt scanned — verify values. Tap "Report scan error" '
-                  'below if anything is off.',
-        );
-      }
-    } catch (e, st) { // ignore: unused_catch_stack
-      if (mounted) {
-        SnackBarHelper.showError(
-          context,
-          l?.scanReceiptFailed(e.toString()) ?? 'Scan failed: $e',
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _scanning = false);
+  Future<void> _reportBadScan() async {
+    final scan = _lastScan;
+    if (scan == null) return;
+    return reportBadReceiptScan(context, _buildScanHostState(), scan);
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _date,
+      firstDate: DateTime(2000),
+      lastDate: DateTime.now().add(const Duration(days: 1)),
+    );
+    if (picked != null) {
+      setState(() => _date = picked);
     }
   }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final fillUp = FillUp(
+      id: DateTime.now().microsecondsSinceEpoch.toString(),
+      date: _date,
+      liters: AddFillUpValidators.parseDouble(_litersCtrl.text),
+      totalCost: AddFillUpValidators.parseDouble(_costCtrl.text),
+      odometerKm: AddFillUpValidators.parseDouble(_odoCtrl.text),
+      fuelType: _fuelType,
+      stationId: widget.stationId,
+      stationName: widget.stationName,
+      notes: _notesCtrl.text.trim().isEmpty ? null : _notesCtrl.text.trim(),
+      vehicleId: _vehicleId,
+    );
+
+    await ref.read(fillUpListProvider.notifier).add(fillUp);
+    if (!mounted) return;
+    context.pop();
+  }
+
+  String _pad(int n) => n.toString().padLeft(2, '0');
 
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
     final dateStr =
         '${_date.year}-${_pad(_date.month)}-${_pad(_date.day)}';
     // Tolerate providers in error state during widget tests without
@@ -267,47 +236,7 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     // #706 — consumption requires a vehicle. When none are configured,
     // show an empty-state CTA instead of the full form.
     if (vehicles.isEmpty) {
-      return PageScaffold(
-        title: l?.addFillUp ?? 'Add fill-up',
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          tooltip: l?.tooltipBack ?? 'Back',
-          onPressed: () => context.pop(),
-        ),
-        bodyPadding: const EdgeInsets.all(32),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                Icons.directions_car_outlined,
-                size: 80,
-                color: theme.colorScheme.primary,
-              ),
-              const SizedBox(height: 24),
-              Text(
-                l?.consumptionNoVehicleTitle ?? 'Add a vehicle first',
-                style: theme.textTheme.headlineSmall,
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                l?.consumptionNoVehicleBody ??
-                    'Fill-ups are attributed to a vehicle. Add your car '
-                        'to start logging consumption.',
-                style: theme.textTheme.bodyMedium,
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 24),
-              FilledButton.icon(
-                onPressed: () => context.push('/vehicles/edit'),
-                icon: const Icon(Icons.add),
-                label: Text(l?.vehicleAdd ?? 'Add vehicle'),
-              ),
-            ],
-          ),
-        ),
-      );
+      return const FillUpNoVehicleCta();
     }
 
     return PageScaffold(
@@ -330,565 +259,38 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
             MediaQuery.of(context).viewPadding.bottom + 96,
           ),
           children: [
-            // #951 — restored to two visible buttons after the
-            // single "Import from…" chip was rolled back. The OBD-II
-            // adapter import path was removed from this screen because
-            // odometer reading via PID 0xA6 is unreliable on real
-            // hardware (Peugeot 107 / generic ELM327). The full OBD-II
-            // trip flow remains accessible from the Consumption screen.
-            _FillUpImportButtons(
+            AddFillUpFormFields(
               scanningReceipt: _scanning,
               scanningPump: _scanningPump,
               onScanReceipt: _scanReceipt,
               onScanPumpDisplay: _scanPumpDisplay,
-            ),
-            const SizedBox(height: 16),
-            // Station pre-fill callout — rendered above the cards so
-            // it's unmissable when the user opened the form from a
-            // station detail screen (#751 phase 2 keeps the original
-            // #581 affordance; it simply graduated from a ListTile
-            // card to the restyled header band).
-            if (widget.stationName != null) ...[
-              _StationPreFillBanner(
-                stationName: widget.stationName!,
-                label: l?.stationPreFilled ?? 'Station pre-filled',
-              ),
-              const SizedBox(height: 16),
-            ],
-            // Card 1: "What you filled" — date, fuel, liters, cost.
-            FormSectionCard(
-              title: l?.fillUpSectionWhatTitle ?? 'What you filled',
-              subtitle: l?.fillUpSectionWhatSubtitle ?? 'Fuel, amount, price',
-              icon: Icons.local_gas_station_outlined,
-              children: [
-                FormFieldTile(
-                  icon: Icons.calendar_today_outlined,
-                  content: InkWell(
-                    onTap: _pickDate,
-                    borderRadius: BorderRadius.circular(8),
-                    child: InputDecorator(
-                      decoration: InputDecoration(
-                        labelText: l?.fillUpDate ?? 'Date',
-                        border: const OutlineInputBorder(),
-                      ),
-                      child: Text(dateStr),
-                    ),
-                  ),
-                ),
-                FormFieldTile(
-                  icon: Icons.directions_car_outlined,
-                  content: FillUpVehicleDropdown(
-                    vehicleId: _vehicleId,
-                    vehicles: vehicles,
-                    onChanged: (id, selected) {
-                      setState(() {
-                        _vehicleId = id;
-                        final derived = _fuelForVehicle(selected);
-                        if (derived != null) _fuelType = derived;
-                      });
-                    },
-                  ),
-                ),
-                if (_vehicleId != null)
-                  FormFieldTile(
-                    icon: Icons.water_drop_outlined,
-                    content: _VehicleFuelPicker(
-                      vehicles: vehicles,
-                      vehicleId: _vehicleId!,
-                      fuelType: _fuelType,
-                      onChanged: (next) => setState(() => _fuelType = next),
-                      onOpenVehicle: () =>
-                          context.push('/vehicles/edit', extra: _vehicleId!),
-                    ),
-                  ),
-                FormFieldTile(
-                  icon: Icons.opacity_outlined,
-                  content: FillUpNumericField(
-                    controller: _litersCtrl,
-                    label: l?.liters ?? 'Liters',
-                    icon: Icons.water_drop_outlined,
-                    validator: _positiveNumberValidator,
-                  ),
-                ),
-                FormFieldTile(
-                  icon: Icons.euro,
-                  content: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      FillUpNumericField(
-                        controller: _costCtrl,
-                        label: l?.totalCost ?? 'Total cost',
-                        icon: Icons.euro,
-                        validator: _positiveNumberValidator,
-                      ),
-                      // Live-derived price/L — #751 §2 bullet 4.
-                      FillUpPricePerLiterReadout(
-                        litersController: _litersCtrl,
-                        costController: _costCtrl,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            // Card 2: "Where you were" — station, odometer, notes.
-            FormSectionCard(
-              title: l?.fillUpSectionWhereTitle ?? 'Where you were',
-              subtitle:
-                  l?.fillUpSectionWhereSubtitle ?? 'Station, odometer, notes',
-              icon: Icons.place_outlined,
-              children: [
-                FormFieldTile(
-                  icon: Icons.speed_outlined,
-                  content: FillUpNumericField(
-                    controller: _odoCtrl,
-                    label: l?.odometerKm ?? 'Odometer (km)',
-                    icon: Icons.speed,
-                    validator: _positiveNumberValidator,
-                  ),
-                ),
-                FormFieldTile(
-                  icon: Icons.edit_note_outlined,
-                  content: FillUpNotesField(controller: _notesCtrl),
-                ),
-                if (_lastScan != null) ...[
-                  const SizedBox(height: 4),
-                  Align(
-                    alignment: AlignmentDirectional.centerEnd,
-                    child: TextButton.icon(
-                      onPressed: _reportBadScan,
-                      icon: const Icon(Icons.flag_outlined, size: 18),
-                      label: Text(
-                        l?.reportScanError ?? 'Report scan error',
-                      ),
-                    ),
-                  ),
-                ],
-              ],
+              stationName: widget.stationName,
+              dateLabel: dateStr,
+              onPickDate: _pickDate,
+              vehicleId: _vehicleId,
+              vehicles: vehicles,
+              onVehicleChanged: (id, selected) {
+                setState(() {
+                  _vehicleId = id;
+                  final derived =
+                      AddFillUpFuelResolver.fuelForVehicle(selected);
+                  if (derived != null) _fuelType = derived;
+                });
+              },
+              fuelType: _fuelType,
+              onFuelChanged: (next) => setState(() => _fuelType = next),
+              onOpenVehicle: () =>
+                  context.push('/vehicles/edit', extra: _vehicleId!),
+              litersCtrl: _litersCtrl,
+              costCtrl: _costCtrl,
+              odoCtrl: _odoCtrl,
+              notesCtrl: _notesCtrl,
+              onReportBadScan: _lastScan != null ? _reportBadScan : null,
             ),
           ],
         ),
       ),
-      bottomNavigationBar: _PinnedSaveBar(onSave: _save),
-    );
-  }
-
-  /// #598 — scan the fuel-pump LCD (Betrag / Abgabe / Preis/Liter) and
-  /// pre-fill the form. Unlike the receipt path there is no brand
-  /// dispatch — every pump emits the same 3-number format — so we
-  /// only need the numeric values and one cross-validity check.
-  ///
-  /// #953 — when parsing fails (`!hasUsableData`) we no longer drop the
-  /// photo silently; we open the [_PumpScanFailureSheet] which lets the
-  /// user pick "Corriger manuellement" (close, leave the form untouched
-  /// so they type values), "Signaler" (open [BadScanReportSheet] with
-  /// [ScanKind.pumpDisplay] so the photo is shipped to GitHub), or
-  /// "Retirer la photo" (delete + close).
-  Future<void> _scanPumpDisplay() async {
-    setState(() => _scanningPump = true);
-    final l = AppLocalizations.of(context);
-    try {
-      _scanService ??= ReceiptScanService();
-      final outcome = await _scanService!.scanPumpDisplay();
-      if (outcome == null || !mounted) return;
-      final result = outcome.parse;
-      if (!result.hasUsableData) {
-        // Pass the outcome straight into the failure sheet so the
-        // bad-scan reporter can ship the photo + raw OCR text without
-        // re-running OCR on a re-captured image.
-        await _showPumpScanFailureSheet(outcome);
-        return;
-      }
-      setState(() {
-        if (result.liters != null) {
-          _litersCtrl.text = result.liters!.toStringAsFixed(2);
-        }
-        if (result.totalCost != null) {
-          _costCtrl.text = result.totalCost!.toStringAsFixed(2);
-        }
-      });
-      if (mounted) {
-        SnackBarHelper.show(
-          context,
-          l?.scanPumpSuccess ?? 'Pump display scanned — verify the values.',
-        );
-      }
-    } catch (e, st) { // ignore: unused_catch_stack
-      if (mounted) {
-        SnackBarHelper.showError(
-          context,
-          l?.scanPumpFailed(e.toString()) ?? 'Pump scan failed: $e',
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _scanningPump = false);
-    }
-  }
-
-  /// Opens the failure-flow bottom sheet for an unreadable pump-display
-  /// scan (#953). The sheet is dismissable; the action the user picks
-  /// determines the next step:
-  ///   - correctManually: close, leave the form untouched.
-  ///   - report: open [BadScanReportSheet] with [ScanKind.pumpDisplay].
-  ///   - removePhoto: delete the temp file and forget the scan.
-  Future<void> _showPumpScanFailureSheet(
-    PumpDisplayScanOutcome outcome,
-  ) async {
-    final action = await showModalBottomSheet<PumpScanFailureAction>(
-      context: context,
-      isScrollControlled: true,
-      builder: (_) => const PumpScanFailureSheet(),
-    );
-    if (!mounted) return;
-    switch (action) {
-      case PumpScanFailureAction.report:
-        await _reportBadPumpScan(outcome);
-        break;
-      case PumpScanFailureAction.removePhoto:
-        await _scanService?.deleteCapturedImage(outcome.imagePath);
-        break;
-      case PumpScanFailureAction.correctManually:
-      case null:
-        // Sheet dismissed or "Correct manually" — keep the photo on
-        // disk so the user can still hit "Report scan error" via the
-        // existing affordance below the form. (The button currently
-        // surfaces only for receipt scans; pump-display reports are
-        // accessible via the failure sheet itself.)
-        break;
-    }
-  }
-
-  Future<void> _reportBadPumpScan(PumpDisplayScanOutcome outcome) async {
-    final liters = double.tryParse(_litersCtrl.text.replaceAll(',', '.'));
-    final cost = double.tryParse(_costCtrl.text.replaceAll(',', '.'));
-    await showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (_) => BadScanReportSheet(
-        kind: ScanKind.pumpDisplay,
-        pumpScan: outcome,
-        enteredLiters: liters,
-        enteredTotalCost: cost,
-        appVersion: AppConstants.appVersion,
-      ),
-    );
-  }
-
-  Future<void> _reportBadScan() async {
-    final scan = _lastScan;
-    if (scan == null) return;
-    final liters = double.tryParse(_litersCtrl.text.replaceAll(',', '.'));
-    final cost = double.tryParse(_costCtrl.text.replaceAll(',', '.'));
-    await showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (_) => BadScanReportSheet(
-        scan: scan,
-        enteredLiters: liters,
-        enteredTotalCost: cost,
-        appVersion: AppConstants.appVersion,
-      ),
-    );
-  }
-
-  Future<void> _pickDate() async {
-    final picked = await showDatePicker(
-      context: context,
-      initialDate: _date,
-      firstDate: DateTime(2000),
-      lastDate: DateTime.now().add(const Duration(days: 1)),
-    );
-    if (picked != null) {
-      setState(() => _date = picked);
-    }
-  }
-
-  String? _positiveNumberValidator(String? value) {
-    final l = AppLocalizations.of(context);
-    if (value == null || value.trim().isEmpty) {
-      return l?.fieldRequired ?? 'Required';
-    }
-    final parsed = double.tryParse(value.replaceAll(',', '.'));
-    if (parsed == null || parsed <= 0) {
-      return l?.fieldInvalidNumber ?? 'Invalid number';
-    }
-    return null;
-  }
-
-  double _parse(TextEditingController ctrl) =>
-      double.parse(ctrl.text.replaceAll(',', '.'));
-
-  Future<void> _save() async {
-    if (!_formKey.currentState!.validate()) return;
-
-    final fillUp = FillUp(
-      id: DateTime.now().microsecondsSinceEpoch.toString(),
-      date: _date,
-      liters: _parse(_litersCtrl),
-      totalCost: _parse(_costCtrl),
-      odometerKm: _parse(_odoCtrl),
-      fuelType: _fuelType,
-      stationId: widget.stationId,
-      stationName: widget.stationName,
-      notes: _notesCtrl.text.trim().isEmpty ? null : _notesCtrl.text.trim(),
-      vehicleId: _vehicleId,
-    );
-
-    await ref.read(fillUpListProvider.notifier).add(fillUp);
-    if (!mounted) return;
-    context.pop();
-  }
-
-  String _pad(int n) => n.toString().padLeft(2, '0');
-
-  /// Resolve the vehicle's fuel type (#698). EV → electric; combustion →
-  /// the stored preferredFuelType parsed back to the typed enum.
-  /// Returns null when the vehicle has no fuel configured.
-  FuelType? _fuelForVehicle(VehicleProfile v) {
-    if (v.type == VehicleType.ev) return FuelType.electric;
-    final raw = v.preferredFuelType;
-    if (raw == null || raw.trim().isEmpty) return null;
-    return FuelType.fromString(raw);
-  }
-}
-
-/// Two side-by-side import buttons restored on the Add-Fill-up form
-/// (#951). The previous single "Import from…" chip + bottom-sheet was
-/// rolled back because the OBD-II tile inside the sheet returned null
-/// for the odometer on the user's real hardware (Peugeot 107 + generic
-/// ELM327 BLE). Until odometer reading via PID 0xA6 is proven reliable
-/// across the supported adapter registry, the OBD-II import path is
-/// hidden from the fill-up screen — see `docs/guides/obd2-adapters.md`.
-///
-/// The full OBD-II trajet flow remains available from the Consumption
-/// screen (#888); only this fill-up entry-point is reduced.
-class _FillUpImportButtons extends StatelessWidget {
-  final bool scanningReceipt;
-  final bool scanningPump;
-  final VoidCallback onScanReceipt;
-  final VoidCallback onScanPumpDisplay;
-
-  const _FillUpImportButtons({
-    required this.scanningReceipt,
-    required this.scanningPump,
-    required this.onScanReceipt,
-    required this.onScanPumpDisplay,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    return Row(
-      children: [
-        Expanded(
-          child: OutlinedButton.icon(
-            key: const Key('import_receipt_button'),
-            onPressed: scanningReceipt ? null : onScanReceipt,
-            icon: scanningReceipt
-                ? const SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.document_scanner_outlined),
-            label: Text(
-              l?.fillUpImportReceiptLabel ?? 'Receipt',
-              maxLines: 2,
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.visible,
-            ),
-          ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: OutlinedButton.icon(
-            key: const Key('import_pump_button'),
-            onPressed: scanningPump ? null : onScanPumpDisplay,
-            icon: scanningPump
-                ? const SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.local_gas_station_outlined),
-            label: Text(
-              l?.fillUpImportPumpLabel ?? 'Pump display',
-              maxLines: 2,
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.visible,
-            ),
-          ),
-        ),
-      ],
+      bottomNavigationBar: FillUpPinnedSaveBar(onSave: _save),
     );
   }
 }
-
-/// Small banner above the form cards announcing the pre-filled
-/// station (#581 affordance restyled for #751 phase 2). Replaces the
-/// old ListTile card so the callout is visible above the fold without
-/// stealing visual weight from the "What you filled" card.
-class _StationPreFillBanner extends StatelessWidget {
-  final String stationName;
-  final String label;
-
-  const _StationPreFillBanner({
-    required this.stationName,
-    required this.label,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.primary.withValues(alpha: 0.08),
-        border: Border.all(
-          color: theme.colorScheme.primary.withValues(alpha: 0.2),
-        ),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        children: [
-          ExcludeSemantics(
-            child: Icon(
-              Icons.place_outlined,
-              color: theme.colorScheme.primary,
-            ),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Semantics(
-              container: true,
-              label: '$label: $stationName',
-              child: ExcludeSemantics(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      label,
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                    Text(
-                      stationName,
-                      style: theme.textTheme.titleMedium,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Pinned bottom Save bar (#751 phase 2). Sits below the scroll view
-/// so the CTA is always one tap away regardless of how many cards
-/// the user has scrolled past. Respects the system nav-bar inset so
-/// it never clips under gesture pills (see
-/// `feedback_scaffold_inset_doubling.md`).
-class _PinnedSaveBar extends StatelessWidget {
-  final VoidCallback onSave;
-  const _PinnedSaveBar({required this.onSave});
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    return Material(
-      elevation: 8,
-      color: theme.colorScheme.surface,
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-          child: FilledButton.icon(
-            onPressed: onSave,
-            style: FilledButton.styleFrom(
-              minimumSize: const Size.fromHeight(52),
-            ),
-            icon: const Icon(Icons.save_outlined),
-            label: Text(l?.save ?? 'Save'),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Fuel picker constrained to the vehicle's compatible fuels (#713).
-///
-/// A petrol car gets [e10, e5, e98, e85]; a diesel car gets
-/// [diesel, dieselPremium]; EV / LPG / CNG / H₂ vehicles pick from
-/// their single applicable fuel only. The initial value is the one
-/// resolved by [_AddFillUpScreenState._resolveDefaultFuel] — profile
-/// preference when compatible, else the vehicle's own fuel — so the
-/// form always loads with the most likely choice but still lets the
-/// user override it for this specific fill-up (e.g. a flex-fuel
-/// E85 car tanking regular SP95 this week).
-class _VehicleFuelPicker extends StatelessWidget {
-  final List<VehicleProfile> vehicles;
-  final String vehicleId;
-  final FuelType fuelType;
-  final ValueChanged<FuelType> onChanged;
-  final VoidCallback onOpenVehicle;
-
-  const _VehicleFuelPicker({
-    required this.vehicles,
-    required this.vehicleId,
-    required this.fuelType,
-    required this.onChanged,
-    required this.onOpenVehicle,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    final vehicle = vehicles.firstWhere((v) => v.id == vehicleId);
-    final vehicleFuel = _fuelForVehicleStatic(vehicle) ?? FuelType.e10;
-    final compatible = compatibleFuelsFor(vehicleFuel);
-    final value =
-        compatible.contains(fuelType) ? fuelType : compatible.first;
-
-    return Row(
-      children: [
-        Expanded(
-          child: FuelTypeDropdown(
-            value: value,
-            options: compatible,
-            prefixIcon: const Icon(Icons.local_gas_station),
-            labelText: '${l?.fuelType ?? 'Fuel type'} • ${vehicle.name}',
-            onChanged: onChanged,
-          ),
-        ),
-        IconButton(
-          icon: const Icon(Icons.open_in_new),
-          tooltip: l?.vehicleEditTitle ?? 'Edit vehicle',
-          onPressed: onOpenVehicle,
-          style: IconButton.styleFrom(
-            foregroundColor: theme.colorScheme.primary,
-          ),
-        ),
-      ],
-    );
-  }
-
-  /// Mirror of [_AddFillUpScreenState._fuelForVehicle] — kept static
-  /// here so the picker can resolve the vehicle's family without
-  /// pulling in a dependency on the parent state.
-  static FuelType? _fuelForVehicleStatic(VehicleProfile v) {
-    if (v.type == VehicleType.ev) return FuelType.electric;
-    final raw = v.preferredFuelType;
-    if (raw == null || raw.trim().isEmpty) return null;
-    return FuelType.fromString(raw);
-  }
-}
-

--- a/lib/features/consumption/presentation/widgets/add_fill_up_form_fields.dart
+++ b/lib/features/consumption/presentation/widgets/add_fill_up_form_fields.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/widgets/form_section_card.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../domain/add_fill_up_validators.dart';
+import 'fill_up_import_buttons_pair.dart';
+import 'fill_up_notes_field.dart';
+import 'fill_up_numeric_field.dart';
+import 'fill_up_price_per_liter_readout.dart';
+import 'fill_up_station_pre_fill_banner.dart';
+import 'fill_up_vehicle_dropdown.dart';
+import 'fill_up_vehicle_fuel_picker.dart';
+
+/// All the input rows on the Add-Fill-up form, composed in the
+/// canonical order: optional station-prefill banner, "What you filled"
+/// card (date, vehicle, fuel, liters, total + price/liter readout),
+/// "Where you were" card (odometer, notes, optional report-bad-scan
+/// button). Pulled out of `add_fill_up_screen.dart` (#563 extraction)
+/// so the screen file drops well below 300 LOC and the form layout
+/// can be exercised as a single widget in tests.
+///
+/// All controllers, the form's `_formKey`, and the busy/scan state are
+/// owned by the screen — this widget is a pure stateless layout that
+/// renders the user-visible structure and dispatches all callbacks
+/// back to the parent.
+class AddFillUpFormFields extends StatelessWidget {
+  /// Busy flag for the "Receipt" import button — drives its spinner.
+  final bool scanningReceipt;
+
+  /// Busy flag for the "Pump display" import button.
+  final bool scanningPump;
+  final VoidCallback onScanReceipt;
+  final VoidCallback onScanPumpDisplay;
+
+  /// Optional station pre-fill banner — non-null station name renders
+  /// the banner above the cards, otherwise the slot is omitted.
+  final String? stationName;
+
+  /// Formatted `YYYY-MM-DD` date string shown on the date row.
+  final String dateLabel;
+  final VoidCallback onPickDate;
+
+  final String? vehicleId;
+  final List<VehicleProfile> vehicles;
+  final void Function(String id, VehicleProfile selected) onVehicleChanged;
+
+  final FuelType fuelType;
+  final ValueChanged<FuelType> onFuelChanged;
+  final VoidCallback onOpenVehicle;
+
+  final TextEditingController litersCtrl;
+  final TextEditingController costCtrl;
+  final TextEditingController odoCtrl;
+  final TextEditingController notesCtrl;
+
+  /// When non-null, shown after the notes field as an affordance to
+  /// flag a wrong receipt scan. Null when the form was filled in
+  /// manually.
+  final VoidCallback? onReportBadScan;
+
+  const AddFillUpFormFields({
+    super.key,
+    required this.scanningReceipt,
+    required this.scanningPump,
+    required this.onScanReceipt,
+    required this.onScanPumpDisplay,
+    required this.stationName,
+    required this.dateLabel,
+    required this.onPickDate,
+    required this.vehicleId,
+    required this.vehicles,
+    required this.onVehicleChanged,
+    required this.fuelType,
+    required this.onFuelChanged,
+    required this.onOpenVehicle,
+    required this.litersCtrl,
+    required this.costCtrl,
+    required this.odoCtrl,
+    required this.notesCtrl,
+    required this.onReportBadScan,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Column(
+      children: [
+        // #951 — restored to two visible buttons after the single
+        // "Import from…" chip was rolled back. The OBD-II adapter
+        // import path was removed from this screen because odometer
+        // reading via PID 0xA6 is unreliable on real hardware (Peugeot
+        // 107 / generic ELM327). The full OBD-II trip flow remains
+        // accessible from the Consumption screen.
+        FillUpImportButtonsPair(
+          scanningReceipt: scanningReceipt,
+          scanningPump: scanningPump,
+          onScanReceipt: onScanReceipt,
+          onScanPumpDisplay: onScanPumpDisplay,
+        ),
+        const SizedBox(height: 16),
+        // Station pre-fill callout — rendered above the cards so it's
+        // unmissable when the user opened the form from a station
+        // detail screen (#751 phase 2 keeps the original #581
+        // affordance; it simply graduated from a ListTile card to the
+        // restyled header band).
+        if (stationName != null) ...[
+          FillUpStationPreFillBanner(
+            stationName: stationName!,
+            label: l?.stationPreFilled ?? 'Station pre-filled',
+          ),
+          const SizedBox(height: 16),
+        ],
+        // Card 1: "What you filled" — date, vehicle, fuel, liters, cost.
+        FormSectionCard(
+          title: l?.fillUpSectionWhatTitle ?? 'What you filled',
+          subtitle: l?.fillUpSectionWhatSubtitle ?? 'Fuel, amount, price',
+          icon: Icons.local_gas_station_outlined,
+          children: [
+            FormFieldTile(
+              icon: Icons.calendar_today_outlined,
+              content: InkWell(
+                onTap: onPickDate,
+                borderRadius: BorderRadius.circular(8),
+                child: InputDecorator(
+                  decoration: InputDecoration(
+                    labelText: l?.fillUpDate ?? 'Date',
+                    border: const OutlineInputBorder(),
+                  ),
+                  child: Text(dateLabel),
+                ),
+              ),
+            ),
+            FormFieldTile(
+              icon: Icons.directions_car_outlined,
+              content: FillUpVehicleDropdown(
+                vehicleId: vehicleId,
+                vehicles: vehicles,
+                onChanged: onVehicleChanged,
+              ),
+            ),
+            if (vehicleId != null)
+              FormFieldTile(
+                icon: Icons.water_drop_outlined,
+                content: FillUpVehicleFuelPicker(
+                  vehicles: vehicles,
+                  vehicleId: vehicleId!,
+                  fuelType: fuelType,
+                  onChanged: onFuelChanged,
+                  onOpenVehicle: onOpenVehicle,
+                ),
+              ),
+            FormFieldTile(
+              icon: Icons.opacity_outlined,
+              content: FillUpNumericField(
+                controller: litersCtrl,
+                label: l?.liters ?? 'Liters',
+                icon: Icons.water_drop_outlined,
+                validator: (v) => AddFillUpValidators.positiveNumber(v, l),
+              ),
+            ),
+            FormFieldTile(
+              icon: Icons.euro,
+              content: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  FillUpNumericField(
+                    controller: costCtrl,
+                    label: l?.totalCost ?? 'Total cost',
+                    icon: Icons.euro,
+                    validator: (v) => AddFillUpValidators.positiveNumber(v, l),
+                  ),
+                  // Live-derived price/L — #751 §2 bullet 4.
+                  FillUpPricePerLiterReadout(
+                    litersController: litersCtrl,
+                    costController: costCtrl,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        // Card 2: "Where you were" — odometer, notes.
+        FormSectionCard(
+          title: l?.fillUpSectionWhereTitle ?? 'Where you were',
+          subtitle:
+              l?.fillUpSectionWhereSubtitle ?? 'Station, odometer, notes',
+          icon: Icons.place_outlined,
+          children: [
+            FormFieldTile(
+              icon: Icons.speed_outlined,
+              content: FillUpNumericField(
+                controller: odoCtrl,
+                label: l?.odometerKm ?? 'Odometer (km)',
+                icon: Icons.speed,
+                validator: (v) => AddFillUpValidators.positiveNumber(v, l),
+              ),
+            ),
+            FormFieldTile(
+              icon: Icons.edit_note_outlined,
+              content: FillUpNotesField(controller: notesCtrl),
+            ),
+            if (onReportBadScan != null) ...[
+              const SizedBox(height: 4),
+              Align(
+                alignment: AlignmentDirectional.centerEnd,
+                child: TextButton.icon(
+                  onPressed: onReportBadScan,
+                  icon: const Icon(Icons.flag_outlined, size: 18),
+                  label: Text(
+                    l?.reportScanError ?? 'Report scan error',
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/fill_up_import_buttons_pair.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_import_buttons_pair.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Two side-by-side import buttons restored on the Add-Fill-up form
+/// (#951). The previous single "Import from…" chip + bottom-sheet was
+/// rolled back because the OBD-II tile inside the sheet returned null
+/// for the odometer on the user's real hardware (Peugeot 107 + generic
+/// ELM327 BLE). Until odometer reading via PID 0xA6 is proven reliable
+/// across the supported adapter registry, the OBD-II import path is
+/// hidden from the fill-up screen — see `docs/guides/obd2-adapters.md`.
+///
+/// The full OBD-II trajet flow remains available from the Consumption
+/// screen (#888); only this fill-up entry-point is reduced.
+///
+/// Pulled out of `add_fill_up_screen.dart` (#563 extraction) so the
+/// screen file drops well below 300 LOC.
+class FillUpImportButtonsPair extends StatelessWidget {
+  final bool scanningReceipt;
+  final bool scanningPump;
+  final VoidCallback onScanReceipt;
+  final VoidCallback onScanPumpDisplay;
+
+  const FillUpImportButtonsPair({
+    super.key,
+    required this.scanningReceipt,
+    required this.scanningPump,
+    required this.onScanReceipt,
+    required this.onScanPumpDisplay,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton.icon(
+            key: const Key('import_receipt_button'),
+            onPressed: scanningReceipt ? null : onScanReceipt,
+            icon: scanningReceipt
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.document_scanner_outlined),
+            label: Text(
+              l?.fillUpImportReceiptLabel ?? 'Receipt',
+              maxLines: 2,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.visible,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: OutlinedButton.icon(
+            key: const Key('import_pump_button'),
+            onPressed: scanningPump ? null : onScanPumpDisplay,
+            icon: scanningPump
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.local_gas_station_outlined),
+            label: Text(
+              l?.fillUpImportPumpLabel ?? 'Pump display',
+              maxLines: 2,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.visible,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/fill_up_no_vehicle_cta.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_no_vehicle_cta.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Empty-state CTA shown by the Add-Fill-up screen when the vehicle
+/// list is empty (#706). Consumption requires a vehicle, so instead of
+/// rendering a useless form we pivot to a "Add a vehicle first" prompt
+/// that links straight into the vehicle editor.
+///
+/// Pulled out of `add_fill_up_screen.dart` (#563 extraction) so the
+/// screen file drops well below 300 LOC. The PageScaffold wrapper is
+/// included here because the empty state owns the whole screen — it
+/// is not a body fragment.
+class FillUpNoVehicleCta extends StatelessWidget {
+  const FillUpNoVehicleCta({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return PageScaffold(
+      title: l?.addFillUp ?? 'Add fill-up',
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: l?.tooltipBack ?? 'Back',
+        onPressed: () => context.pop(),
+      ),
+      bodyPadding: const EdgeInsets.all(32),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.directions_car_outlined,
+              size: 80,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              l?.consumptionNoVehicleTitle ?? 'Add a vehicle first',
+              style: theme.textTheme.headlineSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              l?.consumptionNoVehicleBody ??
+                  'Fill-ups are attributed to a vehicle. Add your car '
+                      'to start logging consumption.',
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: () => context.push('/vehicles/edit'),
+              icon: const Icon(Icons.add),
+              label: Text(l?.vehicleAdd ?? 'Add vehicle'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/fill_up_pinned_save_bar.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_pinned_save_bar.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Pinned bottom Save bar (#751 phase 2). Sits below the scroll view
+/// so the CTA is always one tap away regardless of how many cards
+/// the user has scrolled past. Respects the system nav-bar inset so
+/// it never clips under gesture pills (see
+/// `feedback_scaffold_inset_doubling.md`).
+///
+/// Pulled out of `add_fill_up_screen.dart` (#563 extraction) so the
+/// screen file drops well below 300 LOC.
+class FillUpPinnedSaveBar extends StatelessWidget {
+  final VoidCallback onSave;
+
+  const FillUpPinnedSaveBar({super.key, required this.onSave});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Material(
+      elevation: 8,
+      color: theme.colorScheme.surface,
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+          child: FilledButton.icon(
+            onPressed: onSave,
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(52),
+            ),
+            icon: const Icon(Icons.save_outlined),
+            label: Text(l?.save ?? 'Save'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
@@ -1,0 +1,267 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants/app_constants.dart';
+import '../../../../core/feedback/github_issue_reporter.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+import '../../data/receipt_scan_service.dart';
+import 'bad_scan_report_sheet.dart';
+import 'pump_scan_failure_sheet.dart';
+
+/// Pure UI-side scan flows extracted from `add_fill_up_screen.dart`
+/// (#563 extraction). Each entry-point takes a [BuildContext] plus
+/// the host screen's mutable state (controllers + setters) so the
+/// long async sequences live in one file instead of inflating the
+/// screen.
+///
+/// This is intentionally not a class — every method is a top-level
+/// function so the helper has no state of its own. The host
+/// `_AddFillUpScreenState` keeps owning the controllers, the
+/// `_lastScan`, `_date`, `_vehicleId`, `_fuelType`, and the
+/// `_scanService` — and passes them in via the `state` parameter.
+///
+/// Lifting these flows out of the screen halves its line count and
+/// drops the ad-hoc `// ignore: unused_catch_stack` noise from the
+/// orchestration layer; the catches stay here, contained alongside
+/// the user-facing snackbars they emit.
+
+/// Mutable surface the host screen exposes to the scan helpers. The
+/// helpers only read/write through this struct so the screen can
+/// continue to own all `setState` calls.
+class FillUpScanHostState {
+  final TextEditingController litersCtrl;
+  final TextEditingController costCtrl;
+  final String? vehicleId;
+
+  /// Reads the current scan service (lazily instantiated on first
+  /// scan) and writes it back when the helpers create one.
+  final ReceiptScanService? Function() readService;
+  final void Function(ReceiptScanService) writeService;
+
+  /// Setters for the screen's per-field state. Each setter wraps
+  /// `setState`; the helpers never touch widget state directly.
+  final void Function(bool) setScanning;
+  final void Function(bool) setScanningPump;
+  final void Function(DateTime) setDate;
+  final void Function(FuelType) setFuelType;
+  final void Function(ReceiptScanOutcome) setLastScan;
+
+  /// `mounted` predicate from the host state — checked after every
+  /// `await` so we never call setState on a disposed screen.
+  final bool Function() isMounted;
+
+  const FillUpScanHostState({
+    required this.litersCtrl,
+    required this.costCtrl,
+    required this.vehicleId,
+    required this.readService,
+    required this.writeService,
+    required this.setScanning,
+    required this.setScanningPump,
+    required this.setDate,
+    required this.setFuelType,
+    required this.setLastScan,
+    required this.isMounted,
+  });
+}
+
+/// Receipt scan flow — opens the camera, runs ML Kit, fills the form
+/// from the parsed result, and shows a success / no-data / error
+/// snackbar. Caches the [ReceiptScanOutcome] back into the host so the
+/// "Report scan error" affordance can ship the photo on demand.
+Future<void> runReceiptScan(
+  BuildContext context,
+  FillUpScanHostState state,
+) async {
+  state.setScanning(true);
+  final l = AppLocalizations.of(context);
+  try {
+    var service = state.readService();
+    if (service == null) {
+      service = ReceiptScanService();
+      state.writeService(service);
+    }
+    final outcome = await service.scanReceipt();
+    if (outcome == null || !state.isMounted()) return;
+    final result = outcome.parse;
+
+    if (!result.hasData) {
+      if (context.mounted) {
+        SnackBarHelper.show(
+          context,
+          l?.scanReceiptNoData ?? 'No receipt data found — try again',
+        );
+      }
+      return;
+    }
+
+    if (result.liters != null) {
+      state.litersCtrl.text = result.liters!.toStringAsFixed(2);
+    }
+    if (result.totalCost != null) {
+      state.costCtrl.text = result.totalCost!.toStringAsFixed(2);
+    }
+    if (result.date != null) {
+      state.setDate(result.date!);
+    }
+    // Only pre-select the fuel when there is no vehicle bound — the
+    // vehicle's configured fuel always wins (#698 single source of
+    // truth for fuel).
+    if (result.fuelType != null && state.vehicleId == null) {
+      state.setFuelType(result.fuelType!);
+    }
+    state.setLastScan(outcome);
+
+    if (state.isMounted() && context.mounted) {
+      SnackBarHelper.show(
+        context,
+        l?.scanReceiptSuccess ??
+            'Receipt scanned — verify values. Tap "Report scan error" '
+                'below if anything is off.',
+      );
+    }
+  } catch (e, st) { // ignore: unused_catch_stack
+    if (state.isMounted() && context.mounted) {
+      SnackBarHelper.showError(
+        context,
+        l?.scanReceiptFailed(e.toString()) ?? 'Scan failed: $e',
+      );
+    }
+  } finally {
+    if (state.isMounted()) state.setScanning(false);
+  }
+}
+
+/// Pump-display scan flow (#598). Mirrors [runReceiptScan] but on
+/// failure routes into [PumpScanFailureSheet] (#953) instead of
+/// dropping the photo silently.
+Future<void> runPumpDisplayScan(
+  BuildContext context,
+  FillUpScanHostState state,
+) async {
+  state.setScanningPump(true);
+  final l = AppLocalizations.of(context);
+  try {
+    var service = state.readService();
+    if (service == null) {
+      service = ReceiptScanService();
+      state.writeService(service);
+    }
+    final outcome = await service.scanPumpDisplay();
+    if (outcome == null || !state.isMounted()) return;
+    final result = outcome.parse;
+    if (!result.hasUsableData) {
+      if (context.mounted) {
+        await _showPumpScanFailureSheet(context, state, outcome);
+      }
+      return;
+    }
+    if (result.liters != null) {
+      state.litersCtrl.text = result.liters!.toStringAsFixed(2);
+    }
+    if (result.totalCost != null) {
+      state.costCtrl.text = result.totalCost!.toStringAsFixed(2);
+    }
+    if (state.isMounted() && context.mounted) {
+      SnackBarHelper.show(
+        context,
+        l?.scanPumpSuccess ?? 'Pump display scanned — verify the values.',
+      );
+    }
+  } catch (e, st) { // ignore: unused_catch_stack
+    if (state.isMounted() && context.mounted) {
+      SnackBarHelper.showError(
+        context,
+        l?.scanPumpFailed(e.toString()) ?? 'Pump scan failed: $e',
+      );
+    }
+  } finally {
+    if (state.isMounted()) state.setScanningPump(false);
+  }
+}
+
+/// Opens the failure-flow bottom sheet for an unreadable pump-display
+/// scan (#953). The sheet is dismissable; the action the user picks
+/// determines the next step:
+///   - correctManually: close, leave the form untouched.
+///   - report: open [BadScanReportSheet] with [ScanKind.pumpDisplay].
+///   - removePhoto: delete the temp file and forget the scan.
+Future<void> _showPumpScanFailureSheet(
+  BuildContext context,
+  FillUpScanHostState state,
+  PumpDisplayScanOutcome outcome,
+) async {
+  final action = await showModalBottomSheet<PumpScanFailureAction>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => const PumpScanFailureSheet(),
+  );
+  if (!state.isMounted()) return;
+  switch (action) {
+    case PumpScanFailureAction.report:
+      if (context.mounted) {
+        await reportBadPumpScan(context, state, outcome);
+      }
+      break;
+    case PumpScanFailureAction.removePhoto:
+      await state.readService()?.deleteCapturedImage(outcome.imagePath);
+      break;
+    case PumpScanFailureAction.correctManually:
+    case null:
+      // Sheet dismissed or "Correct manually" — keep the photo on
+      // disk so the user can still hit "Report scan error" via the
+      // existing affordance below the form. (The button currently
+      // surfaces only for receipt scans; pump-display reports are
+      // accessible via the failure sheet itself.)
+      break;
+  }
+}
+
+/// Opens the [BadScanReportSheet] for a failed pump-display scan
+/// (#953). Pre-fills the entered liters/cost so the GitHub issue
+/// captures the user's typed values alongside the OCR output.
+Future<void> reportBadPumpScan(
+  BuildContext context,
+  FillUpScanHostState state,
+  PumpDisplayScanOutcome outcome,
+) async {
+  final liters =
+      double.tryParse(state.litersCtrl.text.replaceAll(',', '.'));
+  final cost = double.tryParse(state.costCtrl.text.replaceAll(',', '.'));
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => BadScanReportSheet(
+      kind: ScanKind.pumpDisplay,
+      pumpScan: outcome,
+      enteredLiters: liters,
+      enteredTotalCost: cost,
+      appVersion: AppConstants.appVersion,
+    ),
+  );
+}
+
+/// Opens the [BadScanReportSheet] for a receipt scan whose values the
+/// user has already corrected on the form (#751 / #952). Pre-fills the
+/// final user-entered values so the diff is captured against the OCR
+/// output.
+Future<void> reportBadReceiptScan(
+  BuildContext context,
+  FillUpScanHostState state,
+  ReceiptScanOutcome scan,
+) async {
+  final liters =
+      double.tryParse(state.litersCtrl.text.replaceAll(',', '.'));
+  final cost = double.tryParse(state.costCtrl.text.replaceAll(',', '.'));
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => BadScanReportSheet(
+      scan: scan,
+      enteredLiters: liters,
+      enteredTotalCost: cost,
+      appVersion: AppConstants.appVersion,
+    ),
+  );
+}

--- a/lib/features/consumption/presentation/widgets/fill_up_station_pre_fill_banner.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_station_pre_fill_banner.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+/// Small banner above the form cards announcing the pre-filled
+/// station (#581 affordance restyled for #751 phase 2). Replaces the
+/// old ListTile card so the callout is visible above the fold without
+/// stealing visual weight from the "What you filled" card.
+///
+/// Pulled out of `add_fill_up_screen.dart` (#563 extraction) so the
+/// screen file drops well below 300 LOC.
+class FillUpStationPreFillBanner extends StatelessWidget {
+  final String stationName;
+  final String label;
+
+  const FillUpStationPreFillBanner({
+    super.key,
+    required this.stationName,
+    required this.label,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary.withValues(alpha: 0.08),
+        border: Border.all(
+          color: theme.colorScheme.primary.withValues(alpha: 0.2),
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          ExcludeSemantics(
+            child: Icon(
+              Icons.place_outlined,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Semantics(
+              container: true,
+              label: '$label: $stationName',
+              child: ExcludeSemantics(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      label,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    Text(
+                      stationName,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/fill_up_vehicle_fuel_picker.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_vehicle_fuel_picker.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/widgets/fuel_type_dropdown.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../domain/add_fill_up_fuel_resolver.dart';
+
+/// Fuel picker constrained to the vehicle's compatible fuels (#713).
+///
+/// A petrol car gets [e10, e5, e98, e85]; a diesel car gets
+/// [diesel, dieselPremium]; EV / LPG / CNG / H₂ vehicles pick from
+/// their single applicable fuel only. The initial value is the one
+/// resolved by [AddFillUpFuelResolver.resolveDefaultFuel] — profile
+/// preference when compatible, else the vehicle's own fuel — so the
+/// form always loads with the most likely choice but still lets the
+/// user override it for this specific fill-up (e.g. a flex-fuel
+/// E85 car tanking regular SP95 this week).
+///
+/// Pulled out of `add_fill_up_screen.dart` (#563 extraction) so the
+/// screen file drops well below 300 LOC.
+class FillUpVehicleFuelPicker extends StatelessWidget {
+  final List<VehicleProfile> vehicles;
+  final String vehicleId;
+  final FuelType fuelType;
+  final ValueChanged<FuelType> onChanged;
+  final VoidCallback onOpenVehicle;
+
+  const FillUpVehicleFuelPicker({
+    super.key,
+    required this.vehicles,
+    required this.vehicleId,
+    required this.fuelType,
+    required this.onChanged,
+    required this.onOpenVehicle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final vehicle = vehicles.firstWhere((v) => v.id == vehicleId);
+    final vehicleFuel =
+        AddFillUpFuelResolver.fuelForVehicle(vehicle) ?? FuelType.e10;
+    final compatible = compatibleFuelsFor(vehicleFuel);
+    final value =
+        compatible.contains(fuelType) ? fuelType : compatible.first;
+
+    return Row(
+      children: [
+        Expanded(
+          child: FuelTypeDropdown(
+            value: value,
+            options: compatible,
+            prefixIcon: const Icon(Icons.local_gas_station),
+            labelText: '${l?.fuelType ?? 'Fuel type'} • ${vehicle.name}',
+            onChanged: onChanged,
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.open_in_new),
+          tooltip: l?.vehicleEditTitle ?? 'Edit vehicle',
+          onPressed: onOpenVehicle,
+          style: IconButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/consumption/domain/add_fill_up_fuel_resolver_test.dart
+++ b/test/features/consumption/domain/add_fill_up_fuel_resolver_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/add_fill_up_fuel_resolver.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+/// Unit tests for the pure helpers extracted from
+/// `add_fill_up_screen.dart` (#563 refactor). Covers:
+///
+///   * fuelForVehicle's three branches (EV → electric, configured
+///     fuel → parsed, unconfigured combustion → null).
+///   * resolveDefaultFuel's full preference chain (preFill →
+///     profilePreferred → vehicle's fuel → e10).
+///   * pickInitialVehicleId's three branches (profile default →
+///     active vehicle → first in list) plus the empty-list edge case.
+void main() {
+  const petrolCar = VehicleProfile(
+    id: 'petrol-1',
+    name: 'Petrol Car',
+    type: VehicleType.combustion,
+    preferredFuelType: 'e10',
+  );
+
+  const flexFuelCar = VehicleProfile(
+    id: 'flex-1',
+    name: 'Flex-Fuel Car',
+    type: VehicleType.combustion,
+    preferredFuelType: 'e85',
+  );
+
+  const dieselCar = VehicleProfile(
+    id: 'diesel-1',
+    name: 'Diesel Car',
+    type: VehicleType.combustion,
+    preferredFuelType: 'diesel',
+  );
+
+  const electricCar = VehicleProfile(
+    id: 'ev-1',
+    name: 'Electric Car',
+    type: VehicleType.ev,
+  );
+
+  const unconfiguredCar = VehicleProfile(
+    id: 'unconf-1',
+    name: 'Unconfigured Car',
+    type: VehicleType.combustion,
+  );
+
+  group('AddFillUpFuelResolver.fuelForVehicle', () {
+    test('EV vehicle resolves to electric regardless of stored fuel', () {
+      expect(
+        AddFillUpFuelResolver.fuelForVehicle(electricCar),
+        equals(FuelType.electric),
+      );
+    });
+
+    test('combustion vehicle resolves to its preferredFuelType', () {
+      expect(
+        AddFillUpFuelResolver.fuelForVehicle(petrolCar),
+        equals(FuelType.e10),
+      );
+      expect(
+        AddFillUpFuelResolver.fuelForVehicle(dieselCar),
+        equals(FuelType.diesel),
+      );
+    });
+
+    test('unconfigured combustion vehicle resolves to null', () {
+      expect(
+        AddFillUpFuelResolver.fuelForVehicle(unconfiguredCar),
+        isNull,
+      );
+    });
+
+    test('empty-string preferredFuelType resolves to null', () {
+      const car = VehicleProfile(
+        id: 'x',
+        name: 'X',
+        type: VehicleType.combustion,
+        preferredFuelType: '   ',
+      );
+      expect(AddFillUpFuelResolver.fuelForVehicle(car), isNull);
+    });
+  });
+
+  group('AddFillUpFuelResolver.resolveDefaultFuel', () {
+    test('preFill wins when compatible with the vehicle', () {
+      // Petrol car accepts E10/E5/E98/E85 — pre-fill with E5 must
+      // surface as the default even though the vehicle's preferred is
+      // E10.
+      expect(
+        AddFillUpFuelResolver.resolveDefaultFuel(
+          vehicle: petrolCar,
+          preFill: FuelType.e5,
+        ),
+        equals(FuelType.e5),
+      );
+    });
+
+    test('preFill ignored when not compatible (petrol car, diesel preFill)',
+        () {
+      expect(
+        AddFillUpFuelResolver.resolveDefaultFuel(
+          vehicle: petrolCar,
+          preFill: FuelType.diesel,
+        ),
+        equals(FuelType.e10),
+      );
+    });
+
+    test('profilePreferred used when no preFill and compatible', () {
+      // Flex-fuel car (E85 family) — profile preferred E10 is in the
+      // petrol compatibility set, so it wins over the vehicle's E85.
+      expect(
+        AddFillUpFuelResolver.resolveDefaultFuel(
+          vehicle: flexFuelCar,
+          profilePreferred: FuelType.e10,
+        ),
+        equals(FuelType.e10),
+      );
+    });
+
+    test(
+      'profilePreferred ignored when not compatible — falls back to '
+      "vehicle's own fuel",
+      () {
+        expect(
+          AddFillUpFuelResolver.resolveDefaultFuel(
+            vehicle: petrolCar,
+            profilePreferred: FuelType.diesel,
+          ),
+          equals(FuelType.e10),
+        );
+      },
+    );
+
+    test("falls back to the vehicle's own fuel when nothing else applies",
+        () {
+      expect(
+        AddFillUpFuelResolver.resolveDefaultFuel(vehicle: dieselCar),
+        equals(FuelType.diesel),
+      );
+    });
+
+    test('falls back to e10 when the vehicle has no configured fuel', () {
+      expect(
+        AddFillUpFuelResolver.resolveDefaultFuel(vehicle: unconfiguredCar),
+        equals(FuelType.e10),
+      );
+    });
+  });
+
+  group('AddFillUpFuelResolver.pickInitialVehicleId', () {
+    test('empty list returns null', () {
+      expect(
+        AddFillUpFuelResolver.pickInitialVehicleId(vehicles: const []),
+        isNull,
+      );
+    });
+
+    test('profile default wins when present in the list', () {
+      expect(
+        AddFillUpFuelResolver.pickInitialVehicleId(
+          vehicles: const [petrolCar, dieselCar],
+          profileDefaultId: 'diesel-1',
+          activeVehicleId: 'petrol-1',
+        ),
+        equals('diesel-1'),
+      );
+    });
+
+    test('falls back to active vehicle when profile default is missing', () {
+      expect(
+        AddFillUpFuelResolver.pickInitialVehicleId(
+          vehicles: const [petrolCar, dieselCar],
+          profileDefaultId: 'ghost-vehicle',
+          activeVehicleId: 'diesel-1',
+        ),
+        equals('diesel-1'),
+      );
+    });
+
+    test('falls back to first vehicle when nothing matches', () {
+      expect(
+        AddFillUpFuelResolver.pickInitialVehicleId(
+          vehicles: const [petrolCar, dieselCar],
+          profileDefaultId: 'ghost-1',
+          activeVehicleId: 'ghost-2',
+        ),
+        equals('petrol-1'),
+      );
+    });
+
+    test('falls back to first vehicle when no hints provided', () {
+      expect(
+        AddFillUpFuelResolver.pickInitialVehicleId(
+          vehicles: const [petrolCar, dieselCar],
+        ),
+        equals('petrol-1'),
+      );
+    });
+  });
+}

--- a/test/features/consumption/domain/add_fill_up_validators_test.dart
+++ b/test/features/consumption/domain/add_fill_up_validators_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/add_fill_up_validators.dart';
+
+/// Unit tests for the pure validators / parsers extracted from
+/// `add_fill_up_screen.dart` (#563 refactor). Each rule is covered
+/// for: blank/null input, unparseable input, boundary values (zero,
+/// negative), and at least one happy-path case.
+///
+/// All tests pass `null` for [AppLocalizations] — the validators
+/// must degrade to English fallbacks ("Required", "Invalid number")
+/// when no localizations are in the tree, which is exactly the path
+/// they take in widget tests that don't pump a MaterialApp with
+/// AppLocalizations.delegate.
+void main() {
+  group('AddFillUpValidators.positiveNumber', () {
+    test('returns Required when value is null', () {
+      expect(
+        AddFillUpValidators.positiveNumber(null, null),
+        equals('Required'),
+      );
+    });
+
+    test('returns Required when value is empty', () {
+      expect(
+        AddFillUpValidators.positiveNumber('', null),
+        equals('Required'),
+      );
+    });
+
+    test('returns Required when value is whitespace only', () {
+      expect(
+        AddFillUpValidators.positiveNumber('   ', null),
+        equals('Required'),
+      );
+    });
+
+    test('returns Invalid number when value is not numeric', () {
+      expect(
+        AddFillUpValidators.positiveNumber('abc', null),
+        equals('Invalid number'),
+      );
+    });
+
+    test('returns Invalid number when value is zero', () {
+      expect(
+        AddFillUpValidators.positiveNumber('0', null),
+        equals('Invalid number'),
+      );
+    });
+
+    test('returns Invalid number when value is negative', () {
+      expect(
+        AddFillUpValidators.positiveNumber('-1', null),
+        equals('Invalid number'),
+      );
+    });
+
+    test('returns null on a positive integer', () {
+      expect(
+        AddFillUpValidators.positiveNumber('40', null),
+        isNull,
+      );
+    });
+
+    test('returns null on a positive decimal with dot', () {
+      expect(
+        AddFillUpValidators.positiveNumber('1.859', null),
+        isNull,
+      );
+    });
+
+    test('returns null on a positive decimal with comma (FR/DE locale)', () {
+      // The form is bilingual — French / German users type a comma
+      // separator. The validator must accept both.
+      expect(
+        AddFillUpValidators.positiveNumber('1,859', null),
+        isNull,
+      );
+    });
+
+    test('returns null on a tiny positive value', () {
+      // The validator's lower bound is "> 0", not ">= 0.01". A 0.01 L
+      // dribble is implausible but not invalid.
+      expect(
+        AddFillUpValidators.positiveNumber('0.01', null),
+        isNull,
+      );
+    });
+  });
+
+  group('AddFillUpValidators.parseDouble', () {
+    test('parses a plain integer string', () {
+      expect(AddFillUpValidators.parseDouble('40'), 40.0);
+    });
+
+    test('parses a dot-decimal string', () {
+      expect(AddFillUpValidators.parseDouble('1.859'), 1.859);
+    });
+
+    test('parses a comma-decimal string by replacing comma with dot', () {
+      // The screen relies on this so the FR/DE-typed values save
+      // correctly to a [FillUp].
+      expect(AddFillUpValidators.parseDouble('1,859'), 1.859);
+    });
+
+    test('throws on unparseable input', () {
+      // Callers must validate before parsing — parseDouble is a
+      // post-validation helper and must not silently swallow garbage.
+      expect(
+        () => AddFillUpValidators.parseDouble('abc'),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/test/features/consumption/domain/fill_up_auto_cost_calculator_test.dart
+++ b/test/features/consumption/domain/fill_up_auto_cost_calculator_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/fill_up_auto_cost_calculator.dart';
+
+/// Unit tests for the auto-cost computation extracted from
+/// `add_fill_up_screen.dart` (#563 refactor).
+///
+/// The contract:
+///   * Recompute when liters parses to > 0 AND the cost field is
+///     either empty or matches the previous auto-fill (so the user's
+///     manually-typed cost is never clobbered).
+///   * Return the formatted "L * price" string in the controller-
+///     ready 2dp format.
+///   * Return null when liters is unparseable / non-positive, or when
+///     the user has typed a custom cost.
+void main() {
+  group('FillUpAutoCostCalculator.recompute', () {
+    test('returns formatted cost when liters and price are positive', () {
+      final calc = FillUpAutoCostCalculator(pricePerLiter: 1.859);
+      expect(
+        calc.recompute(litersText: '40', costText: ''),
+        equals('74.36'),
+      );
+    });
+
+    test('accepts comma as decimal separator (FR/DE locale)', () {
+      final calc = FillUpAutoCostCalculator(pricePerLiter: 2.0);
+      expect(
+        calc.recompute(litersText: '12,5', costText: ''),
+        equals('25.00'),
+      );
+    });
+
+    test('returns null when liters is empty', () {
+      final calc = FillUpAutoCostCalculator(pricePerLiter: 2.0);
+      expect(calc.recompute(litersText: '', costText: ''), isNull);
+    });
+
+    test('returns null when liters is unparseable', () {
+      final calc = FillUpAutoCostCalculator(pricePerLiter: 2.0);
+      expect(calc.recompute(litersText: 'abc', costText: ''), isNull);
+    });
+
+    test('returns null when liters is zero or negative', () {
+      final calc = FillUpAutoCostCalculator(pricePerLiter: 2.0);
+      expect(calc.recompute(litersText: '0', costText: ''), isNull);
+      expect(calc.recompute(litersText: '-5', costText: ''), isNull);
+    });
+
+    test('returns null when the user has typed a custom cost', () {
+      final calc = FillUpAutoCostCalculator(pricePerLiter: 2.0);
+      // First call seeds the auto-fill at 20.00.
+      expect(
+        calc.recompute(litersText: '10', costText: ''),
+        equals('20.00'),
+      );
+      // The user then types 99.99 — a subsequent recompute (e.g.
+      // because liters changed) must NOT clobber the user's value.
+      expect(
+        calc.recompute(litersText: '15', costText: '99.99'),
+        isNull,
+      );
+    });
+
+    test('overwrites a stale auto-fill when liters changes', () {
+      final calc = FillUpAutoCostCalculator(pricePerLiter: 2.0);
+      // Seed the cost at 20.00 from 10 L.
+      expect(
+        calc.recompute(litersText: '10', costText: ''),
+        equals('20.00'),
+      );
+      // Liters bumped to 15 — the cost field still shows the prior
+      // auto-fill (20.00), so the calculator may overwrite it.
+      expect(
+        calc.recompute(litersText: '15', costText: '20.00'),
+        equals('30.00'),
+      );
+    });
+
+    test('updates internal lastAutoCost so the next recompute can compare',
+        () {
+      final calc = FillUpAutoCostCalculator(pricePerLiter: 2.0);
+      // Seed 20.00, then re-seed via the previous-auto path at 30.00.
+      expect(
+        calc.recompute(litersText: '10', costText: ''),
+        equals('20.00'),
+      );
+      expect(
+        calc.recompute(litersText: '15', costText: '20.00'),
+        equals('30.00'),
+      );
+      // After two seeds the lastAutoCost must now match the *latest*
+      // 30.00 — typing 31.00 manually then bumping liters should be
+      // treated as a user override, not a stale auto-fill.
+      expect(
+        calc.recompute(litersText: '20', costText: '31.00'),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Extract `add_fill_up_form_fields.dart`, `fill_up_import_buttons_pair.dart`, `fill_up_station_pre_fill_banner.dart`, `fill_up_pinned_save_bar.dart`, `fill_up_vehicle_fuel_picker.dart`, `fill_up_no_vehicle_cta.dart`, `fill_up_scan_handlers.dart` plus 3 domain helpers (`add_fill_up_validators.dart`, `add_fill_up_fuel_resolver.dart`, `fill_up_auto_cost_calculator.dart`) out of add_fill_up_screen (894 -> 296 LOC).
- Mirror PR #1156's pattern (domain helpers + section widgets).

Refs #563 phase: add_fill_up_screen — epic stays open.

## Test plan
- [x] flutter analyze -> 0 warnings
- [x] all 5 existing add_fill_up screen tests still pass (23 sub-tests)
- [x] new domain tests added for AddFillUpValidators (12 tests), AddFillUpFuelResolver (15 tests), FillUpAutoCostCalculator (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)