### PR TITLE
feat(vehicle): aggregate value objects on VehicleProfile (#1193 phase 1)

### DIFF
--- a/lib/features/vehicle/domain/entities/speed_consumption_histogram.dart
+++ b/lib/features/vehicle/domain/entities/speed_consumption_histogram.dart
@@ -1,0 +1,97 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'speed_consumption_histogram.freezed.dart';
+part 'speed_consumption_histogram.g.dart';
+
+/// One band in the speed-vs-consumption histogram.
+///
+/// A band is a half-open speed interval `[minKmh, maxKmh)` — the lower
+/// bound is inclusive, the upper bound is exclusive. The top band's
+/// upper bound is open-ended; model that case with `maxKmh == null`.
+///
+/// All numeric fields are required and non-nullable. "We have no data
+/// for this band yet" is represented at the parent level — see
+/// [SpeedConsumptionHistogram.bands] — by simply omitting the band
+/// from the list, not by carrying zero values here.
+@freezed
+abstract class SpeedBand with _$SpeedBand {
+  const factory SpeedBand({
+    /// Lower bound of the band (km/h, inclusive).
+    required int minKmh,
+
+    /// Upper bound of the band (km/h, exclusive). `null` for the
+    /// open-ended top band — speeds at or above [minKmh] without an
+    /// upper cutoff (autobahn / motorway "everything else" tail).
+    required int? maxKmh,
+
+    /// Number of speed-consumption samples folded into this band.
+    /// Aggregator-side this is the count of `TripDetailSample`s whose
+    /// instantaneous speed fell inside the half-open interval; phase 2
+    /// owns that classification.
+    required int sampleCount,
+
+    /// Mean fuel consumption across samples in this band, in litres
+    /// per 100 km. Computed by the phase-2 aggregator from the stored
+    /// totals; persisted directly so the UI doesn't have to re-derive.
+    required double meanLPer100km,
+
+    /// Fraction of total observed driving time that fell into this
+    /// band, in `[0, 1]`. Across every band in a populated
+    /// [SpeedConsumptionHistogram] the share rolls up to `1.0`
+    /// (modulo float rounding). Useful for "you spend 40 % of your
+    /// driving in 50–80 km/h" callouts on the vehicle profile screen.
+    required double timeShareFraction,
+  }) = _SpeedBand;
+
+  factory SpeedBand.fromJson(Map<String, dynamic> json) =>
+      _$SpeedBandFromJson(json);
+}
+
+/// Per-vehicle speed-vs-consumption histogram, used by the Carbon
+/// dashboard chart and the vehicle-profile screen. Persisted on
+/// [VehicleProfile] as part of #1193's rolling aggregates.
+///
+/// An empty [bands] list is the cold-start signal — "we have no data
+/// yet". A populated histogram holds at most one [SpeedBand] per
+/// `(minKmh, maxKmh)` template entry from
+/// [standardBandTemplate]; bands the vehicle has never driven in are
+/// simply omitted from the list rather than carrying zero values.
+///
+/// The aggregator (#1193 phase 2) seeds new histograms from
+/// [standardBandTemplate]. Phase 1 only defines the shape and the
+/// canonical layout — the template is intentionally a static `const`
+/// list rather than a `factory` so the boundaries are visible in code
+/// review without running the aggregator.
+@freezed
+abstract class SpeedConsumptionHistogram with _$SpeedConsumptionHistogram {
+  const factory SpeedConsumptionHistogram({
+    @Default(<SpeedBand>[]) List<SpeedBand> bands,
+  }) = _SpeedConsumptionHistogram;
+
+  factory SpeedConsumptionHistogram.fromJson(Map<String, dynamic> json) =>
+      _$SpeedConsumptionHistogramFromJson(json);
+
+  /// Canonical band layout used by the phase-2 aggregator when seeding
+  /// a new histogram. Each tuple is `(minKmh, maxKmh?)`; the final
+  /// band's `maxKmh` is `null` to mark the open-ended top tail.
+  ///
+  ///   * `0–30`    — urban crawl, idle, low-speed manoeuvring.
+  ///   * `30–50`   — typical urban cruise.
+  ///   * `50–80`   — extra-urban / fast town roads.
+  ///   * `80–110`  — secondary-road / national-route cruise.
+  ///   * `110+`    — motorway / autobahn cruise (open-ended).
+  ///
+  /// Stored as `List<(int, int?)>` so a Dart-3 records iteration
+  /// reads naturally on the consumer side without an extra helper
+  /// type. If the layout ever needs to change, bumping this list
+  /// is a recompute trigger — older persisted histograms can keep
+  /// their bands; the aggregator emits the new bands on the next
+  /// pass.
+  static const List<(int, int?)> standardBandTemplate = <(int, int?)>[
+    (0, 30),
+    (30, 50),
+    (50, 80),
+    (80, 110),
+    (110, null),
+  ];
+}

--- a/lib/features/vehicle/domain/entities/speed_consumption_histogram.freezed.dart
+++ b/lib/features/vehicle/domain/entities/speed_consumption_histogram.freezed.dart
@@ -1,0 +1,590 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'speed_consumption_histogram.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SpeedBand {
+
+/// Lower bound of the band (km/h, inclusive).
+ int get minKmh;/// Upper bound of the band (km/h, exclusive). `null` for the
+/// open-ended top band — speeds at or above [minKmh] without an
+/// upper cutoff (autobahn / motorway "everything else" tail).
+ int? get maxKmh;/// Number of speed-consumption samples folded into this band.
+/// Aggregator-side this is the count of `TripDetailSample`s whose
+/// instantaneous speed fell inside the half-open interval; phase 2
+/// owns that classification.
+ int get sampleCount;/// Mean fuel consumption across samples in this band, in litres
+/// per 100 km. Computed by the phase-2 aggregator from the stored
+/// totals; persisted directly so the UI doesn't have to re-derive.
+ double get meanLPer100km;/// Fraction of total observed driving time that fell into this
+/// band, in `[0, 1]`. Across every band in a populated
+/// [SpeedConsumptionHistogram] the share rolls up to `1.0`
+/// (modulo float rounding). Useful for "you spend 40 % of your
+/// driving in 50–80 km/h" callouts on the vehicle profile screen.
+ double get timeShareFraction;
+/// Create a copy of SpeedBand
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SpeedBandCopyWith<SpeedBand> get copyWith => _$SpeedBandCopyWithImpl<SpeedBand>(this as SpeedBand, _$identity);
+
+  /// Serializes this SpeedBand to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SpeedBand&&(identical(other.minKmh, minKmh) || other.minKmh == minKmh)&&(identical(other.maxKmh, maxKmh) || other.maxKmh == maxKmh)&&(identical(other.sampleCount, sampleCount) || other.sampleCount == sampleCount)&&(identical(other.meanLPer100km, meanLPer100km) || other.meanLPer100km == meanLPer100km)&&(identical(other.timeShareFraction, timeShareFraction) || other.timeShareFraction == timeShareFraction));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,minKmh,maxKmh,sampleCount,meanLPer100km,timeShareFraction);
+
+@override
+String toString() {
+  return 'SpeedBand(minKmh: $minKmh, maxKmh: $maxKmh, sampleCount: $sampleCount, meanLPer100km: $meanLPer100km, timeShareFraction: $timeShareFraction)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SpeedBandCopyWith<$Res>  {
+  factory $SpeedBandCopyWith(SpeedBand value, $Res Function(SpeedBand) _then) = _$SpeedBandCopyWithImpl;
+@useResult
+$Res call({
+ int minKmh, int? maxKmh, int sampleCount, double meanLPer100km, double timeShareFraction
+});
+
+
+
+
+}
+/// @nodoc
+class _$SpeedBandCopyWithImpl<$Res>
+    implements $SpeedBandCopyWith<$Res> {
+  _$SpeedBandCopyWithImpl(this._self, this._then);
+
+  final SpeedBand _self;
+  final $Res Function(SpeedBand) _then;
+
+/// Create a copy of SpeedBand
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? minKmh = null,Object? maxKmh = freezed,Object? sampleCount = null,Object? meanLPer100km = null,Object? timeShareFraction = null,}) {
+  return _then(_self.copyWith(
+minKmh: null == minKmh ? _self.minKmh : minKmh // ignore: cast_nullable_to_non_nullable
+as int,maxKmh: freezed == maxKmh ? _self.maxKmh : maxKmh // ignore: cast_nullable_to_non_nullable
+as int?,sampleCount: null == sampleCount ? _self.sampleCount : sampleCount // ignore: cast_nullable_to_non_nullable
+as int,meanLPer100km: null == meanLPer100km ? _self.meanLPer100km : meanLPer100km // ignore: cast_nullable_to_non_nullable
+as double,timeShareFraction: null == timeShareFraction ? _self.timeShareFraction : timeShareFraction // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SpeedBand].
+extension SpeedBandPatterns on SpeedBand {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SpeedBand value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SpeedBand() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SpeedBand value)  $default,){
+final _that = this;
+switch (_that) {
+case _SpeedBand():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SpeedBand value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SpeedBand() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int minKmh,  int? maxKmh,  int sampleCount,  double meanLPer100km,  double timeShareFraction)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SpeedBand() when $default != null:
+return $default(_that.minKmh,_that.maxKmh,_that.sampleCount,_that.meanLPer100km,_that.timeShareFraction);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int minKmh,  int? maxKmh,  int sampleCount,  double meanLPer100km,  double timeShareFraction)  $default,) {final _that = this;
+switch (_that) {
+case _SpeedBand():
+return $default(_that.minKmh,_that.maxKmh,_that.sampleCount,_that.meanLPer100km,_that.timeShareFraction);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int minKmh,  int? maxKmh,  int sampleCount,  double meanLPer100km,  double timeShareFraction)?  $default,) {final _that = this;
+switch (_that) {
+case _SpeedBand() when $default != null:
+return $default(_that.minKmh,_that.maxKmh,_that.sampleCount,_that.meanLPer100km,_that.timeShareFraction);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SpeedBand implements SpeedBand {
+  const _SpeedBand({required this.minKmh, required this.maxKmh, required this.sampleCount, required this.meanLPer100km, required this.timeShareFraction});
+  factory _SpeedBand.fromJson(Map<String, dynamic> json) => _$SpeedBandFromJson(json);
+
+/// Lower bound of the band (km/h, inclusive).
+@override final  int minKmh;
+/// Upper bound of the band (km/h, exclusive). `null` for the
+/// open-ended top band — speeds at or above [minKmh] without an
+/// upper cutoff (autobahn / motorway "everything else" tail).
+@override final  int? maxKmh;
+/// Number of speed-consumption samples folded into this band.
+/// Aggregator-side this is the count of `TripDetailSample`s whose
+/// instantaneous speed fell inside the half-open interval; phase 2
+/// owns that classification.
+@override final  int sampleCount;
+/// Mean fuel consumption across samples in this band, in litres
+/// per 100 km. Computed by the phase-2 aggregator from the stored
+/// totals; persisted directly so the UI doesn't have to re-derive.
+@override final  double meanLPer100km;
+/// Fraction of total observed driving time that fell into this
+/// band, in `[0, 1]`. Across every band in a populated
+/// [SpeedConsumptionHistogram] the share rolls up to `1.0`
+/// (modulo float rounding). Useful for "you spend 40 % of your
+/// driving in 50–80 km/h" callouts on the vehicle profile screen.
+@override final  double timeShareFraction;
+
+/// Create a copy of SpeedBand
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SpeedBandCopyWith<_SpeedBand> get copyWith => __$SpeedBandCopyWithImpl<_SpeedBand>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SpeedBandToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SpeedBand&&(identical(other.minKmh, minKmh) || other.minKmh == minKmh)&&(identical(other.maxKmh, maxKmh) || other.maxKmh == maxKmh)&&(identical(other.sampleCount, sampleCount) || other.sampleCount == sampleCount)&&(identical(other.meanLPer100km, meanLPer100km) || other.meanLPer100km == meanLPer100km)&&(identical(other.timeShareFraction, timeShareFraction) || other.timeShareFraction == timeShareFraction));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,minKmh,maxKmh,sampleCount,meanLPer100km,timeShareFraction);
+
+@override
+String toString() {
+  return 'SpeedBand(minKmh: $minKmh, maxKmh: $maxKmh, sampleCount: $sampleCount, meanLPer100km: $meanLPer100km, timeShareFraction: $timeShareFraction)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SpeedBandCopyWith<$Res> implements $SpeedBandCopyWith<$Res> {
+  factory _$SpeedBandCopyWith(_SpeedBand value, $Res Function(_SpeedBand) _then) = __$SpeedBandCopyWithImpl;
+@override @useResult
+$Res call({
+ int minKmh, int? maxKmh, int sampleCount, double meanLPer100km, double timeShareFraction
+});
+
+
+
+
+}
+/// @nodoc
+class __$SpeedBandCopyWithImpl<$Res>
+    implements _$SpeedBandCopyWith<$Res> {
+  __$SpeedBandCopyWithImpl(this._self, this._then);
+
+  final _SpeedBand _self;
+  final $Res Function(_SpeedBand) _then;
+
+/// Create a copy of SpeedBand
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? minKmh = null,Object? maxKmh = freezed,Object? sampleCount = null,Object? meanLPer100km = null,Object? timeShareFraction = null,}) {
+  return _then(_SpeedBand(
+minKmh: null == minKmh ? _self.minKmh : minKmh // ignore: cast_nullable_to_non_nullable
+as int,maxKmh: freezed == maxKmh ? _self.maxKmh : maxKmh // ignore: cast_nullable_to_non_nullable
+as int?,sampleCount: null == sampleCount ? _self.sampleCount : sampleCount // ignore: cast_nullable_to_non_nullable
+as int,meanLPer100km: null == meanLPer100km ? _self.meanLPer100km : meanLPer100km // ignore: cast_nullable_to_non_nullable
+as double,timeShareFraction: null == timeShareFraction ? _self.timeShareFraction : timeShareFraction // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$SpeedConsumptionHistogram {
+
+ List<SpeedBand> get bands;
+/// Create a copy of SpeedConsumptionHistogram
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SpeedConsumptionHistogramCopyWith<SpeedConsumptionHistogram> get copyWith => _$SpeedConsumptionHistogramCopyWithImpl<SpeedConsumptionHistogram>(this as SpeedConsumptionHistogram, _$identity);
+
+  /// Serializes this SpeedConsumptionHistogram to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SpeedConsumptionHistogram&&const DeepCollectionEquality().equals(other.bands, bands));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(bands));
+
+@override
+String toString() {
+  return 'SpeedConsumptionHistogram(bands: $bands)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SpeedConsumptionHistogramCopyWith<$Res>  {
+  factory $SpeedConsumptionHistogramCopyWith(SpeedConsumptionHistogram value, $Res Function(SpeedConsumptionHistogram) _then) = _$SpeedConsumptionHistogramCopyWithImpl;
+@useResult
+$Res call({
+ List<SpeedBand> bands
+});
+
+
+
+
+}
+/// @nodoc
+class _$SpeedConsumptionHistogramCopyWithImpl<$Res>
+    implements $SpeedConsumptionHistogramCopyWith<$Res> {
+  _$SpeedConsumptionHistogramCopyWithImpl(this._self, this._then);
+
+  final SpeedConsumptionHistogram _self;
+  final $Res Function(SpeedConsumptionHistogram) _then;
+
+/// Create a copy of SpeedConsumptionHistogram
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? bands = null,}) {
+  return _then(_self.copyWith(
+bands: null == bands ? _self.bands : bands // ignore: cast_nullable_to_non_nullable
+as List<SpeedBand>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SpeedConsumptionHistogram].
+extension SpeedConsumptionHistogramPatterns on SpeedConsumptionHistogram {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SpeedConsumptionHistogram value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SpeedConsumptionHistogram() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SpeedConsumptionHistogram value)  $default,){
+final _that = this;
+switch (_that) {
+case _SpeedConsumptionHistogram():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SpeedConsumptionHistogram value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SpeedConsumptionHistogram() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<SpeedBand> bands)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SpeedConsumptionHistogram() when $default != null:
+return $default(_that.bands);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<SpeedBand> bands)  $default,) {final _that = this;
+switch (_that) {
+case _SpeedConsumptionHistogram():
+return $default(_that.bands);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<SpeedBand> bands)?  $default,) {final _that = this;
+switch (_that) {
+case _SpeedConsumptionHistogram() when $default != null:
+return $default(_that.bands);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SpeedConsumptionHistogram implements SpeedConsumptionHistogram {
+  const _SpeedConsumptionHistogram({final  List<SpeedBand> bands = const <SpeedBand>[]}): _bands = bands;
+  factory _SpeedConsumptionHistogram.fromJson(Map<String, dynamic> json) => _$SpeedConsumptionHistogramFromJson(json);
+
+ final  List<SpeedBand> _bands;
+@override@JsonKey() List<SpeedBand> get bands {
+  if (_bands is EqualUnmodifiableListView) return _bands;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_bands);
+}
+
+
+/// Create a copy of SpeedConsumptionHistogram
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SpeedConsumptionHistogramCopyWith<_SpeedConsumptionHistogram> get copyWith => __$SpeedConsumptionHistogramCopyWithImpl<_SpeedConsumptionHistogram>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SpeedConsumptionHistogramToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SpeedConsumptionHistogram&&const DeepCollectionEquality().equals(other._bands, _bands));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_bands));
+
+@override
+String toString() {
+  return 'SpeedConsumptionHistogram(bands: $bands)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SpeedConsumptionHistogramCopyWith<$Res> implements $SpeedConsumptionHistogramCopyWith<$Res> {
+  factory _$SpeedConsumptionHistogramCopyWith(_SpeedConsumptionHistogram value, $Res Function(_SpeedConsumptionHistogram) _then) = __$SpeedConsumptionHistogramCopyWithImpl;
+@override @useResult
+$Res call({
+ List<SpeedBand> bands
+});
+
+
+
+
+}
+/// @nodoc
+class __$SpeedConsumptionHistogramCopyWithImpl<$Res>
+    implements _$SpeedConsumptionHistogramCopyWith<$Res> {
+  __$SpeedConsumptionHistogramCopyWithImpl(this._self, this._then);
+
+  final _SpeedConsumptionHistogram _self;
+  final $Res Function(_SpeedConsumptionHistogram) _then;
+
+/// Create a copy of SpeedConsumptionHistogram
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? bands = null,}) {
+  return _then(_SpeedConsumptionHistogram(
+bands: null == bands ? _self._bands : bands // ignore: cast_nullable_to_non_nullable
+as List<SpeedBand>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/vehicle/domain/entities/speed_consumption_histogram.g.dart
+++ b/lib/features/vehicle/domain/entities/speed_consumption_histogram.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'speed_consumption_histogram.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SpeedBand _$SpeedBandFromJson(Map<String, dynamic> json) => _SpeedBand(
+  minKmh: (json['minKmh'] as num).toInt(),
+  maxKmh: (json['maxKmh'] as num?)?.toInt(),
+  sampleCount: (json['sampleCount'] as num).toInt(),
+  meanLPer100km: (json['meanLPer100km'] as num).toDouble(),
+  timeShareFraction: (json['timeShareFraction'] as num).toDouble(),
+);
+
+Map<String, dynamic> _$SpeedBandToJson(_SpeedBand instance) =>
+    <String, dynamic>{
+      'minKmh': instance.minKmh,
+      'maxKmh': instance.maxKmh,
+      'sampleCount': instance.sampleCount,
+      'meanLPer100km': instance.meanLPer100km,
+      'timeShareFraction': instance.timeShareFraction,
+    };
+
+_SpeedConsumptionHistogram _$SpeedConsumptionHistogramFromJson(
+  Map<String, dynamic> json,
+) => _SpeedConsumptionHistogram(
+  bands:
+      (json['bands'] as List<dynamic>?)
+          ?.map((e) => SpeedBand.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <SpeedBand>[],
+);
+
+Map<String, dynamic> _$SpeedConsumptionHistogramToJson(
+  _SpeedConsumptionHistogram instance,
+) => <String, dynamic>{'bands': instance.bands.map((e) => e.toJson()).toList()};

--- a/lib/features/vehicle/domain/entities/trip_length_breakdown.dart
+++ b/lib/features/vehicle/domain/entities/trip_length_breakdown.dart
@@ -1,0 +1,88 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'trip_length_breakdown.freezed.dart';
+part 'trip_length_breakdown.g.dart';
+
+/// Per-bucket consumption stats for a single trip-length classification
+/// (short / medium / long). Persisted on [VehicleProfile] as part of
+/// the rolling driving aggregates introduced by #1193.
+///
+/// All fields are required and non-nullable — the absence of data is
+/// signalled by the parent [TripLengthBreakdown] holding `null` for the
+/// bucket itself, NOT by the bucket carrying zero/empty values. That
+/// keeps "zero trips so far" distinct from "we have N trips and they
+/// happen to total 0 km" (the latter shouldn't happen, but the former
+/// is the common cold-start case).
+///
+/// Pure value object — no behaviour, no aggregation logic. The fold
+/// pass that produces these instances lives in
+/// `lib/features/vehicle/data/vehicle_aggregate_updater.dart`
+/// (#1193 phase 2).
+@freezed
+abstract class TripLengthBucket with _$TripLengthBucket {
+  const factory TripLengthBucket({
+    /// Number of completed trips folded into this bucket.
+    required int tripCount,
+
+    /// Mean fuel consumption across the bucket, in litres per 100 km.
+    /// Aggregator-side this is computed as `totalLitres / totalDistanceKm * 100`,
+    /// or via Welford-style incremental update when folding a single trip
+    /// into the existing bucket — phase 2 owns that math.
+    required double meanLPer100km,
+
+    /// Sum of distance (km) across every trip in this bucket. Useful
+    /// for the UI "you drove X km on long trips this month" line and
+    /// as the denominator if a consumer needs to recompute the mean
+    /// at higher precision than [meanLPer100km] preserved.
+    required double totalDistanceKm,
+
+    /// Sum of fuel used (litres) across every trip in this bucket.
+    /// Same role as [totalDistanceKm] — kept so the mean can be
+    /// rederived without information loss.
+    required double totalLitres,
+  }) = _TripLengthBucket;
+
+  factory TripLengthBucket.fromJson(Map<String, dynamic> json) =>
+      _$TripLengthBucketFromJson(json);
+}
+
+/// Trip-length breakdown of a vehicle's rolling consumption stats.
+///
+/// Each of [short], [medium], [long] is independently nullable because
+/// a vehicle may have enough trips in one bucket but not the other —
+/// e.g. a city-only car will populate [short] long before [medium] /
+/// [long] cross the per-bucket min-sample threshold. A `null` bucket
+/// means "no data yet"; a populated bucket with a low [TripLengthBucket.tripCount]
+/// is data the UI can choose to surface with a confidence caveat.
+///
+/// Bucket cutoffs (documented here, instantiated phase 2):
+///
+///   * Short  — distance < [shortMaxKm] km.
+///   * Medium — [shortMaxKm] km <= distance < [mediumMaxKm] km.
+///   * Long   — distance >= [mediumMaxKm] km.
+///
+/// The cutoffs are intentionally NOT baked into a method on this value
+/// object — the classifier belongs in
+/// `vehicle_aggregate_updater.dart` (#1193 phase 2) where it can evolve
+/// independently of the persisted shape. Phase 1 only defines the
+/// schema and exposes the constants for the aggregator to read.
+@freezed
+abstract class TripLengthBreakdown with _$TripLengthBreakdown {
+  const factory TripLengthBreakdown({
+    TripLengthBucket? short,
+    TripLengthBucket? medium,
+    TripLengthBucket? long,
+  }) = _TripLengthBreakdown;
+
+  factory TripLengthBreakdown.fromJson(Map<String, dynamic> json) =>
+      _$TripLengthBreakdownFromJson(json);
+
+  /// Upper bound (exclusive) of the "short" bucket, in kilometres.
+  /// Trips with `distanceKm < shortMaxKm` go into [short].
+  static const double shortMaxKm = 15;
+
+  /// Upper bound (exclusive) of the "medium" bucket, in kilometres.
+  /// Trips with `shortMaxKm <= distanceKm < mediumMaxKm` go into
+  /// [medium]; everything from [mediumMaxKm] km up is [long].
+  static const double mediumMaxKm = 50;
+}

--- a/lib/features/vehicle/domain/entities/trip_length_breakdown.freezed.dart
+++ b/lib/features/vehicle/domain/entities/trip_length_breakdown.freezed.dart
@@ -1,0 +1,651 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'trip_length_breakdown.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$TripLengthBucket {
+
+/// Number of completed trips folded into this bucket.
+ int get tripCount;/// Mean fuel consumption across the bucket, in litres per 100 km.
+/// Aggregator-side this is computed as `totalLitres / totalDistanceKm * 100`,
+/// or via Welford-style incremental update when folding a single trip
+/// into the existing bucket — phase 2 owns that math.
+ double get meanLPer100km;/// Sum of distance (km) across every trip in this bucket. Useful
+/// for the UI "you drove X km on long trips this month" line and
+/// as the denominator if a consumer needs to recompute the mean
+/// at higher precision than [meanLPer100km] preserved.
+ double get totalDistanceKm;/// Sum of fuel used (litres) across every trip in this bucket.
+/// Same role as [totalDistanceKm] — kept so the mean can be
+/// rederived without information loss.
+ double get totalLitres;
+/// Create a copy of TripLengthBucket
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TripLengthBucketCopyWith<TripLengthBucket> get copyWith => _$TripLengthBucketCopyWithImpl<TripLengthBucket>(this as TripLengthBucket, _$identity);
+
+  /// Serializes this TripLengthBucket to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TripLengthBucket&&(identical(other.tripCount, tripCount) || other.tripCount == tripCount)&&(identical(other.meanLPer100km, meanLPer100km) || other.meanLPer100km == meanLPer100km)&&(identical(other.totalDistanceKm, totalDistanceKm) || other.totalDistanceKm == totalDistanceKm)&&(identical(other.totalLitres, totalLitres) || other.totalLitres == totalLitres));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,tripCount,meanLPer100km,totalDistanceKm,totalLitres);
+
+@override
+String toString() {
+  return 'TripLengthBucket(tripCount: $tripCount, meanLPer100km: $meanLPer100km, totalDistanceKm: $totalDistanceKm, totalLitres: $totalLitres)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TripLengthBucketCopyWith<$Res>  {
+  factory $TripLengthBucketCopyWith(TripLengthBucket value, $Res Function(TripLengthBucket) _then) = _$TripLengthBucketCopyWithImpl;
+@useResult
+$Res call({
+ int tripCount, double meanLPer100km, double totalDistanceKm, double totalLitres
+});
+
+
+
+
+}
+/// @nodoc
+class _$TripLengthBucketCopyWithImpl<$Res>
+    implements $TripLengthBucketCopyWith<$Res> {
+  _$TripLengthBucketCopyWithImpl(this._self, this._then);
+
+  final TripLengthBucket _self;
+  final $Res Function(TripLengthBucket) _then;
+
+/// Create a copy of TripLengthBucket
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? tripCount = null,Object? meanLPer100km = null,Object? totalDistanceKm = null,Object? totalLitres = null,}) {
+  return _then(_self.copyWith(
+tripCount: null == tripCount ? _self.tripCount : tripCount // ignore: cast_nullable_to_non_nullable
+as int,meanLPer100km: null == meanLPer100km ? _self.meanLPer100km : meanLPer100km // ignore: cast_nullable_to_non_nullable
+as double,totalDistanceKm: null == totalDistanceKm ? _self.totalDistanceKm : totalDistanceKm // ignore: cast_nullable_to_non_nullable
+as double,totalLitres: null == totalLitres ? _self.totalLitres : totalLitres // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TripLengthBucket].
+extension TripLengthBucketPatterns on TripLengthBucket {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TripLengthBucket value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TripLengthBucket() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TripLengthBucket value)  $default,){
+final _that = this;
+switch (_that) {
+case _TripLengthBucket():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TripLengthBucket value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TripLengthBucket() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int tripCount,  double meanLPer100km,  double totalDistanceKm,  double totalLitres)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TripLengthBucket() when $default != null:
+return $default(_that.tripCount,_that.meanLPer100km,_that.totalDistanceKm,_that.totalLitres);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int tripCount,  double meanLPer100km,  double totalDistanceKm,  double totalLitres)  $default,) {final _that = this;
+switch (_that) {
+case _TripLengthBucket():
+return $default(_that.tripCount,_that.meanLPer100km,_that.totalDistanceKm,_that.totalLitres);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int tripCount,  double meanLPer100km,  double totalDistanceKm,  double totalLitres)?  $default,) {final _that = this;
+switch (_that) {
+case _TripLengthBucket() when $default != null:
+return $default(_that.tripCount,_that.meanLPer100km,_that.totalDistanceKm,_that.totalLitres);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TripLengthBucket implements TripLengthBucket {
+  const _TripLengthBucket({required this.tripCount, required this.meanLPer100km, required this.totalDistanceKm, required this.totalLitres});
+  factory _TripLengthBucket.fromJson(Map<String, dynamic> json) => _$TripLengthBucketFromJson(json);
+
+/// Number of completed trips folded into this bucket.
+@override final  int tripCount;
+/// Mean fuel consumption across the bucket, in litres per 100 km.
+/// Aggregator-side this is computed as `totalLitres / totalDistanceKm * 100`,
+/// or via Welford-style incremental update when folding a single trip
+/// into the existing bucket — phase 2 owns that math.
+@override final  double meanLPer100km;
+/// Sum of distance (km) across every trip in this bucket. Useful
+/// for the UI "you drove X km on long trips this month" line and
+/// as the denominator if a consumer needs to recompute the mean
+/// at higher precision than [meanLPer100km] preserved.
+@override final  double totalDistanceKm;
+/// Sum of fuel used (litres) across every trip in this bucket.
+/// Same role as [totalDistanceKm] — kept so the mean can be
+/// rederived without information loss.
+@override final  double totalLitres;
+
+/// Create a copy of TripLengthBucket
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TripLengthBucketCopyWith<_TripLengthBucket> get copyWith => __$TripLengthBucketCopyWithImpl<_TripLengthBucket>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TripLengthBucketToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TripLengthBucket&&(identical(other.tripCount, tripCount) || other.tripCount == tripCount)&&(identical(other.meanLPer100km, meanLPer100km) || other.meanLPer100km == meanLPer100km)&&(identical(other.totalDistanceKm, totalDistanceKm) || other.totalDistanceKm == totalDistanceKm)&&(identical(other.totalLitres, totalLitres) || other.totalLitres == totalLitres));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,tripCount,meanLPer100km,totalDistanceKm,totalLitres);
+
+@override
+String toString() {
+  return 'TripLengthBucket(tripCount: $tripCount, meanLPer100km: $meanLPer100km, totalDistanceKm: $totalDistanceKm, totalLitres: $totalLitres)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TripLengthBucketCopyWith<$Res> implements $TripLengthBucketCopyWith<$Res> {
+  factory _$TripLengthBucketCopyWith(_TripLengthBucket value, $Res Function(_TripLengthBucket) _then) = __$TripLengthBucketCopyWithImpl;
+@override @useResult
+$Res call({
+ int tripCount, double meanLPer100km, double totalDistanceKm, double totalLitres
+});
+
+
+
+
+}
+/// @nodoc
+class __$TripLengthBucketCopyWithImpl<$Res>
+    implements _$TripLengthBucketCopyWith<$Res> {
+  __$TripLengthBucketCopyWithImpl(this._self, this._then);
+
+  final _TripLengthBucket _self;
+  final $Res Function(_TripLengthBucket) _then;
+
+/// Create a copy of TripLengthBucket
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? tripCount = null,Object? meanLPer100km = null,Object? totalDistanceKm = null,Object? totalLitres = null,}) {
+  return _then(_TripLengthBucket(
+tripCount: null == tripCount ? _self.tripCount : tripCount // ignore: cast_nullable_to_non_nullable
+as int,meanLPer100km: null == meanLPer100km ? _self.meanLPer100km : meanLPer100km // ignore: cast_nullable_to_non_nullable
+as double,totalDistanceKm: null == totalDistanceKm ? _self.totalDistanceKm : totalDistanceKm // ignore: cast_nullable_to_non_nullable
+as double,totalLitres: null == totalLitres ? _self.totalLitres : totalLitres // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$TripLengthBreakdown {
+
+ TripLengthBucket? get short; TripLengthBucket? get medium; TripLengthBucket? get long;
+/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TripLengthBreakdownCopyWith<TripLengthBreakdown> get copyWith => _$TripLengthBreakdownCopyWithImpl<TripLengthBreakdown>(this as TripLengthBreakdown, _$identity);
+
+  /// Serializes this TripLengthBreakdown to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TripLengthBreakdown&&(identical(other.short, short) || other.short == short)&&(identical(other.medium, medium) || other.medium == medium)&&(identical(other.long, long) || other.long == long));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,short,medium,long);
+
+@override
+String toString() {
+  return 'TripLengthBreakdown(short: $short, medium: $medium, long: $long)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TripLengthBreakdownCopyWith<$Res>  {
+  factory $TripLengthBreakdownCopyWith(TripLengthBreakdown value, $Res Function(TripLengthBreakdown) _then) = _$TripLengthBreakdownCopyWithImpl;
+@useResult
+$Res call({
+ TripLengthBucket? short, TripLengthBucket? medium, TripLengthBucket? long
+});
+
+
+$TripLengthBucketCopyWith<$Res>? get short;$TripLengthBucketCopyWith<$Res>? get medium;$TripLengthBucketCopyWith<$Res>? get long;
+
+}
+/// @nodoc
+class _$TripLengthBreakdownCopyWithImpl<$Res>
+    implements $TripLengthBreakdownCopyWith<$Res> {
+  _$TripLengthBreakdownCopyWithImpl(this._self, this._then);
+
+  final TripLengthBreakdown _self;
+  final $Res Function(TripLengthBreakdown) _then;
+
+/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? short = freezed,Object? medium = freezed,Object? long = freezed,}) {
+  return _then(_self.copyWith(
+short: freezed == short ? _self.short : short // ignore: cast_nullable_to_non_nullable
+as TripLengthBucket?,medium: freezed == medium ? _self.medium : medium // ignore: cast_nullable_to_non_nullable
+as TripLengthBucket?,long: freezed == long ? _self.long : long // ignore: cast_nullable_to_non_nullable
+as TripLengthBucket?,
+  ));
+}
+/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TripLengthBucketCopyWith<$Res>? get short {
+    if (_self.short == null) {
+    return null;
+  }
+
+  return $TripLengthBucketCopyWith<$Res>(_self.short!, (value) {
+    return _then(_self.copyWith(short: value));
+  });
+}/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TripLengthBucketCopyWith<$Res>? get medium {
+    if (_self.medium == null) {
+    return null;
+  }
+
+  return $TripLengthBucketCopyWith<$Res>(_self.medium!, (value) {
+    return _then(_self.copyWith(medium: value));
+  });
+}/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TripLengthBucketCopyWith<$Res>? get long {
+    if (_self.long == null) {
+    return null;
+  }
+
+  return $TripLengthBucketCopyWith<$Res>(_self.long!, (value) {
+    return _then(_self.copyWith(long: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [TripLengthBreakdown].
+extension TripLengthBreakdownPatterns on TripLengthBreakdown {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TripLengthBreakdown value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TripLengthBreakdown() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TripLengthBreakdown value)  $default,){
+final _that = this;
+switch (_that) {
+case _TripLengthBreakdown():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TripLengthBreakdown value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TripLengthBreakdown() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( TripLengthBucket? short,  TripLengthBucket? medium,  TripLengthBucket? long)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TripLengthBreakdown() when $default != null:
+return $default(_that.short,_that.medium,_that.long);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( TripLengthBucket? short,  TripLengthBucket? medium,  TripLengthBucket? long)  $default,) {final _that = this;
+switch (_that) {
+case _TripLengthBreakdown():
+return $default(_that.short,_that.medium,_that.long);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( TripLengthBucket? short,  TripLengthBucket? medium,  TripLengthBucket? long)?  $default,) {final _that = this;
+switch (_that) {
+case _TripLengthBreakdown() when $default != null:
+return $default(_that.short,_that.medium,_that.long);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TripLengthBreakdown implements TripLengthBreakdown {
+  const _TripLengthBreakdown({this.short, this.medium, this.long});
+  factory _TripLengthBreakdown.fromJson(Map<String, dynamic> json) => _$TripLengthBreakdownFromJson(json);
+
+@override final  TripLengthBucket? short;
+@override final  TripLengthBucket? medium;
+@override final  TripLengthBucket? long;
+
+/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TripLengthBreakdownCopyWith<_TripLengthBreakdown> get copyWith => __$TripLengthBreakdownCopyWithImpl<_TripLengthBreakdown>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TripLengthBreakdownToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TripLengthBreakdown&&(identical(other.short, short) || other.short == short)&&(identical(other.medium, medium) || other.medium == medium)&&(identical(other.long, long) || other.long == long));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,short,medium,long);
+
+@override
+String toString() {
+  return 'TripLengthBreakdown(short: $short, medium: $medium, long: $long)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TripLengthBreakdownCopyWith<$Res> implements $TripLengthBreakdownCopyWith<$Res> {
+  factory _$TripLengthBreakdownCopyWith(_TripLengthBreakdown value, $Res Function(_TripLengthBreakdown) _then) = __$TripLengthBreakdownCopyWithImpl;
+@override @useResult
+$Res call({
+ TripLengthBucket? short, TripLengthBucket? medium, TripLengthBucket? long
+});
+
+
+@override $TripLengthBucketCopyWith<$Res>? get short;@override $TripLengthBucketCopyWith<$Res>? get medium;@override $TripLengthBucketCopyWith<$Res>? get long;
+
+}
+/// @nodoc
+class __$TripLengthBreakdownCopyWithImpl<$Res>
+    implements _$TripLengthBreakdownCopyWith<$Res> {
+  __$TripLengthBreakdownCopyWithImpl(this._self, this._then);
+
+  final _TripLengthBreakdown _self;
+  final $Res Function(_TripLengthBreakdown) _then;
+
+/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? short = freezed,Object? medium = freezed,Object? long = freezed,}) {
+  return _then(_TripLengthBreakdown(
+short: freezed == short ? _self.short : short // ignore: cast_nullable_to_non_nullable
+as TripLengthBucket?,medium: freezed == medium ? _self.medium : medium // ignore: cast_nullable_to_non_nullable
+as TripLengthBucket?,long: freezed == long ? _self.long : long // ignore: cast_nullable_to_non_nullable
+as TripLengthBucket?,
+  ));
+}
+
+/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TripLengthBucketCopyWith<$Res>? get short {
+    if (_self.short == null) {
+    return null;
+  }
+
+  return $TripLengthBucketCopyWith<$Res>(_self.short!, (value) {
+    return _then(_self.copyWith(short: value));
+  });
+}/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TripLengthBucketCopyWith<$Res>? get medium {
+    if (_self.medium == null) {
+    return null;
+  }
+
+  return $TripLengthBucketCopyWith<$Res>(_self.medium!, (value) {
+    return _then(_self.copyWith(medium: value));
+  });
+}/// Create a copy of TripLengthBreakdown
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TripLengthBucketCopyWith<$Res>? get long {
+    if (_self.long == null) {
+    return null;
+  }
+
+  return $TripLengthBucketCopyWith<$Res>(_self.long!, (value) {
+    return _then(_self.copyWith(long: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/vehicle/domain/entities/trip_length_breakdown.g.dart
+++ b/lib/features/vehicle/domain/entities/trip_length_breakdown.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'trip_length_breakdown.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_TripLengthBucket _$TripLengthBucketFromJson(Map<String, dynamic> json) =>
+    _TripLengthBucket(
+      tripCount: (json['tripCount'] as num).toInt(),
+      meanLPer100km: (json['meanLPer100km'] as num).toDouble(),
+      totalDistanceKm: (json['totalDistanceKm'] as num).toDouble(),
+      totalLitres: (json['totalLitres'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$TripLengthBucketToJson(_TripLengthBucket instance) =>
+    <String, dynamic>{
+      'tripCount': instance.tripCount,
+      'meanLPer100km': instance.meanLPer100km,
+      'totalDistanceKm': instance.totalDistanceKm,
+      'totalLitres': instance.totalLitres,
+    };
+
+_TripLengthBreakdown _$TripLengthBreakdownFromJson(Map<String, dynamic> json) =>
+    _TripLengthBreakdown(
+      short: json['short'] == null
+          ? null
+          : TripLengthBucket.fromJson(json['short'] as Map<String, dynamic>),
+      medium: json['medium'] == null
+          ? null
+          : TripLengthBucket.fromJson(json['medium'] as Map<String, dynamic>),
+      long: json['long'] == null
+          ? null
+          : TripLengthBucket.fromJson(json['long'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$TripLengthBreakdownToJson(
+  _TripLengthBreakdown instance,
+) => <String, dynamic>{
+  'short': instance.short?.toJson(),
+  'medium': instance.medium?.toJson(),
+  'long': instance.long?.toJson(),
+};

--- a/lib/features/vehicle/domain/entities/vehicle_profile.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.dart
@@ -1,5 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'speed_consumption_histogram.dart';
+import 'trip_length_breakdown.dart';
+
 part 'vehicle_profile.freezed.dart';
 part 'vehicle_profile.g.dart';
 
@@ -240,6 +243,30 @@ abstract class VehicleProfile with _$VehicleProfile {
     String? model,
     int? year,
     String? referenceVehicleId,
+
+    // Rolling per-vehicle driving aggregates (#1193 phase 1). All four
+    // fields are nullable; they remain null until the first trip
+    // aggregator pass writes them, and a null bucket entry inside the
+    // populated [TripLengthBreakdown] / [SpeedConsumptionHistogram]
+    // means the vehicle has trips overall but not yet enough in that
+    // specific bucket to clear the per-bucket min-sample threshold.
+    //
+    // The phase-1 PR ships these storage fields and the value-object
+    // schemas only — the aggregator service that fills them lives in
+    // `lib/features/vehicle/data/vehicle_aggregate_updater.dart`
+    // (#1193 phase 2), and the vehicle-profile UI section that reads
+    // them lives in the edit/view screens (#1193 phase 3).
+    //
+    //   tripLengthAggregates:    short / medium / long bucket stats.
+    //   speedConsumptionAggregates: per-speed-band L/100 km histogram.
+    //   aggregatesUpdatedAt:     wall-clock time of the last refresh.
+    //   aggregatesTripCount:     # trips folded into the current pass
+    //                            (used by the UI to gate the section
+    //                            below a min-trips threshold).
+    TripLengthBreakdown? tripLengthAggregates,
+    SpeedConsumptionHistogram? speedConsumptionAggregates,
+    DateTime? aggregatesUpdatedAt,
+    int? aggregatesTripCount,
   }) = _VehicleProfile;
 
   factory VehicleProfile.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.freezed.dart
@@ -383,7 +383,26 @@ mixin _$VehicleProfile {
 //     lowercased with non-alphanumerics collapsed to dashes. The
 //     consumer side (obd2_service) resolves the slug back to a
 //     [ReferenceVehicle] via the catalog provider.
- String? get make; String? get model; int? get year; String? get referenceVehicleId;
+ String? get make; String? get model; int? get year; String? get referenceVehicleId;// Rolling per-vehicle driving aggregates (#1193 phase 1). All four
+// fields are nullable; they remain null until the first trip
+// aggregator pass writes them, and a null bucket entry inside the
+// populated [TripLengthBreakdown] / [SpeedConsumptionHistogram]
+// means the vehicle has trips overall but not yet enough in that
+// specific bucket to clear the per-bucket min-sample threshold.
+//
+// The phase-1 PR ships these storage fields and the value-object
+// schemas only — the aggregator service that fills them lives in
+// `lib/features/vehicle/data/vehicle_aggregate_updater.dart`
+// (#1193 phase 2), and the vehicle-profile UI section that reads
+// them lives in the edit/view screens (#1193 phase 3).
+//
+//   tripLengthAggregates:    short / medium / long bucket stats.
+//   speedConsumptionAggregates: per-speed-band L/100 km histogram.
+//   aggregatesUpdatedAt:     wall-clock time of the last refresh.
+//   aggregatesTripCount:     # trips folded into the current pass
+//                            (used by the UI to gate the section
+//                            below a min-trips threshold).
+ TripLengthBreakdown? get tripLengthAggregates; SpeedConsumptionHistogram? get speedConsumptionAggregates; DateTime? get aggregatesUpdatedAt; int? get aggregatesTripCount;
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -396,16 +415,16 @@ $VehicleProfileCopyWith<VehicleProfile> get copyWith => _$VehicleProfileCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent)&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.year, year) || other.year == year)&&(identical(other.referenceVehicleId, referenceVehicleId) || other.referenceVehicleId == referenceVehicleId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other.supportedConnectors, supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent)&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.year, year) || other.year == year)&&(identical(other.referenceVehicleId, referenceVehicleId) || other.referenceVehicleId == referenceVehicleId)&&(identical(other.tripLengthAggregates, tripLengthAggregates) || other.tripLengthAggregates == tripLengthAggregates)&&(identical(other.speedConsumptionAggregates, speedConsumptionAggregates) || other.speedConsumptionAggregates == speedConsumptionAggregates)&&(identical(other.aggregatesUpdatedAt, aggregatesUpdatedAt) || other.aggregatesUpdatedAt == aggregatesUpdatedAt)&&(identical(other.aggregatesTripCount, aggregatesTripCount) || other.aggregatesTripCount == aggregatesTripCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent,make,model,year,referenceVehicleId]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent,make,model,year,referenceVehicleId,tripLengthAggregates,speedConsumptionAggregates,aggregatesUpdatedAt,aggregatesTripCount]);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent, make: $make, model: $model, year: $year, referenceVehicleId: $referenceVehicleId)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent, make: $make, model: $model, year: $year, referenceVehicleId: $referenceVehicleId, tripLengthAggregates: $tripLengthAggregates, speedConsumptionAggregates: $speedConsumptionAggregates, aggregatesUpdatedAt: $aggregatesUpdatedAt, aggregatesTripCount: $aggregatesTripCount)';
 }
 
 
@@ -416,11 +435,11 @@ abstract mixin class $VehicleProfileCopyWith<$Res>  {
   factory $VehicleProfileCopyWith(VehicleProfile value, $Res Function(VehicleProfile) _then) = _$VehicleProfileCopyWithImpl;
 @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent, String? make, String? model, int? year, String? referenceVehicleId
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent, String? make, String? model, int? year, String? referenceVehicleId, TripLengthBreakdown? tripLengthAggregates, SpeedConsumptionHistogram? speedConsumptionAggregates, DateTime? aggregatesUpdatedAt, int? aggregatesTripCount
 });
 
 
-$ChargingPreferencesCopyWith<$Res> get chargingPreferences;
+$ChargingPreferencesCopyWith<$Res> get chargingPreferences;$TripLengthBreakdownCopyWith<$Res>? get tripLengthAggregates;$SpeedConsumptionHistogramCopyWith<$Res>? get speedConsumptionAggregates;
 
 }
 /// @nodoc
@@ -433,7 +452,7 @@ class _$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,Object? make = freezed,Object? model = freezed,Object? year = freezed,Object? referenceVehicleId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,Object? make = freezed,Object? model = freezed,Object? year = freezed,Object? referenceVehicleId = freezed,Object? tripLengthAggregates = freezed,Object? speedConsumptionAggregates = freezed,Object? aggregatesUpdatedAt = freezed,Object? aggregatesTripCount = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -462,7 +481,11 @@ as bool,make: freezed == make ? _self.make : make // ignore: cast_nullable_to_no
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,year: freezed == year ? _self.year : year // ignore: cast_nullable_to_non_nullable
 as int?,referenceVehicleId: freezed == referenceVehicleId ? _self.referenceVehicleId : referenceVehicleId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,tripLengthAggregates: freezed == tripLengthAggregates ? _self.tripLengthAggregates : tripLengthAggregates // ignore: cast_nullable_to_non_nullable
+as TripLengthBreakdown?,speedConsumptionAggregates: freezed == speedConsumptionAggregates ? _self.speedConsumptionAggregates : speedConsumptionAggregates // ignore: cast_nullable_to_non_nullable
+as SpeedConsumptionHistogram?,aggregatesUpdatedAt: freezed == aggregatesUpdatedAt ? _self.aggregatesUpdatedAt : aggregatesUpdatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,aggregatesTripCount: freezed == aggregatesTripCount ? _self.aggregatesTripCount : aggregatesTripCount // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 /// Create a copy of VehicleProfile
@@ -473,6 +496,30 @@ $ChargingPreferencesCopyWith<$Res> get chargingPreferences {
   
   return $ChargingPreferencesCopyWith<$Res>(_self.chargingPreferences, (value) {
     return _then(_self.copyWith(chargingPreferences: value));
+  });
+}/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TripLengthBreakdownCopyWith<$Res>? get tripLengthAggregates {
+    if (_self.tripLengthAggregates == null) {
+    return null;
+  }
+
+  return $TripLengthBreakdownCopyWith<$Res>(_self.tripLengthAggregates!, (value) {
+    return _then(_self.copyWith(tripLengthAggregates: value));
+  });
+}/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SpeedConsumptionHistogramCopyWith<$Res>? get speedConsumptionAggregates {
+    if (_self.speedConsumptionAggregates == null) {
+    return null;
+  }
+
+  return $SpeedConsumptionHistogramCopyWith<$Res>(_self.speedConsumptionAggregates!, (value) {
+    return _then(_self.copyWith(speedConsumptionAggregates: value));
   });
 }
 }
@@ -556,10 +603,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent,  String? make,  String? model,  int? year,  String? referenceVehicleId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent,  String? make,  String? model,  int? year,  String? referenceVehicleId,  TripLengthBreakdown? tripLengthAggregates,  SpeedConsumptionHistogram? speedConsumptionAggregates,  DateTime? aggregatesUpdatedAt,  int? aggregatesTripCount)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent,_that.make,_that.model,_that.year,_that.referenceVehicleId);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent,_that.make,_that.model,_that.year,_that.referenceVehicleId,_that.tripLengthAggregates,_that.speedConsumptionAggregates,_that.aggregatesUpdatedAt,_that.aggregatesTripCount);case _:
   return orElse();
 
 }
@@ -577,10 +624,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent,  String? make,  String? model,  int? year,  String? referenceVehicleId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent,  String? make,  String? model,  int? year,  String? referenceVehicleId,  TripLengthBreakdown? tripLengthAggregates,  SpeedConsumptionHistogram? speedConsumptionAggregates,  DateTime? aggregatesUpdatedAt,  int? aggregatesTripCount)  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile():
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent,_that.make,_that.model,_that.year,_that.referenceVehicleId);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent,_that.make,_that.model,_that.year,_that.referenceVehicleId,_that.tripLengthAggregates,_that.speedConsumptionAggregates,_that.aggregatesUpdatedAt,_that.aggregatesTripCount);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -597,10 +644,10 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent,  String? make,  String? model,  int? year,  String? referenceVehicleId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @VehicleTypeJsonConverter()  VehicleType type,  double? batteryKwh,  double? maxChargingKw, @ConnectorTypeSetConverter()  Set<ConnectorType> supportedConnectors, @ChargingPreferencesJsonConverter()  ChargingPreferences chargingPreferences,  double? tankCapacityL,  String? preferredFuelType,  int? engineDisplacementCc,  int? engineCylinders,  double volumetricEfficiency,  int volumetricEfficiencySamples,  int? curbWeightKg,  String? obd2AdapterMac,  String? obd2AdapterName,  String? vin, @VehicleCalibrationModeJsonConverter()  VehicleCalibrationMode calibrationMode,  bool autoRecord,  String? pairedAdapterMac,  double movementStartThresholdKmh,  int disconnectSaveDelaySec,  bool backgroundLocationConsent,  String? make,  String? model,  int? year,  String? referenceVehicleId,  TripLengthBreakdown? tripLengthAggregates,  SpeedConsumptionHistogram? speedConsumptionAggregates,  DateTime? aggregatesUpdatedAt,  int? aggregatesTripCount)?  $default,) {final _that = this;
 switch (_that) {
 case _VehicleProfile() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent,_that.make,_that.model,_that.year,_that.referenceVehicleId);case _:
+return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargingKw,_that.supportedConnectors,_that.chargingPreferences,_that.tankCapacityL,_that.preferredFuelType,_that.engineDisplacementCc,_that.engineCylinders,_that.volumetricEfficiency,_that.volumetricEfficiencySamples,_that.curbWeightKg,_that.obd2AdapterMac,_that.obd2AdapterName,_that.vin,_that.calibrationMode,_that.autoRecord,_that.pairedAdapterMac,_that.movementStartThresholdKmh,_that.disconnectSaveDelaySec,_that.backgroundLocationConsent,_that.make,_that.model,_that.year,_that.referenceVehicleId,_that.tripLengthAggregates,_that.speedConsumptionAggregates,_that.aggregatesUpdatedAt,_that.aggregatesTripCount);case _:
   return null;
 
 }
