### PR TITLE
fix(ui): harmonize Conso/Favoris sub-tab icons + missing FR translations (#1163)

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -58,8 +58,14 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
         ],
         bottom: TabSwitcher(
           tabs: [
-            TabSwitcherEntry(label: l10n?.favorites ?? 'Favorites'),
-            TabSwitcherEntry(label: l10n?.priceAlerts ?? 'Price Alerts'),
+            TabSwitcherEntry(
+              label: l10n?.favorites ?? 'Favorites',
+              icon: Icons.star_outline,
+            ),
+            TabSwitcherEntry(
+              label: l10n?.priceAlerts ?? 'Price Alerts',
+              icon: Icons.notifications_outlined,
+            ),
           ],
         ),
         bodyPadding: EdgeInsets.zero,

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -897,5 +897,9 @@
   "autoRecordPairedAdapterNone": "Aucun adaptateur appairé. Pairez via l'onboarding OBD2 d'abord.",
   "autoRecordBackgroundLocationLabel": "Localisation en arrière-plan autorisée",
   "autoRecordBackgroundLocationRequest": "Demander la permission",
-  "autoRecordBadgeClearTooltip": "Effacer le compteur"
+  "autoRecordBadgeClearTooltip": "Effacer le compteur",
+  "consumptionLogTitle": "Consommation",
+  "consumptionTabFuel": "Carburant",
+  "trajetsTabLabel": "Trajets",
+  "consumptionTabCharging": "Recharge"
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1610,7 +1610,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Trouver les stations les plus proches avec votre position actuelle';
 
   @override
-  String get consumptionLogTitle => 'Fuel consumption';
+  String get consumptionLogTitle => 'Consommation';
 
   @override
   String get consumptionLogMenuTitle => 'Consumption log';
@@ -3185,10 +3185,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Effacer le compteur';
 
   @override
-  String get consumptionTabFuel => 'Fuel';
+  String get consumptionTabFuel => 'Carburant';
 
   @override
-  String get consumptionTabCharging => 'Charging';
+  String get consumptionTabCharging => 'Recharge';
 
   @override
   String get noChargingLogsTitle => 'No charging logs yet';
@@ -3750,7 +3750,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get trajetsTabLabel => 'Trips';
+  String get trajetsTabLabel => 'Trajets';
 
   @override
   String get trajetsStartRecordingButton => 'Start recording';

--- a/test/accessibility/rtl_layout_test.dart
+++ b/test/accessibility/rtl_layout_test.dart
@@ -410,7 +410,9 @@ void main() {
           overrides: overrides(),
         );
 
-        expect(find.byIcon(Icons.star_outline), findsOneWidget);
+        // #1163 — Icons.star_outline now appears in BOTH the
+        // Favoris sub-tab and the empty-state body, so allow ≥1.
+        expect(find.byIcon(Icons.star_outline), findsAtLeast(1));
       });
     });
 

--- a/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/consumption_screen.dart';
+import 'package:tankstellen/features/consumption/providers/charging_logs_provider.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// #1163 — counterpart to `favorites_screen_tab_icons_test.dart`.
+/// Lock that the Conso sub-tabs keep their icon-above-label rendering.
+/// If anyone strips an icon from `ConsumptionScreen` to "match" Favoris
+/// the wrong way round, this test fails.
+class _FixedFillUpList extends FillUpList {
+  final List<FillUp> _value;
+  _FixedFillUpList(this._value);
+
+  @override
+  List<FillUp> build() => _value;
+}
+
+class _FixedChargingLogs extends ChargingLogs {
+  final List<ChargingLog> _value;
+  _FixedChargingLogs(this._value);
+
+  @override
+  Future<List<ChargingLog>> build() async => _value;
+}
+
+class _FixedActiveVehicle extends ActiveVehicleProfile {
+  final VehicleProfile? _value;
+  _FixedActiveVehicle(this._value);
+
+  @override
+  VehicleProfile? build() => _value;
+}
+
+class _FixedVehicleProfileList extends VehicleProfileList {
+  final List<VehicleProfile> _value;
+  _FixedVehicleProfileList(this._value);
+
+  @override
+  List<VehicleProfile> build() => _value;
+}
+
+const _evVehicle = VehicleProfile(
+  id: 'v-ev',
+  name: 'Tesla Model 3',
+  type: VehicleType.ev,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ConsumptionScreen sub-tab icons (#1163)', () {
+    testWidgets('every TabSwitcher entry renders a leading Icon',
+        (tester) async {
+      final router = GoRouter(
+        initialLocation: '/consumption',
+        routes: [
+          GoRoute(
+            path: '/consumption',
+            builder: (_, _) => const ConsumptionScreen(),
+          ),
+          GoRoute(
+            path: '/consumption/add',
+            builder: (_, _) => const SizedBox(),
+          ),
+          GoRoute(
+            path: '/consumption/pick-station',
+            builder: (_, _) => const SizedBox(),
+          ),
+          GoRoute(path: '/carbon', builder: (_, _) => const SizedBox()),
+          GoRoute(
+            path: '/trip-history',
+            builder: (_, _) => const SizedBox(),
+          ),
+          GoRoute(
+            path: '/vehicles/edit',
+            builder: (_, _) => const SizedBox(),
+          ),
+        ],
+      );
+
+      await pumpApp(
+        tester,
+        MaterialApp.router(routerConfig: router),
+        overrides: [
+          fillUpListProvider.overrideWith(() => _FixedFillUpList(const [])),
+          chargingLogsProvider
+              .overrideWith(() => _FixedChargingLogs(const [])),
+          activeVehicleProfileProvider
+              .overrideWith(() => _FixedActiveVehicle(_evVehicle)),
+          vehicleProfileListProvider
+              .overrideWith(() => _FixedVehicleProfileList(const [_evVehicle])),
+        ],
+      );
+
+      // EV profile keeps the Charging tab visible → 3 Tab widgets.
+      final tabs = tester.widgetList<Tab>(find.byType(Tab)).toList();
+      expect(tabs, hasLength(3),
+          reason: 'EV profile must render Fuel + Trips + Charging');
+
+      // Every Tab must carry an icon — the visual contract this issue
+      // locked across both Conso and Favoris.
+      for (final tab in tabs) {
+        expect(tab.icon, isNotNull,
+            reason: 'Conso sub-tab is missing its leading icon — #1163.');
+      }
+
+      // Spot-check the specific icons defined in `consumption_screen.dart`.
+      // We use findsAtLeast(1) because some of these icons (e.g.
+      // ev_station_outlined) also appear in the empty-state body for
+      // an EV profile with no logs — the tab assertion above is the
+      // strict per-tab guarantee.
+      expect(find.byIcon(Icons.local_gas_station_outlined), findsAtLeast(1));
+      expect(find.byIcon(Icons.route_outlined), findsAtLeast(1));
+      expect(find.byIcon(Icons.ev_station_outlined), findsAtLeast(1));
+    });
+  });
+}

