### PR TITLE
feat(consumption): driving-score composite card on Insights tab (Refs #1041 phase 5a)

### DIFF
--- a/lib/features/consumption/data/driving_score_calculator.dart
+++ b/lib/features/consumption/data/driving_score_calculator.dart
@@ -1,0 +1,193 @@
+/// Pure calculator that turns a stream of [TripSample]s into a
+/// [DrivingScore] composite for the trip Insights tab (#1041 phase 5a
+/// — Card A).
+///
+/// ## Score model
+///
+/// Start at 100 and subtract penalty contributions per category. The
+/// final score is floored at 0 and capped at 100. Weights are
+/// intentionally coarse — the goal is *coaching*, not telematics-grade
+/// scoring. Future phases may calibrate against the per-vehicle
+/// baseline store; until then the same constants used by the cost-line
+/// analyzer (`driving_insights_analyzer.dart`) are reused so the two
+/// surfaces stay consistent.
+///
+/// ## Weights (sum of caps = 85; remaining 15 of headroom keeps the
+/// floor reachable only on truly catastrophic trips)
+///
+///   * Idling: linear in idle-time fraction of trip duration. 100% of
+///     the trip idling = -25. (50 % idling = -12.5.)
+///   * Hard accelerations (≥ 3.0 m/s²): -3 per event, capped at -15
+///     (so 5+ events saturates).
+///   * Hard brakes (≤ -3.0 m/s²): -3 per event, capped at -15.
+///   * High-RPM time (> 3000 RPM): linear in fraction of trip
+///     duration, full saturation at -20 when the entire trip was
+///     above threshold.
+///   * Full-throttle time: linear in fraction of trip duration, full
+///     saturation at -10. Persisted [TripSample]s do not currently
+///     carry throttle %, so this contribution is 0 for legacy trips —
+///     the calculator still exposes the field so the UI does not need
+///     a schema change when throttle persistence lands. The
+///     [TripSample] schema may grow a `throttlePercent` field in a
+///     follow-up; until then the throttle penalty stays a documented
+///     no-op.
+///
+/// ## Sub-text follow-up
+///
+/// The issue body describes a "Better than X% of past trips" sub-text
+/// that consumes the existing baseline store. That store
+/// (`baseline_store.dart`) tracks per-vehicle per-situation
+/// *steady-state baselines*, not per-trip scores, so a trip-history
+/// percentile is its own piece of work. This calculator therefore
+/// returns a single [DrivingScore] without any percentile context;
+/// surfacing percentile / "better than X%" is intentionally deferred
+/// to a follow-up phase.
+library;
+
+import '../domain/driving_score.dart';
+import '../domain/trip_recorder.dart';
+
+/// RPM above which a sample counts as "high RPM". Mirrors the constant
+/// in `driving_insights_analyzer.dart` so the two coaching surfaces
+/// agree on what "above threshold" means.
+const double _highRpmThreshold = 3000;
+
+/// Acceleration (m/s²) above which an interval counts as a hard
+/// acceleration event. Same threshold the analyzer uses.
+const double _hardAccelThresholdMps2 = 3.0;
+
+/// Negative acceleration (m/s²) below which an interval counts as a
+/// hard brake event. Stored as a positive number; comparison uses the
+/// negated form.
+const double _hardBrakeThresholdMps2 = 3.0;
+
+/// Speed (km/h) at or below which the recorder treats the car as
+/// "stationary" for idle accounting. Matches the analyzer's tolerance.
+const double _idleSpeedToleranceKmh = 0.5;
+
+/// Penalty caps per category. Documented in the leading comment.
+const double _idlingPenaltyCap = 25.0;
+const double _hardAccelPenaltyCap = 15.0;
+const double _hardBrakePenaltyCap = 15.0;
+const double _highRpmPenaltyCap = 20.0;
+const double _fullThrottlePenaltyCap = 10.0;
+
+/// Per-event score deductions.
+const double _hardAccelPenaltyPerEvent = 3.0;
+const double _hardBrakePenaltyPerEvent = 3.0;
+
+/// Compute a composite driving score for the given trip samples.
+/// Empty / single-sample trips return [DrivingScore.perfect] — there is
+/// no Δt to integrate, so we cannot fairly attribute any penalty.
+///
+/// The function is pure and synchronous — safe to call from a UI
+/// thread for trip durations the app realistically records (a 60-min
+/// trip at 1 Hz is 3 600 samples; the loop is O(n)).
+DrivingScore computeDrivingScore(List<TripSample> samples) {
+  if (samples.length < 2) return DrivingScore.perfect;
+
+  // Sort by timestamp so out-of-order persistence (#1040 race
+  // conditions) doesn't blow up the integration. Copy first so we
+  // don't mutate the caller's list.
+  final sorted = [...samples]
+    ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+  // Total trip duration — used to compute time-fraction penalties.
+  final totalDt = sorted.last.timestamp
+          .difference(sorted.first.timestamp)
+          .inMicroseconds /
+      Duration.microsecondsPerSecond;
+  if (totalDt <= 0) return DrivingScore.perfect;
+
+  // Accumulators.
+  double idleSeconds = 0;
+  double highRpmSeconds = 0;
+  // Full-throttle accounting is left at zero by design — see the
+  // module-level docstring for why.
+  const double fullThrottleSeconds = 0;
+  int hardAccelEvents = 0;
+  int hardBrakeEvents = 0;
+
+  for (var i = 1; i < sorted.length; i++) {
+    final prev = sorted[i - 1];
+    final cur = sorted[i];
+    final dt =
+        cur.timestamp.difference(prev.timestamp).inMicroseconds /
+            Duration.microsecondsPerSecond;
+    if (dt <= 0) continue;
+
+    // Idle accounting: engine on, car stationary across the whole
+    // interval. Mirrors the analyzer's tolerance to absorb OBD2 noise.
+    if (prev.speedKmh <= _idleSpeedToleranceKmh && prev.rpm > 0) {
+      idleSeconds += dt;
+    }
+
+    // High-RPM accounting: attribute the whole interval to the START
+    // sample's RPM (the ~1 Hz polling cadence is short relative to gear
+    // shifts; matches the analyzer's convention).
+    if (prev.rpm > _highRpmThreshold) {
+      highRpmSeconds += dt;
+    }
+
+    // Hard accel / brake events: derivative of speed across the
+    // interval. Convert km/h → m/s by / 3.6. Threshold is inclusive
+    // for accel and inclusive (negated) for brake — matches the
+    // analyzer.
+    final dvMps = (cur.speedKmh - prev.speedKmh) / 3.6;
+    final accelMps2 = dvMps / dt;
+    if (accelMps2 >= _hardAccelThresholdMps2) {
+      hardAccelEvents++;
+    } else if (accelMps2 <= -_hardBrakeThresholdMps2) {
+      hardBrakeEvents++;
+    }
+  }
+
+  // Per-category penalties.
+  final idlingPenalty =
+      _clamp(idleSeconds / totalDt * _idlingPenaltyCap, 0, _idlingPenaltyCap);
+  final highRpmPenalty = _clamp(
+    highRpmSeconds / totalDt * _highRpmPenaltyCap,
+    0,
+    _highRpmPenaltyCap,
+  );
+  final hardAccelPenalty = _clamp(
+    hardAccelEvents * _hardAccelPenaltyPerEvent,
+    0,
+    _hardAccelPenaltyCap,
+  );
+  final hardBrakePenalty = _clamp(
+    hardBrakeEvents * _hardBrakePenaltyPerEvent,
+    0,
+    _hardBrakePenaltyCap,
+  );
+  final fullThrottlePenalty = _clamp(
+    fullThrottleSeconds / totalDt * _fullThrottlePenaltyCap,
+    0,
+    _fullThrottlePenaltyCap,
+  );
+
+  final raw = 100.0 -
+      idlingPenalty -
+      highRpmPenalty -
+      hardAccelPenalty -
+      hardBrakePenalty -
+      fullThrottlePenalty;
+  // Floor at 0, cap at 100, then round to the nearest integer.
+  final clamped = _clamp(raw, 0, 100);
+  final scoreInt = clamped.round();
+
+  return DrivingScore(
+    score: scoreInt,
+    idlingPenalty: idlingPenalty,
+    hardAccelPenalty: hardAccelPenalty,
+    hardBrakePenalty: hardBrakePenalty,
+    highRpmPenalty: highRpmPenalty,
+    fullThrottlePenalty: fullThrottlePenalty,
+  );
+}
+
+double _clamp(double value, double low, double high) {
+  if (value < low) return low;
+  if (value > high) return high;
+  return value;
+}

--- a/lib/features/consumption/domain/driving_score.dart
+++ b/lib/features/consumption/domain/driving_score.dart
@@ -1,0 +1,100 @@
+import 'package:meta/meta.dart';
+
+/// One composite "driving score" for a single trip on the Trip detail
+/// Insights tab (#1041 phase 5a — Card A).
+///
+/// The score is a 0..100 integer where 100 is "no behaviour-driven
+/// waste detected" and 0 is "every category capped out simultaneously".
+/// Each public penalty field is the contribution (in score points)
+/// subtracted from the starting 100 — exposed so the UI can surface
+/// the top one or two penalty lines as a small explanatory chip row
+/// without having to recompute anything.
+///
+/// The class is intentionally UI-agnostic — no `BuildContext`, no
+/// `AppLocalizations`. The calculator in
+/// `driving_score_calculator.dart` produces this from raw
+/// [TripSample]s; the same value-object can be persisted, replayed, or
+/// aggregated across trips later (phase 4 / phase 5) without touching
+/// UI code.
+@immutable
+class DrivingScore {
+  /// 0..100 composite. Higher is better. Always clamped to the
+  /// inclusive [0, 100] range by the calculator.
+  final int score;
+
+  /// Score-points subtracted because of idle time (engine on, speed
+  /// near zero). Capped at 25 by the calculator. Documented weights
+  /// live alongside the calculator constants.
+  final double idlingPenalty;
+
+  /// Score-points subtracted because of hard-acceleration events
+  /// (≥ 3.0 m/s²). Capped at 15.
+  final double hardAccelPenalty;
+
+  /// Score-points subtracted because of hard-braking events
+  /// (≤ -3.0 m/s²). Capped at 15.
+  final double hardBrakePenalty;
+
+  /// Score-points subtracted because of time spent above the
+  /// high-RPM threshold (3000 RPM). Capped at 20.
+  final double highRpmPenalty;
+
+  /// Score-points subtracted because of time at full throttle. Capped
+  /// at 10. Persisted [TripSample]s do not currently carry throttle
+  /// position, so this contribution stays at 0 for legacy trips — the
+  /// value object still exposes the field so UI / future calculator
+  /// versions don't need a schema change when throttle data lands.
+  final double fullThrottlePenalty;
+
+  const DrivingScore({
+    required this.score,
+    required this.idlingPenalty,
+    required this.hardAccelPenalty,
+    required this.hardBrakePenalty,
+    required this.highRpmPenalty,
+    required this.fullThrottlePenalty,
+  });
+
+  /// A "perfect" 100-point score with no penalties — used as a sentinel
+  /// in tests and as the natural identity for empty trips (the
+  /// calculator returns this for `samples.length < 2`).
+  static const DrivingScore perfect = DrivingScore(
+    score: 100,
+    idlingPenalty: 0,
+    hardAccelPenalty: 0,
+    hardBrakePenalty: 0,
+    highRpmPenalty: 0,
+    fullThrottlePenalty: 0,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DrivingScore &&
+        other.score == score &&
+        other.idlingPenalty == idlingPenalty &&
+        other.hardAccelPenalty == hardAccelPenalty &&
+        other.hardBrakePenalty == hardBrakePenalty &&
+        other.highRpmPenalty == highRpmPenalty &&
+        other.fullThrottlePenalty == fullThrottlePenalty;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        score,
+        idlingPenalty,
+        hardAccelPenalty,
+        hardBrakePenalty,
+        highRpmPenalty,
+        fullThrottlePenalty,
+      );
+
+  @override
+  String toString() => 'DrivingScore('
+      'score: $score, '
+      'idling: ${idlingPenalty.toStringAsFixed(1)}, '
+      'hardAccel: ${hardAccelPenalty.toStringAsFixed(1)}, '
+      'hardBrake: ${hardBrakePenalty.toStringAsFixed(1)}, '
+      'highRpm: ${highRpmPenalty.toStringAsFixed(1)}, '
+      'fullThrottle: ${fullThrottlePenalty.toStringAsFixed(1)})';
+}

--- a/lib/features/consumption/presentation/widgets/driving_score_card.dart
+++ b/lib/features/consumption/presentation/widgets/driving_score_card.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/driving_score.dart';
+
+/// Composite "driving score" card on the Trip detail screen
+/// (#1041 phase 5a — Card A).
+///
+/// Sits at the very top of the Insights group on the trip detail
+/// scroll view: a single big 0..100 number, a localized title above
+/// it, an `out of 100` caption beneath, and an optional one-line
+/// breakdown chip row showing the top one or two penalty contributions
+/// so the driver immediately sees *what* dragged the score down.
+///
+/// The card is purely presentational. Score derivation, weights, and
+/// caps live in `driving_score_calculator.dart`; the widget trusts the
+/// caller's [DrivingScore] without recomputing anything.
+///
+/// ## Sub-text follow-up
+///
+/// The issue body describes a "Better than X% of past trips" sub-text.
+/// `BaselineStore` tracks per-vehicle steady-state baselines, not
+/// per-trip score percentiles, so wiring up that comparison is its
+/// own piece of work. The card surfaces a placeholder caption today;
+/// the percentile sub-text lands in a follow-up phase.
+///
+/// ## EV trips / empty trips
+///
+/// The parent [TripDetailBody] omits the card entirely for EV trips
+/// (RPM-based scoring does not model an EV motor) and for trips with
+/// no samples at all. The widget itself is a no-op `SizedBox.shrink()`
+/// when handed a [DrivingScore.perfect] derived from an empty trip —
+/// belt-and-braces in case a caller forgets to gate it.
+class DrivingScoreCard extends StatelessWidget {
+  /// Pre-computed composite score for the trip. The widget reads
+  /// `score` for the big number and surfaces the top one or two
+  /// penalty contributions as small chips beneath.
+  final DrivingScore score;
+
+  const DrivingScoreCard({super.key, required this.score});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    final scoreText = score.score.toString();
+    final outOf =
+        l?.drivingScoreCardOutOf ?? '/100';
+    final scoreSemanticsLabel =
+        l?.drivingScoreCardSemanticsLabel(scoreText) ??
+            'Driving score $scoreText out of 100';
+
+    final topPenalties = _topPenalties(l);
+
+    return Card(
+      margin: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l?.drivingScoreCardTitle ?? 'Driving score',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Semantics(
+              label: scoreSemanticsLabel,
+              container: true,
+              child: ExcludeSemantics(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.baseline,
+                  textBaseline: TextBaseline.alphabetic,
+                  children: [
+                    Text(
+                      scoreText,
+                      key: const Key('driving_score_big_number'),
+                      style: theme.textTheme.displayLarge?.copyWith(
+                        color: _scoreColor(theme, score.score),
+                        fontWeight: FontWeight.w600,
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      outOf,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              // Placeholder for the future "Better than X% of past
+              // trips" sub-text — see the class docstring for why it's
+              // a follow-up.
+              l?.drivingScoreCardSubtitle ??
+                  'Composite score from idling, hard accelerations, '
+                      'hard braking, and high-RPM time.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            if (topPenalties.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final penalty in topPenalties)
+                    _PenaltyChip(label: penalty),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Pick the top one or two penalty contributions to surface as
+  /// chips. Returns an empty list when every category is below a
+  /// 1-point floor (the trip was clean enough that singling out a
+  /// "biggest" contributor would be misleading).
+  List<String> _topPenalties(AppLocalizations? l) {
+    final entries = <_NamedPenalty>[
+      _NamedPenalty(
+        value: score.idlingPenalty,
+        label: l?.drivingScorePenaltyIdling ?? 'Idling',
+      ),
+      _NamedPenalty(
+        value: score.hardAccelPenalty,
+        label: l?.drivingScorePenaltyHardAccel ?? 'Hard accelerations',
+      ),
+      _NamedPenalty(
+        value: score.hardBrakePenalty,
+        label: l?.drivingScorePenaltyHardBrake ?? 'Hard braking',
+      ),
+      _NamedPenalty(
+        value: score.highRpmPenalty,
+        label: l?.drivingScorePenaltyHighRpm ?? 'High RPM',
+      ),
+      _NamedPenalty(
+        value: score.fullThrottlePenalty,
+        label: l?.drivingScorePenaltyFullThrottle ?? 'Full throttle',
+      ),
+    ]..sort((a, b) => b.value.compareTo(a.value));
+
+    return [
+      for (final e in entries)
+        if (e.value >= 1.0) e.label,
+    ].take(2).toList(growable: false);
+  }
+
+  /// Map the numeric score to a colour band: red below 50, amber
+  /// 50..74, primary above. The thresholds mirror common eco-coach
+  /// conventions ("good / fair / needs work") without leaning on
+  /// theme-specific brand colours.
+  Color _scoreColor(ThemeData theme, int s) {
+    if (s < 50) return theme.colorScheme.error;
+    if (s < 75) return theme.colorScheme.tertiary;
+    return theme.colorScheme.primary;
+  }
+}
+
+class _NamedPenalty {
+  final double value;
+  final String label;
+  const _NamedPenalty({required this.value, required this.label});
+}
+
+/// Compact chip used in the breakdown row beneath the big number.
+/// Visual is a thin outlined pill — keeps the card focused on the
+/// score itself rather than on the breakdown.
+class _PenaltyChip extends StatelessWidget {
+  final String label;
+
+  const _PenaltyChip({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -3,11 +3,14 @@ import 'package:flutter/material.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../data/driving_insights_analyzer.dart';
+import '../../data/driving_score_calculator.dart';
 import '../../data/trip_history_repository.dart';
 import '../../domain/driving_insight.dart';
+import '../../domain/driving_score.dart';
 import '../../domain/services/throttle_rpm_histogram_calculator.dart';
 import '../../domain/trip_recorder.dart';
 import 'driving_insights_card.dart';
+import 'driving_score_card.dart';
 import 'throttle_rpm_histogram_card.dart';
 import 'trip_detail_charts.dart';
 import 'trip_summary_card.dart';
@@ -66,6 +69,16 @@ class _TripDetailBodyState extends State<TripDetailBody> {
   /// disk, the card lights up automatically.
   late final ThrottleRpmHistogram _histogram = _computeHistogram();
 
+  /// Lazily-computed composite driving score (#1041 phase 5a — Card A).
+  /// Cached alongside [_insights] and [_histogram] for the same
+  /// reason — the calculator is O(n), pure, and cheap, but a long trip
+  /// ticks at ~1 Hz so re-running on every locale / theme rebuild adds
+  /// up. EV trips and empty trips return [DrivingScore.perfect] from
+  /// the calculator; the parent gates rendering on the same conditions
+  /// it uses for [DrivingInsightsCard] so the card is hidden in those
+  /// cases.
+  late final DrivingScore _score = _computeScore();
+
   List<DrivingInsight> _computeInsights() {
     if (widget.samples.isEmpty) return const [];
     // Insights are only meaningful for combustion trips — EV trips
@@ -79,6 +92,15 @@ class _TripDetailBodyState extends State<TripDetailBody> {
           growable: false,
         );
     return analyzeTrip(tripSamples);
+  }
+
+  DrivingScore _computeScore() {
+    if (widget.samples.isEmpty) return DrivingScore.perfect;
+    if (widget.isEv) return DrivingScore.perfect;
+    final tripSamples = widget.samples.map(_toTripSample).toList(
+          growable: false,
+        );
+    return computeDrivingScore(tripSamples);
   }
 
   ThrottleRpmHistogram _computeHistogram() {
@@ -129,6 +151,13 @@ class _TripDetailBodyState extends State<TripDetailBody> {
             isEv: widget.isEv,
           ),
           const SizedBox(height: 8),
+          // Composite driving score (#1041 phase 5a — Card A). Sits at
+          // the top of the Insights group: a single big 0..100 number
+          // with a brief breakdown chip row beneath it. EV trips and
+          // empty trips are skipped on the same gating rule as the
+          // cost-line card below.
+          if (!widget.isEv && widget.samples.isNotEmpty)
+            DrivingScoreCard(score: _score),
           // Driving insights — combustion trips only. EV trips skip
           // this card; phase 4 will land an EV-aware version.
           if (!widget.isEv && widget.samples.isNotEmpty)

--- a/lib/l10n/_fragments/driving_score_de.arb
+++ b/lib/l10n/_fragments/driving_score_de.arb
@@ -1,0 +1,11 @@
+{
+  "drivingScoreCardTitle": "Fahrnote",
+  "drivingScoreCardOutOf": "/100",
+  "drivingScoreCardSubtitle": "Gesamtnote aus Leerlauf, starken Beschleunigungen, hartem Bremsen und Zeit über 3000 U/min. Ein Vergleich „besser als X% deiner bisherigen Fahrten“ folgt in einem späteren Release.",
+  "drivingScoreCardSemanticsLabel": "Fahrnote {score} von 100",
+  "drivingScorePenaltyIdling": "Leerlauf",
+  "drivingScorePenaltyHardAccel": "Starke Beschleunigung",
+  "drivingScorePenaltyHardBrake": "Hartes Bremsen",
+  "drivingScorePenaltyHighRpm": "Hohe Drehzahl",
+  "drivingScorePenaltyFullThrottle": "Vollgas"
+}

--- a/lib/l10n/_fragments/driving_score_en.arb
+++ b/lib/l10n/_fragments/driving_score_en.arb
@@ -1,0 +1,43 @@
+{
+  "drivingScoreCardTitle": "Driving score",
+  "@drivingScoreCardTitle": {
+    "description": "Title of the composite driving-score card on the Trip detail screen — sits at the top of the Insights group above the cost-line card (#1041 phase 5a Card A)."
+  },
+  "drivingScoreCardOutOf": "/100",
+  "@drivingScoreCardOutOf": {
+    "description": "Suffix shown next to the big driving-score number on the Trip detail screen — clarifies the 0..100 scale (#1041 phase 5a Card A)."
+  },
+  "drivingScoreCardSubtitle": "Composite score from idling, hard accelerations, hard braking, and high-RPM time. A 'better than X% of past trips' comparison will land in a follow-up release.",
+  "@drivingScoreCardSubtitle": {
+    "description": "Caption beneath the big driving-score number explaining what feeds the composite. Doubles as a placeholder for the future per-trip percentile sub-text (#1041 phase 5a Card A)."
+  },
+  "drivingScoreCardSemanticsLabel": "Driving score {score} out of 100",
+  "@drivingScoreCardSemanticsLabel": {
+    "description": "TalkBack / VoiceOver label for the big driving-score number — bundles the value and the scale into a single accessible utterance (#1041 phase 5a Card A).",
+    "placeholders": {
+      "score": {
+        "type": "String"
+      }
+    }
+  },
+  "drivingScorePenaltyIdling": "Idling",
+  "@drivingScorePenaltyIdling": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the idling penalty was the largest contributor (#1041 phase 5a Card A)."
+  },
+  "drivingScorePenaltyHardAccel": "Hard accelerations",
+  "@drivingScorePenaltyHardAccel": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the hard-acceleration penalty was a top contributor (#1041 phase 5a Card A)."
+  },
+  "drivingScorePenaltyHardBrake": "Hard braking",
+  "@drivingScorePenaltyHardBrake": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the hard-braking penalty was a top contributor (#1041 phase 5a Card A)."
+  },
+  "drivingScorePenaltyHighRpm": "High RPM",
+  "@drivingScorePenaltyHighRpm": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the high-RPM penalty was a top contributor (#1041 phase 5a Card A)."
+  },
+  "drivingScorePenaltyFullThrottle": "Full throttle",
+  "@drivingScorePenaltyFullThrottle": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the full-throttle penalty was a top contributor — currently unused while throttle is not persisted (#1041 phase 5a Card A)."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1300,6 +1300,15 @@
   "insightIdling": "Leerlauf ({pctTime}% der Fahrt): {liters} L verschwendet",
   "insightSubtitlePctOfTrip": "{pctTime}% der Fahrt",
   "insightTrailingLitersWasted": "+{liters} L",
+  "drivingScoreCardTitle": "Fahrnote",
+  "drivingScoreCardOutOf": "/100",
+  "drivingScoreCardSubtitle": "Gesamtnote aus Leerlauf, starken Beschleunigungen, hartem Bremsen und Zeit über 3000 U/min. Ein Vergleich „besser als X% deiner bisherigen Fahrten“ folgt in einem späteren Release.",
+  "drivingScoreCardSemanticsLabel": "Fahrnote {score} von 100",
+  "drivingScorePenaltyIdling": "Leerlauf",
+  "drivingScorePenaltyHardAccel": "Starke Beschleunigung",
+  "drivingScorePenaltyHardBrake": "Hartes Bremsen",
+  "drivingScorePenaltyHighRpm": "Hohe Drehzahl",
+  "drivingScorePenaltyFullThrottle": "Vollgas",
   "ecoRouteOption": "Sparsam",
   "@ecoRouteOption": {
     "description": "Label für den Eco-Routing-Chip in den Routensuche-Bedienelementen (#1123). Wählt Routen aus, die Kraftstoff statt Zeit minimieren."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1660,6 +1660,47 @@
       }
     }
   },
+  "drivingScoreCardTitle": "Driving score",
+  "@drivingScoreCardTitle": {
+    "description": "Title of the composite driving-score card on the Trip detail screen — sits at the top of the Insights group above the cost-line card (#1041 phase 5a Card A)."
+  },
+  "drivingScoreCardOutOf": "/100",
+  "@drivingScoreCardOutOf": {
+    "description": "Suffix shown next to the big driving-score number on the Trip detail screen — clarifies the 0..100 scale (#1041 phase 5a Card A)."
+  },
+  "drivingScoreCardSubtitle": "Composite score from idling, hard accelerations, hard braking, and high-RPM time. A 'better than X% of past trips' comparison will land in a follow-up release.",
+  "@drivingScoreCardSubtitle": {
+    "description": "Caption beneath the big driving-score number explaining what feeds the composite. Doubles as a placeholder for the future per-trip percentile sub-text (#1041 phase 5a Card A)."
+  },
+  "drivingScoreCardSemanticsLabel": "Driving score {score} out of 100",
+  "@drivingScoreCardSemanticsLabel": {
+    "description": "TalkBack / VoiceOver label for the big driving-score number — bundles the value and the scale into a single accessible utterance (#1041 phase 5a Card A).",
+    "placeholders": {
+      "score": {
+        "type": "String"
+      }
+    }
+  },
+  "drivingScorePenaltyIdling": "Idling",
+  "@drivingScorePenaltyIdling": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the idling penalty was the largest contributor (#1041 phase 5a Card A)."
+  },
+  "drivingScorePenaltyHardAccel": "Hard accelerations",
+  "@drivingScorePenaltyHardAccel": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the hard-acceleration penalty was a top contributor (#1041 phase 5a Card A)."
+  },
+  "drivingScorePenaltyHardBrake": "Hard braking",
+  "@drivingScorePenaltyHardBrake": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the hard-braking penalty was a top contributor (#1041 phase 5a Card A)."
+  },
+  "drivingScorePenaltyHighRpm": "High RPM",
+  "@drivingScorePenaltyHighRpm": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the high-RPM penalty was a top contributor (#1041 phase 5a Card A)."
+  },
+  "drivingScorePenaltyFullThrottle": "Full throttle",
+  "@drivingScorePenaltyFullThrottle": {
+    "description": "Breakdown chip surfaced beneath the driving-score big number when the full-throttle penalty was a top contributor — currently unused while throttle is not persisted (#1041 phase 5a Card A)."
+  },
   "ecoRouteOption": "Eco",
   "@ecoRouteOption": {
     "description": "Label for the eco-routing strategy chip on the route search controls (#1123). Picks routes that minimise fuel rather than time."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6128,6 +6128,60 @@ abstract class AppLocalizations {
   /// **'+{liters} L'**
   String insightTrailingLitersWasted(String liters);
 
+  /// Title of the composite driving-score card on the Trip detail screen — sits at the top of the Insights group above the cost-line card (#1041 phase 5a Card A).
+  ///
+  /// In en, this message translates to:
+  /// **'Driving score'**
+  String get drivingScoreCardTitle;
+
+  /// Suffix shown next to the big driving-score number on the Trip detail screen — clarifies the 0..100 scale (#1041 phase 5a Card A).
+  ///
+  /// In en, this message translates to:
+  /// **'/100'**
+  String get drivingScoreCardOutOf;
+
+  /// Caption beneath the big driving-score number explaining what feeds the composite. Doubles as a placeholder for the future per-trip percentile sub-text (#1041 phase 5a Card A).
+  ///
+  /// In en, this message translates to:
+  /// **'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.'**
+  String get drivingScoreCardSubtitle;
+
+  /// TalkBack / VoiceOver label for the big driving-score number — bundles the value and the scale into a single accessible utterance (#1041 phase 5a Card A).
+  ///
+  /// In en, this message translates to:
+  /// **'Driving score {score} out of 100'**
+  String drivingScoreCardSemanticsLabel(String score);
+
+  /// Breakdown chip surfaced beneath the driving-score big number when the idling penalty was the largest contributor (#1041 phase 5a Card A).
+  ///
+  /// In en, this message translates to:
+  /// **'Idling'**
+  String get drivingScorePenaltyIdling;
+
+  /// Breakdown chip surfaced beneath the driving-score big number when the hard-acceleration penalty was a top contributor (#1041 phase 5a Card A).
+  ///
+  /// In en, this message translates to:
+  /// **'Hard accelerations'**
+  String get drivingScorePenaltyHardAccel;
+
+  /// Breakdown chip surfaced beneath the driving-score big number when the hard-braking penalty was a top contributor (#1041 phase 5a Card A).
+  ///
+  /// In en, this message translates to:
+  /// **'Hard braking'**
+  String get drivingScorePenaltyHardBrake;
+
+  /// Breakdown chip surfaced beneath the driving-score big number when the high-RPM penalty was a top contributor (#1041 phase 5a Card A).
+  ///
+  /// In en, this message translates to:
+  /// **'High RPM'**
+  String get drivingScorePenaltyHighRpm;
+
+  /// Breakdown chip surfaced beneath the driving-score big number when the full-throttle penalty was a top contributor — currently unused while throttle is not persisted (#1041 phase 5a Card A).
+  ///
+  /// In en, this message translates to:
+  /// **'Full throttle'**
+  String get drivingScorePenaltyFullThrottle;
+
   /// Label for the eco-routing strategy chip on the route search controls (#1123). Picks routes that minimise fuel rather than time.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3277,6 +3277,36 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3277,6 +3277,36 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3275,6 +3275,36 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3303,6 +3303,36 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Fahrnote';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Gesamtnote aus Leerlauf, starken Beschleunigungen, hartem Bremsen und Zeit über 3000 U/min. Ein Vergleich „besser als X% deiner bisherigen Fahrten“ folgt in einem späteren Release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Fahrnote $score von 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Leerlauf';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Starke Beschleunigung';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hartes Bremsen';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'Hohe Drehzahl';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Vollgas';
+
+  @override
   String get ecoRouteOption => 'Sparsam';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3279,6 +3279,36 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3270,6 +3270,36 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3278,6 +3278,36 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3272,6 +3272,36 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3275,6 +3275,36 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3300,6 +3300,36 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3274,6 +3274,36 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3279,6 +3279,36 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3278,6 +3278,36 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3276,6 +3276,36 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3278,6 +3278,36 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3274,6 +3274,36 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3279,6 +3279,36 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3277,6 +3277,36 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3278,6 +3278,36 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3277,6 +3277,36 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3278,6 +3278,36 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3272,6 +3272,36 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3276,6 +3276,36 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get drivingScoreCardTitle => 'Driving score';
+
+  @override
+  String get drivingScoreCardOutOf => '/100';
+
+  @override
+  String get drivingScoreCardSubtitle =>
+      'Composite score from idling, hard accelerations, hard braking, and high-RPM time. A \'better than X% of past trips\' comparison will land in a follow-up release.';
+
+  @override
+  String drivingScoreCardSemanticsLabel(String score) {
+    return 'Driving score $score out of 100';
+  }
+
+  @override
+  String get drivingScorePenaltyIdling => 'Idling';
+
+  @override
+  String get drivingScorePenaltyHardAccel => 'Hard accelerations';
+
+  @override
+  String get drivingScorePenaltyHardBrake => 'Hard braking';
+
+  @override
+  String get drivingScorePenaltyHighRpm => 'High RPM';
+
+  @override
+  String get drivingScorePenaltyFullThrottle => 'Full throttle';
+
+  @override
   String get ecoRouteOption => 'Eco';
 
   @override

--- a/test/features/consumption/data/driving_score_calculator_test.dart
+++ b/test/features/consumption/data/driving_score_calculator_test.dart
@@ -1,0 +1,363 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/driving_score_calculator.dart';
+import 'package:tankstellen/features/consumption/domain/driving_score.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// Pure-logic tests for the driving-score composite calculator
+/// (#1041 phase 5a — Card A).
+///
+/// The calculator turns a stream of [TripSample]s into a single 0..100
+/// composite, exposing each per-category penalty contribution. Tests
+/// cover the empty-trip identity, steady-state efficient driving,
+/// individual category caps, the floor at 0 for catastrophic trips,
+/// and boundary cases on the RPM and acceleration thresholds.
+void main() {
+  group('computeDrivingScore (#1041 phase 5a)', () {
+    final start = DateTime.utc(2026);
+
+    test('empty samples → perfect 100, no penalties', () {
+      final result = computeDrivingScore(const []);
+      expect(result, equals(DrivingScore.perfect));
+      expect(result.score, 100);
+      expect(result.idlingPenalty, 0);
+      expect(result.hardAccelPenalty, 0);
+      expect(result.hardBrakePenalty, 0);
+      expect(result.highRpmPenalty, 0);
+      expect(result.fullThrottlePenalty, 0);
+    });
+
+    test('single sample → perfect 100 (no Δt to integrate)', () {
+      final samples = [
+        TripSample(timestamp: start, speedKmh: 50, rpm: 2000),
+      ];
+      expect(computeDrivingScore(samples), equals(DrivingScore.perfect));
+    });
+
+    test('steady-state efficient cruise → 100', () {
+      // 10 minutes of smooth highway cruise at 80 km/h, 2000 RPM —
+      // nothing should trip any category.
+      final samples = <TripSample>[
+        for (var i = 0; i <= 10; i++)
+          TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 80,
+            rpm: 2000,
+            fuelRateLPerHour: 5,
+          ),
+      ];
+      final result = computeDrivingScore(samples);
+      expect(result.score, 100);
+      expect(result.idlingPenalty, 0);
+      expect(result.highRpmPenalty, 0);
+      expect(result.hardAccelPenalty, 0);
+      expect(result.hardBrakePenalty, 0);
+    });
+
+    test('pure idle trip (100% idle) → idling cap of 25 → score 75', () {
+      // 20 minutes idling: speed=0, rpm=800 throughout. The whole trip
+      // is idle so the linear penalty saturates at the 25-point cap.
+      final samples = <TripSample>[
+        for (var i = 0; i <= 20; i++)
+          TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 0,
+            rpm: 800,
+          ),
+      ];
+      final result = computeDrivingScore(samples);
+      expect(result.idlingPenalty, closeTo(25, 0.5));
+      expect(result.score, closeTo(75, 1));
+      // No other category should fire on a pure-idle trip.
+      expect(result.highRpmPenalty, 0);
+      expect(result.hardAccelPenalty, 0);
+      expect(result.hardBrakePenalty, 0);
+    });
+
+    test('half-idle trip → idling penalty roughly proportional', () {
+      // 20 minutes total, of which roughly the first half are idle and
+      // the second half are smooth cruise. The recorder attributes
+      // each interval to its START sample, so the transition interval
+      // (where prev is the last idle sample) still counts toward idle
+      // — meaning ~55% of the trip is idle, not exactly 50%. Penalty
+      // should land in a sensible mid-range band rather than at the
+      // 25-point cap or zero.
+      final samples = <TripSample>[
+        for (var i = 0; i <= 10; i++)
+          TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 0,
+            rpm: 800,
+          ),
+        for (var i = 11; i <= 20; i++)
+          TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 80,
+            rpm: 2000,
+          ),
+      ];
+      final result = computeDrivingScore(samples);
+      // Roughly 11/20 of the trip → 11/20 × 25 = 13.75.
+      expect(result.idlingPenalty, closeTo(13.75, 0.5));
+      // Score should be in the mid-80s.
+      expect(result.score, inInclusiveRange(82, 90));
+    });
+
+    test('5 hard-accel events → hardAccelPenalty saturates at 15', () {
+      // 5 strong accelerations: 0 → 50 km/h in 2 s each (≈ 6.94 m/s²,
+      // well above the 3.0 m/s² threshold). 5 × 3 = 15 = the cap.
+      var t = start;
+      final samples = <TripSample>[];
+      for (var i = 0; i < 5; i++) {
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 1000));
+        t = t.add(const Duration(seconds: 2));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2500));
+        t = t.add(const Duration(seconds: 10));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2000));
+        t = t.add(const Duration(seconds: 1));
+      }
+      final result = computeDrivingScore(samples);
+      expect(result.hardAccelPenalty, 15);
+      // Score should be at most 85 (100 - 15) plus or minus other
+      // penalties if any sneak in.
+      expect(result.score, lessThanOrEqualTo(85));
+    });
+
+    test('hardAccelPenalty caps at 15 even with 10 events', () {
+      var t = start;
+      final samples = <TripSample>[];
+      for (var i = 0; i < 10; i++) {
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 1000));
+        t = t.add(const Duration(seconds: 2));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2500));
+        t = t.add(const Duration(seconds: 10));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2000));
+        t = t.add(const Duration(seconds: 1));
+      }
+      final result = computeDrivingScore(samples);
+      expect(result.hardAccelPenalty, 15);
+    });
+
+    test('5 hard-brake events → hardBrakePenalty saturates at 15', () {
+      // 5 strong decelerations: 50 → 0 km/h in 2 s each (≈ -6.94 m/s²).
+      var t = start;
+      final samples = <TripSample>[];
+      for (var i = 0; i < 5; i++) {
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2000));
+        t = t.add(const Duration(seconds: 2));
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 1000));
+        t = t.add(const Duration(seconds: 10));
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 1000));
+        t = t.add(const Duration(seconds: 1));
+      }
+      final result = computeDrivingScore(samples);
+      expect(result.hardBrakePenalty, 15);
+    });
+
+    test('high-RPM cruise across the whole trip → highRpmPenalty caps at 20',
+        () {
+      // 10 minutes above 3000 RPM throughout.
+      final samples = <TripSample>[
+        for (var i = 0; i <= 10; i++)
+          TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 80,
+            rpm: 4000,
+          ),
+      ];
+      final result = computeDrivingScore(samples);
+      expect(result.highRpmPenalty, closeTo(20, 0.5));
+      // No idling on a moving trip, no hard-accel events on cruise.
+      expect(result.idlingPenalty, 0);
+      expect(result.hardAccelPenalty, 0);
+    });
+
+    test('full-throttle penalty stays 0 (no throttle data persisted today)',
+        () {
+      // The TripSample schema does not carry throttle %, so the
+      // calculator can never accumulate full-throttle time today. The
+      // penalty must stay 0 regardless of what other categories fire.
+      final samples = <TripSample>[
+        for (var i = 0; i <= 10; i++)
+          TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 80,
+            rpm: 4000,
+          ),
+      ];
+      final result = computeDrivingScore(samples);
+      expect(result.fullThrottlePenalty, 0);
+    });
+
+    test('catastrophic trip → score floors at 0', () {
+      // Construct a trip that simultaneously saturates idling, high-RPM,
+      // hard-accel, and hard-brake. The raw sum exceeds 100, so the
+      // floor at 0 must clamp.
+      var t = start;
+      final samples = <TripSample>[];
+      // 10 hard accel + 10 hard brake events, each separated by short
+      // intervals to keep total trip duration small.
+      for (var i = 0; i < 10; i++) {
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 4000));
+        t = t.add(const Duration(seconds: 2));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 4000));
+        t = t.add(const Duration(seconds: 2));
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 4000));
+        t = t.add(const Duration(seconds: 1));
+      }
+      final result = computeDrivingScore(samples);
+      expect(result.score, greaterThanOrEqualTo(0));
+      // Caps are reached on hard-accel and hard-brake at minimum.
+      expect(result.hardAccelPenalty, 15);
+      expect(result.hardBrakePenalty, 15);
+    });
+
+    test('boundary: exactly 3000 RPM is NOT high-RPM (strict >)', () {
+      // 5 minutes at exactly 3000 RPM. The high-RPM threshold is `> 3000`
+      // (matches the analyzer), so this trip should not accumulate any
+      // high-RPM penalty.
+      final samples = <TripSample>[
+        for (var i = 0; i <= 5; i++)
+          TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 80,
+            rpm: 3000,
+          ),
+      ];
+      final result = computeDrivingScore(samples);
+      expect(result.highRpmPenalty, 0);
+    });
+
+    test('boundary: just above 3000 RPM IS high-RPM', () {
+      final samples = <TripSample>[
+        for (var i = 0; i <= 5; i++)
+          TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 80,
+            rpm: 3001,
+          ),
+      ];
+      final result = computeDrivingScore(samples);
+      expect(result.highRpmPenalty, greaterThan(0));
+    });
+
+    test('boundary: exactly 3.0 m/s² IS a hard-accel event (inclusive)', () {
+      // 0 → 21.6 km/h in 2 s = 6 m/s ÷ 2 s = 3.0 m/s² exactly. The
+      // analyzer uses `>=`, so the calculator must too.
+      final samples = <TripSample>[
+        TripSample(timestamp: start, speedKmh: 0, rpm: 1000),
+        TripSample(
+          timestamp: start.add(const Duration(seconds: 2)),
+          speedKmh: 21.6,
+          rpm: 2500,
+        ),
+      ];
+      final result = computeDrivingScore(samples);
+      expect(result.hardAccelPenalty, greaterThan(0));
+    });
+
+    test('boundary: just below 3.0 m/s² is NOT a hard-accel event', () {
+      // 0 → 21 km/h in 2 s ≈ 2.92 m/s² — below the threshold.
+      final samples = <TripSample>[
+        TripSample(timestamp: start, speedKmh: 0, rpm: 1000),
+        TripSample(
+          timestamp: start.add(const Duration(seconds: 2)),
+          speedKmh: 21,
+          rpm: 2500,
+        ),
+      ];
+      final result = computeDrivingScore(samples);
+      expect(result.hardAccelPenalty, 0);
+    });
+
+    test('out-of-order samples are sorted before integration', () {
+      final samples = <TripSample>[
+        TripSample(timestamp: start, speedKmh: 0, rpm: 800),
+        TripSample(
+          timestamp: start.add(const Duration(minutes: 20)),
+          speedKmh: 0,
+          rpm: 800,
+        ),
+        TripSample(
+          timestamp: start.add(const Duration(minutes: 10)),
+          speedKmh: 0,
+          rpm: 800,
+        ),
+      ];
+      final result = computeDrivingScore(samples);
+      expect(result.idlingPenalty, closeTo(25, 0.5));
+      expect(result.score, closeTo(75, 1));
+    });
+
+    test('score is always an integer in [0, 100]', () {
+      // A handful of random-ish trips — verify the contract holds for
+      // each one.
+      final scenarios = <List<TripSample>>[
+        const <TripSample>[],
+        <TripSample>[
+          TripSample(timestamp: start, speedKmh: 0, rpm: 800),
+        ],
+        <TripSample>[
+          TripSample(timestamp: start, speedKmh: 80, rpm: 2000),
+          TripSample(
+            timestamp: start.add(const Duration(seconds: 60)),
+            speedKmh: 80,
+            rpm: 2000,
+          ),
+        ],
+        <TripSample>[
+          TripSample(timestamp: start, speedKmh: 0, rpm: 4500),
+          TripSample(
+            timestamp: start.add(const Duration(seconds: 120)),
+            speedKmh: 0,
+            rpm: 4500,
+          ),
+        ],
+      ];
+      for (final s in scenarios) {
+        final result = computeDrivingScore(s);
+        expect(result.score, inInclusiveRange(0, 100));
+      }
+    });
+  });
+
+  group('DrivingScore value-object', () {
+    test('equality and hashCode work as value-objects', () {
+      const a = DrivingScore(
+        score: 80,
+        idlingPenalty: 10,
+        hardAccelPenalty: 6,
+        hardBrakePenalty: 0,
+        highRpmPenalty: 4,
+        fullThrottlePenalty: 0,
+      );
+      const b = DrivingScore(
+        score: 80,
+        idlingPenalty: 10,
+        hardAccelPenalty: 6,
+        hardBrakePenalty: 0,
+        highRpmPenalty: 4,
+        fullThrottlePenalty: 0,
+      );
+      const c = DrivingScore(
+        score: 80,
+        idlingPenalty: 10,
+        hardAccelPenalty: 6,
+        hardBrakePenalty: 0,
+        highRpmPenalty: 5, // ← different
+        fullThrottlePenalty: 0,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+
+    test('perfect sentinel is 100 with zero penalties', () {
+      expect(DrivingScore.perfect.score, 100);
+      expect(DrivingScore.perfect.idlingPenalty, 0);
+      expect(DrivingScore.perfect.hardAccelPenalty, 0);
+      expect(DrivingScore.perfect.hardBrakePenalty, 0);
+      expect(DrivingScore.perfect.highRpmPenalty, 0);
+      expect(DrivingScore.perfect.fullThrottlePenalty, 0);
+    });
+  });
+}

--- a/test/features/consumption/presentation/widgets/driving_score_card_test.dart
+++ b/test/features/consumption/presentation/widgets/driving_score_card_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/driving_score.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/driving_score_card.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Widget-level coverage for [DrivingScoreCard] (#1041 phase 5a — Card A).
+///
+/// The card is purely presentational — it takes a pre-computed
+/// [DrivingScore] and renders the big number, a localized title, an
+/// `out of 100` caption, and a chip row showing the top one or two
+/// penalty contributions. Tests lock down the big-number rendering,
+/// the breakdown chip selection, accessibility (Semantics label,
+/// 48dp tap-target guideline), and the localized title.
+void main() {
+  group('DrivingScoreCard — title and big number', () {
+    testWidgets('renders the localized "Driving score" title',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingScoreCard(score: DrivingScore.perfect),
+      );
+
+      expect(find.text('Driving score'), findsOneWidget);
+    });
+
+    testWidgets('renders the big 0..100 number for the supplied score',
+        (tester) async {
+      const score = DrivingScore(
+        score: 87,
+        idlingPenalty: 8,
+        hardAccelPenalty: 3,
+        hardBrakePenalty: 0,
+        highRpmPenalty: 2,
+        fullThrottlePenalty: 0,
+      );
+      await pumpApp(
+        tester,
+        const DrivingScoreCard(score: score),
+      );
+
+      expect(find.text('87'), findsOneWidget);
+    });
+
+    testWidgets('renders the /100 suffix beside the score', (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingScoreCard(score: DrivingScore.perfect),
+      );
+
+      expect(find.text('/100'), findsOneWidget);
+    });
+
+    testWidgets('renders the explanatory subtitle line', (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingScoreCard(score: DrivingScore.perfect),
+      );
+
+      // The placeholder subtitle is the first sentence of the future
+      // baseline-comparison sub-text.
+      expect(
+        find.textContaining('Composite score from idling'),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('DrivingScoreCard — accessibility', () {
+    testWidgets(
+        'big number carries a "Driving score X out of 100" Semantics label',
+        (tester) async {
+      const score = DrivingScore(
+        score: 72,
+        idlingPenalty: 12,
+        hardAccelPenalty: 6,
+        hardBrakePenalty: 0,
+        highRpmPenalty: 10,
+        fullThrottlePenalty: 0,
+      );
+      await pumpApp(
+        tester,
+        const DrivingScoreCard(score: score),
+      );
+
+      expect(
+        find.bySemanticsLabel('Driving score 72 out of 100'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('passes the Android tap-target guideline', (tester) async {
+      const score = DrivingScore(
+        score: 50,
+        idlingPenalty: 25,
+        hardAccelPenalty: 15,
+        hardBrakePenalty: 0,
+        highRpmPenalty: 10,
+        fullThrottlePenalty: 0,
+      );
+      final handle = tester.ensureSemantics();
+      try {
+        await pumpApp(
+          tester,
+          const DrivingScoreCard(score: score),
+        );
+
+        await expectLater(
+          tester,
+          meetsGuideline(androidTapTargetGuideline),
+        );
+      } finally {
+        handle.dispose();
+      }
+    });
+  });
+
+  group('DrivingScoreCard — breakdown chips', () {
+    testWidgets('shows no chips when every penalty is below 1 point',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingScoreCard(score: DrivingScore.perfect),
+      );
+
+      // None of the breakdown labels should appear — the card stays
+      // focused on the score itself when the trip was clean.
+      expect(find.text('Idling'), findsNothing);
+      expect(find.text('Hard accelerations'), findsNothing);
+      expect(find.text('Hard braking'), findsNothing);
+      expect(find.text('High RPM'), findsNothing);
+      expect(find.text('Full throttle'), findsNothing);
+    });
+
+    testWidgets('shows the single dominant penalty chip when only one fires',
+        (tester) async {
+      const score = DrivingScore(
+        score: 85,
+        idlingPenalty: 0,
+        hardAccelPenalty: 0,
+        hardBrakePenalty: 0,
+        highRpmPenalty: 15,
+        fullThrottlePenalty: 0,
+      );
+      await pumpApp(
+        tester,
+        const DrivingScoreCard(score: score),
+      );
+
+      expect(find.text('High RPM'), findsOneWidget);
+      // Other chips stay hidden.
+      expect(find.text('Idling'), findsNothing);
+      expect(find.text('Hard accelerations'), findsNothing);
+    });
+
+    testWidgets('shows at most two chips even when three penalties fire',
+        (tester) async {
+      const score = DrivingScore(
+        score: 60,
+        idlingPenalty: 12,
+        hardAccelPenalty: 6,
+        hardBrakePenalty: 0,
+        highRpmPenalty: 22,
+        fullThrottlePenalty: 0,
+      );
+      await pumpApp(
+        tester,
+        const DrivingScoreCard(score: score),
+      );
+
+      // Top two penalties: high RPM (22) and idling (12) — hard accel
+      // (6) must not appear.
+      expect(find.text('High RPM'), findsOneWidget);
+      expect(find.text('Idling'), findsOneWidget);
+      expect(find.text('Hard accelerations'), findsNothing);
+    });
+
+    testWidgets('orders chips by penalty magnitude (descending)',
+        (tester) async {
+      const score = DrivingScore(
+        score: 70,
+        idlingPenalty: 4,
+        hardAccelPenalty: 9,
+        hardBrakePenalty: 0,
+        highRpmPenalty: 17,
+        fullThrottlePenalty: 0,
+      );
+      await pumpApp(
+        tester,
+        const DrivingScoreCard(score: score),
+      );
+
+      // Two chips expected — highest first. Verify both render and
+      // that the third-largest penalty (idling, 4) is filtered out.
+      expect(find.text('High RPM'), findsOneWidget);
+      expect(find.text('Hard accelerations'), findsOneWidget);
+      expect(find.text('Idling'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds **Card A** from #1041 — a composite 0..100 driving score, rendered as a single big number above the existing cost-line card on the Trip detail Insights group.
- Score = 100 minus penalty contributions from idling, hard acceleration events, hard braking events, and high-RPM time. Full-throttle slot is wired but stays at 0 until throttle persistence lands.
- Weights and thresholds mirror the constants in `driving_insights_analyzer.dart` so the two coaching surfaces agree on what "above threshold" means.
- EV trips and empty-sample trips skip the card on the same gating rule already used for `DrivingInsightsCard`.
- New ARB fragment in `lib/l10n/_fragments/driving_score_{en,de}.arb` (built via `tool/build_arb.dart`, then `flutter gen-l10n`).

The "Better than X% of past trips" sub-text the issue body describes is intentionally deferred — `BaselineStore` tracks per-vehicle steady-state baselines, not per-trip score percentiles, so that comparison is its own piece of work. The card surfaces a placeholder caption today and the deferral is documented in the calculator and card source.

## Test plan
- [x] `flutter analyze` clean (zero issues)
- [x] `flutter test test/features/consumption/data/driving_score_calculator_test.dart test/features/consumption/presentation/widgets/driving_score_card_test.dart` — all green (29 tests)
- [x] `flutter test test/features/consumption/presentation/widgets/trip_detail_body_test.dart` — existing tests still pass after card insertion
- [x] `flutter test test/lint/arb_fragments_consistency_test.dart` — ARB fragments + canonical files in sync
- [ ] CI: full test suite and analyze on Linux

Refs #1041 phase 5a