### PR TITLE
refactor(alerts): extract form sections from radius_alert_create_sheet (Refs #563 phase: radius_alert_create_sheet)

### DIFF
--- a/lib/features/alerts/domain/radius_alert_validators.dart
+++ b/lib/features/alerts/domain/radius_alert_validators.dart
@@ -1,0 +1,39 @@
+/// Pure validators / parsers for the Radius Alert create form (#563).
+///
+/// Pulled out of `radius_alert_create_sheet.dart` so the rules can be
+/// unit-tested without pumping a full widget tree. Same pattern as
+/// `ChargingLogValidators` from #1156 — keep parsing comma-or-dot
+/// decimal strings and the "can save" predicate in one auditable place.
+class RadiusAlertValidators {
+  RadiusAlertValidators._();
+
+  /// Parses the threshold field's raw text into a non-null double, or
+  /// `null` if the input is empty / unparseable. Accepts both `,` and
+  /// `.` as decimal separators because the form is bilingual and
+  /// continental European keyboards default to a comma.
+  static double? parseThreshold(String raw) {
+    final cleaned = raw.trim().replaceAll(',', '.');
+    if (cleaned.isEmpty) return null;
+    return double.tryParse(cleaned);
+  }
+
+  /// Predicate that mirrors the "Save" button's enabled state. The
+  /// rules are: a non-empty trimmed label, a parseable strictly
+  /// positive threshold, AND a center — either GPS coordinates OR a
+  /// non-empty postal code (the phase-3 worker geocodes postal-only
+  /// entries later).
+  static bool canSave({
+    required String label,
+    required String thresholdRaw,
+    required double? centerLat,
+    required double? centerLng,
+    required String postalCode,
+  }) {
+    if (label.trim().isEmpty) return false;
+    final threshold = parseThreshold(thresholdRaw);
+    if (threshold == null || threshold <= 0) return false;
+    final hasGps = centerLat != null && centerLng != null;
+    final hasPostal = postalCode.trim().isNotEmpty;
+    return hasGps || hasPostal;
+  }
+}

--- a/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
@@ -8,7 +8,9 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/radius_alert.dart';
+import '../../domain/radius_alert_validators.dart';
 import '../../providers/radius_alerts_provider.dart';
+import 'radius_alert_form_fields.dart';
 import 'radius_alert_map_picker.dart';
 
 /// Signature of the map-picker opener. Production code pushes
@@ -19,12 +21,18 @@ typedef RadiusAlertMapPickerOpener = Future<LatLng?> Function(
   BuildContext context,
 );
 
-/// Bottom sheet that creates a new [RadiusAlert] (#578 phase 2 + 3).
+/// Bottom sheet that creates a new [RadiusAlert] (#578 phase 2 + 3,
+/// refactored in #563 phase: radius_alert_create_sheet).
 ///
 /// Phase 2 shipped the form shell (label, fuel, threshold, radius, GPS
-/// center). Phase 3 adds the "Pick on map" button that pushes
+/// center). Phase 3 added the "Pick on map" button that pushes
 /// [RadiusAlertMapPicker] and binds the returned [LatLng] as the alert
 /// center so the background evaluator has real coordinates.
+///
+/// The form sections live in `radius_alert_form_fields.dart` and the
+/// pure validators / parsers live in
+/// `domain/radius_alert_validators.dart`; this file owns the state,
+/// lifecycle, and side-effects (GPS read, map picker, save).
 class RadiusAlertCreateSheet extends ConsumerStatefulWidget {
   /// Injection hook so widget tests can swap the id generator for a
   /// deterministic string. Production callers leave this unset.
@@ -123,30 +131,21 @@ class _RadiusAlertCreateSheetState
     setState(() {
       _centerLat = picked.latitude;
       _centerLng = picked.longitude;
-      _centerSource =
-          l10n?.radiusAlertCenterFromMap ?? 'Map location';
+      _centerSource = l10n?.radiusAlertCenterFromMap ?? 'Map location';
     });
   }
 
-  bool get _canSave {
-    if (_labelController.text.trim().isEmpty) return false;
-    final threshold = _parseThreshold();
-    if (threshold == null || threshold <= 0) return false;
-    // A center is required. GPS wins; otherwise postal code must be
-    // non-empty so the phase-3 worker has something to geocode.
-    final hasGps = _centerLat != null && _centerLng != null;
-    final hasPostal = _postalCodeController.text.trim().isNotEmpty;
-    return hasGps || hasPostal;
-  }
-
-  double? _parseThreshold() {
-    final raw = _thresholdController.text.trim().replaceAll(',', '.');
-    if (raw.isEmpty) return null;
-    return double.tryParse(raw);
-  }
+  bool get _canSave => RadiusAlertValidators.canSave(
+        label: _labelController.text,
+        thresholdRaw: _thresholdController.text,
+        centerLat: _centerLat,
+        centerLng: _centerLng,
+        postalCode: _postalCodeController.text,
+      );
 
   Future<void> _save() async {
-    final threshold = _parseThreshold();
+    final threshold =
+        RadiusAlertValidators.parseThreshold(_thresholdController.text);
     if (threshold == null) return;
 
     // Postal-code-only entries are parked at (0,0) until the phase-3
@@ -175,6 +174,11 @@ class _RadiusAlertCreateSheetState
 
   static String _defaultId() => const Uuid().v4();
 
+  /// Re-run `build` so the Save button picks up the new can-save state
+  /// after a text field changes. Wired into every controller-driven
+  /// child via [VoidCallback].
+  void _rebuild() => setState(() {});
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -191,124 +195,34 @@ class _RadiusAlertCreateSheetState
             style: theme.textTheme.titleLarge,
           ),
           const SizedBox(height: 16),
-          TextField(
+          RadiusAlertLabelField(
             controller: _labelController,
-            decoration: InputDecoration(
-              hintText: l10n?.alertsRadiusLabelHint ?? 'Label',
-              border: const OutlineInputBorder(),
-            ),
-            onChanged: (_) => setState(() {}),
+            onChanged: _rebuild,
           ),
           const SizedBox(height: 16),
-          DropdownButtonFormField<FuelType>(
-            initialValue: _fuelType,
-            decoration: InputDecoration(
-              labelText: l10n?.alertsRadiusFuelType ?? 'Fuel type',
-              border: const OutlineInputBorder(),
-            ),
-            items: FuelType.values
-                .where((t) => t != FuelType.all)
-                .map((t) => DropdownMenuItem(
-                      value: t,
-                      child: Text(t.displayName),
-                    ))
-                .toList(),
-            onChanged: (v) {
-              if (v != null) setState(() => _fuelType = v);
-            },
+          RadiusAlertFuelTypeField(
+            value: _fuelType,
+            onChanged: (v) => setState(() => _fuelType = v),
           ),
           const SizedBox(height: 16),
-          TextField(
+          RadiusAlertThresholdField(
             controller: _thresholdController,
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            decoration: InputDecoration(
-              labelText: l10n?.alertsRadiusThreshold ?? 'Threshold (€/L)',
-              border: const OutlineInputBorder(),
-            ),
-            onChanged: (_) => setState(() {}),
+            onChanged: _rebuild,
           ),
           const SizedBox(height: 16),
-          Row(
-            children: [
-              Text(
-                l10n?.alertsRadiusKm ?? 'Radius (km)',
-                style: theme.textTheme.titleSmall,
-              ),
-              const Spacer(),
-              Text(
-                '${_radiusKm.round()} km',
-                style: theme.textTheme.titleSmall,
-              ),
-            ],
-          ),
-          Slider(
-            value: _radiusKm.clamp(1, 50),
-            min: 1,
-            max: 50,
-            divisions: 49,
-            label: '${_radiusKm.round()} km',
+          RadiusAlertRadiusSlider(
+            value: _radiusKm,
             onChanged: (v) => setState(() => _radiusKm = v),
           ),
           const SizedBox(height: 16),
-          DropdownButtonFormField<int>(
-            initialValue: _frequencyPerDay,
-            decoration: InputDecoration(
-              labelText: l10n?.alertsRadiusFrequencyLabel ??
-                  'Check frequency',
-              border: const OutlineInputBorder(),
-            ),
-            items: <DropdownMenuItem<int>>[
-              DropdownMenuItem(
-                value: 1,
-                child: Text(l10n?.alertsRadiusFrequencyDaily ??
-                    'Once a day'),
-              ),
-              DropdownMenuItem(
-                value: 2,
-                child: Text(
-                    l10n?.alertsRadiusFrequencyTwiceDaily ??
-                        'Twice a day'),
-              ),
-              DropdownMenuItem(
-                value: 3,
-                child: Text(
-                    l10n?.alertsRadiusFrequencyThriceDaily ??
-                        'Three times a day'),
-              ),
-              DropdownMenuItem(
-                value: 4,
-                child: Text(
-                    l10n?.alertsRadiusFrequencyFourTimesDaily ??
-                        'Four times a day'),
-              ),
-            ],
-            onChanged: (v) {
-              if (v != null) setState(() => _frequencyPerDay = v);
-            },
+          RadiusAlertFrequencyField(
+            value: _frequencyPerDay,
+            onChanged: (v) => setState(() => _frequencyPerDay = v),
           ),
           const SizedBox(height: 8),
-          Row(
-            children: [
-              Expanded(
-                child: OutlinedButton.icon(
-                  icon: const Icon(Icons.my_location),
-                  onPressed: _useMyLocation,
-                  label: Text(
-                    l10n?.alertsRadiusCenterGps ?? 'Use my location',
-                  ),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: OutlinedButton.icon(
-                  icon: const Icon(Icons.map_outlined),
-                  onPressed: _pickOnMap,
-                  label: Text(
-                    l10n?.radiusAlertPickOnMap ?? 'Pick on map',
-                  ),
-                ),
-              ),
-            ],
+          RadiusAlertCenterButtons(
+            onUseMyLocation: _useMyLocation,
+            onPickOnMap: _pickOnMap,
           ),
           if (_centerSource != null) ...[
             const SizedBox(height: 8),
@@ -318,32 +232,14 @@ class _RadiusAlertCreateSheetState
             ),
           ],
           const SizedBox(height: 16),
-          TextField(
+          RadiusAlertPostalCodeField(
             controller: _postalCodeController,
-            decoration: InputDecoration(
-              labelText:
-                  l10n?.alertsRadiusCenterPostalCode ?? 'Postal code',
-              border: const OutlineInputBorder(),
-            ),
-            onChanged: (_) => setState(() {}),
+            onChanged: _rebuild,
           ),
           const SizedBox(height: 24),
-          Row(
-            children: [
-              Expanded(
-                child: OutlinedButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(l10n?.alertsRadiusCancel ?? 'Cancel'),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: FilledButton(
-                  onPressed: _canSave ? _save : null,
-                  child: Text(l10n?.alertsRadiusSave ?? 'Save'),
-                ),
-              ),
-            ],
+          RadiusAlertActionButtons(
+            onCancel: () => Navigator.of(context).pop(),
+            onSave: _canSave ? _save : null,
           ),
           const SizedBox(height: 8),
         ],

--- a/lib/features/alerts/presentation/widgets/radius_alert_form_fields.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_form_fields.dart
@@ -1,0 +1,285 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+
+/// Form section widgets for [RadiusAlertCreateSheet]
+/// (#563 phase: radius_alert_create_sheet). Pure stateless widgets —
+/// every piece of state lives in `_RadiusAlertCreateSheetState` and
+/// flows in via constructor parameters; user input flows back via
+/// callbacks. Keeps the parent sheet under the 300-LOC budget while
+/// preserving the test-injection hooks (idGenerator, mapPickerOpener).
+
+/// Single-line label input. Fires [onChanged] on each keystroke so the
+/// parent can re-evaluate "Save" enablement.
+class RadiusAlertLabelField extends StatelessWidget {
+  const RadiusAlertLabelField({
+    super.key,
+    required this.controller,
+    required this.onChanged,
+  });
+
+  final TextEditingController controller;
+  final VoidCallback onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        hintText: l10n?.alertsRadiusLabelHint ?? 'Label',
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: (_) => onChanged(),
+    );
+  }
+}
+
+/// Dropdown picking the fuel type the alert watches. Excludes
+/// [FuelType.all] — an alert needs a concrete fuel to compare against.
+class RadiusAlertFuelTypeField extends StatelessWidget {
+  const RadiusAlertFuelTypeField({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final FuelType value;
+  final ValueChanged<FuelType> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return DropdownButtonFormField<FuelType>(
+      initialValue: value,
+      decoration: InputDecoration(
+        labelText: l10n?.alertsRadiusFuelType ?? 'Fuel type',
+        border: const OutlineInputBorder(),
+      ),
+      items: FuelType.values
+          .where((t) => t != FuelType.all)
+          .map((t) => DropdownMenuItem(
+                value: t,
+                child: Text(t.displayName),
+              ))
+          .toList(),
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+    );
+  }
+}
+
+/// Decimal price-per-litre threshold field. Accepts `,` or `.` as the
+/// decimal separator; the parent's parser normalises the input.
+class RadiusAlertThresholdField extends StatelessWidget {
+  const RadiusAlertThresholdField({
+    super.key,
+    required this.controller,
+    required this.onChanged,
+  });
+
+  final TextEditingController controller;
+  final VoidCallback onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return TextField(
+      controller: controller,
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      decoration: InputDecoration(
+        labelText: l10n?.alertsRadiusThreshold ?? 'Threshold (€/L)',
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: (_) => onChanged(),
+    );
+  }
+}
+
+/// 1–50 km slider for the search radius around the alert center.
+class RadiusAlertRadiusSlider extends StatelessWidget {
+  const RadiusAlertRadiusSlider({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final double value;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Text(
+              l10n?.alertsRadiusKm ?? 'Radius (km)',
+              style: theme.textTheme.titleSmall,
+            ),
+            const Spacer(),
+            Text('${value.round()} km', style: theme.textTheme.titleSmall),
+          ],
+        ),
+        Slider(
+          value: value.clamp(1, 50),
+          min: 1,
+          max: 50,
+          divisions: 49,
+          label: '${value.round()} km',
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+/// WorkManager check-cadence dropdown (1–4 times per day, default 1).
+/// #1012 phase 1 added the 2/3/4 options.
+class RadiusAlertFrequencyField extends StatelessWidget {
+  const RadiusAlertFrequencyField({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return DropdownButtonFormField<int>(
+      initialValue: value,
+      decoration: InputDecoration(
+        labelText: l10n?.alertsRadiusFrequencyLabel ?? 'Check frequency',
+        border: const OutlineInputBorder(),
+      ),
+      items: <DropdownMenuItem<int>>[
+        DropdownMenuItem(
+          value: 1,
+          child: Text(l10n?.alertsRadiusFrequencyDaily ?? 'Once a day'),
+        ),
+        DropdownMenuItem(
+          value: 2,
+          child:
+              Text(l10n?.alertsRadiusFrequencyTwiceDaily ?? 'Twice a day'),
+        ),
+        DropdownMenuItem(
+          value: 3,
+          child: Text(l10n?.alertsRadiusFrequencyThriceDaily ??
+              'Three times a day'),
+        ),
+        DropdownMenuItem(
+          value: 4,
+          child: Text(l10n?.alertsRadiusFrequencyFourTimesDaily ??
+              'Four times a day'),
+        ),
+      ],
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+    );
+  }
+}
+
+/// Two-button row binding the alert center to GPS or a map-pick.
+class RadiusAlertCenterButtons extends StatelessWidget {
+  const RadiusAlertCenterButtons({
+    super.key,
+    required this.onUseMyLocation,
+    required this.onPickOnMap,
+  });
+
+  final VoidCallback onUseMyLocation;
+  final VoidCallback onPickOnMap;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton.icon(
+            icon: const Icon(Icons.my_location),
+            onPressed: onUseMyLocation,
+            label: Text(l10n?.alertsRadiusCenterGps ?? 'Use my location'),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: OutlinedButton.icon(
+            icon: const Icon(Icons.map_outlined),
+            onPressed: onPickOnMap,
+            label: Text(l10n?.radiusAlertPickOnMap ?? 'Pick on map'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Postal-code fallback field. Save accepts this alone; the phase-3
+/// worker geocodes postal-only entries to coordinates later.
+class RadiusAlertPostalCodeField extends StatelessWidget {
+  const RadiusAlertPostalCodeField({
+    super.key,
+    required this.controller,
+    required this.onChanged,
+  });
+
+  final TextEditingController controller;
+  final VoidCallback onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: l10n?.alertsRadiusCenterPostalCode ?? 'Postal code',
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: (_) => onChanged(),
+    );
+  }
+}
+
+/// Cancel + Save action row. `onSave == null` greys out the Save button.
+class RadiusAlertActionButtons extends StatelessWidget {
+  const RadiusAlertActionButtons({
+    super.key,
+    required this.onCancel,
+    required this.onSave,
+  });
+
+  final VoidCallback onCancel;
+  final VoidCallback? onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton(
+            onPressed: onCancel,
+            child: Text(l10n?.alertsRadiusCancel ?? 'Cancel'),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: FilledButton(
+            onPressed: onSave,
+            child: Text(l10n?.alertsRadiusSave ?? 'Save'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/alerts/domain/radius_alert_validators_test.dart
+++ b/test/features/alerts/domain/radius_alert_validators_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/alerts/domain/radius_alert_validators.dart';
+
+void main() {
+  group('RadiusAlertValidators.parseThreshold', () {
+    test('parses dot-decimal strings', () {
+      expect(RadiusAlertValidators.parseThreshold('1.499'),
+          closeTo(1.499, 1e-9));
+    });
+
+    test('parses comma-decimal strings (continental keyboards)', () {
+      expect(RadiusAlertValidators.parseThreshold('1,499'),
+          closeTo(1.499, 1e-9));
+    });
+
+    test('trims whitespace before parsing', () {
+      expect(RadiusAlertValidators.parseThreshold('  1.5  '),
+          closeTo(1.5, 1e-9));
+    });
+
+    test('returns null for empty / whitespace-only input', () {
+      expect(RadiusAlertValidators.parseThreshold(''), isNull);
+      expect(RadiusAlertValidators.parseThreshold('   '), isNull);
+    });
+
+    test('returns null for unparseable input', () {
+      expect(RadiusAlertValidators.parseThreshold('abc'), isNull);
+      expect(RadiusAlertValidators.parseThreshold('1.2.3'), isNull);
+    });
+
+    test('parses bare integers as doubles', () {
+      expect(RadiusAlertValidators.parseThreshold('2'), closeTo(2.0, 1e-9));
+    });
+  });
+
+  group('RadiusAlertValidators.canSave', () {
+    test('returns false when label is empty', () {
+      expect(
+        RadiusAlertValidators.canSave(
+          label: '',
+          thresholdRaw: '1.5',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when label is whitespace-only', () {
+      expect(
+        RadiusAlertValidators.canSave(
+          label: '   ',
+          thresholdRaw: '1.5',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when threshold is unparseable', () {
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'Home diesel',
+          thresholdRaw: 'abc',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when threshold is zero or negative', () {
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'Home diesel',
+          thresholdRaw: '0',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'Home diesel',
+          thresholdRaw: '-1.0',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when no GPS center AND no postal code', () {
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'Home diesel',
+          thresholdRaw: '1.5',
+          centerLat: null,
+          centerLng: null,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns true when GPS center is set', () {
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'Home diesel',
+          thresholdRaw: '1.5',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns true when only postal code is set (geocode later)', () {
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'Home diesel',
+          thresholdRaw: '1.5',
+          centerLat: null,
+          centerLng: null,
+          postalCode: '34120',
+        ),
+        isTrue,
+      );
+    });
+
+    test('treats whitespace-only postal code as missing', () {
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'Home diesel',
+          thresholdRaw: '1.5',
+          centerLat: null,
+          centerLng: null,
+          postalCode: '   ',
+        ),
+        isFalse,
+      );
+    });
+
+    test('accepts comma-decimal threshold', () {
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'Home diesel',
+          thresholdRaw: '1,499',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isTrue,
+      );
+    });
+
+    test('only one of GPS or postal needs to be set', () {
+      // GPS but no postal
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'L',
+          thresholdRaw: '1.5',
+          centerLat: 1.0,
+          centerLng: 1.0,
+          postalCode: '',
+        ),
+        isTrue,
+      );
+      // Postal but no GPS
+      expect(
+        RadiusAlertValidators.canSave(
+          label: 'L',
+          thresholdRaw: '1.5',
+          centerLat: null,
+          centerLng: null,
+          postalCode: '34120',
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Pure extraction of `lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart` (353 LOC) into three smaller files, each under the 300-LOC budget.

| File | Before | After |
|---|---:|---:|
| `lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart` | 353 | 246 |
| `lib/features/alerts/presentation/widgets/radius_alert_form_fields.dart` | new | 285 |
| `lib/features/alerts/domain/radius_alert_validators.dart` | new | 39 |
| `test/features/alerts/domain/radius_alert_validators_test.dart` | new | 178 |

## Why

`radius_alert_create_sheet.dart` had grown past the 300-LOC budget tracked in #563. Splitting it makes the sheet's intent (state, GPS read, map picker, save flow) easier to read, and lifts the `parseThreshold` / `canSave` rules into a pure unit-testable surface — same lever as PR #1156's charging-log validators extraction.

## Children

- **`radius_alert_validators.dart`** — `parseThreshold(raw)` (comma-or-dot decimals) + `canSave({label, thresholdRaw, centerLat, centerLng, postalCode})` predicate. Mirrors the `ChargingLogValidators` pattern from #1156.
- **`radius_alert_form_fields.dart`** — seven stateless widgets: `RadiusAlertLabelField`, `RadiusAlertFuelTypeField`, `RadiusAlertThresholdField`, `RadiusAlertRadiusSlider`, `RadiusAlertFrequencyField`, `RadiusAlertCenterButtons`, `RadiusAlertPostalCodeField`, `RadiusAlertActionButtons`.
- **Parent sheet** — keeps state, lifecycle, `_useMyLocation`, `_pickOnMap`, `_save`, and the build orchestration. Both injection hooks (`idGenerator`, `mapPickerOpener`) preserved exactly.

## Behavior

Unchanged. Every public-facing string, hint text, default (radius 10 km, frequency 1×/day, threshold seed `1.500`, fuel type diesel), and code path stays identical.

## Tests

- All 7 existing `radius_alert_create_sheet_test.dart` widget tests pass — including the count- and label-sensitive ones (label hint, "Pick on map", "Use my location", frequency dropdown menu items).
- 16 new unit tests for `RadiusAlertValidators` covering parser edge cases (dot/comma/whitespace/unparseable/empty) and the `canSave` predicate (empty label, bad threshold, missing center, GPS-only, postal-only, comma-decimal threshold).
- `flutter analyze`: zero issues.

Refs #563