@@ -612,7 +659,7 @@ return $default(_that.id,_that.name,_that.type,_that.batteryKwh,_that.maxChargin
 @JsonSerializable()
 
 class _VehicleProfile extends VehicleProfile {
-  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.volumetricEfficiencySamples = 0, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName, this.vin, @VehicleCalibrationModeJsonConverter() this.calibrationMode = VehicleCalibrationMode.rule, this.autoRecord = false, this.pairedAdapterMac, this.movementStartThresholdKmh = 5.0, this.disconnectSaveDelaySec = 60, this.backgroundLocationConsent = false, this.make, this.model, this.year, this.referenceVehicleId}): _supportedConnectors = supportedConnectors,super._();
+  const _VehicleProfile({required this.id, required this.name, @VehicleTypeJsonConverter() this.type = VehicleType.combustion, this.batteryKwh, this.maxChargingKw, @ConnectorTypeSetConverter() final  Set<ConnectorType> supportedConnectors = const <ConnectorType>{}, @ChargingPreferencesJsonConverter() this.chargingPreferences = const ChargingPreferences(), this.tankCapacityL, this.preferredFuelType, this.engineDisplacementCc, this.engineCylinders, this.volumetricEfficiency = 0.85, this.volumetricEfficiencySamples = 0, this.curbWeightKg, this.obd2AdapterMac, this.obd2AdapterName, this.vin, @VehicleCalibrationModeJsonConverter() this.calibrationMode = VehicleCalibrationMode.rule, this.autoRecord = false, this.pairedAdapterMac, this.movementStartThresholdKmh = 5.0, this.disconnectSaveDelaySec = 60, this.backgroundLocationConsent = false, this.make, this.model, this.year, this.referenceVehicleId, this.tripLengthAggregates, this.speedConsumptionAggregates, this.aggregatesUpdatedAt, this.aggregatesTripCount}): _supportedConnectors = supportedConnectors,super._();
   factory _VehicleProfile.fromJson(Map<String, dynamic> json) => _$VehicleProfileFromJson(json);
 
 @override final  String id;
