### PR TITLE
test(data): cover SupabaseAuthRepository + data_providers (Refs #561)

### DIFF
--- a/test/core/data/data_providers_test.dart
+++ b/test/core/data/data_providers_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/auth_repository.dart';
+import 'package:tankstellen/core/data/data_providers.dart';
+import 'package:tankstellen/core/data/impl/supabase_auth_repository.dart';
+import 'package:tankstellen/core/data/impl/supabase_sync_repository.dart';
+import 'package:tankstellen/core/data/sync_repository.dart';
+
+/// Tests the Riverpod factory providers in [data_providers.dart].
+///
+/// These providers are `@Riverpod(keepAlive: true)` — they wire the abstract
+/// repository interfaces to concrete Supabase implementations. The test
+/// verifies the factory wiring, the type erasure to the abstract interface,
+/// and the keepAlive caching contract (same instance on second read).
+void main() {
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer();
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  group('syncRepositoryProvider', () {
+    test('returns a SupabaseSyncRepository instance', () {
+      final repo = container.read(syncRepositoryProvider);
+      expect(repo, isA<SupabaseSyncRepository>());
+    });
+
+    test('exposes the SyncRepository abstract interface', () {
+      final repo = container.read(syncRepositoryProvider);
+      expect(repo, isA<SyncRepository>());
+    });
+
+    test('returns the same instance on second read (keepAlive caching)', () {
+      final first = container.read(syncRepositoryProvider);
+      final second = container.read(syncRepositoryProvider);
+      expect(identical(first, second), isTrue);
+    });
+  });
+
+  group('authRepositoryProvider', () {
+    test('returns a SupabaseAuthRepository instance', () {
+      final repo = container.read(authRepositoryProvider);
+      expect(repo, isA<SupabaseAuthRepository>());
+    });
+
+    test('exposes the AuthRepository abstract interface', () {
+      final repo = container.read(authRepositoryProvider);
+      expect(repo, isA<AuthRepository>());
+    });
+
+    test('returns the same instance on second read (keepAlive caching)', () {
+      final first = container.read(authRepositoryProvider);
+      final second = container.read(authRepositoryProvider);
+      expect(identical(first, second), isTrue);
+    });
+  });
+
+  group('provider isolation', () {
+    test('sync and auth providers return different instances', () {
+      final sync = container.read(syncRepositoryProvider);
+      final auth = container.read(authRepositoryProvider);
+      expect(identical(sync, auth), isFalse);
+    });
+
+    test('a fresh container produces a fresh sync repository', () {
+      final repoA = container.read(syncRepositoryProvider);
+
+      final containerB = ProviderContainer();
+      addTearDown(containerB.dispose);
+      final repoB = containerB.read(syncRepositoryProvider);
+
+      expect(identical(repoA, repoB), isFalse);
+    });
+
+    test('a fresh container produces a fresh auth repository', () {
+      final repoA = container.read(authRepositoryProvider);
+
+      final containerB = ProviderContainer();
+      addTearDown(containerB.dispose);
+      final repoB = containerB.read(authRepositoryProvider);
+
+      expect(identical(repoA, repoB), isFalse);
+    });
+  });
+}

--- a/test/core/data/supabase_auth_repository_test.dart
+++ b/test/core/data/supabase_auth_repository_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/auth_repository.dart';
+import 'package:tankstellen/core/data/impl/supabase_auth_repository.dart';
+
+/// Tests that [SupabaseAuthRepository] is a thin adapter delegating to
+/// [TankSyncClient]'s static methods. Since TankSyncClient is not initialized
+/// in tests, all methods hit the "no client" fallback path — returning
+/// null / false / no-op. This verifies the delegation works end-to-end.
+void main() {
+  late SupabaseAuthRepository repo;
+
+  setUp(() {
+    repo = SupabaseAuthRepository();
+  });
+
+  group('SupabaseAuthRepository implements AuthRepository', () {
+    test('is an AuthRepository', () {
+      expect(repo, isA<AuthRepository>());
+    });
+
+    test('isConnected returns false when TankSyncClient not initialized', () {
+      expect(repo.isConnected, isFalse);
+    });
+
+    test('currentEmail returns null when not connected', () {
+      expect(repo.currentEmail, isNull);
+    });
+
+    test('hasEmailAccount returns false when not connected', () {
+      expect(repo.hasEmailAccount, isFalse);
+    });
+  });
+
+  group('SupabaseAuthRepository - unauthenticated delegation', () {
+    // All methods delegate to TankSyncClient static methods.
+    // Without an initialized client, sign-in methods return null
+    // and signOut is a no-op.
+
+    test('signInAnonymously returns null when client not initialized',
+        () async {
+      final result = await repo.signInAnonymously();
+      expect(result, isNull);
+    });
+
+    test('signUpWithEmail returns null when client not initialized', () async {
+      final result = await repo.signUpWithEmail(
+        'test@example.com',
+        'password123',
+      );
+      expect(result, isNull);
+    });
+
+    test('signInWithEmail returns null when client not initialized', () async {
+      final result = await repo.signInWithEmail(
+        'test@example.com',
+        'password123',
+      );
+      expect(result, isNull);
+    });
+
+    test('signOut completes without error when client not initialized',
+        () async {
+      // Should not throw — just no-ops when client is null
+      await expectLater(repo.signOut(), completes);
+    });
+  });
+
+  group('SupabaseAuthRepository - init validation', () {
+    // init() delegates to TankSyncClient.init, which validates the URL
+    // before touching Supabase. Invalid URLs should throw ArgumentError.
+
+    test('init throws ArgumentError on invalid URL', () async {
+      await expectLater(
+        repo.init(url: 'not-a-url', anonKey: 'anon'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('init throws ArgumentError on empty URL', () async {
+      await expectLater(
+        repo.init(url: '', anonKey: 'anon'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Scope

Bundled phase PR for the test-coverage epic (#561). Adds unit tests for two zero-coverage thin-delegator files in `lib/core/data/`:

- **`supabase_auth_repository.dart`** (36 LOC) — `AuthRepository` adapter that delegates every method to `TankSyncClient`'s static surface. New tests cover interface conformance, the unauthenticated/uninitialized fallback path (sign-in methods return `null`, `signOut` no-ops, `isConnected`/`hasEmailAccount` false, `currentEmail` null), and `ArgumentError` surfacing from `init()` URL validation.
- **`data_providers.dart`** (20 LOC) — Riverpod factory exposing `syncRepositoryProvider` and `authRepositoryProvider`. New tests verify the factory wiring, type erasure to the abstract interfaces, the `keepAlive: true` caching contract (same instance on second read), and isolation across `ProviderContainer` boundaries.

No production code changes.

## Why

Two thin delegators sat at 0% coverage even though they're on every TankSync code path. They're cheap to lock in (~175 LOC of tests, vanilla `ProviderContainer`, no fakes/mocks), and uncovered factory wiring is the kind of thing that breaks silently when interfaces shift.

`Refs #561` (epic stays open until 80% threshold reached).

## Test plan

- `flutter analyze` — 0 issues
- `flutter test test/core/data/supabase_auth_repository_test.dart test/core/data/data_providers_test.dart` — 19/19 pass (10 auth + 9 data_providers)