### PR TITLE
refactor(search): extract sub-widgets out of all_prices_station_card (Refs #563 phase: all_prices_station_card)

### DIFF
--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -5,6 +5,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/station.dart';
 
+part 'all_prices_station_card_parts.dart';
+
 /// A detailed station card that shows ALL available fuel prices.
 ///
 /// Designed for the all-prices list view, similar to Essence&Co.
@@ -194,118 +196,5 @@ class AllPricesStationCard extends StatelessWidget {
     }
 
     return badges;
-  }
-}
-
-class _FuelBadge extends StatelessWidget {
-  final String label;
-  final double? price;
-  final FuelType fuelType;
-  final bool isUnavailable;
-  final bool isCheapest;
-
-  /// When true, this badge is the user's preferred fuel type and should be
-  /// rendered larger with a thicker border to stand out.
-  final bool isProfileFuel;
-
-  const _FuelBadge({
-    required this.label,
-    required this.price,
-    required this.fuelType,
-    this.isUnavailable = false,
-    this.isCheapest = false,
-    this.isProfileFuel = false,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-    final color = FuelColors.forType(fuelType);
-
-    final isHighlighted = isProfileFuel && !isUnavailable;
-    final isChampion = isCheapest && !isUnavailable;
-
-    final borderColor = isChampion ? color : color;
-    final bgColor = isChampion
-        ? color
-        : isHighlighted
-            ? FuelColors.forType(fuelType).withValues(alpha: 0.22)
-            : FuelColors.forTypeLight(fuelType);
-
-    final borderWidth = isChampion ? 1.5 : (isHighlighted ? 1.5 : 0.5);
-    final labelFontSize = isHighlighted ? 11.0 : 10.0;
-    final priceFontSize = isHighlighted ? 13.0 : 11.0;
-    final dotSize = isHighlighted ? 8.0 : 6.0;
-    final verticalPadding = isHighlighted ? 5.0 : 4.0;
-    final horizontalPadding = isHighlighted ? 10.0 : 8.0;
-
-    return Container(
-      padding: EdgeInsets.symmetric(
-        horizontal: horizontalPadding,
-        vertical: verticalPadding,
-      ),
-      decoration: BoxDecoration(
-        color: isUnavailable
-            ? theme.colorScheme.surfaceContainerHighest
-            : bgColor,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: isUnavailable
-              ? theme.colorScheme.outlineVariant
-              : borderColor,
-          width: borderWidth,
-        ),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: dotSize,
-            height: dotSize,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: isUnavailable
-                  ? theme.colorScheme.onSurfaceVariant
-                  : isChampion
-                      ? Colors.white
-                      : color,
-            ),
-          ),
-          const SizedBox(width: 4),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: labelFontSize,
-              fontWeight: isHighlighted || isChampion
-                  ? FontWeight.bold
-                  : FontWeight.w600,
-              color: isUnavailable
-                  ? theme.colorScheme.onSurfaceVariant
-                  : isChampion
-                      ? Colors.white
-                      : color,
-            ),
-          ),
-          const SizedBox(width: 4),
-          Text(
-            isUnavailable
-                ? (l10n?.outOfStock ?? 'Out of stock')
-                : PriceFormatter.formatPriceCompact(price),
-            style: TextStyle(
-              fontSize: priceFontSize,
-              fontWeight: FontWeight.bold,
-              color: isUnavailable
-                  ? theme.colorScheme.onSurfaceVariant
-                  : isChampion
-                      ? Colors.white
-                      : isHighlighted
-                          ? color
-                          : theme.colorScheme.onSurface,
-            ),
-          ),
-        ],
-      ),
-    );
   }
 }

