### PR TITLE
fix(sync): localized friendly auth error mapper (Closes #1186)

### DIFF
--- a/lib/features/sync/data/auth_error_mapper.dart
+++ b/lib/features/sync/data/auth_error_mapper.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../core/logging/error_logger.dart';
+import '../../../l10n/app_localizations.dart';
+
+/// Maps a raw [error] thrown from a Supabase / network auth call into a
+/// localized, user-safe message suitable for the auth-screen error pill.
+///
+/// Why this exists (#1186):
+///   The auth screen previously called `_formNotifier.setError(e.toString())`
+///   in every catch block. For a `gotrue` retryable fetch failure that
+///   produces a string like
+///   `AuthRetryableFetchException: ClientException: ... uri=https://klelxnkzrxlpzuddhpfg.supabase.co/...`
+///   — leaking the project URL into the UI and confronting the user with
+///   exception type names. This function classifies the error first by
+///   runtime type (network / DNS / Supabase auth), then by substring on
+///   the message for the well-known Supabase error codes
+///   (`invalid_credentials`, `user_already_exists`, `email_not_confirmed`),
+///   and falls back to a generic "Something went wrong" string.
+///
+/// The original error (and stack trace, if available) is always logged
+/// via [errorLogger] so observability is preserved — only the *display*
+/// is sanitized. Callers should pass `stackTrace` when they have one.
+///
+/// The function is pure with respect to its non-logging output: given the
+/// same `error` and `l10n`, it returns the same string. This makes the
+/// mapper trivially unit-testable without a Riverpod or widget harness.
+String mapAuthErrorToLocalized(
+  Object error,
+  AppLocalizations l10n, {
+  StackTrace? stackTrace,
+}) {
+  // Always log the original error — observability must outlive the
+  // friendly translation. Fire-and-forget; ErrorLogger.log is documented
+  // as never-throwing.
+  // ignore: discarded_futures
+  errorLogger.log(
+    ErrorLayer.sync,
+    error,
+    stackTrace,
+    context: <String, Object?>{'phase': 'auth'},
+  );
+
+  // 1. Network / DNS classes — show "no network" before drilling into
+  //    Supabase-specific messages. AuthRetryableFetchException is the
+  //    common gotrue wrapper for "could not reach the server", so it
+  //    belongs in this bucket rather than "generic".
+  if (error is SocketException ||
+      error is http.ClientException ||
+      error is AuthRetryableFetchException) {
+    return l10n.authErrorNoNetwork;
+  }
+
+  // OS errno=7 (`No address associated with hostname` on Android) bubbles
+  // up wrapped in different exception types depending on the http stack.
+  // A substring match on the error's `toString()` catches the cases we
+  // do not classify by runtime type above.
+  final message = error.toString();
+  if (message.contains('errno = 7') ||
+      message.contains('Failed host lookup') ||
+      message.contains('SocketException') ||
+      message.contains('Network is unreachable') ||
+      message.contains('ClientException')) {
+    return l10n.authErrorNoNetwork;
+  }
+
+  // 2. Supabase-known auth error codes — substring match on the message
+  //    field of the AuthException (or the toString if a non-typed error
+  //    leaked through).
+  if (message.contains('invalid_credentials') ||
+      message.contains('Invalid login credentials')) {
+    return l10n.authErrorInvalidCredentials;
+  }
+  if (message.contains('user_already_exists') ||
+      message.contains('already registered') ||
+      message.contains('User already registered')) {
+    return l10n.authErrorUserAlreadyExists;
+  }
+  if (message.contains('email_not_confirmed') ||
+      message.contains('Email not confirmed')) {
+    return l10n.authErrorEmailNotConfirmed;
+  }
+
+  // 3. Default — never expose `toString()` to the user.
+  return l10n.authErrorGeneric;
+}

--- a/lib/features/sync/presentation/screens/auth_screen.dart
+++ b/lib/features/sync/presentation/screens/auth_screen.dart
@@ -9,6 +9,7 @@ import '../../../../core/utils/password_validator.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../data/auth_error_mapper.dart';
 import '../../providers/auth_form_provider.dart';
 import '../widgets/auth_info_card.dart';
 import '../widgets/auth_status_cards.dart';
@@ -77,8 +78,17 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
           context.pop();
         }
       }
