### PR TITLE
fix(consumption): skip OBD2 picker when active vehicle has paired adapter (Closes #1188)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -130,6 +130,39 @@ class Obd2ConnectionService {
       rethrow;
     }
   }
+
+  /// Pinned-adapter fast path (#1188). Runs a short scan and, as soon
+  /// as a candidate matching [mac] appears, opens a connection without
+  /// involving the picker UI. Returns null when [timeout] elapses
+  /// without a match (the adapter is off, out of range, or the user
+  /// has changed adapters since the MAC was persisted) so the caller
+  /// can fall back to the manual picker. [Obd2ConnectionError]
+  /// thrown by the underlying scan/connect flow propagates to the
+  /// caller — those are real failures (permission denied, init
+  /// timeout) that the caller should surface, not silently swallow.
+  Future<Obd2Service?> connectByMac(
+    String mac, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    final stream = scan(timeout: timeout);
+    ResolvedObd2Candidate? match;
+    try {
+      await for (final batch in stream) {
+        for (final c in batch) {
+          if (c.candidate.deviceId == mac) {
+            match = c;
+            break;
+          }
+        }
+        if (match != null) break;
+      }
+    } on Obd2ScanTimeout {
+      // No adapters at all in range — fall through to picker.
+      return null;
+    }
+    if (match == null) return null;
+    return connect(match);
+  }
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../l10n/app_localizations.dart';
+import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/obd2/adapter_registry.dart';
 import '../../data/obd2/obd2_connection_errors.dart';
 import '../../data/obd2/obd2_connection_service.dart';
@@ -19,7 +20,74 @@ import '../../data/obd2/obd2_service.dart';
 /// injected [Obd2ConnectionService], so widget tests swap it via a
 /// Riverpod override of `obd2ConnectionProvider` and drive the full
 /// flow without a BLE stack.
-Future<Obd2Service?> showObd2AdapterPicker(BuildContext context) {
+///
+/// When [pinnedMac] is non-null (#1188), the picker first tries a
+/// silent direct connect via [Obd2ConnectionService.connectByMac].
+/// On success the future resolves with the connected service and the
+/// modal sheet is never shown — eliminating the 2-tap friction for
+/// returning users with a paired adapter. On failure (adapter off,
+/// out of range, init error) the sheet is shown with a snackbar built
+/// from [pinnedAdapterName] so the user understands why the picker
+/// reappeared.
+Future<Obd2Service?> showObd2AdapterPicker(
+  BuildContext context, {
+  String? pinnedMac,
+  String? pinnedAdapterName,
+}) async {
+  // Pinned-MAC fast path (#1188). When the active vehicle has an
+  // adapter paired we want zero UI — connect silently and resolve
+  // immediately, falling back to the sheet on any failure.
+  if (pinnedMac != null && pinnedMac.isNotEmpty) {
+    final container = ProviderScope.containerOf(context, listen: false);
+    Obd2Service? service;
+    try {
+      service = await container.read(obd2ConnectionProvider).connectByMac(
+            pinnedMac,
+          );
+    } on Obd2ConnectionError catch (e, st) {
+      // Real connect failure (permission denied, init timeout). Drop
+      // through to the sheet so the user can pick another adapter;
+      // the snackbar surfaces the mishap.
+      debugPrint('showObd2AdapterPicker pinned connect failed: $e\n$st');
+    }
+    if (service != null) {
+      return service;
+    }
+    // Fall-through: open the sheet with a fallback snackbar. Schedule
+    // the snackbar after the first frame so it lands on the surrounding
+    // Scaffold and not on the modal route.
+    if (!context.mounted) return null;
+    return _showPickerSheet(
+      context,
+      fallbackAdapterName: pinnedAdapterName,
+    );
+  }
+  return _showPickerSheet(context);
+}
+
+Future<Obd2Service?> _showPickerSheet(
+  BuildContext context, {
+  String? fallbackAdapterName,
+}) {
+  if (fallbackAdapterName != null && fallbackAdapterName.isNotEmpty) {
+    // Surface the snackbar against the surrounding Scaffold (not the
+    // modal route). Schedules after the current frame so the modal
+    // is mounted by the time the snackbar slides in.
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    final l = AppLocalizations.of(context);
+    if (messenger != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(
+              l?.obd2PickerPinnedFallback(fallbackAdapterName) ??
+                  "Couldn't reach '$fallbackAdapterName' — pick another adapter",
+            ),
+          ),
+        );
+      });
+    }
+  }
   return showModalBottomSheet<Obd2Service>(
     context: context,
     isScrollControlled: true,
@@ -115,6 +183,12 @@ class _Obd2AdapterPickerSheetState
       final service = await ref
           .read(obd2ConnectionProvider)
           .connect(candidate);
+      // #1188 — persist MAC + display name back onto the active
+      // vehicle profile so the next session takes the pinned-MAC fast
+      // path and skips the picker entirely. Best-effort: a missing
+      // active vehicle, or a failed save, must not block the connect
+      // path the user just completed.
+      await _persistPickedAdapterToActiveVehicle(candidate);
       if (!mounted) return;
       Navigator.of(context).pop(service);
     } on Obd2ConnectionError catch (e, st) { // ignore: unused_catch_stack
@@ -123,6 +197,36 @@ class _Obd2AdapterPickerSheetState
         _error = e;
         _phase = _Phase.error;
       });
