### PR TITLE
feat(obd2): AutoRecordTraceLog instrumentation for AutoTripCoordinator (Refs #1004 phase 2a-trace)

### DIFF
--- a/lib/features/consumption/data/obd2/auto_record_trace_log.dart
+++ b/lib/features/consumption/data/obd2/auto_record_trace_log.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../../core/telemetry/collectors/breadcrumb_collector.dart';
+
+/// Kinds of state transitions the auto-record flow goes through. Used
+/// by [AutoRecordTraceLog] so the user (and a future debug screen) can
+/// answer "did anything happen at all?" — a question that
+/// `errorLogger.log` cannot answer because no exception was thrown on
+/// the silent-failure path. See #1004 phase 2a-trace.
+enum AutoRecordEventKind {
+  /// Coordinator's [start] entered — bridge armed, waiting for the
+  /// adapter to come into range.
+  coordinatorStarted,
+
+  /// Coordinator's [stop] entered — every subscription torn down.
+  coordinatorStopped,
+
+  /// `AdapterConnected` event observed for the configured MAC.
+  adapterConnected,
+
+  /// `AdapterConnected` event observed for a foreign MAC; the
+  /// coordinator dropped it because of the MAC filter (multi-vehicle
+  /// case).
+  adapterConnectIgnoredOtherMac,
+
+  /// `AdapterDisconnected` event observed for the configured MAC.
+  adapterDisconnected,
+
+  /// `AdapterDisconnected` event for a foreign MAC; dropped.
+  adapterDisconnectIgnoredOtherMac,
+
+  /// A speed sample crossed above the movement threshold; the
+  /// consecutive-window counter just incremented.
+  speedSampleSupraThreshold,
+
+  /// A speed sample landed at or below the movement threshold; the
+  /// counter was reset.
+  speedSampleSubThreshold,
+
+  /// The Nth consecutive supra-threshold sample arrived (N =
+  /// `consecutiveSamplesWindow`) — `startTrip()` is about to be
+  /// called.
+  thresholdCrossed,
+
+  /// `startTrip()` returned a successful outcome and a trip is now
+  /// active.
+  tripStarted,
+
+  /// `startTrip()` returned an outcome other than `started` (e.g.
+  /// `alreadyActive`, `noActiveProfile`). Detail carries the outcome.
+  tripStartFailed,
+
+  /// Disconnect debounce timer was scheduled — waiting for either
+  /// reconnect (cancel) or fire (save).
+  disconnectTimerStarted,
+
+  /// Reconnect within the debounce window cancelled the pending save
+  /// timer; the trip carries on.
+  disconnectTimerCancelled,
+
+  /// Disconnect debounce timer fired — about to call
+  /// `stopAndSaveAutomatic`.
+  disconnectTimerFired,
+
+  /// `stopAndSaveAutomatic()` completed; the trip is in history.
+  tripSavedAuto,
+
+  /// `stopAndSaveAutomatic()` threw. Detail carries the exception
+  /// message.
+  tripSaveFailed,
+
+  /// Generic catch — detail carries a free-form message. Used
+  /// sparingly so the enum stays the contract.
+  error,
+}
+
+/// One entry in the auto-record event ring. Immutable so a snapshot
+/// can be safely handed to debug UI / log export without risking
+/// concurrent mutation.
+@immutable
+class AutoRecordEvent {
+  /// Wall-clock instant the event was recorded. Defaults to
+  /// `DateTime.now()` in production; tests inject a fixed clock via
+  /// [AutoRecordTraceLog.add]'s `clock` parameter.
+  final DateTime timestamp;
+
+  /// Which transition this entry captures.
+  final AutoRecordEventKind kind;
+
+  /// MAC of the adapter the transition refers to, when relevant
+  /// (connect / disconnect events; the coordinator-lifecycle events
+  /// leave it null).
+  final String? mac;
+
+  /// Free-form context — e.g. "speed=12.3 kmh, count=2/3" for a
+  /// supra-threshold sample, "delaySec=60" for a timer start. Kept as
+  /// a string so the ring stays cheap to format and serialise.
+  final String? detail;
+
+  const AutoRecordEvent({
+    required this.timestamp,
+    required this.kind,
+    this.mac,
+    this.detail,
+  });
+}
+
+/// In-memory ring buffer of auto-record state transitions, so the
+/// user can answer "did anything happen at all?" without an error
+/// to attach to. Mirrors every entry to [BreadcrumbCollector] so
+/// the error-trace pipeline still sees the last 25 events when
+/// something does crash.
+///
+/// **Persistence:** in-memory only for phase 2a-trace. A future phase
+/// can add Hive backing (note that `hive_boxes.dart` is hot-file —
+/// don't touch it casually).
+///
+/// **Capacity:** 100 events. Older entries drop off the front when
+/// the ring fills. The user's typical debugging window is "one
+/// driving session," well under 100 transitions.
+///
+/// **Thread-safety:** the ring is a static `List`. The auto-record
+/// flow is single-isolate (Dart side of the foreground service +
+/// main isolate), so no synchronisation is needed; if a future phase
+/// promotes this to a cross-isolate data structure it should switch
+/// to `IsolateNameServer`-mediated access (same pattern as
+/// `IsolateErrorSpool`).
+class AutoRecordTraceLog {
+  /// Maximum number of events kept in the ring. Older entries fall
+  /// off the front when this is exceeded.
+  static const int maxEvents = 100;
+
+  static final List<AutoRecordEvent> _ring = <AutoRecordEvent>[];
+
+  /// Records [kind] with optional [mac] and [detail] context. Mirrors
+  /// to `BreadcrumbCollector.add(...)` so the error-trace pipeline
+  /// also captures the event when something later crashes.
+  ///
+  /// Test seam: pass a [clock] to control the timestamp; production
+  /// code leaves it null and the wall clock is used.
+  static void add(
+    AutoRecordEventKind kind, {
+    String? mac,
+    String? detail,
+    DateTime Function()? clock,
+  }) {
+    final DateTime ts = clock != null ? clock() : DateTime.now();
+    _ring.add(AutoRecordEvent(
+      timestamp: ts,
+      kind: kind,
+      mac: mac,
+      detail: detail,
+    ));
+    while (_ring.length > maxEvents) {
+      _ring.removeAt(0);
+    }
+    final List<String> parts = <String>[
+      if (mac != null) 'mac=$mac',
+      ?detail,
+    ];
+    BreadcrumbCollector.add(
+      'auto_record:${kind.name}',
+      detail: parts.isEmpty ? null : parts.join(' '),
+    );
+  }
+
+  /// Read-only snapshot for debug screens / future log export.
+  static List<AutoRecordEvent> snapshot() => List.unmodifiable(_ring);
+
+  /// Test reset — drops every entry. Production callers should not
+  /// invoke this; the ring is meant to survive across tear-downs so
+  /// post-mortem inspection is possible after the user stops the
+  /// flow.
+  @visibleForTesting
+  static void clear() => _ring.clear();
+}

--- a/lib/features/consumption/data/obd2/auto_trip_coordinator.dart
+++ b/lib/features/consumption/data/obd2/auto_trip_coordinator.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../../../../core/logging/error_logger.dart';
+import 'auto_record_trace_log.dart';
 import 'background_adapter_listener.dart';
 
 /// Immutable snapshot of the auto-record fields off [VehicleProfile]
@@ -173,6 +174,13 @@ class AutoTripCoordinator {
   Future<void> start() async {
     if (_started) return;
     _started = true;
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.coordinatorStarted,
+      mac: config.mac,
+      detail: 'thresholdKmh=${config.movementStartThresholdKmh} '
+          'delaySec=${config.disconnectSaveDelay.inSeconds} '
+          'window=$consecutiveSamplesWindow',
+    );
     try {
       await listener.start(mac: config.mac);
     } catch (e, st) {
@@ -181,6 +189,11 @@ class AutoTripCoordinator {
       // and bail so the coordinator stays in a clean idle state and
       // the next start attempt can re-arm.
       _started = false;
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.error,
+        mac: config.mac,
+        detail: 'start failed: $e',
+      );
       await errorLogger.log(
         ErrorLayer.background,
         e,
@@ -207,6 +220,10 @@ class AutoTripCoordinator {
       // in directly. The flags below all start in the "nothing to do"
       // state on a fresh instance.
     }
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.coordinatorStopped,
+      mac: config.mac,
+    );
     _started = false;
     _disconnectTimer?.cancel();
     _disconnectTimer = null;
@@ -220,6 +237,11 @@ class AutoTripCoordinator {
     } catch (e, st) {
       // Native bridge teardown failure shouldn't propagate — the
       // coordinator is already idle from the Dart side's perspective.
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.error,
+        mac: config.mac,
+        detail: 'stop failed: $e',
+      );
       await errorLogger.log(
         ErrorLayer.background,
         e,
@@ -237,12 +259,31 @@ class AutoTripCoordinator {
     // the same listener (phase 2b may centralise the bridge) would
     // emit events for an unrelated MAC; we drop them silently rather
     // than risk auto-recording the wrong car's drive.
-    if (event.mac != config.mac) return;
+    if (event.mac != config.mac) {
+      AutoRecordTraceLog.add(
+        switch (event) {
+          AdapterConnected() =>
+            AutoRecordEventKind.adapterConnectIgnoredOtherMac,
+          AdapterDisconnected() =>
+            AutoRecordEventKind.adapterDisconnectIgnoredOtherMac,
+        },
+        mac: event.mac,
+      );
+      return;
+    }
 
     switch (event) {
       case AdapterConnected():
+        AutoRecordTraceLog.add(
+          AutoRecordEventKind.adapterConnected,
+          mac: event.mac,
+        );
         _onConnected();
       case AdapterDisconnected():
+        AutoRecordTraceLog.add(
+          AutoRecordEventKind.adapterDisconnected,
+          mac: event.mac,
+        );
         _onDisconnected();
     }
   }
@@ -257,6 +298,10 @@ class AutoTripCoordinator {
     if (_disconnectTimer?.isActive ?? false) {
       _disconnectTimer!.cancel();
       _disconnectTimer = null;
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.disconnectTimerCancelled,
+        mac: config.mac,
+      );
     }
     _consecutiveSupraThreshold = 0;
     _speedSub?.cancel();
@@ -274,16 +319,39 @@ class AutoTripCoordinator {
     // and we save.
     _disconnectTimer?.cancel();
     _disconnectTimer = Timer(config.disconnectSaveDelay, _onSaveTimerFired);
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.disconnectTimerStarted,
+      mac: config.mac,
+      detail: 'delaySec=${config.disconnectSaveDelay.inSeconds} '
+          'delayMs=${config.disconnectSaveDelay.inMilliseconds}',
+    );
   }
 
   void _onSpeedSample(double kmh) {
     if (_tripActive) return;
     if (kmh > config.movementStartThresholdKmh) {
       _consecutiveSupraThreshold++;
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.speedSampleSupraThreshold,
+        mac: config.mac,
+        detail:
+            'speed=${kmh.toStringAsFixed(1)} kmh, '
+            'count=$_consecutiveSupraThreshold/$consecutiveSamplesWindow',
+      );
     } else {
       _consecutiveSupraThreshold = 0;
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.speedSampleSubThreshold,
+        mac: config.mac,
+        detail: 'speed=${kmh.toStringAsFixed(1)} kmh',
+      );
     }
     if (_consecutiveSupraThreshold >= consecutiveSamplesWindow) {
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.thresholdCrossed,
+        mac: config.mac,
+        detail: 'speed=${kmh.toStringAsFixed(1)} kmh',
+      );
       _tripActive = true;
       _consecutiveSupraThreshold = 0;
       // Fire-and-forget — the coordinator's contract is "we observed
@@ -297,6 +365,11 @@ class AutoTripCoordinator {
   void _onSaveTimerFired() {
     final firedAt = _now();
     _disconnectTimer = null;
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.disconnectTimerFired,
+      mac: config.mac,
+      detail: 'tripActive=$_tripActive',
+    );
     if (!_tripActive) {
       // Edge case: connect, no movement detected, disconnect, timer
       // fires. Nothing to save. Stay idle and let the next connect
@@ -309,8 +382,33 @@ class AutoTripCoordinator {
 
   Future<void> _invokeStartTrip(double observedSpeedKmh) async {
     try {
-      await startTrip();
+      final Object? outcome = await startTrip();
+      // The coordinator is decoupled from `StartTripOutcome` (it lives
+      // in the providers layer). We classify outcomes by their string
+      // form: enum `toString()` is `EnumName.value`, so the trailing
+      // segment after the dot is the value name. `null` is the test
+      // stub's signal for "no outcome to report" and is treated as
+      // success — production wiring always returns a typed outcome.
+      final String? outcomeName = outcome?.toString().split('.').last;
+      if (outcome == null || outcomeName == 'started') {
+        AutoRecordTraceLog.add(
+          AutoRecordEventKind.tripStarted,
+          mac: config.mac,
+          detail: 'observedSpeedKmh=${observedSpeedKmh.toStringAsFixed(1)}',
+        );
+      } else {
+        AutoRecordTraceLog.add(
+          AutoRecordEventKind.tripStartFailed,
+          mac: config.mac,
+          detail: 'outcome=$outcomeName',
+        );
+      }
     } catch (e, st) {
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.tripStartFailed,
+        mac: config.mac,
+        detail: 'exception=$e',
+      );
       await errorLogger.log(
         ErrorLayer.background,
         e,
@@ -327,7 +425,17 @@ class AutoTripCoordinator {
   Future<void> _invokeStopAndSave(DateTime firedAt) async {
     try {
       await stopAndSaveAutomatic();
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.tripSavedAuto,
+        mac: config.mac,
+        detail: 'firedAt=${firedAt.toIso8601String()}',
+      );
     } catch (e, st) {
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.tripSaveFailed,
+        mac: config.mac,
+        detail: 'exception=$e',
+      );
       await errorLogger.log(
         ErrorLayer.background,
         e,

--- a/test/features/consumption/data/obd2/auto_record_trace_log_test.dart
+++ b/test/features/consumption/data/obd2/auto_record_trace_log_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/features/consumption/data/obd2/auto_record_trace_log.dart';
+
+/// Coverage for [AutoRecordTraceLog] — the in-memory ring of
+/// auto-record state transitions added in #1004 phase 2a-trace.
+///
+/// Asserts the four invariants the coordinator depends on: append +
+/// snapshot order, ring capacity, clear, and the breadcrumb mirror.
+void main() {
+  setUp(() {
+    AutoRecordTraceLog.clear();
+    BreadcrumbCollector.clear();
+  });
+
+  test('add() appends to ring; snapshot() returns events in order', () {
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.coordinatorStarted,
+      mac: 'AA:BB:CC:DD:EE:FF',
+      detail: 'thresholdKmh=5.0',
+    );
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.adapterConnected,
+      mac: 'AA:BB:CC:DD:EE:FF',
+    );
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.speedSampleSupraThreshold,
+      mac: 'AA:BB:CC:DD:EE:FF',
+      detail: 'speed=12.3 kmh, count=1/3',
+    );
+
+    final List<AutoRecordEvent> snapshot = AutoRecordTraceLog.snapshot();
+    expect(snapshot, hasLength(3));
+    expect(snapshot[0].kind, AutoRecordEventKind.coordinatorStarted);
+    expect(snapshot[0].mac, 'AA:BB:CC:DD:EE:FF');
+    expect(snapshot[0].detail, 'thresholdKmh=5.0');
+    expect(snapshot[1].kind, AutoRecordEventKind.adapterConnected);
+    expect(snapshot[1].mac, 'AA:BB:CC:DD:EE:FF');
+    expect(snapshot[1].detail, isNull);
+    expect(snapshot[2].kind, AutoRecordEventKind.speedSampleSupraThreshold);
+    expect(snapshot[2].detail, 'speed=12.3 kmh, count=1/3');
+  });
+
+  test('snapshot() returns an unmodifiable list', () {
+    AutoRecordTraceLog.add(AutoRecordEventKind.coordinatorStarted);
+    final List<AutoRecordEvent> snapshot = AutoRecordTraceLog.snapshot();
+    expect(
+      () => snapshot.add(AutoRecordEvent(
+        timestamp: DateTime.now(),
+        kind: AutoRecordEventKind.error,
+      )),
+      throwsUnsupportedError,
+      reason: 'snapshot must protect the ring from outside mutation',
+    );
+  });
+
+  test('ring capacity: 101 adds keep the latest 100', () {
+    // Push 101 events with a distinguishable detail so we can check
+    // the oldest fell off and the newest stuck.
+    for (int i = 0; i < 101; i++) {
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.speedSampleSupraThreshold,
+        detail: 'i=$i',
+      );
+    }
+    final List<AutoRecordEvent> snapshot = AutoRecordTraceLog.snapshot();
+    expect(snapshot, hasLength(AutoRecordTraceLog.maxEvents));
+    expect(snapshot.first.detail, 'i=1',
+        reason: 'i=0 must have been dropped to make room for i=100');
+    expect(snapshot.last.detail, 'i=100',
+        reason: 'the newest event must remain at the tail');
+  });
+
+  test('clear() empties the ring', () {
+    AutoRecordTraceLog.add(AutoRecordEventKind.coordinatorStarted);
+    AutoRecordTraceLog.add(AutoRecordEventKind.adapterConnected);
+    expect(AutoRecordTraceLog.snapshot(), hasLength(2));
+
+    AutoRecordTraceLog.clear();
+    expect(AutoRecordTraceLog.snapshot(), isEmpty);
+  });
+
+  test('custom clock is honoured exactly, not DateTime.now()', () {
+    final DateTime fixed = DateTime.utc(2024, 1, 15, 9, 30, 0);
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.tripStarted,
+      clock: () => fixed,
+    );
+    final AutoRecordEvent event = AutoRecordTraceLog.snapshot().single;
+    expect(event.timestamp, fixed,
+        reason: 'a test seam clock must not be ignored');
+  });
+
+  test('mirrors entry to BreadcrumbCollector with the auto_record: prefix',
+      () {
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.adapterConnected,
+      mac: 'AA:BB:CC:DD:EE:FF',
+    );
+    final Breadcrumb crumb = BreadcrumbCollector.snapshot().last;
+    expect(crumb.action, 'auto_record:adapterConnected');
+    expect(crumb.detail, isNotNull);
+    expect(crumb.detail, contains('mac=AA:BB:CC:DD:EE:FF'));
+  });
+
+  test('mirror collapses null mac and null detail to a null breadcrumb detail',
+      () {
+    // The coordinator emits some kinds (e.g. coordinatorStopped) with
+    // mac alone and no detail. The mirror should not crash on null
+    // inputs and the breadcrumb should not contain literal "null".
+    AutoRecordTraceLog.add(AutoRecordEventKind.coordinatorStopped);
+    final Breadcrumb crumb = BreadcrumbCollector.snapshot().last;
+    expect(crumb.action, 'auto_record:coordinatorStopped');
+    expect(crumb.detail, isNull,
+        reason: 'breadcrumbs must collapse to null when neither mac nor '
+            'detail is provided');
+  });
+
+  test('mirror joins mac and detail in the breadcrumb', () {
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.speedSampleSupraThreshold,
+      mac: 'AA:BB:CC:DD:EE:FF',
+      detail: 'speed=12.3 kmh, count=2/3',
+    );
+    final Breadcrumb crumb = BreadcrumbCollector.snapshot().last;
+    expect(crumb.action, 'auto_record:speedSampleSupraThreshold');
+    expect(crumb.detail, contains('mac=AA:BB:CC:DD:EE:FF'));
+    expect(crumb.detail, contains('speed=12.3 kmh'));
+  });
+}

--- a/test/features/consumption/data/obd2/auto_trip_coordinator_test.dart
+++ b/test/features/consumption/data/obd2/auto_trip_coordinator_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/auto_record_trace_log.dart';
 import 'package:tankstellen/features/consumption/data/obd2/auto_trip_coordinator.dart';
 import 'package:tankstellen/features/consumption/data/obd2/fake_background_adapter_listener.dart';
 
@@ -47,6 +48,7 @@ void main() {
   }
 
   setUp(() {
+    AutoRecordTraceLog.clear();
     listener = FakeBackgroundAdapterListener();
     speed = StreamController<double>.broadcast();
     startTripCalls = 0;
@@ -88,6 +90,25 @@ void main() {
     expect(startTripCalls, 1,
         reason: 'startTrip is idempotent within a single connect '
             'cycle — extra samples should not double-fire');
+
+    // Trace assertions: the ring should have recorded coordinatorStarted,
+    // adapterConnected, three supra-threshold samples, thresholdCrossed,
+    // and finally tripStarted in that order.
+    final List<AutoRecordEventKind> kinds =
+        AutoRecordTraceLog.snapshot().map((e) => e.kind).toList();
+    expect(kinds.first, AutoRecordEventKind.coordinatorStarted);
+    expect(kinds.contains(AutoRecordEventKind.adapterConnected), isTrue);
+    expect(
+      kinds.where((k) => k == AutoRecordEventKind.speedSampleSupraThreshold)
+          .length,
+      3,
+      reason: 'three supra-threshold samples must each emit a trace entry',
+    );
+    final int crossedAt = kinds.indexOf(AutoRecordEventKind.thresholdCrossed);
+    final int startedAt = kinds.indexOf(AutoRecordEventKind.tripStarted);
+    expect(crossedAt, greaterThan(0));
+    expect(startedAt, greaterThan(crossedAt),
+        reason: 'thresholdCrossed must be emitted before tripStarted');
   });
 
   test('sub-threshold samples never reach the consecutive window', () async {
@@ -104,6 +125,17 @@ void main() {
 
     expect(startTripCalls, 0,
         reason: 'sub-threshold samples must never trigger startTrip');
+
+    final List<AutoRecordEventKind> kinds =
+        AutoRecordTraceLog.snapshot().map((e) => e.kind).toList();
+    expect(
+      kinds.where((k) => k == AutoRecordEventKind.speedSampleSubThreshold)
+          .length,
+      5,
+      reason: 'each sub-threshold sample must emit a trace entry',
+    );
+    expect(kinds.contains(AutoRecordEventKind.thresholdCrossed), isFalse);
+    expect(kinds.contains(AutoRecordEventKind.tripStarted), isFalse);
   });
 
   test('fluctuating samples do not satisfy the consecutive window', () async {
@@ -156,6 +188,25 @@ void main() {
     await Future<void>.delayed(shortDelay * 2);
     expect(stopAndSaveCalls, 0,
         reason: 'a cancelled timer must not still call stopAndSave');
+
+    final List<AutoRecordEventKind> kinds =
+        AutoRecordTraceLog.snapshot().map((e) => e.kind).toList();
+    final int timerStartedAt =
+        kinds.indexOf(AutoRecordEventKind.disconnectTimerStarted);
+    final int reconnectedAt =
+        kinds.lastIndexOf(AutoRecordEventKind.adapterConnected);
+    final int cancelledAt =
+        kinds.indexOf(AutoRecordEventKind.disconnectTimerCancelled);
+    expect(timerStartedAt, greaterThan(-1),
+        reason: 'disconnect must record disconnectTimerStarted');
+    expect(reconnectedAt, greaterThan(timerStartedAt),
+        reason: 'reconnect must record adapterConnected after the timer '
+            'started');
+    expect(cancelledAt, greaterThan(reconnectedAt),
+        reason: 'reconnect must trigger disconnectTimerCancelled');
+    expect(kinds.contains(AutoRecordEventKind.disconnectTimerFired), isFalse,
+        reason: 'a cancelled timer must not record a fired entry');
+    expect(kinds.contains(AutoRecordEventKind.tripSavedAuto), isFalse);
   });
 
   test('disconnect timer fires → stopAndSaveAutomatic called once', () async {
@@ -174,6 +225,15 @@ void main() {
 
     expect(stopAndSaveCalls, 1,
         reason: 'timer fire must call stopAndSaveAutomatic exactly once');
+
+    final List<AutoRecordEventKind> kinds =
+        AutoRecordTraceLog.snapshot().map((e) => e.kind).toList();
+    final int firedAt = kinds.indexOf(AutoRecordEventKind.disconnectTimerFired);
+    final int savedAt = kinds.indexOf(AutoRecordEventKind.tripSavedAuto);
+    expect(firedAt, greaterThan(-1),
+        reason: 'timer fire must record disconnectTimerFired');
+    expect(savedAt, greaterThan(firedAt),
+        reason: 'tripSavedAuto must follow disconnectTimerFired');
   });
 
   test('disconnect with no active trip → timer fires but no save', () async {
@@ -205,6 +265,22 @@ void main() {
         reason: 'disconnect for the wrong MAC must not arm the timer');
     await Future<void>.delayed(shortDelay * 3);
     expect(stopAndSaveCalls, 0);
+
+    // Trace must record the foreign MAC as ignored (so the user can
+    // see "an event arrived but it wasn't ours") rather than silently
+    // dropping it.
+    final List<AutoRecordEvent> events = AutoRecordTraceLog.snapshot();
+    final AutoRecordEvent ignoredConnect = events.firstWhere(
+      (e) => e.kind == AutoRecordEventKind.adapterConnectIgnoredOtherMac,
+    );
+    expect(ignoredConnect.mac, otherMac);
+    final AutoRecordEvent ignoredDisconnect = events.firstWhere(
+      (e) => e.kind == AutoRecordEventKind.adapterDisconnectIgnoredOtherMac,
+    );
+    expect(ignoredDisconnect.mac, otherMac);
+    expect(events.any((e) => e.kind == AutoRecordEventKind.adapterConnected),
+        isFalse,
+        reason: 'no AdapterConnected for the configured mac should appear');
   });
 
   test('start() is idempotent — second call does not double-subscribe',
@@ -266,6 +342,16 @@ void main() {
     expect(coordinator.isStarted, isFalse);
     expect(listener.stopCalls, 2,
         reason: 'each stop() call forwards once to the listener');
+
+    // Both stop() calls record a coordinatorStopped entry — the trace
+    // is "what happened from the coordinator's POV", not "what changed
+    // state".
+    final List<AutoRecordEventKind> kinds =
+        AutoRecordTraceLog.snapshot().map((e) => e.kind).toList();
+    expect(
+      kinds.where((k) => k == AutoRecordEventKind.coordinatorStopped).length,
+      2,
+    );
   });
 
   test('connect → disconnect → reconnect → 3 supra samples → only one save',


### PR DESCRIPTION
## Summary

Refs #1004 phase 2a-trace.

Adds an in-memory event ring (`AutoRecordTraceLog`, 100-entry capacity) and instruments every state transition in `AutoTripCoordinator` so the auto-record flow is debuggable without an exception to attach to.

## Why

Quoting the user-asked motivation: _"traces can be used for debugging and analyzing what worked and what not."_

The auto-record flow runs in the background — the user can't see it work. If a trip didn't auto-record yesterday, today's debugging is "uh, no idea." `errorLogger.log` only fires on exceptions, and `BreadcrumbCollector` only surfaces on the next error trace. We need a flow-specific event ring inspectable even when nothing crashed.

## What changed

- **New** `lib/features/consumption/data/obd2/auto_record_trace_log.dart`
  - `AutoRecordEventKind` enum covering 17 transitions: coordinator lifecycle, adapter connect/disconnect (matching + foreign MAC), supra/sub-threshold speed samples, threshold-crossing, trip start/save outcomes, disconnect debounce timer (started/cancelled/fired), generic error.
  - `AutoRecordEvent` immutable record (timestamp, kind, mac?, detail?).
  - `AutoRecordTraceLog.add(...)` appends to a static 100-entry ring (oldest drops off the front) **and** mirrors every entry to `BreadcrumbCollector` with the prefix `auto_record:<kind>` so the existing error-trace pipeline still captures the last 25 events when something later crashes.
  - Test seam: pluggable `clock` parameter; `@visibleForTesting clear()` resets the ring.
- **Modified** `lib/features/consumption/data/obd2/auto_trip_coordinator.dart`
  - Wired `AutoRecordTraceLog.add(...)` at every state transition.
  - Existing `errorLogger.log(ErrorLayer.background, ...)` calls unchanged — trace entries are additive on the success path, complementary on the failure path.
  - `_invokeStartTrip` now classifies outcomes via `outcome?.toString().split('.').last == 'started'` so the coordinator stays decoupled from the providers-layer `StartTripOutcome` enum (the typed outcome name is recorded as the failure detail).
- **Modified** `test/features/consumption/data/obd2/auto_trip_coordinator_test.dart`
  - Added `AutoRecordTraceLog.clear()` in `setUp`.
  - Added trace-ring assertions to 6 of the existing 11 cases (3-supra path, all-sub path, reconnect-cancels-timer, timer-fires-and-saves, foreign-MAC, double-stop). All existing behavioural assertions preserved.
- **New** `test/features/consumption/data/obd2/auto_record_trace_log_test.dart`
  - Append + ordering, snapshot is unmodifiable, capacity (101 adds → keep latest 100), `clear()`, custom-clock honoured, breadcrumb mirror with mac, breadcrumb mirror collapses to null, breadcrumb mirror joins mac+detail.

## Persistence

In-memory only. A future phase can add Hive backing — `hive_boxes.dart` is hot-file so this PR deliberately stays out of it.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test test/features/consumption/data/obd2/` — all 506 tests pass
- [x] `flutter test test/lint/` — no_silent_catch and no_raw_debugprint_error pass

## Out of scope

- No `android/` changes
- No new Hive boxes / `hive_boxes.dart` edits
- No new dependencies in `pubspec.yaml`
- No UI exposing the trace log (debug screen comes in a later phase)
- No `.arb` changes
- No refactoring of the existing `AutoTripCoordinator` logic — only add trace calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)