### PR TITLE
test(domain): cover LoyaltyCard + MaintenanceSuggestion equality (Refs #561)

### DIFF
--- a/test/features/consumption/domain/entities/maintenance_suggestion_test.dart
+++ b/test/features/consumption/domain/entities/maintenance_suggestion_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/maintenance_suggestion.dart';
+
+MaintenanceSuggestion _makeSuggestion({
+  MaintenanceSignal signal = MaintenanceSignal.idleRpmCreep,
+  double confidence = 0.6,
+  double observedDelta = 4.5,
+  int sampleTripCount = 12,
+  DateTime? computedAt,
+}) {
+  return MaintenanceSuggestion(
+    signal: signal,
+    confidence: confidence,
+    observedDelta: observedDelta,
+    sampleTripCount: sampleTripCount,
+    computedAt: computedAt ?? DateTime.utc(2026, 4, 10, 9),
+  );
+}
+
+void main() {
+  group('MaintenanceSignal enum', () {
+    test('has exactly 2 values', () {
+      expect(MaintenanceSignal.values, hasLength(2));
+      expect(
+        MaintenanceSignal.values,
+        containsAll(<MaintenanceSignal>[
+          MaintenanceSignal.idleRpmCreep,
+          MaintenanceSignal.mafDeviation,
+        ]),
+      );
+    });
+  });
+
+  group('MaintenanceSuggestion construction', () {
+    test('const constructor exposes all 5 fields verbatim', () {
+      final computedAt = DateTime.utc(2026, 4, 10, 9);
+      final suggestion = MaintenanceSuggestion(
+        signal: MaintenanceSignal.mafDeviation,
+        confidence: 0.85,
+        observedDelta: 7.25,
+        sampleTripCount: 17,
+        computedAt: computedAt,
+      );
+
+      expect(suggestion.signal, MaintenanceSignal.mafDeviation);
+      expect(suggestion.confidence, 0.85);
+      expect(suggestion.observedDelta, 7.25);
+      expect(suggestion.sampleTripCount, 17);
+      expect(suggestion.computedAt, computedAt);
+    });
+  });
+
+  group('MaintenanceSuggestion equality', () {
+    test('is reflexive: a == a', () {
+      final a = _makeSuggestion();
+      expect(a == a, isTrue);
+    });
+
+    test('is symmetric: if a == b then b == a', () {
+      final a = _makeSuggestion();
+      final b = _makeSuggestion();
+      expect(a == b, isTrue);
+      expect(b == a, isTrue);
+    });
+
+    test('two instances with identical field values are equal', () {
+      final a = _makeSuggestion();
+      final b = _makeSuggestion();
+      expect(a, equals(b));
+    });
+
+    test('differs when signal differs', () {
+      final a = _makeSuggestion(signal: MaintenanceSignal.idleRpmCreep);
+      final b = _makeSuggestion(signal: MaintenanceSignal.mafDeviation);
+      expect(a == b, isFalse);
+    });
+
+    test('differs when confidence differs', () {
+      final a = _makeSuggestion(confidence: 0.5);
+      final b = _makeSuggestion(confidence: 0.9);
+      expect(a == b, isFalse);
+    });
+
+    test('differs when observedDelta differs', () {
+      final a = _makeSuggestion(observedDelta: 4.5);
+      final b = _makeSuggestion(observedDelta: 9.0);
+      expect(a == b, isFalse);
+    });
+
+    test('differs when sampleTripCount differs', () {
+      final a = _makeSuggestion(sampleTripCount: 12);
+      final b = _makeSuggestion(sampleTripCount: 18);
+      expect(a == b, isFalse);
+    });
+
+    test('differs when computedAt differs', () {
+      final a = _makeSuggestion(computedAt: DateTime.utc(2026, 4, 10));
+      final b = _makeSuggestion(computedAt: DateTime.utc(2026, 4, 11));
+      expect(a == b, isFalse);
+    });
+
+    test('short-circuits on identical(a, a)', () {
+      final a = _makeSuggestion();
+      // identical-instance comparison hits the `identical(this, other)` arm
+      // of operator== first, so this is true even before any field check.
+      expect(identical(a, a), isTrue);
+      expect(a == a, isTrue);
+    });
+
+    test('returns false when compared against a non-MaintenanceSuggestion',
+        () {
+      final a = _makeSuggestion();
+      // ignore: unrelated_type_equality_checks
+      expect(a == Object(), isFalse);
+    });
+  });
+
+  group('MaintenanceSuggestion hashCode', () {
+    test('is equal for two equal suggestions', () {
+      final a = _makeSuggestion();
+      final b = _makeSuggestion();
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('computes a non-zero value for typical inputs (smoke)', () {
+      final a = _makeSuggestion();
+      // Object.hash never returns 0 for typical inputs; the contract only
+      // requires equal-objects-equal-hashes, but a non-zero result confirms
+      // the override actually ran.
+      expect(a.hashCode, isNot(0));
+    });
+  });
+}

--- a/test/features/loyalty/domain/entities/loyalty_card_test.dart
+++ b/test/features/loyalty/domain/entities/loyalty_card_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/loyalty/domain/entities/loyalty_card.dart';
+
+LoyaltyCard _makeCard({
+  String id = 'card-1',
+  LoyaltyBrand brand = LoyaltyBrand.totalEnergies,
+  double discountPerLiter = 0.05,
+  String label = 'Personal',
+  DateTime? addedAt,
+  bool enabled = true,
+}) {
+  return LoyaltyCard(
+    id: id,
+    brand: brand,
+    discountPerLiter: discountPerLiter,
+    label: label,
+    addedAt: addedAt ?? DateTime.utc(2026, 3, 15, 12),
+    enabled: enabled,
+  );
+}
+
+void main() {
+  group('LoyaltyBrand enum', () {
+    test('has exactly 5 values', () {
+      expect(LoyaltyBrand.values, hasLength(5));
+    });
+
+    test('exposes documented canonical brand strings', () {
+      expect(LoyaltyBrand.totalEnergies.canonicalBrand, 'TotalEnergies');
+      expect(LoyaltyBrand.aral.canonicalBrand, 'Aral');
+      expect(LoyaltyBrand.shell.canonicalBrand, 'Shell');
+      expect(LoyaltyBrand.bp.canonicalBrand, 'BP');
+      expect(LoyaltyBrand.esso.canonicalBrand, 'Esso');
+    });
+  });
+
+  group('LoyaltyBrand.fromCanonical', () {
+    test('returns null for null input', () {
+      expect(LoyaltyBrand.fromCanonical(null), isNull);
+    });
+
+    test('returns the matching brand for each canonical string', () {
+      expect(
+        LoyaltyBrand.fromCanonical('TotalEnergies'),
+        LoyaltyBrand.totalEnergies,
+      );
+      expect(LoyaltyBrand.fromCanonical('Aral'), LoyaltyBrand.aral);
+      expect(LoyaltyBrand.fromCanonical('Shell'), LoyaltyBrand.shell);
+      expect(LoyaltyBrand.fromCanonical('BP'), LoyaltyBrand.bp);
+      expect(LoyaltyBrand.fromCanonical('Esso'), LoyaltyBrand.esso);
+    });
+
+    test('returns null for an unknown canonical string', () {
+      expect(LoyaltyBrand.fromCanonical('Unknown'), isNull);
+    });
+
+    test('is case-sensitive (lowercase variant is not matched)', () {
+      expect(LoyaltyBrand.fromCanonical('totalenergies'), isNull);
+    });
+
+    test('returns null for the empty string', () {
+      expect(LoyaltyBrand.fromCanonical(''), isNull);
+    });
+  });
+
+  group('LoyaltyCard construction', () {
+    test('accepts all required fields with default enabled = true', () {
+      final card = LoyaltyCard(
+        id: 'card-1',
+        brand: LoyaltyBrand.totalEnergies,
+        discountPerLiter: 0.05,
+        label: 'Personal',
+        addedAt: DateTime.utc(2026, 3, 15),
+      );
+
+      expect(card.id, 'card-1');
+      expect(card.brand, LoyaltyBrand.totalEnergies);
+      expect(card.discountPerLiter, 0.05);
+      expect(card.label, 'Personal');
+      expect(card.addedAt, DateTime.utc(2026, 3, 15));
+      expect(card.enabled, isTrue);
+    });
+
+    test('accepts an explicit enabled = false override', () {
+      final card = _makeCard(enabled: false);
+      expect(card.enabled, isFalse);
+    });
+  });
+
+  group('LoyaltyCard equality (freezed)', () {
+    test('two cards built from identical field values are equal', () {
+      final a = _makeCard();
+      final b = _makeCard();
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('differs on id', () {
+      final a = _makeCard();
+      final b = a.copyWith(id: 'card-2');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differs on brand', () {
+      final a = _makeCard();
+      final b = a.copyWith(brand: LoyaltyBrand.shell);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differs on discountPerLiter', () {
+      final a = _makeCard();
+      final b = a.copyWith(discountPerLiter: 0.07);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differs on label', () {
+      final a = _makeCard();
+      final b = a.copyWith(label: 'Company');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differs on addedAt', () {
+      final a = _makeCard();
+      final b = a.copyWith(addedAt: DateTime.utc(2027, 1, 1));
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differs on enabled', () {
+      final a = _makeCard();
+      final b = a.copyWith(enabled: false);
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  group('LoyaltyCard JSON', () {
+    test('round-trips through toJson / fromJson with all fields populated', () {
+      final original = LoyaltyCard(
+        id: 'card-42',
+        brand: LoyaltyBrand.aral,
+        discountPerLiter: 0.08,
+        label: 'Company',
+        addedAt: DateTime.utc(2026, 4, 1, 8, 30, 15),
+        enabled: false,
+      );
+
+      final json = original.toJson();
+      final restored = LoyaltyCard.fromJson(json);
+
+      expect(restored, equals(original));
+    });
+
+    test('honors the enabled default (true) when missing from JSON', () {
+      final restored = LoyaltyCard.fromJson(<String, dynamic>{
+        'id': 'card-7',
+        'brand': 'totalEnergies',
+        'discountPerLiter': 0.05,
+        'label': 'Personal',
+        'addedAt': DateTime.utc(2026, 3, 15).toIso8601String(),
+      });
+
+      expect(restored.enabled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds direct unit-test coverage for two pure-Dart domain entities that were
previously only exercised indirectly via consumer tests:

- `lib/features/loyalty/domain/entities/loyalty_card.dart` — exercises the
  `LoyaltyBrand` enum, the `LoyaltyBrand.fromCanonical` static lookup
  (null / each known brand / unknown / case-sensitivity / empty input),
  freezed equality across each field via `copyWith`, and a
  `toJson` / `fromJson` round-trip including the `enabled` default.
- `lib/features/consumption/domain/entities/maintenance_suggestion.dart` —
  exercises the `MaintenanceSignal` enum, the const constructor, and the
  hand-written `==` / `hashCode` (reflexive, symmetric, per-field
  difference, identity short-circuit, cross-type comparison, hash
  smoke + equality contract).

Refs #561.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/features/loyalty/domain/entities/loyalty_card_test.dart test/features/consumption/domain/entities/maintenance_suggestion_test.dart` — 32 / 32 passing