### PR TITLE
refactor(map): extract sub-widget out of route_map_view (Refs #563 phase: route_map_view)

### DIFF
--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -16,7 +16,7 @@ import '../../../search/providers/search_provider.dart';
 import '../../../profile/providers/profile_provider.dart';
 import 'route_best_stops_list.dart';
 import 'route_info_bar.dart';
-import 'route_view_mode_chip.dart';
+import 'route_view_mode_bar.dart';
 import 'station_map_layers.dart';
 
 /// View modes for the route map.
@@ -72,11 +72,26 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
         ? result.route.geometry[midIdx]
         : const LatLng(48.8566, 2.3522);
     final zoom = _zoomForRoute(result.route.distanceKm);
-    final theme = Theme.of(context);
 
     return Column(
       children: [
-        _buildViewModeToggle(theme, l10n, allFuelStations, result),
+        RouteViewModeBar(
+          allStationsSelected: _viewMode == RouteViewMode.allStations,
+          bestStopsSelected: _viewMode == RouteViewMode.bestStops,
+          selectedCount: _selectedStationIds.length,
+          onTapAllStations: () => setState(() {
+            _viewMode = RouteViewMode.allStations;
+            _selectedStationIds.clear();
+          }),
+          onTapBestStops: () => setState(() {
+            _viewMode = RouteViewMode.bestStops;
+            _selectedStationIds.clear();
+            for (final s in _getBestStopStations(allFuelStations, result)) {
+              _selectedStationIds.add(s.id);
+            }
+          }),
+          onOpenSelectedInMaps: () => _openSelectedInMaps(result),
+        ),
         Expanded(
           child: StationMapLayers(
             mapController: widget.mapController,
@@ -118,62 +133,6 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
           onOpenInMaps: () => _openSelectedInMaps(result),
         ),
       ],
-    );
-  }
-  Widget _buildViewModeToggle(
-    ThemeData theme,
-    AppLocalizations? l10n,
-    List<Station> allFuelStations,
-    RouteSearchResult result,
-  ) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      color: theme.colorScheme.surfaceContainerHighest,
-      child: Row(
-        children: [
-          RouteViewModeChip(
-            label: l10n?.allStations ?? 'All stations',
-            icon: Icons.local_gas_station,
-            selected: _viewMode == RouteViewMode.allStations,
-            onTap: () => setState(() {
-              _viewMode = RouteViewMode.allStations;
-              _selectedStationIds.clear();
-            }),
-          ),
-          const SizedBox(width: 8),
-          RouteViewModeChip(
-            label: l10n?.bestStops ?? 'Best stops',
-            icon: Icons.star,
-            selected: _viewMode == RouteViewMode.bestStops,
-            onTap: () => setState(() {
-              _viewMode = RouteViewMode.bestStops;
-              _selectedStationIds.clear();
-              for (final s in _getBestStopStations(allFuelStations, result)) {
-                _selectedStationIds.add(s.id);
-              }
-            }),
-          ),
-          const Spacer(),
-          if (_selectedStationIds.isNotEmpty) ...[
-            Text(
-              '${_selectedStationIds.length}',
-              style: theme.textTheme.bodySmall?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: theme.colorScheme.primary,
-              ),
-            ),
-            const SizedBox(width: 4),
-            IconButton(
-              icon: Icon(Icons.navigation,
-                  size: 18, color: theme.colorScheme.primary),
-              tooltip: l10n?.openInMaps ?? 'Open in Maps',
-              onPressed: () => _openSelectedInMaps(result),
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
-            ),
-          ],
-        ],
-      ),
     );
   }
   Future<void> _showSaveRouteDialog(

--- a/lib/features/map/presentation/widgets/route_view_mode_bar.dart
+++ b/lib/features/map/presentation/widgets/route_view_mode_bar.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import 'route_view_mode_chip.dart';
+
+/// Top bar for the route map: hosts the "All stations" / "Best stops" mode
+/// chips plus the selection-count + open-in-maps shortcut on the trailing
+/// edge.
+///
+/// Extracted from [RouteMapView] so the parent stays under the 300-line
+/// per-file budget. Stateless: the parent owns the selected mode and the
+/// set of selected station ids and just hands the relevant fragments down.
+class RouteViewModeBar extends StatelessWidget {
+  final bool allStationsSelected;
+  final bool bestStopsSelected;
+  final int selectedCount;
+  final VoidCallback onTapAllStations;
+  final VoidCallback onTapBestStops;
+  final VoidCallback onOpenSelectedInMaps;
+
+  const RouteViewModeBar({
+    super.key,
+    required this.allStationsSelected,
+    required this.bestStopsSelected,
+    required this.selectedCount,
+    required this.onTapAllStations,
+    required this.onTapBestStops,
+    required this.onOpenSelectedInMaps,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: Row(
+        children: [
+          RouteViewModeChip(
+            label: l10n?.allStations ?? 'All stations',
+            icon: Icons.local_gas_station,
+            selected: allStationsSelected,
+            onTap: onTapAllStations,
+          ),
+          const SizedBox(width: 8),
+          RouteViewModeChip(
+            label: l10n?.bestStops ?? 'Best stops',
+            icon: Icons.star,
+            selected: bestStopsSelected,
+            onTap: onTapBestStops,
+          ),
+          const Spacer(),
+          if (selectedCount > 0) ...[
+            Text(
+              '$selectedCount',
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+            const SizedBox(width: 4),
+            IconButton(
+              icon: Icon(Icons.navigation,
+                  size: 18, color: theme.colorScheme.primary),
+              tooltip: l10n?.openInMaps ?? 'Open in Maps',
+              onPressed: onOpenSelectedInMaps,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Move the inline `_buildViewModeToggle` builder out of `route_map_view.dart` into a new sibling `route_view_mode_bar.dart`, bringing the parent file under the 300-LOC budget.

The parent `RouteMapView` keeps ownership of `_viewMode` and `_selectedStationIds`. The new stateless `RouteViewModeBar` widget just renders the two mode chips and the trailing selection-count + "open in maps" shortcut, taking the relevant state fragments + callbacks as inputs.

## LOC

| File | Before | After |
|------|--------|-------|
| `route_map_view.dart` | 305 | 264 |
| `route_view_mode_bar.dart` (new) | - | 77 |

## Behavior preservation

- Public API of `RouteMapView` unchanged (same constructor, same children).
- View-mode toggling, station tapping, route polyline rendering — all unchanged.
- All 16 widget tests under `test/features/map/presentation/widgets/route_map_view_test.dart` (including the existing `RouteViewModeChip` tests) still pass.

## Test plan

- [x] `flutter analyze` clean (0 issues)
- [x] `flutter test test/features/map/presentation/widgets/route_map_view_test.dart test/features/map/presentation/widgets/route_view_mode_chip_test.dart` — all 16 tests pass
- [ ] CI runs the full suite

Refs #563 phase: route_map_view