### PR TITLE
fix(consumption): save trip as TripHistoryEntry not fill-up (Closes #1185)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -11,16 +11,24 @@ import '../../domain/trip_recorder.dart';
 import '../../providers/trip_recording_provider.dart';
 import '../../providers/wakelock_facade.dart';
 
-/// Result returned when the user saves a recorded trip as a fill-up
-/// (#726). Null means the user cancelled or discarded.
+/// Result returned when the user confirms saving a recorded trip
+/// from the summary screen (#726, #1185).
+///
+/// The trip itself is already persisted to [TripHistoryRepository] by
+/// the time the summary screen renders — `TripRecording.stop()` writes
+/// the [TripHistoryEntry] before this screen flips to the summary
+/// view. The id is exposed here so the caller can refresh its trip
+/// list / scroll to the new row, but the save action itself NEVER
+/// creates a fill-up. Null means the user cancelled or discarded.
 class TripSaveResult {
-  final double? odometerKm;
-  final double? litersConsumed;
+  /// Id of the persisted [TripHistoryEntry] for this trip. Matches
+  /// the id used by [TripHistoryRepository.save] (ISO start timestamp
+  /// when available, otherwise the save-time fallback).
+  final String entryId;
   final TripSummary summary;
 
   const TripSaveResult({
-    required this.odometerKm,
-    required this.litersConsumed,
+    required this.entryId,
     required this.summary,
   });
 }
@@ -133,12 +141,22 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
   }
 
   void _onSave() {
+    // #1185 — the trip is ALREADY persisted to the rolling
+    // [TripHistoryRepository] by `TripRecording.stop()` before this
+    // summary screen renders, so this handler is a confirm-and-pop
+    // affordance, not a write site. We DELIBERATELY do not push
+    // `AddFillUpScreen` from here: a trip is a consumption record,
+    // a fill-up is a refuel event at a pump — the two must not be
+    // conflated (see issue #1185 for the wrong-semantics report).
     final r = _stopped!;
+    // Match the id derivation in `TripRecording._saveToHistory` so
+    // the popped id resolves to the entry that was just written.
+    final entryId = r.summary.startedAt?.toIso8601String() ??
+        DateTime.now().toIso8601String();
     ref.read(tripRecordingProvider.notifier).reset();
     Navigator.of(context).pop(
       TripSaveResult(
-        odometerKm: r.endOdometerKm,
-        litersConsumed: r.summary.fuelLitersConsumed,
+        entryId: entryId,
         summary: r.summary,
       ),
     );
@@ -328,7 +346,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
           key: const Key('tripSaveButton'),
           onPressed: _onSave,
           icon: const Icon(Icons.save),
-          label: Text(l?.tripSaveAsFillUp ?? 'Save as fill-up'),
+          label: Text(l?.tripSaveRecording ?? 'Save trip'),
         ),
         const SizedBox(height: 8),
         TextButton(

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -892,6 +892,7 @@
   "situationHardAccel": "Harte Beschl.",
   "situationFuelCut": "Schubabschaltung",
   "tripSaveAsFillUp": "Als Tankfüllung speichern",
+  "tripSaveRecording": "Fahrt speichern",
   "tripDiscard": "Verwerfen",
   "obdOdometerRead": "Kilometerstand gelesen: {km} km",
   "@obdOdometerRead": {

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -945,6 +945,13 @@
   "situationHardAccel": "Hard accel",
   "situationFuelCut": "Fuel cut — coast",
   "tripSaveAsFillUp": "Save as fill-up",
+  "@tripSaveAsFillUp": {
+    "description": "DEPRECATED (#1185): replaced by tripSaveRecording. Retained for parity with non-EN locales until the orphan-key sweep lands."
+  },
+  "tripSaveRecording": "Save trip",
+  "@tripSaveRecording": {
+    "description": "Trip-summary CTA: persists a TripHistoryEntry only — no fill-up created. (#1185)"
+  },
   "tripDiscard": "Discard",
   "obdOdometerRead": "Odometer read: {km} km",
   "@obdOdometerRead": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -892,6 +892,7 @@
   "situationHardAccel": "Harte Beschl.",
   "situationFuelCut": "Schubabschaltung",
   "tripSaveAsFillUp": "Als Tankfüllung speichern",
+  "tripSaveRecording": "Fahrt speichern",
   "tripDiscard": "Verwerfen",
   "obdOdometerRead": "Kilometerstand gelesen: {km} km",
   "@obdOdometerRead": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -945,6 +945,13 @@
   "situationHardAccel": "Hard accel",
   "situationFuelCut": "Fuel cut — coast",
   "tripSaveAsFillUp": "Save as fill-up",
+  "@tripSaveAsFillUp": {
+    "description": "DEPRECATED (#1185): replaced by tripSaveRecording. Retained for parity with non-EN locales until the orphan-key sweep lands."
+  },
+  "tripSaveRecording": "Save trip",
+  "@tripSaveRecording": {
+    "description": "Trip-summary CTA: persists a TripHistoryEntry only — no fill-up created. (#1185)"
+  },
   "tripDiscard": "Discard",
   "obdOdometerRead": "Odometer read: {km} km",
   "@obdOdometerRead": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -832,6 +832,7 @@
   "situationHardAccel": "Accél. forte",
   "situationFuelCut": "Coupure — roue libre",
   "tripSaveAsFillUp": "Enregistrer comme plein",
+  "tripSaveRecording": "Enregistrer le trajet",
   "tripDiscard": "Abandonner",
   "obdOdometerRead": "Compteur lu : {km} km",
   "@obdOdometerRead": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4015,11 +4015,17 @@ abstract class AppLocalizations {
   /// **'Fuel cut — coast'**
   String get situationFuelCut;
 
-  /// No description provided for @tripSaveAsFillUp.
+  /// DEPRECATED (#1185): replaced by tripSaveRecording. Retained for parity with non-EN locales until the orphan-key sweep lands.
   ///
   /// In en, this message translates to:
   /// **'Save as fill-up'**
   String get tripSaveAsFillUp;
+
+  /// Trip-summary CTA: persists a TripHistoryEntry only — no fill-up created. (#1185)
+  ///
+  /// In en, this message translates to:
+  /// **'Save trip'**
+  String get tripSaveRecording;
 
   /// No description provided for @tripDiscard.
   ///

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2120,6 +2120,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2120,6 +2120,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2118,6 +2118,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2133,6 +2133,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tripSaveAsFillUp => 'Als Tankfüllung speichern';
 
   @override
+  String get tripSaveRecording => 'Fahrt speichern';
+
+  @override
   String get tripDiscard => 'Verwerfen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2122,6 +2122,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2113,6 +2113,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2121,6 +2121,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2115,6 +2115,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2118,6 +2118,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2131,6 +2131,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tripSaveAsFillUp => 'Enregistrer comme plein';
 
   @override
+  String get tripSaveRecording => 'Enregistrer le trajet';
+
+  @override
   String get tripDiscard => 'Abandonner';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2117,6 +2117,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2122,6 +2122,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2121,6 +2121,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2119,6 +2119,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2121,6 +2121,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2117,6 +2117,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2122,6 +2122,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2120,6 +2120,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2121,6 +2121,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2120,6 +2120,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2121,6 +2121,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2115,6 +2115,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2119,6 +2119,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get tripSaveAsFillUp => 'Save as fill-up';
 
   @override
+  String get tripSaveRecording => 'Save trip';
+
+  @override
   String get tripDiscard => 'Discard';
 
   @override

--- a/test/features/consumption/presentation/screens/trip_recording_screen_save_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_save_test.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/add_fill_up_screen.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Regression coverage for #1185 — the Trip-summary CTA must save a
+/// trip as a consumption record, NOT pretend to be a fill-up.
+///
+/// The trip itself is persisted by [TripRecording.stop()] (already
+/// covered upstream in the provider tests). What this file pins down
+/// is the post-stop summary screen behaviour:
+///
+///  1. Button label reads "Save trip" via [AppLocalizations.tripSaveRecording]
+///     — the legacy "Save as fill-up" copy is gone.
+///  2. Tapping the button pops the screen with a [TripSaveResult] whose
+///     `entryId` matches the id [TripRecording._saveToHistory] would
+///     have used (ISO start timestamp).
+///  3. Tapping the button does NOT push [AddFillUpScreen] — a trip and
+///     a fill-up are different domain entities.
+///
+/// We don't drive the live recording loop here — instead we hand the
+/// fake `stop()` a deterministic [StoppedTripResult] so the save path
+/// runs without a real OBD2 stack.
+
+class _FakeWakelockFacade implements WakelockFacade {
+  @override
+  Future<void> enable() async {}
+
+  @override
+  Future<void> disable() async {}
+}
+
+class _StoppingFakeTripRecording extends TripRecording {
+  _StoppingFakeTripRecording(this._stoppedResult);
+
+  final StoppedTripResult _stoppedResult;
+  int resetCalls = 0;
+
+  @override
+  TripRecordingState build() => const TripRecordingState(
+        phase: TripRecordingPhase.recording,
+        situation: DrivingSituation.highwayCruise,
+        band: ConsumptionBand.normal,
+      );
+
+  @override
+  Future<StoppedTripResult> stop({bool automatic = false}) async {
+    state = state.copyWith(phase: TripRecordingPhase.finished);
+    return _stoppedResult;
+  }
+
+  @override
+  void reset() {
+    resetCalls++;
+    state = const TripRecordingState();
+  }
+}
+
+/// Builds a deterministic [StoppedTripResult] with a known
+/// `startedAt` so the assertion on [TripSaveResult.entryId] is stable.
+StoppedTripResult _stoppedAt(DateTime startedAt) {
+  return StoppedTripResult(
+    summary: TripSummary(
+      distanceKm: 2.95,
+      maxRpm: 0,
+      highRpmSeconds: 0,
+      idleSeconds: 0,
+      harshBrakes: 0,
+      harshAccelerations: 0,
+      avgLPer100Km: 9.1,
+      fuelLitersConsumed: 0.27,
+      startedAt: startedAt,
+      endedAt: startedAt.add(const Duration(minutes: 5)),
+    ),
+    odometerStartKm: 12000,
+    odometerLatestKm: 12003,
+  );
+}
+
+Future<void> _pumpAndStop(
+  WidgetTester tester, {
+  required _StoppingFakeTripRecording notifier,
+  Object? popResult,
+}) async {
+  // Wrap the screen in a Navigator so we can capture the pop value the
+  // save handler emits — and so the screen has a route to pop.
+  await pumpApp(
+    tester,
+    Builder(
+      builder: (context) => ElevatedButton(
+        key: const Key('open_trip_screen'),
+        onPressed: () async {
+          final result = await Navigator.of(context).push<TripSaveResult?>(
+            MaterialPageRoute(
+              builder: (_) => const TripRecordingScreen(),
+            ),
+          );
+          popResult = result;
+        },
+        child: const Text('Open'),
+      ),
+    ),
+    overrides: [
+      tripRecordingProvider.overrideWith(() => notifier),
+      wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+    ],
+  );
+
+  await tester.tap(find.byKey(const Key('open_trip_screen')));
+  await tester.pumpAndSettle();
+
+  // Tap stop → the fake's `stop()` resolves with the canned result and
+  // the screen flips into the summary view.
+  await tester.tap(find.byKey(const Key('tripStopButton')));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TripRecordingScreen save (#1185)', () {
+    testWidgets('summary CTA reads "Save trip" — not "Save as fill-up"',
+        (tester) async {
+      final notifier = _StoppingFakeTripRecording(
+        _stoppedAt(DateTime.utc(2026, 4, 27, 8)),
+      );
+      await _pumpAndStop(tester, notifier: notifier);
+
+      // New, semantic label.
+      expect(find.text('Save trip'), findsOneWidget);
+      // Legacy "fill-up" copy must not survive the rename.
+      expect(find.text('Save as fill-up'), findsNothing);
+      // The save button keeps its key so existing tests / accessibility
+      // tooling can still find it.
+      expect(find.byKey(const Key('tripSaveButton')), findsOneWidget);
+    });
+
+    testWidgets('tapping Save trip pops with a TripSaveResult carrying '
+        'the persisted entry id', (tester) async {
+      final startedAt = DateTime.utc(2026, 4, 27, 8);
+      final notifier = _StoppingFakeTripRecording(_stoppedAt(startedAt));
+
+      // Capture the popped value via the GlobalKey-less Navigator
+      // pattern: a Builder pushes the screen, awaits the pop, and
+      // we read the result from a closure-scoped variable.
+      TripSaveResult? captured;
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) => ElevatedButton(
+            key: const Key('open_trip_screen'),
+            onPressed: () async {
+              final result = await Navigator.of(context)
+                  .push<TripSaveResult?>(
+                MaterialPageRoute(
+                  builder: (_) => const TripRecordingScreen(),
+                ),
+              );
+              captured = result;
+            },
+            child: const Text('Open'),
+          ),
+        ),
+        overrides: [
+          tripRecordingProvider.overrideWith(() => notifier),
+          wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+        ],
+      );
+
+      await tester.tap(find.byKey(const Key('open_trip_screen')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('tripStopButton')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('tripSaveButton')));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      // Id derivation must mirror `TripRecording._saveToHistory` so
+      // the popped result resolves to the persisted entry.
+      expect(captured!.entryId, startedAt.toIso8601String());
+      // Summary forwarded — the caller can use it for an immediate
+      // refresh / scroll-to without re-reading from Hive.
+      expect(captured!.summary.distanceKm, 2.95);
+      expect(captured!.summary.fuelLitersConsumed, 0.27);
+      // The provider must be reset so the next recording starts clean.
+      expect(notifier.resetCalls, 1);
+    });
+
+    testWidgets('tapping Save trip does NOT push AddFillUpScreen '
+        '(trip-as-consumption-record fix)', (tester) async {
+      final notifier = _StoppingFakeTripRecording(
+        _stoppedAt(DateTime.utc(2026, 4, 27, 8)),
+      );
+      await _pumpAndStop(tester, notifier: notifier);
+
+      expect(find.byType(AddFillUpScreen), findsNothing,
+          reason: 'Pre-save sanity: AddFillUpScreen must not be on the stack');
+
+      await tester.tap(find.byKey(const Key('tripSaveButton')));
+      await tester.pumpAndSettle();
+
+      // After save: still no AddFillUpScreen — saving a trip MUST NOT
+      // funnel the user into the fill-up creation flow (#1185).
+      expect(find.byType(AddFillUpScreen), findsNothing,
+          reason: 'Saving a trip must not push AddFillUpScreen — a '
+              'trip is a consumption record, not a refuel event.');
+    });
+
+    testWidgets('discard does not pop a TripSaveResult', (tester) async {
+      final notifier = _StoppingFakeTripRecording(
+        _stoppedAt(DateTime.utc(2026, 4, 27, 8)),
+      );
+      TripSaveResult? captured;
+      Object? sentinel = const Object();
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) => ElevatedButton(
+            key: const Key('open_trip_screen'),
+            onPressed: () async {
+              final result = await Navigator.of(context)
+                  .push<TripSaveResult?>(
+                MaterialPageRoute(
+                  builder: (_) => const TripRecordingScreen(),
+                ),
+              );
+              captured = result;
+              sentinel = null;
+            },
+            child: const Text('Open'),
+          ),
+        ),
+        overrides: [
+          tripRecordingProvider.overrideWith(() => notifier),
+          wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+        ],
+      );
+
+      await tester.tap(find.byKey(const Key('open_trip_screen')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('tripStopButton')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('tripDiscardButton')));
+      await tester.pumpAndSettle();
+
+      expect(sentinel, isNull,
+          reason: 'Discard must complete the push so the caller resumes');
+      expect(captured, isNull,
+          reason: 'Discard pops with null — no TripSaveResult');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the wrong-semantics report in #1185: the trip-summary CTA was
labelled `Enregistrer comme plein` / `Save as fill-up`, conflating a
fuel-consumption record with a refuel event. Pressing it on a 0.27 L
trip would have written a fake fill-up of 0.27 L into the ledger that
powers price-win analysis (#1117).

## What changed

- **ARB rename**: introduce `tripSaveRecording` ("Save trip" /
  "Fahrt speichern" / "Enregistrer le trajet") in `_base_en.arb`,
  `_base_de.arb`, and `app_fr.arb`. Re-runs `tool/build_arb.dart` +
  `flutter gen-l10n` (23 locales regenerated).
- **Deprecation cushion**: the legacy `tripSaveAsFillUp` key stays in
  the EN/DE/FR sources for now so the 20 non-translated locales (which
  still carry the old key) don't fail the ARB-key-parity subset check.
  Follow-up: orphan-key sweep across the non-translated locales.
- **`trip_recording_screen.dart`**:
  - Button label now reads via `l?.tripSaveRecording ?? 'Save trip'`.
  - `_onSave()` is documented as a confirm-and-pop affordance (the
    trip itself was persisted by `TripRecording.stop()`'s
    `_saveToHistory` call before the summary screen rendered).
  - `TripSaveResult` is reshaped to carry the persisted `entryId`
    instead of fill-up-shaped fields (`litersConsumed`, `odometerKm`),
    matching issue acceptance #2.
- **New test file** `trip_recording_screen_save_test.dart`:
  - Asserts the button text is "Save trip", not "Save as fill-up".
  - Asserts the popped result is a `TripSaveResult` whose `entryId`
    matches the id `_saveToHistory` derives (`startedAt.toIso8601String()`).
  - Asserts no `AddFillUpScreen` is on the navigator before or after save.
  - Asserts discard pops with `null`.

## Why

> A trip is a record of fuel consumption. A fill-up is a refuel event
> at a pump. The two must not be conflated.

(Issue #1185, leitmotiv: clean trip data feeds driving-insights /
driving-score; clean fill-up data feeds price-win analysis.)

Tank-balance bookkeeping is explicitly **out of scope** per the issue.

## Acceptance

- [x] Trip summary CTA reads "Enregistrer le trajet" / "Save trip" / "Fahrt speichern"
- [x] Tapping it persists a `TripHistoryEntry` (already done by `stop()`) and does NOT push `AddFillUpScreen`
- [x] No fill-up row is created on save
- [x] All 23 locales regenerated via the ARB-fragment pipeline (build_arb + gen-l10n)

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/features/consumption/presentation/screens/trip_recording_screen_save_test.dart` — 4 new tests pass
- [x] `flutter test test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart test/features/consumption/presentation/widgets/trajets_tab_test.dart` — 23 existing tests pass
- [x] `flutter test test/i18n/ test/lint/` — 97 tests pass (ARB parity, fragment consistency, no-silent-catch, etc.)

Closes #1185

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>