### PR TITLE
feat(obd2): native Android auto-record bridge (Refs #1004 phase 2b-1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ docs/guides/*
 !docs/guides/obd2-adapters.md
 !docs/guides/vehicle-catalog.md
 !docs/guides/driving-insights.md
+!docs/guides/auto-record.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,21 @@
     <uses-feature android:name="android.hardware.bluetooth_le"
         android:required="false"/>
 
+    <!-- Hands-free trip auto-record (#1004 phase 2b-1).
+         The AutoRecordForegroundService observes BLE auto-connect for
+         the paired adapter while the app is not in the foreground. It
+         requires:
+           * FOREGROUND_SERVICE              base permission since API 28
+           * FOREGROUND_SERVICE_CONNECTED_DEVICE  required by Android 14
+             (API 34+) for `connectedDevice` foreground service type
+           * POST_NOTIFICATIONS              Android 13+ runtime perm so
+             the persistent low-importance auto-record notification can
+             render. Without it the service still runs but the channel
+             is silenced. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application
         android:label="Fuel Prices"
         android:name="${applicationName}"
@@ -75,6 +90,16 @@
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
+
+        <!-- Hands-free trip auto-record foreground service (#1004
+             phase 2b-1). Internal-only — exported=false so no other
+             app can bind. foregroundServiceType="connectedDevice"
+             matches the BLE listener's role: observe transitions on
+             the paired OBD2 adapter only. -->
+        <service
+            android:name=".autorecord.AutoRecordForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice"/>
 
         <!-- Android Auto car app service -->
         <!-- exported=true required: Android Auto host binds via this intent-filter.

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
@@ -1,5 +1,6 @@
 package de.tankstellen.tankstellen
 
+import de.tankstellen.tankstellen.autorecord.BackgroundAdapterChannel
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 
@@ -11,5 +12,14 @@ class MainActivity : FlutterActivity() {
         // Android module free of extra Gradle artefacts; the plugin is
         // app-internal and never shipped to pub.dev.
         Obd2ClassicPlugin.registerWith(flutterEngine, applicationContext)
+
+        // Hands-free auto-record bridge (#1004 phase 2b-1). Same
+        // rationale as Obd2ClassicPlugin: the channel is app-internal
+        // and never shipped to pub.dev. The Dart side
+        // (AndroidBackgroundAdapterListener) talks to this engine via
+        // the MethodChannel + EventChannel registered here; the
+        // foreground service that the channel starts on demand owns
+        // its own GATT client.
+        BackgroundAdapterChannel.registerWith(flutterEngine, applicationContext)
     }
 }

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/AutoRecordForegroundService.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/AutoRecordForegroundService.kt
@@ -1,0 +1,242 @@
+package de.tankstellen.tankstellen.autorecord
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import de.tankstellen.tankstellen.R
+
+/**
+ * Long-running foreground service that drives hands-free trip
+ * auto-record (#1004 phase 2b-1).
+ *
+ * Why a foreground service?
+ *  - Android Doze + App Standby will kill ordinary background services
+ *    and suspend BLE callbacks while the app is not visible. The user's
+ *    car drives by in the morning, the phone is in the kitchen, the
+ *    app's process is dead — a non-foreground service simply will not
+ *    run. A foreground service with a `connectedDevice` type and a
+ *    persistent (low-importance) notification is the OS-supported way
+ *    to keep a BLE listener alive.
+ *
+ * Why stock [BluetoothGatt] instead of flutter_blue_plus?
+ *  - flutter_blue_plus owns its own state machine that lives inside the
+ *    Flutter activity. Sharing one instance across an activity-less
+ *    Android service is fragile (the plugin's binding spans
+ *    `FlutterEngine` + `FlutterPluginBinding.getApplicationContext`).
+ *    The service's only job is observing connect/disconnect; for that
+ *    a 60-line stock GATT client with `autoConnect=true` is the simpler
+ *    and OS-blessed shape. Once the user opens the app, the existing
+ *    [FlutterBluePlusElmChannel] takes over for the actual ELM327
+ *    session.
+ *
+ * Idempotency:
+ *  - If the service is started for the same MAC it's already armed for,
+ *    it's a no-op.
+ *  - If started for a different MAC, the prior GATT is closed and we
+ *    re-arm against the new MAC.
+ */
+class AutoRecordForegroundService : Service() {
+    companion object {
+        private const val TAG = "AutoRecordFgService"
+        const val EXTRA_MAC = "mac"
+
+        private const val CHANNEL_ID = "auto_record"
+        private const val CHANNEL_NAME = "Trip auto-record"
+        private const val NOTIFICATION_ID = 4221
+    }
+
+    private var gatt: BluetoothGatt? = null
+    private var armedMac: String? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val mac = intent?.getStringExtra(EXTRA_MAC)
+        if (mac.isNullOrBlank()) {
+            Log.w(TAG, "onStartCommand: missing MAC extra; stopping")
+            stopSelfSafe()
+            return START_NOT_STICKY
+        }
+
+        startForegroundSafe()
+
+        if (mac.equals(armedMac, ignoreCase = true) && gatt != null) {
+            // Idempotent: same MAC already armed. Nothing to do.
+            return START_STICKY
+        }
+
+        // Different MAC (or first arm). Close any prior GATT.
+        closeGatt()
+        armedMac = mac
+        armGatt(mac)
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        closeGatt()
+        BackgroundAdapterChannel.markStopped()
+        super.onDestroy()
+    }
+
+    private fun ensureNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        if (nm.getNotificationChannel(CHANNEL_ID) == null) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "Watches your paired OBD2 adapter to start trips automatically."
+                setShowBadge(false)
+            }
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    private fun startForegroundSafe() {
+        val notification: Notification = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, CHANNEL_ID)
+                .setContentTitle("Trip auto-record")
+                .setContentText("Watching for your OBD2 adapter")
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setOngoing(true)
+                .build()
+        } else {
+            @Suppress("DEPRECATION")
+            Notification.Builder(this)
+                .setContentTitle("Trip auto-record")
+                .setContentText("Watching for your OBD2 adapter")
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setOngoing(true)
+                .setPriority(Notification.PRIORITY_LOW)
+                .build()
+        }
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                // Android 10+ accepts the foregroundServiceType variant.
+                @Suppress("DEPRECATION")
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        } catch (e: SecurityException) {
+            Log.w(TAG, "startForeground: SecurityException", e)
+            stopSelfSafe()
+        } catch (e: IllegalStateException) {
+            Log.w(TAG, "startForeground: IllegalStateException (Android 12+ background?)", e)
+            stopSelfSafe()
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun armGatt(mac: String) {
+        val manager = getSystemService(BLUETOOTH_SERVICE) as? BluetoothManager
+        val adapter: BluetoothAdapter? = manager?.adapter
+        if (adapter == null) {
+            Log.w(TAG, "armGatt: no BluetoothAdapter; stopping")
+            stopSelfSafe()
+            return
+        }
+        if (!hasBluetoothConnectPermission()) {
+            Log.w(TAG, "armGatt: BLUETOOTH_CONNECT not granted; stopping")
+            stopSelfSafe()
+            return
+        }
+
+        val device = try {
+            adapter.getRemoteDevice(mac)
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "armGatt: invalid MAC '$mac'", e)
+            stopSelfSafe()
+            return
+        }
+
+        val callback = object : BluetoothGattCallback() {
+            override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) {
+                val type = when (newState) {
+                    BluetoothProfile.STATE_CONNECTED -> "connect"
+                    BluetoothProfile.STATE_DISCONNECTED -> "disconnect"
+                    else -> null
+                }
+                if (type != null) {
+                    BackgroundAdapterChannel.post(
+                        mapOf<String, Any>(
+                            "type" to type,
+                            "mac" to mac,
+                            "atMillis" to System.currentTimeMillis(),
+                        ),
+                    )
+                }
+            }
+        }
+
+        gatt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            device.connectGatt(this, /* autoConnect = */ true, callback, BluetoothDevice.TRANSPORT_LE)
+        } else {
+            @Suppress("DEPRECATION")
+            device.connectGatt(this, true, callback)
+        }
+    }
+
+    private fun hasBluetoothConnectPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return checkSelfPermission(android.Manifest.permission.BLUETOOTH_CONNECT) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun closeGatt() {
+        val g = gatt ?: return
+        try {
+            g.disconnect()
+        } catch (e: SecurityException) {
+            Log.w(TAG, "closeGatt: SecurityException on disconnect", e)
+        }
+        try {
+            g.close()
+        } catch (e: SecurityException) {
+            Log.w(TAG, "closeGatt: SecurityException on close", e)
+        }
+        gatt = null
+        armedMac = null
+    }
+
+    private fun stopSelfSafe() {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+            } else {
+                @Suppress("DEPRECATION")
+                stopForeground(true)
+            }
+        } catch (e: IllegalStateException) {
+            Log.w(TAG, "stopSelfSafe: stopForeground failed", e)
+        }
+        stopSelf()
+        BackgroundAdapterChannel.markStopped()
+    }
+}

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/AutoRecordForegroundService.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/AutoRecordForegroundService.kt
@@ -133,8 +133,10 @@ class AutoRecordForegroundService : Service() {
 
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                // Android 10+ accepts the foregroundServiceType variant.
-                @Suppress("DEPRECATION")
+                // Android 10+ accepts the foregroundServiceType variant
+                // — required on Android 14+ so the OS knows we are the
+                // connectedDevice flavour and can size the timeout
+                // window accordingly.
                 startForeground(
                     NOTIFICATION_ID,
                     notification,

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BackgroundAdapterChannel.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BackgroundAdapterChannel.kt
@@ -1,0 +1,168 @@
+package de.tankstellen.tankstellen.autorecord
+
+import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Bridge between [AutoRecordForegroundService] and the Dart-side
+ * `AndroidBackgroundAdapterListener` (#1004 phase 2b-1).
+ *
+ * Two channels:
+ *  - `tankstellen/auto_record/methods` (MethodChannel):
+ *       start(mac: String) -> Bool   starts the foreground service
+ *       stop()             -> Bool   stops the foreground service
+ *       isRunning()        -> Bool   true while the service is alive
+ *  - `tankstellen/auto_record/events` (EventChannel):
+ *       Stream<Map>  events of the form
+ *          {"type": "connect" | "disconnect", "mac": "<MAC>", "atMillis": <Long>}
+ *
+ * Architecture notes:
+ *  - The service emits events through this object via [post]; the
+ *    object forwards them on the platform main thread to the
+ *    [EventChannel.EventSink] when one is attached.
+ *  - When no Dart subscriber is attached (the app process is dead and
+ *    the service is firing alone) we buffer the most recent events in
+ *    a small ring so the coordinator can replay state on resume. The
+ *    ring size is intentionally tiny (16) — the coordinator only needs
+ *    to know the current connected/disconnected state, not a full
+ *    history.
+ *  - We deliberately do NOT share the flutter_blue_plus stack with
+ *    the foreground service. The service owns its own stock
+ *    `BluetoothGatt` client whose only job is observing connection
+ *    transitions; the active trip-recording session re-uses the
+ *    existing `FlutterBluePlusElmChannel` once the Flutter activity
+ *    is back in the foreground.
+ */
+object BackgroundAdapterChannel {
+    private const val TAG = "BackgroundAdapter"
+    private const val METHOD_CHANNEL = "tankstellen/auto_record/methods"
+    private const val EVENT_CHANNEL = "tankstellen/auto_record/events"
+
+    /** Cached app context for starting / stopping the service. Set in [registerWith]. */
+    @Volatile
+    private var appContext: Context? = null
+
+    /** Live EventSink, or null when no Dart subscriber is attached. */
+    @Volatile
+    private var eventSink: EventChannel.EventSink? = null
+
+    /**
+     * Last-N ring buffer of events seen while no subscriber was
+     * attached. Replayed in order on [EventChannel.StreamHandler.onListen].
+     */
+    private val pending = ArrayDeque<Map<String, Any>>()
+    private const val PENDING_CAPACITY = 16
+
+    /** Tracks whether the foreground service is currently running. */
+    @Volatile
+    private var running: Boolean = false
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    fun registerWith(flutterEngine: FlutterEngine, context: Context) {
+        appContext = context.applicationContext
+
+        val method = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, METHOD_CHANNEL)
+        method.setMethodCallHandler { call, result -> handle(call, result) }
+
+        val events = EventChannel(flutterEngine.dartExecutor.binaryMessenger, EVENT_CHANNEL)
+        events.setStreamHandler(object : EventChannel.StreamHandler {
+            override fun onListen(arguments: Any?, sink: EventChannel.EventSink?) {
+                eventSink = sink
+                drainPending()
+            }
+
+            override fun onCancel(arguments: Any?) {
+                eventSink = null
+            }
+        })
+    }
+
+    private fun handle(call: MethodCall, result: MethodChannel.Result) {
+        val ctx = appContext
+        if (ctx == null) {
+            result.error("state", "BackgroundAdapterChannel not initialised", null)
+            return
+        }
+        when (call.method) {
+            "start" -> {
+                val mac = call.argument<String>("mac")
+                if (mac.isNullOrBlank()) {
+                    result.error("arg", "mac missing", null)
+                    return
+                }
+                val intent = Intent(ctx, AutoRecordForegroundService::class.java).apply {
+                    putExtra(AutoRecordForegroundService.EXTRA_MAC, mac)
+                }
+                try {
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                        ctx.startForegroundService(intent)
+                    } else {
+                        ctx.startService(intent)
+                    }
+                    running = true
+                    result.success(true)
+                } catch (e: SecurityException) {
+                    Log.w(TAG, "start: missing FOREGROUND_SERVICE permission", e)
+                    result.error("permission", e.message ?: "permission denied", null)
+                } catch (e: IllegalStateException) {
+                    // App in background on Android 12+ — caller must
+                    // arm the service from a foreground context. Bubble
+                    // up so Dart can decide what to do.
+                    Log.w(TAG, "start: cannot start FGS from background", e)
+                    result.error("state", e.message ?: "cannot start fgs", null)
+                }
+            }
+            "stop" -> {
+                val intent = Intent(ctx, AutoRecordForegroundService::class.java)
+                try {
+                    ctx.stopService(intent)
+                } catch (e: SecurityException) {
+                    Log.w(TAG, "stop: SecurityException", e)
+                }
+                running = false
+                result.success(true)
+            }
+            "isRunning" -> result.success(running)
+            else -> result.notImplemented()
+        }
+    }
+
+    /**
+     * Called by [AutoRecordForegroundService] on every connection
+     * transition. Forwards on the main thread to the EventSink, or
+     * buffers in the ring when no subscriber is attached.
+     */
+    fun post(event: Map<String, Any>) {
+        mainHandler.post {
+            val sink = eventSink
+            if (sink != null) {
+                sink.success(event)
+            } else {
+                if (pending.size >= PENDING_CAPACITY) {
+                    pending.removeFirst()
+                }
+                pending.addLast(event)
+            }
+        }
+    }
+
+    /** Marker called by the service so we can flip [isRunning] off when the OS kills it. */
+    fun markStopped() {
+        running = false
+    }
+
+    private fun drainPending() {
+        val sink = eventSink ?: return
+        while (pending.isNotEmpty()) {
+            sink.success(pending.removeFirst())
+        }
+    }
+}

--- a/docs/guides/auto-record.md
+++ b/docs/guides/auto-record.md
@@ -1,0 +1,118 @@
+# Hands-free trip auto-record (Android)
+
+Status: phase 2b-1 — native bridge shipped, production wiring of
+`AutoTripCoordinator` is phase 2b-2.
+
+This document explains the Android-side foreground service that drives
+hands-free trip auto-record (issue #1004) and how to verify a build.
+
+## Why a foreground service?
+
+Modern Android (Doze + App Standby + Android 12+ background-launch
+restrictions) will kill ordinary background services and suspend BLE
+callbacks while the app is not visible. The user's car drives by in
+the morning, the phone is in the kitchen, the app process is dead — a
+non-foreground service simply will not run.
+
+A foreground service with `foregroundServiceType="connectedDevice"`
+and a persistent low-importance notification is the OS-supported way
+to keep a BLE listener alive long enough to observe the user's paired
+adapter coming into range.
+
+## Permissions
+
+Declared in `android/app/src/main/AndroidManifest.xml`:
+
+| Permission | Why |
+| --- | --- |
+| `android.permission.FOREGROUND_SERVICE` | Required to start any foreground service since Android 9 (API 28). |
+| `android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE` | Required by Android 14 (API 34+) for the `connectedDevice` foreground service type. |
+| `android.permission.POST_NOTIFICATIONS` | Android 13+ runtime permission so the persistent low-importance auto-record notification can render. Without it the service still runs but the channel is silenced. |
+| `android.permission.BLUETOOTH_CONNECT` (already declared for #716) | Needed for `getRemoteDevice()` + `connectGatt()` on Android 12+. |
+
+The service entry inside `<application>`:
+
+```xml
+<service
+    android:name=".autorecord.AutoRecordForegroundService"
+    android:exported="false"
+    android:foregroundServiceType="connectedDevice"/>
+```
+
+## Why stock `BluetoothGatt`, not `flutter_blue_plus`?
+
+`flutter_blue_plus` owns its own state machine that lives inside the
+Flutter activity. Sharing one instance across an activity-less Android
+service is fragile (the plugin's binding spans `FlutterEngine` plus
+`FlutterPluginBinding.getApplicationContext`).
+
+The service's only job is observing connect / disconnect; for that a
+small stock GATT client with `connectGatt(autoConnect = true, ...)` is
+the simpler and OS-blessed shape. Once the user opens the app, the
+existing `FlutterBluePlusElmChannel` takes over for the actual ELM327
+trip-recording session — there is no shared state to coordinate.
+
+## Architecture
+
+```
++-------------------+      MethodChannel       +-----------------------+
+| Dart side         |  tankstellen/auto_record |                       |
+| AndroidBackground |  /methods                |                       |
+| AdapterListener   | -----------------------> |                       |
+|                   |                          | BackgroundAdapter     |
+|                   |  EventChannel            | Channel (Kotlin       |
+|                   |  /events                 | singleton)            |
+|                   | <----------------------- |                       |
++-------------------+                          +-----------+-----------+
+                                                           |
+                                                  startService(intent)
+                                                           |
+                                                           v
+                                          +----------------------------+
+                                          | AutoRecordForegroundService|
+                                          |  - notification channel    |
+                                          |    "auto_record"           |
+                                          |  - BluetoothGatt callback  |
+                                          |    autoConnect=true        |
+                                          +----------------------------+
+                                                           |
+                                                           | connect / disconnect
+                                                           |
+                                                           v
+                                            BackgroundAdapterChannel.post(...)
+```
+
+Connection events take the form `{"type": "connect" | "disconnect",
+"mac": "<MAC>", "atMillis": <epoch ms>}`. The Dart-side listener
+translates those maps into the sealed `AdapterConnected` /
+`AdapterDisconnected` envelope that `AutoTripCoordinator` consumes.
+
+## Test plan for the user
+
+1. Install a build that has phase 2b-2 wiring (this PR is bridge-only,
+   so the auto-record toggle in the consumption screen does not yet
+   start the service).
+2. Pair the OBD2 adapter once via Android settings.
+3. Enable auto-record on the active vehicle profile.
+4. Lock the phone, walk to the car, plug the adapter in (or step into
+   range if it's permanently plugged).
+5. Verify within ~60 s:
+   * The persistent notification "Trip auto-record — Watching for your
+     OBD2 adapter" is visible.
+   * `AutoRecordTraceLog` shows a `connect` line for your MAC.
+6. Drive for 5 minutes, then exit the car / turn off the ignition.
+7. Verify:
+   * `AutoRecordTraceLog` shows a `disconnect` line.
+   * After the configured `disconnectSaveDelay` (default 60 s) the
+     trip is saved to history.
+
+## Files
+
+| Layer | Path |
+| --- | --- |
+| Service | `android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/AutoRecordForegroundService.kt` |
+| Bridge | `android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BackgroundAdapterChannel.kt` |
+| Activity wiring | `android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt` |
+| Manifest | `android/app/src/main/AndroidManifest.xml` |
+| Dart bridge | `lib/features/consumption/data/obd2/android_background_adapter_listener.dart` |
+| Tests | `test/features/consumption/data/obd2/android_background_adapter_listener_test.dart` |

--- a/lib/features/consumption/data/obd2/android_background_adapter_listener.dart
+++ b/lib/features/consumption/data/obd2/android_background_adapter_listener.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'background_adapter_listener.dart';
+
+/// Production [BackgroundAdapterListener] backed by the native Android
+/// foreground service shipped in #1004 phase 2b-1.
+///
+/// The Kotlin side ([AutoRecordForegroundService] +
+/// [BackgroundAdapterChannel]) registers two platform channels:
+///  * `tankstellen/auto_record/methods` — `start(mac)` / `stop()` /
+///    `isRunning()` to control the foreground service from Dart.
+///  * `tankstellen/auto_record/events` — broadcast stream of
+///    `{"type": "connect"|"disconnect", "mac": "...", "atMillis": <ms>}`
+///    payloads, one per BLE GATT transition for the armed adapter.
+///
+/// This file is the bridge file. Phase 2b-1 ships it present-but-unused
+/// so the existing [AutoTripCoordinator] (Refs #1004 phase 2a) has a
+/// real listener to bind against in phase 2b-2 — this PR does NOT wire
+/// it into any production Riverpod provider yet.
+///
+/// Channels are constructor-injected so unit tests can swap the names
+/// to per-test channels and exercise the parsing without colliding
+/// with another test running in parallel.
+class AndroidBackgroundAdapterListener implements BackgroundAdapterListener {
+  /// Platform channel exposing `start` / `stop` / `isRunning`.
+  final MethodChannel _methods;
+
+  /// Platform channel that streams `{type, mac, atMillis}` maps.
+  final EventChannel _events;
+
+  /// Single in-process broadcast stream that fans the parsed events out
+  /// to the coordinator. We translate each platform map into a
+  /// [BackgroundAdapterEvent] subclass exactly once so every subscriber
+  /// sees the same instance.
+  final StreamController<BackgroundAdapterEvent> _controller =
+      StreamController<BackgroundAdapterEvent>.broadcast();
+
+  /// Native EventChannel subscription, opened on the first [start] call
+  /// and closed on [stop]. We keep at most one open subscription —
+  /// re-arming with a different MAC does NOT churn the EventChannel.
+  StreamSubscription<dynamic>? _platformSubscription;
+
+  /// Default constructor for production use. Channel names match the
+  /// strings in [BackgroundAdapterChannel] on the Kotlin side; keep
+  /// them in sync.
+  AndroidBackgroundAdapterListener()
+      : _methods = const MethodChannel('tankstellen/auto_record/methods'),
+        _events = const EventChannel('tankstellen/auto_record/events');
+
+  /// Test-only constructor that injects custom channels. Useful when
+  /// running multiple isolation-level tests in parallel — each test
+  /// owns its own channel name and so its own
+  /// [TestDefaultBinaryMessenger] handler.
+  @visibleForTesting
+  AndroidBackgroundAdapterListener.withChannels({
+    required MethodChannel methodChannel,
+    required EventChannel eventChannel,
+  })  : _methods = methodChannel,
+        _events = eventChannel;
+
+  @override
+  Stream<BackgroundAdapterEvent> get events => _controller.stream;
+
+  @override
+  Future<void> start({required String mac}) async {
+    // Ensure we're listening to the EventChannel BEFORE the service
+    // arms — otherwise an early connect event from a fast adapter
+    // could beat us to the EventChannel and be dropped. The native
+    // ring buffer mitigates this further but the cheapest defence is
+    // to subscribe first.
+    _platformSubscription ??= _events
+        .receiveBroadcastStream()
+        .listen(
+          _onPlatformEvent,
+          onError: (Object error, StackTrace stack) {
+            // Non-fatal: native side reported a stream error. We do
+            // NOT close the broadcast stream — coordinator restart
+            // would otherwise miss every subsequent event.
+            debugPrint(
+              'AndroidBackgroundAdapterListener: platform stream error: $error',
+            );
+          },
+        );
+
+    await _methods.invokeMethod<bool>('start', <String, Object?>{'mac': mac});
+  }
+
+  @override
+  Future<void> stop() async {
+    await _methods.invokeMethod<bool>('stop');
+    await _platformSubscription?.cancel();
+    _platformSubscription = null;
+  }
+
+  /// Whether the native foreground service is currently armed. Useful
+  /// for diagnostics and for an idempotent "start if not started" flow
+  /// in the production coordinator wiring (phase 2b-2). Best-effort —
+  /// the OS may have killed the service since the last call.
+  Future<bool> isRunning() async {
+    final ok = await _methods.invokeMethod<bool>('isRunning');
+    return ok ?? false;
+  }
+
+  void _onPlatformEvent(Object? raw) {
+    // Malformed events are dropped via debugPrint inside [_parseEvent]
+    // — never silenced. A bad payload is a real bug on the native side;
+    // we want it visible in the Flutter run / test log so it shows up
+    // during device testing without crashing the stream.
+    final event = _parseEvent(raw);
+    if (event == null) return;
+    _controller.add(event);
+  }
+
+  /// Returns a typed [BackgroundAdapterEvent], or `null` if the payload
+  /// is malformed. Pulled out to keep [_onPlatformEvent] readable and
+  /// to give tests a deterministic place to assert parsing rules.
+  BackgroundAdapterEvent? _parseEvent(Object? raw) {
+    if (raw is! Map) {
+      debugPrint(
+        'AndroidBackgroundAdapterListener: dropping non-Map event '
+        '(${raw.runtimeType})',
+      );
+      return null;
+    }
+    final type = raw['type'];
+    final mac = raw['mac'];
+    final atMillis = raw['atMillis'];
+    if (type is! String || mac is! String) {
+      debugPrint(
+        'AndroidBackgroundAdapterListener: dropping event with bad '
+        'type/mac fields: $raw',
+      );
+      return null;
+    }
+    DateTime at;
+    if (atMillis is int) {
+      at = DateTime.fromMillisecondsSinceEpoch(atMillis);
+    } else if (atMillis is num) {
+      // Some platforms (and JSON channels) round-trip ints as doubles.
+      at = DateTime.fromMillisecondsSinceEpoch(atMillis.toInt());
+    } else {
+      debugPrint(
+        'AndroidBackgroundAdapterListener: dropping event with bad '
+        'atMillis (${atMillis.runtimeType}): $raw',
+      );
+      return null;
+    }
+    switch (type) {
+      case 'connect':
+        return AdapterConnected(mac: mac, at: at);
+      case 'disconnect':
+        return AdapterDisconnected(mac: mac, at: at);
+      default:
+        debugPrint(
+          'AndroidBackgroundAdapterListener: dropping event with '
+          'unknown type "$type"',
+        );
+        return null;
+    }
+  }
+
+  /// Test-only hook to drain resources between tests.
+  @visibleForTesting
+  Future<void> dispose() async {
+    await _platformSubscription?.cancel();
+    _platformSubscription = null;
+    if (!_controller.isClosed) {
+      await _controller.close();
+    }
+  }
+}

--- a/test/features/consumption/data/obd2/android_background_adapter_listener_test.dart
+++ b/test/features/consumption/data/obd2/android_background_adapter_listener_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/android_background_adapter_listener.dart';
+import 'package:tankstellen/features/consumption/data/obd2/background_adapter_listener.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Per-test channel names so the binary messenger handlers from one
+  // test cannot leak into another. Real production code uses the
+  // strings hard-coded in [AndroidBackgroundAdapterListener]; the
+  // bridge file already pins those, so testing an isolated channel
+  // name is fine here.
+  const methodChannel =
+      MethodChannel('test/tankstellen/auto_record/methods');
+  const eventChannel =
+      EventChannel('test/tankstellen/auto_record/events');
+
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  late AndroidBackgroundAdapterListener listener;
+
+  setUp(() {
+    listener = AndroidBackgroundAdapterListener.withChannels(
+      methodChannel: methodChannel,
+      eventChannel: eventChannel,
+    );
+  });
+
+  tearDown(() async {
+    messenger.setMockMethodCallHandler(methodChannel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockStreamHandler(eventChannel, null);
+    await listener.dispose();
+  });
+
+  group('AndroidBackgroundAdapterListener (#1004 phase 2b-1)', () {
+    test('start invokes the platform `start` method with the mac arg',
+        () async {
+      final List<MethodCall> calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        calls.add(call);
+        return true;
+      });
+      // Empty event stream — start subscribes during invocation, so we
+      // need a stream handler installed even if no events flow.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChannel,
+        MockStreamHandler.inline(onListen: (_, _) {}),
+      );
+
+      await listener.start(mac: 'AA:BB:CC:DD:EE:01');
+
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'start');
+      expect(calls.single.arguments, {'mac': 'AA:BB:CC:DD:EE:01'});
+    });
+
+    test('events from the EventChannel are translated to typed events',
+        () async {
+      messenger.setMockMethodCallHandler(
+        methodChannel,
+        (call) async => true,
+      );
+
+      late MockStreamHandlerEventSink sink;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChannel,
+        MockStreamHandler.inline(
+          onListen: (_, events) {
+            sink = events;
+          },
+        ),
+      );
+
+      final received = <BackgroundAdapterEvent>[];
+      final sub = listener.events.listen(received.add);
+
+      await listener.start(mac: 'AA:BB:CC:DD:EE:01');
+
+      // The platform handler captures the EventSink synchronously on
+      // first listen. Push two events through it.
+      sink.success(<String, Object?>{
+        'type': 'connect',
+        'mac': 'AA:BB:CC:DD:EE:01',
+        'atMillis': 1700000000000,
+      });
+      sink.success(<String, Object?>{
+        'type': 'disconnect',
+        'mac': 'AA:BB:CC:DD:EE:01',
+        'atMillis': 1700000060000,
+      });
+
+      // Pump a microtask so the broadcast stream delivers.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(2));
+      expect(received[0], isA<AdapterConnected>());
+      expect(received[0].mac, 'AA:BB:CC:DD:EE:01');
+      expect(
+        received[0].at.millisecondsSinceEpoch,
+        1700000000000,
+      );
+      expect(received[1], isA<AdapterDisconnected>());
+      expect(
+        received[1].at.millisecondsSinceEpoch,
+        1700000060000,
+      );
+
+      await sub.cancel();
+    });
+
+    test('malformed events are dropped (no crash, no sealed-event emission)',
+        () async {
+      messenger.setMockMethodCallHandler(
+        methodChannel,
+        (call) async => true,
+      );
+
+      late MockStreamHandlerEventSink sink;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChannel,
+        MockStreamHandler.inline(
+          onListen: (_, events) {
+            sink = events;
+          },
+        ),
+      );
+
+      final received = <BackgroundAdapterEvent>[];
+      final sub = listener.events.listen(received.add);
+
+      await listener.start(mac: 'AA:BB:CC:DD:EE:01');
+
+      // 1. Non-Map payload.
+      sink.success('garbage');
+      // 2. Map missing the `mac` field.
+      sink.success(<String, Object?>{
+        'type': 'connect',
+        'atMillis': 1700000000000,
+      });
+      // 3. Map with an unknown `type`.
+      sink.success(<String, Object?>{
+        'type': 'unknown',
+        'mac': 'AA:BB:CC:DD:EE:01',
+        'atMillis': 1700000000000,
+      });
+      // 4. Map with a non-numeric atMillis.
+      sink.success(<String, Object?>{
+        'type': 'connect',
+        'mac': 'AA:BB:CC:DD:EE:01',
+        'atMillis': 'not a number',
+      });
+      // 5. A valid event AFTER the malformed ones — proves the stream
+      //    was not closed by the bad payloads.
+      sink.success(<String, Object?>{
+        'type': 'connect',
+        'mac': 'AA:BB:CC:DD:EE:01',
+        'atMillis': 1700000000000,
+      });
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.single, isA<AdapterConnected>());
+
+      await sub.cancel();
+    });
+
+    test('stop invokes the platform `stop` method', () async {
+      final List<MethodCall> calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        calls.add(call);
+        return true;
+      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChannel,
+        MockStreamHandler.inline(onListen: (_, _) {}),
+      );
+
+      await listener.start(mac: 'AA:BB:CC:DD:EE:01');
+      await listener.stop();
+
+      expect(
+        calls.map((c) => c.method),
+        containsAllInOrder(<String>['start', 'stop']),
+      );
+    });
+
+    test('atMillis can be a num that rounds down to int', () async {
+      messenger.setMockMethodCallHandler(
+        methodChannel,
+        (call) async => true,
+      );
+
+      late MockStreamHandlerEventSink sink;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChannel,
+        MockStreamHandler.inline(
+          onListen: (_, events) {
+            sink = events;
+          },
+        ),
+      );
+
+      final received = <BackgroundAdapterEvent>[];
+      final sub = listener.events.listen(received.add);
+
+      await listener.start(mac: 'AA:BB:CC:DD:EE:01');
+
+      sink.success(<String, Object?>{
+        'type': 'disconnect',
+        'mac': 'AA:BB:CC:DD:EE:01',
+        // Some channels round-trip ints as doubles in JSON.
+        'atMillis': 1700000060000.0,
+      });
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.single, isA<AdapterDisconnected>());
+      expect(
+        received.single.at.millisecondsSinceEpoch,
+        1700000060000,
+      );
+
+      await sub.cancel();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Replace `UnimplementedBackgroundAdapterListener` with a real Android implementation that drives BLE auto-connect from a native foreground service. **Production wiring of `AutoTripCoordinator` is out of scope for this phase** — the bridge ships present-but-unused so phase 2b-2 can flip the production provider over.