@@ -741,6 +788,29 @@ class _VehicleProfile extends VehicleProfile {
 @override final  String? model;
 @override final  int? year;
 @override final  String? referenceVehicleId;
+// Rolling per-vehicle driving aggregates (#1193 phase 1). All four
+// fields are nullable; they remain null until the first trip
+// aggregator pass writes them, and a null bucket entry inside the
+// populated [TripLengthBreakdown] / [SpeedConsumptionHistogram]
+// means the vehicle has trips overall but not yet enough in that
+// specific bucket to clear the per-bucket min-sample threshold.
+//
+// The phase-1 PR ships these storage fields and the value-object
+// schemas only — the aggregator service that fills them lives in
+// `lib/features/vehicle/data/vehicle_aggregate_updater.dart`
+// (#1193 phase 2), and the vehicle-profile UI section that reads
+// them lives in the edit/view screens (#1193 phase 3).
+//
+//   tripLengthAggregates:    short / medium / long bucket stats.
+//   speedConsumptionAggregates: per-speed-band L/100 km histogram.
+//   aggregatesUpdatedAt:     wall-clock time of the last refresh.
+//   aggregatesTripCount:     # trips folded into the current pass
+//                            (used by the UI to gate the section
+//                            below a min-trips threshold).
+@override final  TripLengthBreakdown? tripLengthAggregates;
+@override final  SpeedConsumptionHistogram? speedConsumptionAggregates;
+@override final  DateTime? aggregatesUpdatedAt;
+@override final  int? aggregatesTripCount;
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
@@ -755,16 +825,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent)&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.year, year) || other.year == year)&&(identical(other.referenceVehicleId, referenceVehicleId) || other.referenceVehicleId == referenceVehicleId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VehicleProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.batteryKwh, batteryKwh) || other.batteryKwh == batteryKwh)&&(identical(other.maxChargingKw, maxChargingKw) || other.maxChargingKw == maxChargingKw)&&const DeepCollectionEquality().equals(other._supportedConnectors, _supportedConnectors)&&(identical(other.chargingPreferences, chargingPreferences) || other.chargingPreferences == chargingPreferences)&&(identical(other.tankCapacityL, tankCapacityL) || other.tankCapacityL == tankCapacityL)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.engineDisplacementCc, engineDisplacementCc) || other.engineDisplacementCc == engineDisplacementCc)&&(identical(other.engineCylinders, engineCylinders) || other.engineCylinders == engineCylinders)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.volumetricEfficiencySamples, volumetricEfficiencySamples) || other.volumetricEfficiencySamples == volumetricEfficiencySamples)&&(identical(other.curbWeightKg, curbWeightKg) || other.curbWeightKg == curbWeightKg)&&(identical(other.obd2AdapterMac, obd2AdapterMac) || other.obd2AdapterMac == obd2AdapterMac)&&(identical(other.obd2AdapterName, obd2AdapterName) || other.obd2AdapterName == obd2AdapterName)&&(identical(other.vin, vin) || other.vin == vin)&&(identical(other.calibrationMode, calibrationMode) || other.calibrationMode == calibrationMode)&&(identical(other.autoRecord, autoRecord) || other.autoRecord == autoRecord)&&(identical(other.pairedAdapterMac, pairedAdapterMac) || other.pairedAdapterMac == pairedAdapterMac)&&(identical(other.movementStartThresholdKmh, movementStartThresholdKmh) || other.movementStartThresholdKmh == movementStartThresholdKmh)&&(identical(other.disconnectSaveDelaySec, disconnectSaveDelaySec) || other.disconnectSaveDelaySec == disconnectSaveDelaySec)&&(identical(other.backgroundLocationConsent, backgroundLocationConsent) || other.backgroundLocationConsent == backgroundLocationConsent)&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.year, year) || other.year == year)&&(identical(other.referenceVehicleId, referenceVehicleId) || other.referenceVehicleId == referenceVehicleId)&&(identical(other.tripLengthAggregates, tripLengthAggregates) || other.tripLengthAggregates == tripLengthAggregates)&&(identical(other.speedConsumptionAggregates, speedConsumptionAggregates) || other.speedConsumptionAggregates == speedConsumptionAggregates)&&(identical(other.aggregatesUpdatedAt, aggregatesUpdatedAt) || other.aggregatesUpdatedAt == aggregatesUpdatedAt)&&(identical(other.aggregatesTripCount, aggregatesTripCount) || other.aggregatesTripCount == aggregatesTripCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent,make,model,year,referenceVehicleId]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,batteryKwh,maxChargingKw,const DeepCollectionEquality().hash(_supportedConnectors),chargingPreferences,tankCapacityL,preferredFuelType,engineDisplacementCc,engineCylinders,volumetricEfficiency,volumetricEfficiencySamples,curbWeightKg,obd2AdapterMac,obd2AdapterName,vin,calibrationMode,autoRecord,pairedAdapterMac,movementStartThresholdKmh,disconnectSaveDelaySec,backgroundLocationConsent,make,model,year,referenceVehicleId,tripLengthAggregates,speedConsumptionAggregates,aggregatesUpdatedAt,aggregatesTripCount]);
 
 @override
 String toString() {
-  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent, make: $make, model: $model, year: $year, referenceVehicleId: $referenceVehicleId)';
+  return 'VehicleProfile(id: $id, name: $name, type: $type, batteryKwh: $batteryKwh, maxChargingKw: $maxChargingKw, supportedConnectors: $supportedConnectors, chargingPreferences: $chargingPreferences, tankCapacityL: $tankCapacityL, preferredFuelType: $preferredFuelType, engineDisplacementCc: $engineDisplacementCc, engineCylinders: $engineCylinders, volumetricEfficiency: $volumetricEfficiency, volumetricEfficiencySamples: $volumetricEfficiencySamples, curbWeightKg: $curbWeightKg, obd2AdapterMac: $obd2AdapterMac, obd2AdapterName: $obd2AdapterName, vin: $vin, calibrationMode: $calibrationMode, autoRecord: $autoRecord, pairedAdapterMac: $pairedAdapterMac, movementStartThresholdKmh: $movementStartThresholdKmh, disconnectSaveDelaySec: $disconnectSaveDelaySec, backgroundLocationConsent: $backgroundLocationConsent, make: $make, model: $model, year: $year, referenceVehicleId: $referenceVehicleId, tripLengthAggregates: $tripLengthAggregates, speedConsumptionAggregates: $speedConsumptionAggregates, aggregatesUpdatedAt: $aggregatesUpdatedAt, aggregatesTripCount: $aggregatesTripCount)';
 }
 
 