--- a/lib/features/search/presentation/widgets/all_prices_station_card_parts.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card_parts.dart
@@ -1,0 +1,117 @@
+part of 'all_prices_station_card.dart';
+
+/// A single fuel badge rendered inside [AllPricesStationCard].
+///
+/// Library-private (`part of`) so the public API of the card stays unchanged.
+class _FuelBadge extends StatelessWidget {
+  final String label;
+  final double? price;
+  final FuelType fuelType;
+  final bool isUnavailable;
+  final bool isCheapest;
+
+  /// When true, this badge is the user's preferred fuel type and should be
+  /// rendered larger with a thicker border to stand out.
+  final bool isProfileFuel;
+
+  const _FuelBadge({
+    required this.label,
+    required this.price,
+    required this.fuelType,
+    this.isUnavailable = false,
+    this.isCheapest = false,
+    this.isProfileFuel = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final color = FuelColors.forType(fuelType);
+
+    final isHighlighted = isProfileFuel && !isUnavailable;
+    final isChampion = isCheapest && !isUnavailable;
+
+    final borderColor = isChampion ? color : color;
+    final bgColor = isChampion
+        ? color
+        : isHighlighted
+            ? FuelColors.forType(fuelType).withValues(alpha: 0.22)
+            : FuelColors.forTypeLight(fuelType);
+
+    final borderWidth = isChampion ? 1.5 : (isHighlighted ? 1.5 : 0.5);
+    final labelFontSize = isHighlighted ? 11.0 : 10.0;
+    final priceFontSize = isHighlighted ? 13.0 : 11.0;
+    final dotSize = isHighlighted ? 8.0 : 6.0;
+    final verticalPadding = isHighlighted ? 5.0 : 4.0;
+    final horizontalPadding = isHighlighted ? 10.0 : 8.0;
+
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: horizontalPadding,
+        vertical: verticalPadding,
+      ),
+      decoration: BoxDecoration(
+        color: isUnavailable
+            ? theme.colorScheme.surfaceContainerHighest
+            : bgColor,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: isUnavailable
+              ? theme.colorScheme.outlineVariant
+              : borderColor,
+          width: borderWidth,
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: dotSize,
+            height: dotSize,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: isUnavailable
+                  ? theme.colorScheme.onSurfaceVariant
+                  : isChampion
+                      ? Colors.white
+                      : color,
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: labelFontSize,
+              fontWeight: isHighlighted || isChampion
+                  ? FontWeight.bold
+                  : FontWeight.w600,
+              color: isUnavailable
+                  ? theme.colorScheme.onSurfaceVariant
+                  : isChampion
+                      ? Colors.white
+                      : color,
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            isUnavailable
+                ? (l10n?.outOfStock ?? 'Out of stock')
+                : PriceFormatter.formatPriceCompact(price),
+            style: TextStyle(
+              fontSize: priceFontSize,
+              fontWeight: FontWeight.bold,
+              color: isUnavailable
+                  ? theme.colorScheme.onSurfaceVariant
+                  : isChampion
+                      ? Colors.white
+                      : isHighlighted
+                          ? color
+                          : theme.colorScheme.onSurface,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Extract the private `_FuelBadge` widget from `all_prices_station_card.dart` into a sibling part file to bring the main file back under the 300-LOC screen-file budget.

- **Before:** 311 LOC (over budget)
- **After:** 200 LOC (main) + 117 LOC (`all_prices_station_card_parts.dart`)
- Mechanism: Dart `part` / `part of` keeps `_FuelBadge` library-private. Public API of `AllPricesStationCard` is unchanged.

## Why

`#563` epic — keep screen/widget files under 300 LOC. `_FuelBadge` is a self-contained sub-widget and was the dominant block (~110 LOC), so a single extraction is enough; no over-engineering.

## Behavior

No behavior change. Constructor, params, and rendering are byte-identical.

## Tests

- `test/features/search/presentation/widgets/all_prices_station_card_test.dart` - all 29 tests pass unchanged.
- `test/a11y/text_scaling_test.dart` - text-scaling regression tests for the card pass unchanged.
- `flutter analyze` - clean (no issues).

Refs #563 phase: all_prices_station_card

🤖 Generated with [Claude Code](https://claude.com/claude-code)