### PR TITLE
refactor(loyalty): extract loyalty_settings_screen widgets (Refs #563 phase: loyalty_settings)

### DIFF
--- a/lib/features/loyalty/domain/loyalty_card_validators.dart
+++ b/lib/features/loyalty/domain/loyalty_card_validators.dart
@@ -1,0 +1,31 @@
+/// Pure-domain helpers for the fuel-club card add/edit form (#1120).
+///
+/// Extracted from `loyalty_settings_screen.dart` so the parsing and
+/// validation rules can be exercised by plain Dart unit tests without
+/// pumping a widget tree.
+library;
+
+/// Parse the user's discount input. Accepts both '.' and ',' as the
+/// decimal separator so a German/French keyboard layout works without
+/// nagging the user about the "right" character.
+///
+/// Returns `null` for `null`, an empty/whitespace-only input, or a
+/// string that does not parse as a number after the comma-to-dot
+/// substitution. The caller decides whether `null` means "invalid"
+/// (Save short-circuits) or "still being typed" (no error yet).
+double? parseDiscountInput(String? raw) {
+  if (raw == null) return null;
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) return null;
+  return double.tryParse(trimmed.replaceAll(',', '.'));
+}
+
+/// Whether [raw] is a valid per-litre discount: a positive number
+/// (strictly `> 0`) when parsed via [parseDiscountInput].
+///
+/// Centralising the rule here keeps the form validator and any
+/// future bulk-import / sync layer consistent.
+bool isValidDiscountInput(String? raw) {
+  final parsed = parseDiscountInput(raw);
+  return parsed != null && parsed > 0;
+}

--- a/lib/features/loyalty/presentation/loyalty_settings_screen.dart
+++ b/lib/features/loyalty/presentation/loyalty_settings_screen.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/widgets/page_scaffold.dart';
 import '../../../l10n/app_localizations.dart';
 import '../domain/entities/loyalty_card.dart';
 import '../providers/loyalty_provider.dart';
+import 'widgets/loyalty_add_card_sheet.dart';
+import 'widgets/loyalty_card_tile.dart';
+import 'widgets/loyalty_empty_state.dart';
 
 /// Settings sub-screen that lists every registered fuel-club card and
 /// lets the user add, toggle, and delete one (#1120 pilot).
@@ -16,6 +18,10 @@ import '../providers/loyalty_provider.dart';
 /// deleting it, and a `FloatingActionButton` that opens the add-card
 /// bottom sheet. When the list is empty an explanatory empty state
 /// stands in for the cards so first-time users know what to do.
