### PR TITLE
refactor(route_search): extract EcoRouteCandidate + scoring helpers (Refs #563 phase: eco_route)

### DIFF
--- a/lib/features/route_search/data/strategies/eco_route_candidate.dart
+++ b/lib/features/route_search/data/strategies/eco_route_candidate.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../../../core/utils/geo_utils.dart' as geo;
+import '../../domain/entities/route_info.dart';
+
+/// A single OSRM alternative (or any candidate route) scored by the
+/// eco strategy. Bundles the raw OSRM-derived metrics we need to
+/// compute `time + α × elevation + β × speed_variance_penalty`.
+///
+/// `elevationGainMeters` is null when OSRM did not return an
+/// elevation profile (the public demo server typically doesn't).
+/// In that case `EcoRouteSearchStrategy.scoreCandidate` falls back
+/// to time + speed-variance only — see the strategy's class docs.
+@immutable
+class EcoRouteCandidate {
+  const EcoRouteCandidate({
+    required this.geometry,
+    required this.distanceKm,
+    required this.durationMinutes,
+    this.elevationGainMeters,
+    this.legSpeedsKmh = const <double>[],
+  });
+
+  final List<LatLng> geometry;
+  final double distanceKm;
+  final double durationMinutes;
+
+  /// Total positive elevation gain along the candidate, in metres.
+  /// Null when the OSRM response carries no elevation data.
+  final double? elevationGainMeters;
+
+  /// Per-leg average speed in km/h. Used to compute a speed-variance
+  /// penalty: routes that mix highway + slow stretches burn more
+  /// fuel than a flat-cruise highway-only route. Empty list means
+  /// "we couldn't sample legs" and the variance penalty is 0.
+  final List<double> legSpeedsKmh;
+
+  /// Convert to the public `RouteInfo` shape, sampling every ~15 km
+  /// for downstream station-along-route queries (mirrors
+  /// `RoutingService._sampleAlongPolyline`).
+  RouteInfo toRouteInfo() {
+    final samples = sampleAlongPolyline(geometry, 15.0);
+    return RouteInfo(
+      geometry: geometry,
+      distanceKm: distanceKm,
+      durationMinutes: durationMinutes,
+      samplePoints: samples,
+    );
+  }
+}
+
+/// Sample a polyline at roughly [intervalKm] spacing, always
+/// including the first and last points. Mirrors the heuristic used
+/// by `RoutingService._sampleAlongPolyline` — kept as a top-level
+/// helper so eco-specific tests can exercise the sampling logic
+/// without instantiating an [EcoRouteCandidate].
+@visibleForTesting
+List<LatLng> sampleAlongPolyline(
+  List<LatLng> polyline,
+  double intervalKm,
+) {
+  if (polyline.isEmpty) return const <LatLng>[];
+  final samples = <LatLng>[polyline.first];
+  double accumulated = 0;
+  for (var i = 1; i < polyline.length; i++) {
+    final prev = polyline[i - 1];
+    final curr = polyline[i];
+    accumulated += geo.distanceKm(
+      prev.latitude,
+      prev.longitude,
+      curr.latitude,
+      curr.longitude,
+    );
+    if (accumulated >= intervalKm) {
+      samples.add(curr);
+      accumulated = 0;
+    }
+  }
+  if (samples.last != polyline.last) {
+    samples.add(polyline.last);
+  }
+  return samples;
+}

--- a/lib/features/route_search/data/strategies/eco_route_scoring.dart
+++ b/lib/features/route_search/data/strategies/eco_route_scoring.dart
@@ -1,0 +1,101 @@
+import 'eco_route_candidate.dart';
+
+/// Pure scoring math for the eco strategy (#1123).
+///
+/// Pulled out of [`EcoRouteSearchStrategy`] so the weighting
+/// formula and its tuning constants live in one short, well-tested
+/// file. The strategy class delegates to these helpers; they have
+/// no Flutter or networking dependencies and are trivial to fuzz.
+///
+/// Formula:
+///
+///     weight = time_minutes
+///            + alpha × elevationGainMeters
+///            + beta  × speedVariancePenalty
+///
+/// When OSRM returns no elevation profile (the public demo server
+/// strips it), the elevation term is dropped and the formula
+/// degrades to `time + beta × speedVariance` — see [scoreCandidate].
+class EcoRouteScoring {
+  const EcoRouteScoring._();
+
+  /// Cost in `score units` per metre of cumulative elevation gain.
+  ///
+  /// Tuning rationale: a typical 100 km highway leg with 200 m of
+  /// gain represents ~+0.3 L of fuel for a 7 L/100 km vehicle.
+  /// We want that to *outweigh* a +5 minute detour penalty around
+  /// the gain — so 1 m ≈ 0.05 minutes of equivalent "cost" puts
+  /// 200 m of climb on par with a 10 minute detour. That feels
+  /// right for "ship the flatter route unless it's wildly slower".
+  static const double alpha = 0.05;
+
+  /// Cost in `score units` per (km/h)² of speed variance across
+  /// route legs. Highway-only candidates have variance ≈ 0;
+  /// city + highway mixes can hit 600–900 km²/h². The constant
+  /// 0.02 makes a variance of 500 worth ~10 minutes of equivalent
+  /// detour, which discourages stop-and-go shortcuts.
+  static const double beta = 0.02;
+
+  /// Cap on how much slower the eco choice may be vs the fastest
+  /// candidate. Above this ratio the eco strategy gives up on the
+  /// alternative and re-selects the fastest, on the theory that
+  /// the user came to drive, not to crawl. Matches the issue's
+  /// "≤ 15 % slower" acceptance bullet.
+  static const double maxSlowdownRatio = 1.15;
+
+  /// Score a single candidate. Public so tests can pin the
+  /// weighting math without going through OSRM.
+  static double scoreCandidate(EcoRouteCandidate c) {
+    final elevTerm =
+        c.elevationGainMeters == null ? 0.0 : alpha * c.elevationGainMeters!;
+    final variance = speedVariance(c.legSpeedsKmh);
+    final varianceTerm = beta * variance;
+    return c.durationMinutes + elevTerm + varianceTerm;
+  }
+
+  /// Select the eco-best candidate from a list. Returns the
+  /// fastest candidate when:
+  ///   * the list is empty (caller-side error — never hits here
+  ///     in practice),
+  ///   * only one candidate exists,
+  ///   * every alternative is more than [maxSlowdownRatio] slower
+  ///     than the fastest.
+  ///
+  /// Otherwise returns the lowest-weight candidate within the
+  /// slowdown cap.
+  static EcoRouteCandidate selectEcoRoute(List<EcoRouteCandidate> candidates) {
+    if (candidates.isEmpty) {
+      throw ArgumentError('selectEcoRoute requires at least one candidate');
+    }
+    if (candidates.length == 1) return candidates.first;
+
+    final fastest = candidates
+        .reduce((a, b) => a.durationMinutes <= b.durationMinutes ? a : b);
+    final cap = fastest.durationMinutes * maxSlowdownRatio;
+
+    EcoRouteCandidate best = fastest;
+    double bestScore = scoreCandidate(fastest);
+    for (final c in candidates) {
+      if (c.durationMinutes > cap) continue;
+      final s = scoreCandidate(c);
+      if (s < bestScore) {
+        bestScore = s;
+        best = c;
+      }
+    }
+    return best;
+  }
+
+  /// Population variance of the per-leg speeds. Returns 0 for
+  /// empty/single-element lists (no penalty when we have no signal).
+  static double speedVariance(List<double> speeds) {
+    if (speeds.length < 2) return 0;
+    final mean = speeds.reduce((a, b) => a + b) / speeds.length;
+    double sumSq = 0;
+    for (final s in speeds) {
+      final d = s - mean;
+      sumSq += d * d;
+    }
+    return sumSq / speeds.length;
+  }
+}

--- a/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
@@ -9,79 +9,15 @@ import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
 import '../helpers/batch_query_helper.dart';
+import 'eco_route_candidate.dart';
+import 'eco_route_scoring.dart';
 
-/// A single OSRM alternative (or any candidate route) scored by the
-/// eco strategy. Bundles the raw OSRM-derived metrics we need to
-/// compute `time + α × elevation + β × speed_variance_penalty`.
-///
-/// `elevationGainMeters` is null when OSRM did not return an
-/// elevation profile (the public demo server typically doesn't).
-/// In that case `EcoRouteSearchStrategy.scoreCandidate` falls back
-/// to time + speed-variance only — see the strategy's class docs.
-@immutable
-class EcoRouteCandidate {
-  const EcoRouteCandidate({
-    required this.geometry,
-    required this.distanceKm,
-    required this.durationMinutes,
-    this.elevationGainMeters,
-    this.legSpeedsKmh = const <double>[],
-  });
-
-  final List<LatLng> geometry;
-  final double distanceKm;
-  final double durationMinutes;
-
-  /// Total positive elevation gain along the candidate, in metres.
-  /// Null when the OSRM response carries no elevation data.
-  final double? elevationGainMeters;
-
-  /// Per-leg average speed in km/h. Used to compute a speed-variance
-  /// penalty: routes that mix highway + slow stretches burn more
-  /// fuel than a flat-cruise highway-only route. Empty list means
-  /// "we couldn't sample legs" and the variance penalty is 0.
-  final List<double> legSpeedsKmh;
-
-  /// Convert to the public `RouteInfo` shape, sampling every ~15 km
-  /// for downstream station-along-route queries (mirrors
-  /// `RoutingService._sampleAlongPolyline`).
-  RouteInfo toRouteInfo() {
-    final samples = _sampleAlongPolyline(geometry, 15.0);
-    return RouteInfo(
-      geometry: geometry,
-      distanceKm: distanceKm,
-      durationMinutes: durationMinutes,
-      samplePoints: samples,
-    );
-  }
-
-  static List<LatLng> _sampleAlongPolyline(
-    List<LatLng> polyline,
-    double intervalKm,
-  ) {
-    if (polyline.isEmpty) return const <LatLng>[];
-    final samples = <LatLng>[polyline.first];
-    double accumulated = 0;
-    for (var i = 1; i < polyline.length; i++) {
-      final prev = polyline[i - 1];
-      final curr = polyline[i];
-      accumulated += geo.distanceKm(
-        prev.latitude,
-        prev.longitude,
-        curr.latitude,
-        curr.longitude,
-      );
-      if (accumulated >= intervalKm) {
-        samples.add(curr);
-        accumulated = 0;
-      }
-    }
-    if (samples.last != polyline.last) {
-      samples.add(polyline.last);
-    }
-    return samples;
-  }
-}
+// Re-export the value types so existing imports of
+// `eco_route_search_strategy.dart` continue to resolve
+// `EcoRouteCandidate` and `EcoSavingsEstimator` symbols without
+// touching every callsite.
+export 'eco_route_candidate.dart' show EcoRouteCandidate;
+export 'eco_savings_estimator.dart' show EcoSavingsEstimator;
 
 /// Eco routing strategy (#1123).
 ///
@@ -92,11 +28,13 @@ class EcoRouteCandidate {
 ///            + α × elevationGainMeters
 ///            + β × speedVariancePenalty
 ///
-/// and returns the candidate with the lowest weight. The constants
-/// [alpha] and [beta] are tuned so that a route up to ~15 % slower
-/// than the fastest option but with markedly less elevation gain
-/// or steadier speeds wins. They are documented in-source so a
-/// future maintainer can re-tune from one place.
+/// and returns the candidate with the lowest weight. The tuning
+/// constants ([EcoRouteScoring.alpha], [EcoRouteScoring.beta],
+/// [EcoRouteScoring.maxSlowdownRatio]) are calibrated so that a
+/// route up to ~15 % slower than the fastest option but with
+/// markedly less elevation gain or steadier speeds wins. They live
+/// on [EcoRouteScoring] so a future maintainer can re-tune from
+/// one place.
 ///
 /// ### Fallback
 /// When OSRM returns no elevation profile (the public demo server
@@ -105,84 +43,29 @@ class EcoRouteCandidate {
 /// highway over zigzag-shortcut alternatives.
 ///
 /// ### Scope
-/// This file owns the *route-selection* logic. The station-search
-/// portion of the strategy (sampling along the chosen polyline,
-/// filtering by detour, ordering by itinerary) mirrors
-/// [`UniformSearchStrategy`] — once the eco route is picked, the
-/// stations-along-route problem is the same one.
+/// This file owns the *route-selection orchestration*. The pure
+/// scoring math lives in `eco_route_scoring.dart`; the candidate
+/// value type lives in `eco_route_candidate.dart`. The
+/// station-search portion of the strategy (sampling along the
+/// chosen polyline, filtering by detour, ordering by itinerary)
+/// mirrors [`UniformSearchStrategy`] — once the eco route is
+/// picked, the stations-along-route problem is the same one.
 class EcoRouteSearchStrategy implements RouteSearchStrategy {
-  /// Cost in `score units` per metre of cumulative elevation gain.
-  ///
-  /// Tuning rationale: a typical 100 km highway leg with 200 m of
-  /// gain represents ~+0.3 L of fuel for a 7 L/100 km vehicle.
-  /// We want that to *outweigh* a +5 minute detour penalty around
-  /// the gain — so 1 m ≈ 0.05 minutes of equivalent "cost" puts
-  /// 200 m of climb on par with a 10 minute detour. That feels
-  /// right for "ship the flatter route unless it's wildly slower".
-  static const double alpha = 0.05;
-
-  /// Cost in `score units` per (km/h)² of speed variance across
-  /// route legs. Highway-only candidates have variance ≈ 0;
-  /// city + highway mixes can hit 600–900 km²/h². The constant
-  /// 0.02 makes a variance of 500 worth ~10 minutes of equivalent
-  /// detour, which discourages stop-and-go shortcuts.
-  static const double beta = 0.02;
-
-  /// Cap on how much slower the eco choice may be vs the fastest
-  /// candidate. Above this ratio the eco strategy gives up on the
-  /// alternative and re-selects the fastest, on the theory that
-  /// the user came to drive, not to crawl. Matches the issue's
-  /// "≤ 15 % slower" acceptance bullet.
-  static const double maxSlowdownRatio = 1.15;
-
   @override
   String get name => 'Eco';
 
   @override
   String get l10nKey => 'ecoSearch';
 
-  /// Score a single candidate. Public so tests can pin the
-  /// weighting math without going through OSRM.
-  static double scoreCandidate(EcoRouteCandidate c) {
-    final elevTerm =
-        c.elevationGainMeters == null ? 0.0 : alpha * c.elevationGainMeters!;
-    final variance = _speedVariance(c.legSpeedsKmh);
-    final varianceTerm = beta * variance;
-    return c.durationMinutes + elevTerm + varianceTerm;
-  }
+  /// Score a single candidate. Delegates to [EcoRouteScoring.scoreCandidate]
+  /// — the implementation lives there so the math is testable in isolation.
+  static double scoreCandidate(EcoRouteCandidate c) =>
+      EcoRouteScoring.scoreCandidate(c);
 
-  /// Select the eco-best candidate from a list. Returns the
-  /// fastest candidate when:
-  ///   * the list is empty (caller-side error — never hits here
-  ///     in practice),
-  ///   * only one candidate exists,
-  ///   * every alternative is more than [maxSlowdownRatio] slower
-  ///     than the fastest.
-  ///
-  /// Otherwise returns the lowest-weight candidate within the
-  /// slowdown cap.
-  static EcoRouteCandidate selectEcoRoute(List<EcoRouteCandidate> candidates) {
-    if (candidates.isEmpty) {
-      throw ArgumentError('selectEcoRoute requires at least one candidate');
-    }
-    if (candidates.length == 1) return candidates.first;
-
-    final fastest = candidates
-        .reduce((a, b) => a.durationMinutes <= b.durationMinutes ? a : b);
-    final cap = fastest.durationMinutes * maxSlowdownRatio;
-
-    EcoRouteCandidate best = fastest;
-    double bestScore = scoreCandidate(fastest);
-    for (final c in candidates) {
-      if (c.durationMinutes > cap) continue;
-      final s = scoreCandidate(c);
-      if (s < bestScore) {
-        bestScore = s;
-        best = c;
-      }
-    }
-    return best;
-  }
+  /// Select the eco-best candidate from a list. Delegates to
+  /// [EcoRouteScoring.selectEcoRoute].
+  static EcoRouteCandidate selectEcoRoute(List<EcoRouteCandidate> candidates) =>
+      EcoRouteScoring.selectEcoRoute(candidates);
 
   /// Parse an OSRM `/route/v1/driving/...?alternatives=true` JSON
   /// response into a list of [EcoRouteCandidate]s. Tolerates the
@@ -400,64 +283,5 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
       final db = geo.distanceAlongPolyline(b.lat, b.lng, geometry);
       return da.compareTo(db);
     });
-  }
-
-  /// Population variance of the per-leg speeds. Returns 0 for
-  /// empty/single-element lists (no penalty when we have no signal).
-  static double _speedVariance(List<double> speeds) {
-    if (speeds.length < 2) return 0;
-    final mean = speeds.reduce((a, b) => a + b) / speeds.length;
-    double sumSq = 0;
-    for (final s in speeds) {
-      final d = s - mean;
-      sumSq += d * d;
-    }
-    return sumSq / speeds.length;
-  }
-}
-
-/// Estimated litres saved by picking the eco route over the fastest.
-///
-/// Simple model: distance × consumption_baseline_lPer100km / 100,
-/// adjusted by the eco route's expected efficiency uplift relative
-/// to the fastest. We assume the eco route burns
-/// `1 / (1 + ecoEfficiencyLift)` as much per km as the fastest —
-/// `0.07` (7 % less) is a defensible default for a steady-cruise
-/// vs zigzag delta on a typical European motorway+B-road mix.
-///
-/// Returns 0.0 when either route is empty or the math underflows.
-class EcoSavingsEstimator {
-  /// Default consumption (L / 100 km) when the user hasn't set a
-  /// vehicle baseline. 7 L is roughly the EU fleet average for
-  /// petrol passenger cars (EEA 2023). Diesel users will see a
-  /// slight over-estimate — fine for a UI hint.
-  static const double defaultConsumptionLPer100km = 7.0;
-
-  /// Eco route burns `1 / (1 + lift)` × the fastest route's per-km
-  /// consumption. 7 % is a conservative midpoint of the
-  /// 5–10 % range reported by EU eco-driving studies for steady
-  /// cruise vs aggressive variable-speed driving.
-  static const double ecoEfficiencyLift = 0.07;
-
-  /// Compute estimated litres saved by switching from [fastest] to
-  /// [eco]. Both arguments are total-route distances in km +
-  /// total-route durations in minutes; consumption is L/100 km.
-  ///
-  /// Returns a non-negative value (clamped at 0) — if the model
-  /// somehow predicts the eco route burns *more*, we hide the
-  /// preview rather than scare the user.
-  static double estimateLitersSaved({
-    required double fastestDistanceKm,
-    required double ecoDistanceKm,
-    required double consumptionLPer100km,
-  }) {
-    if (fastestDistanceKm <= 0 || ecoDistanceKm <= 0) return 0.0;
-    if (consumptionLPer100km <= 0) return 0.0;
-    final fastestL = fastestDistanceKm * consumptionLPer100km / 100.0;
-    final ecoConsumption =
-        consumptionLPer100km / (1.0 + ecoEfficiencyLift);
-    final ecoL = ecoDistanceKm * ecoConsumption / 100.0;
-    final delta = fastestL - ecoL;
-    return delta > 0 ? delta : 0.0;
   }
 }