@@ -775,11 +845,11 @@ abstract mixin class _$VehicleProfileCopyWith<$Res> implements $VehicleProfileCo
   factory _$VehicleProfileCopyWith(_VehicleProfile value, $Res Function(_VehicleProfile) _then) = __$VehicleProfileCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent, String? make, String? model, int? year, String? referenceVehicleId
+ String id, String name,@VehicleTypeJsonConverter() VehicleType type, double? batteryKwh, double? maxChargingKw,@ConnectorTypeSetConverter() Set<ConnectorType> supportedConnectors,@ChargingPreferencesJsonConverter() ChargingPreferences chargingPreferences, double? tankCapacityL, String? preferredFuelType, int? engineDisplacementCc, int? engineCylinders, double volumetricEfficiency, int volumetricEfficiencySamples, int? curbWeightKg, String? obd2AdapterMac, String? obd2AdapterName, String? vin,@VehicleCalibrationModeJsonConverter() VehicleCalibrationMode calibrationMode, bool autoRecord, String? pairedAdapterMac, double movementStartThresholdKmh, int disconnectSaveDelaySec, bool backgroundLocationConsent, String? make, String? model, int? year, String? referenceVehicleId, TripLengthBreakdown? tripLengthAggregates, SpeedConsumptionHistogram? speedConsumptionAggregates, DateTime? aggregatesUpdatedAt, int? aggregatesTripCount
 });
 
 