+///
+/// The empty state, list tile, and add-card bottom sheet were
+/// extracted to `widgets/` (#563) to keep this file under the 300-LOC
+/// guideline. Behaviour is unchanged.
 class LoyaltySettingsScreen extends ConsumerWidget {
   const LoyaltySettingsScreen({super.key});
 
@@ -30,14 +36,14 @@ class LoyaltySettingsScreen extends ConsumerWidget {
           'Apply your loyalty discount to displayed prices',
       bannerIcon: Icons.card_membership,
       body: cards.isEmpty
-          ? _LoyaltyEmptyState(onAdd: () => _openAddSheet(context, ref))
+          ? LoyaltyEmptyState(onAdd: () => _openAddSheet(context, ref))
           : ListView.separated(
               padding: const EdgeInsets.only(bottom: 96),
               itemCount: cards.length,
               separatorBuilder: (_, _) => const SizedBox(height: 8),
               itemBuilder: (context, index) {
                 final card = cards[index];
-                return _LoyaltyCardTile(
+                return LoyaltyCardTile(
                   key: Key('loyalty-card-${card.id}'),
                   card: card,
                   onToggle: (enabled) => ref
@@ -60,7 +66,7 @@ class LoyaltySettingsScreen extends ConsumerWidget {
     final result = await showModalBottomSheet<LoyaltyCard>(
       context: context,
       isScrollControlled: true,
-      builder: (sheetContext) => const _AddLoyaltyCardSheet(),
+      builder: (sheetContext) => const LoyaltyAddCardSheet(),
     );
     if (result != null) {
       await ref.read(loyaltyCardsProvider.notifier).upsert(result);
@@ -96,258 +102,5 @@ class LoyaltySettingsScreen extends ConsumerWidget {
     if (confirmed == true) {
       await ref.read(loyaltyCardsProvider.notifier).remove(card.id);
     }
-  }
-}
-
-class _LoyaltyEmptyState extends StatelessWidget {
-  final VoidCallback onAdd;
-
-  const _LoyaltyEmptyState({required this.onAdd});
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.card_membership,
-              size: 64,
-              color: theme.colorScheme.primary.withValues(alpha: 0.6),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              l?.loyaltyEmptyTitle ?? 'No fuel club cards yet',
-              style: theme.textTheme.titleMedium,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              l?.loyaltyEmptyBody ??
-                  'Add a card to apply your per-litre discount to '
-                      'matching stations automatically.',
-              style: theme.textTheme.bodyMedium,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            FilledButton.icon(
-              onPressed: onAdd,
-              icon: const Icon(Icons.add),
-              label: Text(l?.loyaltyAddCard ?? 'Add card'),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _LoyaltyCardTile extends StatelessWidget {
-  final LoyaltyCard card;
-  final ValueChanged<bool> onToggle;
-  final VoidCallback onDeleteRequested;
-
-  const _LoyaltyCardTile({
-    super.key,
-    required this.card,
-    required this.onToggle,
-    required this.onDeleteRequested,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    final discountText = '${card.discountPerLiter.toStringAsFixed(2)} /L';
-    return Dismissible(
-      key: ValueKey('loyalty-dismiss-${card.id}'),
-      direction: DismissDirection.endToStart,
-      background: Container(
-        alignment: Alignment.centerRight,
-        padding: const EdgeInsets.symmetric(horizontal: 24),
-        color: theme.colorScheme.error,
-        child: Icon(Icons.delete, color: theme.colorScheme.onError),
-      ),
-      confirmDismiss: (_) async {
-        // Confirmation dialog lives on the screen so a dismissed
-        // card is restored to the list visually if the user cancels.
-        onDeleteRequested();
-        return false;
-      },
-      child: Card(
-        margin: EdgeInsets.zero,
-        child: ListTile(
-          leading: Icon(
-            Icons.card_membership,
-            color: card.enabled
-                ? theme.colorScheme.primary
-                : theme.colorScheme.onSurfaceVariant,
-          ),
-          title: Text(
-            card.label.isEmpty ? card.brand.canonicalBrand : card.label,
-            style: theme.textTheme.titleSmall
-                ?.copyWith(fontWeight: FontWeight.bold),
-          ),
-          subtitle: Text(
-            '${card.brand.canonicalBrand} · −$discountText',
-            style: theme.textTheme.bodySmall,
-          ),
-          trailing: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Switch(
-                value: card.enabled,
-                onChanged: onToggle,
-              ),
-              IconButton(
-                icon: const Icon(Icons.delete_outline),
-                tooltip: l?.delete ?? 'Delete',
-                onPressed: onDeleteRequested,
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _AddLoyaltyCardSheet extends StatefulWidget {
-  const _AddLoyaltyCardSheet();
-
-  @override
-  State<_AddLoyaltyCardSheet> createState() => _AddLoyaltyCardSheetState();
-}
-
-class _AddLoyaltyCardSheetState extends State<_AddLoyaltyCardSheet> {
-  final _formKey = GlobalKey<FormState>();
-  final _labelController = TextEditingController();
-  final _discountController = TextEditingController();
-  LoyaltyBrand _brand = LoyaltyBrand.totalEnergies;
-
-  @override
-  void dispose() {
-    _labelController.dispose();
-    _discountController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final viewInsets = MediaQuery.of(context).viewInsets.bottom;
-    return Padding(
-      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + viewInsets),
-      child: Form(
-        key: _formKey,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              l?.loyaltyAddCardSheetTitle ?? 'Add fuel club card',
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
-            const SizedBox(height: 16),
-            DropdownButtonFormField<LoyaltyBrand>(
-              initialValue: _brand,
-              decoration: InputDecoration(
-                labelText: l?.loyaltyBrandLabel ?? 'Brand',
-                border: const OutlineInputBorder(),
-              ),
-              items: [
-                for (final brand in LoyaltyBrand.values)
-                  DropdownMenuItem(
-                    value: brand,
-                    child: Text(brand.canonicalBrand),
-                  ),
-              ],
-              onChanged: (v) {
-                if (v != null) setState(() => _brand = v);
-              },
-            ),
-            const SizedBox(height: 12),
-            TextFormField(
-              controller: _labelController,
-              decoration: InputDecoration(
-                labelText: l?.loyaltyCardLabelLabel ?? 'Label (optional)',
-                border: const OutlineInputBorder(),
-              ),
-              textInputAction: TextInputAction.next,
-            ),
-            const SizedBox(height: 12),
-            TextFormField(
-              controller: _discountController,
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
-              inputFormatters: [
-                // Accept either '.' or ',' so a French keyboard works.
-                FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
-              ],
-              decoration: InputDecoration(
-                labelText: l?.loyaltyDiscountLabel ?? 'Discount (per litre)',
-                hintText: '0.05',
-                border: const OutlineInputBorder(),
-              ),
-              validator: (value) {
-                final parsed = _parseDecimal(value);
-                if (parsed == null || parsed <= 0) {
-                  return l?.loyaltyDiscountInvalid ??
-                      'Enter a positive number';
-                }
-                return null;
-              },
-            ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: Text(l?.cancel ?? 'Cancel'),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: FilledButton(
-                    onPressed: _onSave,
-                    child: Text(l?.save ?? 'Save'),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _onSave() {
-    final form = _formKey.currentState;
-    if (form == null || !form.validate()) return;
-    final discount = _parseDecimal(_discountController.text);
-    if (discount == null) return;
-    final card = LoyaltyCard(
-      id: 'loyalty-${DateTime.now().microsecondsSinceEpoch}',
-      brand: _brand,
-      discountPerLiter: discount,
-      label: _labelController.text.trim(),
-      addedAt: DateTime.now(),
-    );
-    Navigator.of(context).pop(card);
-  }
-
-  /// Parse the user's discount input. Accepts both '.' and ',' as the
-  /// decimal separator so a German/French keyboard layout works without
-  /// nagging the user about the "right" character.
-  static double? _parseDecimal(String? raw) {
-    if (raw == null) return null;
-    final trimmed = raw.trim();
-    if (trimmed.isEmpty) return null;
-    return double.tryParse(trimmed.replaceAll(',', '.'));
   }
 }

--- a/lib/features/loyalty/presentation/widgets/loyalty_add_card_sheet.dart
+++ b/lib/features/loyalty/presentation/widgets/loyalty_add_card_sheet.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/loyalty_card.dart';
+import '../../domain/loyalty_card_validators.dart';
+
+/// Bottom-sheet form that creates a new [LoyaltyCard].
+///
+/// Pops with the freshly-built card on Save, or with `null` on
+/// Cancel — the parent screen handles persistence so this widget
+/// stays free of provider plumbing and can be unit-tested with a
+/// plain `pumpApp`.
+///
+/// Extracted from `loyalty_settings_screen.dart` (#563). Validation
+/// rules live in `domain/loyalty_card_validators.dart` so the form
+/// and any future bulk-import path stay consistent.
+class LoyaltyAddCardSheet extends StatefulWidget {
+  const LoyaltyAddCardSheet({super.key});
+
+  @override
+  State<LoyaltyAddCardSheet> createState() => _LoyaltyAddCardSheetState();
+}
+
+class _LoyaltyAddCardSheetState extends State<LoyaltyAddCardSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _labelController = TextEditingController();
+  final _discountController = TextEditingController();
+  LoyaltyBrand _brand = LoyaltyBrand.totalEnergies;
+
+  @override
+  void dispose() {
+    _labelController.dispose();
+    _discountController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final viewInsets = MediaQuery.of(context).viewInsets.bottom;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + viewInsets),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              l?.loyaltyAddCardSheetTitle ?? 'Add fuel club card',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<LoyaltyBrand>(
+              initialValue: _brand,
+              decoration: InputDecoration(
+                labelText: l?.loyaltyBrandLabel ?? 'Brand',
+                border: const OutlineInputBorder(),
+              ),
+              items: [
+                for (final brand in LoyaltyBrand.values)
+                  DropdownMenuItem(
+                    value: brand,
+                    child: Text(brand.canonicalBrand),
+                  ),
+              ],
+              onChanged: (v) {
+                if (v != null) setState(() => _brand = v);
+              },
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _labelController,
+              decoration: InputDecoration(
+                labelText: l?.loyaltyCardLabelLabel ?? 'Label (optional)',
+                border: const OutlineInputBorder(),
+              ),
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _discountController,
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
+              inputFormatters: [
+                // Accept either '.' or ',' so a French keyboard works.
+                FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+              ],
+              decoration: InputDecoration(
+                labelText: l?.loyaltyDiscountLabel ?? 'Discount (per litre)',
+                hintText: '0.05',
+                border: const OutlineInputBorder(),
+              ),
+              validator: (value) {
+                if (!isValidDiscountInput(value)) {
+                  return l?.loyaltyDiscountInvalid ??
+                      'Enter a positive number';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(l?.cancel ?? 'Cancel'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: FilledButton(
+                    onPressed: _onSave,
+                    child: Text(l?.save ?? 'Save'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onSave() {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+    final discount = parseDiscountInput(_discountController.text);
+    if (discount == null) return;
+    final card = LoyaltyCard(
+      id: 'loyalty-${DateTime.now().microsecondsSinceEpoch}',
+      brand: _brand,
+      discountPerLiter: discount,
+      label: _labelController.text.trim(),
+      addedAt: DateTime.now(),
+    );
+    Navigator.of(context).pop(card);
+  }
+}

--- a/lib/features/loyalty/presentation/widgets/loyalty_card_tile.dart
+++ b/lib/features/loyalty/presentation/widgets/loyalty_card_tile.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/loyalty_card.dart';
+
+/// Single row in the loyalty settings list: brand badge + label +
+/// per-litre discount, with a `Switch` for enable/disable and a
+/// trash-can `IconButton` (the screen also wraps the tile in a
+/// [Dismissible] with end-to-start swipe-to-delete that calls back
+/// into [onDeleteRequested]).
+///
+/// Extracted from `loyalty_settings_screen.dart` (#563). Pure
+/// presentation: the parent owns the confirm dialog so a dismissed
+/// card visually snaps back if the user cancels.
+class LoyaltyCardTile extends StatelessWidget {
+  final LoyaltyCard card;
+  final ValueChanged<bool> onToggle;
+  final VoidCallback onDeleteRequested;
+
+  const LoyaltyCardTile({
+    super.key,
+    required this.card,
+    required this.onToggle,
+    required this.onDeleteRequested,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final discountText = '${card.discountPerLiter.toStringAsFixed(2)} /L';
+    return Dismissible(
+      key: ValueKey('loyalty-dismiss-${card.id}'),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        color: theme.colorScheme.error,
+        child: Icon(Icons.delete, color: theme.colorScheme.onError),
+      ),
+      confirmDismiss: (_) async {
+        // Confirmation dialog lives on the screen so a dismissed
+        // card is restored to the list visually if the user cancels.
+        onDeleteRequested();
+        return false;
+      },
+      child: Card(
+        margin: EdgeInsets.zero,
+        child: ListTile(
+          leading: Icon(
+            Icons.card_membership,
+            color: card.enabled
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurfaceVariant,
+          ),
+          title: Text(
+            card.label.isEmpty ? card.brand.canonicalBrand : card.label,
+            style: theme.textTheme.titleSmall
+                ?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          subtitle: Text(
+            '${card.brand.canonicalBrand} · −$discountText',
+            style: theme.textTheme.bodySmall,
+          ),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Switch(
+                value: card.enabled,
+                onChanged: onToggle,
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                tooltip: l?.delete ?? 'Delete',
+                onPressed: onDeleteRequested,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/loyalty/presentation/widgets/loyalty_empty_state.dart
+++ b/lib/features/loyalty/presentation/widgets/loyalty_empty_state.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Explanatory placeholder shown on the loyalty settings screen when
+/// the user has not registered any fuel-club card yet.
+///
+/// Renders the brand-membership icon, a short explanation of what a
+/// card buys the user, and a primary "Add card" CTA that delegates to
+/// [onAdd] (the parent screen typically opens the add-card bottom
+/// sheet). Extracted from `loyalty_settings_screen.dart` (#563) to keep
+/// the screen file under the 300-LOC guideline; behaviour and visual
+/// contract are unchanged.
+class LoyaltyEmptyState extends StatelessWidget {
+  /// Invoked when the user taps the empty-state CTA. The parent screen
+  /// is expected to open the add-card sheet (or any equivalent flow).
+  final VoidCallback onAdd;
+
+  const LoyaltyEmptyState({super.key, required this.onAdd});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.card_membership,
+              size: 64,
+              color: theme.colorScheme.primary.withValues(alpha: 0.6),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              l?.loyaltyEmptyTitle ?? 'No fuel club cards yet',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l?.loyaltyEmptyBody ??
+                  'Add a card to apply your per-litre discount to '
+                      'matching stations automatically.',
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onAdd,
+              icon: const Icon(Icons.add),
+              label: Text(l?.loyaltyAddCard ?? 'Add card'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/loyalty/domain/loyalty_card_validators_test.dart
+++ b/test/features/loyalty/domain/loyalty_card_validators_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/loyalty/domain/loyalty_card_validators.dart';
+
+void main() {
+  group('parseDiscountInput', () {
+    test('returns null for null input', () {
+      expect(parseDiscountInput(null), isNull);
+    });
+
+    test('returns null for an empty string', () {
+      expect(parseDiscountInput(''), isNull);
+    });
+
+    test('returns null for whitespace-only input', () {
+      expect(parseDiscountInput('   '), isNull);
+    });
+
+    test('parses a plain dot-decimal number', () {
+      expect(parseDiscountInput('0.05'), 0.05);
+    });
+
+    test('parses a comma-decimal number (French/German keyboard)', () {
+      expect(parseDiscountInput('0,05'), 0.05);
+    });
+
+    test('trims surrounding whitespace before parsing', () {
+      expect(parseDiscountInput('  0.12  '), 0.12);
+    });
+
+    test('returns null for a non-numeric input', () {
+      expect(parseDiscountInput('abc'), isNull);
+    });
+
+    test('returns null for trailing characters after the number', () {
+      // double.tryParse rejects "0.05€" — confirms no permissive fallback.
+      expect(parseDiscountInput('0.05€'), isNull);
+    });
+  });
+
+  group('isValidDiscountInput', () {
+    test('rejects null', () {
+      expect(isValidDiscountInput(null), isFalse);
+    });
+
+    test('rejects an empty string', () {
+      expect(isValidDiscountInput(''), isFalse);
+    });
+
+    test('rejects zero', () {
+      expect(isValidDiscountInput('0'), isFalse);
+      expect(isValidDiscountInput('0.0'), isFalse);
+    });
+
+    test('rejects a negative number', () {
+      expect(isValidDiscountInput('-0.05'), isFalse);
+    });
+
+    test('accepts a positive dot-decimal number', () {
+      expect(isValidDiscountInput('0.05'), isTrue);
+    });
+
+    test('accepts a positive comma-decimal number', () {
+      expect(isValidDiscountInput('0,05'), isTrue);
+    });
+
+    test('rejects a non-numeric input', () {
+      expect(isValidDiscountInput('abc'), isFalse);
+    });
+  });
+}

--- a/test/features/loyalty/presentation/widgets/loyalty_add_card_sheet_test.dart
+++ b/test/features/loyalty/presentation/widgets/loyalty_add_card_sheet_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/loyalty/domain/entities/loyalty_card.dart';
+import 'package:tankstellen/features/loyalty/presentation/widgets/loyalty_add_card_sheet.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Pumps the sheet inside a host widget with a button that opens it
+/// via `showModalBottomSheet`, capturing the popped [LoyaltyCard] (or
+/// `null` on cancel) for assertion. Mirrors the production call site
+/// in `LoyaltySettingsScreen._openAddSheet`.
+class _SheetHost extends StatefulWidget {
+  final void Function(LoyaltyCard?) onResult;
+
+  const _SheetHost({required this.onResult});
+
+  @override
+  State<_SheetHost> createState() => _SheetHostState();
+}
+
+class _SheetHostState extends State<_SheetHost> {
+  Future<void> _open() async {
+    final card = await showModalBottomSheet<LoyaltyCard>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const LoyaltyAddCardSheet(),
+    );
+    widget.onResult(card);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        onPressed: _open,
+        child: const Text('open'),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('LoyaltyAddCardSheet', () {
+    testWidgets(
+        'renders the brand dropdown, label, discount field and action row',
+        (tester) async {
+      await pumpApp(
+        tester,
+        _SheetHost(onResult: (_) {}),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add fuel club card'), findsOneWidget);
+      expect(find.text('Brand'), findsOneWidget);
+      expect(find.text('Label (optional)'), findsOneWidget);
+      expect(find.text('Discount (per litre)'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, 'Cancel'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Save'), findsOneWidget);
+    });
+
+    testWidgets('Save with an empty discount surfaces the validator error',
+        (tester) async {
+      LoyaltyCard? captured;
+      var resolved = false;
+      await pumpApp(
+        tester,
+        _SheetHost(onResult: (c) {
+          captured = c;
+          resolved = true;
+        }),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Enter a positive number'), findsOneWidget);
+      // Sheet stayed open — onResult was not invoked yet.
+      expect(resolved, isFalse);
+      expect(captured, isNull);
+    });
+
+    testWidgets('Save with a valid discount pops the sheet with a card',
+        (tester) async {
+      LoyaltyCard? captured;
+      await pumpApp(
+        tester,
+        _SheetHost(onResult: (c) => captured = c),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Discount (per litre)'),
+        '0.07',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Label (optional)'),
+        'Personal',
+      );
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.discountPerLiter, 0.07);
+      expect(captured!.label, 'Personal');
+      expect(captured!.brand, LoyaltyBrand.totalEnergies);
+      expect(captured!.enabled, isTrue);
+    });
+
+    testWidgets('comma-decimal input is accepted (German/French keyboard)',
+        (tester) async {
+      LoyaltyCard? captured;
+      await pumpApp(
+        tester,
+        _SheetHost(onResult: (c) => captured = c),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Discount (per litre)'),
+        '0,08',
+      );
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.discountPerLiter, 0.08);
+    });
+
+    testWidgets('Cancel pops the sheet with null', (tester) async {
+      LoyaltyCard? captured;
+      var resolved = false;
+      await pumpApp(
+        tester,
+        _SheetHost(onResult: (c) {
+          captured = c;
+          resolved = true;
+        }),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(resolved, isTrue);
+      expect(captured, isNull);
+    });
+  });
+}

--- a/test/features/loyalty/presentation/widgets/loyalty_card_tile_test.dart
+++ b/test/features/loyalty/presentation/widgets/loyalty_card_tile_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/loyalty/domain/entities/loyalty_card.dart';
+import 'package:tankstellen/features/loyalty/presentation/widgets/loyalty_card_tile.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+LoyaltyCard _makeCard({
+  String id = 'card-1',
+  String label = 'Personal',
+  double discount = 0.05,
+  LoyaltyBrand brand = LoyaltyBrand.totalEnergies,
+  bool enabled = true,
+}) {
+  return LoyaltyCard(
+    id: id,
+    brand: brand,
+    discountPerLiter: discount,
+    label: label,
+    addedAt: DateTime(2026, 4, 1),
+    enabled: enabled,
+  );
+}
+
+void main() {
+  group('LoyaltyCardTile', () {
+    testWidgets(
+        'renders the user-supplied label, brand and discount line',
+        (tester) async {
+      await pumpApp(
+        tester,
+        LoyaltyCardTile(
+          card: _makeCard(),
+          onToggle: (_) {},
+          onDeleteRequested: () {},
+        ),
+      );
+
+      // Title row uses the user-supplied label, not the brand name.
+      expect(find.text('Personal'), findsOneWidget);
+      // Subtitle exposes the canonical brand and the formatted discount.
+      expect(find.textContaining('TotalEnergies'), findsOneWidget);
+      expect(find.textContaining('−0.05 /L'), findsOneWidget);
+    });
+
+    testWidgets('falls back to canonical brand when label is empty',
+        (tester) async {
+      await pumpApp(
+        tester,
+        LoyaltyCardTile(
+          card: _makeCard(label: ''),
+          onToggle: (_) {},
+          onDeleteRequested: () {},
+        ),
+      );
+
+      // Title row falls back to "TotalEnergies" (brand canonicalBrand).
+      expect(find.text('TotalEnergies'), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('Switch reflects the card.enabled flag', (tester) async {
+      await pumpApp(
+        tester,
+        LoyaltyCardTile(
+          card: _makeCard(enabled: false),
+          onToggle: (_) {},
+          onDeleteRequested: () {},
+        ),
+      );
+
+      final switchWidget = tester.widget<Switch>(find.byType(Switch));
+      expect(switchWidget.value, isFalse);
+    });
+
+    testWidgets('flipping the Switch invokes onToggle with the new value',
+        (tester) async {
+      bool? lastValue;
+      await pumpApp(
+        tester,
+        LoyaltyCardTile(
+          card: _makeCard(enabled: false),
+          onToggle: (v) => lastValue = v,
+          onDeleteRequested: () {},
+        ),
+      );
+
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+
+      expect(lastValue, isTrue);
+    });
+
+    testWidgets('tapping the trash icon invokes onDeleteRequested',
+        (tester) async {
+      var deleteCalls = 0;
+      await pumpApp(
+        tester,
+        LoyaltyCardTile(
+          card: _makeCard(),
+          onToggle: (_) {},
+          onDeleteRequested: () => deleteCalls++,
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pumpAndSettle();
+
+      expect(deleteCalls, 1);
+    });
+
+    testWidgets('trash IconButton exposes a tooltip', (tester) async {
+      await pumpApp(
+        tester,
+        LoyaltyCardTile(
+          card: _makeCard(),
+          onToggle: (_) {},
+          onDeleteRequested: () {},
+        ),
+      );
+
+      // English fallback string from the localization helper.
+      expect(find.byTooltip('Delete'), findsOneWidget);
+    });
+
+    testWidgets('end-to-start swipe routes through onDeleteRequested',
+        (tester) async {
+      var deleteCalls = 0;
+      await pumpApp(
+        tester,
+        LoyaltyCardTile(
+          card: _makeCard(),
+          onToggle: (_) {},
+          onDeleteRequested: () => deleteCalls++,
+        ),
+      );
+
+      // Swipe the Dismissible from end to start past the dismiss
+      // threshold; confirmDismiss returns false but still calls back.
+      await tester.drag(find.byType(Dismissible), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+
+      expect(deleteCalls, greaterThanOrEqualTo(1));
+    });
+
+    testWidgets('hit targets meet the Android tap-target guideline',
+        (tester) async {
+      await pumpApp(
+        tester,
+        LoyaltyCardTile(
+          card: _makeCard(),
+          onToggle: (_) {},
+          onDeleteRequested: () {},
+        ),
+      );
+
+      await expectLater(
+        tester,
+        meetsGuideline(androidTapTargetGuideline),
+      );
+    });
+  });
+}

--- a/test/features/loyalty/presentation/widgets/loyalty_empty_state_test.dart
+++ b/test/features/loyalty/presentation/widgets/loyalty_empty_state_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/loyalty/presentation/widgets/loyalty_empty_state.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('LoyaltyEmptyState', () {
+    testWidgets('renders the empty-title, body and "Add card" CTA',
+        (tester) async {
+      await pumpApp(
+        tester,
+        LoyaltyEmptyState(onAdd: () {}),
+      );
+
+      expect(find.text('No fuel club cards yet'), findsOneWidget);
+      expect(
+        find.textContaining('Add a card to apply your per-litre discount'),
+        findsOneWidget,
+      );
+      // Primary CTA — the FilledButton.icon variant exposes both an
+      // icon and the "Add card" label.
+      expect(find.widgetWithText(FilledButton, 'Add card'), findsOneWidget);
+      expect(find.byIcon(Icons.add), findsOneWidget);
+      // The marquee membership icon at 64px.
+      expect(find.byIcon(Icons.card_membership), findsOneWidget);
+    });
+
+    testWidgets('invokes onAdd when the CTA is tapped', (tester) async {
+      var taps = 0;
+      await pumpApp(
+        tester,
+        LoyaltyEmptyState(onAdd: () => taps++),
+      );
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Add card'));
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+    });
+
+    testWidgets('CTA hit target meets the Android tap-target guideline',
+        (tester) async {
+      await pumpApp(
+        tester,
+        LoyaltyEmptyState(onAdd: () {}),
+      );
+
+      await expectLater(
+        tester,
+        meetsGuideline(androidTapTargetGuideline),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Refs #563 phase: loyalty_settings

Extracts the inline private widgets from `lib/features/loyalty/presentation/loyalty_settings_screen.dart` so the screen drops from **353 LOC -> 106 LOC** (well under the 300-line guideline).

### What moved
- `_LoyaltyEmptyState` -> `lib/features/loyalty/presentation/widgets/loyalty_empty_state.dart` (61 LOC)
- `_LoyaltyCardTile` (Dismissible + ListTile + Switch + trash IconButton) -> `lib/features/loyalty/presentation/widgets/loyalty_card_tile.dart` (83 LOC)
- `_AddLoyaltyCardSheet` (StatefulWidget bottom-sheet form) -> `lib/features/loyalty/presentation/widgets/loyalty_add_card_sheet.dart` (141 LOC)
- `_parseDecimal` -> `parseDiscountInput` + new `isValidDiscountInput` in `lib/features/loyalty/domain/loyalty_card_validators.dart` (pure-domain helpers, no Flutter import)

### Behaviour
Pure refactor. Same swipe-to-delete with confirmation dialog, same toggle wiring, same FAB-opens-sheet flow. The existing `LoyaltySettingsScreen` widget tests continue to pass unchanged (now exercising the public widgets transitively).

## Test plan
- [x] `flutter analyze` clean (0 issues)
- [x] `flutter test test/features/loyalty/` -> 60 tests pass (existing screen tests + new validator unit tests + new widget tests for each extracted widget)
- [x] New widget tests cover: empty state CTA, card tile rendering / Switch / swipe-to-delete / trash IconButton tooltip / `meetsGuideline(androidTapTargetGuideline)`, add-sheet validation + Save + Cancel + comma-decimal input
- [x] Pure-domain unit tests for `parseDiscountInput` / `isValidDiscountInput` (16 cases incl. comma-decimal, whitespace, negative, non-numeric)
- [ ] CI runs the full suite

## Out of scope
The other 11 oversized files in #563 stay open — this is one phased PR for the loyalty screen specifically.