--- a/test/features/favorites/presentation/screens/favorites_screen_tab_icons_test.dart
+++ b/test/features/favorites/presentation/screens/favorites_screen_tab_icons_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/features/favorites/presentation/screens/favorites_screen.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// #1163 — the `Favoris` and `Conso` bottom-nav destinations both use the
+/// shared `TabSwitcher`, but historically only `ConsumptionScreen` passed
+/// icons to its `TabSwitcherEntry` list. This left the Favoris sub-tabs
+/// label-only — visually inconsistent across two adjacent destinations.
+///
+/// Lock the harmonised contract: every entry on the Favoris TabSwitcher
+/// must carry both a star icon (Favoris) and a bell icon (Alertes de
+/// prix), so both sub-tab rows render with the same icon-above-label
+/// vertical rhythm.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FavoritesScreen sub-tab icons (#1163)', () {
+    testWidgets(
+      'Favoris tab carries Icons.star_outline and Alertes de prix '
+      'tab carries Icons.notifications_outlined',
+      (tester) async {
+        final test = standardTestOverrides(favoriteIds: const []);
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const FavoritesScreen(),
+          overrides: test.overrides,
+        );
+
+        // The TabSwitcher renders one Tab per entry. Both Tabs must
+        // surface their icon — the visual fix the issue asks for.
+        final tabs = tester.widgetList<Tab>(find.byType(Tab)).toList();
+        expect(tabs, hasLength(2),
+            reason: 'FavoritesScreen has exactly two sub-tabs');
+
+        // Each Tab must have an Icon child (the symptom the issue
+        // describes is that historically these were null).
+        for (final tab in tabs) {
+          expect(tab.icon, isNotNull,
+              reason: 'Every Favoris sub-tab must carry an icon to match '
+                  'the Conso style — #1163.');
+        }
+
+        // Targeted icon presence — find by IconData on the rendered tree.
+        // Star outline lives on the Favoris tab; the empty-state body
+        // also renders a star, so we tolerate >=1 here.
+        expect(find.byIcon(Icons.star_outline), findsAtLeast(1));
+        expect(find.byIcon(Icons.notifications_outlined), findsOneWidget);
+      },
+    );
+  });
+}

--- a/test/features/favorites/presentation/screens/favorites_screen_test.dart
+++ b/test/features/favorites/presentation/screens/favorites_screen_test.dart
@@ -52,8 +52,11 @@ void main() {
         overrides: test.overrides,
       );
 
-      // Empty state shows star_border icon and "No favorites yet" text
-      expect(find.byIcon(Icons.star_outline), findsOneWidget);
+      // Empty state shows star_outline icon and "No favorites yet" text.
+      // #1163 — the Favoris sub-tab now also renders Icons.star_outline,
+      // so we expect at least 2 occurrences (one in the tab row, one in
+      // the empty-state body) instead of exactly one.
+      expect(find.byIcon(Icons.star_outline), findsAtLeast(2));
       expect(find.text('No favorites yet'), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary
- Add `Icons.star_outline` + `Icons.notifications_outlined` to Favoris sub-tabs (matches Conso style).
- Translate the four missing keys to French so the Conso AppBar + tab labels stop falling back to English: `consumptionLogTitle` -> "Consommation", `consumptionTabFuel` -> "Carburant", `trajetsTabLabel` -> "Trajets", `consumptionTabCharging` -> "Recharge".

Closes #1163.

## Notes on the i18n approach
The `tool/build_arb.dart` fragment merger only reads `_en` and `_de` fragments. French translations live directly in `lib/l10n/app_fr.arb` (per the precedent set by every existing FR key in that file). I appended the four keys at the end of `app_fr.arb` and ran `flutter gen-l10n` to regenerate `app_localizations_fr.dart` — only the FR generated file changed, all other 21 generated files were untouched.

## Test plan
- [x] `flutter analyze` — 0 warnings, 0 infos
- [x] new widget test asserts both Favoris sub-tabs carry an icon (`favorites_screen_tab_icons_test.dart`)
- [x] new widget test asserts every Conso sub-tab carries an icon (`consumption_screen_tab_icons_test.dart`)
- [x] existing `favorites_screen_test.dart` updated — empty-state asserted >=2 `Icons.star_outline` (one in tab + one in body) instead of exactly 1
- [x] FR locale renders Consommation / Carburant / Trajets / Recharge — verified in `app_localizations_fr.dart`
- [x] existing i18n parity + completeness tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)