### PR TITLE
refactor(vehicle): extract sub-widget out of service_reminder_section (Refs #563 phase: service_reminder_section)

### DIFF
--- a/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
+++ b/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
@@ -6,6 +6,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/service_reminder.dart';
 import '../../providers/service_reminder_providers.dart';
 
+part 'service_reminder_section_parts.dart';
+
 /// Service-reminders section of the vehicle edit screen (#584).
 ///
 /// Renders a preset chip row ("Oil 15000 km", "Tires 20000 km",
@@ -207,44 +209,6 @@ class ServiceReminderSection extends ConsumerWidget {
       labelCtrl.dispose();
       intervalCtrl.dispose();
     }
-  }
-}
-
-class _PresetChipRow extends StatelessWidget {
-  final void Function(String label, double intervalKm) onAdd;
-
-  const _PresetChipRow({required this.onAdd});
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    return Wrap(
-      spacing: 8,
-      runSpacing: 8,
-      children: [
-        ActionChip(
-          avatar: const Icon(Icons.oil_barrel_outlined, size: 18),
-          label:
-              Text(l?.serviceReminderPresetOil ?? 'Oil (15,000 km)'),
-          onPressed: () =>
-              onAdd(l?.serviceReminderPresetOilLabel ?? 'Oil change', 15000),
-        ),
-        ActionChip(
-          avatar: const Icon(Icons.tire_repair_outlined, size: 18),
-          label:
-              Text(l?.serviceReminderPresetTires ?? 'Tires (20,000 km)'),
-          onPressed: () =>
-              onAdd(l?.serviceReminderPresetTiresLabel ?? 'Tires', 20000),
-        ),
-        ActionChip(
-          avatar: const Icon(Icons.build_outlined, size: 18),
-          label: Text(
-              l?.serviceReminderPresetInspection ?? 'Inspection (30,000 km)'),
-          onPressed: () => onAdd(
-              l?.serviceReminderPresetInspectionLabel ?? 'Inspection', 30000),
-        ),
-      ],
-    );
   }
 }
 

--- a/lib/features/vehicle/presentation/widgets/service_reminder_section_parts.dart
+++ b/lib/features/vehicle/presentation/widgets/service_reminder_section_parts.dart
@@ -1,0 +1,49 @@
+part of 'service_reminder_section.dart';
+
+/// Preset chip row rendered above the reminder list inside
+/// [ServiceReminderSection].
+///
+/// Three [ActionChip]s exposing the most common service intervals
+/// (oil 15,000 km, tires 20,000 km, inspection 30,000 km). Each chip
+/// fires [onAdd] with a localized label and the interval in km — the
+/// parent owns the actual storage call.
+///
+/// Library-private (`part of`) so the public API of the section stays
+/// unchanged.
+class _PresetChipRow extends StatelessWidget {
+  final void Function(String label, double intervalKm) onAdd;
+
+  const _PresetChipRow({required this.onAdd});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        ActionChip(
+          avatar: const Icon(Icons.oil_barrel_outlined, size: 18),
+          label:
+              Text(l?.serviceReminderPresetOil ?? 'Oil (15,000 km)'),
+          onPressed: () =>
+              onAdd(l?.serviceReminderPresetOilLabel ?? 'Oil change', 15000),
+        ),
+        ActionChip(
+          avatar: const Icon(Icons.tire_repair_outlined, size: 18),
+          label:
+              Text(l?.serviceReminderPresetTires ?? 'Tires (20,000 km)'),
+          onPressed: () =>
+              onAdd(l?.serviceReminderPresetTiresLabel ?? 'Tires', 20000),
+        ),
+        ActionChip(
+          avatar: const Icon(Icons.build_outlined, size: 18),
+          label: Text(
+              l?.serviceReminderPresetInspection ?? 'Inspection (30,000 km)'),
+          onPressed: () => onAdd(
+              l?.serviceReminderPresetInspectionLabel ?? 'Inspection', 30000),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Extract the inline `_PresetChipRow` widget out of `service_reminder_section.dart` into a library-private `part of` companion file, slimming the parent section back under the 300-line guidance for #563.

- `service_reminder_section.dart`: **309 to 273 LOC**
- New: `service_reminder_section_parts.dart` (49 LOC, `part of` the section)
- Public API of `ServiceReminderSection` unchanged
- `_PresetChipRow` stays library-private (`part of` import)

Refs #563 phase: service_reminder_section

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test test/features/vehicle/presentation/widgets/service_reminder_section_test.dart` — 5/5 pass
- [ ] CI runs the full suite

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>