-@override $ChargingPreferencesCopyWith<$Res> get chargingPreferences;
+@override $ChargingPreferencesCopyWith<$Res> get chargingPreferences;@override $TripLengthBreakdownCopyWith<$Res>? get tripLengthAggregates;@override $SpeedConsumptionHistogramCopyWith<$Res>? get speedConsumptionAggregates;
 
 }
 /// @nodoc
@@ -792,7 +862,7 @@ class __$VehicleProfileCopyWithImpl<$Res>
 
 /// Create a copy of VehicleProfile
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,Object? make = freezed,Object? model = freezed,Object? year = freezed,Object? referenceVehicleId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? batteryKwh = freezed,Object? maxChargingKw = freezed,Object? supportedConnectors = null,Object? chargingPreferences = null,Object? tankCapacityL = freezed,Object? preferredFuelType = freezed,Object? engineDisplacementCc = freezed,Object? engineCylinders = freezed,Object? volumetricEfficiency = null,Object? volumetricEfficiencySamples = null,Object? curbWeightKg = freezed,Object? obd2AdapterMac = freezed,Object? obd2AdapterName = freezed,Object? vin = freezed,Object? calibrationMode = null,Object? autoRecord = null,Object? pairedAdapterMac = freezed,Object? movementStartThresholdKmh = null,Object? disconnectSaveDelaySec = null,Object? backgroundLocationConsent = null,Object? make = freezed,Object? model = freezed,Object? year = freezed,Object? referenceVehicleId = freezed,Object? tripLengthAggregates = freezed,Object? speedConsumptionAggregates = freezed,Object? aggregatesUpdatedAt = freezed,Object? aggregatesTripCount = freezed,}) {
   return _then(_VehicleProfile(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -821,7 +891,11 @@ as bool,make: freezed == make ? _self.make : make // ignore: cast_nullable_to_no
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,year: freezed == year ? _self.year : year // ignore: cast_nullable_to_non_nullable
 as int?,referenceVehicleId: freezed == referenceVehicleId ? _self.referenceVehicleId : referenceVehicleId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,tripLengthAggregates: freezed == tripLengthAggregates ? _self.tripLengthAggregates : tripLengthAggregates // ignore: cast_nullable_to_non_nullable
+as TripLengthBreakdown?,speedConsumptionAggregates: freezed == speedConsumptionAggregates ? _self.speedConsumptionAggregates : speedConsumptionAggregates // ignore: cast_nullable_to_non_nullable
+as SpeedConsumptionHistogram?,aggregatesUpdatedAt: freezed == aggregatesUpdatedAt ? _self.aggregatesUpdatedAt : aggregatesUpdatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,aggregatesTripCount: freezed == aggregatesTripCount ? _self.aggregatesTripCount : aggregatesTripCount // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -833,6 +907,30 @@ $ChargingPreferencesCopyWith<$Res> get chargingPreferences {
   
   return $ChargingPreferencesCopyWith<$Res>(_self.chargingPreferences, (value) {
     return _then(_self.copyWith(chargingPreferences: value));
+  });
+}/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TripLengthBreakdownCopyWith<$Res>? get tripLengthAggregates {
+    if (_self.tripLengthAggregates == null) {
+    return null;
+  }
+
+  return $TripLengthBreakdownCopyWith<$Res>(_self.tripLengthAggregates!, (value) {
+    return _then(_self.copyWith(tripLengthAggregates: value));
+  });
+}/// Create a copy of VehicleProfile
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SpeedConsumptionHistogramCopyWith<$Res>? get speedConsumptionAggregates {
+    if (_self.speedConsumptionAggregates == null) {
+    return null;
+  }
+
+  return $SpeedConsumptionHistogramCopyWith<$Res>(_self.speedConsumptionAggregates!, (value) {
+    return _then(_self.copyWith(speedConsumptionAggregates: value));
   });
 }
 }

--- a/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.g.dart
@@ -73,41 +73,60 @@ _VehicleProfile _$VehicleProfileFromJson(Map<String, dynamic> json) =>
       model: json['model'] as String?,
       year: (json['year'] as num?)?.toInt(),
       referenceVehicleId: json['referenceVehicleId'] as String?,
+      tripLengthAggregates: json['tripLengthAggregates'] == null
+          ? null
+          : TripLengthBreakdown.fromJson(
+              json['tripLengthAggregates'] as Map<String, dynamic>,
+            ),
+      speedConsumptionAggregates: json['speedConsumptionAggregates'] == null
+          ? null
+          : SpeedConsumptionHistogram.fromJson(
+              json['speedConsumptionAggregates'] as Map<String, dynamic>,
+            ),
+      aggregatesUpdatedAt: json['aggregatesUpdatedAt'] == null
+          ? null
+          : DateTime.parse(json['aggregatesUpdatedAt'] as String),
+      aggregatesTripCount: (json['aggregatesTripCount'] as num?)?.toInt(),
     );
 
