### PR TITLE
refactor(route): extract sub-widget out of route_input (Refs #563 phase: route_input)

### DIFF
--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -13,6 +13,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/route_info.dart';
 import '../../providers/route_input_provider.dart';
 import 'city_autocomplete_field.dart';
+import 'route_search_button.dart';
 
 /// Input widget for route-based search: start, optional stops, destination.
 ///
@@ -280,25 +281,11 @@ class _RouteInputState extends ConsumerState<RouteInput> {
 
         // Search button — listens to controllers so it enables as the user
         // types, without needing setState.
-        ListenableBuilder(
-          listenable: Listenable.merge([_startController, _endController]),
-          builder: (context, _) {
-            final canSearch = _startController.text.isNotEmpty &&
-                _endController.text.isNotEmpty &&
-                !routeState.isSearching;
-            return FilledButton.icon(
-              onPressed: canSearch ? _resolveAndSearch : null,
-              icon: routeState.isSearching
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(
-                          strokeWidth: 2, color: Colors.white),
-                    )
-                  : const Icon(Icons.route),
-              label: Text(l10n?.searchAlongRoute ?? 'Search along route'),
-            );
-          },
+        RouteSearchButton(
+          startController: _startController,
+          endController: _endController,
+          isSearching: routeState.isSearching,
+          onSearch: _resolveAndSearch,
         ),
       ],
     );

--- a/lib/features/route_search/presentation/widgets/route_search_button.dart
+++ b/lib/features/route_search/presentation/widgets/route_search_button.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Submit button for [RouteInput].
+///
+/// Listens to the start/end text controllers so it enables as the user types
+/// without forcing a parent rebuild, and renders a progress spinner while a
+/// route resolution is in flight.
+class RouteSearchButton extends StatelessWidget {
+  final TextEditingController startController;
+  final TextEditingController endController;
+  final bool isSearching;
+  final VoidCallback onSearch;
+
+  const RouteSearchButton({
+    super.key,
+    required this.startController,
+    required this.endController,
+    required this.isSearching,
+    required this.onSearch,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return ListenableBuilder(
+      listenable: Listenable.merge([startController, endController]),
+      builder: (context, _) {
+        final canSearch = startController.text.isNotEmpty &&
+            endController.text.isNotEmpty &&
+            !isSearching;
+        return FilledButton.icon(
+          onPressed: canSearch ? onSearch : null,
+          icon: isSearching
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                      strokeWidth: 2, color: Colors.white),
+                )
+              : const Icon(Icons.route),
+          label: Text(l10n?.searchAlongRoute ?? 'Search along route'),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Move the search-submit `FilledButton.icon` (with its `ListenableBuilder` and progress spinner) out of `route_input.dart` into a sibling `RouteSearchButton` widget.
- Pure code-motion. No behavior change: same start/end controller listening, same `isSearching` spinner, same enablement rule.

## LOC
- `route_input.dart`: **306 -> 293** LOC (under the 300 target).
- New `route_search_button.dart`: 48 LOC.

## Testing
- `flutter analyze`: clean (No issues found).
- `flutter test test/features/route_search/`: 104 tests pass.

Refs #563 phase: route_input