-    } catch (e, st) { // ignore: unused_catch_stack
-      _formNotifier.setError(e.toString());
+    } catch (e, st) {
+      debugPrint('AuthScreen._continueAsGuest failed: $e');
+      if (mounted) {
+        final l10n = AppLocalizations.of(context);
+        if (l10n != null) {
+          _formNotifier
+              .setError(mapAuthErrorToLocalized(e, l10n, stackTrace: st));
+        } else {
+          _formNotifier.setError('Something went wrong. Please try again.');
+        }
+      }
     } finally {
       _formNotifier.setLoading(false);
     }
@@ -124,20 +134,16 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                 : (l10n?.signedIn ?? 'Signed in!'));
         context.pop();
       }
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      debugPrint('AuthScreen._submitEmail failed: $e');
       if (mounted) {
-        String errorMsg = e.toString();
-        if (errorMsg.contains('invalid_credentials')) {
-          errorMsg = 'Invalid email or password. Check your credentials.';
-        } else if (errorMsg.contains('user_already_exists') ||
-            errorMsg.contains('already registered')) {
-          errorMsg =
-              'This email is already registered. Try signing in instead.';
-        } else if (errorMsg.contains('email_not_confirmed')) {
-          errorMsg =
-              'Please check your email and confirm your account first.';
+        final l10n = AppLocalizations.of(context);
+        if (l10n != null) {
+          _formNotifier
+              .setError(mapAuthErrorToLocalized(e, l10n, stackTrace: st));
+        } else {
+          _formNotifier.setError('Something went wrong. Please try again.');
         }
-        _formNotifier.setError(errorMsg);
       }
     } finally {
       _formNotifier.setLoading(false);
@@ -155,8 +161,17 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                 'Switched to anonymous session');
         context.pop();
       }
-    } catch (e, st) { // ignore: unused_catch_stack
-      _formNotifier.setError(e.toString());
+    } catch (e, st) {
+      debugPrint('AuthScreen._switchToAnonymous failed: $e');
+      if (mounted) {
+        final l10n = AppLocalizations.of(context);
+        if (l10n != null) {
+          _formNotifier
+              .setError(mapAuthErrorToLocalized(e, l10n, stackTrace: st));
+        } else {
+          _formNotifier.setError('Something went wrong. Please try again.');
+        }
+      }
     } finally {
       _formNotifier.setLoading(false);
     }

--- a/lib/l10n/_fragments/sync_de.arb
+++ b/lib/l10n/_fragments/sync_de.arb
@@ -1,0 +1,7 @@
+{
+  "authErrorNoNetwork": "Keine Netzwerkverbindung. Bitte später erneut versuchen.",
+  "authErrorInvalidCredentials": "Ungültige E-Mail oder Passwort. Bitte überprüfen.",
+  "authErrorUserAlreadyExists": "Ein Konto mit dieser E-Mail existiert bereits.",
+  "authErrorEmailNotConfirmed": "Bitte bestätige deine E-Mail vor der Anmeldung.",
+  "authErrorGeneric": "Etwas ist schiefgelaufen. Bitte erneut versuchen."
+}