-Map<String, dynamic> _$VehicleProfileToJson(_VehicleProfile instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'type': const VehicleTypeJsonConverter().toJson(instance.type),
-      'batteryKwh': instance.batteryKwh,
-      'maxChargingKw': instance.maxChargingKw,
-      'supportedConnectors': const ConnectorTypeSetConverter().toJson(
-        instance.supportedConnectors,
-      ),
-      'chargingPreferences': const ChargingPreferencesJsonConverter().toJson(
-        instance.chargingPreferences,
-      ),
-      'tankCapacityL': instance.tankCapacityL,
-      'preferredFuelType': instance.preferredFuelType,
-      'engineDisplacementCc': instance.engineDisplacementCc,
-      'engineCylinders': instance.engineCylinders,
-      'volumetricEfficiency': instance.volumetricEfficiency,
-      'volumetricEfficiencySamples': instance.volumetricEfficiencySamples,
-      'curbWeightKg': instance.curbWeightKg,
-      'obd2AdapterMac': instance.obd2AdapterMac,
-      'obd2AdapterName': instance.obd2AdapterName,
-      'vin': instance.vin,
-      'calibrationMode': const VehicleCalibrationModeJsonConverter().toJson(
-        instance.calibrationMode,
-      ),
-      'autoRecord': instance.autoRecord,
-      'pairedAdapterMac': instance.pairedAdapterMac,
-      'movementStartThresholdKmh': instance.movementStartThresholdKmh,
-      'disconnectSaveDelaySec': instance.disconnectSaveDelaySec,
-      'backgroundLocationConsent': instance.backgroundLocationConsent,
-      'make': instance.make,
-      'model': instance.model,
-      'year': instance.year,
-      'referenceVehicleId': instance.referenceVehicleId,
-    };
+Map<String, dynamic> _$VehicleProfileToJson(
+  _VehicleProfile instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'name': instance.name,
+  'type': const VehicleTypeJsonConverter().toJson(instance.type),
+  'batteryKwh': instance.batteryKwh,
+  'maxChargingKw': instance.maxChargingKw,
+  'supportedConnectors': const ConnectorTypeSetConverter().toJson(
+    instance.supportedConnectors,
+  ),
+  'chargingPreferences': const ChargingPreferencesJsonConverter().toJson(
+    instance.chargingPreferences,
+  ),
+  'tankCapacityL': instance.tankCapacityL,
+  'preferredFuelType': instance.preferredFuelType,
+  'engineDisplacementCc': instance.engineDisplacementCc,
+  'engineCylinders': instance.engineCylinders,
+  'volumetricEfficiency': instance.volumetricEfficiency,
+  'volumetricEfficiencySamples': instance.volumetricEfficiencySamples,
+  'curbWeightKg': instance.curbWeightKg,
+  'obd2AdapterMac': instance.obd2AdapterMac,
+  'obd2AdapterName': instance.obd2AdapterName,
+  'vin': instance.vin,
+  'calibrationMode': const VehicleCalibrationModeJsonConverter().toJson(
+    instance.calibrationMode,
+  ),
+  'autoRecord': instance.autoRecord,
+  'pairedAdapterMac': instance.pairedAdapterMac,
+  'movementStartThresholdKmh': instance.movementStartThresholdKmh,
+  'disconnectSaveDelaySec': instance.disconnectSaveDelaySec,
+  'backgroundLocationConsent': instance.backgroundLocationConsent,
+  'make': instance.make,
+  'model': instance.model,
+  'year': instance.year,
+  'referenceVehicleId': instance.referenceVehicleId,
+  'tripLengthAggregates': instance.tripLengthAggregates?.toJson(),
+  'speedConsumptionAggregates': instance.speedConsumptionAggregates?.toJson(),
+  'aggregatesUpdatedAt': instance.aggregatesUpdatedAt?.toIso8601String(),
+  'aggregatesTripCount': instance.aggregatesTripCount,
+};

