### PR TITLE
refactor(app): extract per-feature route definitions out of router (Refs #563 phase: router)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,45 +1,18 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../core/data/storage_repository.dart';
 import '../core/telemetry/integrations/navigation_trace_observer.dart';
 import '../core/storage/storage_keys.dart';
 import '../core/storage/storage_providers.dart';
-import '../features/consent/presentation/screens/gdpr_consent_screen.dart';
-import '../features/favorites/presentation/screens/favorites_screen.dart';
-import '../features/map/presentation/screens/map_screen.dart';
-import '../features/profile/presentation/screens/privacy_dashboard_screen.dart';
-import '../features/profile/presentation/screens/profile_screen.dart';
-import '../features/profile/presentation/screens/theme_settings_screen.dart';
-import '../features/search/presentation/screens/search_criteria_screen.dart';
-import '../features/search/presentation/screens/search_screen.dart';
-import '../features/setup/presentation/screens/onboarding_wizard_screen.dart';
-import '../features/alerts/presentation/screens/alerts_screen.dart';
-import '../features/calculator/presentation/screens/calculator_screen.dart';
-import '../features/carbon/presentation/screens/carbon_dashboard_screen.dart';
-import '../features/report/presentation/screens/report_screen.dart';
-import '../features/consumption/presentation/screens/add_fill_up_screen.dart';
-import '../features/consumption/presentation/screens/consumption_screen.dart';
-import '../features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart';
-import '../features/consumption/presentation/screens/trip_detail_screen.dart';
-import '../features/consumption/presentation/screens/trip_history_screen.dart';
-import '../features/consumption/presentation/screens/trip_recording_screen.dart';
-import '../features/search/domain/entities/fuel_type.dart';
-import '../features/price_history/presentation/screens/price_history_screen.dart';
-import '../features/ev/domain/entities/charging_station.dart';
-import '../features/search/presentation/screens/ev_station_detail_screen.dart';
-import '../features/station_detail/presentation/screens/station_detail_screen.dart';
-import '../features/driving/presentation/screens/driving_mode_screen.dart';
-import '../features/itinerary/presentation/screens/itineraries_screen.dart';
-import '../features/loyalty/presentation/loyalty_settings_screen.dart';
-import '../features/sync/presentation/screens/auth_screen.dart';
-import '../features/sync/presentation/screens/data_transparency_screen.dart';
-import '../features/sync/presentation/screens/link_device_screen.dart';
-import '../features/sync/presentation/screens/sync_setup_screen.dart';
-import '../features/vehicle/presentation/screens/edit_vehicle_screen.dart';
-import '../features/vehicle/presentation/screens/vehicle_list_screen.dart';
+import 'routes/consumption_routes.dart';
+import 'routes/onboarding_routes.dart';
+import 'routes/profile_routes.dart';
+import 'routes/search_routes.dart';
+import 'routes/shell_branches.dart';
+import 'routes/station_routes.dart';
+import 'routes/sync_routes.dart';
 import 'shell_screen.dart';
-import 'station_id_validator.dart';
 
 part 'router.g.dart';
 
@@ -65,30 +38,6 @@ String resolveLandingLocation(StorageRepository storage) {
     default:
       return '/';
   }
-}
-
-Widget _invalidIdScreen(BuildContext context, String path) {
-  return Scaffold(
-    appBar: AppBar(title: const Text('Invalid link')),
-    body: Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Icon(Icons.link_off, size: 64, color: Colors.grey),
-          const SizedBox(height: 16),
-          Text(
-            'The link "$path" is not valid.',
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () => context.go('/'),
-            child: const Text('Home'),
-          ),
-        ],
-      ),
-    ),
-  );
 }
 
 @riverpod
@@ -149,259 +98,17 @@ GoRouter router(Ref ref) {
       return null;
     },
     routes: [
-      GoRoute(
-        path: '/consent',
-        builder: (context, state) => const GdprConsentScreen(),
-      ),
-      GoRoute(
-        path: '/setup',
-        builder: (context, state) => const OnboardingWizardScreen(),
-      ),
+      ...onboardingRoutes,
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) =>
             ShellScreen(navigationShell: navigationShell),
