### PR TITLE
feat(obd2): wire auto-record coordinator to vehicle profiles (Refs #1004 phase 2b-2)

### DIFF
--- a/docs/guides/auto-record.md
+++ b/docs/guides/auto-record.md
@@ -1,7 +1,7 @@
 # Hands-free trip auto-record (Android)
 
-Status: phase 2b-1 — native bridge shipped, production wiring of
-`AutoTripCoordinator` is phase 2b-2.
+Status: phase 2b-2 — native bridge shipped, `AutoTripCoordinator` wired
+to the active vehicle list via `AutoRecordOrchestrator`.
 
 This document explains the Android-side foreground service that drives
 hands-free trip auto-record (issue #1004) and how to verify a build.
@@ -106,6 +106,36 @@ translates those maps into the sealed `AdapterConnected` /
    * After the configured `disconnectSaveDelay` (default 60 s) the
      trip is saved to history.
 
+## Production wiring (phase 2b-2)
+
+`AutoRecordOrchestrator` (`lib/features/consumption/providers/auto_record_orchestrator.dart`)
+is the single Riverpod-keepAlive provider that turns the foreground
+service on. Boot sequence:
+
+1. `AppInitializer._launch` reads `autoRecordOrchestratorProvider` from
+   a post-first-frame microtask. Failures are logged but never block
+   the launch path — a bug in the listener factory cannot crash boot.
+2. The orchestrator subscribes to `vehicleProfileListProvider` and
+   diffs every change. Any vehicle with both `autoRecord: true` and a
+   non-null `pairedAdapterMac` gets a fresh `AutoTripCoordinator`.
+3. The coordinator constructs its own `BackgroundAdapterListener`. On
+   Android (`defaultTargetPlatform == TargetPlatform.android`) this is
+   `AndroidBackgroundAdapterListener` — calling `start(mac)` triggers
+   the Kotlin foreground service. On other platforms the orchestrator
+   falls back to `UnimplementedBackgroundAdapterListener` so iOS /
+   desktop builds still compile.
+4. A vehicle that flips `autoRecord` off, drops its paired MAC, or
+   gets deleted has its coordinator stopped. A `pairedAdapterMac`
+   change is treated as drop + recreate: the foreground service
+   watches a single MAC, so re-arming is the only way to switch.
+5. Speed is sourced from `Geolocator.getPositionStream`
+   (m/s → km/h) for phase 2b-2. Phase 2b-3 will switch to OBD2 PID
+   0x0D once the on-connect session-handoff design is decided.
+6. On orchestrator dispose (Riverpod container teardown / app exit)
+   every coordinator is stopped, which in turn calls
+   `AndroidBackgroundAdapterListener.stop()` and the foreground
+   service is dismissed.
+
 ## Files
 
 | Layer | Path |
@@ -115,4 +145,7 @@ translates those maps into the sealed `AdapterConnected` /
 | Activity wiring | `android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt` |
 | Manifest | `android/app/src/main/AndroidManifest.xml` |
 | Dart bridge | `lib/features/consumption/data/obd2/android_background_adapter_listener.dart` |
-| Tests | `test/features/consumption/data/obd2/android_background_adapter_listener_test.dart` |
+| Coordinator | `lib/features/consumption/data/obd2/auto_trip_coordinator.dart` |
+| Orchestrator | `lib/features/consumption/providers/auto_record_orchestrator.dart` |
+| App boot | `lib/app/app_initializer.dart` |
+| Tests | `test/features/consumption/data/obd2/android_background_adapter_listener_test.dart`, `test/features/consumption/providers/auto_record_orchestrator_test.dart` |

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -22,6 +22,7 @@ import '../core/sync/community_config.dart';
 import '../core/sync/supabase_client.dart';
 import '../core/telemetry/pii_scrubber.dart';
 import '../core/utils/edge_to_edge.dart';
+import '../features/consumption/providers/auto_record_orchestrator.dart';
 import '../features/profile/data/repositories/profile_repository.dart';
 import '../features/vehicle/data/reference_vehicle_catalog_provider.dart';
 import '../features/vehicle/data/repositories/vehicle_profile_repository.dart';
@@ -413,6 +414,24 @@ class AppInitializer {
     } catch (e, st) {
       debugPrint('AppInitializer: nearestWidgetRefresh start failed: $e\n$st');
     }
+
+    // #1004 phase 2b-2 — instantiate the auto-record orchestrator. The
+    // provider is `keepAlive: true` and watches the vehicle list
+    // internally; reading it once is enough to spin up coordinators
+    // for any vehicle that already has `autoRecord: true`. Deferred to
+    // a post-frame microtask so a slow listener factory (Android
+    // platform channel handshake) cannot delay the first paint. The
+    // try/catch belongs here, not just inside the provider, because a
+    // bug in `defaultTargetPlatform` resolution or in the listener
+    // factory would otherwise crash the whole launch path.
+    _deferPostFirstFrame(() async {
+      try {
+        container.read(autoRecordOrchestratorProvider);
+      } catch (e, st) {
+        debugPrint(
+            'AppInitializer: autoRecordOrchestrator init failed: $e\n$st');
+      }
+    });
 
     // #1105 — drain the background-isolate error spool through the
     // foreground TraceRecorder. WorkManager runs without Riverpod, so

--- a/lib/features/consumption/providers/auto_record_orchestrator.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator.dart
@@ -1,0 +1,279 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../vehicle/providers/vehicle_providers.dart';
+import '../data/obd2/android_background_adapter_listener.dart';
+import '../data/obd2/auto_trip_coordinator.dart';
+import '../data/obd2/background_adapter_listener.dart';
+import 'trip_recording_provider.dart';
+
+part 'auto_record_orchestrator.g.dart';
+
+/// Production wiring for the hands-free auto-record flow (#1004 phase 2b-2).
+///
+/// Sits between [vehicleProfileListProvider] and the per-vehicle
+/// [AutoTripCoordinator]: watches the vehicle list for changes and
+/// keeps a long-lived coordinator alive for every profile that has
+/// `autoRecord: true` AND a non-null `pairedAdapterMac`. The
+/// coordinator(s) in turn observe the native Android foreground service
+/// (phase 2b-1) and bridge into [TripRecording] when movement is
+/// detected.
+///
+/// ## Lifecycle invariants
+///
+/// 1. A vehicle that flips `autoRecord: false` (or removes its paired
+///    MAC) gets its coordinator stopped and disposed.
+/// 2. A vehicle that changes its `pairedAdapterMac` gets the old
+///    coordinator stopped and a new one started for the new MAC — the
+///    foreground service watches a single MAC at a time on the Kotlin
+///    side, so re-arming is the only way to switch.
+/// 3. Two vehicles can be tracked independently. Each gets its own
+///    coordinator, its own foreground-service arm, and its own
+///    disconnect-save timer.
+/// 4. On orchestrator dispose (e.g. test teardown), every active
+///    coordinator is stopped.
+///
+/// ## Listener selection
+///
+/// The orchestrator selects the [BackgroundAdapterListener] implementation
+/// per platform:
+///
+/// * Android → [AndroidBackgroundAdapterListener] (production bridge).
+/// * Anything else → [UnimplementedBackgroundAdapterListener] (throws
+///   on first event read; the orchestrator only constructs it when
+///   [defaultTargetPlatform] is non-Android, keeping iOS / desktop
+///   builds compiling without a runtime arming).
+///
+/// Tests override [_listenerFactory] via
+/// [autoRecordListenerFactoryProvider] to inject a
+/// [FakeBackgroundAdapterListener]; the same hook lets a future
+/// platform implementation slot in without touching this file.
+///
+/// ## Speed-stream source
+///
+/// Phase 2b-2 ships GPS-only: each coordinator wraps
+/// [Geolocator.getPositionStream] and converts m/s → km/h. This is
+/// intentional — opening an OBD2 session inline (PID 0x0D) on every
+/// `AdapterConnected` event would conflict with the manual flow's
+/// existing `Obd2ConnectionService.takeover` semantics. Phase 2b-3 will
+/// switch to OBD2 PID 0x0D once the on-connect session-handoff design
+/// is settled. The GPS source is good enough to detect "the car
+/// started moving"; we are not measuring instantaneous speed for
+/// telemetry here.
+@Riverpod(keepAlive: true)
+class AutoRecordOrchestrator extends _$AutoRecordOrchestrator {
+  /// Active coordinators keyed by vehicle id. Read by tests through
+  /// [activeVehicleIdsForTest]; production callers do not interact
+  /// directly.
+  final Map<String, _OrchestratorEntry> _entries =
+      <String, _OrchestratorEntry>{};
+
+  @override
+  void build() {
+    // ref.listen fires on every change to the vehicle list, including
+    // the synthetic initial fire when this provider is first read. We
+    // route both the initial fire and subsequent updates through the
+    // same diff so the production wiring (added in app_initializer)
+    // can `ref.read(autoRecordOrchestratorProvider)` once and then
+    // forget about it.
+    ref.listen<List<VehicleProfile>>(
+      vehicleProfileListProvider,
+      (prev, next) => _onVehicleListChanged(next),
+      fireImmediately: true,
+    );
+    ref.onDispose(_disposeAll);
+  }
+
+  /// Test seam — returns the set of vehicle ids that currently have
+  /// an active coordinator. Lets unit tests assert add/remove behaviour
+  /// without poking private state directly.
+  @visibleForTesting
+  Set<String> get activeVehicleIdsForTest => _entries.keys.toSet();
+
+  /// Test seam — returns the MAC the coordinator for [vehicleId] is
+  /// armed against, or `null` when no coordinator is active for that
+  /// vehicle. Used by the "MAC change re-arms" test.
+  @visibleForTesting
+  String? armedMacForTest(String vehicleId) =>
+      _entries[vehicleId]?.coordinator.config.mac;
+
+  void _onVehicleListChanged(List<VehicleProfile> profiles) {
+    final Map<String, VehicleProfile> wanted = <String, VehicleProfile>{};
+    for (final p in profiles) {
+      if (_isAutoRecordReady(p)) {
+        wanted[p.id] = p;
+      }
+    }
+
+    // Remove entries for vehicles that disappeared, flipped autoRecord
+    // off, or lost their paired MAC. Done first so a MAC-change
+    // (treated below as remove + add) cannot accidentally orphan two
+    // coordinators on the same vehicle id.
+    final List<String> toRemove = <String>[];
+    for (final entry in _entries.entries) {
+      final wantedProfile = wanted[entry.key];
+      if (wantedProfile == null) {
+        toRemove.add(entry.key);
+      } else if (wantedProfile.pairedAdapterMac != entry.value.armedMac) {
+        // MAC changed — drop and let the add loop spin up a fresh
+        // coordinator below.
+        toRemove.add(entry.key);
+      }
+    }
+    for (final id in toRemove) {
+      final removed = _entries.remove(id);
+      if (removed != null) {
+        unawaited(_stopAndDispose(removed));
+      }
+    }
+
+    // Add coordinators for vehicles that newly satisfy the gate (or
+    // whose MAC just changed and were dropped above).
+    for (final p in wanted.values) {
+      if (_entries.containsKey(p.id)) continue;
+      final entry = _buildEntry(p);
+      if (entry == null) continue;
+      _entries[p.id] = entry;
+      unawaited(_startEntry(entry));
+    }
+  }
+
+  bool _isAutoRecordReady(VehicleProfile p) {
+    if (!p.autoRecord) return false;
+    final mac = p.pairedAdapterMac;
+    if (mac == null || mac.isEmpty) return false;
+    return true;
+  }
+
+  _OrchestratorEntry? _buildEntry(VehicleProfile profile) {
+    final mac = profile.pairedAdapterMac;
+    if (mac == null || mac.isEmpty) return null;
+
+    final listenerFactory = ref.read(autoRecordListenerFactoryProvider);
+    final speedStreamFactory = ref.read(autoRecordSpeedStreamFactoryProvider);
+
+    final listener = listenerFactory();
+    final coordinator = AutoTripCoordinator(
+      listener: listener,
+      startTrip: () async {
+        // The coordinator is decoupled from `StartTripOutcome` (it
+        // lives in the providers layer). Forwarding the typed enum
+        // back lets the coordinator distinguish "actually started"
+        // from "alreadyActive" / "needsPicker" via its existing
+        // string-form classifier.
+        return ref
+            .read(tripRecordingProvider.notifier)
+            .startTrip(vehicleId: profile.id, adapterMac: mac);
+      },
+      stopAndSaveAutomatic: () async {
+        await ref.read(tripRecordingProvider.notifier).stopAndSaveAutomatic();
+      },
+      speedStream: speedStreamFactory(),
+      config: _configFor(profile, mac),
+    );
+    return _OrchestratorEntry(
+      coordinator: coordinator,
+      armedMac: mac,
+    );
+  }
+
+  AutoRecordConfig _configFor(VehicleProfile profile, String mac) {
+    return AutoRecordConfig(
+      mac: mac,
+      movementStartThresholdKmh: profile.movementStartThresholdKmh,
+      disconnectSaveDelay: Duration(seconds: profile.disconnectSaveDelaySec),
+    );
+  }
+
+  Future<void> _startEntry(_OrchestratorEntry entry) async {
+    try {
+      await entry.coordinator.start();
+    } catch (e, st) {
+      // The coordinator already routes its own start failure through
+      // errorLogger + AutoRecordTraceLog; the orchestrator's own
+      // try/catch is a belt-and-braces guard so a bug in the listener
+      // factory doesn't crash the Riverpod build phase.
+      debugPrint(
+        'AutoRecordOrchestrator: coordinator start failed '
+        '(mac=${entry.armedMac}): $e\n$st',
+      );
+    }
+  }
+
+  Future<void> _stopAndDispose(_OrchestratorEntry entry) async {
+    try {
+      await entry.coordinator.stop();
+    } catch (e, st) {
+      debugPrint(
+        'AutoRecordOrchestrator: coordinator stop failed '
+        '(mac=${entry.armedMac}): $e\n$st',
+      );
+    }
+  }
+
+  Future<void> _disposeAll() async {
+    final futures = _entries.values.map(_stopAndDispose).toList();
+    _entries.clear();
+    await Future.wait<void>(futures);
+  }
+}
+
+/// Bundle of a coordinator and the MAC it was armed against. Lets the
+/// orchestrator detect a `pairedAdapterMac` change cheaply — the
+/// `coordinator.config.mac` getter would also work, but caching here
+/// keeps the diff loop O(1) per vehicle without reaching through
+/// foreign objects.
+class _OrchestratorEntry {
+  final AutoTripCoordinator coordinator;
+  final String armedMac;
+
+  _OrchestratorEntry({
+    required this.coordinator,
+    required this.armedMac,
+  });
+}
+
+/// Factory that returns a fresh [BackgroundAdapterListener] per
+/// coordinator. Each coordinator owns its own listener so a MAC change
+/// (drop + recreate) cannot leak the previous listener's
+/// `MethodChannel.start` into the new arm.
+typedef BackgroundAdapterListenerFactory = BackgroundAdapterListener
+    Function();
+
+/// Default factory: Android in production, an unimplemented stub
+/// elsewhere. Tests override this provider to inject a
+/// [FakeBackgroundAdapterListener] without touching platform-detection
+/// code.
+@Riverpod(keepAlive: true)
+BackgroundAdapterListenerFactory autoRecordListenerFactory(Ref ref) {
+  return () {
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      return AndroidBackgroundAdapterListener();
+    }
+    return const UnimplementedBackgroundAdapterListener();
+  };
+}
+
+/// Factory that returns a fresh GPS speed stream (km/h) per coordinator.
+///
+/// Phase 2b-2 starter — wraps [Geolocator.getPositionStream] and maps
+/// `position.speed` (m/s) to km/h. Tests override this provider with a
+/// controlled stream so the coordinator's threshold logic is exercised
+/// without touching the platform's location stack.
+typedef SpeedStreamFactory = Stream<double> Function();
+
+@Riverpod(keepAlive: true)
+SpeedStreamFactory autoRecordSpeedStreamFactory(Ref ref) {
+  return () {
+    return Geolocator.getPositionStream(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.high,
+        distanceFilter: 0,
+      ),
+    ).map((position) => position.speed * 3.6);
+  };
+}