--- a/test/features/vehicle/domain/entities/speed_consumption_histogram_test.dart
+++ b/test/features/vehicle/domain/entities/speed_consumption_histogram_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/speed_consumption_histogram.dart';
+
+/// Pure value-object tests for [SpeedBand] and
+/// [SpeedConsumptionHistogram] (#1193 phase 1).
+void main() {
+  group('SpeedBand', () {
+    test('construct: holds the supplied values, including null maxKmh', () {
+      const band = SpeedBand(
+        minKmh: 110,
+        maxKmh: null,
+        sampleCount: 84,
+        meanLPer100km: 7.8,
+        timeShareFraction: 0.22,
+      );
+      expect(band.minKmh, 110);
+      expect(band.maxKmh, isNull);
+      expect(band.sampleCount, 84);
+      expect(band.meanLPer100km, 7.8);
+      expect(band.timeShareFraction, 0.22);
+    });
+
+    test('value equality: same fields => equal', () {
+      const a = SpeedBand(
+        minKmh: 50,
+        maxKmh: 80,
+        sampleCount: 12,
+        meanLPer100km: 5.4,
+        timeShareFraction: 0.35,
+      );
+      const b = SpeedBand(
+        minKmh: 50,
+        maxKmh: 80,
+        sampleCount: 12,
+        meanLPer100km: 5.4,
+        timeShareFraction: 0.35,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('frozen: copyWith produces a new instance, original untouched', () {
+      const original = SpeedBand(
+        minKmh: 30,
+        maxKmh: 50,
+        sampleCount: 3,
+        meanLPer100km: 6.1,
+        timeShareFraction: 0.1,
+      );
+      final updated = original.copyWith(sampleCount: 4);
+      expect(updated.sampleCount, 4);
+      expect(original.sampleCount, 3);
+      expect(updated, isNot(equals(original)));
+    });
+
+    test('JSON round-trip with finite max preserves equality', () {
+      const original = SpeedBand(
+        minKmh: 0,
+        maxKmh: 30,
+        sampleCount: 250,
+        meanLPer100km: 11.4,
+        timeShareFraction: 0.18,
+      );
+      final json = original.toJson();
+      final restored = SpeedBand.fromJson(json);
+      expect(restored, equals(original));
+    });
+
+    test('JSON round-trip with null maxKmh (open-ended top band)', () {
+      const original = SpeedBand(
+        minKmh: 110,
+        maxKmh: null,
+        sampleCount: 31,
+        meanLPer100km: 8.9,
+        timeShareFraction: 0.07,
+      );
+      final json = original.toJson();
+      expect(json['maxKmh'], isNull);
+      final restored = SpeedBand.fromJson(json);
+      expect(restored, equals(original));
+      expect(restored.maxKmh, isNull);
+    });
+  });
+
+  group('SpeedConsumptionHistogram', () {
+    test('default empty histogram has empty bands list', () {
+      const empty = SpeedConsumptionHistogram();
+      expect(empty.bands, isEmpty);
+    });
+
+    test('value equality across populated bands', () {
+      const a = SpeedConsumptionHistogram(
+        bands: <SpeedBand>[
+          SpeedBand(
+            minKmh: 0,
+            maxKmh: 30,
+            sampleCount: 10,
+            meanLPer100km: 12,
+            timeShareFraction: 0.5,
+          ),
+          SpeedBand(
+            minKmh: 30,
+            maxKmh: 50,
+            sampleCount: 8,
+            meanLPer100km: 7,
+            timeShareFraction: 0.5,
+          ),
+        ],
+      );
+      const b = SpeedConsumptionHistogram(
+        bands: <SpeedBand>[
+          SpeedBand(
+            minKmh: 0,
+            maxKmh: 30,
+            sampleCount: 10,
+            meanLPer100km: 12,
+            timeShareFraction: 0.5,
+          ),
+          SpeedBand(
+            minKmh: 30,
+            maxKmh: 50,
+            sampleCount: 8,
+            meanLPer100km: 7,
+            timeShareFraction: 0.5,
+          ),
+        ],
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('JSON round-trip with full standard band layout', () {
+      const original = SpeedConsumptionHistogram(
+        bands: <SpeedBand>[
+          SpeedBand(
+            minKmh: 0,
+            maxKmh: 30,
+            sampleCount: 200,
+            meanLPer100km: 13.2,
+            timeShareFraction: 0.14,
+          ),
+          SpeedBand(
+            minKmh: 30,
+            maxKmh: 50,
+            sampleCount: 410,
+            meanLPer100km: 8.7,
+            timeShareFraction: 0.28,
+          ),
+          SpeedBand(
+            minKmh: 50,
+            maxKmh: 80,
+            sampleCount: 530,
+            meanLPer100km: 6.4,
+            timeShareFraction: 0.36,
+          ),
+          SpeedBand(
+            minKmh: 80,
+            maxKmh: 110,
+            sampleCount: 220,
+            meanLPer100km: 5.9,
+            timeShareFraction: 0.15,
+          ),
+          SpeedBand(
+            minKmh: 110,
+            maxKmh: null,
+            sampleCount: 95,
+            meanLPer100km: 7.3,
+            timeShareFraction: 0.07,
+          ),
+        ],
+      );
+      final json = original.toJson();
+      final restored = SpeedConsumptionHistogram.fromJson(json);
+      expect(restored, equals(original));
+      expect(restored.bands.length, 5);
+      expect(restored.bands.last.maxKmh, isNull);
+
+      // Time shares roll up to ~1.0 (modulo float rounding) — pin so a
+      // future test-data tweak that breaks this invariant trips.
+      final total = restored.bands
+          .map((b) => b.timeShareFraction)
+          .fold<double>(0, (a, b) => a + b);
+      expect(total, closeTo(1.0, 0.0001));
+    });
+
+    test('JSON round-trip with empty bands (cold-start state)', () {
+      const original = SpeedConsumptionHistogram();
+      final json = original.toJson();
+      final restored = SpeedConsumptionHistogram.fromJson(json);
+      expect(restored, equals(original));
+      expect(restored.bands, isEmpty);
+    });
+
+    test('standardBandTemplate matches documented layout', () {
+      // Pin the canonical layout that the phase-2 aggregator instantiates
+      // from. Order matters because the consumer iterates left-to-right.
+      expect(
+        SpeedConsumptionHistogram.standardBandTemplate,
+        const <(int, int?)>[
+          (0, 30),
+          (30, 50),
+          (50, 80),
+          (80, 110),
+          (110, null),
+        ],
+      );
+    });
+  });
+}

--- a/test/features/vehicle/domain/entities/trip_length_breakdown_test.dart
+++ b/test/features/vehicle/domain/entities/trip_length_breakdown_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/trip_length_breakdown.dart';
+
+/// Pure value-object tests for [TripLengthBucket] and
+/// [TripLengthBreakdown] (#1193 phase 1).
+///
+/// No mocks, no fakes — these are freezed data holders and the only
+/// behaviour to pin is JSON round-trip + value-equality.
+void main() {
+  group('TripLengthBucket', () {
+    test('construct: holds the supplied values verbatim', () {
+      const bucket = TripLengthBucket(
+        tripCount: 4,
+        meanLPer100km: 6.7,
+        totalDistanceKm: 120.5,
+        totalLitres: 8.07,
+      );
+      expect(bucket.tripCount, 4);
+      expect(bucket.meanLPer100km, 6.7);
+      expect(bucket.totalDistanceKm, 120.5);
+      expect(bucket.totalLitres, 8.07);
+    });
+
+    test('value equality: same fields => equal, hashCode matches', () {
+      const a = TripLengthBucket(
+        tripCount: 2,
+        meanLPer100km: 5.5,
+        totalDistanceKm: 30,
+        totalLitres: 1.65,
+      );
+      const b = TripLengthBucket(
+        tripCount: 2,
+        meanLPer100km: 5.5,
+        totalDistanceKm: 30,
+        totalLitres: 1.65,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('frozen: copyWith produces a new instance, original untouched', () {
+      const original = TripLengthBucket(
+        tripCount: 1,
+        meanLPer100km: 7.2,
+        totalDistanceKm: 12,
+        totalLitres: 0.864,
+      );
+      final updated = original.copyWith(tripCount: 5);
+      expect(updated.tripCount, 5);
+      expect(original.tripCount, 1);
+      expect(updated, isNot(equals(original)));
+    });
+
+    test('JSON round-trip preserves equality', () {
+      const original = TripLengthBucket(
+        tripCount: 17,
+        meanLPer100km: 6.83,
+        totalDistanceKm: 982.4,
+        totalLitres: 67.07,
+      );
+      final json = original.toJson();
+      final restored = TripLengthBucket.fromJson(json);
+      expect(restored, equals(original));
+    });
+  });
+
+  group('TripLengthBreakdown', () {
+    test('all buckets null is a valid construction', () {
+      const empty = TripLengthBreakdown();
+      expect(empty.short, isNull);
+      expect(empty.medium, isNull);
+      expect(empty.long, isNull);
+    });
+
+    test('value equality across buckets', () {
+      const bucket = TripLengthBucket(
+        tripCount: 3,
+        meanLPer100km: 6.0,
+        totalDistanceKm: 90,
+        totalLitres: 5.4,
+      );
+      const a = TripLengthBreakdown(short: bucket);
+      const b = TripLengthBreakdown(short: bucket);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('JSON round-trip with all three buckets populated', () {
+      const original = TripLengthBreakdown(
+        short: TripLengthBucket(
+          tripCount: 12,
+          meanLPer100km: 8.4,
+          totalDistanceKm: 90.2,
+          totalLitres: 7.58,
+        ),
+        medium: TripLengthBucket(
+          tripCount: 7,
+          meanLPer100km: 6.1,
+          totalDistanceKm: 220.0,
+          totalLitres: 13.42,
+        ),
+        long: TripLengthBucket(
+          tripCount: 3,
+          meanLPer100km: 5.3,
+          totalDistanceKm: 380.5,
+          totalLitres: 20.17,
+        ),
+      );
+      final json = original.toJson();
+      final restored = TripLengthBreakdown.fromJson(json);
+      expect(restored, equals(original));
+      expect(restored.short, equals(original.short));
+      expect(restored.medium, equals(original.medium));
+      expect(restored.long, equals(original.long));
+    });
+
+    test('JSON round-trip with sparse buckets (medium null) preserves nulls',
+        () {
+      const original = TripLengthBreakdown(
+        short: TripLengthBucket(
+          tripCount: 2,
+          meanLPer100km: 9.0,
+          totalDistanceKm: 18,
+          totalLitres: 1.62,
+        ),
+        long: TripLengthBucket(
+          tripCount: 1,
+          meanLPer100km: 5.0,
+          totalDistanceKm: 110,
+          totalLitres: 5.5,
+        ),
+      );
+      final json = original.toJson();
+      final restored = TripLengthBreakdown.fromJson(json);
+      expect(restored, equals(original));
+      expect(restored.medium, isNull);
+    });
+
+    test('JSON round-trip with all buckets null', () {
+      const original = TripLengthBreakdown();
+      final json = original.toJson();
+      final restored = TripLengthBreakdown.fromJson(json);
+      expect(restored, equals(original));
+    });
+
+    test('cutoff constants match documented values', () {
+      // Phase 2 reads these to classify trips. Pin them so an
+      // accidental edit (e.g. typo to 0.15 km) trips the tests.
+      expect(TripLengthBreakdown.shortMaxKm, 15);
+      expect(TripLengthBreakdown.mediumMaxKm, 50);
+    });
+  });
+}

--- a/test/features/vehicle/domain/entities/vehicle_profile_test.dart
+++ b/test/features/vehicle/domain/entities/vehicle_profile_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/speed_consumption_histogram.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/trip_length_breakdown.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 
 /// Unit tests for the pure freezed [VehicleProfile] entity (Refs #561).
@@ -210,6 +212,105 @@ void main() {
         containsAll(<String>['ccs', 'three_pin']),
       );
       expect(connectors.length, 2);
+    });
+  });
+
+  group('VehicleProfile aggregate fields (#1193 phase 1)', () {
+    test('round-trip with all four new fields populated preserves equality',
+        () {
+      final updatedAt = DateTime.utc(2026, 4, 27, 9, 30);
+      final original = VehicleProfile(
+        id: 'agg-profile',
+        name: 'AggProfile',
+        type: VehicleType.combustion,
+        tripLengthAggregates: const TripLengthBreakdown(
+          short: TripLengthBucket(
+            tripCount: 8,
+            meanLPer100km: 9.4,
+            totalDistanceKm: 64,
+            totalLitres: 6.02,
+          ),
+          medium: TripLengthBucket(
+            tripCount: 4,
+            meanLPer100km: 6.8,
+            totalDistanceKm: 132,
+            totalLitres: 8.98,
+          ),
+          long: TripLengthBucket(
+            tripCount: 2,
+            meanLPer100km: 5.4,
+            totalDistanceKm: 240,
+            totalLitres: 12.96,
+          ),
+        ),
+        speedConsumptionAggregates: const SpeedConsumptionHistogram(
+          bands: <SpeedBand>[
+            SpeedBand(
+              minKmh: 0,
+              maxKmh: 30,
+              sampleCount: 200,
+              meanLPer100km: 12.1,
+              timeShareFraction: 0.18,
+            ),
+            SpeedBand(
+              minKmh: 110,
+              maxKmh: null,
+              sampleCount: 50,
+              meanLPer100km: 7.6,
+              timeShareFraction: 0.12,
+            ),
+          ],
+        ),
+        aggregatesUpdatedAt: updatedAt,
+        aggregatesTripCount: 14,
+      );
+
+      final json = original.toJson();
+      final restored = VehicleProfile.fromJson(json);
+
+      expect(restored, equals(original));
+      expect(restored.tripLengthAggregates, equals(original.tripLengthAggregates));
+      expect(
+        restored.speedConsumptionAggregates,
+        equals(original.speedConsumptionAggregates),
+      );
+      expect(restored.aggregatesUpdatedAt, equals(updatedAt));
+      expect(restored.aggregatesTripCount, 14);
+    });
+
+    test('round-trip with all four new fields null preserves equality '
+        '(backwards compat)', () {
+      const original = VehicleProfile(id: 'no-agg', name: 'NoAgg');
+      // Explicit null for clarity even though they default to null.
+      expect(original.tripLengthAggregates, isNull);
+      expect(original.speedConsumptionAggregates, isNull);
+      expect(original.aggregatesUpdatedAt, isNull);
+      expect(original.aggregatesTripCount, isNull);
+
+      final json = original.toJson();
+      final restored = VehicleProfile.fromJson(json);
+
+      expect(restored, equals(original));
+      expect(restored.tripLengthAggregates, isNull);
+      expect(restored.speedConsumptionAggregates, isNull);
+      expect(restored.aggregatesUpdatedAt, isNull);
+      expect(restored.aggregatesTripCount, isNull);
+    });
+
+    test('legacy JSON without aggregate keys deserializes with nulls', () {
+      // Pre-#1193 Hive payloads simply omit the new keys. freezed's
+      // nullable factory parameters must surface them as null rather
+      // than throwing during fromJson.
+      final json = <String, dynamic>{
+        'id': 'legacy',
+        'name': 'Legacy',
+        'type': 'combustion',
+      };
+      final restored = VehicleProfile.fromJson(json);
+      expect(restored.tripLengthAggregates, isNull);
+      expect(restored.speedConsumptionAggregates, isNull);
+      expect(restored.aggregatesUpdatedAt, isNull);
+      expect(restored.aggregatesTripCount, isNull);
     });
   });
 


### PR DESCRIPTION
Refs #1193 phase 1

## Summary

Phase 1 of #1193: define the freezed value-object schemas
(`TripLengthBreakdown` / `TripLengthBucket` and `SpeedConsumptionHistogram`
/ `SpeedBand`) and add four nullable storage fields to `VehicleProfile`
so the rolling driving-aggregates pipeline has a place to land. No
behaviour, no aggregation, no UI — pure schema.

This phase deliberately ships ahead of #1193's full scope so the sibling
issues #1191 (trip-length analysis) and #1192 (consumption-vs-speed
analysis) have value objects to consume from a single source of truth.

## What's in this PR

- **`lib/features/vehicle/domain/entities/trip_length_breakdown.dart`**
  - `TripLengthBucket` (freezed, json_serializable): `tripCount`,
    `meanLPer100km`, `totalDistanceKm`, `totalLitres` — all required
    non-nullable.
  - `TripLengthBreakdown` (freezed): three independently nullable
    buckets (`short`, `medium`, `long`).
  - Cutoffs documented as `static const` on the breakdown class
    (`shortMaxKm = 15`, `mediumMaxKm = 50`). The classifier itself
    lives in phase 2.

- **`lib/features/vehicle/domain/entities/speed_consumption_histogram.dart`**
  - `SpeedBand` (freezed): half-open `[minKmh, maxKmh)` interval with
    `maxKmh: int?` (null = open-ended top tail), `sampleCount`,
    `meanLPer100km`, `timeShareFraction`.
  - `SpeedConsumptionHistogram` (freezed): `List<SpeedBand> bands`,
    empty list = cold-start signal.
  - `standardBandTemplate` static const documents the canonical
    `[(0,30),(30,50),(50,80),(80,110),(110,null)]` layout the phase-2
    aggregator instantiates from.

- **`lib/features/vehicle/domain/entities/vehicle_profile.dart`**
  - Adds `tripLengthAggregates`, `speedConsumptionAggregates`,
    `aggregatesUpdatedAt`, `aggregatesTripCount` at the end of the
    constructor argument list — nullable; legacy Hive payloads that
    omit the keys deserialize cleanly.
  - `DateTime` field uses the standard json_serializable handling
    matching the existing pattern in `consumption_stats.dart`,
    `charging_station.dart`, and `charging_tariff.dart`.

- **Tests** (53 new assertions across three files):
  - `test/features/vehicle/domain/entities/trip_length_breakdown_test.dart`
    — construction, value equality, copyWith, JSON round-trip with
    populated + sparse + empty buckets, cutoff constants pin.
  - `test/features/vehicle/domain/entities/speed_consumption_histogram_test.dart`
    — same shape, plus `null maxKmh` round-trip, `timeShareFraction`
    sums to 1.0, `standardBandTemplate` shape pin.
  - `test/features/vehicle/domain/entities/vehicle_profile_test.dart`
    extended with three round-trip cases for the new fields:
    populated, all-null, and pre-#1193 legacy JSON missing the keys.

- Generated `.freezed.dart` / `.g.dart` parts for the three entity
  files. Unrelated `riverpod_generator` drift on other `.g.dart`
  files (formatter touch-ups) was reverted to keep the diff focused.

## What's NOT in this PR

- **`vehicle_aggregate_updater.dart`** — the service that reads
  `TripHistoryEntry` + `TripDetailSample` and writes the aggregates
  back to the profile. Phase 2 of #1193.
- **Vehicle profile screen UI section** — the "Driving stats"
  surfacing on `edit_vehicle_screen.dart` / `auto_record_section.dart`.
  Phase 3 of #1193.
- **Carbon dashboard wiring** — once phase 2 lands, the dashboard
  reads the precomputed stats; today it still recomputes on every
  open. Phase 3 of #1193.
- **Closes #1193** — phases 2 and 3 follow; this PR keeps the issue
  open with the `in-progress` label.

## Test plan

- [x] `flutter pub get` succeeds.
- [x] `flutter analyze` — `No issues found!` (plain analyze, covers
      `lib/` + `test/`).
- [x] `flutter test test/features/vehicle/domain/entities/` — 73
      tests pass (incl. all new round-trip cases).
- [x] `flutter test test/features/vehicle/` — 398 tests pass, no
      regression in existing vehicle suite.
- [x] `flutter test test/lint/` — 29 tests pass; static-lint scanners
      clean on the new files (no banned identifiers in comments /
      strings).
- [x] `git diff --stat` confirms only the 12 expected files (3
      entities × source + freezed + g.dart, plus 3 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)