+    }
+  }
+
+  /// Write the user's picked adapter MAC + display name onto the
+  /// active vehicle profile when missing or different (#1188). Runs
+  /// only when an active profile exists; no-op otherwise. Errors are
+  /// swallowed (debug-printed) — the connect path the user is
+  /// completing is the priority.
+  Future<void> _persistPickedAdapterToActiveVehicle(
+    ResolvedObd2Candidate candidate,
+  ) async {
+    try {
+      final active = ref.read(activeVehicleProfileProvider);
+      if (active == null) return;
+      final mac = candidate.candidate.deviceId;
+      final name = candidate.candidate.deviceName.isEmpty
+          ? candidate.profile.displayName
+          : candidate.candidate.deviceName;
+      if (active.obd2AdapterMac == mac && active.obd2AdapterName == name) {
+        return; // already persisted — skip the redundant write.
+      }
+      final updated = active.copyWith(
+        obd2AdapterMac: mac,
+        obd2AdapterName: name,
+      );
+      await ref.read(vehicleProfileListProvider.notifier).save(updated);
+    } catch (e, st) {
+      debugPrint(
+        'Obd2AdapterPickerSheet._persistPickedAdapterToActiveVehicle: $e\n$st',
+      );
     }
   }
 

--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -64,7 +64,19 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
       // didn't. `needsPicker` is the expected path here: surface the
       // picker, then hand the resulting service back to the provider
       // (same pattern as AddFillUpScreen).
-      final service = await showObd2AdapterPicker(context);
+      //
+      // #1188 — when the active vehicle has an adapter paired, the
+      // picker takes a silent fast path: it tries `connectByMac` and
+      // only opens the modal sheet when the connect fails. Plumbing
+      // both the MAC and the display name lets the picker surface a
+      // concrete fallback snackbar ("Couldn't reach 'X' …") rather
+      // than a generic message.
+      final activeVehicle = ref.read(activeVehicleProfileProvider);
+      final service = await showObd2AdapterPicker(
+        context,
+        pinnedMac: activeVehicle?.obd2AdapterMac,
+        pinnedAdapterName: activeVehicle?.obd2AdapterName,
+      );
       if (service == null || !mounted) return;
       await notifier.start(service);
       if (!mounted) return;

--- a/lib/l10n/_fragments/obd2_picker_de.arb
+++ b/lib/l10n/_fragments/obd2_picker_de.arb
@@ -1,0 +1,11 @@
+{
+  "obd2PickerPinnedFallback": "Konnte '{adapterName}' nicht erreichen — wähle einen anderen Adapter",
+  "@obd2PickerPinnedFallback": {
+    "description": "Snackbar shown after the OBD2 picker falls back from a silent pinned-MAC connect to the manual sheet (#1188). The placeholder is the display name of the previously paired adapter so the user knows which one was unreachable.",
+    "placeholders": {
+      "adapterName": {
+        "type": "String"
+      }
+    }
+  }
+}