-        branches: [
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/',
-                builder: (context, state) => const SearchScreen(),
-              ),
-            ],
-          ),
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/map',
-                builder: (context, state) => const MapScreen(),
-              ),
-            ],
-          ),
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/favorites',
-                builder: (context, state) => const FavoritesScreen(),
-              ),
-            ],
-          ),
-          // Consumption is the 4th tab (#778) — sits between
-          // Favorites and Settings so the "behind-the-wheel savings"
-          // workflow has a first-class entry point. Path stays
-          // `/consumption-tab` to avoid colliding with the existing
-          // `/consumption` deep link (which still pushes on top of
-          // the current branch from station detail etc.).
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/consumption-tab',
-                builder: (_, _) => const ConsumptionScreen(),
-              ),
-            ],
-          ),
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/profile',
-                builder: (context, state) => const ProfileScreen(),
-              ),
-            ],
-          ),
-        ],
+        branches: shellBranches,
       ),
-      GoRoute(
-        path: '/search/criteria',
-        builder: (context, state) => const SearchCriteriaScreen(),
-      ),
-      GoRoute(
-        path: '/driving',
-        builder: (context, state) => const DrivingModeScreen(),
-      ),
-      GoRoute(
-        path: '/alerts',
-        builder: (context, state) => const AlertsScreen(),
-      ),
-      GoRoute(
-        path: '/calculator',
-        builder: (context, state) => const CalculatorScreen(),
-      ),
-      GoRoute(
-        path: '/consumption',
-        builder: (context, state) => const ConsumptionScreen(),
-      ),
-      GoRoute(
-        path: '/carbon',
-        builder: (context, state) => const CarbonDashboardScreen(),
-      ),
-      GoRoute(
-        path: '/vehicles',
-        builder: (context, state) => const VehicleListScreen(),
-      ),
-      GoRoute(
-        path: '/vehicles/edit',
-        builder: (context, state) {
-          final extra = state.extra;
-          final vehicleId = extra is String ? extra : null;
-          return EditVehicleScreen(vehicleId: vehicleId);
-        },
-      ),
-      GoRoute(
-        path: '/consumption/pick-station',
-        builder: (_, _) => const PickStationForFillUpScreen(),
-      ),
-      // #726 — global trip recording view. The recording session
-      // itself lives in `tripRecordingProvider` (keepAlive), so this
-      // screen is a thin viewer that can come and go without losing
-      // state. Opened from AddFillUpScreen after OBD2 connect, and
-      // re-entered by tapping the banner shown on every screen
-      // while a trip is active.
-      GoRoute(
-        path: '/trip-recording',
-        builder: (_, _) => const TripRecordingScreen(),
-      ),
-      GoRoute(
-        path: '/trip-history',
-        builder: (_, _) => const TripHistoryScreen(),
-      ),
-      // #889 — placeholder trip-detail route wired up alongside the
-      // new Trajets tab on the Consumption screen. Full detail UI
-      // (timeline / per-minute consumption / map) lands in #890.
-      GoRoute(
-        path: '/trip/:id',
-        builder: (context, state) {
-          final id = state.pathParameters['id'];
-          if (id == null || id.isEmpty) {
-            return _invalidIdScreen(context, state.matchedLocation);
-          }
-          return TripDetailScreen(tripId: id);
-        },
-      ),
-      GoRoute(
-        path: '/consumption/add',
-        builder: (context, state) {
-          final extra = state.extra;
-          String? stationId;
-          String? stationName;
-          FuelType? fuelType;
-          double? pricePerLiter;
-          if (extra is Map) {
-            stationId = extra['stationId']?.toString();
-            stationName = extra['stationName']?.toString();
-            final ft = extra['fuelType'];
-            if (ft is FuelType) fuelType = ft;
-            final price = extra['pricePerLiter'];
-            if (price is num) pricePerLiter = price.toDouble();
-          }
-          return AddFillUpScreen(
-            stationId: stationId,
-            stationName: stationName,
-            preFilledFuelType: fuelType,
-            preFilledPricePerLiter: pricePerLiter,
-          );
-        },
-      ),
-      GoRoute(
-        path: '/station/:id/history',
-        builder: (context, state) {
-          final id = state.pathParameters['id'];
-          if (!isValidStationId(id)) {
-            return _invalidIdScreen(context, state.matchedLocation);
-          }
-          return PriceHistoryScreen(stationId: id!);
-        },
-      ),
-      GoRoute(
-        path: '/station/:id',
-        builder: (context, state) {
-          final id = state.pathParameters['id'];
-          if (!isValidStationId(id)) {
-            return _invalidIdScreen(context, state.matchedLocation);
-          }
-          return StationDetailScreen(stationId: id!);
-        },
-      ),
-      GoRoute(
-        path: '/ev-station',
-        builder: (context, state) {
-          final station = state.extra as ChargingStation;
-          return EVStationDetailScreen(station: station);
-        },
-      ),
-      // Deep-link friendly EV detail: takes the station id in the
-      // path and hydrates the ChargingStation from storage (#713
-      // widget → station detail flow). Used when the caller has
-      // only the id — e.g. a home-screen widget tap or an external
-      // URL. Falls back to the invalid-id screen when the id is
-      // unknown or the cached JSON is missing.
-      GoRoute(
-        path: '/ev-station/:id',
-        builder: (context, state) {
-          final id = state.pathParameters['id'];
-          if (!isValidStationId(id)) {
-            return _invalidIdScreen(context, state.matchedLocation);
-          }
-          final storage = ref.watch(storageRepositoryProvider);
-          final raw = storage.getEvFavoriteStationData(id!);
-          if (raw == null) {
-            return _invalidIdScreen(context, state.matchedLocation);
-          }
-          try {
-            final station = ChargingStation.fromJson(raw);
-            return EVStationDetailScreen(station: station);
-          } catch (e, st) { // ignore: unused_catch_stack
-            return _invalidIdScreen(context, state.matchedLocation);
-          }
-        },
-      ),
-      GoRoute(
-        path: '/report/:id',
-        builder: (context, state) {
-          final id = state.pathParameters['id'];
-          if (!isValidStationId(id)) {
-            return _invalidIdScreen(context, state.matchedLocation);
-          }
-          return ReportScreen(stationId: id!);
-        },
-      ),
-      GoRoute(
-        path: '/sync-setup',
-        builder: (context, state) => const SyncSetupScreen(),
-      ),
-      GoRoute(
-        path: '/link-device',
-        builder: (context, state) => const LinkDeviceScreen(),
-      ),
-      GoRoute(
-        path: '/data-transparency',
-        builder: (context, state) => const DataTransparencyScreen(),
-      ),
-      GoRoute(
-        path: '/auth',
-        builder: (context, state) => const AuthScreen(),
-      ),
-      GoRoute(
-        path: '/itineraries',
-        builder: (context, state) => const ItinerariesScreen(),
-      ),
-      GoRoute(
-        path: '/privacy-dashboard',
-        builder: (context, state) => const PrivacyDashboardScreen(),
-      ),
-      // #897 — dedicated Theme settings screen, pushed from the
-      // Theme card on the profile/settings screen. Extracted from
-      // the inline bottom sheet so the Theme entry matches the
-      // Privacy + Storage card pattern.
-      GoRoute(
-        path: '/theme-settings',
-        builder: (context, state) => const ThemeSettingsScreen(),
-      ),
-      // #1120 — fuel-club / loyalty discount settings. Pilot ships
-      // with one brand (Total Energies); the screen lists, adds,
-      // toggles, and deletes user-entered cards.
-      GoRoute(
-        path: '/loyalty-settings',
-        builder: (context, state) => const LoyaltySettingsScreen(),
-      ),
+      ...searchRoutes,
+      ...profileRoutes,
+      ...consumptionRoutes,
+      ...stationRoutes(ref),
+      ...syncRoutes,
     ],
   );
 }

