### PR TITLE
refactor(consumption): extract heuristic helpers out of maintenance_analyzer (Refs #563 phase: maintenance_analyzer)

### DIFF
--- a/lib/features/consumption/domain/services/_maf_deviation_detector.dart
+++ b/lib/features/consumption/domain/services/_maf_deviation_detector.dart
@@ -1,0 +1,61 @@
+/// MAF-deviation pilot heuristic for [MaintenanceAnalyzer] (#1124).
+///
+/// Split out of `maintenance_analyzer.dart` to keep that file under the
+/// 300-LOC budget (Refs #563). The heuristic stays internal to the
+/// analyzer library via `part of` — no public API surface changes.
+part of 'maintenance_analyzer.dart';
+
+/// Second pilot heuristic: median cruise fuel rate in the second half
+/// of the window > 10 % lower than the median in the first half. Same
+/// half-split machinery as the idle creep detector — only the per-trip
+/// reduction differs.
+MaintenanceSuggestion? _detectMafDeviation(
+  List<TripHistoryEntry> tripsOldestFirst,
+  DateTime now,
+) {
+  final perTripCruise = <_TimedValue>[];
+  for (final trip in tripsOldestFirst) {
+    final m = _medianCruiseFuelRate(trip.samples);
+    if (m == null) continue;
+    perTripCruise.add(_TimedValue(at: trip.summary.startedAt!, value: m));
+  }
+  return _emitHalfSplitSignal(
+    perTripValues: perTripCruise,
+    now: now,
+    triggerWhen: (firstMedian, secondMedian) {
+      if (firstMedian <= 0) return null;
+      final delta = (firstMedian - secondMedian) / firstMedian;
+      if (delta <= MaintenanceAnalyzerThresholds.mafDeviationDropFraction) {
+        return null;
+      }
+      return delta * 100.0;
+    },
+    signal: MaintenanceSignal.mafDeviation,
+    nowForStamp: now,
+  );
+}
+
+/// Compute the median fuel rate during steady-cruise samples in
+/// [samples]. Cruise = speed `[60, 100]` km/h AND rpm `[1500, 2500]`.
+/// Returns null when fewer than four samples qualify or when the
+/// trip's recording stack didn't carry the fuel-rate PID (older car
+/// without PID 5E or MAF).
+double? _medianCruiseFuelRate(List<TripSample> samples) {
+  if (samples.isEmpty) return null;
+  final rates = <double>[];
+  for (final s in samples) {
+    final fuel = s.fuelRateLPerHour;
+    if (fuel == null) continue;
+    if (s.speedKmh < MaintenanceAnalyzerThresholds.cruiseSpeedMinKmh) {
+      continue;
+    }
+    if (s.speedKmh > MaintenanceAnalyzerThresholds.cruiseSpeedMaxKmh) {
+      continue;
+    }
+    if (s.rpm < MaintenanceAnalyzerThresholds.cruiseRpmMin) continue;
+    if (s.rpm > MaintenanceAnalyzerThresholds.cruiseRpmMax) continue;
+    rates.add(fuel);
+  }
+  if (rates.length < 4) return null;
+  return _median(rates);
+}

--- a/lib/features/consumption/domain/services/maintenance_analyzer.dart
+++ b/lib/features/consumption/domain/services/maintenance_analyzer.dart
@@ -31,6 +31,8 @@ import '../../data/trip_history_repository.dart';
 import '../entities/maintenance_suggestion.dart';
 import '../trip_recorder.dart';
 
+part '_maf_deviation_detector.dart';
+
 /// Default thresholds for the two pilot heuristics. Exposed as
 /// top-level constants so the provider, the tests, and any future UI
 /// "explain why" affordance can read the same source of truth.
@@ -173,36 +175,6 @@ MaintenanceSuggestion? _detectIdleRpmCreep(
   );
 }
 