--- a/lib/features/route_search/data/strategies/eco_savings_estimator.dart
+++ b/lib/features/route_search/data/strategies/eco_savings_estimator.dart
@@ -1,0 +1,45 @@
+/// Estimated litres saved by picking the eco route over the fastest.
+///
+/// Simple model: distance × consumption_baseline_lPer100km / 100,
+/// adjusted by the eco route's expected efficiency uplift relative
+/// to the fastest. We assume the eco route burns
+/// `1 / (1 + ecoEfficiencyLift)` as much per km as the fastest —
+/// `0.07` (7 % less) is a defensible default for a steady-cruise
+/// vs zigzag delta on a typical European motorway+B-road mix.
+///
+/// Returns 0.0 when either route is empty or the math underflows.
+class EcoSavingsEstimator {
+  /// Default consumption (L / 100 km) when the user hasn't set a
+  /// vehicle baseline. 7 L is roughly the EU fleet average for
+  /// petrol passenger cars (EEA 2023). Diesel users will see a
+  /// slight over-estimate — fine for a UI hint.
+  static const double defaultConsumptionLPer100km = 7.0;
+
+  /// Eco route burns `1 / (1 + lift)` × the fastest route's per-km
+  /// consumption. 7 % is a conservative midpoint of the
+  /// 5–10 % range reported by EU eco-driving studies for steady
+  /// cruise vs aggressive variable-speed driving.
+  static const double ecoEfficiencyLift = 0.07;
+
+  /// Compute estimated litres saved by switching from [fastest] to
+  /// [eco]. Both arguments are total-route distances in km +
+  /// total-route durations in minutes; consumption is L/100 km.
+  ///
+  /// Returns a non-negative value (clamped at 0) — if the model
+  /// somehow predicts the eco route burns *more*, we hide the
+  /// preview rather than scare the user.
+  static double estimateLitersSaved({
+    required double fastestDistanceKm,
+    required double ecoDistanceKm,
+    required double consumptionLPer100km,
+  }) {
+    if (fastestDistanceKm <= 0 || ecoDistanceKm <= 0) return 0.0;
+    if (consumptionLPer100km <= 0) return 0.0;
+    final fastestL = fastestDistanceKm * consumptionLPer100km / 100.0;
+    final ecoConsumption =
+        consumptionLPer100km / (1.0 + ecoEfficiencyLift);
+    final ecoL = ecoDistanceKm * ecoConsumption / 100.0;
+    final delta = fastestL - ecoL;
+    return delta > 0 ? delta : 0.0;
+  }
+}