--- a/lib/app/routes/consumption_routes.dart
+++ b/lib/app/routes/consumption_routes.dart
@@ -1,0 +1,81 @@
+import 'package:go_router/go_router.dart';
+
+import '../../features/carbon/presentation/screens/carbon_dashboard_screen.dart';
+import '../../features/consumption/presentation/screens/add_fill_up_screen.dart';
+import '../../features/consumption/presentation/screens/consumption_screen.dart';
+import '../../features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart';
+import '../../features/consumption/presentation/screens/trip_detail_screen.dart';
+import '../../features/consumption/presentation/screens/trip_history_screen.dart';
+import '../../features/consumption/presentation/screens/trip_recording_screen.dart';
+import '../../features/search/domain/entities/fuel_type.dart';
+import 'invalid_id_screen.dart';
+
+/// Routes that drive the "behind-the-wheel" savings lens: consumption logging,
+/// trip recording/history/detail, the carbon dashboard, and the deep-linkable
+/// fill-up flow. The `/consumption-tab` path lives in [shellBranches]; this
+/// file owns every consumption route that pushes on top of the shell.
+List<RouteBase> get consumptionRoutes => [
+      GoRoute(
+        path: '/consumption',
+        builder: (context, state) => const ConsumptionScreen(),
+      ),
+      GoRoute(
+        path: '/carbon',
+        builder: (context, state) => const CarbonDashboardScreen(),
+      ),
+      GoRoute(
+        path: '/consumption/pick-station',
+        builder: (_, _) => const PickStationForFillUpScreen(),
+      ),
+      // #726 — global trip recording view. The recording session
+      // itself lives in `tripRecordingProvider` (keepAlive), so this
+      // screen is a thin viewer that can come and go without losing
+      // state. Opened from AddFillUpScreen after OBD2 connect, and
+      // re-entered by tapping the banner shown on every screen
+      // while a trip is active.
+      GoRoute(
+        path: '/trip-recording',
+        builder: (_, _) => const TripRecordingScreen(),
+      ),
+      GoRoute(
+        path: '/trip-history',
+        builder: (_, _) => const TripHistoryScreen(),
+      ),
+      // #889 — placeholder trip-detail route wired up alongside the
+      // new Trajets tab on the Consumption screen. Full detail UI
+      // (timeline / per-minute consumption / map) lands in #890.
+      GoRoute(
+        path: '/trip/:id',
+        builder: (context, state) {
+          final id = state.pathParameters['id'];
+          if (id == null || id.isEmpty) {
+            return invalidIdScreen(context, state.matchedLocation);
+          }
+          return TripDetailScreen(tripId: id);
+        },
+      ),
+      GoRoute(
+        path: '/consumption/add',
+        builder: (context, state) {
+          final extra = state.extra;
+          String? stationId;
+          String? stationName;
+          FuelType? fuelType;
+          double? pricePerLiter;
+          if (extra is Map) {
+            stationId = extra['stationId']?.toString();
+            stationName = extra['stationName']?.toString();
+            final ft = extra['fuelType'];
+            if (ft is FuelType) fuelType = ft;
+            final price = extra['pricePerLiter'];
+            if (price is num) pricePerLiter = price.toDouble();
+          }
+          return AddFillUpScreen(
+            stationId: stationId,
+            stationName: stationName,
+            preFilledFuelType: fuelType,
+            preFilledPricePerLiter: pricePerLiter,
+          );
+        },
+      ),
+    ];

