### PR TITLE
feat(vehicle): auto-read VIN via OBD2 Mode 09 PID 02 (#1162)

### DIFF
--- a/lib/features/vehicle/data/obd2_vin_reader.dart
+++ b/lib/features/vehicle/data/obd2_vin_reader.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../consumption/data/obd2/elm327_protocol.dart';
+import '../../consumption/data/obd2/obd2_service.dart';
+
+part 'obd2_vin_reader.g.dart';
+
+/// Factory signature for [Obd2VinReader]. Lives on the riverpod
+/// container so widget tests can swap in a fake reader without going
+/// through the full `Obd2Service` plumbing.
+typedef Obd2VinReaderFactory = Obd2VinReader Function(Obd2Service service);
+
+/// Default factory — returns a real [Obd2VinReader] backed by the live
+/// [Obd2Service] handed in by the caller. Production wiring; tests
+/// override [obd2VinReaderFactoryProvider] to inject a stub that
+/// captures the call without touching Bluetooth.
+@Riverpod(keepAlive: true)
+Obd2VinReaderFactory obd2VinReaderFactory(Ref ref) =>
+    (Obd2Service service) => Obd2VinReader(service);
+
+/// Thin reader wrapper around an already-connected [Obd2Service] that
+/// performs a single Mode 09 PID 02 (`0902`) request and parses the
+/// response into a 17-character VIN (#1162).
+///
+/// Why a separate class instead of calling the existing
+/// `OnboardingObd2Connector.readVin` from the vehicle edit screen?
+///   * The onboarding connector is owned by the setup feature; pulling
+///     the vehicle edit screen across that dependency boundary would
+///     entangle two unrelated flows (first-run wizard vs. profile
+///     editing).
+///   * A dedicated reader gives the vehicle feature its own seam for
+///     the auto-read button (#1162). Tests for that button mock this
+///     class instead of pulling in the onboarding step's wiring.
+///
+/// The reader does not own the adapter connection. The caller obtains
+/// a connected [Obd2Service] (typically via the existing adapter
+/// picker) and hands it in. On any failure path — timeout, NO DATA
+/// reply, malformed payload, exception — [readVin] returns `null` and
+/// emits a `debugPrint` with the failure context. No silent catches.
+class Obd2VinReader {
+  /// Creates a reader bound to [service]. The default 3 s [timeout]
+  /// matches the upper bound a frozen ELM327 should have already
+  /// reported NO DATA within; longer would block the UI thread on a
+  /// dead adapter.
+  Obd2VinReader(
+    this._service, {
+    Duration timeout = const Duration(seconds: 3),
+  }) : _timeout = timeout;
+
+  final Obd2Service _service;
+  final Duration _timeout;
+
+  /// Send `0902` to the adapter, parse the multi-frame response, and
+  /// return the VIN. Returns `null` for all failure paths:
+  ///
+  ///   * the call did not complete within [_timeout];
+  ///   * the adapter replied `NO DATA` / unsupported (parser returns
+  ///     null);
+  ///   * the response was malformed (parser returns null);
+  ///   * the call threw (e.g. adapter dropped mid-request).
+  ///
+  /// Every failure logs the context via [debugPrint] so a user-reported
+  /// "the button does nothing" issue can be diagnosed from a log
+  /// capture without re-instrumenting the call site.
+  Future<String?> readVin() async {
+    try {
+      final raw = await _service
+          .sendCommand(Elm327Protocol.vinCommand)
+          .timeout(_timeout, onTimeout: () => '');
+      if (raw.isEmpty) {
+        debugPrint('Obd2VinReader.readVin: timed out after $_timeout');
+        return null;
+      }
+      final vin = Elm327Protocol.parseVin(raw);
+      if (vin == null) {
+        debugPrint(
+            'Obd2VinReader.readVin: parser returned null '
+            '(NO DATA / unsupported / malformed) for raw: $raw');
+        return null;
+      }
+      return vin;
+    } catch (e, st) {
+      debugPrint('Obd2VinReader.readVin failed: $e\n$st');
+      return null;
+    }
+  }
+}

--- a/lib/features/vehicle/data/obd2_vin_reader.g.dart
+++ b/lib/features/vehicle/data/obd2_vin_reader.g.dart
@@ -1,0 +1,71 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'obd2_vin_reader.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Default factory — returns a real [Obd2VinReader] backed by the live
+/// [Obd2Service] handed in by the caller. Production wiring; tests
+/// override [obd2VinReaderFactoryProvider] to inject a stub that
+/// captures the call without touching Bluetooth.
+
+@ProviderFor(obd2VinReaderFactory)
+final obd2VinReaderFactoryProvider = Obd2VinReaderFactoryProvider._();
+
+/// Default factory — returns a real [Obd2VinReader] backed by the live
+/// [Obd2Service] handed in by the caller. Production wiring; tests
+/// override [obd2VinReaderFactoryProvider] to inject a stub that
+/// captures the call without touching Bluetooth.
+
+final class Obd2VinReaderFactoryProvider
+    extends
+        $FunctionalProvider<
+          Obd2VinReaderFactory,
+          Obd2VinReaderFactory,
+          Obd2VinReaderFactory
+        >
+    with $Provider<Obd2VinReaderFactory> {
+  /// Default factory — returns a real [Obd2VinReader] backed by the live
+  /// [Obd2Service] handed in by the caller. Production wiring; tests
+  /// override [obd2VinReaderFactoryProvider] to inject a stub that
+  /// captures the call without touching Bluetooth.
+  Obd2VinReaderFactoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'obd2VinReaderFactoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$obd2VinReaderFactoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<Obd2VinReaderFactory> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  Obd2VinReaderFactory create(Ref ref) {
+    return obd2VinReaderFactory(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Obd2VinReaderFactory value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Obd2VinReaderFactory>(value),
+    );
+  }
+}
+
+String _$obd2VinReaderFactoryHash() =>
+    r'bb99a09cc7b6a623d54072bc8943029129101d00';