--- a/test/features/route_search/data/strategies/eco_route_candidate_test.dart
+++ b/test/features/route_search/data/strategies/eco_route_candidate_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/route_search/data/strategies/eco_route_candidate.dart';
+
+/// Direct tests for the helpers extracted out of
+/// `eco_route_search_strategy.dart`. The integration-level
+/// behaviour is covered by the existing
+/// `eco_route_search_strategy_test.dart`; here we pin the pure
+/// mechanics so a refactor of one helper can't silently break
+/// `toRouteInfo` downstream.
+void main() {
+  group('sampleAlongPolyline', () {
+    test('returns empty list for an empty polyline', () {
+      expect(sampleAlongPolyline(const <LatLng>[], 15.0), isEmpty);
+    });
+
+    test('returns a single-point polyline as itself', () {
+      const input = <LatLng>[LatLng(48.0, 2.0)];
+      final out = sampleAlongPolyline(input, 15.0);
+      expect(out, equals(input));
+    });
+
+    test('always includes both first and last points', () {
+      const input = [
+        LatLng(48.0, 2.0),
+        LatLng(48.001, 2.001), // ~140m apart — well below 15km interval
+        LatLng(48.002, 2.002),
+      ];
+      final out = sampleAlongPolyline(input, 15.0);
+      expect(out.first, equals(input.first));
+      expect(out.last, equals(input.last));
+    });
+
+    test('emits intermediate samples roughly every intervalKm', () {
+      // ~1° latitude ≈ 111 km. Step from 48° to 49° in 4 hops gives
+      // ~28 km between hops — at 15 km interval, every hop should
+      // trigger a sample.
+      const input = [
+        LatLng(48.00, 2.0),
+        LatLng(48.25, 2.0),
+        LatLng(48.50, 2.0),
+        LatLng(48.75, 2.0),
+        LatLng(49.00, 2.0),
+      ];
+      final out = sampleAlongPolyline(input, 15.0);
+      // First + 3 intermediate hops cross the threshold + last.
+      // Intermediate hops are added as soon as accumulated >= 15 km.
+      expect(out.length, greaterThanOrEqualTo(4));
+      expect(out.first, equals(input.first));
+      expect(out.last, equals(input.last));
+    });
+
+    test('does not duplicate the last point when it matches a sample', () {
+      // Two-point polyline 28 km apart — the threshold triggers on
+      // the second point, which is already the last. The function
+      // must NOT add it twice.
+      const input = [
+        LatLng(48.0, 2.0),
+        LatLng(48.25, 2.0),
+      ];
+      final out = sampleAlongPolyline(input, 15.0);
+      expect(out.length, 2);
+      expect(out.first, equals(input.first));
+      expect(out.last, equals(input.last));
+    });
+  });
+
+  group('EcoRouteCandidate', () {
+    test('default legSpeedsKmh is empty + elevation is null', () {
+      const c = EcoRouteCandidate(
+        geometry: <LatLng>[],
+        distanceKm: 100,
+        durationMinutes: 60,
+      );
+      expect(c.legSpeedsKmh, isEmpty);
+      expect(c.elevationGainMeters, isNull);
+    });
+
+    test('toRouteInfo carries distance/duration/geometry through', () {
+      const c = EcoRouteCandidate(
+        geometry: [LatLng(48.0, 2.0), LatLng(48.5, 2.5)],
+        distanceKm: 60,
+        durationMinutes: 50,
+        elevationGainMeters: 120,
+      );
+      final info = c.toRouteInfo();
+      expect(info.distanceKm, 60);
+      expect(info.durationMinutes, 50);
+      expect(info.geometry.length, 2);
+      // sample points always include first + last, even on a 2-point line.
+      expect(info.samplePoints.first, equals(c.geometry.first));
+      expect(info.samplePoints.last, equals(c.geometry.last));
+    });
+  });
+}