--- a/lib/app/routes/invalid_id_screen.dart
+++ b/lib/app/routes/invalid_id_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Fallback widget shown when a deep link supplies an id that fails
+/// [isValidStationId] or otherwise fails to hydrate. Centralised so every
+/// route file that builds an id-keyed screen renders the same UX.
+Widget invalidIdScreen(BuildContext context, String path) {
+  return Scaffold(
+    appBar: AppBar(title: const Text('Invalid link')),
+    body: Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.link_off, size: 64, color: Colors.grey),
+          const SizedBox(height: 16),
+          Text(
+            'The link "$path" is not valid.',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: () => context.go('/'),
+            child: const Text('Home'),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/app/routes/onboarding_routes.dart
+++ b/lib/app/routes/onboarding_routes.dart
@@ -1,0 +1,18 @@
+import 'package:go_router/go_router.dart';
+
+import '../../features/consent/presentation/screens/gdpr_consent_screen.dart';
+import '../../features/setup/presentation/screens/onboarding_wizard_screen.dart';
+
+/// Routes that gate the app at first launch — GDPR consent and the onboarding
+/// wizard. Sit at the top of the route table so the redirect logic in
+/// [routerProvider] can deep-link straight to either of them.
+List<RouteBase> get onboardingRoutes => [
+      GoRoute(
+        path: '/consent',
+        builder: (context, state) => const GdprConsentScreen(),
+      ),
+      GoRoute(
+        path: '/setup',
+        builder: (context, state) => const OnboardingWizardScreen(),
+      ),
+    ];

--- a/lib/app/routes/profile_routes.dart
+++ b/lib/app/routes/profile_routes.dart
@@ -1,0 +1,49 @@
+import 'package:go_router/go_router.dart';
+
+import '../../features/itinerary/presentation/screens/itineraries_screen.dart';
+import '../../features/loyalty/presentation/loyalty_settings_screen.dart';
+import '../../features/profile/presentation/screens/privacy_dashboard_screen.dart';
+import '../../features/profile/presentation/screens/theme_settings_screen.dart';
+import '../../features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import '../../features/vehicle/presentation/screens/vehicle_list_screen.dart';
+
+/// Profile/settings sub-screens that push on top of the Profile shell branch:
+/// vehicle list and editor, saved itineraries, privacy dashboard, theme
+/// settings (#897), and loyalty/fuel-club discount cards (#1120).
+List<RouteBase> get profileRoutes => [
+      GoRoute(
+        path: '/vehicles',
+        builder: (context, state) => const VehicleListScreen(),
+      ),
+      GoRoute(
+        path: '/vehicles/edit',
+        builder: (context, state) {
+          final extra = state.extra;
+          final vehicleId = extra is String ? extra : null;
+          return EditVehicleScreen(vehicleId: vehicleId);
+        },
+      ),
+      GoRoute(
+        path: '/itineraries',
+        builder: (context, state) => const ItinerariesScreen(),
+      ),
+      GoRoute(
+        path: '/privacy-dashboard',
+        builder: (context, state) => const PrivacyDashboardScreen(),
+      ),
+      // #897 — dedicated Theme settings screen, pushed from the
+      // Theme card on the profile/settings screen. Extracted from
+      // the inline bottom sheet so the Theme entry matches the
+      // Privacy + Storage card pattern.
+      GoRoute(
+        path: '/theme-settings',
+        builder: (context, state) => const ThemeSettingsScreen(),
+      ),
+      // #1120 — fuel-club / loyalty discount settings. Pilot ships
+      // with one brand (Total Energies); the screen lists, adds,
+      // toggles, and deletes user-entered cards.
+      GoRoute(
+        path: '/loyalty-settings',
+        builder: (context, state) => const LoyaltySettingsScreen(),
+      ),
+    ];

--- a/lib/app/routes/search_routes.dart
+++ b/lib/app/routes/search_routes.dart
@@ -1,0 +1,29 @@
+import 'package:go_router/go_router.dart';
+
+import '../../features/alerts/presentation/screens/alerts_screen.dart';
+import '../../features/calculator/presentation/screens/calculator_screen.dart';
+import '../../features/driving/presentation/screens/driving_mode_screen.dart';
+import '../../features/search/presentation/screens/search_criteria_screen.dart';
+
+/// Search-adjacent routes that push on top of the bottom-nav shell:
+/// the search-criteria screen, driving mode, alerts list, and the
+/// fuel-cost calculator. These all live under the search/results flow
+/// even though they are not part of any shell branch.
+List<RouteBase> get searchRoutes => [
+      GoRoute(
+        path: '/search/criteria',
+        builder: (context, state) => const SearchCriteriaScreen(),
+      ),
+      GoRoute(
+        path: '/driving',
+        builder: (context, state) => const DrivingModeScreen(),
+      ),
+      GoRoute(
+        path: '/alerts',
+        builder: (context, state) => const AlertsScreen(),
+      ),
+      GoRoute(
+        path: '/calculator',
+        builder: (context, state) => const CalculatorScreen(),
+      ),
+    ];

--- a/lib/app/routes/shell_branches.dart
+++ b/lib/app/routes/shell_branches.dart
@@ -1,0 +1,59 @@
+import 'package:go_router/go_router.dart';
+
+import '../../features/consumption/presentation/screens/consumption_screen.dart';
+import '../../features/favorites/presentation/screens/favorites_screen.dart';
+import '../../features/map/presentation/screens/map_screen.dart';
+import '../../features/profile/presentation/screens/profile_screen.dart';
+import '../../features/search/presentation/screens/search_screen.dart';
+
+/// Branches of the bottom-nav `StatefulShellRoute.indexedStack`. Each branch
+/// owns the top-level route for one tab — Search, Map, Favorites, Consumption
+/// (#778), Profile.
+List<StatefulShellBranch> get shellBranches => [
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const SearchScreen(),
+          ),
+        ],
+      ),
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            path: '/map',
+            builder: (context, state) => const MapScreen(),
+          ),
+        ],
+      ),
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            path: '/favorites',
+            builder: (context, state) => const FavoritesScreen(),
+          ),
+        ],
+      ),
+      // Consumption is the 4th tab (#778) — sits between
+      // Favorites and Settings so the "behind-the-wheel savings"
+      // workflow has a first-class entry point. Path stays
+      // `/consumption-tab` to avoid colliding with the existing
+      // `/consumption` deep link (which still pushes on top of
+      // the current branch from station detail etc.).
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            path: '/consumption-tab',
+            builder: (_, _) => const ConsumptionScreen(),
+          ),
+        ],
+      ),
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            path: '/profile',
+            builder: (context, state) => const ProfileScreen(),
+          ),
+        ],
+      ),
+    ];

