### PR TITLE
fix(map): render tiles on first open + restore AppBar title contrast (#1164)

### DIFF
--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -163,11 +163,12 @@ class _MapScreenState extends ConsumerState<MapScreen> {
     // app-bar theme (FlexColorScheme) and preserve it explicitly.
     final foregroundColor = appBarTheme.foregroundColor ??
         theme.colorScheme.onSurface;
-    // Don't fall back to `theme.textTheme.titleLarge` — the
-    // `no_inline_title_theme_test` lint (#923) bans inline title
-    // textTheme refs in feature screens. The explicit `copyWith` below
-    // sets fontSize/color directly, and any unset family/weight is
-    // inherited from the AppBar's defaults via DefaultTextStyle.
+    // Inline title text-theme refs are banned in feature screens by
+    // the `no_inline_title_theme_test` lint (#923) — including in
+    // comments, since the static scan greps for the literal string.
+    // The explicit `copyWith` below sets fontSize/color directly, and
+    // any unset family/weight is inherited from the AppBar default
+    // via DefaultTextStyle when `appBarTheme.titleTextStyle` is null.
     final baseTitleStyle = appBarTheme.titleTextStyle ?? const TextStyle();
     final compactTitleStyle = baseTitleStyle.copyWith(
       fontSize: 16,

--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -163,9 +163,12 @@ class _MapScreenState extends ConsumerState<MapScreen> {
     // app-bar theme (FlexColorScheme) and preserve it explicitly.
     final foregroundColor = appBarTheme.foregroundColor ??
         theme.colorScheme.onSurface;
-    final baseTitleStyle = appBarTheme.titleTextStyle ??
-        theme.textTheme.titleLarge ??
-        const TextStyle();
+    // Don't fall back to `theme.textTheme.titleLarge` — the
+    // `no_inline_title_theme_test` lint (#923) bans inline title
+    // textTheme refs in feature screens. The explicit `copyWith` below
+    // sets fontSize/color directly, and any unset family/weight is
+    // inherited from the AppBar's defaults via DefaultTextStyle.
+    final baseTitleStyle = appBarTheme.titleTextStyle ?? const TextStyle();
     final compactTitleStyle = baseTitleStyle.copyWith(
       fontSize: 16,
       color: foregroundColor,

--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -38,6 +38,29 @@ import '../widgets/route_map_view.dart';
 /// when price-refreshes landed (#709 regression). Camera moves on
 /// search results are nudged inside [NearbyMapView] / [RouteMapView]
 /// instead.
+///
+/// ## First-open zero-size guard ([LayoutBuilder])
+///
+/// The [_mapIncarnation] listener handles repeat visits but cannot
+/// fully cover the cold-start case (#1164): when the user taps Carte
+/// for the first time, the listener fires AFTER the IndexedStack has
+/// already promoted the offstage-mounted MapScreen to onstage, leaving
+/// a one-frame window in which TileLayer has already captured its
+/// zero-sized viewport. Wrapping the body in a [LayoutBuilder] that
+/// suppresses the FlutterMap subtree until constraints are non-zero
+/// guarantees the TileLayer NEVER sees degenerate constraints — its
+/// first layout pass always uses the real post-mount size.
+///
+/// ## App-bar title color (#1164 bug 2)
+///
+/// `PageScaffold(titleTextStyle: const TextStyle(fontSize: 16))` would
+/// strip the inherited foreground color: AppBar's title text-style
+/// resolution does NOT merge with `defaults.titleTextStyle` when the
+/// caller supplies a non-null `titleTextStyle`, so the title would
+/// render in the DefaultTextStyle fallback (near-invisible against the
+/// FlexColorScheme app bar surface). We resolve the theme's
+/// foreground color explicitly so the compact 16pt size still inherits
+/// the proper on-surface contrast.
 class MapScreen extends ConsumerStatefulWidget {
   const MapScreen({super.key});
 
@@ -99,30 +122,60 @@ class _MapScreenState extends ConsumerState<MapScreen> {
     final routeState = ref.watch(routeSearchStateProvider);
     final showEv = ref.watch(evShowOnMapProvider);
     final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final appBarTheme = theme.appBarTheme;
 
     final hasRouteResults = routeState.hasValue && routeState.value != null;
 
-    final body = KeyedSubtree(
-      key: ValueKey<int>(_mapIncarnation),
-      child: hasRouteResults
-          ? RouteMapView(
-              routeResult: routeState.value!,
-              selectedFuel: selectedFuel,
-              mapController: _mapController,
-            )
-          : NearbyMapView(
-              searchState: searchState,
-              selectedFuel: selectedFuel,
-              searchRadiusKm: searchRadius,
-              mapController: _mapController,
-            ),
+    // #1164 — gate the FlutterMap subtree on real (non-zero) constraints
+    // so its TileLayer never captures the offstage IndexedStack's
+    // degenerate viewport. Combined with the [_mapIncarnation] rebuild
+    // on tab-flip, this fully covers cold-start (first tap) and repeat
+    // visits.
+    final body = LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth <= 0 || constraints.maxHeight <= 0) {
+          return const SizedBox.shrink();
+        }
+        return KeyedSubtree(
+          key: ValueKey<int>(_mapIncarnation),
+          child: hasRouteResults
+              ? RouteMapView(
+                  routeResult: routeState.value!,
+                  selectedFuel: selectedFuel,
+                  mapController: _mapController,
+                )
+              : NearbyMapView(
+                  searchState: searchState,
+                  selectedFuel: selectedFuel,
+                  searchRadiusKm: searchRadius,
+                  mapController: _mapController,
+                ),
+        );
+      },
+    );
+
+    // #1164 — restore the inherited foreground color when overriding
+    // `titleTextStyle`. AppBar does NOT merge with the default title
+    // style when the caller supplies a non-null `titleTextStyle`, so a
+    // bare `TextStyle(fontSize: 16)` strips the color and the title
+    // renders near-invisible. Resolve the foreground color from the
+    // app-bar theme (FlexColorScheme) and preserve it explicitly.
+    final foregroundColor = appBarTheme.foregroundColor ??
+        theme.colorScheme.onSurface;
+    final baseTitleStyle = appBarTheme.titleTextStyle ??
+        theme.textTheme.titleLarge ??
+        const TextStyle();
+    final compactTitleStyle = baseTitleStyle.copyWith(
+      fontSize: 16,
+      color: foregroundColor,
     );
 
     return PageScaffold(
       title: l10n?.map ?? 'Map',
       toolbarHeight: 36,
       titleSpacing: 12,
-      titleTextStyle: const TextStyle(fontSize: 16),
+      titleTextStyle: compactTitleStyle,
       bodyPadding: EdgeInsets.zero,
       floatingActionButton: const DrivingModeFab(),
       body: Column(

--- a/test/features/map/presentation/screens/map_screen_test.dart
+++ b/test/features/map/presentation/screens/map_screen_test.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/app/current_shell_branch_provider.dart';
+import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/widgets/page_scaffold.dart';
 import 'package:tankstellen/features/map/presentation/screens/map_screen.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
@@ -138,5 +143,241 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'mounts FlutterMap with non-zero constraints on first open '
+      '(#1164 bug 1 — gray-tile race)',
+      (tester) async {
+        // Wide-enough viewport so the LayoutBuilder gate opens.
+        tester.view.physicalSize = const Size(900, 1600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const MapScreen(),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+            searchStateProvider.overrideWith(
+              () => _LoadedSearchState(const [_seedStation]),
+            ),
+          ],
+        );
+
+        // FlutterMap must be in the tree — the LayoutBuilder gate
+        // would have suppressed it if the constraints were degenerate
+        // (zero width/height).
+        expect(
+          find.byType(FlutterMap),
+          findsOneWidget,
+          reason:
+              'FlutterMap must render once the body has real constraints. '
+              'A SizedBox.shrink() placeholder would mean the gate is '
+              'closed and the user sees the gray-tile bug (#1164).',
+        );
+
+        // The FlutterMap has been laid out with non-zero size — this is
+        // the precondition for TileLayer to fetch tiles, and the
+        // explicit fix for bug 1: the offstage IndexedStack pre-mount
+        // must NEVER reach FlutterMap with degenerate constraints.
+        final mapBox = tester.renderObject<RenderBox>(find.byType(FlutterMap));
+        expect(mapBox.size.width, greaterThan(0));
+        expect(mapBox.size.height, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'suppresses the FlutterMap subtree when wrapped in zero-sized '
+      'constraints (offstage IndexedStack pre-mount, #1164 bug 1)',
+      (tester) async {
+        // Simulate the IndexedStack offstage-mount path: render
+        // MapScreen inside a zero-sized container so its body's
+        // LayoutBuilder receives degenerate constraints.
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          // SizedBox.shrink forces zero constraints on its child.
+          const SizedBox.shrink(child: MapScreen()),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+            searchStateProvider.overrideWith(
+              () => _LoadedSearchState(const [_seedStation]),
+            ),
+          ],
+        );
+
+        // With zero-sized constraints reaching the LayoutBuilder, the
+        // FlutterMap subtree must NOT mount. If it did, its TileLayer
+        // would capture the degenerate viewport and never re-issue
+        // tile fetches when real constraints arrive — the #1164 bug 1
+        // gray-tile regression.
+        expect(
+          find.byType(FlutterMap),
+          findsNothing,
+          reason:
+              'LayoutBuilder gate must suppress FlutterMap when '
+              'constraints are zero. Otherwise TileLayer captures the '
+              'offstage viewport and stays gray (#1164 bug 1).',
+        );
+      },
+    );
+
+    testWidgets(
+      'AppBar title preserves theme foreground color when titleTextStyle '
+      'is overridden (#1164 bug 2 — invisible title)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const MapScreen(),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+          ],
+        );
+
+        // Locate the AppBar in MapScreen and assert its titleTextStyle
+        // carries an explicit color. AppBar's title-style resolution
+        // does NOT merge with the theme defaults when the caller
+        // supplies a non-null titleTextStyle, so a bare
+        // `TextStyle(fontSize: 16)` would leave the title color null
+        // and fall back to the DefaultTextStyle of the surrounding
+        // material — near-invisible against the FlexColorScheme app
+        // bar surface.
+        final appBar = tester.widget<AppBar>(
+          find.descendant(
+            of: find.byType(MapScreen),
+            matching: find.byType(AppBar),
+          ),
+        );
+
+        expect(
+          appBar.titleTextStyle,
+          isNotNull,
+          reason: 'MapScreen passes a custom titleTextStyle.',
+        );
+        expect(
+          appBar.titleTextStyle!.color,
+          isNotNull,
+          reason:
+              'titleTextStyle.color must be non-null. Otherwise AppBar '
+              'wraps the title in a DefaultTextStyle with color: null '
+              'and the title inherits whatever DefaultTextStyle ancestor '
+              'is in scope (typically near-invisible against the '
+              'FlexColorScheme app bar surface). #1164 bug 2.',
+        );
+
+        // The expected color is the theme foreground for the AppBar —
+        // either appBarTheme.foregroundColor or colorScheme.onSurface.
+        final context = tester.element(find.byType(MapScreen));
+        final theme = Theme.of(context);
+        final expectedForeground = theme.appBarTheme.foregroundColor ??
+            theme.colorScheme.onSurface;
+        expect(
+          appBar.titleTextStyle!.color,
+          expectedForeground,
+          reason:
+              'Title color must match the theme foreground so it stays '
+              'legible (≥ AA contrast against the app bar surface) '
+              'across cold-start and tab round-trip — #1164 bug 2.',
+        );
+
+        // The compact-mode font-size override must still apply.
+        expect(appBar.titleTextStyle!.fontSize, 16);
+      },
+    );
+
+    testWidgets(
+      'AppBar title color survives a tab round-trip '
+      '(#1164 bug 2 regression guard)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const MapScreen(),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+          ],
+        );
+
+        AppBar appBarSnapshot() => tester.widget<AppBar>(
+              find.descendant(
+                of: find.byType(MapScreen),
+                matching: find.byType(AppBar),
+              ),
+            );
+
+        final initialColor = appBarSnapshot().titleTextStyle!.color;
+
+        // Simulate the tab round-trip that historically corrupted the
+        // title color: leave Carte (branch 0), then re-enter (branch 1).
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MapScreen)),
+        );
+        container.read(currentShellBranchProvider.notifier).set(0);
+        await tester.pump();
+        await tester.pump();
+        container.read(currentShellBranchProvider.notifier).set(1);
+        await tester.pump();
+        await tester.pump();
+
+        final afterRoundTripColor = appBarSnapshot().titleTextStyle!.color;
+        expect(
+          afterRoundTripColor,
+          equals(initialColor),
+          reason:
+              'AppBar title color must remain stable across tab '
+              'round-trips. The stale-theme bug (#1164 bug 2) flipped '
+              'the foreground to a near-invisible default when tiles '
+              'painted after the second visit.',
+        );
+      },
+    );
   });
 }
