### PR TITLE
refactor(route): extract helper out of route_search_provider (Refs #563 phase: route_search_provider)

### DIFF
--- a/lib/features/route_search/domain/route_search_result.dart
+++ b/lib/features/route_search/domain/route_search_result.dart
@@ -1,0 +1,25 @@
+import '../../search/domain/entities/search_result_item.dart';
+import 'entities/route_info.dart';
+import 'route_search_strategy.dart';
+
+/// State for route-based search: the route itself + stations found along it.
+class RouteSearchResult {
+  final RouteInfo route;
+  final List<SearchResultItem> stations;
+  final String? cheapestId;
+
+  /// Maps segment index to the cheapest station ID within that segment.
+  /// Segments are computed based on [segmentKm] intervals along the route.
+  final Map<int, String>? cheapestPerSegment;
+
+  /// Which strategy was used for this search.
+  final RouteSearchStrategyType strategyType;
+
+  const RouteSearchResult({
+    required this.route,
+    required this.stations,
+    this.cheapestId,
+    this.cheapestPerSegment,
+    this.strategyType = RouteSearchStrategyType.uniform,
+  });
+}

--- a/lib/features/route_search/domain/route_search_strategy_factory.dart
+++ b/lib/features/route_search/domain/route_search_strategy_factory.dart
@@ -1,0 +1,19 @@
+import '../data/strategies/balanced_search_strategy.dart';
+import '../data/strategies/cheapest_search_strategy.dart';
+import '../data/strategies/eco_route_search_strategy.dart';
+import '../data/strategies/uniform_search_strategy.dart';
+import 'route_search_strategy.dart';
+
+/// Factory to get the right strategy implementation.
+RouteSearchStrategy strategyFor(RouteSearchStrategyType type) {
+  switch (type) {
+    case RouteSearchStrategyType.uniform:
+      return UniformSearchStrategy();
+    case RouteSearchStrategyType.cheapest:
+      return CheapestSearchStrategy();
+    case RouteSearchStrategyType.balanced:
+      return BalancedSearchStrategy();
+    case RouteSearchStrategyType.eco:
+      return EcoRouteSearchStrategy();
+  }
+}

--- a/lib/features/route_search/providers/route_search_provider.dart
+++ b/lib/features/route_search/providers/route_search_provider.dart
@@ -14,50 +14,16 @@ import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/search_result_item.dart';
 import '../../profile/providers/profile_provider.dart';
 import '../data/services/routing_service.dart';
-import '../data/strategies/uniform_search_strategy.dart';
-import '../data/strategies/cheapest_search_strategy.dart';
-import '../data/strategies/balanced_search_strategy.dart';
-import '../data/strategies/eco_route_search_strategy.dart';
 import '../domain/entities/route_info.dart';
+import '../domain/route_search_result.dart';
 import '../domain/route_search_strategy.dart';
+import '../domain/route_search_strategy_factory.dart';
+
+// Re-export so existing imports of route_search_provider.dart keep working.
+export '../domain/route_search_result.dart';
+export '../domain/route_search_strategy_factory.dart';
 
 part 'route_search_provider.g.dart';
-
-/// State for route-based search: the route itself + stations found along it.
-class RouteSearchResult {
-  final RouteInfo route;
-  final List<SearchResultItem> stations;
-  final String? cheapestId;
-
-  /// Maps segment index to the cheapest station ID within that segment.
-  /// Segments are computed based on [segmentKm] intervals along the route.
-  final Map<int, String>? cheapestPerSegment;
-
-  /// Which strategy was used for this search.
-  final RouteSearchStrategyType strategyType;
-
-  const RouteSearchResult({
-    required this.route,
-    required this.stations,
-    this.cheapestId,
-    this.cheapestPerSegment,
-    this.strategyType = RouteSearchStrategyType.uniform,
-  });
-}
-
-/// Factory to get the right strategy implementation.
-RouteSearchStrategy strategyFor(RouteSearchStrategyType type) {
-  switch (type) {
-    case RouteSearchStrategyType.uniform:
-      return UniformSearchStrategy();
-    case RouteSearchStrategyType.cheapest:
-      return CheapestSearchStrategy();
-    case RouteSearchStrategyType.balanced:
-      return BalancedSearchStrategy();
-    case RouteSearchStrategyType.eco:
-      return EcoRouteSearchStrategy();
-  }
-}
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///


### PR DESCRIPTION
## Summary

Slim `route_search_provider.dart` (263 LOC) below the **250-LOC provider-file cap** acceptance criterion of #563.

- Extracted `RouteSearchResult` to `lib/features/route_search/domain/route_search_result.dart` (25 LOC)
- Extracted `strategyFor()` factory to `lib/features/route_search/domain/route_search_strategy_factory.dart` (19 LOC)
- Provider re-exports both via `export` directives so existing imports (incl. the generated `route_search_provider.g.dart` and the test file) keep working unchanged.

**LOC**: `route_search_provider.dart` 263 -> **229** (under 250).

No public API change, no `.g.dart` regeneration needed (the part-file references resolve through the re-exports). Behaviour preserved.

Refs #563 phase: route_search_provider

## Test plan

- [x] `flutter analyze` clean (lib + test)
- [x] `flutter test test/features/route_search/providers/` -> 23/23 passed
- [ ] CI runs the full suite