--- a/lib/app/routes/station_routes.dart
+++ b/lib/app/routes/station_routes.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/storage/storage_providers.dart';
+import '../../features/ev/domain/entities/charging_station.dart';
+import '../../features/price_history/presentation/screens/price_history_screen.dart';
+import '../../features/report/presentation/screens/report_screen.dart';
+import '../../features/search/presentation/screens/ev_station_detail_screen.dart';
+import '../../features/station_detail/presentation/screens/station_detail_screen.dart';
+import '../station_id_validator.dart';
+import 'invalid_id_screen.dart';
+
+/// Detail-level routes anchored on a single station id: fuel and EV
+/// detail screens, price history, and the user report flow. The EV
+/// deep-link variant (`/ev-station/:id`) needs storage access to hydrate
+/// the [ChargingStation] payload from the cached widget JSON, so the
+/// list is parameterised with the router's [Ref].
+List<RouteBase> stationRoutes(Ref ref) => [
+      GoRoute(
+        path: '/station/:id/history',
+        builder: (context, state) {
+          final id = state.pathParameters['id'];
+          if (!isValidStationId(id)) {
+            return invalidIdScreen(context, state.matchedLocation);
+          }
+          return PriceHistoryScreen(stationId: id!);
+        },
+      ),
+      GoRoute(
+        path: '/station/:id',
+        builder: (context, state) {
+          final id = state.pathParameters['id'];
+          if (!isValidStationId(id)) {
+            return invalidIdScreen(context, state.matchedLocation);
+          }
+          return StationDetailScreen(stationId: id!);
+        },
+      ),
+      GoRoute(
+        path: '/ev-station',
+        builder: (context, state) {
+          final station = state.extra as ChargingStation;
+          return EVStationDetailScreen(station: station);
+        },
+      ),
+      // Deep-link friendly EV detail: takes the station id in the
+      // path and hydrates the ChargingStation from storage (#713
+      // widget → station detail flow). Used when the caller has
+      // only the id — e.g. a home-screen widget tap or an external
+      // URL. Falls back to the invalid-id screen when the id is
+      // unknown or the cached JSON is missing.
+      GoRoute(
+        path: '/ev-station/:id',
+        builder: (context, state) {
+          final id = state.pathParameters['id'];
+          if (!isValidStationId(id)) {
+            return invalidIdScreen(context, state.matchedLocation);
+          }
+          final storage = ref.watch(storageRepositoryProvider);
+          final raw = storage.getEvFavoriteStationData(id!);
+          if (raw == null) {
+            return invalidIdScreen(context, state.matchedLocation);
+          }
+          try {
+            final station = ChargingStation.fromJson(raw);
+            return EVStationDetailScreen(station: station);
+          } catch (e, st) { // ignore: unused_catch_stack
+            return invalidIdScreen(context, state.matchedLocation);
+          }
+        },
+      ),
+      GoRoute(
+        path: '/report/:id',
+        builder: (context, state) {
+          final id = state.pathParameters['id'];
+          if (!isValidStationId(id)) {
+            return invalidIdScreen(context, state.matchedLocation);
+          }
+          return ReportScreen(stationId: id!);
+        },
+      ),
+    ];

