### PR TITLE
refactor(alerts): extract radius_alert_create_sheet sections (Refs #563 phase: radius_alert_create_sheet)

### DIFF
--- a/lib/features/alerts/domain/radius_alert_form_resolver.dart
+++ b/lib/features/alerts/domain/radius_alert_form_resolver.dart
@@ -1,0 +1,82 @@
+/// Pure helpers for the radius-alert create form (#563 phase:
+/// radius_alert_create_sheet extract).
+///
+/// The bottom sheet itself is widget-heavy, but the validation rules
+/// — "is this threshold a positive number?", "does this form have
+/// enough state to save?" — are pure logic. Lifting them out keeps
+/// the widget under the 300-LOC guideline and gives us cheap
+/// unit-test coverage that does not need to spin up a `pumpApp`.
+library;
+
+/// Parses the threshold string the user typed into the price field.
+///
+/// Accepts comma decimals (`'1,499'`) the same way the user keypad
+/// renders them on a German/French Android keyboard, normalises to a
+/// `double`, and returns `null` for blank or unparseable input. The
+/// returned value is *not* clamped to a positive range — that's the
+/// caller's job (`canSaveRadiusAlertForm` handles it).
+double? parseRadiusAlertThreshold(String raw) {
+  final trimmed = raw.trim().replaceAll(',', '.');
+  if (trimmed.isEmpty) return null;
+  return double.tryParse(trimmed);
+}
+
+/// Returns `true` when the form has enough state to materialise a
+/// [RadiusAlert]. Mirrors the legacy `_canSave` getter from the
+/// pre-extract sheet:
+///
+/// * label must be non-blank,
+/// * threshold must parse and be strictly positive,
+/// * a center must be available — either GPS coordinates *or* a
+///   non-blank postal code (the geocoder fills in the coordinates
+///   later in #578 phase 3+).
+bool canSaveRadiusAlertForm({
+  required String label,
+  required String thresholdRaw,
+  required double? centerLat,
+  required double? centerLng,
+  required String postalCode,
+}) {
+  if (label.trim().isEmpty) return false;
+  final threshold = parseRadiusAlertThreshold(thresholdRaw);
+  if (threshold == null || threshold <= 0) return false;
+  final hasGps = centerLat != null && centerLng != null;
+  final hasPostal = postalCode.trim().isNotEmpty;
+  return hasGps || hasPostal;
+}
+
+/// The center binding the user has chosen for the new alert.
+///
+/// This pairs the latitude/longitude (when known) with a
+/// human-readable [source] caption so the UI can tell the user
+/// *which* center is currently bound — "GPS", "Map location", or a
+/// reverse-geocoded address. A `null` instance means no center is
+/// bound yet.
+class RadiusAlertCenterBinding {
+  /// The latitude bound to the alert. `null` until either GPS
+  /// resolves or the map picker returns a [LatLng].
+  final double? lat;
+
+  /// The longitude bound to the alert. `null` until either GPS
+  /// resolves or the map picker returns a [LatLng].
+  final double? lng;
+
+  /// Human-readable caption for the bound center (e.g. `'GPS'`,
+  /// `'Map location'`). The sheet renders this directly under the
+  /// center buttons so the user knows which source is active.
+  final String source;
+
+  const RadiusAlertCenterBinding({
+    required this.lat,
+    required this.lng,
+    required this.source,
+  });
+
+  /// Coordinates the persistence layer should store. Postal-code-only
+  /// entries are parked at `(0, 0)` until the geocoder resolves them
+  /// — see the legacy `_save` comment for context. Returning a
+  /// 2-tuple keeps the call site readable on both branches.
+  ({double lat, double lng}) coordinatesOrZero() {
+    return (lat: lat ?? 0.0, lng: lng ?? 0.0);
+  }
+}

--- a/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
@@ -8,7 +8,9 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/radius_alert.dart';
+import '../../domain/radius_alert_form_resolver.dart';
 import '../../providers/radius_alerts_provider.dart';
+import 'radius_alert_form_sections.dart';
 import 'radius_alert_map_picker.dart';
 
 /// Signature of the map-picker opener. Production code pushes
@@ -22,9 +24,12 @@ typedef RadiusAlertMapPickerOpener = Future<LatLng?> Function(
 /// Bottom sheet that creates a new [RadiusAlert] (#578 phase 2 + 3).
 ///
 /// Phase 2 shipped the form shell (label, fuel, threshold, radius, GPS
-/// center). Phase 3 adds the "Pick on map" button that pushes
+/// center). Phase 3 added the "Pick on map" button that pushes
 /// [RadiusAlertMapPicker] and binds the returned [LatLng] as the alert
-/// center so the background evaluator has real coordinates.
+/// center so the background evaluator has real coordinates. Section
+/// widgets and validation helpers were extracted in #563 phase
+/// `radius_alert_create_sheet`; this file is now the orchestration
+/// shell that owns the controllers and mutable state.
 class RadiusAlertCreateSheet extends ConsumerStatefulWidget {
   /// Injection hook so widget tests can swap the id generator for a
   /// deterministic string. Production callers leave this unset.
@@ -123,45 +128,39 @@ class _RadiusAlertCreateSheetState
     setState(() {
       _centerLat = picked.latitude;
       _centerLng = picked.longitude;
-      _centerSource =
-          l10n?.radiusAlertCenterFromMap ?? 'Map location';
+      _centerSource = l10n?.radiusAlertCenterFromMap ?? 'Map location';
     });
   }
 
-  bool get _canSave {
-    if (_labelController.text.trim().isEmpty) return false;
-    final threshold = _parseThreshold();
-    if (threshold == null || threshold <= 0) return false;
-    // A center is required. GPS wins; otherwise postal code must be
-    // non-empty so the phase-3 worker has something to geocode.
-    final hasGps = _centerLat != null && _centerLng != null;
-    final hasPostal = _postalCodeController.text.trim().isNotEmpty;
-    return hasGps || hasPostal;
-  }
-
-  double? _parseThreshold() {
-    final raw = _thresholdController.text.trim().replaceAll(',', '.');
-    if (raw.isEmpty) return null;
-    return double.tryParse(raw);
-  }
+  bool get _canSave => canSaveRadiusAlertForm(
+        label: _labelController.text,
+        thresholdRaw: _thresholdController.text,
+        centerLat: _centerLat,
+        centerLng: _centerLng,
+        postalCode: _postalCodeController.text,
+      );
 
   Future<void> _save() async {
-    final threshold = _parseThreshold();
+    final threshold = parseRadiusAlertThreshold(_thresholdController.text);
     if (threshold == null) return;
 
     // Postal-code-only entries are parked at (0,0) until the phase-3
     // worker geocodes them. The stored postal code lives in the
     // label so the user can see what they asked for; the coordinates
     // are filled in once the geocoding lands.
-    final lat = _centerLat ?? 0.0;
-    final lng = _centerLng ?? 0.0;
+    final binding = RadiusAlertCenterBinding(
+      lat: _centerLat,
+      lng: _centerLng,
+      source: _centerSource ?? '',
+    );
+    final coords = binding.coordinatesOrZero();
 
     final alert = RadiusAlert(
       id: (widget.idGenerator ?? _defaultId)(),
       fuelType: _fuelType.apiValue,
       threshold: threshold,
-      centerLat: lat,
-      centerLng: lng,
+      centerLat: coords.lat,
+      centerLng: coords.lng,
       radiusKm: _radiusKm,
       label: _labelController.text.trim(),
       createdAt: DateTime.now(),
@@ -174,6 +173,8 @@ class _RadiusAlertCreateSheetState
   }
 
   static String _defaultId() => const Uuid().v4();
+
+  void _rebuild() => setState(() {});
 
   @override
   Widget build(BuildContext context) {
@@ -191,159 +192,45 @@ class _RadiusAlertCreateSheetState
             style: theme.textTheme.titleLarge,
           ),
           const SizedBox(height: 16),
-          TextField(
+          RadiusAlertLabelField(
             controller: _labelController,
-            decoration: InputDecoration(
-              hintText: l10n?.alertsRadiusLabelHint ?? 'Label',
-              border: const OutlineInputBorder(),
-            ),
-            onChanged: (_) => setState(() {}),
+            onChanged: _rebuild,
           ),
           const SizedBox(height: 16),
-          DropdownButtonFormField<FuelType>(
-            initialValue: _fuelType,
-            decoration: InputDecoration(
-              labelText: l10n?.alertsRadiusFuelType ?? 'Fuel type',
-              border: const OutlineInputBorder(),
-            ),
-            items: FuelType.values
-                .where((t) => t != FuelType.all)
-                .map((t) => DropdownMenuItem(
-                      value: t,
-                      child: Text(t.displayName),
-                    ))
-                .toList(),
-            onChanged: (v) {
-              if (v != null) setState(() => _fuelType = v);
-            },
+          RadiusAlertFuelTypeField(
+            value: _fuelType,
+            onChanged: (v) => setState(() => _fuelType = v),
           ),
           const SizedBox(height: 16),
-          TextField(
+          RadiusAlertThresholdField(
             controller: _thresholdController,
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            decoration: InputDecoration(
-              labelText: l10n?.alertsRadiusThreshold ?? 'Threshold (€/L)',
-              border: const OutlineInputBorder(),
-            ),
-            onChanged: (_) => setState(() {}),
+            onChanged: _rebuild,
           ),
           const SizedBox(height: 16),
-          Row(
-            children: [
-              Text(
-                l10n?.alertsRadiusKm ?? 'Radius (km)',
-                style: theme.textTheme.titleSmall,
-              ),
-              const Spacer(),
-              Text(
-                '${_radiusKm.round()} km',
-                style: theme.textTheme.titleSmall,
-              ),
-            ],
-          ),
-          Slider(
-            value: _radiusKm.clamp(1, 50),
-            min: 1,
-            max: 50,
-            divisions: 49,
-            label: '${_radiusKm.round()} km',
+          RadiusAlertRadiusSlider(
+            radiusKm: _radiusKm,
             onChanged: (v) => setState(() => _radiusKm = v),
           ),
           const SizedBox(height: 16),
-          DropdownButtonFormField<int>(
-            initialValue: _frequencyPerDay,
-            decoration: InputDecoration(
-              labelText: l10n?.alertsRadiusFrequencyLabel ??
-                  'Check frequency',
-              border: const OutlineInputBorder(),
-            ),
-            items: <DropdownMenuItem<int>>[
-              DropdownMenuItem(
-                value: 1,
-                child: Text(l10n?.alertsRadiusFrequencyDaily ??
-                    'Once a day'),
-              ),
-              DropdownMenuItem(
-                value: 2,
-                child: Text(
-                    l10n?.alertsRadiusFrequencyTwiceDaily ??
-                        'Twice a day'),
-              ),
-              DropdownMenuItem(
-                value: 3,
-                child: Text(
-                    l10n?.alertsRadiusFrequencyThriceDaily ??
-                        'Three times a day'),
-              ),
-              DropdownMenuItem(
-                value: 4,
-                child: Text(
-                    l10n?.alertsRadiusFrequencyFourTimesDaily ??
-                        'Four times a day'),
-              ),
-            ],
-            onChanged: (v) {
-              if (v != null) setState(() => _frequencyPerDay = v);
-            },
+          RadiusAlertFrequencyField(
+            value: _frequencyPerDay,
+            onChanged: (v) => setState(() => _frequencyPerDay = v),
           ),
           const SizedBox(height: 8),
-          Row(
-            children: [
-              Expanded(
-                child: OutlinedButton.icon(
-                  icon: const Icon(Icons.my_location),
-                  onPressed: _useMyLocation,
-                  label: Text(
-                    l10n?.alertsRadiusCenterGps ?? 'Use my location',
-                  ),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: OutlinedButton.icon(
-                  icon: const Icon(Icons.map_outlined),
-                  onPressed: _pickOnMap,
-                  label: Text(
-                    l10n?.radiusAlertPickOnMap ?? 'Pick on map',
-                  ),
-                ),
-              ),
-            ],
+          RadiusAlertCenterButtons(
+            onUseGps: _useMyLocation,
+            onPickOnMap: _pickOnMap,
+            centerSource: _centerSource,
           ),
-          if (_centerSource != null) ...[
-            const SizedBox(height: 8),
-            Text(
-              _centerSource!,
-              style: theme.textTheme.bodySmall,
-            ),
-          ],
           const SizedBox(height: 16),
-          TextField(
+          RadiusAlertPostalCodeField(
             controller: _postalCodeController,
-            decoration: InputDecoration(
-              labelText:
-                  l10n?.alertsRadiusCenterPostalCode ?? 'Postal code',
-              border: const OutlineInputBorder(),
-            ),
-            onChanged: (_) => setState(() {}),
+            onChanged: _rebuild,
           ),
           const SizedBox(height: 24),
-          Row(
-            children: [
-              Expanded(
-                child: OutlinedButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(l10n?.alertsRadiusCancel ?? 'Cancel'),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: FilledButton(
-                  onPressed: _canSave ? _save : null,
-                  child: Text(l10n?.alertsRadiusSave ?? 'Save'),
-                ),
-              ),
-            ],
+          RadiusAlertActionRow(
+            onCancel: () => Navigator.of(context).pop(),
+            onSave: _canSave ? _save : null,
           ),
           const SizedBox(height: 8),
         ],

--- a/lib/features/alerts/presentation/widgets/radius_alert_form_sections.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_form_sections.dart
@@ -1,0 +1,311 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+
+/// Section widgets for [RadiusAlertCreateSheet] (#563 phase:
+/// radius_alert_create_sheet extract).
+///
+/// Each section is a self-contained `StatelessWidget` so the sheet's
+/// `build()` reads top-to-bottom as a list of named fields. The
+/// sheet still owns the controllers and the mutable state — these
+/// widgets are pure presentation, fed by parameters and callbacks.
+
+/// Label text field at the top of the create sheet. Calls
+/// [onChanged] on every keystroke so the parent can re-evaluate
+/// [canSave] and toggle the Save button.
+class RadiusAlertLabelField extends StatelessWidget {
+  final TextEditingController controller;
+  final VoidCallback onChanged;
+
+  const RadiusAlertLabelField({
+    super.key,
+    required this.controller,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        hintText: l10n?.alertsRadiusLabelHint ?? 'Label',
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: (_) => onChanged(),
+    );
+  }
+}
+
+/// Fuel-type dropdown. Hides [FuelType.all] because an alert with
+/// "all fuels" wouldn't have a single threshold to compare against.
+class RadiusAlertFuelTypeField extends StatelessWidget {
+  final FuelType value;
+  final ValueChanged<FuelType> onChanged;
+
+  const RadiusAlertFuelTypeField({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return DropdownButtonFormField<FuelType>(
+      initialValue: value,
+      decoration: InputDecoration(
+        labelText: l10n?.alertsRadiusFuelType ?? 'Fuel type',
+        border: const OutlineInputBorder(),
+      ),
+      items: FuelType.values
+          .where((t) => t != FuelType.all)
+          .map((t) => DropdownMenuItem(
+                value: t,
+                child: Text(t.displayName),
+              ))
+          .toList(),
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+    );
+  }
+}
+
+/// Threshold price field. Accepts decimal input (German/French
+/// keyboards send a comma; the parser normalises that downstream).
+class RadiusAlertThresholdField extends StatelessWidget {
+  final TextEditingController controller;
+  final VoidCallback onChanged;
+
+  const RadiusAlertThresholdField({
+    super.key,
+    required this.controller,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return TextField(
+      controller: controller,
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      decoration: InputDecoration(
+        labelText: l10n?.alertsRadiusThreshold ?? 'Threshold (€/L)',
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: (_) => onChanged(),
+    );
+  }
+}
+
+/// Radius slider (1-50 km) with the live value on the right.
+class RadiusAlertRadiusSlider extends StatelessWidget {
+  final double radiusKm;
+  final ValueChanged<double> onChanged;
+
+  const RadiusAlertRadiusSlider({
+    super.key,
+    required this.radiusKm,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Text(
+              l10n?.alertsRadiusKm ?? 'Radius (km)',
+              style: theme.textTheme.titleSmall,
+            ),
+            const Spacer(),
+            Text(
+              '${radiusKm.round()} km',
+              style: theme.textTheme.titleSmall,
+            ),
+          ],
+        ),
+        Slider(
+          value: radiusKm.clamp(1, 50),
+          min: 1,
+          max: 50,
+          divisions: 49,
+          label: '${radiusKm.round()} km',
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+/// Daily-frequency dropdown (1×, 2×, 3×, 4× per day).
+class RadiusAlertFrequencyField extends StatelessWidget {
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  const RadiusAlertFrequencyField({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return DropdownButtonFormField<int>(
+      initialValue: value,
+      decoration: InputDecoration(
+        labelText: l10n?.alertsRadiusFrequencyLabel ?? 'Check frequency',
+        border: const OutlineInputBorder(),
+      ),
+      items: <DropdownMenuItem<int>>[
+        DropdownMenuItem(
+          value: 1,
+          child: Text(l10n?.alertsRadiusFrequencyDaily ?? 'Once a day'),
+        ),
+        DropdownMenuItem(
+          value: 2,
+          child: Text(
+              l10n?.alertsRadiusFrequencyTwiceDaily ?? 'Twice a day'),
+        ),
+        DropdownMenuItem(
+          value: 3,
+          child: Text(
+              l10n?.alertsRadiusFrequencyThriceDaily ?? 'Three times a day'),
+        ),
+        DropdownMenuItem(
+          value: 4,
+          child: Text(l10n?.alertsRadiusFrequencyFourTimesDaily ??
+              'Four times a day'),
+        ),
+      ],
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+    );
+  }
+}
+
+/// "Use my location" + "Pick on map" button row, plus the optional
+/// caption underneath that names the bound center source.
+class RadiusAlertCenterButtons extends StatelessWidget {
+  final VoidCallback onUseGps;
+  final VoidCallback onPickOnMap;
+  final String? centerSource;
+
+  const RadiusAlertCenterButtons({
+    super.key,
+    required this.onUseGps,
+    required this.onPickOnMap,
+    required this.centerSource,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton.icon(
+                icon: const Icon(Icons.my_location),
+                onPressed: onUseGps,
+                label: Text(
+                  l10n?.alertsRadiusCenterGps ?? 'Use my location',
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: OutlinedButton.icon(
+                icon: const Icon(Icons.map_outlined),
+                onPressed: onPickOnMap,
+                label: Text(
+                  l10n?.radiusAlertPickOnMap ?? 'Pick on map',
+                ),
+              ),
+            ),
+          ],
+        ),
+        if (centerSource != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            centerSource!,
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// Postal-code fallback field. The phase-3 worker geocodes this when
+/// no GPS center is bound.
+class RadiusAlertPostalCodeField extends StatelessWidget {
+  final TextEditingController controller;
+  final VoidCallback onChanged;
+
+  const RadiusAlertPostalCodeField({
+    super.key,
+    required this.controller,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: l10n?.alertsRadiusCenterPostalCode ?? 'Postal code',
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: (_) => onChanged(),
+    );
+  }
+}
+
+/// Cancel + Save action row at the bottom of the sheet. [onSave] is
+/// `null` until [canSaveRadiusAlertForm] is satisfied — the
+/// `FilledButton` greys out automatically in that state.
+class RadiusAlertActionRow extends StatelessWidget {
+  final VoidCallback onCancel;
+  final VoidCallback? onSave;
+
+  const RadiusAlertActionRow({
+    super.key,
+    required this.onCancel,
+    required this.onSave,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton(
+            onPressed: onCancel,
+            child: Text(l10n?.alertsRadiusCancel ?? 'Cancel'),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: FilledButton(
+            onPressed: onSave,
+            child: Text(l10n?.alertsRadiusSave ?? 'Save'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/alerts/domain/radius_alert_form_resolver_test.dart
+++ b/test/features/alerts/domain/radius_alert_form_resolver_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/alerts/domain/radius_alert_form_resolver.dart';
+
+void main() {
+  group('parseRadiusAlertThreshold', () {
+    test('parses dot-decimal input', () {
+      expect(parseRadiusAlertThreshold('1.499'), closeTo(1.499, 1e-9));
+    });
+
+    test('normalises comma-decimal input from German/French keypads', () {
+      expect(parseRadiusAlertThreshold('1,499'), closeTo(1.499, 1e-9));
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(parseRadiusAlertThreshold('  2.05  '), closeTo(2.05, 1e-9));
+    });
+
+    test('returns null for blank input', () {
+      expect(parseRadiusAlertThreshold(''), isNull);
+      expect(parseRadiusAlertThreshold('   '), isNull);
+    });
+
+    test('returns null for unparseable input', () {
+      expect(parseRadiusAlertThreshold('abc'), isNull);
+      expect(parseRadiusAlertThreshold('1.2.3'), isNull);
+    });
+
+    test('does not clamp negative input — caller decides', () {
+      // Keeps the parser pure; canSaveRadiusAlertForm rejects <= 0.
+      expect(parseRadiusAlertThreshold('-1.0'), closeTo(-1.0, 1e-9));
+    });
+  });
+
+  group('canSaveRadiusAlertForm', () {
+    test('rejects blank label', () {
+      expect(
+        canSaveRadiusAlertForm(
+          label: '   ',
+          thresholdRaw: '1.5',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects unparseable threshold', () {
+      expect(
+        canSaveRadiusAlertForm(
+          label: 'Home',
+          thresholdRaw: 'abc',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects zero or negative threshold', () {
+      expect(
+        canSaveRadiusAlertForm(
+          label: 'Home',
+          thresholdRaw: '0',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+      expect(
+        canSaveRadiusAlertForm(
+          label: 'Home',
+          thresholdRaw: '-1',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects when neither GPS nor postal code is set', () {
+      expect(
+        canSaveRadiusAlertForm(
+          label: 'Home',
+          thresholdRaw: '1.5',
+          centerLat: null,
+          centerLng: null,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+
+    test('accepts when GPS coordinates are set', () {
+      expect(
+        canSaveRadiusAlertForm(
+          label: 'Home',
+          thresholdRaw: '1.5',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '',
+        ),
+        isTrue,
+      );
+    });
+
+    test('accepts when postal code is set without GPS', () {
+      expect(
+        canSaveRadiusAlertForm(
+          label: 'Home',
+          thresholdRaw: '1.5',
+          centerLat: null,
+          centerLng: null,
+          postalCode: '34120',
+        ),
+        isTrue,
+      );
+    });
+
+    test('accepts when both GPS and postal code are present', () {
+      expect(
+        canSaveRadiusAlertForm(
+          label: 'Home',
+          thresholdRaw: '1.5',
+          centerLat: 48.85,
+          centerLng: 2.35,
+          postalCode: '75001',
+        ),
+        isTrue,
+      );
+    });
+
+    test('treats whitespace-only postal code as missing', () {
+      expect(
+        canSaveRadiusAlertForm(
+          label: 'Home',
+          thresholdRaw: '1.5',
+          centerLat: null,
+          centerLng: null,
+          postalCode: '   ',
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects when only one of lat/lng is set', () {
+      // The form binds lat+lng together, but the helper should not
+      // assume that — half a coordinate is unusable.
+      expect(
+        canSaveRadiusAlertForm(
+          label: 'Home',
+          thresholdRaw: '1.5',
+          centerLat: 48.85,
+          centerLng: null,
+          postalCode: '',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('RadiusAlertCenterBinding.coordinatesOrZero', () {
+    test('returns the GPS coordinates when both are set', () {
+      const binding = RadiusAlertCenterBinding(
+        lat: 48.85,
+        lng: 2.35,
+        source: 'GPS',
+      );
+      final coords = binding.coordinatesOrZero();
+      expect(coords.lat, closeTo(48.85, 1e-9));
+      expect(coords.lng, closeTo(2.35, 1e-9));
+    });
+
+    test('parks unbound coordinates at (0, 0) for the geocoder to fill in',
+        () {
+      const binding = RadiusAlertCenterBinding(
+        lat: null,
+        lng: null,
+        source: '',
+      );
+      final coords = binding.coordinatesOrZero();
+      expect(coords.lat, 0.0);
+      expect(coords.lng, 0.0);
+    });
+
+    test('treats half-bound coordinates as unbound on the missing axis', () {
+      const binding = RadiusAlertCenterBinding(
+        lat: 48.85,
+        lng: null,
+        source: 'GPS',
+      );
+      final coords = binding.coordinatesOrZero();
+      expect(coords.lat, closeTo(48.85, 1e-9));
+      expect(coords.lng, 0.0);
+    });
+  });
+}

--- a/test/features/alerts/presentation/widgets/radius_alert_form_sections_test.dart
+++ b/test/features/alerts/presentation/widgets/radius_alert_form_sections_test.dart
@@ -1,0 +1,377 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/alerts/presentation/widgets/radius_alert_form_sections.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  group('RadiusAlertLabelField', () {
+    testWidgets('renders the localised hint text', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await pumpApp(
+        tester,
+        RadiusAlertLabelField(
+          controller: controller,
+          onChanged: () {},
+        ),
+      );
+
+      expect(find.text('Label (e.g. Home diesel)'), findsOneWidget);
+    });
+
+    testWidgets('forwards keystrokes to the controller and fires onChanged',
+        (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      var changes = 0;
+
+      await pumpApp(
+        tester,
+        RadiusAlertLabelField(
+          controller: controller,
+          onChanged: () => changes++,
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'Home diesel');
+      await tester.pump();
+
+      expect(controller.text, 'Home diesel');
+      expect(changes, greaterThanOrEqualTo(1));
+    });
+  });
+
+  group('RadiusAlertFuelTypeField', () {
+    testWidgets('renders the current value and hides FuelType.all',
+        (tester) async {
+      await pumpApp(
+        tester,
+        RadiusAlertFuelTypeField(
+          value: FuelType.diesel,
+          onChanged: (_) {},
+        ),
+      );
+
+      // The dropdown shows the current selection (diesel) on the
+      // closed surface; FuelType.all has no menu entry, but we
+      // verify by tapping and counting items.
+      await tester.tap(find.byType(DropdownButtonFormField<FuelType>));
+      await tester.pumpAndSettle();
+
+      // The expected count equals FuelType.values.length minus the
+      // "all" sentinel.
+      final expectedItems =
+          FuelType.values.where((t) => t != FuelType.all).length;
+      // Each rendered menu item is a DropdownMenuItem<FuelType>.
+      expect(
+        find.byType(DropdownMenuItem<FuelType>, skipOffstage: false),
+        // The dropdown duplicates items for the field surface; the
+        // menu adds one more set, so count is at least expectedItems.
+        findsAtLeast(expectedItems),
+      );
+    });
+
+    testWidgets('calls onChanged when a new fuel is picked', (tester) async {
+      FuelType? picked;
+
+      await pumpApp(
+        tester,
+        RadiusAlertFuelTypeField(
+          value: FuelType.diesel,
+          onChanged: (v) => picked = v,
+        ),
+      );
+
+      await tester.tap(find.byType(DropdownButtonFormField<FuelType>));
+      await tester.pumpAndSettle();
+      // Pick e10 — using `last` to grab the menu copy, not the
+      // collapsed surface copy.
+      await tester.tap(find.text(FuelType.e10.displayName).last);
+      await tester.pumpAndSettle();
+
+      expect(picked, FuelType.e10);
+    });
+  });
+
+  group('RadiusAlertThresholdField', () {
+    testWidgets('uses a numeric-with-decimal keyboard', (tester) async {
+      final controller = TextEditingController(text: '1.500');
+      addTearDown(controller.dispose);
+
+      await pumpApp(
+        tester,
+        RadiusAlertThresholdField(
+          controller: controller,
+          onChanged: () {},
+        ),
+      );
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.keyboardType,
+          const TextInputType.numberWithOptions(decimal: true));
+    });
+
+    testWidgets('fires onChanged on every keystroke', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      var changes = 0;
+
+      await pumpApp(
+        tester,
+        RadiusAlertThresholdField(
+          controller: controller,
+          onChanged: () => changes++,
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), '1.499');
+      await tester.pump();
+      expect(changes, greaterThanOrEqualTo(1));
+    });
+  });
+
+  group('RadiusAlertRadiusSlider', () {
+    testWidgets('shows the rounded radius value', (tester) async {
+      await pumpApp(
+        tester,
+        RadiusAlertRadiusSlider(
+          radiusKm: 12.4,
+          onChanged: (_) {},
+        ),
+      );
+
+      // 12.4 rounds to 12 — the row caption should match.
+      expect(find.text('12 km'), findsAtLeast(1));
+    });
+
+    testWidgets('clamps below 1 km without throwing', (tester) async {
+      await pumpApp(
+        tester,
+        RadiusAlertRadiusSlider(
+          radiusKm: 0.0,
+          onChanged: (_) {},
+        ),
+      );
+
+      // No exceptions and the slider builds.
+      expect(find.byType(Slider), findsOneWidget);
+    });
+  });
+
+  group('RadiusAlertFrequencyField', () {
+    testWidgets('renders all four daily-frequency options', (tester) async {
+      await pumpApp(
+        tester,
+        RadiusAlertFrequencyField(
+          value: 1,
+          onChanged: (_) {},
+        ),
+      );
+
+      await tester.tap(find.byType(DropdownButtonFormField<int>));
+      await tester.pumpAndSettle();
+
+      // Each label appears at least once in the open menu.
+      expect(find.text('Once a day'), findsAtLeast(1));
+      expect(find.text('Twice a day'), findsAtLeast(1));
+      expect(find.text('Three times a day'), findsAtLeast(1));
+      expect(find.text('Four times a day'), findsAtLeast(1));
+    });
+
+    testWidgets('forwards the picked frequency to onChanged', (tester) async {
+      int? picked;
+
+      await pumpApp(
+        tester,
+        RadiusAlertFrequencyField(
+          value: 1,
+          onChanged: (v) => picked = v,
+        ),
+      );
+
+      await tester.tap(find.byType(DropdownButtonFormField<int>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Three times a day').last);
+      await tester.pumpAndSettle();
+
+      expect(picked, 3);
+    });
+  });
+
+  group('RadiusAlertCenterButtons', () {
+    testWidgets('renders both buttons and meets tap-target guideline',
+        (tester) async {
+      await pumpApp(
+        tester,
+        RadiusAlertCenterButtons(
+          onUseGps: () {},
+          onPickOnMap: () {},
+          centerSource: null,
+        ),
+      );
+
+      expect(find.text('Use my location'), findsOneWidget);
+      expect(find.text('Pick on map'), findsOneWidget);
+
+      await expectLater(
+        tester,
+        meetsGuideline(androidTapTargetGuideline),
+      );
+    });
+
+    testWidgets('shows the center caption when bound', (tester) async {
+      await pumpApp(
+        tester,
+        RadiusAlertCenterButtons(
+          onUseGps: () {},
+          onPickOnMap: () {},
+          centerSource: 'GPS',
+        ),
+      );
+
+      expect(find.text('GPS'), findsOneWidget);
+    });
+
+    testWidgets('hides the caption when no center is bound', (tester) async {
+      await pumpApp(
+        tester,
+        RadiusAlertCenterButtons(
+          onUseGps: () {},
+          onPickOnMap: () {},
+          centerSource: null,
+        ),
+      );
+
+      // Only the two buttons should carry text.
+      expect(find.text('GPS'), findsNothing);
+      expect(find.text('Map location'), findsNothing);
+    });
+
+    testWidgets('GPS button fires onUseGps; map button fires onPickOnMap',
+        (tester) async {
+      var gps = 0;
+      var map = 0;
+
+      await pumpApp(
+        tester,
+        RadiusAlertCenterButtons(
+          onUseGps: () => gps++,
+          onPickOnMap: () => map++,
+          centerSource: null,
+        ),
+      );
+
+      await tester.tap(find.text('Use my location'));
+      await tester.pump();
+      expect(gps, 1);
+      expect(map, 0);
+
+      await tester.tap(find.text('Pick on map'));
+      await tester.pump();
+      expect(gps, 1);
+      expect(map, 1);
+    });
+  });
+
+  group('RadiusAlertPostalCodeField', () {
+    testWidgets('renders the localised postal-code label', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await pumpApp(
+        tester,
+        RadiusAlertPostalCodeField(
+          controller: controller,
+          onChanged: () {},
+        ),
+      );
+
+      expect(find.text('Postal code'), findsOneWidget);
+    });
+
+    testWidgets('records typed input via the controller', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await pumpApp(
+        tester,
+        RadiusAlertPostalCodeField(
+          controller: controller,
+          onChanged: () {},
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), '34120');
+      await tester.pump();
+      expect(controller.text, '34120');
+    });
+  });
+
+  group('RadiusAlertActionRow', () {
+    testWidgets('save button is disabled when onSave is null',
+        (tester) async {
+      await pumpApp(
+        tester,
+        RadiusAlertActionRow(
+          onCancel: () {},
+          onSave: null,
+        ),
+      );
+
+      final save = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Save'),
+      );
+      expect(save.onPressed, isNull);
+    });
+
+    testWidgets('save button is enabled when onSave is set', (tester) async {
+      var saved = 0;
+
+      await pumpApp(
+        tester,
+        RadiusAlertActionRow(
+          onCancel: () {},
+          onSave: () => saved++,
+        ),
+      );
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pump();
+      expect(saved, 1);
+    });
+
+    testWidgets('cancel button fires onCancel', (tester) async {
+      var cancelled = 0;
+
+      await pumpApp(
+        tester,
+        RadiusAlertActionRow(
+          onCancel: () => cancelled++,
+          onSave: () {},
+        ),
+      );
+
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Cancel'));
+      await tester.pump();
+      expect(cancelled, 1);
+    });
+
+    testWidgets('meets androidTapTargetGuideline', (tester) async {
+      await pumpApp(
+        tester,
+        RadiusAlertActionRow(
+          onCancel: () {},
+          onSave: () {},
+        ),
+      );
+
+      await expectLater(
+        tester,
+        meetsGuideline(androidTapTargetGuideline),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Refs #563 phase: radius_alert_create_sheet

Lift the radius-alert form into section widgets + a pure-domain helper so `radius_alert_create_sheet.dart` drops from 353 LOC to 240 LOC (under the 300-line guideline).

- New `lib/features/alerts/domain/radius_alert_form_resolver.dart` — pure helpers for threshold parsing, save-eligibility validation, and center-binding coordinate resolution.
- New `lib/features/alerts/presentation/widgets/radius_alert_form_sections.dart` — seven small `StatelessWidget`s (label, fuel, threshold, radius slider, frequency, GPS/map buttons + caption, postal code, action row).
- `radius_alert_create_sheet.dart` is now an orchestration shell that owns controllers and mutable state and composes the section widgets.

No behavior changes:
- Same submit flow (label/fuel/threshold/radius/frequency/center/postal-code → `radiusAlertsProvider.add`).
- Same `idGenerator` and `mapPickerOpener` injection seams.
- Same `static show()` entry point.
- Same `_canSave` rules — the existing widget tests under `test/features/alerts/presentation/widgets/radius_alert_create_sheet_test.dart` continue to pass without modification.

## Test plan

- [x] `flutter analyze` clean (zero warnings, zero infos)
- [x] `flutter test test/features/alerts/` — 245 tests pass, including the unmodified `RadiusAlertCreateSheet` suite
- [x] New unit tests cover threshold parsing (dot/comma/blank/garbage/negative), `canSaveRadiusAlertForm` (every false branch + GPS-or-postal accept paths), and `RadiusAlertCenterBinding.coordinatesOrZero` (bound/unbound/half-bound)
- [x] New widget tests cover each section widget: rendering, controller forwarding, callbacks, and `androidTapTargetGuideline` for the interactive rows
- [x] Existing `RadiusAlertCreateSheet` widget tests assert the same public behavior (save flow, `Pick on map` round-trip, frequency dropdown, cancel) and pass against the refactored sheet