--- a/lib/l10n/_fragments/obd2_picker_en.arb
+++ b/lib/l10n/_fragments/obd2_picker_en.arb
@@ -1,0 +1,11 @@
+{
+  "obd2PickerPinnedFallback": "Couldn't reach '{adapterName}' — pick another adapter",
+  "@obd2PickerPinnedFallback": {
+    "description": "Snackbar shown after the OBD2 picker falls back from a silent pinned-MAC connect to the manual sheet (#1188). The placeholder is the display name of the previously paired adapter so the user knows which one was unreachable.",
+    "placeholders": {
+      "adapterName": {
+        "type": "String"
+      }
+    }
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1444,6 +1444,15 @@
   "consumptionMonthlyDistanceLabel": "Strecke",
   "consumptionMonthlyAvgConsumptionLabel": "Ø Verbrauch",
   "consumptionMonthlyComparisonNotReliable": "Mindestens 3 Fahrten pro Monat für den Vergleich nötig",
+  "obd2PickerPinnedFallback": "Konnte '{adapterName}' nicht erreichen — wähle einen anderen Adapter",
+  "@obd2PickerPinnedFallback": {
+    "description": "Snackbar shown after the OBD2 picker falls back from a silent pinned-MAC connect to the manual sheet (#1188). The placeholder is the display name of the previously paired adapter so the user knows which one was unreachable.",
+    "placeholders": {
+      "adapterName": {
+        "type": "String"
+      }
+    }
+  },
   "onboardingObd2StepTitle": "OBD2-Adapter verbinden",
   "onboardingObd2StepBody": "Stecke deinen OBD2-Adapter in den Anschluss des Fahrzeugs und schalte die Zündung ein. Wir lesen die VIN aus und füllen die Motordaten automatisch.",
   "onboardingObd2ConnectButton": "Adapter verbinden",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2114,6 +2114,15 @@
   "@consumptionMonthlyComparisonNotReliable": {
     "description": "Caption shown on the monthly-insights card when one or both months has fewer than 3 trips. The card still shows the current-month numbers but skips the previous-month column and the delta arrows (#1041 phase 4)."
   },
+  "obd2PickerPinnedFallback": "Couldn't reach '{adapterName}' — pick another adapter",
+  "@obd2PickerPinnedFallback": {
+    "description": "Snackbar shown after the OBD2 picker falls back from a silent pinned-MAC connect to the manual sheet (#1188). The placeholder is the display name of the previously paired adapter so the user knows which one was unreachable.",
+    "placeholders": {
+      "adapterName": {
+        "type": "String"
+      }
+    }
+  },
   "onboardingObd2StepTitle": "Connect your OBD2 adapter",
   "@onboardingObd2StepTitle": {
     "description": "Title of the optional onboarding step (#816) that offers to connect an OBD2 adapter, read the VIN, and auto-fill the vehicle profile."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -758,6 +758,7 @@
   "obdPickerTitle": "Choisir un adaptateur OBD2",
   "obdPickerScanning": "Recherche d'adaptateurs…",
   "obdPickerConnecting": "Connexion…",
+  "obd2PickerPinnedFallback": "Impossible de joindre '{adapterName}' — choisissez un autre adaptateur",
   "themeSettingTitle": "Thème",
   "themeModeLight": "Clair",
   "themeModeDark": "Sombre",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6800,6 +6800,12 @@ abstract class AppLocalizations {
   /// **'Need at least 3 trips per month for comparison'**
   String get consumptionMonthlyComparisonNotReliable;
 
+  /// Snackbar shown after the OBD2 picker falls back from a silent pinned-MAC connect to the manual sheet (#1188). The placeholder is the display name of the previously paired adapter so the user knows which one was unreachable.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t reach \'{adapterName}\' — pick another adapter'**
+  String obd2PickerPinnedFallback(String adapterName);
+
   /// Title of the optional onboarding step (#816) that offers to connect an OBD2 adapter, read the VIN, and auto-fill the vehicle profile.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3647,6 +3647,11 @@ class AppLocalizationsBg extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3647,6 +3647,11 @@ class AppLocalizationsCs extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3645,6 +3645,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3678,6 +3678,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Mindestens 3 Fahrten pro Monat für den Vergleich nötig';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Konnte \'$adapterName\' nicht erreichen — wähle einen anderen Adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'OBD2-Adapter verbinden';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3649,6 +3649,11 @@ class AppLocalizationsEl extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3640,6 +3640,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3648,6 +3648,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3642,6 +3642,11 @@ class AppLocalizationsEt extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3645,6 +3645,11 @@ class AppLocalizationsFi extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3672,6 +3672,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Au moins 3 trajets par mois sont nécessaires pour la comparaison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Impossible de joindre \'$adapterName\' — choisissez un autre adaptateur';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connecter votre adaptateur OBD2';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3644,6 +3644,11 @@ class AppLocalizationsHr extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3649,6 +3649,11 @@ class AppLocalizationsHu extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3648,6 +3648,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3646,6 +3646,11 @@ class AppLocalizationsLt extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3648,6 +3648,11 @@ class AppLocalizationsLv extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3644,6 +3644,11 @@ class AppLocalizationsNb extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3649,6 +3649,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3647,6 +3647,11 @@ class AppLocalizationsPl extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3648,6 +3648,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3647,6 +3647,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3648,6 +3648,11 @@ class AppLocalizationsSk extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3642,6 +3642,11 @@ class AppLocalizationsSl extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3646,6 +3646,11 @@ class AppLocalizationsSv extends AppLocalizations {
       'Need at least 3 trips per month for comparison';
 
   @override
+  String obd2PickerPinnedFallback(String adapterName) {
+    return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
+  }
+
+  @override
   String get onboardingObd2StepTitle => 'Connect your OBD2 adapter';
 
   @override

--- a/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
@@ -8,7 +8,9 @@ import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart
 import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/obd2_adapter_picker.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('Obd2AdapterPickerSheet (#743)', () {
@@ -70,6 +72,187 @@ void main() {
           findsOneWidget);
     });
   });
+
+  // #1188 — pinned-MAC fast path. `showObd2AdapterPicker` accepts a
+  // [pinnedMac] for the active vehicle's adapter. When set, it tries
+  // a silent direct connect via [Obd2ConnectionService.connectByMac]
+  // and only falls back to the modal sheet when that fails.
+  group('showObd2AdapterPicker pinned-MAC fast path (#1188)', () {
+    testWidgets('pinnedMac=null shows the sheet (regression check)',
+        (tester) async {
+      final svc = _RecordingFakeConnection.success();
+      final completer = Completer<Obd2Service?>();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (ctx) => ElevatedButton(
+                  onPressed: () {
+                    completer.complete(showObd2AdapterPicker(ctx));
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      // Sheet rendered → its title is on screen.
+      expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
+      expect(svc.connectByMacCalls, isEmpty);
+      // Tear down the open future cleanly.
+      Navigator.of(tester.element(find.text('Pick an OBD2 adapter')))
+          .pop();
+      await tester.pumpAndSettle();
+      await completer.future;
+    });
+
+    testWidgets(
+        'pinnedMac with successful connect resolves silently (no sheet)',
+        (tester) async {
+      final fakeService = _NoopObd2Service();
+      final svc = _RecordingFakeConnection(
+        connectByMacResult: fakeService,
+      );
+      final completer = Completer<Obd2Service?>();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (ctx) => ElevatedButton(
+                  onPressed: () {
+                    completer.complete(showObd2AdapterPicker(
+                      ctx,
+                      pinnedMac: 'AA:BB:CC:DD:EE:FF',
+                      pinnedAdapterName: 'vLinker FS',
+                    ));
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(svc.connectByMacCalls, ['AA:BB:CC:DD:EE:FF']);
+      // No sheet rendered.
+      expect(find.text('Pick an OBD2 adapter'), findsNothing);
+      // Future resolved with the service.
+      final resolved = await completer.future;
+      expect(resolved, same(fakeService));
+    });
+
+    testWidgets(
+        'pinnedMac with failed connect (returns null) opens sheet + snackbar',
+        (tester) async {
+      final svc = _RecordingFakeConnection(
+        connectByMacResult: null, // simulate timeout / out-of-range
+      );
+      final completer = Completer<Obd2Service?>();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (ctx) => ElevatedButton(
+                  onPressed: () {
+                    completer.complete(showObd2AdapterPicker(
+                      ctx,
+                      pinnedMac: 'AA:BB:CC:DD:EE:FF',
+                      pinnedAdapterName: 'vLinker FS',
+                    ));
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(svc.connectByMacCalls, ['AA:BB:CC:DD:EE:FF']);
+      // Sheet IS rendered now (fallback) — its title shows.
+      expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
+      // Snackbar with the pinned name carries the localized message.
+      expect(
+        find.textContaining("Couldn't reach 'vLinker FS'"),
+        findsOneWidget,
+      );
+
+      // Drain the picker — the underlying scan stream is empty so it
+      // sits in `scanning`. Pop the sheet to resolve the future.
+      Navigator.of(tester.element(find.text('Pick an OBD2 adapter')))
+          .pop();
+      await tester.pumpAndSettle();
+      await completer.future;
+    });
+  });
+}
+
+/// Recording fake for [Obd2ConnectionService] that lets the pinned-MAC
+/// tests drive `connectByMac` without spinning up a real BLE stack.
+/// Sheet-fallback paths still need a working `scan` because the
+/// underlying [Obd2AdapterPickerSheet] subscribes to it on init —
+/// returning an empty stream sits the sheet in its scanning state
+/// indefinitely, which is exactly what the tests need to assert
+/// "the sheet IS rendered" without chasing further state transitions.
+class _RecordingFakeConnection extends Obd2ConnectionService {
+  _RecordingFakeConnection({this.connectByMacResult})
+      : super(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _FakePermissions(Obd2PermissionState.granted),
+          bluetooth: _StreamingFacade(const []),
+        );
+  factory _RecordingFakeConnection.success() =>
+      _RecordingFakeConnection(connectByMacResult: _NoopObd2Service());
+
+  final Obd2Service? connectByMacResult;
+  final List<String> connectByMacCalls = [];
+
+  @override
+  Future<Obd2Service?> connectByMac(
+    String mac, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    connectByMacCalls.add(mac);
+    return connectByMacResult;
+  }
+
+  @override
+  Stream<List<ResolvedObd2Candidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    // Empty stream — the picker sheet sits in its scanning state.
+  }
+}
+
+/// Minimal [Obd2Service] stand-in. The pinned-MAC tests only need
+/// identity comparison (`same(fakeService)`); no transport calls fire.
+class _NoopObd2Service implements Obd2Service {
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 // --- helpers ---------------------------------------------------------

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -2,7 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tankstellen/core/widgets/empty_state.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
@@ -90,6 +95,93 @@ class _IdleTripRecording extends TripRecording {
   }
 }
 
+/// Fake that returns [StartTripOutcome.needsPicker] — drives the
+/// picker code path in `_onStartRecording` (#1188).
+class _NeedsPickerTripRecording extends TripRecording {
+  int startTripCallCount = 0;
+  int startServiceCallCount = 0;
+
+  @override
+  TripRecordingState build() => const TripRecordingState();
+
+  @override
+  Future<StartTripOutcome> startTrip({
+    String? vehicleId,
+    String? adapterMac,
+    Obd2Service? service,
+  }) async {
+    startTripCallCount++;
+    return StartTripOutcome.needsPicker;
+  }
+
+  @override
+  Future<void> start(Obd2Service service) async {
+    startServiceCallCount++;
+  }
+}
+
+/// Fake [Obd2ConnectionService] that records `connectByMac` calls and
+/// returns a synthetic [Obd2Service] (or null to force the sheet
+/// fallback) so the trajets_tab pinned-MAC tests don't spin up any
+/// Bluetooth stack. The constructor uses the existing fake permissions
+/// + bluetooth facades so the underlying scan path also stays inert.
+class _RecordingFakeConnection extends Obd2ConnectionService {
+  _RecordingFakeConnection({this.connectByMacResult})
+      : super(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _AlwaysGrantedPermissions(),
+          bluetooth: _EmptyBluetoothFacade(),
+        );
+
+  final Obd2Service? connectByMacResult;
+  final List<String> connectByMacCalls = [];
+
+  @override
+  Future<Obd2Service?> connectByMac(
+    String mac, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    connectByMacCalls.add(mac);
+    return connectByMacResult;
+  }
+
+  @override
+  Stream<List<ResolvedObd2Candidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    // Empty stream — the picker sheet (when shown) sits in scanning.
+  }
+}
+
+class _AlwaysGrantedPermissions implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+}
+
+class _EmptyBluetoothFacade implements BluetoothFacade {
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) {
+    throw UnimplementedError('not used in trajets_tab tests');
+  }
+}
+
+class _NoopObd2Service implements Obd2Service {
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 /// Builds a [TripHistoryEntry] with sensible defaults so each test
 /// only spells out the fields it cares about.
 TripHistoryEntry _entry({
@@ -127,6 +219,7 @@ Future<void> _pumpTab(
   List<VehicleProfile> vehicles = const [],
   VehicleProfile? activeVehicle,
   TripRecording Function()? recordingFactory,
+  Obd2ConnectionService? obd2Connection,
 }) async {
   _lastTripIdVisited = null;
   final router = GoRouter(
@@ -157,6 +250,8 @@ Future<void> _pumpTab(
           .overrideWith(() => _FixedActiveVehicle(activeVehicle)),
       tripRecordingProvider
           .overrideWith(recordingFactory ?? () => _IdleTripRecording()),
+      if (obd2Connection != null)
+        obd2ConnectionProvider.overrideWith((_) => obd2Connection),
     ],
   );
 }
@@ -494,6 +589,92 @@ void main() {
 
       expect(find.text('18.5 kWh/100 km'), findsOneWidget);
       expect(find.textContaining('L/100 km'), findsNothing);
+    });
+  });
+
+  // #1188 — pinned-MAC fast path. When the active vehicle has an
+  // adapter paired (`obd2AdapterMac` non-null), tapping Start
+  // recording must NOT show the picker sheet. The picker calls
+  // `connectByMac` silently and pushes straight into the recording
+  // screen.
+  group('TrajetsTab — pinned-MAC fast path (#1188)', () {
+    const pairedVehicle = VehicleProfile(
+      id: 'v1',
+      name: 'Daily Driver',
+      type: VehicleType.combustion,
+      obd2AdapterMac: 'AA:BB:CC:DD:EE:FF',
+      obd2AdapterName: 'vLinker FS',
+    );
+    const unpairedVehicle = VehicleProfile(
+      id: 'v2',
+      name: 'Daily Driver',
+      type: VehicleType.combustion,
+    );
+
+    testWidgets(
+        'paired vehicle skips the picker sheet on Start recording',
+        (tester) async {
+      final fakeService = _NoopObd2Service();
+      final connection = _RecordingFakeConnection(
+        connectByMacResult: fakeService,
+      );
+      final notifier = _NeedsPickerTripRecording();
+
+      await _pumpTab(
+        tester,
+        vehicleId: null,
+        trips: const [],
+        activeVehicle: pairedVehicle,
+        recordingFactory: () => notifier,
+        obd2Connection: connection,
+      );
+
+      await tester.tap(
+        find.byKey(const Key('trajets_start_recording_button')),
+      );
+      // Need to pump enough for the futures to chain through. Don't
+      // pumpAndSettle — the recording screen push would attempt to
+      // build the full TripRecordingScreen.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // startTrip fired and returned needsPicker.
+      expect(notifier.startTripCallCount, 1);
+      // Picker called connectByMac with the pinned MAC.
+      expect(connection.connectByMacCalls, ['AA:BB:CC:DD:EE:FF']);
+      // Sheet title NEVER appears — the picker short-circuited.
+      expect(find.text('Pick an OBD2 adapter'), findsNothing);
+      // The notifier received the connected service from the silent
+      // pinned-MAC fast path.
+      expect(notifier.startServiceCallCount, 1);
+    });
+
+    testWidgets(
+        'unpaired vehicle still opens the picker sheet on Start recording',
+        (tester) async {
+      final connection = _RecordingFakeConnection();
+      final notifier = _NeedsPickerTripRecording();
+
+      await _pumpTab(
+        tester,
+        vehicleId: null,
+        trips: const [],
+        activeVehicle: unpairedVehicle,
+        recordingFactory: () => notifier,
+        obd2Connection: connection,
+      );
+
+      await tester.tap(
+        find.byKey(const Key('trajets_start_recording_button')),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(notifier.startTripCallCount, 1);
+      // No pinned MAC → picker did not attempt the silent connect.
+      expect(connection.connectByMacCalls, isEmpty);
+      // Sheet IS shown — the title text on the modal is rendered.
+      expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Symptom

Tapping `Start recording` on the Trajets tab always opened the `Choisir un adaptateur OBD2` bottom sheet — listing every nearby adapter — even when the active vehicle profile already had a paired adapter. For a returning user with one car + one adapter, every recording session had a 2-tap friction layer that should not exist.

## Root cause

`TripRecording.startTrip()` returned `needsPicker` even when a pinned MAC was present, deferring the connect to the UI layer. The UI in `trajets_tab.dart` then called `showObd2AdapterPicker(context)` with no `pinnedMac` argument — so the promised "short-circuits on the pinned MAC" never happened.

## Fix (Option 2 from the issue body)

* `showObd2AdapterPicker` now accepts a `pinnedMac` and a `pinnedAdapterName`. When `pinnedMac` is non-null, the picker tries `Obd2ConnectionService.connectByMac` first and resolves silently on success — no modal sheet shown.
* On pinned-MAC failure (timeout, out of range, init error), the sheet opens with a localized snackbar (`obd2PickerPinnedFallback`) explaining which adapter was unreachable so the user understands why the picker reappeared.
* When the user picks an adapter manually, the picker writes the MAC + display name back onto the active vehicle profile (via `vehicleProfileListProvider.save`) so the next session takes the silent fast path. Persistence happens inside the picker (per the issue's "pragmatic alternative") — it keeps `trajets_tab.dart` lean.
* New `Obd2ConnectionService.connectByMac(mac, {timeout: 5s})` is the thin helper that runs a short scan, matches the MAC, and dispatches to the existing `connect` flow. Returns `null` on timeout / no match so the caller can fall back; rethrows real `Obd2ConnectionError`s.

## ARB

New key `obd2PickerPinnedFallback(adapterName)` added to:
* `lib/l10n/_fragments/obd2_picker_en.arb` — `Couldn't reach '{adapterName}' — pick another adapter`
* `lib/l10n/_fragments/obd2_picker_de.arb` — `Konnte '{adapterName}' nicht erreichen — wähle einen anderen Adapter`
* `lib/l10n/app_fr.arb` — `Impossible de joindre '{adapterName}' — choisissez un autre adaptateur`

`dart run tool/build_arb.dart` + `flutter gen-l10n` regenerated all 23 locale dart files.

## Acceptance checklist

- [x] Active vehicle with `obd2AdapterMac` set → tapping `Start recording` opens the recording screen directly with no picker.
- [x] Active vehicle without `obd2AdapterMac` → picker shown; on selection, MAC + name are persisted to the profile.
- [x] No active vehicle → picker shown (unchanged).
- [x] Pinned MAC unreachable → picker shown with a snackbar explaining the fallback.
- [x] Existing `auto_trip_coordinator` + `auto_record_trace_log` paths still work.
- [x] Widget test: `Trajets tab` with a paired vehicle does NOT find `Pick an OBD2 adapter` text after tapping the start button.

## Test plan

- [x] `flutter analyze` — 0 issues.
- [x] `flutter test test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart test/features/consumption/presentation/widgets/trajets_tab_test.dart` — 20/20 pass (5 new for #1188).

Closes #1188