--- a/lib/app/routes/sync_routes.dart
+++ b/lib/app/routes/sync_routes.dart
@@ -1,0 +1,28 @@
+import 'package:go_router/go_router.dart';
+
+import '../../features/sync/presentation/screens/auth_screen.dart';
+import '../../features/sync/presentation/screens/data_transparency_screen.dart';
+import '../../features/sync/presentation/screens/link_device_screen.dart';
+import '../../features/sync/presentation/screens/sync_setup_screen.dart';
+
+/// TankSync (cloud-sync) routes — anonymous-auth screen, sync setup wizard,
+/// link-a-device flow, and the data-transparency screen. All optional —
+/// users who never opt into sync never see them.
+List<RouteBase> get syncRoutes => [
+      GoRoute(
+        path: '/sync-setup',
+        builder: (context, state) => const SyncSetupScreen(),
+      ),
+      GoRoute(
+        path: '/link-device',
+        builder: (context, state) => const LinkDeviceScreen(),
+      ),
+      GoRoute(
+        path: '/data-transparency',
+        builder: (context, state) => const DataTransparencyScreen(),
+      ),
+      GoRoute(
+        path: '/auth',
+        builder: (context, state) => const AuthScreen(),
+      ),
+    ];


### PR DESCRIPTION
## Summary