-/// Second pilot heuristic: median cruise fuel rate in the second half
-/// of the window > 10 % lower than the median in the first half. Same
-/// half-split machinery as the idle creep detector — only the per-trip
-/// reduction differs.
-MaintenanceSuggestion? _detectMafDeviation(
-  List<TripHistoryEntry> tripsOldestFirst,
-  DateTime now,
-) {
-  final perTripCruise = <_TimedValue>[];
-  for (final trip in tripsOldestFirst) {
-    final m = _medianCruiseFuelRate(trip.samples);
-    if (m == null) continue;
-    perTripCruise.add(_TimedValue(at: trip.summary.startedAt!, value: m));
-  }
-  return _emitHalfSplitSignal(
-    perTripValues: perTripCruise,
-    now: now,
-    triggerWhen: (firstMedian, secondMedian) {
-      if (firstMedian <= 0) return null;
-      final delta = (firstMedian - secondMedian) / firstMedian;
-      if (delta <= MaintenanceAnalyzerThresholds.mafDeviationDropFraction) {
-        return null;
-      }
-      return delta * 100.0;
-    },
-    signal: MaintenanceSignal.mafDeviation,
-    nowForStamp: now,
-  );
-}
-
 /// Compute the median RPM over the idle samples in [samples]. Idle =
 /// `speedKmh <= idleSpeedKmhCutoff` AND `rpm >= minIdleRpm`. Returns
 /// null when fewer than four samples qualify (per-trip medians need
@@ -220,31 +192,6 @@ double? _medianIdleRpm(List<TripSample> samples) {
   }
   if (idle.length < 4) return null;
   return _median(idle);
-}
-
-/// Compute the median fuel rate during steady-cruise samples in
-/// [samples]. Cruise = speed `[60, 100]` km/h AND rpm `[1500, 2500]`.
-/// Returns null when fewer than four samples qualify or when the
-/// trip's recording stack didn't carry the fuel-rate PID (older car
-/// without PID 5E or MAF).
-double? _medianCruiseFuelRate(List<TripSample> samples) {
-  if (samples.isEmpty) return null;
-  final rates = <double>[];
-  for (final s in samples) {
-    final fuel = s.fuelRateLPerHour;
-    if (fuel == null) continue;
-    if (s.speedKmh < MaintenanceAnalyzerThresholds.cruiseSpeedMinKmh) {
-      continue;
-    }
-    if (s.speedKmh > MaintenanceAnalyzerThresholds.cruiseSpeedMaxKmh) {
-      continue;
-    }
-    if (s.rpm < MaintenanceAnalyzerThresholds.cruiseRpmMin) continue;
-    if (s.rpm > MaintenanceAnalyzerThresholds.cruiseRpmMax) continue;
-    rates.add(fuel);
-  }
-  if (rates.length < 4) return null;
-  return _median(rates);
 }
 
 /// Shared half-split + emit shape used by both heuristics. [triggerWhen]


### PR DESCRIPTION
## Summary
- Brings `lib/features/consumption/domain/services/maintenance_analyzer.dart` under the 300-LOC budget (Refs #563).
- Extracts the MAF-deviation heuristic (`_detectMafDeviation` + `_medianCruiseFuelRate`) into sibling part file `_maf_deviation_detector.dart`.
- Library-private types (`_TimedValue`, `_emitHalfSplitSignal`, `_median`) stay truly private via `part` / `part of` — no public API surface change.

## LOC
- `maintenance_analyzer.dart`: **322 -> 269** LOC (target met)
- `_maf_deviation_detector.dart` (new): 61 LOC

## Behavior
- Public API (`analyzeMaintenance`, `MaintenanceAnalyzerThresholds`) unchanged.
- Pure-function semantics preserved (no Hive, Riverpod, system clock).
- Existing `test/features/consumption/domain/services/maintenance_analyzer_test.dart` (10 cases) passes unchanged.

## Test plan
- [x] `flutter analyze` clean (no issues)
- [x] `flutter test test/features/consumption/domain/services/maintenance_analyzer_test.dart` — 10/10 pass
- [ ] CI green on full suite

Refs #563 phase: maintenance_analyzer (epic continues — no `Closes`).