--- a/lib/features/consumption/providers/auto_record_orchestrator.g.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator.g.dart
@@ -1,0 +1,381 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auto_record_orchestrator.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Production wiring for the hands-free auto-record flow (#1004 phase 2b-2).
+///
+/// Sits between [vehicleProfileListProvider] and the per-vehicle
+/// [AutoTripCoordinator]: watches the vehicle list for changes and
+/// keeps a long-lived coordinator alive for every profile that has
+/// `autoRecord: true` AND a non-null `pairedAdapterMac`. The
+/// coordinator(s) in turn observe the native Android foreground service
+/// (phase 2b-1) and bridge into [TripRecording] when movement is
+/// detected.
+///
+/// ## Lifecycle invariants
+///
+/// 1. A vehicle that flips `autoRecord: false` (or removes its paired
+///    MAC) gets its coordinator stopped and disposed.
+/// 2. A vehicle that changes its `pairedAdapterMac` gets the old
+///    coordinator stopped and a new one started for the new MAC — the
+///    foreground service watches a single MAC at a time on the Kotlin
+///    side, so re-arming is the only way to switch.
+/// 3. Two vehicles can be tracked independently. Each gets its own
+///    coordinator, its own foreground-service arm, and its own
+///    disconnect-save timer.
+/// 4. On orchestrator dispose (e.g. test teardown), every active
+///    coordinator is stopped.
+///
+/// ## Listener selection
+///
+/// The orchestrator selects the [BackgroundAdapterListener] implementation
+/// per platform:
+///
+/// * Android → [AndroidBackgroundAdapterListener] (production bridge).
+/// * Anything else → [UnimplementedBackgroundAdapterListener] (throws
+///   on first event read; the orchestrator only constructs it when
+///   [defaultTargetPlatform] is non-Android, keeping iOS / desktop
+///   builds compiling without a runtime arming).
+///
+/// Tests override [_listenerFactory] via
+/// [autoRecordListenerFactoryProvider] to inject a
+/// [FakeBackgroundAdapterListener]; the same hook lets a future
+/// platform implementation slot in without touching this file.
+///
+/// ## Speed-stream source
+///
+/// Phase 2b-2 ships GPS-only: each coordinator wraps
+/// [Geolocator.getPositionStream] and converts m/s → km/h. This is
+/// intentional — opening an OBD2 session inline (PID 0x0D) on every
+/// `AdapterConnected` event would conflict with the manual flow's
+/// existing `Obd2ConnectionService.takeover` semantics. Phase 2b-3 will
+/// switch to OBD2 PID 0x0D once the on-connect session-handoff design
+/// is settled. The GPS source is good enough to detect "the car
+/// started moving"; we are not measuring instantaneous speed for
+/// telemetry here.
+
+@ProviderFor(AutoRecordOrchestrator)
+final autoRecordOrchestratorProvider = AutoRecordOrchestratorProvider._();
+
+/// Production wiring for the hands-free auto-record flow (#1004 phase 2b-2).
+///
+/// Sits between [vehicleProfileListProvider] and the per-vehicle
+/// [AutoTripCoordinator]: watches the vehicle list for changes and
+/// keeps a long-lived coordinator alive for every profile that has
+/// `autoRecord: true` AND a non-null `pairedAdapterMac`. The
+/// coordinator(s) in turn observe the native Android foreground service
+/// (phase 2b-1) and bridge into [TripRecording] when movement is
+/// detected.
+///
+/// ## Lifecycle invariants
+///
+/// 1. A vehicle that flips `autoRecord: false` (or removes its paired
+///    MAC) gets its coordinator stopped and disposed.
+/// 2. A vehicle that changes its `pairedAdapterMac` gets the old
+///    coordinator stopped and a new one started for the new MAC — the
+///    foreground service watches a single MAC at a time on the Kotlin
+///    side, so re-arming is the only way to switch.
+/// 3. Two vehicles can be tracked independently. Each gets its own
+///    coordinator, its own foreground-service arm, and its own
+///    disconnect-save timer.
+/// 4. On orchestrator dispose (e.g. test teardown), every active
+///    coordinator is stopped.
+///
+/// ## Listener selection
+///
+/// The orchestrator selects the [BackgroundAdapterListener] implementation
+/// per platform:
+///
+/// * Android → [AndroidBackgroundAdapterListener] (production bridge).
+/// * Anything else → [UnimplementedBackgroundAdapterListener] (throws
+///   on first event read; the orchestrator only constructs it when
+///   [defaultTargetPlatform] is non-Android, keeping iOS / desktop
+///   builds compiling without a runtime arming).
+///
+/// Tests override [_listenerFactory] via
+/// [autoRecordListenerFactoryProvider] to inject a
+/// [FakeBackgroundAdapterListener]; the same hook lets a future
+/// platform implementation slot in without touching this file.
+///
+/// ## Speed-stream source
+///
+/// Phase 2b-2 ships GPS-only: each coordinator wraps
+/// [Geolocator.getPositionStream] and converts m/s → km/h. This is
+/// intentional — opening an OBD2 session inline (PID 0x0D) on every
+/// `AdapterConnected` event would conflict with the manual flow's
+/// existing `Obd2ConnectionService.takeover` semantics. Phase 2b-3 will
+/// switch to OBD2 PID 0x0D once the on-connect session-handoff design
+/// is settled. The GPS source is good enough to detect "the car
+/// started moving"; we are not measuring instantaneous speed for
+/// telemetry here.
+final class AutoRecordOrchestratorProvider
+    extends $NotifierProvider<AutoRecordOrchestrator, void> {
+  /// Production wiring for the hands-free auto-record flow (#1004 phase 2b-2).
+  ///
+  /// Sits between [vehicleProfileListProvider] and the per-vehicle
+  /// [AutoTripCoordinator]: watches the vehicle list for changes and
+  /// keeps a long-lived coordinator alive for every profile that has
+  /// `autoRecord: true` AND a non-null `pairedAdapterMac`. The
+  /// coordinator(s) in turn observe the native Android foreground service
+  /// (phase 2b-1) and bridge into [TripRecording] when movement is
+  /// detected.
+  ///
+  /// ## Lifecycle invariants
+  ///
+  /// 1. A vehicle that flips `autoRecord: false` (or removes its paired
+  ///    MAC) gets its coordinator stopped and disposed.
+  /// 2. A vehicle that changes its `pairedAdapterMac` gets the old
+  ///    coordinator stopped and a new one started for the new MAC — the
+  ///    foreground service watches a single MAC at a time on the Kotlin
+  ///    side, so re-arming is the only way to switch.
+  /// 3. Two vehicles can be tracked independently. Each gets its own
+  ///    coordinator, its own foreground-service arm, and its own
+  ///    disconnect-save timer.
+  /// 4. On orchestrator dispose (e.g. test teardown), every active
+  ///    coordinator is stopped.
+  ///
+  /// ## Listener selection
+  ///
+  /// The orchestrator selects the [BackgroundAdapterListener] implementation
+  /// per platform:
+  ///
+  /// * Android → [AndroidBackgroundAdapterListener] (production bridge).
+  /// * Anything else → [UnimplementedBackgroundAdapterListener] (throws
+  ///   on first event read; the orchestrator only constructs it when
+  ///   [defaultTargetPlatform] is non-Android, keeping iOS / desktop
+  ///   builds compiling without a runtime arming).
+  ///
+  /// Tests override [_listenerFactory] via
+  /// [autoRecordListenerFactoryProvider] to inject a
+  /// [FakeBackgroundAdapterListener]; the same hook lets a future
+  /// platform implementation slot in without touching this file.
+  ///
+  /// ## Speed-stream source
+  ///
+  /// Phase 2b-2 ships GPS-only: each coordinator wraps
+  /// [Geolocator.getPositionStream] and converts m/s → km/h. This is
+  /// intentional — opening an OBD2 session inline (PID 0x0D) on every
+  /// `AdapterConnected` event would conflict with the manual flow's
+  /// existing `Obd2ConnectionService.takeover` semantics. Phase 2b-3 will
+  /// switch to OBD2 PID 0x0D once the on-connect session-handoff design
+  /// is settled. The GPS source is good enough to detect "the car
+  /// started moving"; we are not measuring instantaneous speed for
+  /// telemetry here.
+  AutoRecordOrchestratorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'autoRecordOrchestratorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoRecordOrchestratorHash();
+
+  @$internal
+  @override
+  AutoRecordOrchestrator create() => AutoRecordOrchestrator();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$autoRecordOrchestratorHash() =>
+    r'9d2c1df4b54a3c7f408be77fe74891266f82f18e';
+
+/// Production wiring for the hands-free auto-record flow (#1004 phase 2b-2).
+///
+/// Sits between [vehicleProfileListProvider] and the per-vehicle
+/// [AutoTripCoordinator]: watches the vehicle list for changes and
+/// keeps a long-lived coordinator alive for every profile that has
+/// `autoRecord: true` AND a non-null `pairedAdapterMac`. The
+/// coordinator(s) in turn observe the native Android foreground service
+/// (phase 2b-1) and bridge into [TripRecording] when movement is
+/// detected.
+///
+/// ## Lifecycle invariants
+///
+/// 1. A vehicle that flips `autoRecord: false` (or removes its paired
+///    MAC) gets its coordinator stopped and disposed.
+/// 2. A vehicle that changes its `pairedAdapterMac` gets the old
+///    coordinator stopped and a new one started for the new MAC — the
+///    foreground service watches a single MAC at a time on the Kotlin
+///    side, so re-arming is the only way to switch.
+/// 3. Two vehicles can be tracked independently. Each gets its own
+///    coordinator, its own foreground-service arm, and its own
+///    disconnect-save timer.
+/// 4. On orchestrator dispose (e.g. test teardown), every active
+///    coordinator is stopped.
+///
+/// ## Listener selection
+///
+/// The orchestrator selects the [BackgroundAdapterListener] implementation
+/// per platform:
+///
+/// * Android → [AndroidBackgroundAdapterListener] (production bridge).
+/// * Anything else → [UnimplementedBackgroundAdapterListener] (throws
+///   on first event read; the orchestrator only constructs it when
+///   [defaultTargetPlatform] is non-Android, keeping iOS / desktop
+///   builds compiling without a runtime arming).
+///
+/// Tests override [_listenerFactory] via
+/// [autoRecordListenerFactoryProvider] to inject a
+/// [FakeBackgroundAdapterListener]; the same hook lets a future
+/// platform implementation slot in without touching this file.
+///
+/// ## Speed-stream source
+///
+/// Phase 2b-2 ships GPS-only: each coordinator wraps
+/// [Geolocator.getPositionStream] and converts m/s → km/h. This is
+/// intentional — opening an OBD2 session inline (PID 0x0D) on every
+/// `AdapterConnected` event would conflict with the manual flow's
+/// existing `Obd2ConnectionService.takeover` semantics. Phase 2b-3 will
+/// switch to OBD2 PID 0x0D once the on-connect session-handoff design
+/// is settled. The GPS source is good enough to detect "the car
+/// started moving"; we are not measuring instantaneous speed for
+/// telemetry here.
+
+abstract class _$AutoRecordOrchestrator extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<void, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<void, void>,
+              void,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+/// Default factory: Android in production, an unimplemented stub
+/// elsewhere. Tests override this provider to inject a
+/// [FakeBackgroundAdapterListener] without touching platform-detection
+/// code.
+
+@ProviderFor(autoRecordListenerFactory)
+final autoRecordListenerFactoryProvider = AutoRecordListenerFactoryProvider._();
+
+/// Default factory: Android in production, an unimplemented stub
+/// elsewhere. Tests override this provider to inject a
+/// [FakeBackgroundAdapterListener] without touching platform-detection
+/// code.
+
+final class AutoRecordListenerFactoryProvider
+    extends
+        $FunctionalProvider<
+          BackgroundAdapterListenerFactory,
+          BackgroundAdapterListenerFactory,
+          BackgroundAdapterListenerFactory
+        >
+    with $Provider<BackgroundAdapterListenerFactory> {
+  /// Default factory: Android in production, an unimplemented stub
+  /// elsewhere. Tests override this provider to inject a
+  /// [FakeBackgroundAdapterListener] without touching platform-detection
+  /// code.
+  AutoRecordListenerFactoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'autoRecordListenerFactoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoRecordListenerFactoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<BackgroundAdapterListenerFactory> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  BackgroundAdapterListenerFactory create(Ref ref) {
+    return autoRecordListenerFactory(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BackgroundAdapterListenerFactory value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BackgroundAdapterListenerFactory>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$autoRecordListenerFactoryHash() =>
+    r'3ac9db8a2ce1a0919d0fb75fc9b9906b736d40af';
+
+@ProviderFor(autoRecordSpeedStreamFactory)
+final autoRecordSpeedStreamFactoryProvider =
+    AutoRecordSpeedStreamFactoryProvider._();
+
+final class AutoRecordSpeedStreamFactoryProvider
+    extends
+        $FunctionalProvider<
+          SpeedStreamFactory,
+          SpeedStreamFactory,
+          SpeedStreamFactory
+        >
+    with $Provider<SpeedStreamFactory> {
+  AutoRecordSpeedStreamFactoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'autoRecordSpeedStreamFactoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoRecordSpeedStreamFactoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<SpeedStreamFactory> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SpeedStreamFactory create(Ref ref) {
+    return autoRecordSpeedStreamFactory(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SpeedStreamFactory value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SpeedStreamFactory>(value),
+    );
+  }
+}
+
+String _$autoRecordSpeedStreamFactoryHash() =>
+    r'b829693bb5405b843f8cff4d2fc2b81ee065d24e';

--- a/test/features/consumption/providers/auto_record_orchestrator_test.dart
+++ b/test/features/consumption/providers/auto_record_orchestrator_test.dart
@@ -1,0 +1,386 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/auto_record_trace_log.dart';
+import 'package:tankstellen/features/consumption/data/obd2/fake_background_adapter_listener.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/providers/auto_record_orchestrator.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+/// Tests for the auto-record orchestrator (#1004 phase 2b-2).
+///
+/// Drives the orchestrator with:
+///  - a fake [VehicleProfileList] notifier so the test can imperatively
+///    push vehicle-list snapshots and observe the diff behaviour;
+///  - a per-test factory that hands out fresh [FakeBackgroundAdapterListener]
+///    instances so each coordinator gets its own listener (the orchestrator
+///    constructs one listener per coordinator on purpose — see the
+///    "MAC change" test);
+///  - a controllable speed stream factory so threshold logic stays
+///    deterministic without touching Geolocator;
+///  - a fake [TripRecording] notifier counting `startTrip` / `stopAndSaveAutomatic`
+///    calls.
+///
+/// Each test owns its own [ProviderContainer] and disposes it in the
+/// teardown so the keepAlive providers don't leak across tests.
+
+class _FakeVehicleProfileList extends VehicleProfileList {
+  _FakeVehicleProfileList(this._initial);
+
+  List<VehicleProfile> _initial;
+
+  @override
+  List<VehicleProfile> build() => _initial;
+
+  void setProfiles(List<VehicleProfile> next) {
+    _initial = next;
+    state = next;
+  }
+}
+
+/// Fake [TripRecording] that records start/stop calls. We override the
+/// notifier (not its state) because the orchestrator calls into the
+/// notifier via `ref.read(...notifier)` — a state override would not
+/// intercept those method calls.
+class _FakeTripRecording extends TripRecording {
+  int startTripCalls = 0;
+  int stopAndSaveCalls = 0;
+  final List<String?> startTripVehicleIds = <String?>[];
+  final List<String?> startTripAdapterMacs = <String?>[];
+
+  @override
+  TripRecordingState build() => const TripRecordingState();
+
+  @override
+  Future<StartTripOutcome> startTrip({
+    String? vehicleId,
+    String? adapterMac,
+    Obd2Service? service,
+  }) async {
+    startTripCalls++;
+    startTripVehicleIds.add(vehicleId);
+    startTripAdapterMacs.add(adapterMac);
+    return StartTripOutcome.started;
+  }
+
+  @override
+  Future<void> stopAndSaveAutomatic() async {
+    stopAndSaveCalls++;
+  }
+}
+
+/// Bookkeeping bundle that pairs each fake listener with the MAC it was
+/// armed against. Lets the test recover the listener for a vehicle id
+/// (via the orchestrator's `armedMacForTest`) and emit synthetic events
+/// at the right time.
+class _ListenerHarness {
+  final List<FakeBackgroundAdapterListener> created =
+      <FakeBackgroundAdapterListener>[];
+
+  /// Returns a factory closure compatible with
+  /// [BackgroundAdapterListenerFactory]. Each call mints a fresh fake
+  /// listener — the orchestrator constructs one listener per
+  /// coordinator, so we want fresh instances on every diff add.
+  BackgroundAdapterListenerFactory factory() {
+    return () {
+      final listener = FakeBackgroundAdapterListener();
+      created.add(listener);
+      return listener;
+    };
+  }
+
+  /// Last listener whose first arm matches [mac]. The orchestrator
+  /// calls `start(mac: ...)` exactly once per coordinator so the first
+  /// armed MAC unambiguously identifies which fake belongs to which
+  /// vehicle.
+  FakeBackgroundAdapterListener? listenerArmedFor(String mac) {
+    for (final l in created.reversed) {
+      if (l.startedMacs.isNotEmpty && l.startedMacs.first == mac) {
+        return l;
+      }
+    }
+    return null;
+  }
+
+  Future<void> disposeAll() async {
+    for (final l in created) {
+      await l.dispose();
+    }
+  }
+}
+
+VehicleProfile _profile({
+  required String id,
+  bool autoRecord = true,
+  String? mac = 'AA:BB:CC:DD:EE:FF',
+  double thresholdKmh = 5.0,
+  int delaySec = 60,
+}) {
+  return VehicleProfile(
+    id: id,
+    name: 'Test $id',
+    type: VehicleType.combustion,
+    autoRecord: autoRecord,
+    pairedAdapterMac: mac,
+    movementStartThresholdKmh: thresholdKmh,
+    disconnectSaveDelaySec: delaySec,
+  );
+}
+
+void main() {
+  late _ListenerHarness harness;
+  late StreamController<double> speed;
+  late _FakeTripRecording fakeTripRecording;
+
+  setUp(() {
+    AutoRecordTraceLog.clear();
+    harness = _ListenerHarness();
+    speed = StreamController<double>.broadcast();
+    fakeTripRecording = _FakeTripRecording();
+  });
+
+  tearDown(() async {
+    await speed.close();
+    await harness.disposeAll();
+  });
+
+  ProviderContainer makeContainer({
+    required _FakeVehicleProfileList vehicleList,
+  }) {
+    return ProviderContainer(
+      overrides: [
+        vehicleProfileListProvider.overrideWith(() => vehicleList),
+        tripRecordingProvider.overrideWith(() => fakeTripRecording),
+        autoRecordListenerFactoryProvider.overrideWithValue(harness.factory()),
+        autoRecordSpeedStreamFactoryProvider.overrideWithValue(
+          () => speed.stream,
+        ),
+      ],
+    );
+  }
+
+  test(
+      'new vehicle with autoRecord=true and pairedAdapterMac creates and starts coordinator',
+      () async {
+    final list = _FakeVehicleProfileList(
+      [_profile(id: 'v1')],
+    );
+    final container = makeContainer(vehicleList: list);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    // The orchestrator schedules `coordinator.start()` via
+    // `unawaited(...)`; let the microtask queue flush so the listener
+    // observes the arming call before we assert.
+    await Future<void>.delayed(Duration.zero);
+
+    final orchestrator =
+        container.read(autoRecordOrchestratorProvider.notifier);
+    expect(orchestrator.activeVehicleIdsForTest, {'v1'});
+    expect(orchestrator.armedMacForTest('v1'), 'AA:BB:CC:DD:EE:FF');
+
+    final listener = harness.listenerArmedFor('AA:BB:CC:DD:EE:FF');
+    expect(listener, isNotNull,
+        reason: 'A listener must be armed for the wanted MAC');
+    expect(listener!.startCalls, 1);
+    expect(listener.startedMacs, ['AA:BB:CC:DD:EE:FF']);
+  });
+
+  test('vehicle with autoRecord=false is ignored', () async {
+    final list = _FakeVehicleProfileList(
+      [_profile(id: 'v1', autoRecord: false)],
+    );
+    final container = makeContainer(vehicleList: list);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final orchestrator =
+        container.read(autoRecordOrchestratorProvider.notifier);
+    expect(orchestrator.activeVehicleIdsForTest, isEmpty);
+    expect(harness.created, isEmpty);
+  });
+
+  test('vehicle without pairedAdapterMac is ignored', () async {
+    final list = _FakeVehicleProfileList(
+      [_profile(id: 'v1', mac: null)],
+    );
+    final container = makeContainer(vehicleList: list);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final orchestrator =
+        container.read(autoRecordOrchestratorProvider.notifier);
+    expect(orchestrator.activeVehicleIdsForTest, isEmpty);
+  });
+
+  test(
+      'flipping autoRecord to false stops and removes the coordinator',
+      () async {
+    final list = _FakeVehicleProfileList(
+      [_profile(id: 'v1')],
+    );
+    final container = makeContainer(vehicleList: list);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final listener = harness.listenerArmedFor('AA:BB:CC:DD:EE:FF')!;
+    expect(listener.startCalls, 1);
+
+    list.setProfiles([_profile(id: 'v1', autoRecord: false)]);
+    await Future<void>.delayed(Duration.zero);
+
+    final orchestrator =
+        container.read(autoRecordOrchestratorProvider.notifier);
+    expect(orchestrator.activeVehicleIdsForTest, isEmpty);
+    expect(listener.stopCalls, 1,
+        reason: 'Disabling autoRecord must call stop() on the listener');
+  });
+
+  test('changing pairedAdapterMac stops old coordinator and starts a new one',
+      () async {
+    final list = _FakeVehicleProfileList(
+      [_profile(id: 'v1', mac: 'AA:AA:AA:AA:AA:AA')],
+    );
+    final container = makeContainer(vehicleList: list);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final firstListener = harness.listenerArmedFor('AA:AA:AA:AA:AA:AA');
+    expect(firstListener, isNotNull);
+    expect(firstListener!.startCalls, 1);
+
+    list.setProfiles([_profile(id: 'v1', mac: 'BB:BB:BB:BB:BB:BB')]);
+    await Future<void>.delayed(Duration.zero);
+
+    final orchestrator =
+        container.read(autoRecordOrchestratorProvider.notifier);
+    expect(orchestrator.activeVehicleIdsForTest, {'v1'});
+    expect(orchestrator.armedMacForTest('v1'), 'BB:BB:BB:BB:BB:BB');
+    expect(firstListener.stopCalls, 1,
+        reason: 'Old listener must be stopped on MAC change');
+
+    final secondListener = harness.listenerArmedFor('BB:BB:BB:BB:BB:BB');
+    expect(secondListener, isNotNull);
+    expect(secondListener!.startCalls, 1);
+    expect(identical(firstListener, secondListener), isFalse,
+        reason:
+            'A MAC change must spin up a fresh listener, not re-arm the old one');
+  });
+
+  test('removing a vehicle from the list stops its coordinator', () async {
+    final list = _FakeVehicleProfileList(
+      [_profile(id: 'v1')],
+    );
+    final container = makeContainer(vehicleList: list);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final listener = harness.listenerArmedFor('AA:BB:CC:DD:EE:FF')!;
+    expect(listener.startCalls, 1);
+
+    list.setProfiles(const []);
+    await Future<void>.delayed(Duration.zero);
+
+    final orchestrator =
+        container.read(autoRecordOrchestratorProvider.notifier);
+    expect(orchestrator.activeVehicleIdsForTest, isEmpty);
+    expect(listener.stopCalls, 1);
+  });
+
+  test(
+      'two vehicles with autoRecord=true result in two independent coordinators',
+      () async {
+    final list = _FakeVehicleProfileList([
+      _profile(id: 'v1', mac: 'AA:AA:AA:AA:AA:AA'),
+      _profile(id: 'v2', mac: 'BB:BB:BB:BB:BB:BB'),
+    ]);
+    final container = makeContainer(vehicleList: list);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final orchestrator =
+        container.read(autoRecordOrchestratorProvider.notifier);
+    expect(orchestrator.activeVehicleIdsForTest, {'v1', 'v2'});
+    expect(orchestrator.armedMacForTest('v1'), 'AA:AA:AA:AA:AA:AA');
+    expect(orchestrator.armedMacForTest('v2'), 'BB:BB:BB:BB:BB:BB');
+
+    final listenerA = harness.listenerArmedFor('AA:AA:AA:AA:AA:AA');
+    final listenerB = harness.listenerArmedFor('BB:BB:BB:BB:BB:BB');
+    expect(listenerA, isNotNull);
+    expect(listenerB, isNotNull);
+    expect(identical(listenerA, listenerB), isFalse,
+        reason: 'Each vehicle must own a distinct listener instance');
+  });
+
+  test('disposing the orchestrator stops every active coordinator', () async {
+    final list = _FakeVehicleProfileList([
+      _profile(id: 'v1', mac: 'AA:AA:AA:AA:AA:AA'),
+      _profile(id: 'v2', mac: 'BB:BB:BB:BB:BB:BB'),
+    ]);
+    final container = makeContainer(vehicleList: list);
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final listenerA = harness.listenerArmedFor('AA:AA:AA:AA:AA:AA')!;
+    final listenerB = harness.listenerArmedFor('BB:BB:BB:BB:BB:BB')!;
+    expect(listenerA.startCalls, 1);
+    expect(listenerB.startCalls, 1);
+
+    container.dispose();
+    // Disposal kicks `unawaited(stop)` calls; flush the microtask queue
+    // so the listener bookkeeping reflects the requested stops.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(listenerA.stopCalls, 1);
+    expect(listenerB.stopCalls, 1);
+  });
+
+  test(
+      'connect + supra-threshold speed stream forwards startTrip with vehicleId and adapterMac',
+      () async {
+    final list = _FakeVehicleProfileList(
+      [
+        _profile(
+          id: 'v1',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          thresholdKmh: 5.0,
+        ),
+      ],
+    );
+    final container = makeContainer(vehicleList: list);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final listener = harness.listenerArmedFor('AA:BB:CC:DD:EE:FF')!;
+    listener.emitConnected('AA:BB:CC:DD:EE:FF');
+    await Future<void>.delayed(Duration.zero);
+
+    speed.add(20);
+    speed.add(25);
+    speed.add(30);
+    await Future<void>.delayed(Duration.zero);
+    // Allow the unawaited startTrip call to land.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(fakeTripRecording.startTripCalls, 1);
+    expect(fakeTripRecording.startTripVehicleIds, ['v1']);
+    expect(fakeTripRecording.startTripAdapterMacs, ['AA:BB:CC:DD:EE:FF']);
+  });
+}


### PR DESCRIPTION
Refs #1004 phase 2b-2

## What

Phase 2b-2 of the hands-free auto-record flow. Connects the bridge
from phase 2b-1 (PR #1183) and the state machine from phase 2a
(PR #1170) into a single orchestrator that watches the active vehicle
list and lifecycle-matches one `AutoTripCoordinator` per profile that
has both `autoRecord: true` and a non-null `pairedAdapterMac`.

## Architecture

* `AutoRecordOrchestrator` (`@Riverpod(keepAlive: true)`) subscribes to
  `vehicleProfileListProvider` via `ref.listen(fireImmediately: true)`
  and diffs every change.
* New / matching vehicles get a fresh `AutoTripCoordinator` with their
  own `BackgroundAdapterListener`. A `pairedAdapterMac` change is
  treated as drop + recreate (the foreground service watches one MAC
  at a time on the Kotlin side).
* The listener factory selects `AndroidBackgroundAdapterListener` when
  `defaultTargetPlatform == TargetPlatform.android` and
  `UnimplementedBackgroundAdapterListener` everywhere else, so
  iOS / desktop builds compile but never arm a real listener.
* `AppInitializer._launch` reads the orchestrator from a
  `_deferPostFirstFrame` microtask wrapped in try/catch — failures
  log via `debugPrint` but never block the launch path.

## Speed-stream source

GPS via `Geolocator.getPositionStream` mapped `m/s -> km/h`. Chosen
because opening an OBD2 session inline on every `AdapterConnected`
event would conflict with the manual flow's existing
`Obd2ConnectionService.takeover` semantics. Phase 2b-3 will switch to
OBD2 PID 0x0D once the on-connect session-handoff design is settled.

## Files added / modified

Added:
- `lib/features/consumption/providers/auto_record_orchestrator.dart`
- `lib/features/consumption/providers/auto_record_orchestrator.g.dart`
- `test/features/consumption/providers/auto_record_orchestrator_test.dart`

Modified:
- `lib/app/app_initializer.dart` (post-frame orchestrator init)
- `docs/guides/auto-record.md` (production-wiring section + status bump)

## Out of scope (deferred)

- OBD2 PID 0x0D speed stream and session-open on connect (phase 2b-3).
- Phase 4 WAL recovery for app-kill-during-disconnect-timer.
- iOS implementation.

## Acceptance

Device test by repo owner (sideload + plug in adapter, verify
foreground notification + trace-log events).

## Test plan

- [x] `flutter analyze` — clean.
- [x] `flutter test test/features/consumption/` — 1694 tests pass
      (9 new orchestrator-specific cases included).
- [x] `flutter test test/lint/` — passes.
- [x] `flutter test test/app/` — passes (app-initializer regression check).
- [ ] Device test (acceptance — repo owner).