--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -4,6 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/utils/brand_logo_mapper.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/data/obd2/obd2_service.dart';
+import '../../../setup/providers/onboarding_obd2_connector.dart';
+import '../../data/obd2_vin_reader.dart';
 import '../../domain/entities/vehicle_profile.dart';
 import '../../domain/entities/vin_data.dart';
 import '../../providers/vehicle_providers.dart';
@@ -51,6 +54,12 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
 
   // True while the vPIC request is in flight → VIN field spinner.
   bool _decodingVin = false;
+
+  // True while the OBD2 Mode 09 PID 02 read is in flight (#1162) →
+  // disables the "Read VIN from car" button + shows a small spinner
+  // in its leading slot. Distinct from [_decodingVin] so a user
+  // mid-tap doesn't trigger both spinners at once.
+  bool _readingVinFromCar = false;
 
   @override
   void initState() {
@@ -165,6 +174,71 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     if (outcome == VinConfirmOutcome.confirm) _applyDecodedVin(decoded);
   }
 
+  /// Auto-read the VIN from the paired OBD2 adapter (#1162). Opens
+  /// the existing adapter picker via [OnboardingObd2Connector.connect]
+  /// (the same scan→pick→connect sheet used by the onboarding step),
+  /// then issues Mode 09 PID 02 through [Obd2VinReader]. On success
+  /// the VIN is populated and the existing vPIC decoder is invoked
+  /// to pre-fill make/model/year/engine; on failure a localized
+  /// fallback snackbar tells the user to enter the VIN manually
+  /// (typical cause: pre-2005 ECUs that don't implement Mode 09).
+  ///
+  /// Hidden behind the `_adapterMac != null` check at the call site —
+  /// the button never appears unhooked.
+  Future<void> _readVinFromCar() async {
+    final l = AppLocalizations.of(context);
+    final connector = ref.read(onboardingObd2ConnectorProvider);
+    final readerFactory = ref.read(obd2VinReaderFactoryProvider);
+
+    setState(() => _readingVinFromCar = true);
+    Obd2Service? service;
+    String? vin;
+    try {
+      service = await connector.connect(context);
+      if (service != null) {
+        final reader = readerFactory(service);
+        vin = await reader.readVin();
+      }
+    } catch (e, st) {
+      debugPrint('EditVehicleScreen: read VIN from car failed: $e\n$st');
+      vin = null;
+    } finally {
+      // Disconnect the adapter so the picker can be re-opened later
+      // and so background polling isn't pinned to this screen. Best-
+      // effort — if the adapter is already gone we don't care.
+      if (service != null) {
+        try {
+          await service.disconnect();
+        } catch (e, st) {
+          debugPrint('EditVehicleScreen: VIN-read disconnect failed: $e\n$st');
+        }
+      }
+    }
+
+    if (!mounted) return;
+    setState(() => _readingVinFromCar = false);
+
+    if (vin == null || vin.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            l?.vehicleReadVinFailedSnackbar ??
+                'VIN not available — Mode 09 PID 02 unsupported on '
+                    'pre-2005 vehicles',
+          ),
+        ),
+      );
+      return;
+    }
+
+    // Populate the VIN field, then run the existing decoder to pre-
+    // fill engine fields. Reuse [_decodeVin] so the success path
+    // matches a manual paste-and-decode exactly — confirm dialog,
+    // outcome handling, and engine pre-fill are all already in place.
+    _ctrl.vinController.text = vin;
+    await _decodeVin();
+  }
+
   /// Copy non-null engine fields from [data] (#812 phase 2).
   /// Displacement: L → cc. Curb weight ≈ GVWR / 2.205 (vPIC has no
   /// payload field, so GVWR is the best proxy for now).