+
+class _LoadedSearchState extends SearchState {
+  _LoadedSearchState(this._stations);
+  final List<Station> _stations;
+
+  @override
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => AsyncValue.data(
+        ServiceResult(
+          data: _stations
+              .map((s) => FuelStationResult(s) as SearchResultItem)
+              .toList(),
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+}
+
+const _seedStation = Station(
+  id: 'seed-1',
+  name: 'Seed Station',
+  brand: 'JET',
+  street: 'Berliner Str.',
+  houseNumber: '1',
+  postCode: '10178',
+  place: 'Berlin',
+  lat: 52.5210,
+  lng: 13.4100,
+  dist: 0.8,
+  e5: 1.799,
+  e10: 1.739,
+  diesel: 1.599,
+  isOpen: true,
+);


### PR DESCRIPTION
## Summary
- **Bug 1 (gray tiles on first open):** the IndexedStack offstage pre-mount reached FlutterMap with zero-sized constraints, letting TileLayer capture an empty viewport that never re-issued fetches when real constraints arrived. Wrap the body in a `LayoutBuilder` that suppresses the FlutterMap subtree until constraints are non-zero so TileLayer's first layout pass always uses the real post-mount size.
- **Bug 2 (invisible AppBar title after tab round-trip):** `MapScreen` passed `titleTextStyle: const TextStyle(fontSize: 16)` with `color: null`. AppBar's title-style resolution does NOT merge with the theme defaults when the caller supplies a non-null `titleTextStyle`, so the title was rendered with no color and inherited whatever DefaultTextStyle was in scope (near-invisible against the FlexColorScheme app bar surface). Resolve the foreground color from `appBarTheme.foregroundColor` (falling back to `colorScheme.onSurface`) and `copyWith` into the compact 16pt style.
- Two tightly-scoped changes to `lib/features/map/presentation/screens/map_screen.dart` plus four new widget tests.

Closes #1164.

## Test plan
- [x] `flutter analyze` -> 0 issues
- [x] `flutter test test/features/map/` -> 117/117 green
- [x] `flutter test test/app/shell_screen_test.dart test/app/shell_screen_responsive_test.dart` -> 14/14 green
- [x] New tests cover: FlutterMap mounts with non-zero constraints; LayoutBuilder gate suppresses FlutterMap when constraints are zero; AppBar title color is non-null and matches `appBarTheme.foregroundColor`; title color survives a simulated tab round-trip
- [x] Verified each new test fails when its corresponding fix is reverted (genuine regression guard, not a tautology)
- [ ] Manual verification on cold-start + tab round-trip (device test pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)