--- a/lib/l10n/_fragments/sync_en.arb
+++ b/lib/l10n/_fragments/sync_en.arb
@@ -1,0 +1,22 @@
+{
+  "authErrorNoNetwork": "No network connection. Try again later.",
+  "@authErrorNoNetwork": {
+    "description": "Friendly error pill on the auth screen when sign-in / sign-up fails because the device is offline or the Supabase host cannot be resolved (#1186). Replaces raw exception text like 'AuthRetryableFetchException' that previously leaked the project URL."
+  },
+  "authErrorInvalidCredentials": "Invalid email or password. Check your credentials.",
+  "@authErrorInvalidCredentials": {
+    "description": "Friendly error pill when Supabase returns invalid_credentials on email sign-in (#1186)."
+  },
+  "authErrorUserAlreadyExists": "An account with this email already exists.",
+  "@authErrorUserAlreadyExists": {
+    "description": "Friendly error pill when Supabase rejects a sign-up because the email is already registered (#1186)."
+  },
+  "authErrorEmailNotConfirmed": "Please confirm your email before signing in.",
+  "@authErrorEmailNotConfirmed": {
+    "description": "Friendly error pill when Supabase blocks a sign-in because the user has not confirmed their email yet (#1186)."
+  },
+  "authErrorGeneric": "Something went wrong. Please try again.",
+  "@authErrorGeneric": {
+    "description": "Default friendly error pill on the auth screen when no specific cause is detected. Used as the fallback after the friendly-error mapper exhausts all known cases (#1186)."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1468,6 +1468,11 @@
   "@splashLoadingLabel": {
     "description": "Barrierefreiheits-Label, das TalkBack/VoiceOver während des animierten Splash-Screens ansagt. Wird nicht sichtbar gerendert; kurz und sprechbar halten."
   },
+  "authErrorNoNetwork": "Keine Netzwerkverbindung. Bitte später erneut versuchen.",
+  "authErrorInvalidCredentials": "Ungültige E-Mail oder Passwort. Bitte überprüfen.",
+  "authErrorUserAlreadyExists": "Ein Konto mit dieser E-Mail existiert bereits.",
+  "authErrorEmailNotConfirmed": "Bitte bestätige deine E-Mail vor der Anmeldung.",
+  "authErrorGeneric": "Etwas ist schiefgelaufen. Bitte erneut versuchen.",
   "themeCardTitle": "Design",
   "themeCardSubtitleSystem": "System",
   "themeCardSubtitleLight": "Hell",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2215,6 +2215,26 @@
   "@splashLoadingLabel": {
     "description": "Accessibility label announced by TalkBack/VoiceOver while the animated splash screen is visible. Not rendered visually; keep it concise and speakable."
   },
+  "authErrorNoNetwork": "No network connection. Try again later.",
+  "@authErrorNoNetwork": {
+    "description": "Friendly error pill on the auth screen when sign-in / sign-up fails because the device is offline or the Supabase host cannot be resolved (#1186). Replaces raw exception text like 'AuthRetryableFetchException' that previously leaked the project URL."
+  },
+  "authErrorInvalidCredentials": "Invalid email or password. Check your credentials.",
+  "@authErrorInvalidCredentials": {
+    "description": "Friendly error pill when Supabase returns invalid_credentials on email sign-in (#1186)."
+  },
+  "authErrorUserAlreadyExists": "An account with this email already exists.",
+  "@authErrorUserAlreadyExists": {
+    "description": "Friendly error pill when Supabase rejects a sign-up because the email is already registered (#1186)."
+  },
+  "authErrorEmailNotConfirmed": "Please confirm your email before signing in.",
+  "@authErrorEmailNotConfirmed": {
+    "description": "Friendly error pill when Supabase blocks a sign-in because the user has not confirmed their email yet (#1186)."
+  },
+  "authErrorGeneric": "Something went wrong. Please try again.",
+  "@authErrorGeneric": {
+    "description": "Default friendly error pill on the auth screen when no specific cause is detected. Used as the fallback after the friendly-error mapper exhausts all known cases (#1186)."
+  },
   "themeCardTitle": "Theme",
   "@themeCardTitle": {
     "description": "Title of the Theme card on the Settings screen (#897). The card matches the Privacy + Storage card pattern and navigates to a dedicated theme picker screen."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -913,5 +913,10 @@
   "consumptionMonthlyDriveTimeLabel": "Temps de conduite",
   "consumptionMonthlyDistanceLabel": "Distance",
   "consumptionMonthlyAvgConsumptionLabel": "Conso. moyenne",
-  "consumptionMonthlyComparisonNotReliable": "Au moins 3 trajets par mois sont nécessaires pour la comparaison"
+  "consumptionMonthlyComparisonNotReliable": "Au moins 3 trajets par mois sont nécessaires pour la comparaison",
+  "authErrorNoNetwork": "Pas de connexion réseau. Réessayez plus tard.",
+  "authErrorInvalidCredentials": "E-mail ou mot de passe invalide. Vérifiez vos identifiants.",
+  "authErrorUserAlreadyExists": "Un compte avec cet e-mail existe déjà.",
+  "authErrorEmailNotConfirmed": "Veuillez confirmer votre e-mail avant de vous connecter.",
+  "authErrorGeneric": "Une erreur est survenue. Veuillez réessayer."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6926,6 +6926,36 @@ abstract class AppLocalizations {
   /// **'Loading Tankstellen'**
   String get splashLoadingLabel;
 
+  /// Friendly error pill on the auth screen when sign-in / sign-up fails because the device is offline or the Supabase host cannot be resolved (#1186). Replaces raw exception text like 'AuthRetryableFetchException' that previously leaked the project URL.
+  ///
+  /// In en, this message translates to:
+  /// **'No network connection. Try again later.'**
+  String get authErrorNoNetwork;
+
+  /// Friendly error pill when Supabase returns invalid_credentials on email sign-in (#1186).
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid email or password. Check your credentials.'**
+  String get authErrorInvalidCredentials;
+
+  /// Friendly error pill when Supabase rejects a sign-up because the email is already registered (#1186).
+  ///
+  /// In en, this message translates to:
+  /// **'An account with this email already exists.'**
+  String get authErrorUserAlreadyExists;
+
+  /// Friendly error pill when Supabase blocks a sign-in because the user has not confirmed their email yet (#1186).
+  ///
+  /// In en, this message translates to:
+  /// **'Please confirm your email before signing in.'**
+  String get authErrorEmailNotConfirmed;
+
+  /// Default friendly error pill on the auth screen when no specific cause is detected. Used as the fallback after the friendly-error mapper exhausts all known cases (#1186).
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong. Please try again.'**
+  String get authErrorGeneric;
+
   /// Title of the Theme card on the Settings screen (#897). The card matches the Privacy + Storage card pattern and navigates to a dedicated theme picker screen.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3718,6 +3718,24 @@ class AppLocalizationsBg extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3718,6 +3718,24 @@ class AppLocalizationsCs extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3716,6 +3716,24 @@ class AppLocalizationsDa extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3749,6 +3749,26 @@ class AppLocalizationsDe extends AppLocalizations {
   String get splashLoadingLabel => 'Tankstellen wird geladen';
 
   @override
+  String get authErrorNoNetwork =>
+      'Keine Netzwerkverbindung. Bitte später erneut versuchen.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Ungültige E-Mail oder Passwort. Bitte überprüfen.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'Ein Konto mit dieser E-Mail existiert bereits.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Bitte bestätige deine E-Mail vor der Anmeldung.';
+
+  @override
+  String get authErrorGeneric =>
+      'Etwas ist schiefgelaufen. Bitte erneut versuchen.';
+
+  @override
   String get themeCardTitle => 'Design';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3720,6 +3720,24 @@ class AppLocalizationsEl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3711,6 +3711,24 @@ class AppLocalizationsEn extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3719,6 +3719,24 @@ class AppLocalizationsEs extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3713,6 +3713,24 @@ class AppLocalizationsEt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3716,6 +3716,24 @@ class AppLocalizationsFi extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3743,6 +3743,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork =>
+      'Pas de connexion réseau. Réessayez plus tard.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'E-mail ou mot de passe invalide. Vérifiez vos identifiants.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'Un compte avec cet e-mail existe déjà.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Veuillez confirmer votre e-mail avant de vous connecter.';
+
+  @override
+  String get authErrorGeneric => 'Une erreur est survenue. Veuillez réessayer.';
+
+  @override
   String get themeCardTitle => 'Thème';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3715,6 +3715,24 @@ class AppLocalizationsHr extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3720,6 +3720,24 @@ class AppLocalizationsHu extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3719,6 +3719,24 @@ class AppLocalizationsIt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3717,6 +3717,24 @@ class AppLocalizationsLt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3719,6 +3719,24 @@ class AppLocalizationsLv extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3715,6 +3715,24 @@ class AppLocalizationsNb extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3720,6 +3720,24 @@ class AppLocalizationsNl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3718,6 +3718,24 @@ class AppLocalizationsPl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3719,6 +3719,24 @@ class AppLocalizationsPt extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3718,6 +3718,24 @@ class AppLocalizationsRo extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3719,6 +3719,24 @@ class AppLocalizationsSk extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3713,6 +3713,24 @@ class AppLocalizationsSl extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3717,6 +3717,24 @@ class AppLocalizationsSv extends AppLocalizations {
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override
+  String get authErrorNoNetwork => 'No network connection. Try again later.';
+
+  @override
+  String get authErrorInvalidCredentials =>
+      'Invalid email or password. Check your credentials.';
+
+  @override
+  String get authErrorUserAlreadyExists =>
+      'An account with this email already exists.';
+
+  @override
+  String get authErrorEmailNotConfirmed =>
+      'Please confirm your email before signing in.';
+
+  @override
+  String get authErrorGeneric => 'Something went wrong. Please try again.';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/test/features/sync/data/auth_error_mapper_test.dart
+++ b/test/features/sync/data/auth_error_mapper_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/features/sync/data/auth_error_mapper.dart';
+import 'package:tankstellen/l10n/app_localizations_de.dart';
+import 'package:tankstellen/l10n/app_localizations_en.dart';
+import 'package:tankstellen/l10n/app_localizations_fr.dart';
+
+/// Pure unit tests for [mapAuthErrorToLocalized] (#1186).
+///
+/// These tests deliberately do NOT spin up a Riverpod container or a
+/// widget tree — they instantiate the localization classes directly so
+/// we can exercise the mapper across en / de / fr without a heavy
+/// pumpApp harness.
+void main() {
+  final en = AppLocalizationsEn();
+  final de = AppLocalizationsDe();
+  final fr = AppLocalizationsFr();
+
+  setUp(() {
+    // The mapper logs the original error via [errorLogger]. Without a
+    // bound foreground container, the logger falls through to the
+    // Hive-backed spool which would fail (Hive isn't initialised in
+    // these pure tests). Override the enqueue to a no-op so the
+    // logging side-effect is exercised but doesn't drag Hive in.
+    errorLogger.spoolEnqueueOverride = ({
+      required String isolateTaskName,
+      required Object error,
+      StackTrace? stack,
+      Map<String, dynamic>? contextMap,
+      DateTime? timestamp,
+    }) async {};
+  });
+
+  tearDown(() {
+    errorLogger.resetForTest();
+  });
+
+  group('mapAuthErrorToLocalized', () {
+    test('Supabase invalid_credentials -> friendly localized string', () {
+      const err = AuthException('invalid_credentials');
+      expect(mapAuthErrorToLocalized(err, en), en.authErrorInvalidCredentials);
+      expect(mapAuthErrorToLocalized(err, de), de.authErrorInvalidCredentials);
+      expect(mapAuthErrorToLocalized(err, fr), fr.authErrorInvalidCredentials);
+    });
+
+    test('Supabase user_already_exists -> friendly localized string', () {
+      const err = AuthException('user_already_exists');
+      expect(mapAuthErrorToLocalized(err, en), en.authErrorUserAlreadyExists);
+      expect(mapAuthErrorToLocalized(err, de), de.authErrorUserAlreadyExists);
+      expect(mapAuthErrorToLocalized(err, fr), fr.authErrorUserAlreadyExists);
+    });
+
+    test('Supabase email_not_confirmed -> friendly localized string', () {
+      const err = AuthException('email_not_confirmed');
+      expect(mapAuthErrorToLocalized(err, en), en.authErrorEmailNotConfirmed);
+      expect(mapAuthErrorToLocalized(err, de), de.authErrorEmailNotConfirmed);
+      expect(mapAuthErrorToLocalized(err, fr), fr.authErrorEmailNotConfirmed);
+    });
+
+    test('SocketException -> "no network" localized string', () {
+      const err = SocketException('Failed host lookup: example.com');
+      expect(mapAuthErrorToLocalized(err, en), en.authErrorNoNetwork);
+      expect(mapAuthErrorToLocalized(err, de), de.authErrorNoNetwork);
+      expect(mapAuthErrorToLocalized(err, fr), fr.authErrorNoNetwork);
+    });
+
+    test('AuthRetryableFetchException -> "no network" localized string', () {
+      // This is the literal exception type users currently see leak into
+      // the error pill (#1186) — guard against regression.
+      final err = AuthRetryableFetchException();
+      expect(mapAuthErrorToLocalized(err, en), en.authErrorNoNetwork);
+      expect(mapAuthErrorToLocalized(err, de), de.authErrorNoNetwork);
+      expect(mapAuthErrorToLocalized(err, fr), fr.authErrorNoNetwork);
+    });
+
+    test('http.ClientException -> "no network" localized string', () {
+      final err = http.ClientException('Connection refused');
+      expect(mapAuthErrorToLocalized(err, en), en.authErrorNoNetwork);
+    });
+
+    test('default fallback for an unrecognized error', () {
+      final err = StateError('something completely unrelated');
+      expect(mapAuthErrorToLocalized(err, en), en.authErrorGeneric);
+      expect(mapAuthErrorToLocalized(err, de), de.authErrorGeneric);
+      expect(mapAuthErrorToLocalized(err, fr), fr.authErrorGeneric);
+    });
+
+    test('never returns the raw toString() (no exception type names)', () {
+      // Defensive: the friendly result must not contain any of the
+      // type-name fragments that trigger #1186 in the first place.
+      final cases = <Object>[
+        AuthRetryableFetchException(),
+        const SocketException('Failed host lookup: foo.supabase.co'),
+        const AuthException(
+            'invalid_credentials at https://klelxnkzrxlpzuddhpfg.supabase.co'),
+        StateError('whatever'),
+      ];
+      for (final err in cases) {
+        final out = mapAuthErrorToLocalized(err, en);
+        expect(out, isNot(contains('Exception')),
+            reason: 'mapped output must not leak the exception name: $err');
+        expect(out, isNot(contains('klelxnkzrxlpzuddhpfg')),
+            reason: 'mapped output must not leak the project URL: $err');
+      }
+    });
+
+    test('Failed host lookup substring routes to no-network', () {
+      // gotrue sometimes wraps DNS failures in AuthUnknownException whose
+      // toString() contains "Failed host lookup". Verify the substring
+      // path rather than the runtime-type path.
+      final err = StateError('Failed host lookup: example.supabase.co');
+      expect(mapAuthErrorToLocalized(err, en), en.authErrorNoNetwork);
+    });
+  });
+}

--- a/test/features/sync/presentation/screens/auth_screen_test.dart
+++ b/test/features/sync/presentation/screens/auth_screen_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/sync/sync_config.dart';
 import 'package:tankstellen/core/sync/sync_provider.dart';
 import 'package:tankstellen/core/widgets/page_scaffold.dart';
@@ -74,7 +76,45 @@ class _FakeSyncState extends SyncState {
   SyncConfig build() => _config;
 }
 
+/// Fake [SyncState] whose [signInWithEmail] always throws the supplied
+/// error. Used to verify the catch-block goes through the friendly-error
+/// mapper rather than dumping `e.toString()` onto the screen (#1186).
+class _ThrowingSyncState extends SyncState {
+  _ThrowingSyncState(this._error);
+  final Object _error;
+
+  @override
+  SyncConfig build() => const SyncConfig();
+
+  @override
+  Future<void> signInWithEmail(
+    String email,
+    String password, {
+    bool isSignUp = true,
+  }) async {
+    throw _error;
+  }
+}
+
 void main() {
+  setUp(() {
+    // The friendly-error mapper used by AuthScreen logs through
+    // errorLogger, which falls through to the Hive-backed spool when
+    // no foreground container is bound. Hive is not initialised in
+    // pure widget tests, so override the enqueue to a no-op.
+    errorLogger.spoolEnqueueOverride = ({
+      required String isolateTaskName,
+      required Object error,
+      StackTrace? stack,
+      Map<String, dynamic>? contextMap,
+      DateTime? timestamp,
+    }) async {};
+  });
+
+  tearDown(() {
+    errorLogger.resetForTest();
+  });
+
   group('AuthScreen', () {
     Future<_FakeAuthFormController> pumpAuthScreen(
       WidgetTester tester, {
@@ -237,6 +277,78 @@ void main() {
       final fake = await pumpAuthScreen(tester);
       // pumpApp ends with pumpAndSettle so the post-frame callback has run.
       expect(fake.resetCalls, 1);
+    });
+
+    testWidgets(
+        'submitting email when sign-in throws a retryable fetch error '
+        'renders the localized "no network" string and never leaks the '
+        'project URL or exception type name (#1186)',
+        (tester) async {
+      // Drive _submitEmail by tapping the submit button — the throwing
+      // SyncState fakes the worst-case scenario from the bug: the user
+      // enters credentials, the server is unreachable, and the catch
+      // block previously rendered something like
+      // `AuthRetryableFetchException: ...
+      // uri=https://klelxnkzrxlpzuddhpfg.supabase.co/...`.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authFormControllerProvider
+                .overrideWith(() => _FakeAuthFormController(
+                      const AuthFormState(isSignUp: false),
+                    )),
+            syncStateProvider.overrideWith(
+              () => _ThrowingSyncState(
+                AuthRetryableFetchException(
+                  message:
+                      'AuthRetryableFetchException: ClientException with '
+                      'SocketException: Failed host lookup '
+                      'klelxnkzrxlpzuddhpfg.supabase.co',
+                ),
+              ),
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: Locale('en'),
+            home: AuthScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Type credentials so the early-return validators don't short-circuit.
+      await tester.enterText(
+          find.widgetWithText(TextField, 'Email'), 'someone@example.com');
+      await tester.enterText(
+          find.widgetWithText(TextField, 'Password'), 'Hunter22!');
+      await tester.pump();
+
+      // Tap the submit button (FilledButton inside the EmailAuthCard).
+      await tester.tap(find.byType(FilledButton).first);
+      // The throwing future resolves on the next microtask; pumpAndSettle
+      // would loop on the spinner while it's flipped on.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // The friendly localized string is what the user sees.
+      expect(find.text('No network connection. Try again later.'),
+          findsOneWidget);
+
+      // None of these forbidden strings appear anywhere on the rendered
+      // tree. This is the core regression test for #1186.
+      final allText = find
+          .byType(Text)
+          .evaluate()
+          .map((e) => (e.widget as Text).data ?? '')
+          .join(' \n ');
+      expect(allText, isNot(contains('AuthRetryableFetchException')),
+          reason: 'exception type name must not leak into the UI');
+      expect(allText, isNot(contains('klelxnkzrxlpzuddhpfg')),
+          reason: 'project URL must not leak into the UI');
+      expect(allText, isNot(contains('supabase.co')),
+          reason: 'project host must not leak into the UI');
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes #1186

The auth screen used to call `_formNotifier.setError(e.toString())` in every catch block. For a Supabase retryable fetch failure this produced strings like:

> `AuthRetryableFetchException: ClientException with SocketException: Failed host lookup klelxnkzrxlpzuddhpfg.supabase.co`

— leaking the project URL into the user-facing error pill and confronting the user with a Dart exception type name.

This PR introduces a pure friendly-error mapper at `lib/features/sync/data/auth_error_mapper.dart` that:

- Classifies by runtime type first (`SocketException`, `http.ClientException`, gotrue's `AuthRetryableFetchException`, `AuthException`).
- Falls back to substring matches on the message for the well-known Supabase codes (`invalid_credentials`, `user_already_exists`, `email_not_confirmed`) and a few DNS-failure substrings (`Failed host lookup`, `errno = 7`, `Network is unreachable`).
- Returns a generic localized "Something went wrong" string when nothing else matches.
- Always forwards the original error + stack trace to `errorLogger.log(...)` so observability is preserved.

All four catch blocks in `auth_screen.dart` (`_continueAsGuest`, `_submitEmail`, `_switchToAnonymous`, plus the inline-mapping block in `_submitEmail`) now route through the mapper. **No call to `e.toString()` reaches `setError(...)` any more.**

## Before / after

Before (rendered in the error pill):
> `Exception: AuthRetryableFetchException: ClientException with SocketException: Failed host lookup klelxnkzrxlpzuddhpfg.supabase.co`

After (FR / EN / DE):
> "Pas de connexion réseau. Réessayez plus tard." / "No network connection. Try again later." / "Keine Netzwerkverbindung. Bitte später erneut versuchen."

## ARB keys added

Five keys in `lib/l10n/_fragments/sync_{en,de}.arb` + direct entries in `app_fr.arb`:

- `authErrorNoNetwork`
- `authErrorInvalidCredentials`
- `authErrorUserAlreadyExists`
- `authErrorEmailNotConfirmed`
- `authErrorGeneric`

`dart run tool/build_arb.dart` + `flutter gen-l10n` were re-run; the regenerated `app_*.arb` and `app_localizations_*.dart` are committed.

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test test/features/sync/data/auth_error_mapper_test.dart` — 9 cases (every classification path across en/de/fr + defensive "raw URL never appears" guard)
- [x] `flutter test test/features/sync/presentation/screens/auth_screen_test.dart` — new widget test simulates the exact `AuthRetryableFetchException` from #1186 via a throwing fake `SyncState`, asserts the rendered pill shows the localized "no network" string and never contains `klelxnkzrxlpzuddhpfg`, `supabase.co`, or `AuthRetryableFetchException`
- [x] `flutter test test/features/sync/ test/lint/` — 333 tests pass (includes the ARB-fragment consistency scanner)
- [ ] Device verification: trigger sign-in while offline, confirm the error pill shows the friendly localized string

🤖 Generated with [Claude Code](https://claude.com/claude-code)