### PR TITLE
refactor(export): extract per-category serializers out of data_exporter (Refs #563 phase: data_exporter)

### DIFF
--- a/lib/core/export/_csv_encoder.dart
+++ b/lib/core/export/_csv_encoder.dart
@@ -1,0 +1,35 @@
+/// RFC 4180 CSV encoder used by [DataExporter].
+///
+/// Kept as a sibling helper (private to the package via the leading
+/// underscore filename convention) to keep `data_exporter.dart` focused
+/// on the per-category serialization logic.
+library;
+
+/// Encodes a list of rows into an RFC 4180 CSV string.
+///
+/// - Uses `,` separator and `\r\n` line ending (Excel-friendly).
+/// - Wraps fields in `"` when they contain `,`, `"`, `\r`, or `\n`.
+/// - Doubles embedded `"` characters inside quoted fields.
+/// - `null` renders as an empty cell.
+String encodeCsv(List<List<Object?>> rows) {
+  final buf = StringBuffer();
+  for (final row in rows) {
+    for (var i = 0; i < row.length; i++) {
+      if (i > 0) buf.write(',');
+      buf.write(_encodeCell(row[i]));
+    }
+    buf.write('\r\n');
+  }
+  return buf.toString();
+}
+
+String _encodeCell(Object? value) {
+  if (value == null) return '';
+  final s = value.toString();
+  final needsQuoting = s.contains(',') ||
+      s.contains('"') ||
+      s.contains('\n') ||
+      s.contains('\r');
+  if (!needsQuoting) return s;
+  return '"${s.replaceAll('"', '""')}"';
+}

--- a/lib/core/export/data_exporter.dart
+++ b/lib/core/export/data_exporter.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import '../data/storage_repository.dart';
+import '_csv_encoder.dart';
 
 /// Categories of user data that can be exported individually.
 ///
@@ -122,7 +123,7 @@ class DataExporter {
         m['lng'] ?? m['lon'],
       ]);
     }
-    return _encodeCsv(rows);
+    return encodeCsv(rows);
   }
 
   String _priceHistoryCsv() {
@@ -146,7 +147,7 @@ class DataExporter {
         }
       }
     }
-    return _encodeCsv(rows);
+    return encodeCsv(rows);
   }
 
   String _alertsCsv() {
@@ -171,7 +172,7 @@ class DataExporter {
         a['createdAt'] ?? a['created_at'],
       ]);
     }
-    return _encodeCsv(rows);
+    return encodeCsv(rows);
   }
 
   String _fillUpsCsv() {
@@ -202,14 +203,14 @@ class DataExporter {
         f['notes'],
       ]);
     }
-    return _encodeCsv(rows);
+    return encodeCsv(rows);
   }
 
   String _ratingsCsv() {
     const header = ['station_id', 'rating'];
     final rows = <List<Object?>>[header];
     _storage.getRatings().forEach((k, v) => rows.add([k, v]));
-    return _encodeCsv(rows);
+    return encodeCsv(rows);
   }
 
   String _ignoredCsv() {
@@ -218,7 +219,7 @@ class DataExporter {
     for (final id in _storage.getIgnoredIds()) {
       rows.add([id]);
     }
-    return _encodeCsv(rows);
+    return encodeCsv(rows);
   }
 
   String _profilesCsv() {
@@ -233,7 +234,7 @@ class DataExporter {
         p['sortBy'] ?? p['sort_by'],
       ]);
     }
-    return _encodeCsv(rows);
+    return encodeCsv(rows);
   }
 
   String _itinerariesCsv() {
@@ -248,7 +249,7 @@ class DataExporter {
         it['createdAt'] ?? it['created_at'],
       ]);
     }
-    return _encodeCsv(rows);
+    return encodeCsv(rows);
   }
 
   // --------------------------------------------------------------------------
@@ -275,34 +276,5 @@ class DataExporter {
       result[key] = _storage.getPriceRecords(key);
     }
     return result;
-  }
-
-  /// RFC 4180 CSV encoder — no dependency on the `csv` package.
-  ///
-  /// - Uses `,` separator and `\r\n` line ending (Excel-friendly).
-  /// - Wraps fields in `"` when they contain `,`, `"`, `\r`, or `\n`.
-  /// - Doubles embedded `"` characters inside quoted fields.
-  /// - `null` renders as an empty cell.
-  String _encodeCsv(List<List<Object?>> rows) {
-    final buf = StringBuffer();
-    for (final row in rows) {
-      for (var i = 0; i < row.length; i++) {
-        if (i > 0) buf.write(',');
-        buf.write(_encodeCell(row[i]));
-      }
-      buf.write('\r\n');
-    }
-    return buf.toString();
-  }
-
-  String _encodeCell(Object? value) {
-    if (value == null) return '';
-    final s = value.toString();
-    final needsQuoting = s.contains(',') ||
-        s.contains('"') ||
-        s.contains('\n') ||
-        s.contains('\r');
-    if (!needsQuoting) return s;
-    return '"${s.replaceAll('"', '""')}"';
   }
 }


### PR DESCRIPTION
## Summary
- Extract the RFC 4180 CSV primitives (`encodeCsv` + cell escaping) into `lib/core/export/_csv_encoder.dart`.
- `data_exporter.dart` now focuses on per-category serialization and delegates encoding to the helper.

## Why
`data_exporter.dart` was at 308 LOC, just over the 300-LOC target tracked in #563. The CSV encoder is a pure utility with no dependence on `StorageRepository`, so it lifts out cleanly.

## LOC
- `lib/core/export/data_exporter.dart`: 308 -> 280
- `lib/core/export/_csv_encoder.dart`: new, 35 LOC

## Behavior
- Public API of `DataExporter` unchanged.
- Exporter remains a pure function — no I/O introduced.
- `flutter analyze` clean.
- All 11 tests in `test/core/export/data_exporter_test.dart` pass locally.

Refs #563 phase: data_exporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)