Splits `lib/app/router.dart` (407 LOC) into a slim composition root plus seven feature-grouped route files, each well under the 300-LOC target tracked by #563.

### Before / after LOC

| File | Before | After |
| --- | --- | --- |
| `lib/app/router.dart` | 407 | **114** |
| `lib/app/routes/shell_branches.dart` | — | 59 |
| `lib/app/routes/onboarding_routes.dart` | — | 18 |
| `lib/app/routes/search_routes.dart` | — | 29 |
| `lib/app/routes/profile_routes.dart` | — | 49 |
| `lib/app/routes/consumption_routes.dart` | — | 81 |
| `lib/app/routes/station_routes.dart` | — | 82 |
| `lib/app/routes/sync_routes.dart` | — | 28 |
| `lib/app/routes/invalid_id_screen.dart` | — | 29 |

Every file is < 300 LOC and the parent router is now ~28% of its original size.

### Feature groupings

- `shell_branches.dart` — the five `StatefulShellBranch`es backing the bottom-nav (Search, Map, Favorites, Consumption #778, Profile).
- `onboarding_routes.dart` — `/consent` + `/setup`.
- `search_routes.dart` — `/search/criteria`, `/driving`, `/alerts`, `/calculator`.
- `consumption_routes.dart` — `/consumption`, `/carbon`, `/consumption/pick-station`, `/consumption/add`, `/trip-recording`, `/trip-history`, `/trip/:id`.
- `station_routes.dart` — `/station/:id` + `/station/:id/history`, `/ev-station` + `/ev-station/:id`, `/report/:id`. Parameterised with `Ref` because the EV deep-link variant hydrates `ChargingStation` from storage.
- `profile_routes.dart` — `/vehicles`, `/vehicles/edit`, `/itineraries`, `/privacy-dashboard`, `/theme-settings`, `/loyalty-settings`.
- `sync_routes.dart` — TankSync screens (`/sync-setup`, `/link-device`, `/data-transparency`, `/auth`).
- `invalid_id_screen.dart` — shared fallback widget previously inlined as `_invalidIdScreen`.

### Behavioral guarantees

- **No route paths added, removed, or changed.**
- Redirect logic, error builder, observer wiring, and `initialLocation` stay verbatim in `router.dart`.
- `resolveLandingLocation(StorageRepository)` keeps its public export — `test/app/landing_screen_routing_test.dart` and `test/app/landing_screen_integration_test.dart` import it unchanged.
- `router.g.dart` is **not** regenerated — the `@riverpod`-annotated `router` function is identical, so the existing generated code still matches.

## Test plan

- [x] `flutter analyze` — clean, zero issues
- [x] `flutter test test/app/router_test.dart` — 13 / 13 pass
- [x] `flutter test test/app/landing_screen_routing_test.dart` — 10 / 10 pass
- [x] `flutter test test/app/landing_screen_integration_test.dart` — 5 / 5 pass
- [x] `flutter test test/app/` — full app suite green (129 / 129)

Refs #563