--- a/test/features/route_search/data/strategies/eco_route_scoring_test.dart
+++ b/test/features/route_search/data/strategies/eco_route_scoring_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/route_search/data/strategies/eco_route_candidate.dart';
+import 'package:tankstellen/features/route_search/data/strategies/eco_route_scoring.dart';
+
+/// Direct tests against the pure scoring helpers extracted out of
+/// `eco_route_search_strategy.dart`. The integration tests in
+/// `eco_route_search_strategy_test.dart` continue to drive scoring
+/// through the strategy class — these tests pin the math itself so
+/// future tuning changes can be reviewed against explicit
+/// numerical fixtures.
+void main() {
+  group('EcoRouteScoring constants', () {
+    test('alpha, beta, maxSlowdownRatio retain documented defaults', () {
+      // If these change, the issue acceptance bullets need re-tuning.
+      // Pin them here so a "try a different alpha" experiment is
+      // forced to update the test deliberately.
+      expect(EcoRouteScoring.alpha, 0.05);
+      expect(EcoRouteScoring.beta, 0.02);
+      expect(EcoRouteScoring.maxSlowdownRatio, 1.15);
+    });
+  });
+
+  group('EcoRouteScoring.speedVariance', () {
+    test('returns 0 for empty list', () {
+      expect(EcoRouteScoring.speedVariance(const <double>[]), 0.0);
+    });
+
+    test('returns 0 for a single-element list (no signal)', () {
+      expect(EcoRouteScoring.speedVariance(const [110.0]), 0.0);
+    });
+
+    test('returns 0 for a constant-speed list', () {
+      expect(EcoRouteScoring.speedVariance(const [110.0, 110.0, 110.0]), 0.0);
+    });
+
+    test('matches population variance (not sample variance) for two values', () {
+      // [40, 120]: mean = 80, deviations = [-40, +40], sumSq = 3200.
+      // population variance = 3200 / 2 = 1600.
+      // sample variance     = 3200 / 1 = 3200 — would fail.
+      expect(
+        EcoRouteScoring.speedVariance(const [40.0, 120.0]),
+        closeTo(1600.0, 1e-9),
+      );
+    });
+
+    test('matches population variance for three highway-mixed values', () {
+      // [60, 90, 120]: mean = 90; deviations = [-30, 0, +30].
+      // sumSq = 900 + 0 + 900 = 1800; variance = 1800 / 3 = 600.
+      expect(
+        EcoRouteScoring.speedVariance(const [60.0, 90.0, 120.0]),
+        closeTo(600.0, 1e-9),
+      );
+    });
+  });
+
+  group('EcoRouteScoring.scoreCandidate', () {
+    test('drops the elevation term entirely when null', () {
+      const c = EcoRouteCandidate(
+        geometry: <LatLng>[],
+        distanceKm: 100,
+        durationMinutes: 60,
+      );
+      // 60 + 0 + 0 = 60 (no variance, no elevation).
+      expect(EcoRouteScoring.scoreCandidate(c), 60.0);
+    });
+
+    test('combines elevation + variance terms additively', () {
+      const c = EcoRouteCandidate(
+        geometry: <LatLng>[],
+        distanceKm: 100,
+        durationMinutes: 60,
+        elevationGainMeters: 200,
+        legSpeedsKmh: [40, 120], // variance = 1600
+      );
+      // 60 + 0.05 × 200 + 0.02 × 1600 = 60 + 10 + 32 = 102.
+      expect(EcoRouteScoring.scoreCandidate(c), closeTo(102.0, 1e-9));
+    });
+  });
+
+  group('EcoRouteScoring.selectEcoRoute', () {
+    test('throws ArgumentError on empty list', () {
+      expect(
+        () => EcoRouteScoring.selectEcoRoute(const []),
+        throwsArgumentError,
+      );
+    });
+
+    test('returns the only candidate when given a one-element list', () {
+      const c = EcoRouteCandidate(
+        geometry: <LatLng>[],
+        distanceKm: 100,
+        durationMinutes: 60,
+      );
+      expect(identical(EcoRouteScoring.selectEcoRoute([c]), c), isTrue);
+    });
+
+    test('rejects candidates above the 15 % slowdown cap', () {
+      const fastest = EcoRouteCandidate(
+        geometry: <LatLng>[],
+        distanceKm: 100,
+        durationMinutes: 60,
+        elevationGainMeters: 500,
+        legSpeedsKmh: [40, 130],
+      );
+      // 20 % slower — must be rejected even though its eco score is great.
+      const tooSlowFlat = EcoRouteCandidate(
+        geometry: <LatLng>[],
+        distanceKm: 100,
+        durationMinutes: 72,
+        elevationGainMeters: 10,
+        legSpeedsKmh: [110, 115],
+      );
+
+      final picked =
+          EcoRouteScoring.selectEcoRoute([fastest, tooSlowFlat]);
+      expect(identical(picked, fastest), isTrue);
+    });
+
+    test('picks the lower-scoring candidate within the slowdown cap', () {
+      // Both within 15 % of each other, eco wins on flat + steady.
+      const steep = EcoRouteCandidate(
+        geometry: <LatLng>[],
+        distanceKm: 100,
+        durationMinutes: 60,
+        elevationGainMeters: 500,
+        legSpeedsKmh: [40, 130], // variance ~2025
+      );
+      const flat = EcoRouteCandidate(
+        geometry: <LatLng>[],
+        distanceKm: 100,
+        durationMinutes: 65, // 8 % slower — under cap
+        elevationGainMeters: 30,
+        legSpeedsKmh: [110, 115], // variance ~6.25
+      );
+      final picked = EcoRouteScoring.selectEcoRoute([steep, flat]);
+      expect(identical(picked, flat), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Extract `EcoRouteCandidate` (+ polyline sampler), `EcoRouteScoring` (alpha/beta/cap + scoreCandidate/selectEcoRoute/speedVariance) and `EcoSavingsEstimator` out of `eco_route_search_strategy.dart` (463 -> 287 LOC).
- Public API unchanged: strategy file re-exports `EcoRouteCandidate` and `EcoSavingsEstimator`; static `scoreCandidate` / `selectEcoRoute` on the strategy class delegate to `EcoRouteScoring`. No callsite in `lib/` or `test/` was modified.

Refs #563 phase: eco_route — epic stays open.

## Test plan
- [x] `flutter analyze` -> 0 warnings
- [x] existing `eco_route_search_strategy_test` still passes (no edits)
- [x] new tests added for extracted helpers (`eco_route_candidate_test.dart`, `eco_route_scoring_test.dart`)
- [x] full `test/features/route_search/` slice green (104 tests)

New files:
- `lib/features/route_search/data/strategies/eco_route_candidate.dart` (84 LOC)
- `lib/features/route_search/data/strategies/eco_route_scoring.dart` (101 LOC)
- `lib/features/route_search/data/strategies/eco_savings_estimator.dart` (45 LOC)
- `test/features/route_search/data/strategies/eco_route_candidate_test.dart`
- `test/features/route_search/data/strategies/eco_route_scoring_test.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)