### PR TITLE
feat(obd2): AutoTripCoordinator + BackgroundAdapterListener interface (Refs #1004 phase 2a)

### DIFF
--- a/lib/features/consumption/data/obd2/auto_trip_coordinator.dart
+++ b/lib/features/consumption/data/obd2/auto_trip_coordinator.dart
@@ -1,0 +1,343 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../../core/logging/error_logger.dart';
+import 'background_adapter_listener.dart';
+
+/// Immutable snapshot of the auto-record fields off [VehicleProfile]
+/// (#1004 phase 1) the coordinator needs to make decisions.
+///
+/// Modelled as a value object instead of holding the whole profile
+/// because the coordinator doesn't care about brand, fuel type, or
+/// odometer — only the MAC to filter on, the speed threshold to count
+/// against, and the disconnect debounce window. Detaching from the
+/// profile also makes this safe to copy into a future
+/// background-isolate hand-off without dragging Hive types.
+@immutable
+class AutoRecordConfig {
+  /// MAC address of the paired ELM327 adapter, sourced from
+  /// `VehicleProfile.pairedAdapterMac`. The coordinator drops every
+  /// event whose MAC does not equal this string — the multi-vehicle
+  /// case (a household with two paired cars) only treats the active
+  /// profile's adapter as live.
+  final String mac;
+
+  /// Speed (km/h) above which a sustained run kicks `startTrip()`.
+  /// Sourced from `VehicleProfile.movementStartThresholdKmh`. Default
+  /// in the profile is 5 km/h — low enough to catch pulling out of a
+  /// parking spot, high enough to filter the brief speed spikes BLE
+  /// adapters sometimes report on first connect.
+  final double movementStartThresholdKmh;
+
+  /// Debounce window before a disconnect triggers `stopAndSave`.
+  /// Sourced from `VehicleProfile.disconnectSaveDelaySec`. Default in
+  /// the profile is 60 s — long enough to absorb a tunnel or a
+  /// parking-garage lift, short enough that the user sees a saved
+  /// trip when they walk into the kitchen.
+  final Duration disconnectSaveDelay;
+
+  const AutoRecordConfig({
+    required this.mac,
+    required this.movementStartThresholdKmh,
+    required this.disconnectSaveDelay,
+  });
+}
+
+/// Coordinates the hands-free auto-record state machine: BLE connect
+/// → movement detected → start trip → BLE disconnect (debounced) →
+/// stop and save (#1004 phases 3+4, Dart side only).
+///
+/// ## State machine (high level)
+///
+/// ```
+///   ┌─────────┐  AdapterConnected(matching mac)  ┌────────────────┐
+///   │  Idle   │ ───────────────────────────────► │ Watching speed │
+///   └─────────┘                                  └────────┬───────┘
+///         ▲                                               │
+///         │ stopAndSaveAutomatic                          │ N consecutive
+///         │ (timer fired)                                 │ supra-threshold
+///         │                                               ▼ samples
+///   ┌──────────────┐  AdapterDisconnected           ┌────────────┐
+///   │ Awaiting save│ ◄──────────────────────────── │ Recording   │
+///   │  (timer)     │                                │             │
+///   └──────────────┘                                └────────────┘
+///       │  AdapterConnected (within window) → cancel timer, back to Recording
+/// ```
+///
+/// ## Why this is a separate class
+///
+/// The trip-recording provider already owns the OBD2 session lifecycle
+/// (start, pause, resume, stop). The coordinator does NOT replace any
+/// of that — it just observes adapter / movement signals and forwards
+/// `startTrip` and `stopAndSaveAutomatic` calls into the existing
+/// provider. Keeping it as a thin orchestrator means the manual flow
+/// (the user explicitly tapping "Start trip") stays the simple,
+/// well-tested code path; the auto path is purely additive.
+///
+/// ## Phase 2a vs phase 2b
+///
+/// This file ships with phase 2a — Dart scaffolding plus the
+/// state-machine logic. The actual BLE auto-connect that produces
+/// `AdapterConnected` / `AdapterDisconnected` events lives in the
+/// native Android foreground service (phase 2b, NOT in this PR). Until
+/// the bridge ships, [BackgroundAdapterListener] is wired to
+/// [UnimplementedBackgroundAdapterListener] in production so the
+/// coordinator never observes a live event.
+class AutoTripCoordinator {
+  /// Source of BLE connect / disconnect transitions. In production a
+  /// native-bridge implementation; in tests the
+  /// [FakeBackgroundAdapterListener].
+  final BackgroundAdapterListener listener;
+
+  /// Bridge to [TripRecording.startTrip]. Returns the outcome enum so
+  /// the coordinator can stay silent when a trip is already active
+  /// (e.g. the user manually tapped Start before driving away).
+  ///
+  /// Typed as `Future<Object?>` because [StartTripOutcome] lives in
+  /// the providers layer and pulling it into `lib/features/consumption/data/`
+  /// would invert the data → providers dependency direction. The
+  /// coordinator only checks "did we successfully fire?" which is
+  /// captured by the future completing without throwing.
+  final Future<Object?> Function() startTrip;
+
+  /// Bridge to [TripRecording.stopAndSaveAutomatic]. The thin wrapper
+  /// added in phase 2a guarantees the `automatic: true` flag reaches
+  /// `_saveToHistory`, which in turn bumps the launcher-icon badge so
+  /// the user sees "something happened while I was driving" without
+  /// opening the app.
+  final Future<void> Function() stopAndSaveAutomatic;
+
+  /// Stream of vehicle speed in km/h. The coordinator subscribes only
+  /// while a connected adapter is reachable; closes the subscription
+  /// on disconnect to avoid leaking listeners on the OBD2 transport
+  /// when the user has parked. The stream may emit nothing at all
+  /// (engine off, parked) — we just wait.
+  final Stream<double> speedStream;
+
+  /// Snapshot of the auto-record fields off the active vehicle
+  /// profile. Captured by value at construction time so a profile edit
+  /// during a drive does not mutate the rule the in-flight state
+  /// machine is following. Phase 2b will rebuild the coordinator on
+  /// profile changes.
+  final AutoRecordConfig config;
+
+  /// Number of consecutive supra-threshold samples required to
+  /// transition into "actually started driving". 3 is the default —
+  /// noisy enough to filter a single-tick speed spike, fast enough to
+  /// catch a real pull-out within a second of speed.
+  final int consecutiveSamplesWindow;
+
+  /// Test seam for `DateTime.now()` reads. The coordinator itself uses
+  /// this only for diagnostic logging; the disconnect-save delay is
+  /// driven by `Timer`, not by wall-clock arithmetic, so production
+  /// timing is unaffected by injecting a fake clock.
+  final DateTime Function() _now;
+
+  StreamSubscription<BackgroundAdapterEvent>? _adapterSub;
+  StreamSubscription<double>? _speedSub;
+  Timer? _disconnectTimer;
+  int _consecutiveSupraThreshold = 0;
+  bool _started = false;
+  bool _tripActive = false;
+
+  AutoTripCoordinator({
+    required this.listener,
+    required this.startTrip,
+    required this.stopAndSaveAutomatic,
+    required this.speedStream,
+    required this.config,
+    int? consecutiveSamplesWindow,
+    DateTime Function()? now,
+  })  : consecutiveSamplesWindow = consecutiveSamplesWindow ?? 3,
+        _now = now ?? DateTime.now;
+
+  /// Whether the coordinator is currently running. Mostly a test seam
+  /// — the production flow always pairs `start` with a matching
+  /// `stop` on tear-down, so the flag is invariant.
+  @visibleForTesting
+  bool get isStarted => _started;
+
+  /// Whether a disconnect-save timer is currently armed. Exposed for
+  /// tests that want to assert "reconnect cancelled the timer" without
+  /// reaching into private state.
+  @visibleForTesting
+  bool get hasPendingDisconnectTimer => _disconnectTimer?.isActive ?? false;
+
+  /// Begin watching for BLE transitions. Idempotent — calling `start`
+  /// while already started is a no-op (does not double-subscribe to
+  /// `listener.events`, does not arm the bridge twice). The native
+  /// bridge is armed via [BackgroundAdapterListener.start] before the
+  /// stream subscription so any back-pressured replay of the most
+  /// recent state lands on a live subscriber.
+  Future<void> start() async {
+    if (_started) return;
+    _started = true;
+    try {
+      await listener.start(mac: config.mac);
+    } catch (e, st) {
+      // The native bridge throwing here is a developer error in
+      // production (see [UnimplementedBackgroundAdapterListener]); log
+      // and bail so the coordinator stays in a clean idle state and
+      // the next start attempt can re-arm.
+      _started = false;
+      await errorLogger.log(
+        ErrorLayer.background,
+        e,
+        st,
+        context: <String, Object?>{
+          'phase': 'AutoTripCoordinator.start',
+          'mac': config.mac,
+        },
+      );
+      return;
+    }
+    _adapterSub = listener.events.listen(_onAdapterEvent);
+  }
+
+  /// Stop watching, cancel any pending disconnect timer, and unwind
+  /// every subscription. Safe to call when not started; safe to call
+  /// twice. Does NOT save an in-flight trip — if one is running the
+  /// caller (the manual flow's stop button, or the timer) is
+  /// responsible for that, otherwise a developer-initiated tear-down
+  /// (test, lifecycle reset) would silently auto-save.
+  Future<void> stop() async {
+    if (!_started) {
+      // Defensive: still unwind any timer/subs in case a test reaches
+      // in directly. The flags below all start in the "nothing to do"
+      // state on a fresh instance.
+    }
+    _started = false;
+    _disconnectTimer?.cancel();
+    _disconnectTimer = null;
+    _consecutiveSupraThreshold = 0;
+    await _adapterSub?.cancel();
+    _adapterSub = null;
+    await _speedSub?.cancel();
+    _speedSub = null;
+    try {
+      await listener.stop();
+    } catch (e, st) {
+      // Native bridge teardown failure shouldn't propagate — the
+      // coordinator is already idle from the Dart side's perspective.
+      await errorLogger.log(
+        ErrorLayer.background,
+        e,
+        st,
+        context: <String, Object?>{
+          'phase': 'AutoTripCoordinator.stop',
+          'mac': config.mac,
+        },
+      );
+    }
+  }
+
+  void _onAdapterEvent(BackgroundAdapterEvent event) {
+    // MAC filter — multi-vehicle support. A second paired car sharing
+    // the same listener (phase 2b may centralise the bridge) would
+    // emit events for an unrelated MAC; we drop them silently rather
+    // than risk auto-recording the wrong car's drive.
+    if (event.mac != config.mac) return;
+
+    switch (event) {
+      case AdapterConnected():
+        _onConnected();
+      case AdapterDisconnected():
+        _onDisconnected();
+    }
+  }
+
+  void _onConnected() {
+    // Reconnect within the disconnect-save window: cancel the timer
+    // and let the existing trip continue. Speed-watching is already
+    // wired from the previous connect, but we re-attach defensively
+    // in case the native bridge tore the OBD2 session down on
+    // disconnect (which it does in production — the speed stream from
+    // the previous session has stopped emitting).
+    if (_disconnectTimer?.isActive ?? false) {
+      _disconnectTimer!.cancel();
+      _disconnectTimer = null;
+    }
+    _consecutiveSupraThreshold = 0;
+    _speedSub?.cancel();
+    _speedSub = speedStream.listen(_onSpeedSample);
+  }
+
+  void _onDisconnected() {
+    // Stop counting movement samples — the OBD2 session is gone, no
+    // more speed will arrive until the adapter reappears.
+    _consecutiveSupraThreshold = 0;
+    _speedSub?.cancel();
+    _speedSub = null;
+    // Arm the debounce. A reconnect within `disconnectSaveDelay`
+    // cancels it and the trip carries on; otherwise the timer fires
+    // and we save.
+    _disconnectTimer?.cancel();
+    _disconnectTimer = Timer(config.disconnectSaveDelay, _onSaveTimerFired);
+  }
+
+  void _onSpeedSample(double kmh) {
+    if (_tripActive) return;
+    if (kmh > config.movementStartThresholdKmh) {
+      _consecutiveSupraThreshold++;
+    } else {
+      _consecutiveSupraThreshold = 0;
+    }
+    if (_consecutiveSupraThreshold >= consecutiveSamplesWindow) {
+      _tripActive = true;
+      _consecutiveSupraThreshold = 0;
+      // Fire-and-forget — the coordinator's contract is "we observed
+      // movement, the provider knows what to do". Errors are logged
+      // through `errorLogger` rather than re-thrown into the speed
+      // stream, where they'd kill the subscription.
+      unawaited(_invokeStartTrip(kmh));
+    }
+  }
+
+  void _onSaveTimerFired() {
+    final firedAt = _now();
+    _disconnectTimer = null;
+    if (!_tripActive) {
+      // Edge case: connect, no movement detected, disconnect, timer
+      // fires. Nothing to save. Stay idle and let the next connect
+      // start the cycle over.
+      return;
+    }
+    _tripActive = false;
+    unawaited(_invokeStopAndSave(firedAt));
+  }
+
+  Future<void> _invokeStartTrip(double observedSpeedKmh) async {
+    try {
+      await startTrip();
+    } catch (e, st) {
+      await errorLogger.log(
+        ErrorLayer.background,
+        e,
+        st,
+        context: <String, Object?>{
+          'phase': 'AutoTripCoordinator.startTrip',
+          'mac': config.mac,
+          'observedSpeedKmh': observedSpeedKmh,
+        },
+      );
+    }
+  }
+
+  Future<void> _invokeStopAndSave(DateTime firedAt) async {
+    try {
+      await stopAndSaveAutomatic();
+    } catch (e, st) {
+      await errorLogger.log(
+        ErrorLayer.background,
+        e,
+        st,
+        context: <String, Object?>{
+          'phase': 'AutoTripCoordinator.stopAndSaveAutomatic',
+          'mac': config.mac,
+          'firedAt': firedAt.toIso8601String(),
+        },
+      );
+    }
+  }
+}

--- a/lib/features/consumption/data/obd2/background_adapter_listener.dart
+++ b/lib/features/consumption/data/obd2/background_adapter_listener.dart
@@ -1,0 +1,129 @@
+/// Abstract event source for the OS-level Bluetooth auto-connect
+/// bridge that drives hands-free trip recording (#1004 phase 2).
+///
+/// The native Android foreground service (phase 2b — not yet shipped)
+/// observes BLE connect / disconnect transitions for the user's paired
+/// ELM327 adapter and bridges them through a `MethodChannel` /
+/// `EventChannel` into [BackgroundAdapterListener.events]. Tests inject
+/// a [FakeBackgroundAdapterListener] from
+/// `fake_background_adapter_listener.dart` to drive the
+/// [AutoTripCoordinator] state machine deterministically without any
+/// real Bluetooth stack.
+///
+/// The interface deliberately exposes only what the coordinator needs
+/// (start watching a single MAC, stop watching, observe a stream of
+/// connect / disconnect events). RSSI, advertisement data, and other
+/// scan metadata stay encapsulated inside the bridge — the auto-record
+/// flow only cares whether the paired adapter is reachable right now.
+library;
+
+/// Sealed envelope for everything the listener emits. Sealed so the
+/// coordinator's `switch` is exhaustively checked at compile time —
+/// adding a new event type (e.g. `AdapterUnavailable`) forces every
+/// consumer to acknowledge it.
+sealed class BackgroundAdapterEvent {
+  /// MAC address of the adapter the event refers to. The coordinator
+  /// filters on this value so events for a different paired vehicle do
+  /// not trigger a trip on the active one.
+  String get mac;
+
+  /// Wall-clock instant the bridge observed the transition. Sourced
+  /// from the platform side so a delay between native delivery and
+  /// Dart processing does not skew the disconnect-save timer window.
+  DateTime get at;
+
+  const BackgroundAdapterEvent();
+}
+
+/// The paired adapter has come into BLE range and a session is open.
+/// In production this maps to the native foreground service receiving
+/// `ACTION_ACL_CONNECTED` (or the equivalent flutter_blue_plus state)
+/// for the device matching the configured MAC.
+class AdapterConnected extends BackgroundAdapterEvent {
+  @override
+  final String mac;
+  @override
+  final DateTime at;
+
+  const AdapterConnected({required this.mac, required this.at});
+
+  @override
+  String toString() => 'AdapterConnected(mac=$mac, at=$at)';
+}
+
+/// The paired adapter has dropped — either the user walked out of
+/// range, parked and stepped out of the car, or a transient BLE glitch
+/// kicked the link. The coordinator does NOT save immediately; it
+/// starts a debounce timer (configurable via
+/// `disconnectSaveDelaySec`) so that a brief re-pair does not leave a
+/// half-saved trip in the history list.
+class AdapterDisconnected extends BackgroundAdapterEvent {
+  @override
+  final String mac;
+  @override
+  final DateTime at;
+
+  const AdapterDisconnected({required this.mac, required this.at});
+
+  @override
+  String toString() => 'AdapterDisconnected(mac=$mac, at=$at)';
+}
+
+/// The contract the coordinator binds against. Production wires this
+/// to the native foreground service via a `MethodChannel`; tests wire
+/// it to [FakeBackgroundAdapterListener].
+abstract class BackgroundAdapterListener {
+  /// Broadcast stream of connect / disconnect transitions. Late
+  /// subscribers MUST be tolerated — the coordinator may attach after
+  /// the native bridge has already started emitting; the listener is
+  /// responsible for buffering or replaying the most recent state if
+  /// that matters for its implementation. (The fake uses a broadcast
+  /// stream, which simply drops events with no live subscriber; the
+  /// production bridge gates emission on `start` so this is moot in
+  /// practice.)
+  Stream<BackgroundAdapterEvent> get events;
+
+  /// Begin listening for transitions on [mac]. Idempotent: calling
+  /// `start` twice with the same MAC is a no-op; calling it with a
+  /// different MAC implicitly stops the previous watch. Must be called
+  /// before the coordinator subscribes to [events]; the production
+  /// bridge will not deliver events until `start` arms it.
+  Future<void> start({required String mac});
+
+  /// Stop watching. Releases native resources (the foreground service
+  /// may keep running for other consumers; the bridge unregisters its
+  /// own subscriber). Safe to call when no watch is active.
+  Future<void> stop();
+}
+
+/// Production stub for the time between this PR (phase 2a, Dart
+/// scaffolding only) and phase 2b (the native Android bridge).
+///
+/// Every method throws so a Riverpod provider that accidentally wires
+/// the coordinator into production before the native bridge is ready
+/// fails loudly on the first event read instead of silently consuming
+/// every disconnect. This is the same defensive pattern as
+/// `UnimplementedError` on a `freezed` `union` arm — the program never
+/// reaches the `throw` in practice (the auto-record flow is gated on
+/// the `autoRecord` flag in [VehicleProfile], which stays `false` by
+/// default), but if someone forgets the gate the failure is loud.
+class UnimplementedBackgroundAdapterListener
+    implements BackgroundAdapterListener {
+  const UnimplementedBackgroundAdapterListener();
+
+  static const String _why =
+      'Phase 2 native foreground service not yet implemented '
+      '(#1004 phase 2). AutoTripCoordinator should be gated on the '
+      'autoRecord vehicle config; until the native bridge lands the '
+      'coordinator should never be wired.';
+
+  @override
+  Stream<BackgroundAdapterEvent> get events => throw UnimplementedError(_why);
+
+  @override
+  Future<void> start({required String mac}) =>
+      throw UnimplementedError(_why);
+
+  @override
+  Future<void> stop() => throw UnimplementedError(_why);
+}

--- a/lib/features/consumption/data/obd2/fake_background_adapter_listener.dart
+++ b/lib/features/consumption/data/obd2/fake_background_adapter_listener.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+
+import 'background_adapter_listener.dart';
+
+/// Test-only [BackgroundAdapterListener] that lets a unit / widget /
+/// integration test drive the [AutoTripCoordinator] state machine
+/// deterministically (#1004 phase 2a).
+///
+/// Lives under `lib/` rather than `test/` because widget and
+/// integration tests outside the Dart unit-test directory also need
+/// to inject it (the coordinator will eventually be exposed via a
+/// Riverpod provider whose override has to import a public symbol).
+///
+/// ## Capabilities
+/// - [emitConnected] / [emitDisconnected] push synthetic events into
+///   the broadcast stream so a test reads exactly the timeline it set
+///   up — no real BT stack involved.
+/// - [startCalls] / [stopCalls] / [startedMacs] record every lifecycle
+///   call so a test can assert that the coordinator armed and tore
+///   down the bridge correctly.
+class FakeBackgroundAdapterListener implements BackgroundAdapterListener {
+  /// Broadcast so multiple listeners (e.g. the coordinator AND a test
+  /// observer) can attach without competing for a single-subscriber
+  /// stream.
+  final StreamController<BackgroundAdapterEvent> _events =
+      StreamController<BackgroundAdapterEvent>.broadcast();
+
+  /// Number of times [start] has been called over the fake's lifetime.
+  /// Lets a test assert idempotency without snapshotting [startedMacs].
+  int startCalls = 0;
+
+  /// Number of times [stop] has been called.
+  int stopCalls = 0;
+
+  /// MAC addresses passed to [start] in call order. The coordinator's
+  /// idempotency rule says "second start with the same MAC is a no-op"
+  /// — the test peeks at this list to verify the rule.
+  final List<String> startedMacs = <String>[];
+
+  @override
+  Stream<BackgroundAdapterEvent> get events => _events.stream;
+
+  @override
+  Future<void> start({required String mac}) async {
+    startCalls++;
+    startedMacs.add(mac);
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+  }
+
+  /// Push a synthetic connect event. Defaults [at] to `DateTime.now()`
+  /// so simple tests don't have to fabricate a timestamp; tests that
+  /// care about timing pass it explicitly.
+  void emitConnected(String mac, {DateTime? at}) {
+    _events.add(AdapterConnected(mac: mac, at: at ?? DateTime.now()));
+  }
+
+  /// Push a synthetic disconnect event. Same `at` semantics as
+  /// [emitConnected].
+  void emitDisconnected(String mac, {DateTime? at}) {
+    _events.add(AdapterDisconnected(mac: mac, at: at ?? DateTime.now()));
+  }
+
+  /// Close the underlying stream controller. Tests should call this in
+  /// `tearDown` so the broadcast stream's resources are released and
+  /// pending listeners do not leak across tests.
+  Future<void> dispose() async {
+    if (!_events.isClosed) {
+      await _events.close();
+    }
+  }
+}

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -401,7 +401,14 @@ class TripRecording extends _$TripRecording {
   /// release the service, and return the accumulated [TripSummary].
   /// Safe to call when no trip is active — returns a default empty
   /// summary so callers don't have to null-check.
-  Future<StoppedTripResult> stop() async {
+  ///
+  /// [automatic] flags the saved [TripHistoryEntry] as auto-recorded
+  /// (#1004 phase 2a). Defaults to `false` so existing manual call
+  /// sites keep their behaviour unchanged. The hands-free
+  /// [AutoTripCoordinator] calls [stopAndSaveAutomatic] (the typed
+  /// wrapper below) so the launcher-icon badge increments only when
+  /// the coordinator was the one that decided to save.
+  Future<StoppedTripResult> stop({bool automatic = false}) async {
     final ctl = _controller;
     final svc = _service;
     if (ctl == null || svc == null) {
@@ -429,7 +436,11 @@ class TripRecording extends _$TripRecording {
     // (including discarded ones) is logged; the fill-up flow is a
     // *separate* decision. Best-effort: a Hive write failure here
     // shouldn't block service teardown.
-    await _saveToHistory(summary, samples: capturedSamples);
+    await _saveToHistory(
+      summary,
+      samples: capturedSamples,
+      automatic: automatic,
+    );
     // #769 — flush learned baselines before releasing the service so
     // the next trip starts from the updated values. Best-effort: a
     // Hive write failure here shouldn't block teardown.
@@ -463,6 +474,17 @@ class TripRecording extends _$TripRecording {
       odometerStartKm: odometerStartKm,
       odometerLatestKm: odometerLatestKm,
     );
+  }
+
+  /// Typed entry point for the hands-free [AutoTripCoordinator]
+  /// (#1004 phase 2a). Forwards to [stop] with `automatic: true` so
+  /// the saved [TripHistoryEntry] is tagged as auto-recorded and the
+  /// launcher-icon badge increments. Kept as a thin wrapper so the
+  /// coordinator binds to a stable, no-arg `Future<void>` seam — the
+  /// internal stop signature can grow more flags later without
+  /// breaking the coordinator's call site.
+  Future<void> stopAndSaveAutomatic() async {
+    await stop(automatic: true);
   }
 
   /// Return to idle — used after the caller consumes the

--- a/test/features/consumption/data/obd2/auto_trip_coordinator_test.dart
+++ b/test/features/consumption/data/obd2/auto_trip_coordinator_test.dart
@@ -1,0 +1,300 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/auto_trip_coordinator.dart';
+import 'package:tankstellen/features/consumption/data/obd2/fake_background_adapter_listener.dart';
+
+/// Coordinator state-machine tests for #1004 phase 2a. Drives the
+/// scaffolding from synthetic adapter events + a stream-controlled
+/// speed source so the assertions stay deterministic without a real
+/// BLE stack or OBD2 transport.
+void main() {
+  // The default disconnect-save delay in production is 60 s; tests
+  // shrink it to 50 ms so the timer fires inside `pumpEventQueue`
+  // without burning real wall-clock time.
+  const String mac = 'AA:BB:CC:DD:EE:FF';
+  const String otherMac = 'FF:EE:DD:CC:BB:AA';
+  const Duration shortDelay = Duration(milliseconds: 50);
+
+  late FakeBackgroundAdapterListener listener;
+  late StreamController<double> speed;
+  late int startTripCalls;
+  late int stopAndSaveCalls;
+  late AutoTripCoordinator coordinator;
+
+  AutoTripCoordinator buildCoordinator({
+    int consecutive = 3,
+    Duration delay = shortDelay,
+    double threshold = 5.0,
+  }) {
+    return AutoTripCoordinator(
+      listener: listener,
+      startTrip: () async {
+        startTripCalls++;
+        return null;
+      },
+      stopAndSaveAutomatic: () async {
+        stopAndSaveCalls++;
+      },
+      speedStream: speed.stream,
+      config: AutoRecordConfig(
+        mac: mac,
+        movementStartThresholdKmh: threshold,
+        disconnectSaveDelay: delay,
+      ),
+      consecutiveSamplesWindow: consecutive,
+    );
+  }
+
+  setUp(() {
+    listener = FakeBackgroundAdapterListener();
+    speed = StreamController<double>.broadcast();
+    startTripCalls = 0;
+    stopAndSaveCalls = 0;
+    coordinator = buildCoordinator();
+  });
+
+  tearDown(() async {
+    await coordinator.stop();
+    await speed.close();
+    await listener.dispose();
+  });
+
+  test('3 consecutive supra-threshold samples trigger startTrip exactly once',
+      () async {
+    await coordinator.start();
+    listener.emitConnected(mac);
+    // Allow the coordinator's listener subscription to wire through
+    // the broadcast queue before we push speed samples.
+    await Future<void>.delayed(Duration.zero);
+
+    // Push 3 samples > threshold; coordinator should fire startTrip.
+    speed.add(20);
+    speed.add(25);
+    speed.add(30);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(startTripCalls, 1,
+        reason: '3 consecutive supra-threshold samples must trigger '
+            'startTrip exactly once');
+
+    // Pushing more samples while the trip is active does not fire
+    // again — the coordinator gates on `_tripActive`.
+    speed.add(40);
+    speed.add(45);
+    speed.add(50);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(startTripCalls, 1,
+        reason: 'startTrip is idempotent within a single connect '
+            'cycle — extra samples should not double-fire');
+  });
+
+  test('sub-threshold samples never reach the consecutive window', () async {
+    await coordinator.start();
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+
+    // Five sub-threshold samples — well past the consecutive window
+    // count, but each one resets the counter.
+    for (int i = 0; i < 5; i++) {
+      speed.add(2.0);
+    }
+    await Future<void>.delayed(Duration.zero);
+
+    expect(startTripCalls, 0,
+        reason: 'sub-threshold samples must never trigger startTrip');
+  });
+
+  test('fluctuating samples do not satisfy the consecutive window', () async {
+    await coordinator.start();
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+
+    // Pattern: above, above, below — counter must reset on the third
+    // sample so the window is never satisfied.
+    speed.add(10);
+    speed.add(15);
+    speed.add(0);
+    speed.add(20);
+    speed.add(2);
+    speed.add(25);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(startTripCalls, 0,
+        reason: 'A sub-threshold sample in the middle of a run must '
+            'reset the consecutive counter');
+  });
+
+  test('disconnect arms timer; reconnect within window cancels save',
+      () async {
+    await coordinator.start();
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+    speed.add(20);
+    speed.add(25);
+    speed.add(30);
+    await Future<void>.delayed(Duration.zero);
+    expect(startTripCalls, 1);
+
+    listener.emitDisconnected(mac);
+    // Broadcast streams deliver asynchronously — flush the microtask
+    // queue so the coordinator's _onAdapterEvent has run before we
+    // peek at the timer state.
+    await Future<void>.delayed(Duration.zero);
+    expect(coordinator.hasPendingDisconnectTimer, isTrue,
+        reason: 'disconnect must arm the debounce timer');
+
+    // Reconnect well within the window.
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+    expect(coordinator.hasPendingDisconnectTimer, isFalse,
+        reason: 'reconnect within the debounce window must cancel '
+            'the pending save timer');
+
+    // Wait past the original delay — no save should fire.
+    await Future<void>.delayed(shortDelay * 2);
+    expect(stopAndSaveCalls, 0,
+        reason: 'a cancelled timer must not still call stopAndSave');
+  });
+
+  test('disconnect timer fires → stopAndSaveAutomatic called once', () async {
+    await coordinator.start();
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+    speed.add(20);
+    speed.add(25);
+    speed.add(30);
+    await Future<void>.delayed(Duration.zero);
+    expect(startTripCalls, 1);
+
+    listener.emitDisconnected(mac);
+    // Wait past the debounce window so the timer fires.
+    await Future<void>.delayed(shortDelay * 3);
+
+    expect(stopAndSaveCalls, 1,
+        reason: 'timer fire must call stopAndSaveAutomatic exactly once');
+  });
+
+  test('disconnect with no active trip → timer fires but no save', () async {
+    await coordinator.start();
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+    // No speed samples — startTrip never fires.
+    listener.emitDisconnected(mac);
+    await Future<void>.delayed(shortDelay * 3);
+
+    expect(startTripCalls, 0);
+    expect(stopAndSaveCalls, 0,
+        reason: 'no trip was active — nothing to save');
+  });
+
+  test('events for a different MAC are ignored', () async {
+    await coordinator.start();
+    listener.emitConnected(otherMac);
+    await Future<void>.delayed(Duration.zero);
+    speed.add(20);
+    speed.add(25);
+    speed.add(30);
+    await Future<void>.delayed(Duration.zero);
+    expect(startTripCalls, 0,
+        reason: 'connect for the wrong MAC must not subscribe to speed');
+
+    listener.emitDisconnected(otherMac);
+    expect(coordinator.hasPendingDisconnectTimer, isFalse,
+        reason: 'disconnect for the wrong MAC must not arm the timer');
+    await Future<void>.delayed(shortDelay * 3);
+    expect(stopAndSaveCalls, 0);
+  });
+
+  test('start() is idempotent — second call does not double-subscribe',
+      () async {
+    await coordinator.start();
+    await coordinator.start();
+    expect(coordinator.isStarted, isTrue);
+    expect(listener.startCalls, 1,
+        reason: 'second start() must not re-arm the native bridge');
+
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+    speed.add(20);
+    speed.add(25);
+    speed.add(30);
+    await Future<void>.delayed(Duration.zero);
+
+    // If the second start had double-subscribed, the speed handler
+    // would run twice and startTrip would fire twice (since
+    // `_tripActive` is set inside the callback path that fires).
+    // Even though `_tripActive` gates the callback, the underlying
+    // adapter-event subscription would also be doubled, leading to
+    // doubled `_onConnected` runs which would re-subscribe speed
+    // doubly. Either way the count must stay at 1.
+    expect(startTripCalls, 1,
+        reason: 'idempotent start must not duplicate subscriptions');
+  });
+
+  test('stop() cancels a pending disconnect timer', () async {
+    await coordinator.start();
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+    speed.add(20);
+    speed.add(25);
+    speed.add(30);
+    await Future<void>.delayed(Duration.zero);
+
+    listener.emitDisconnected(mac);
+    // Flush microtasks so the coordinator's adapter-event handler has
+    // armed the timer before we inspect it.
+    await Future<void>.delayed(Duration.zero);
+    expect(coordinator.hasPendingDisconnectTimer, isTrue);
+
+    await coordinator.stop();
+    expect(coordinator.hasPendingDisconnectTimer, isFalse,
+        reason: 'stop() must cancel the pending disconnect timer so a '
+            'developer-initiated tear-down does not auto-save');
+
+    await Future<void>.delayed(shortDelay * 3);
+    expect(stopAndSaveCalls, 0,
+        reason: 'a cancelled timer must not still fire stopAndSaveAutomatic '
+            'after stop()');
+  });
+
+  test('stop() called twice is safe', () async {
+    await coordinator.start();
+    await coordinator.stop();
+    await coordinator.stop(); // No throw, no double tear-down side effects.
+    expect(coordinator.isStarted, isFalse);
+    expect(listener.stopCalls, 2,
+        reason: 'each stop() call forwards once to the listener');
+  });
+
+  test('connect → disconnect → reconnect → 3 supra samples → only one save',
+      () async {
+    // The reconnect-within-window path needs to leave the trip
+    // running; a second supra-threshold burst must NOT re-fire
+    // startTrip (the trip is still active from the first burst).
+    await coordinator.start();
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+    speed.add(20);
+    speed.add(25);
+    speed.add(30);
+    await Future<void>.delayed(Duration.zero);
+    expect(startTripCalls, 1);
+
+    listener.emitDisconnected(mac);
+    listener.emitConnected(mac);
+    await Future<void>.delayed(Duration.zero);
+    // Push another supra burst — trip is still active, must not
+    // re-fire.
+    speed.add(40);
+    speed.add(45);
+    speed.add(50);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(startTripCalls, 1,
+        reason: 'reconnect must NOT clear `_tripActive`; the trip '
+            'survives the brief drop and a new supra burst is just '
+            'continued movement, not a new trip');
+  });
+}

--- a/test/features/consumption/data/obd2/background_adapter_listener_test.dart
+++ b/test/features/consumption/data/obd2/background_adapter_listener_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/background_adapter_listener.dart';
+import 'package:tankstellen/features/consumption/data/obd2/fake_background_adapter_listener.dart';
+
+void main() {
+  group('UnimplementedBackgroundAdapterListener (#1004 phase 2a)', () {
+    // The production stub must throw on every method so a Riverpod
+    // wiring that accidentally points at this class before phase 2b
+    // ships fails loudly instead of silently swallowing every BLE
+    // event.
+
+    test('events getter throws UnimplementedError', () {
+      const listener = UnimplementedBackgroundAdapterListener();
+      expect(() => listener.events, throwsUnimplementedError);
+    });
+
+    test('start throws UnimplementedError', () async {
+      const listener = UnimplementedBackgroundAdapterListener();
+      expect(
+        () => listener.start(mac: 'AA:BB:CC:DD:EE:FF'),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('stop throws UnimplementedError', () async {
+      const listener = UnimplementedBackgroundAdapterListener();
+      expect(() => listener.stop(), throwsUnimplementedError);
+    });
+
+    test('error message names the issue and the gate', () {
+      const listener = UnimplementedBackgroundAdapterListener();
+      // The gate hint is the load-bearing part: it tells the next
+      // developer where to look (`autoRecord` flag) before they think
+      // they need to implement the bridge. Inspect the thrown error
+      // via `throwsA(predicate)` rather than a try/catch on the Error
+      // subclass (which the analyzer flags as `avoid_catching_errors`).
+      expect(
+        () => listener.events,
+        throwsA(
+          isA<UnimplementedError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('#1004 phase 2'),
+              contains('autoRecord'),
+            ),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('FakeBackgroundAdapterListener', () {
+    late FakeBackgroundAdapterListener fake;
+
+    setUp(() {
+      fake = FakeBackgroundAdapterListener();
+    });
+
+    tearDown(() async {
+      await fake.dispose();
+    });
+
+    test('start records every call and the requested MAC', () async {
+      await fake.start(mac: 'AA:BB:CC:DD:EE:FF');
+      await fake.start(mac: '11:22:33:44:55:66');
+      expect(fake.startCalls, 2);
+      expect(fake.startedMacs,
+          ['AA:BB:CC:DD:EE:FF', '11:22:33:44:55:66']);
+    });
+
+    test('stop records every call', () async {
+      await fake.stop();
+      await fake.stop();
+      expect(fake.stopCalls, 2);
+    });
+
+    test('emitConnected pushes an AdapterConnected event with the MAC',
+        () async {
+      const mac = 'AA:BB:CC:DD:EE:FF';
+      final received = <BackgroundAdapterEvent>[];
+      final sub = fake.events.listen(received.add);
+
+      fake.emitConnected(mac);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      final evt = received.single;
+      expect(evt, isA<AdapterConnected>());
+      expect(evt.mac, mac);
+
+      await sub.cancel();
+    });
+
+    test('emitDisconnected pushes an AdapterDisconnected event', () async {
+      const mac = 'AA:BB:CC:DD:EE:FF';
+      final received = <BackgroundAdapterEvent>[];
+      final sub = fake.events.listen(received.add);
+
+      fake.emitDisconnected(mac);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.single, isA<AdapterDisconnected>());
+      expect(received.single.mac, mac);
+
+      await sub.cancel();
+    });
+
+    test('events stream is broadcast — multiple listeners both observe',
+        () async {
+      const mac = 'AA:BB:CC:DD:EE:FF';
+      final a = <BackgroundAdapterEvent>[];
+      final b = <BackgroundAdapterEvent>[];
+      final subA = fake.events.listen(a.add);
+      final subB = fake.events.listen(b.add);
+
+      fake.emitConnected(mac);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(a, hasLength(1));
+      expect(b, hasLength(1));
+
+      await subA.cancel();
+      await subB.cancel();
+    });
+
+    test('explicit `at` timestamp survives through the event', () async {
+      const mac = 'AA:BB:CC:DD:EE:FF';
+      final ts = DateTime(2026, 4, 26, 12, 0, 0);
+      final received = <BackgroundAdapterEvent>[];
+      final sub = fake.events.listen(received.add);
+
+      fake.emitConnected(mac, at: ts);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received.single.at, ts);
+      await sub.cancel();
+    });
+  });
+}

--- a/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
+++ b/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
@@ -42,7 +42,7 @@ class _FakeTripRecording extends TripRecording {
   TripRecordingState build() => _initial;
 
   @override
-  Future<StoppedTripResult> stop() async {
+  Future<StoppedTripResult> stop({bool automatic = false}) async {
     state = state.copyWith(phase: TripRecordingPhase.finished);
     return const StoppedTripResult(
       summary: TripSummary(

--- a/test/features/consumption/presentation/widgets/obd2_pause_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_pause_banner_test.dart
@@ -35,7 +35,7 @@ class _FakeTripRecording extends TripRecording {
   }
 
   @override
-  Future<StoppedTripResult> stop() async {
+  Future<StoppedTripResult> stop({bool automatic = false}) async {
     stopCalls++;
     return const StoppedTripResult.empty();
   }

--- a/test/features/consumption/providers/trip_recording_provider_automatic_flag_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_automatic_flag_test.dart
@@ -1,0 +1,190 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/feedback/auto_record_badge_provider.dart';
+import 'package:tankstellen/core/feedback/auto_record_badge_service.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+
+/// Tests for the public `automatic` flag plumbing through the trip
+/// recording provider (#1004 phase 2a).
+///
+/// The flag piggy-backs on the existing `_saveToHistory(automatic:)`
+/// path. Asserting it lands in the persisted [TripHistoryEntry] *and*
+/// triggers a badge increment proves both halves of the plumbing —
+/// the manual call sites that omit the flag must keep their old
+/// behaviour, and the new `stopAndSaveAutomatic` wrapper must reach
+/// the same code path as `stop(automatic: true)`.
+///
+/// We drive a real [TripRecording] notifier with a [FakeObd2Transport]
+/// and inject a handful of samples via `debugController.debugInjectSample`
+/// so the recorder sets `startedAt` and accumulates non-zero distance
+/// — without that the empty-trip early-return inside `_saveToHistory`
+/// would skip the badge bump entirely, and we'd be testing nothing.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('trip_auto_flag_test_');
+    Hive.init(tmpDir.path);
+    await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2TripHistory).deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  Future<TripHistoryEntry> runOnce(
+    ProviderContainer container, {
+    required Future<void> Function(TripRecording notifier) stopper,
+  }) async {
+    final service = Obd2Service(FakeObd2Transport(_elmOk()));
+    await service.connect();
+
+    final notifier = container.read(tripRecordingProvider.notifier);
+    await notifier.start(service);
+    final ctl = notifier.debugController;
+    expect(ctl, isNotNull,
+        reason: 'provider must own a controller while recording');
+    final start = DateTime.now();
+    // Inject 5 deterministic samples so the summary has startedAt set
+    // and the distance accumulator clears the 0.01 km early-return
+    // floor in `_saveToHistory`. Without this the badge path is never
+    // reached and we'd assert against a no-op.
+    for (int i = 0; i < 5; i++) {
+      ctl!.debugInjectSample(
+        speedKmh: 50 + i.toDouble(),
+        rpm: 2000 + i * 10,
+        at: start.add(Duration(seconds: i)),
+        fuelRateLPerHour: 6.0,
+      );
+    }
+    await stopper(notifier);
+
+    final repo = container.read(tripHistoryRepositoryProvider);
+    expect(repo, isNotNull);
+    final history = repo!.loadAll();
+    expect(history, isNotEmpty,
+        reason: 'stop() must have persisted a TripHistoryEntry — the '
+            'sample-injection above guarantees a non-empty summary');
+    return history.first;
+  }
+
+  test(
+    'stop(automatic: true) marks the persisted entry as auto-recorded '
+    'and increments the badge',
+    () async {
+      final fakeBadge = _FakeAutoRecordBadgeService();
+      final container = ProviderContainer(overrides: [
+        autoRecordBadgeServiceProvider.overrideWith((ref) async => fakeBadge),
+      ]);
+      addTearDown(container.dispose);
+
+      final entry = await runOnce(
+        container,
+        stopper: (n) => n.stop(automatic: true),
+      );
+
+      expect(entry.automatic, isTrue,
+          reason: 'stop(automatic: true) must persist '
+              'TripHistoryEntry.automatic = true so the trip-detail '
+              'screen knows to decrement the badge on view');
+      expect(fakeBadge.incrementCalls, 1,
+          reason: 'auto-recorded saves bump the launcher-icon badge');
+    },
+  );
+
+  test(
+    'stopAndSaveAutomatic() is the same path as stop(automatic: true)',
+    () async {
+      final fakeBadge = _FakeAutoRecordBadgeService();
+      final container = ProviderContainer(overrides: [
+        autoRecordBadgeServiceProvider.overrideWith((ref) async => fakeBadge),
+      ]);
+      addTearDown(container.dispose);
+
+      final entry = await runOnce(
+        container,
+        stopper: (n) => n.stopAndSaveAutomatic(),
+      );
+
+      expect(entry.automatic, isTrue,
+          reason: 'stopAndSaveAutomatic must reach _saveToHistory '
+              'with automatic: true');
+      expect(fakeBadge.incrementCalls, 1,
+          reason: 'stopAndSaveAutomatic must increment the badge once');
+    },
+  );
+
+  test(
+    'stop() with no automatic flag stays manual — no badge increment',
+    () async {
+      final fakeBadge = _FakeAutoRecordBadgeService();
+      final container = ProviderContainer(overrides: [
+        autoRecordBadgeServiceProvider.overrideWith((ref) async => fakeBadge),
+      ]);
+      addTearDown(container.dispose);
+
+      final entry = await runOnce(
+        container,
+        stopper: (n) => n.stop(),
+      );
+
+      expect(entry.automatic, isFalse,
+          reason: 'manual stop() must NOT mark the entry as automatic');
+      expect(fakeBadge.incrementCalls, 0,
+          reason: 'manual stops must not bump the badge — that\'s the '
+              'whole reason the flag exists');
+    },
+  );
+}
+
+/// Fake badge service that records `increment` calls so the test can
+/// assert the auto-record path bumped it without standing up a real
+/// SharedPreferences mock.
+class _FakeAutoRecordBadgeService implements AutoRecordBadgeService {
+  int _count = 0;
+  int incrementCalls = 0;
+  int decrementCalls = 0;
+  int markAllCalls = 0;
+
+  @override
+  int get count => _count;
+
+  @override
+  Future<void> increment() async {
+    incrementCalls++;
+    _count++;
+  }
+
+  @override
+  Future<void> decrement() async {
+    decrementCalls++;
+    if (_count > 0) _count--;
+  }
+
+  @override
+  Future<void> markAllAsRead() async {
+    markAllCalls++;
+    _count = 0;
+  }
+}
+
+Map<String, String> _elmOk() => const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '01A6': '41 A6 00 01 6A 2C>',
+    };


### PR DESCRIPTION
Refs #1004 phase 2a

## Summary
Dart-side scaffolding for the hands-free auto-record flow (#1004). Phases 1, 5, 6 already shipped; this PR lays down the Dart half of phase 2 so the native Android foreground service (phase 2b) can hook in without restructuring the provider layer.

- `BackgroundAdapterListener` interface — sealed `AdapterConnected` / `AdapterDisconnected` events
- `UnimplementedBackgroundAdapterListener` — production stub that throws on every call so a Riverpod wiring before phase 2b ships fails loudly
- `FakeBackgroundAdapterListener` — `lib/`-side test seam (widget + integration tests need to import it, not just unit tests)
- `AutoTripCoordinator` — state machine: connect → 3 consecutive supra-threshold speed samples → `startTrip`; disconnect → debounce timer → `stopAndSaveAutomatic`; reconnect within window cancels timer
- `automatic` flag plumbed through public `TripRecording.stop()` + new `stopAndSaveAutomatic()` typed wrapper so the coordinator binds to a stable seam and the badge increment fires only on auto-recorded saves

## Out of scope (phase 2b — separate PR, requires user device testing)
- `android/` — no manifest changes, no Kotlin, no Gradle
- Foreground service for the BLE auto-connect
- `MethodChannel` / `EventChannel` bridge wiring native events into `BackgroundAdapterListener.events`
- Real BT auto-connect against a paired adapter
- Riverpod provider that selects between the production bridge and the unimplemented stub
- Real-device testing on Samsung / Pixel
- Any user-facing strings or `.arb` changes (the coordinator is invisible until phase 2b lands)

## Test plan
- [x] `flutter analyze` — zero warnings, zero infos
- [x] `flutter test test/features/consumption/data/obd2/auto_trip_coordinator_test.dart` — 11 cases (3 supra → start once, sub-threshold ignored, fluctuating ignored, disconnect arms timer, reconnect cancels timer, timer fires save, no-trip disconnect drops, MAC filter, idempotent start, stop cancels timer, double-stop safe)
- [x] `flutter test test/features/consumption/data/obd2/background_adapter_listener_test.dart` — Unimplemented throws on all members + Fake records calls and emits
- [x] `flutter test test/features/consumption/providers/trip_recording_provider_automatic_flag_test.dart` — `stop(automatic: true)` and `stopAndSaveAutomatic()` both bump the badge and tag the entry; `stop()` without flag stays manual
- [x] `flutter test test/features/consumption/data/obd2/ test/features/consumption/providers/` — 593/593 pass; existing manual flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)