## Why

Hands-free auto-record (#1004) needs the OS to wake the app the moment the paired OBD2 adapter comes into BLE range — even when the app process has been killed by Doze. A non-foreground listener simply cannot do that on modern Android. This PR adds the foreground service + platform-channel bridge that phase 2b-2 will wire into the existing coordinator state machine shipped in #1170.

## Architecture summary

The user's device runs an in-app foreground service while auto-record is enabled. The service owns a stock `BluetoothGatt` client with `autoConnect=true` for the paired adapter MAC. When the device comes into range and BLE connects, the service posts a `connect` event through `BackgroundAdapterChannel`; when BLE drops, a `disconnect`. The `connectedDevice` foreground service type plus a low-importance notification keep the listener alive across Doze. The Dart-side `AndroidBackgroundAdapterListener` translates the platform `{type, mac, atMillis}` maps into the existing sealed `BackgroundAdapterEvent` envelope. Once the app's Flutter activity resumes, the existing `FlutterBluePlusElmChannel` takes over for the actual ELM327 trip session — the service's `BluetoothGatt` client is never used for OBD2 commands.

## Files added / modified

Added:
- `android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/AutoRecordForegroundService.kt`
- `android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BackgroundAdapterChannel.kt`
- `lib/features/consumption/data/obd2/android_background_adapter_listener.dart`
- `test/features/consumption/data/obd2/android_background_adapter_listener_test.dart`
- `docs/guides/auto-record.md`

Modified:
- `android/app/src/main/AndroidManifest.xml` (permissions + service entry)
- `android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt` (channel registration)
- `.gitignore` (whitelist the new doc)

## Permissions added to manifest

| Permission | Why |
| --- | --- |
| `FOREGROUND_SERVICE` | Required to start any foreground service since Android 9 (API 28). |
| `FOREGROUND_SERVICE_CONNECTED_DEVICE` | Required by Android 14 (API 34+) for the `connectedDevice` service type. |
| `POST_NOTIFICATIONS` | Android 13+ runtime permission so the persistent low-importance auto-record notification can render. |

Plus a new `<service>` entry inside `<application>` with `android:exported="false"` and `android:foregroundServiceType="connectedDevice"`.

## Acceptance

Acceptance: device test by repo owner (5 sessions across 7 days). Code-only ship; CI gates on compile + Dart tests.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test test/features/consumption/data/obd2/` — 511/511 green (includes new bridge tests)
- [x] `flutter test test/lint/` — 29/29 green (silent-catch + const + i18n scans)
- [ ] `flutter build appbundle --release --flavor play` — skipped locally (Kotlin compile exceeded the 10-min wallclock budget on this hardware); CI will run on push.
- [ ] Phase 2b-2 will exercise the bridge end-to-end on device.

Refs #1004 phase 2b-1