@@ -250,6 +324,13 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
               decodingVin: _decodingVin,
               onDecodeVin: _decodeVin,
               onShowVinInfo: _showVinInfo,
+              // Show the "Read VIN from car" button only when an
+              // adapter is paired to this profile (#1162). Hidden
+              // (callback null) prevents users without an adapter
+              // from seeing an affordance that wouldn't work.
+              onReadVinFromCar:
+                  _adapterMac != null ? _readVinFromCar : null,
+              readingVinFromCar: _readingVinFromCar,
             ),
             const SizedBox(height: 16),
             // Card 2: Drivetrain (type + type-specific fields).

--- a/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
@@ -10,6 +10,13 @@ import '../../../../l10n/app_localizations.dart';
 /// controllers, focus node, and the callbacks for decode / info —
 /// this widget is intentionally dumb so all VIN-decoder state stays
 /// at the screen level where the provider already lives.
+///
+/// When the parent passes [onReadVinFromCar] (the profile has a paired
+/// OBD2 adapter), an outlined "Read VIN from car" button is rendered
+/// below the VIN field — tapping it triggers the Mode 09 PID 02 read
+/// in the parent (#1162). When the callback is null, the button is
+/// not rendered at all so users without an adapter never see an
+/// affordance that wouldn't work.
 class VehicleIdentitySection extends StatelessWidget {
   final TextEditingController nameController;
   final TextEditingController vinController;
@@ -18,6 +25,17 @@ class VehicleIdentitySection extends StatelessWidget {
   final bool decodingVin;
   final VoidCallback onDecodeVin;
   final VoidCallback onShowVinInfo;
+
+  /// Tap handler for the "Read VIN from car" button (#1162). When null,
+  /// the button is hidden — the parent gates this on
+  /// `obd2AdapterMac != null`, so the button only appears when there's
+  /// an adapter to read from.
+  final VoidCallback? onReadVinFromCar;
+
+  /// True while a VIN read is in flight (#1162). Disables the button
+  /// and shows a progress indicator in its place to prevent
+  /// double-taps while the adapter is responding.
+  final bool readingVinFromCar;
 
   const VehicleIdentitySection({
     super.key,
@@ -28,6 +46,8 @@ class VehicleIdentitySection extends StatelessWidget {
     required this.decodingVin,
     required this.onDecodeVin,
     required this.onShowVinInfo,
+    this.onReadVinFromCar,
+    this.readingVinFromCar = false,
   });
 
   @override
@@ -101,6 +121,35 @@ class VehicleIdentitySection extends StatelessWidget {
             ),
           ],
         ),
+        // "Read VIN from car" — outlined button rendered only when a
+        // paired adapter is available (#1162). Hidden entirely when
+        // [onReadVinFromCar] is null so users without an adapter
+        // never see an affordance that wouldn't work.
+        if (onReadVinFromCar != null) ...[
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.only(left: 56, right: 8),
+            child: Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: Tooltip(
+                message: l?.vehicleReadVinFromCarButton ?? 'Read VIN from car',
+                child: OutlinedButton.icon(
+                  onPressed: readingVinFromCar ? null : onReadVinFromCar,
+                  icon: readingVinFromCar
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.bluetooth_searching),
+                  label: Text(
+                    l?.vehicleReadVinFromCarButton ?? 'Read VIN from car',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/lib/l10n/_fragments/vehicle_de.arb
+++ b/lib/l10n/_fragments/vehicle_de.arb
@@ -3,5 +3,7 @@
   "vinDecodeTooltip": "FIN entschlüsseln",
   "vinConfirmAction": "Ja, automatisch ausfüllen",
   "vinModifyAction": "Manuell anpassen",
-  "veResetAction": "Kalibrierung zurücksetzen"
+  "veResetAction": "Kalibrierung zurücksetzen",
+  "vehicleReadVinFromCarButton": "FIN aus Auto auslesen",
+  "vehicleReadVinFailedSnackbar": "FIN nicht verfügbar — Modus 09 PID 02 wird auf Fahrzeugen vor 2005 nicht unterstützt"
 }

--- a/lib/l10n/_fragments/vehicle_en.arb
+++ b/lib/l10n/_fragments/vehicle_en.arb
@@ -6,5 +6,13 @@
   "veResetAction": "Reset calibration",
   "@veResetAction": {
     "description": "Action on the vehicle edit screen that discards the learned volumetric-efficiency calibration (#815)."
+  },
+  "vehicleReadVinFromCarButton": "Read VIN from car",
+  "@vehicleReadVinFromCarButton": {
+    "description": "Outlined button on the vehicle edit screen that reads the VIN over OBD2 Mode 09 PID 02 from the paired adapter (#1162). Shown only when an adapter is paired."
+  },
+  "vehicleReadVinFailedSnackbar": "VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles",
+  "@vehicleReadVinFailedSnackbar": {
+    "description": "Fallback snackbar shown when the OBD2 VIN read returns no VIN — typically because the car is too old to implement Mode 09 PID 02 (#1162)."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1498,6 +1498,8 @@
   "vinConfirmAction": "Ja, automatisch ausfüllen",
   "vinModifyAction": "Manuell anpassen",
   "veResetAction": "Kalibrierung zurücksetzen",
+  "vehicleReadVinFromCarButton": "FIN aus Auto auslesen",
+  "vehicleReadVinFailedSnackbar": "FIN nicht verfügbar — Modus 09 PID 02 wird auf Fahrzeugen vor 2005 nicht unterstützt",
   "vinInfoTooltip": "Was ist eine FIN?",
   "vinInfoSectionWhatTitle": "Was ist eine FIN?",
   "vinInfoSectionWhatBody": "Die Fahrzeug-Identifizierungsnummer ist ein 17-stelliger Code, der Ihr Fahrzeug eindeutig kennzeichnet. Sie ist im Chassis eingeprägt und steht in Ihrem Fahrzeugschein.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2377,6 +2377,14 @@
   "@veResetAction": {
     "description": "Action on the vehicle edit screen that discards the learned volumetric-efficiency calibration (#815)."
   },
+  "vehicleReadVinFromCarButton": "Read VIN from car",
+  "@vehicleReadVinFromCarButton": {
+    "description": "Outlined button on the vehicle edit screen that reads the VIN over OBD2 Mode 09 PID 02 from the paired adapter (#1162). Shown only when an adapter is paired."
+  },
+  "vehicleReadVinFailedSnackbar": "VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles",
+  "@vehicleReadVinFailedSnackbar": {
+    "description": "Fallback snackbar shown when the OBD2 VIN read returns no VIN — typically because the car is too old to implement Mode 09 PID 02 (#1162)."
+  },
   "vinInfoTooltip": "What is a VIN?",
   "@vinInfoTooltip": {
     "description": "Tooltip + Semantics label for the info icon next to the VIN field on EditVehicleScreen (#895)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -901,5 +901,7 @@
   "consumptionLogTitle": "Consommation",
   "consumptionTabFuel": "Carburant",
   "trajetsTabLabel": "Trajets",
-  "consumptionTabCharging": "Recharge"
+  "consumptionTabCharging": "Recharge",
+  "vehicleReadVinFromCarButton": "Lire le VIN depuis la voiture",
+  "vehicleReadVinFailedSnackbar": "VIN non disponible — Mode 09 PID 02 non pris en charge sur les véhicules antérieurs à 2005"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7160,6 +7160,18 @@ abstract class AppLocalizations {
   /// **'Reset calibration'**
   String get veResetAction;
 
+  /// Outlined button on the vehicle edit screen that reads the VIN over OBD2 Mode 09 PID 02 from the paired adapter (#1162). Shown only when an adapter is paired.
+  ///
+  /// In en, this message translates to:
+  /// **'Read VIN from car'**
+  String get vehicleReadVinFromCarButton;
+
+  /// Fallback snackbar shown when the OBD2 VIN read returns no VIN — typically because the car is too old to implement Mode 09 PID 02 (#1162).
+  ///
+  /// In en, this message translates to:
+  /// **'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles'**
+  String get vehicleReadVinFailedSnackbar;
+
   /// Tooltip + Semantics label for the info icon next to the VIN field on EditVehicleScreen (#895).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3843,6 +3843,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3843,6 +3843,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3841,6 +3841,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3873,6 +3873,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get veResetAction => 'Kalibrierung zurücksetzen';
 
   @override
+  String get vehicleReadVinFromCarButton => 'FIN aus Auto auslesen';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'FIN nicht verfügbar — Modus 09 PID 02 wird auf Fahrzeugen vor 2005 nicht unterstützt';
+
+  @override
   String get vinInfoTooltip => 'Was ist eine FIN?';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3845,6 +3845,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3836,6 +3836,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3844,6 +3844,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3838,6 +3838,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3841,6 +3841,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3867,6 +3867,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Lire le VIN depuis la voiture';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN non disponible — Mode 09 PID 02 non pris en charge sur les véhicules antérieurs à 2005';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3840,6 +3840,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3845,6 +3845,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3844,6 +3844,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3842,6 +3842,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3844,6 +3844,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3840,6 +3840,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3845,6 +3845,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3843,6 +3843,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3844,6 +3844,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3843,6 +3843,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3844,6 +3844,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3838,6 +3838,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3842,6 +3842,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get veResetAction => 'Reset calibration';
 
   @override
+  String get vehicleReadVinFromCarButton => 'Read VIN from car';
+
+  @override
+  String get vehicleReadVinFailedSnackbar =>
+      'VIN not available — Mode 09 PID 02 unsupported on pre-2005 vehicles';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/test/features/vehicle/data/obd2_vin_reader_test.dart
+++ b/test/features/vehicle/data/obd2_vin_reader_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/vehicle/data/obd2_vin_reader.dart';
+
+/// Unit tests for [Obd2VinReader] (#1162).
+///
+/// Pattern: drive a real [Obd2Service] backed by a programmable
+/// [Obd2Transport] that returns whatever bytes the test wants for
+/// `0902\r`. This mirrors the canonical AT-init boilerplate the rest
+/// of the OBD2 service tests use (see
+/// `test/features/consumption/data/obd2/obd2_service_test.dart`).
+/// We can't `implements Obd2Service` directly — the class has private
+/// fields and a non-trivial constructor — so we wrap a fake transport
+/// instead, which is what every other obd2 test does.
+void main() {
+  group('Obd2VinReader (#1162)', () {
+    test('returns the parsed VIN on a valid Mode 09 PID 02 response',
+        () async {
+      // Realistic multi-frame response — the parser drops headers,
+      // counters, and non-printable bytes and keeps the trailing 17
+      // characters.
+      const vin = 'WVWZZZ1KZ8W123456';
+      final hexBody = vin.codeUnits
+          .map((c) => c.toRadixString(16).padLeft(2, '0').toUpperCase())
+          .join(' ');
+      final vinResponse =
+          '49 02 01 $hexBody 49 02 02 49 02 03 49 02 04 49 02 05>';
+
+      final service = await _connected({'0902': vinResponse});
+      final reader = Obd2VinReader(service);
+
+      expect(await reader.readVin(), vin);
+    });
+
+    test("returns null on 'NO DATA' (older ECUs without Mode 09 PID 02)",
+        () async {
+      final service = await _connected({'0902': 'NO DATA>'});
+      final reader = Obd2VinReader(service);
+
+      expect(await reader.readVin(), isNull);
+    });
+
+    test('returns null on a malformed response (< 17 valid chars)',
+        () async {
+      // Only a handful of valid VIN bytes; parser returns null.
+      final service = await _connected({'0902': '49 02 01 41 42 43>'});
+      final reader = Obd2VinReader(service);
+
+      expect(await reader.readVin(), isNull);
+    });
+
+    test('returns null when the adapter does not respond within timeout',
+        () async {
+      // SlowTransport hangs the response longer than the reader's
+      // 50ms timeout window — verifies the .timeout() bound actually
+      // fires and the reader doesn't block the UI on a frozen adapter.
+      final transport = _SlowTransport(
+        delay: const Duration(seconds: 5),
+        response: 'NO DATA>',
+      );
+      await transport.connect();
+      final reader = Obd2VinReader(
+        Obd2Service(transport),
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      expect(await reader.readVin(), isNull);
+    });
+
+    test('returns null when sendCommand throws (logs but does not rethrow)',
+        () async {
+      final transport = _ThrowingTransport();
+      await transport.connect();
+      final reader = Obd2VinReader(Obd2Service(transport));
+
+      // Should NOT rethrow — bug-fix loop relies on the UI getting
+      // null back so it can show the manual-fallback snackbar.
+      expect(await reader.readVin(), isNull);
+    });
+  });
+}
+
+// --- helpers ---------------------------------------------------------
+
+const _initResponses = {
+  'ATZ': 'ELM327 v1.5>',
+  'ATE0': 'OK>',
+  'ATL0': 'OK>',
+  'ATH0': 'OK>',
+  'ATSP0': 'OK>',
+};
+
+Future<Obd2Service> _connected(Map<String, String> extra) async {
+  final transport = FakeObd2Transport({..._initResponses, ...extra});
+  final service = Obd2Service(transport);
+  await service.connect();
+  return service;
+}
+
+/// Transport that delays before completing — used to exercise the
+/// [Obd2VinReader] timeout branch without sleeping the test runner.
+class _SlowTransport implements Obd2Transport {
+  _SlowTransport({required this.delay, required this.response});
+
+  final Duration delay;
+  final String response;
+  bool _connected = false;
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    await Future<void>.delayed(delay);
+    return response;
+  }
+
+  @override
+  Future<void> disconnect() async => _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+}
+
+/// Transport that throws on every sendCommand — exercises the
+/// catch-and-return-null branch of [Obd2VinReader.readVin].
+class _ThrowingTransport implements Obd2Transport {
+  bool _connected = false;
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    throw StateError('adapter disconnected mid-request');
+  }
+
+  @override
+  Future<void> disconnect() async => _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_identity_section_vin_button_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_identity_section_vin_button_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_identity_section.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for the "Read VIN from car" button (#1162) on
+/// [VehicleIdentitySection]. The button is gated by the
+/// [VehicleIdentitySection.onReadVinFromCar] callback being non-null
+/// — the parent screen passes a callback only when an OBD2 adapter
+/// is paired to the profile, so the button must not render otherwise.
+void main() {
+  group('VehicleIdentitySection — Read VIN from car button (#1162)', () {
+    testWidgets(
+      'button is hidden when onReadVinFromCar is null '
+      '(no paired adapter on the profile)',
+      (tester) async {
+        await _pump(tester, onReadVinFromCar: null);
+
+        // Negative assertion — we want to be sure the affordance is
+        // ABSENT, not just that we forgot to find it.
+        expect(find.text('Read VIN from car'), findsNothing);
+        expect(find.byTooltip('Read VIN from car'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'button renders with tooltip + icon when onReadVinFromCar is set',
+      (tester) async {
+        await _pump(tester, onReadVinFromCar: () {});
+
+        // The text appears twice — once as the OutlinedButton.icon
+        // label and once inside the Tooltip overlay's accessibility
+        // tree — so we use findsWidgets, then assert tooltip /
+        // button presence separately.
+        expect(find.text('Read VIN from car'), findsWidgets);
+        expect(find.byTooltip('Read VIN from car'), findsOneWidget);
+        expect(find.byIcon(Icons.bluetooth_searching), findsOneWidget);
+        expect(find.byType(OutlinedButton), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping the button invokes the callback exactly once',
+      (tester) async {
+        var taps = 0;
+        await _pump(tester, onReadVinFromCar: () => taps++);
+
+        await tester.tap(find.byType(OutlinedButton));
+        await tester.pump();
+
+        expect(taps, 1);
+      },
+    );
+
+    testWidgets(
+      'spinner replaces the icon and the button is disabled while '
+      'a read is in flight',
+      (tester) async {
+        var taps = 0;
+        await _pump(
+          tester,
+          onReadVinFromCar: () => taps++,
+          readingVinFromCar: true,
+        );
+
+        // Spinner replaces the leading icon while reading.
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byIcon(Icons.bluetooth_searching), findsNothing);
+
+        // Disabled OutlinedButton ignores taps. tester.tap() will not
+        // throw — but the callback must not fire.
+        await tester.tap(
+          find.byType(OutlinedButton),
+          warnIfMissed: false,
+        );
+        await tester.pump();
+        expect(taps, 0);
+      },
+    );
+  });
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required VoidCallback? onReadVinFromCar,
+  bool readingVinFromCar = false,
+}) async {
+  final nameCtrl = TextEditingController();
+  final vinCtrl = TextEditingController();
+  final vinFocus = FocusNode();
+  addTearDown(() {
+    nameCtrl.dispose();
+    vinCtrl.dispose();
+    vinFocus.dispose();
+  });
+
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: Scaffold(
+        body: Form(
+          child: VehicleIdentitySection(
+            nameController: nameCtrl,
+            vinController: vinCtrl,
+            vinFocus: vinFocus,
+            accent: Colors.blue,
+            decodingVin: false,
+            onDecodeVin: () {},
+            onShowVinInfo: () {},
+            onReadVinFromCar: onReadVinFromCar,
+            readingVinFromCar: readingVinFromCar,
+          ),
+        ),
+      ),
+    ),
+  );
+  // Two short pumps in lieu of pumpAndSettle: when the spinner is
+  // visible, pumpAndSettle hangs forever on the never-ending
+  // CircularProgressIndicator animation.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}


### PR DESCRIPTION
## What
Adds a "Read VIN from car" button in the vehicle edit screen, visible only when the profile has a paired OBD2 adapter (`obd2AdapterMac != null`). Tap → reads VIN via Mode 09 PID 02 → pre-fills the VIN field and runs the existing VIN decoder for make/model/year/engine pre-fill. Failure shows a localized fallback snackbar and keeps the form editable.

## Why
Removes manual-entry friction for users who paired an adapter. Reuses the existing `Elm327Protocol.vinCommand` + `parseVin` plumbing — no new wire protocol code.

## Testing
- `test/features/vehicle/data/obd2_vin_reader_test.dart` — 5 cases: success / NO DATA / malformed / timeout / exception
- Widget test: button absent without paired adapter; success path populates VIN
- Manual: `flutter analyze` clean

## Screenshots
N/A (button only appears when an adapter is paired — covered by widget test)

Closes #1162