### PR TITLE
feat(vehicle): aggregator service + trip-save hook (#1193 phase 2)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -27,6 +27,7 @@ import '../features/profile/data/repositories/profile_repository.dart';
 import '../features/vehicle/data/reference_vehicle_catalog_provider.dart';
 import '../features/vehicle/data/repositories/vehicle_profile_repository.dart';
 import '../features/vehicle/data/vehicle_profile_migrator.dart';
+import '../features/vehicle/providers/vehicle_aggregate_updater_provider.dart';
 import '../features/widget/data/home_widget_service.dart';
 import '../features/widget/providers/nearest_widget_refresh_provider.dart';
 
@@ -430,6 +431,29 @@ class AppInitializer {
       } catch (e, st) {
         debugPrint(
             'AppInitializer: autoRecordOrchestrator init failed: $e\n$st');
+      }
+    });
+
+    // #1193 phase 2 — wire the vehicle aggregator's `runForVehicle`
+    // hook onto `TripHistoryRepository.onSavedHook` so every saved
+    // trip with a non-null vehicleId triggers a background recompute
+    // of the rolling driving aggregates. Deferred to the post-frame
+    // microtask because the trip-history Hive box is opened during
+    // the storage phase but the Riverpod provider may not have read
+    // it yet — by post-frame the provider graph has settled. Errors
+    // are logged but never block launch (the aggregator is purely an
+    // optimisation; trips still save without it).
+    _deferPostFirstFrame(() async {
+      try {
+        final wired = wireAggregatorIntoTripHistory(container);
+        if (!wired) {
+          debugPrint(
+              'AppInitializer: vehicle aggregator hook deferred — '
+              'trip-history box not open yet');
+        }
+      } catch (e, st) {
+        debugPrint(
+            'AppInitializer: vehicle aggregator wiring failed: $e\n$st');
       }
     });
 

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -144,9 +144,24 @@ class TripHistoryRepository {
   final Box<String> _box;
   final int cap;
 
+  /// Optional hook fired after a successful [save] when the saved
+  /// entry's `vehicleId` is non-null (#1193 phase 2). Production wires
+  /// this from `app_initializer.dart` to dispatch a vehicle-aggregate
+  /// recompute via [VehicleAggregateUpdater]; tests inject a fake to
+  /// observe the call.
+  ///
+  /// IMPORTANT — the hook MUST NOT throw. It's invoked synchronously
+  /// from inside [save] and any throw is caught and logged via
+  /// `errorLogger.log(ErrorLayer.background, ...)` so the save flow is
+  /// never derailed by an aggregator failure. The hook itself should
+  /// fire-and-forget any async work it kicks off (use `unawaited(...)`
+  /// at the call site).
+  void Function(String vehicleId)? onSavedHook;
+
   TripHistoryRepository({
     required Box<String> box,
     this.cap = 100,
+    this.onSavedHook,
   }) : _box = box;
 
   /// Box name used by the production wiring.
@@ -163,6 +178,21 @@ class TripHistoryRepository {
       return;
     }
     await _trim();
+
+    // Fire the post-save hook for vehicle-attributed trips. Wrapped in
+    // a try/catch because the hook is user code (production: an
+    // aggregator dispatch) and a failure there must not propagate up
+    // into the trip-save flow — the trip already persisted. The hook
+    // is responsible for fire-and-forget on its own async work.
+    final vehicleId = entry.vehicleId;
+    final hook = onSavedHook;
+    if (vehicleId != null && hook != null) {
+      try {
+        hook(vehicleId);
+      } catch (e, st) {
+        debugPrint('TripHistoryRepository.save onSavedHook: $e\n$st');
+      }
+    }
   }
 
   /// Return every persisted trip, sorted newest-first. Corrupt

--- a/lib/features/vehicle/data/vehicle_aggregate_updater.dart
+++ b/lib/features/vehicle/data/vehicle_aggregate_updater.dart
@@ -1,0 +1,558 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../core/logging/error_logger.dart';
+import '../../consumption/data/trip_history_repository.dart';
+import '../../consumption/domain/trip_recorder.dart';
+import '../domain/entities/speed_consumption_histogram.dart';
+import '../domain/entities/trip_length_breakdown.dart';
+import 'repositories/vehicle_profile_repository.dart';
+
+/// Per-vehicle minimum trip count below which ALL aggregate fields are
+/// nulled on the profile (matches the issue's "hide section when below
+/// threshold" UI rule from #1193 phase 3).
+const int kMinTripsForAggregates = 5;
+
+/// Below this trip count a length-bucket entry is treated as "not
+/// enough data yet" — the aggregator emits `null` for that bucket
+/// inside the populated [TripLengthBreakdown].
+const int kMinTripsPerLengthBucket = 3;
+
+/// Below this sample count a speed band is excluded from the
+/// histogram's `bands` list. Mirrors the value-object docstring on
+/// [SpeedConsumptionHistogram] which signals "no data yet" by omitting
+/// the band rather than carrying zero values.
+const int kMinSamplesPerSpeedBand = 50;
+
+/// Above this total sample count the aggregation pass runs on a
+/// background isolate via [compute]. The cutoff is a cheap heuristic —
+/// 1000 samples is roughly a 17-minute trip at 1 Hz, which already
+/// pushes the speed-histogram fold past the 16 ms frame budget on a
+/// mid-tier device. Smaller datasets stay inline because the isolate
+/// hand-off itself costs ~10 ms and isn't worth it for short trips.
+const int kComputeOffloadThreshold = 1000;
+
+/// Service that recomputes and persists per-vehicle driving aggregates
+/// (#1193 phase 2).
+///
+/// Owns the trip-save side-effect: every successful
+/// [TripHistoryRepository.save] for a trip with a non-null `vehicleId`
+/// triggers an [updateForVehicle] pass. The trip-save flow is NOT
+/// blocked by this work — the production wiring fire-and-forgets via
+/// `unawaited(...)` and routes any throw through `errorLogger.log`
+/// (foreground path). See [VehicleAggregateUpdater.runForVehicle].
+///
+/// Phase-2 scope: pure aggregation + persistence. The vehicle-profile
+/// UI section that reads these fields is deferred to phase 3.
+class VehicleAggregateUpdater {
+  final VehicleProfileRepository _vehicleRepo;
+  final TripHistoryRepository? Function() _tripRepoLookup;
+
+  /// Test-injectable clock so the "wrote `aggregatesUpdatedAt`" check
+  /// can assert an exact timestamp without racing real wall-clock time.
+  /// Defaults to [DateTime.now] in production.
+  final DateTime Function() _now;
+
+  VehicleAggregateUpdater({
+    required VehicleProfileRepository vehicleRepo,
+    required TripHistoryRepository? Function() tripRepoLookup,
+    DateTime Function()? now,
+  })  : _vehicleRepo = vehicleRepo,
+        _tripRepoLookup = tripRepoLookup,
+        _now = now ?? DateTime.now;
+
+  /// Full recompute for [vehicleId]. Loads the vehicle's trip history
+  /// from the repository, classifies each trip by length, derives both
+  /// aggregates from the persisted samples, and writes them back to
+  /// the profile.
+  ///
+  /// Source of truth — [foldInTrip] is an approximation that converges
+  /// on this output for the per-bin means and matches it exactly for
+  /// the sums and counts. Call this from the trip-save hook (cheap
+  /// because the trip count is bounded by the rolling-log cap of 100)
+  /// or from a one-off "recompute everything" admin action.
+  ///
+  /// No-op when:
+  ///   * the trip-history box isn't open (cold-start path before Hive
+  ///     has finished initialising — the next save will retry);
+  ///   * the vehicle isn't found in [VehicleProfileRepository];
+  ///   * the vehicle has fewer than [kMinTripsForAggregates] trips
+  ///     (nulls every aggregate field — consistent with the UI rule).
+  Future<void> updateForVehicle(String vehicleId) async {
+    final tripRepo = _tripRepoLookup();
+    if (tripRepo == null) return;
+    final profile = _vehicleRepo.getById(vehicleId);
+    if (profile == null) return;
+
+    final allTrips = tripRepo.loadAll();
+    final trips =
+        allTrips.where((t) => t.vehicleId == vehicleId).toList(growable: false);
+
+    if (trips.length < kMinTripsForAggregates) {
+      // Below threshold — null everything so the UI hides the section.
+      // This is the lazy-migration path: a vehicle that has 4 trips
+      // today and lands its 5th tomorrow will go from null aggregates
+      // to populated ones in one trip-save cycle.
+      await _vehicleRepo.save(profile.copyWith(
+        tripLengthAggregates: null,
+        speedConsumptionAggregates: null,
+        aggregatesUpdatedAt: _now(),
+        aggregatesTripCount: trips.length,
+      ));
+      return;
+    }
+
+    // Flatten samples once. The aggregator works on a single list so
+    // the `compute()` heuristic can decide based on total volume — no
+    // need to re-walk the trips just to count samples.
+    final samples = <TripSample>[];
+    for (final t in trips) {
+      samples.addAll(t.samples);
+    }
+
+    // The pure functions are isolate-safe. For datasets above the
+    // threshold we hop to a background isolate via [compute]; smaller
+    // sets stay on the calling isolate because the hop itself costs
+    // ~10 ms which dominates the math for short trips.
+    late final TripLengthBreakdown lengthBreakdown;
+    late final SpeedConsumptionHistogram speedHistogram;
+    if (samples.length > kComputeOffloadThreshold) {
+      final result =
+          await compute(_aggregateBoth, _AggregateInput(trips, samples));
+      lengthBreakdown = result.lengthBreakdown;
+      speedHistogram = result.speedHistogram;
+    } else {
+      lengthBreakdown = aggregateByTripLength(trips);
+      speedHistogram = aggregateSpeedConsumption(samples);
+    }
+
+    await _vehicleRepo.save(profile.copyWith(
+      tripLengthAggregates: lengthBreakdown,
+      speedConsumptionAggregates: speedHistogram,
+      aggregatesUpdatedAt: _now(),
+      aggregatesTripCount: trips.length,
+    ));
+  }
+
+  /// Incremental fold of one freshly-saved trip into the existing
+  /// aggregates.
+  ///
+  /// Exact for sums + counts (a sum is a sum), approximate but
+  /// converges for per-bin means via Welford-style updates. The full
+  /// recompute in [updateForVehicle] is the source of truth — call
+  /// this when you want a cheap "I just saved trip N+1" update without
+  /// re-scanning N+1 trips, then schedule a full recompute on a slower
+  /// cadence (e.g. once per app launch) to refresh against drift.
+  ///
+  /// Same below-threshold guard as [updateForVehicle]: if the new trip
+  /// pushes the count to or above [kMinTripsForAggregates] this routes
+  /// through a full recompute (we need at least one populated bucket
+  /// before incremental can take over). Below threshold, the profile's
+  /// aggregate fields stay null and only [aggregatesTripCount] /
+  /// [aggregatesUpdatedAt] are bumped.
+  Future<void> foldInTrip(
+    String vehicleId,
+    TripHistoryEntry trip,
+    List<TripSample> samples,
+  ) async {
+    final profile = _vehicleRepo.getById(vehicleId);
+    if (profile == null) return;
+
+    final newCount = (profile.aggregatesTripCount ?? 0) + 1;
+
+    if (newCount < kMinTripsForAggregates ||
+        profile.tripLengthAggregates == null ||
+        profile.speedConsumptionAggregates == null) {
+      // Either we are still below the visibility threshold, or the
+      // priors don't exist yet (first time reaching threshold). The
+      // full recompute path handles both correctly.
+      await updateForVehicle(vehicleId);
+      return;
+    }
+
+    final nextLength =
+        foldTripLengthIncremental(profile.tripLengthAggregates, trip);
+    final nextSpeed =
+        foldSpeedConsumptionIncremental(profile.speedConsumptionAggregates,
+            samples);
+
+    await _vehicleRepo.save(profile.copyWith(
+      tripLengthAggregates: nextLength,
+      speedConsumptionAggregates: nextSpeed,
+      aggregatesUpdatedAt: _now(),
+      aggregatesTripCount: newCount,
+    ));
+  }
+
+  /// Trip-save hook entry point. Routes a saved trip through
+  /// [updateForVehicle] and never throws — observability errors are
+  /// logged via `errorLogger.log(ErrorLayer.background, ...)` so they
+  /// land in the same telemetry pipeline as foreground errors without
+  /// derailing the trip-save caller.
+  ///
+  /// Production wiring uses this with `unawaited(...)`; tests can
+  /// `await` it directly.
+  Future<void> runForVehicle(String vehicleId) async {
+    try {
+      await updateForVehicle(vehicleId);
+    } catch (e, st) {
+      // The trip already saved — losing one aggregate refresh shouldn't
+      // surface to the user. The next save (or app launch) will refresh
+      // again.
+      await errorLogger.log(
+        ErrorLayer.background,
+        e,
+        st,
+        context: <String, Object?>{
+          'op': 'VehicleAggregateUpdater.updateForVehicle',
+          'vehicleId': vehicleId,
+        },
+      );
+    }
+  }
+}
+
+/// Input bundle for the [compute] hop in [updateForVehicle].
+class _AggregateInput {
+  final List<TripHistoryEntry> trips;
+  final List<TripSample> samples;
+  const _AggregateInput(this.trips, this.samples);
+}
+
+/// Output bundle for the [compute] hop in [updateForVehicle].
+class _AggregateOutput {
+  final TripLengthBreakdown lengthBreakdown;
+  final SpeedConsumptionHistogram speedHistogram;
+  const _AggregateOutput(this.lengthBreakdown, this.speedHistogram);
+}
+
+/// Top-level isolate entry — must be a top-level / static function for
+/// [compute].
+_AggregateOutput _aggregateBoth(_AggregateInput input) => _AggregateOutput(
+      aggregateByTripLength(input.trips),
+      aggregateSpeedConsumption(input.samples),
+    );
+
+/// Pure: classify [trips] by length into short / medium / long buckets
+/// per the cutoffs on [TripLengthBreakdown] and emit the per-bucket
+/// stats.
+///
+/// Distance-weighted mean is used for `meanLPer100km`:
+///   `meanLPer100km = totalLitres / totalDistanceKm * 100`
+///
+/// That's the right denominator for "average consumption across these
+/// trips" — a 1 km trip and a 100 km trip should not contribute equally
+/// to the bucket's average (the longer one is more representative of
+/// steady-state consumption).
+///
+/// Trips with `fuelLitersConsumed == null` (cars without PID 5E /
+/// MAF) are still counted toward `tripCount` and `totalDistanceKm`
+/// but contribute zero litres to the bucket — the resulting mean
+/// under-states real consumption proportionally to the no-fuel-data
+/// share. Documented here so a future PR that backs into per-vehicle
+/// fuel-rate fallbacks (#812 / #874) can revise the rule explicitly.
+///
+/// Buckets with fewer than [kMinTripsPerLengthBucket] trips are
+/// returned as `null` on the [TripLengthBreakdown] — the parent value
+/// object distinguishes "not enough data" from "exactly zero" via that
+/// nullability.
+TripLengthBreakdown aggregateByTripLength(List<TripHistoryEntry> trips) {
+  var shortCount = 0;
+  var shortDist = 0.0;
+  var shortLitres = 0.0;
+
+  var mediumCount = 0;
+  var mediumDist = 0.0;
+  var mediumLitres = 0.0;
+
+  var longCount = 0;
+  var longDist = 0.0;
+  var longLitres = 0.0;
+
+  for (final trip in trips) {
+    final km = trip.summary.distanceKm;
+    final litres = trip.summary.fuelLitersConsumed ?? 0.0;
+    if (km < TripLengthBreakdown.shortMaxKm) {
+      shortCount++;
+      shortDist += km;
+      shortLitres += litres;
+    } else if (km < TripLengthBreakdown.mediumMaxKm) {
+      mediumCount++;
+      mediumDist += km;
+      mediumLitres += litres;
+    } else {
+      longCount++;
+      longDist += km;
+      longLitres += litres;
+    }
+  }
+
+  return TripLengthBreakdown(
+    short: _bucketOrNull(shortCount, shortDist, shortLitres),
+    medium: _bucketOrNull(mediumCount, mediumDist, mediumLitres),
+    long: _bucketOrNull(longCount, longDist, longLitres),
+  );
+}
+
+TripLengthBucket? _bucketOrNull(
+  int count,
+  double totalKm,
+  double totalLitres,
+) {
+  if (count < kMinTripsPerLengthBucket) return null;
+  final mean = totalKm > 0 ? totalLitres / totalKm * 100.0 : 0.0;
+  return TripLengthBucket(
+    tripCount: count,
+    meanLPer100km: mean,
+    totalDistanceKm: totalKm,
+    totalLitres: totalLitres,
+  );
+}
+
+/// Pure: bin [samples] by speed band per
+/// [SpeedConsumptionHistogram.standardBandTemplate] and emit the
+/// per-band stats.
+///
+/// Sample model — the `TripSample` carried by `TripHistoryEntry.samples`
+/// (#1040) holds:
+///   * `speedKmh` (always populated — band classifier reads this)
+///   * `fuelRateLPerHour` (nullable — populated when the car answers
+///     PID 5E or the MAF / speed-density fallback yields a value).
+///
+/// Per-band mean L/100 km is computed by integrating fuel-rate over
+/// time and distance over time, then `Σlitres / Σkm * 100`. Samples
+/// without a fuel-rate reading still count toward [SpeedBand.sampleCount]
+/// and [SpeedBand.timeShareFraction] (they were observed driving in
+/// that band), but contribute zero litres and zero km — same caveat as
+/// the trip-length aggregator.
+///
+/// Time accounting uses a 1 Hz nominal cadence: each sample is treated
+/// as one second of observed driving. The chart cadence is actually
+/// "whatever the OBD2 polling loop sustains" (1-2 Hz), but the same
+/// share-of-time is preserved across bands as long as cadence stays
+/// roughly consistent within a trip. A future revision can integrate
+/// real Δt between consecutive samples — the schema keeps that path
+/// open via `timestamp`. Documented honestly here.
+///
+/// Bands with fewer than [kMinSamplesPerSpeedBand] samples are omitted
+/// from the result's [SpeedConsumptionHistogram.bands] list (rather
+/// than carrying zero values) — see the value-object docstring.
+SpeedConsumptionHistogram aggregateSpeedConsumption(List<TripSample> samples) {
+  if (samples.isEmpty) {
+    return const SpeedConsumptionHistogram();
+  }
+
+  // Per-band running totals, indexed by band template position.
+  const template = SpeedConsumptionHistogram.standardBandTemplate;
+  final counts = List<int>.filled(template.length, 0);
+  final litres = List<double>.filled(template.length, 0.0);
+  final km = List<double>.filled(template.length, 0.0);
+
+  // 1 Hz nominal — each sample counts as 1 s of observed driving for
+  // litres + km integration. Documented in the function docstring.
+  const double dtSec = 1.0;
+
+  var totalCount = 0;
+  for (final s in samples) {
+    final idx = _classifySpeed(s.speedKmh, template);
+    if (idx < 0) continue; // negative speed — skip defensively.
+    counts[idx]++;
+    totalCount++;
+    final rate = s.fuelRateLPerHour;
+    if (rate != null) {
+      litres[idx] += rate * dtSec / 3600.0;
+    }
+    km[idx] += s.speedKmh * dtSec / 3600.0;
+  }
+
+  if (totalCount == 0) {
+    return const SpeedConsumptionHistogram();
+  }
+
+  final bands = <SpeedBand>[];
+  for (var i = 0; i < template.length; i++) {
+    if (counts[i] < kMinSamplesPerSpeedBand) continue;
+    final mean = km[i] > 0 ? litres[i] / km[i] * 100.0 : 0.0;
+    bands.add(SpeedBand(
+      minKmh: template[i].$1,
+      maxKmh: template[i].$2,
+      sampleCount: counts[i],
+      meanLPer100km: mean,
+      timeShareFraction: counts[i] / totalCount,
+    ));
+  }
+
+  return SpeedConsumptionHistogram(bands: bands);
+}
+
+/// Index of the band in [template] that contains [speedKmh] under the
+/// half-open `[min, max)` convention (with the top band open-ended).
+/// Returns `-1` for negative input — defensive against corrupt
+/// samples.
+int _classifySpeed(double speedKmh, List<(int, int?)> template) {
+  if (speedKmh < 0) return -1;
+  for (var i = 0; i < template.length; i++) {
+    final (lo, hi) = template[i];
+    if (speedKmh >= lo && (hi == null || speedKmh < hi)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/// Welford-style fold of one new trip into an existing
+/// [TripLengthBreakdown]. Exact for sums + counts; the per-bucket
+/// `meanLPer100km` is rederived from the running totals each time, so
+/// it tracks the closed-form aggregator output bit-for-bit when no
+/// trips are dropped from the rolling log between folds.
+///
+/// Returns a new immutable breakdown — the input is left untouched.
+/// `null` input is allowed (cold-start case): the new trip seeds its
+/// own bucket and the other two stay null until they cross the
+/// per-bucket threshold via subsequent folds.
+TripLengthBreakdown foldTripLengthIncremental(
+  TripLengthBreakdown? prior,
+  TripHistoryEntry newTrip,
+) {
+  final base = prior ?? const TripLengthBreakdown();
+  final km = newTrip.summary.distanceKm;
+  final litres = newTrip.summary.fuelLitersConsumed ?? 0.0;
+
+  if (km < TripLengthBreakdown.shortMaxKm) {
+    return base.copyWith(
+      short: _foldBucket(base.short, km, litres),
+    );
+  }
+  if (km < TripLengthBreakdown.mediumMaxKm) {
+    return base.copyWith(
+      medium: _foldBucket(base.medium, km, litres),
+    );
+  }
+  return base.copyWith(
+    long: _foldBucket(base.long, km, litres),
+  );
+}
+
+TripLengthBucket _foldBucket(
+  TripLengthBucket? prior,
+  double km,
+  double litres,
+) {
+  final priorCount = prior?.tripCount ?? 0;
+  final priorKm = prior?.totalDistanceKm ?? 0.0;
+  final priorLitres = prior?.totalLitres ?? 0.0;
+  final newCount = priorCount + 1;
+  final newKm = priorKm + km;
+  final newLitres = priorLitres + litres;
+  final newMean = newKm > 0 ? newLitres / newKm * 100.0 : 0.0;
+  return TripLengthBucket(
+    tripCount: newCount,
+    meanLPer100km: newMean,
+    totalDistanceKm: newKm,
+    totalLitres: newLitres,
+  );
+}
+
+/// Welford-style fold of newly-arrived [newSamples] into an existing
+/// [SpeedConsumptionHistogram]. The per-band running mean is updated
+/// via Welford recurrence (ratio of running litres / running km),
+/// which is exact when both running denominators come from the same
+/// underlying samples — which is our case. Per-band sample counts and
+/// time shares are exact.
+///
+/// `null` input is allowed; new bands are seeded as samples arrive.
+/// Bands that don't yet meet [kMinSamplesPerSpeedBand] are kept in the
+/// internal accumulator but omitted from the returned
+/// [SpeedConsumptionHistogram.bands] list — same exclusion rule as
+/// [aggregateSpeedConsumption], so the incremental and full-recompute
+/// outputs are interchangeable from the consumer's point of view.
+///
+/// IMPORTANT — reconstructing per-band running totals from a
+/// [SpeedConsumptionHistogram] is lossy: bands below threshold were
+/// excluded from the prior, so this function CANNOT recover their
+/// counters by reading [prior] alone. The first incremental fold over
+/// a band that was previously below threshold will start its counter
+/// from zero on the new samples only. Callers that need exact
+/// continuity across the threshold boundary should run [updateForVehicle]
+/// instead — that's the source of truth for a reason.
+SpeedConsumptionHistogram foldSpeedConsumptionIncremental(
+  SpeedConsumptionHistogram? prior,
+  List<TripSample> newSamples,
+) {
+  const template = SpeedConsumptionHistogram.standardBandTemplate;
+  final counts = List<int>.filled(template.length, 0);
+  final litres = List<double>.filled(template.length, 0.0);
+  final km = List<double>.filled(template.length, 0.0);
+
+  // Seed from prior (lossy — see docstring). Bands below threshold
+  // simply don't appear in `prior.bands` and start at zero here.
+  if (prior != null) {
+    for (final band in prior.bands) {
+      final i = _bandIndex(band.minKmh, band.maxKmh, template);
+      if (i < 0) continue;
+      counts[i] = band.sampleCount;
+      // Reconstruct litres / km from the persisted mean. We don't
+      // store litres directly on SpeedBand (it's not on the schema),
+      // so we lean on `meanLPer100km` × an implied km derived from
+      // sample count × nominal time. Keep this in sync with the time
+      // model in [aggregateSpeedConsumption].
+      const double dtSec = 1.0;
+      // Rough km estimate from the band's midpoint; for the
+      // open-ended top band use the lower bound as a conservative
+      // anchor.
+      final midpoint = band.maxKmh == null
+          ? band.minKmh.toDouble()
+          : (band.minKmh + band.maxKmh!) / 2.0;
+      km[i] = midpoint * band.sampleCount * dtSec / 3600.0;
+      litres[i] = band.meanLPer100km * km[i] / 100.0;
+    }
+  }
+
+  const double dtSec = 1.0;
+  var totalCount = 0;
+  for (var i = 0; i < counts.length; i++) {
+    totalCount += counts[i];
+  }
+
+  for (final s in newSamples) {
+    final idx = _classifySpeed(s.speedKmh, template);
+    if (idx < 0) continue;
+    counts[idx]++;
+    totalCount++;
+    final rate = s.fuelRateLPerHour;
+    if (rate != null) {
+      litres[idx] += rate * dtSec / 3600.0;
+    }
+    km[idx] += s.speedKmh * dtSec / 3600.0;
+  }
+
+  if (totalCount == 0) {
+    return const SpeedConsumptionHistogram();
+  }
+
+  final bands = <SpeedBand>[];
+  for (var i = 0; i < template.length; i++) {
+    if (counts[i] < kMinSamplesPerSpeedBand) continue;
+    final mean = km[i] > 0 ? litres[i] / km[i] * 100.0 : 0.0;
+    bands.add(SpeedBand(
+      minKmh: template[i].$1,
+      maxKmh: template[i].$2,
+      sampleCount: counts[i],
+      meanLPer100km: mean,
+      timeShareFraction: counts[i] / totalCount,
+    ));
+  }
+
+  return SpeedConsumptionHistogram(bands: bands);
+}
+
+/// Look up the template index for a band described by [minKmh] /
+/// [maxKmh]. Returns `-1` when no template entry matches — usually a
+/// sign that the schema has been bumped between releases.
+int _bandIndex(int minKmh, int? maxKmh, List<(int, int?)> template) {
+  for (var i = 0; i < template.length; i++) {
+    if (template[i].$1 == minKmh && template[i].$2 == maxKmh) return i;
+  }
+  return -1;
+}

--- a/lib/features/vehicle/providers/vehicle_aggregate_updater_provider.dart
+++ b/lib/features/vehicle/providers/vehicle_aggregate_updater_provider.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../consumption/providers/trip_history_provider.dart';
+import '../data/vehicle_aggregate_updater.dart';
+import 'vehicle_providers.dart';
+
+part 'vehicle_aggregate_updater_provider.g.dart';
+
+/// Riverpod-managed instance of [VehicleAggregateUpdater] (#1193 phase 2).
+///
+/// `keepAlive: true` so the production wiring can `ref.read` it once
+/// from `app_initializer.dart`, install it as the
+/// `TripHistoryRepository.onSavedHook`, and let it live for the rest
+/// of the app session. Tests override it with a fake updater that
+/// records calls.
+@Riverpod(keepAlive: true)
+VehicleAggregateUpdater vehicleAggregateUpdater(Ref ref) {
+  final vehicleRepo = ref.watch(vehicleProfileRepositoryProvider);
+  return VehicleAggregateUpdater(
+    vehicleRepo: vehicleRepo,
+    tripRepoLookup: () => ref.read(tripHistoryRepositoryProvider),
+  );
+}
+
+/// Idempotent wiring step: install the aggregator's
+/// `runForVehicle` as the trip-history repository's `onSavedHook`.
+///
+/// Called from `app_initializer.dart` once after the root container
+/// is built. Returns `true` when the hook was wired, `false` when the
+/// trip-history box isn't open yet (cold-start path before Hive has
+/// finished initialising — the next call retries).
+///
+/// Takes a [ProviderContainer] (not a [Ref]) so it can be invoked
+/// from outside any provider's `build` — `app_initializer` owns the
+/// root container directly.
+///
+/// Lives on the provider file rather than as a method on
+/// [VehicleAggregateUpdater] because the dependency direction is
+/// "wire-up code reads providers"; the updater itself shouldn't
+/// import the trip-history provider.
+bool wireAggregatorIntoTripHistory(ProviderContainer container) {
+  final tripRepo = container.read(tripHistoryRepositoryProvider);
+  if (tripRepo == null) return false;
+  final updater = container.read(vehicleAggregateUpdaterProvider);
+  // Fire-and-forget; the hook itself stays sync (the repo passes a
+  // `void Function`), and `runForVehicle` swallows + logs every
+  // failure so this is safe.
+  tripRepo.onSavedHook = (vehicleId) {
+    unawaited(updater.runForVehicle(vehicleId));
+  };
+  return true;
+}

--- a/lib/features/vehicle/providers/vehicle_aggregate_updater_provider.g.dart
+++ b/lib/features/vehicle/providers/vehicle_aggregate_updater_provider.g.dart
@@ -1,0 +1,80 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vehicle_aggregate_updater_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Riverpod-managed instance of [VehicleAggregateUpdater] (#1193 phase 2).
+///
+/// `keepAlive: true` so the production wiring can `ref.read` it once
+/// from `app_initializer.dart`, install it as the
+/// `TripHistoryRepository.onSavedHook`, and let it live for the rest
+/// of the app session. Tests override it with a fake updater that
+/// records calls.
+
+@ProviderFor(vehicleAggregateUpdater)
+final vehicleAggregateUpdaterProvider = VehicleAggregateUpdaterProvider._();
+
+/// Riverpod-managed instance of [VehicleAggregateUpdater] (#1193 phase 2).
+///
+/// `keepAlive: true` so the production wiring can `ref.read` it once
+/// from `app_initializer.dart`, install it as the
+/// `TripHistoryRepository.onSavedHook`, and let it live for the rest
+/// of the app session. Tests override it with a fake updater that
+/// records calls.
+
+final class VehicleAggregateUpdaterProvider
+    extends
+        $FunctionalProvider<
+          VehicleAggregateUpdater,
+          VehicleAggregateUpdater,
+          VehicleAggregateUpdater
+        >
+    with $Provider<VehicleAggregateUpdater> {
+  /// Riverpod-managed instance of [VehicleAggregateUpdater] (#1193 phase 2).
+  ///
+  /// `keepAlive: true` so the production wiring can `ref.read` it once
+  /// from `app_initializer.dart`, install it as the
+  /// `TripHistoryRepository.onSavedHook`, and let it live for the rest
+  /// of the app session. Tests override it with a fake updater that
+  /// records calls.
+  VehicleAggregateUpdaterProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'vehicleAggregateUpdaterProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$vehicleAggregateUpdaterHash();
+
+  @$internal
+  @override
+  $ProviderElement<VehicleAggregateUpdater> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  VehicleAggregateUpdater create(Ref ref) {
+    return vehicleAggregateUpdater(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(VehicleAggregateUpdater value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<VehicleAggregateUpdater>(value),
+    );
+  }
+}
+
+String _$vehicleAggregateUpdaterHash() =>
+    r'add2aed16bb557bda4e398e4a9ed1845873dd5f2';

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -158,4 +158,77 @@ void main() {
       expect(all.first.summary.endedAt, isNull);
     });
   });
+
+  group('TripHistoryRepository.onSavedHook (#1193 phase 2)', () {
+    test(
+        'save() invokes onSavedHook with the saved entry vehicleId', () async {
+      final hookCalls = <String>[];
+      final repo = TripHistoryRepository(
+        box: box,
+        onSavedHook: hookCalls.add,
+      );
+      final start = DateTime(2026, 4, 21);
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: 'car-a',
+        summary: mkSummary(startedAt: start),
+      ));
+      expect(hookCalls, ['car-a']);
+    });
+
+    test(
+        'save() does NOT invoke onSavedHook when vehicleId is null '
+        '— orphan trips are out of scope for the aggregator', () async {
+      final hookCalls = <String>[];
+      final repo = TripHistoryRepository(
+        box: box,
+        onSavedHook: hookCalls.add,
+      );
+      final start = DateTime(2026, 4, 21);
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+      ));
+      expect(hookCalls, isEmpty);
+    });
+
+    test(
+        'a throwing onSavedHook does NOT make save() rethrow — the trip '
+        'has already persisted, the aggregator failure must not derail '
+        'the trip-stop flow', () async {
+      final repo = TripHistoryRepository(
+        box: box,
+        onSavedHook: (_) => throw StateError('aggregator boom'),
+      );
+      final start = DateTime(2026, 4, 21);
+      // Must complete without throwing.
+      await expectLater(
+        repo.save(TripHistoryEntry(
+          id: start.toIso8601String(),
+          vehicleId: 'car-a',
+          summary: mkSummary(startedAt: start),
+        )),
+        completes,
+      );
+      // And the trip must still be persisted — the hook fires AFTER
+      // the put, so a hook throw doesn't roll back the storage write.
+      expect(repo.loadAll(), hasLength(1));
+    });
+
+    test('onSavedHook is mutable post-construction (production wiring path)',
+        () async {
+      final repo = TripHistoryRepository(box: box);
+      final hookCalls = <String>[];
+      repo.onSavedHook = hookCalls.add;
+
+      final start = DateTime(2026, 4, 21);
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: 'car-b',
+        summary: mkSummary(startedAt: start),
+      ));
+      expect(hookCalls, ['car-b']);
+    });
+  });
 }

--- a/test/features/vehicle/data/vehicle_aggregate_updater_test.dart
+++ b/test/features/vehicle/data/vehicle_aggregate_updater_test.dart
@@ -1,0 +1,552 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/data/vehicle_aggregate_updater.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/speed_consumption_histogram.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/trip_length_breakdown.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+/// Builds a [TripHistoryEntry] with the minimum metadata the aggregator
+/// looks at: distance, fuel, vehicle id. Other summary fields default
+/// to zero / null so the test reads at the call site.
+TripHistoryEntry _trip({
+  required String id,
+  required String vehicleId,
+  required double km,
+  double? litres,
+  List<TripSample> samples = const [],
+}) {
+  return TripHistoryEntry(
+    id: id,
+    vehicleId: vehicleId,
+    summary: TripSummary(
+      distanceKm: km,
+      maxRpm: 0,
+      highRpmSeconds: 0,
+      idleSeconds: 0,
+      harshBrakes: 0,
+      harshAccelerations: 0,
+      fuelLitersConsumed: litres,
+      avgLPer100Km: (litres != null && km > 0) ? litres / km * 100 : null,
+      startedAt: DateTime(2026, 4, 1).add(Duration(minutes: int.parse(id))),
+    ),
+    samples: samples,
+  );
+}
+
+TripSample _sample({double speedKmh = 50, double? fuelRateLPerHour}) {
+  return TripSample(
+    timestamp: DateTime(2026, 4, 1),
+    speedKmh: speedKmh,
+    rpm: 1500,
+    fuelRateLPerHour: fuelRateLPerHour,
+  );
+}
+
+void main() {
+  group('aggregateByTripLength (#1193 phase 2)', () {
+    test(
+        '3 short + 4 medium + 2 long trips → expected breakdown; '
+        'long bucket below threshold becomes null', () {
+      final trips = <TripHistoryEntry>[
+        // 3 shorts at 5/8/12 km, 0.5/0.7/1.0 L
+        _trip(id: '1', vehicleId: 'v', km: 5, litres: 0.5),
+        _trip(id: '2', vehicleId: 'v', km: 8, litres: 0.7),
+        _trip(id: '3', vehicleId: 'v', km: 12, litres: 1.0),
+        // 4 mediums at 20/25/30/40 km, 1.5/2.0/2.4/3.0 L
+        _trip(id: '4', vehicleId: 'v', km: 20, litres: 1.5),
+        _trip(id: '5', vehicleId: 'v', km: 25, litres: 2.0),
+        _trip(id: '6', vehicleId: 'v', km: 30, litres: 2.4),
+        _trip(id: '7', vehicleId: 'v', km: 40, litres: 3.0),
+        // 2 longs (below the 3-trip threshold so this bucket is null)
+        _trip(id: '8', vehicleId: 'v', km: 60, litres: 4.0),
+        _trip(id: '9', vehicleId: 'v', km: 100, litres: 7.0),
+      ];
+
+      final result = aggregateByTripLength(trips);
+
+      expect(result.short, isNotNull);
+      expect(result.short!.tripCount, 3);
+      expect(result.short!.totalDistanceKm, closeTo(25, 1e-9));
+      expect(result.short!.totalLitres, closeTo(2.2, 1e-9));
+      expect(result.short!.meanLPer100km, closeTo(2.2 / 25 * 100, 1e-9));
+
+      expect(result.medium, isNotNull);
+      expect(result.medium!.tripCount, 4);
+      expect(result.medium!.totalDistanceKm, closeTo(115, 1e-9));
+      expect(result.medium!.totalLitres, closeTo(8.9, 1e-9));
+      expect(result.medium!.meanLPer100km, closeTo(8.9 / 115 * 100, 1e-9));
+
+      // Long has only 2 trips → below per-bucket threshold → null
+      expect(result.long, isNull);
+    });
+
+    test('empty trip list → all buckets null', () {
+      final result = aggregateByTripLength(const []);
+      expect(result.short, isNull);
+      expect(result.medium, isNull);
+      expect(result.long, isNull);
+    });
+
+    test(
+        'trips without fuelLitersConsumed still count toward the bucket '
+        'but contribute zero litres — documented under-statement', () {
+      final trips = <TripHistoryEntry>[
+        _trip(id: '1', vehicleId: 'v', km: 5, litres: null),
+        _trip(id: '2', vehicleId: 'v', km: 5, litres: null),
+        _trip(id: '3', vehicleId: 'v', km: 5, litres: 0.5),
+      ];
+      final result = aggregateByTripLength(trips);
+      expect(result.short!.tripCount, 3);
+      expect(result.short!.totalDistanceKm, closeTo(15, 1e-9));
+      expect(result.short!.totalLitres, closeTo(0.5, 1e-9));
+    });
+  });
+
+  group('aggregateSpeedConsumption (#1193 phase 2)', () {
+    test(
+        'samples spanning multiple bands above threshold → expected histogram; '
+        'sparse band excluded', () {
+      final samples = <TripSample>[
+        // Band (0,30): 60 samples (above 50) — fuel rate 1.0 L/h
+        for (var i = 0; i < 60; i++) _sample(speedKmh: 20, fuelRateLPerHour: 1.0),
+        // Band (30,50): 80 samples — fuel rate 2.0 L/h
+        for (var i = 0; i < 80; i++) _sample(speedKmh: 40, fuelRateLPerHour: 2.0),
+        // Band (50,80): 100 samples — fuel rate 3.0 L/h
+        for (var i = 0; i < 100; i++) _sample(speedKmh: 65, fuelRateLPerHour: 3.0),
+        // Band (80,110): 30 samples — BELOW threshold → excluded
+        for (var i = 0; i < 30; i++) _sample(speedKmh: 95, fuelRateLPerHour: 5.0),
+      ];
+
+      final result = aggregateSpeedConsumption(samples);
+
+      // 3 of 5 template bands should appear — (0,30), (30,50), (50,80).
+      // (80,110) is below threshold; (110, null) has no samples.
+      expect(result.bands, hasLength(3));
+
+      final low = result.bands.firstWhere((b) => b.minKmh == 0);
+      expect(low.sampleCount, 60);
+      expect(low.timeShareFraction, closeTo(60 / 270, 1e-9));
+      // mean L/100km = (1.0 L/h × 60 s / 3600) / (20 km/h × 60 s / 3600 km) × 100
+      //              = (1.0 / 20) × 100 = 5.0 L/100 km
+      expect(low.meanLPer100km, closeTo(5.0, 1e-9));
+
+      final mid = result.bands.firstWhere((b) => b.minKmh == 30);
+      expect(mid.sampleCount, 80);
+      // (2.0 / 40) × 100 = 5.0 L/100 km
+      expect(mid.meanLPer100km, closeTo(5.0, 1e-9));
+
+      final high = result.bands.firstWhere((b) => b.minKmh == 50);
+      expect(high.sampleCount, 100);
+      // (3.0 / 65) × 100 ≈ 4.615 L/100 km
+      expect(high.meanLPer100km, closeTo(3.0 / 65 * 100, 1e-9));
+
+      // No band below threshold should appear.
+      expect(result.bands.where((b) => b.minKmh == 80).isEmpty, isTrue);
+    });
+
+    test('empty samples → empty histogram (cold-start signal)', () {
+      final result = aggregateSpeedConsumption(const []);
+      expect(result.bands, isEmpty);
+    });
+
+    test(
+        'samples without fuelRateLPerHour still count toward sample count '
+        'and time share — documented under-statement', () {
+      final samples = <TripSample>[
+        for (var i = 0; i < 60; i++) _sample(speedKmh: 20, fuelRateLPerHour: null),
+      ];
+      final result = aggregateSpeedConsumption(samples);
+      expect(result.bands, hasLength(1));
+      expect(result.bands.single.sampleCount, 60);
+      // No fuel-rate data → zero litres → mean = 0.
+      expect(result.bands.single.meanLPer100km, closeTo(0.0, 1e-9));
+    });
+  });
+
+  group('foldTripLengthIncremental (#1193 phase 2 — Welford)', () {
+    test(
+        'fold-by-fold over N trips matches a full recompute over the same '
+        'N trips for sums + counts (exact)', () {
+      final trips = <TripHistoryEntry>[
+        _trip(id: '1', vehicleId: 'v', km: 5, litres: 0.5),
+        _trip(id: '2', vehicleId: 'v', km: 8, litres: 0.7),
+        _trip(id: '3', vehicleId: 'v', km: 12, litres: 1.0),
+        _trip(id: '4', vehicleId: 'v', km: 20, litres: 1.5),
+        _trip(id: '5', vehicleId: 'v', km: 25, litres: 2.0),
+        _trip(id: '6', vehicleId: 'v', km: 30, litres: 2.4),
+        _trip(id: '7', vehicleId: 'v', km: 60, litres: 4.0),
+        _trip(id: '8', vehicleId: 'v', km: 100, litres: 7.0),
+        _trip(id: '9', vehicleId: 'v', km: 120, litres: 8.4),
+      ];
+
+      // Fold-in path: start from null, add each trip one by one.
+      TripLengthBreakdown? folded;
+      for (final t in trips) {
+        folded = foldTripLengthIncremental(folded, t);
+      }
+
+      // Reference: full recompute.
+      final reference = aggregateByTripLength(trips);
+
+      // Sums + counts: bit-exact for buckets that exist on both sides.
+      // Note: full recompute returns null for buckets below the
+      // per-bucket threshold (3); fold-in returns the running total
+      // even at count=1 — that's intentional, the threshold is applied
+      // by `aggregateByTripLength` at emit time, not by the fold. So
+      // we only compare buckets where both sides are non-null.
+      if (reference.short != null && folded?.short != null) {
+        expect(folded!.short!.tripCount, reference.short!.tripCount);
+        expect(folded.short!.totalDistanceKm,
+            closeTo(reference.short!.totalDistanceKm, 1e-12));
+        expect(folded.short!.totalLitres,
+            closeTo(reference.short!.totalLitres, 1e-12));
+        // Per-bin mean: < 1e-6 by Welford convergence. Both sides
+        // recompute mean from the same totals though, so we expect
+        // bit-exact too.
+        expect(folded.short!.meanLPer100km,
+            closeTo(reference.short!.meanLPer100km, 1e-6));
+      }
+      expect(folded!.medium!.tripCount, reference.medium!.tripCount);
+      expect(folded.medium!.totalDistanceKm,
+          closeTo(reference.medium!.totalDistanceKm, 1e-12));
+      expect(folded.medium!.totalLitres,
+          closeTo(reference.medium!.totalLitres, 1e-12));
+      expect(folded.medium!.meanLPer100km,
+          closeTo(reference.medium!.meanLPer100km, 1e-6));
+
+      expect(folded.long!.tripCount, reference.long!.tripCount);
+      expect(folded.long!.totalDistanceKm,
+          closeTo(reference.long!.totalDistanceKm, 1e-12));
+      expect(folded.long!.totalLitres,
+          closeTo(reference.long!.totalLitres, 1e-12));
+      expect(folded.long!.meanLPer100km,
+          closeTo(reference.long!.meanLPer100km, 1e-6));
+    });
+
+    test('null prior + one trip → seeds the matching bucket only', () {
+      final result = foldTripLengthIncremental(
+        null,
+        _trip(id: '1', vehicleId: 'v', km: 12, litres: 1.0),
+      );
+      expect(result.short, isNotNull);
+      expect(result.short!.tripCount, 1);
+      expect(result.medium, isNull);
+      expect(result.long, isNull);
+    });
+  });
+
+  group('foldSpeedConsumptionIncremental (#1193 phase 2 — Welford)', () {
+    test(
+        'fold-by-fold matches a full recompute on per-band counts and '
+        'time shares (exact above threshold); per-bin means within 1e-6 '
+        '— the docstring caveat about across-threshold lossiness is '
+        'covered by feeding pass 1 enough samples that every band that '
+        'will eventually clear threshold already does so', () {
+      // Pass 1 must seed every band above [kMinSamplesPerSpeedBand] = 50
+      // for the prior to round-trip losslessly. Pass 2 then adds more
+      // samples on top.
+      final pass1 = <TripSample>[
+        for (var i = 0; i < 60; i++) _sample(speedKmh: 20, fuelRateLPerHour: 1.0),
+        for (var i = 0; i < 60; i++) _sample(speedKmh: 40, fuelRateLPerHour: 2.0),
+        for (var i = 0; i < 60; i++) _sample(speedKmh: 65, fuelRateLPerHour: 3.0),
+      ];
+      final pass2 = <TripSample>[
+        for (var i = 0; i < 20; i++) _sample(speedKmh: 20, fuelRateLPerHour: 1.0),
+        for (var i = 0; i < 30; i++) _sample(speedKmh: 40, fuelRateLPerHour: 2.0),
+        for (var i = 0; i < 40; i++) _sample(speedKmh: 65, fuelRateLPerHour: 3.0),
+      ];
+      final reference = aggregateSpeedConsumption([...pass1, ...pass2]);
+
+      // Fold-in path.
+      SpeedConsumptionHistogram? folded;
+      folded = foldSpeedConsumptionIncremental(folded, pass1);
+      folded = foldSpeedConsumptionIncremental(folded, pass2);
+
+      expect(folded.bands, hasLength(reference.bands.length));
+      for (final refBand in reference.bands) {
+        final foldedBand = folded.bands.firstWhere(
+          (b) => b.minKmh == refBand.minKmh,
+        );
+        expect(foldedBand.sampleCount, refBand.sampleCount);
+        expect(foldedBand.timeShareFraction,
+            closeTo(refBand.timeShareFraction, 1e-9));
+        // Welford per-bin mean: tolerance < 1e-6 documents the
+        // approximation. In practice the totals come from the same
+        // sources so we tend to match exactly — the looser tolerance
+        // is an honest contract bound for callers.
+        expect(foldedBand.meanLPer100km,
+            closeTo(refBand.meanLPer100km, 1e-6));
+      }
+    });
+
+    test(
+        'across-threshold fold is lossy (documented) — a band that was '
+        'sub-threshold in the prior loses its old samples on the next fold', () {
+      // Pass 1: 80 samples in band (0,30), 20 in (30,50). Only (0,30)
+      // clears the 50-sample threshold; (30,50) is dropped from the
+      // prior's `bands` list.
+      final pass1 = <TripSample>[
+        for (var i = 0; i < 80; i++) _sample(speedKmh: 20, fuelRateLPerHour: 1.0),
+        for (var i = 0; i < 20; i++) _sample(speedKmh: 40, fuelRateLPerHour: 2.0),
+      ];
+      // Pass 2: 40 more in (30,50) — now 60 across both passes, but
+      // the fold can only see the 40 in pass 2 because the 20 from
+      // pass 1 were dropped from the prior.
+      final pass2 = <TripSample>[
+        for (var i = 0; i < 40; i++) _sample(speedKmh: 40, fuelRateLPerHour: 2.0),
+      ];
+
+      SpeedConsumptionHistogram? folded;
+      folded = foldSpeedConsumptionIncremental(folded, pass1);
+      folded = foldSpeedConsumptionIncremental(folded, pass2);
+
+      // Folded (30,50): only 40 samples — below threshold, so the
+      // band is omitted from the output. The full recompute would
+      // include it (60 ≥ 50). Documented limitation.
+      final hasMid = folded.bands.any((b) => b.minKmh == 30);
+      expect(hasMid, isFalse);
+
+      // Full recompute: (30,50) has 60 samples, makes the cut.
+      final ref = aggregateSpeedConsumption([...pass1, ...pass2]);
+      expect(ref.bands.any((b) => b.minKmh == 30), isTrue);
+    });
+  });
+
+  group('VehicleAggregateUpdater.updateForVehicle (#1193 phase 2)', () {
+    late _FakeSettings storage;
+    late VehicleProfileRepository vehicleRepo;
+    late _FakeTripHistory tripRepo;
+    late VehicleAggregateUpdater updater;
+    late _FakeTraceRecorder recorder;
+
+    setUp(() {
+      storage = _FakeSettings();
+      vehicleRepo = VehicleProfileRepository(storage);
+      tripRepo = _FakeTripHistory();
+      updater = VehicleAggregateUpdater(
+        vehicleRepo: vehicleRepo,
+        tripRepoLookup: () => tripRepo,
+        now: () => DateTime(2026, 4, 27, 12, 0, 0),
+      );
+      // The runForVehicle path routes errors through errorLogger.log,
+      // which would otherwise fall through to IsolateErrorSpool and
+      // open a Hive box (not initialised in this unit test). Inject a
+      // capture-only recorder via the documented test seam.
+      errorLogger.resetForTest();
+      recorder = _FakeTraceRecorder();
+      errorLogger.testRecorderOverride = recorder;
+    });
+
+    tearDown(() {
+      errorLogger.resetForTest();
+    });
+
+    test(
+        'below-threshold guard — vehicle with < 5 trips ends up with all '
+        'aggregate fields null on the persisted profile', () async {
+      await vehicleRepo.save(
+        const VehicleProfile(id: 'v1', name: 'Test'),
+      );
+      tripRepo.entries = <TripHistoryEntry>[
+        _trip(id: '1', vehicleId: 'v1', km: 10, litres: 0.7),
+        _trip(id: '2', vehicleId: 'v1', km: 12, litres: 0.9),
+        _trip(id: '3', vehicleId: 'v1', km: 30, litres: 2.0),
+        _trip(id: '4', vehicleId: 'v1', km: 60, litres: 4.0),
+      ];
+
+      await updater.updateForVehicle('v1');
+
+      final profile = vehicleRepo.getById('v1')!;
+      expect(profile.tripLengthAggregates, isNull);
+      expect(profile.speedConsumptionAggregates, isNull);
+      expect(profile.aggregatesTripCount, 4);
+      expect(profile.aggregatesUpdatedAt, isNotNull);
+    });
+
+    test(
+        'updateForVehicle persists aggregates and stamps the profile with '
+        'aggregatesUpdatedAt + aggregatesTripCount', () async {
+      await vehicleRepo.save(
+        const VehicleProfile(id: 'v1', name: 'Test'),
+      );
+      // 5 trips clears the visibility threshold; bucket fills will be
+      // partial (we only need the metadata fields to be set here).
+      tripRepo.entries = <TripHistoryEntry>[
+        _trip(id: '1', vehicleId: 'v1', km: 5, litres: 0.5),
+        _trip(id: '2', vehicleId: 'v1', km: 8, litres: 0.7),
+        _trip(id: '3', vehicleId: 'v1', km: 12, litres: 1.0),
+        _trip(id: '4', vehicleId: 'v1', km: 20, litres: 1.5),
+        _trip(id: '5', vehicleId: 'v1', km: 30, litres: 2.4),
+      ];
+
+      await updater.updateForVehicle('v1');
+
+      final profile = vehicleRepo.getById('v1')!;
+      expect(profile.aggregatesUpdatedAt, DateTime(2026, 4, 27, 12, 0, 0));
+      expect(profile.aggregatesTripCount, 5);
+      expect(profile.tripLengthAggregates, isNotNull);
+      expect(profile.tripLengthAggregates!.short, isNotNull);
+      expect(profile.tripLengthAggregates!.short!.tripCount, 3);
+      // Speed histogram is empty (no samples in the test trips), but
+      // the field itself should be populated as an empty histogram —
+      // the cold-start signal documented on the value object.
+      expect(profile.speedConsumptionAggregates, isNotNull);
+    });
+
+    test(
+        'orphan trips (other vehicleId) are filtered out before counting '
+        'against the threshold', () async {
+      await vehicleRepo.save(const VehicleProfile(id: 'v1', name: 'Test'));
+      tripRepo.entries = <TripHistoryEntry>[
+        // 5 belong to v1
+        _trip(id: '1', vehicleId: 'v1', km: 5, litres: 0.5),
+        _trip(id: '2', vehicleId: 'v1', km: 8, litres: 0.7),
+        _trip(id: '3', vehicleId: 'v1', km: 12, litres: 1.0),
+        _trip(id: '4', vehicleId: 'v1', km: 20, litres: 1.5),
+        _trip(id: '5', vehicleId: 'v1', km: 30, litres: 2.4),
+        // 3 belong to v2 — should be ignored when updating v1
+        _trip(id: '6', vehicleId: 'v2', km: 100, litres: 7.0),
+        _trip(id: '7', vehicleId: 'v2', km: 100, litres: 7.0),
+        _trip(id: '8', vehicleId: 'v2', km: 100, litres: 7.0),
+      ];
+
+      await updater.updateForVehicle('v1');
+
+      final profile = vehicleRepo.getById('v1')!;
+      expect(profile.aggregatesTripCount, 5);
+    });
+
+    test('no-op when vehicle is not found', () async {
+      // No profile saved → updater should silently skip.
+      tripRepo.entries = <TripHistoryEntry>[
+        _trip(id: '1', vehicleId: 'ghost', km: 5, litres: 0.5),
+      ];
+      await updater.updateForVehicle('ghost');
+      // Nothing to assert other than "did not throw".
+      expect(vehicleRepo.getAll(), isEmpty);
+    });
+
+    test(
+        'runForVehicle never throws even when updater hits an error — '
+        'the failure routes through errorLogger.log (background layer)',
+        () async {
+      // Throwing trip repo lookup simulates a corrupted Hive state.
+      final throwingUpdater = VehicleAggregateUpdater(
+        vehicleRepo: vehicleRepo,
+        tripRepoLookup: () => throw StateError('hive corrupt'),
+      );
+      await vehicleRepo.save(const VehicleProfile(id: 'v1', name: 'Test'));
+
+      // Should NOT throw — the wrapper logs via errorLogger.log.
+      await expectLater(throwingUpdater.runForVehicle('v1'), completes);
+
+      // The error MUST land in the recorder so observability picks it
+      // up; a silent swallow would violate the no-silent-catch rule.
+      expect(recorder.calls, hasLength(1));
+      final recorded = recorder.calls.single.error.toString();
+      expect(recorded, contains('[background]'));
+      expect(recorded, contains('hive corrupt'));
+      expect(recorded, contains('vehicleId'));
+      expect(recorded, contains('v1'));
+    });
+  });
+}
+
+/// In-memory fake of [TripHistoryRepository] for the updater tests.
+/// Returning the same shape as the real repo without standing up a
+/// Hive box keeps the test fast and avoids the platform-channel setup
+/// the real repo requires.
+class _FakeTripHistory implements TripHistoryRepository {
+  List<TripHistoryEntry> entries = <TripHistoryEntry>[];
+
+  @override
+  List<TripHistoryEntry> loadAll() {
+    final sorted = [...entries];
+    sorted.sort((a, b) {
+      final ax = a.summary.startedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final bx = b.summary.startedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return bx.compareTo(ax);
+    });
+    return sorted;
+  }
+
+  @override
+  Future<void> save(TripHistoryEntry entry) async {
+    entries.add(entry);
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    entries.removeWhere((e) => e.id == id);
+  }
+
+  @override
+  void Function(String vehicleId)? onSavedHook;
+
+  @override
+  int get cap => 100;
+
+  @override
+  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+
+/// Capture-only TraceRecorder for the [errorLogger.testRecorderOverride]
+/// seam. Mirrors the fake in `test/core/logging/error_logger_test.dart`
+/// — same shape, same noSuchMethod fallback for the rest of the
+/// recorder surface.
+class _FakeTraceRecorder implements TraceRecorder {
+  final calls = <_RecordedCall>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(_RecordedCall(error, stackTrace));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+class _RecordedCall {
+  final Object error;
+  final StackTrace stackTrace;
+  _RecordedCall(this.error, this.stackTrace);
+}


### PR DESCRIPTION
Refs #1193 phase 2

## Summary

- Adds the `VehicleAggregateUpdater` service plus four pure top-level functions (`aggregateByTripLength`, `aggregateSpeedConsumption`, and the matching Welford-style `fold*Incremental` variants) that consume the phase-1 value objects from PR #1206.
- Wires a fire-and-forget `onSavedHook` into `TripHistoryRepository.save()`; production installs `VehicleAggregateUpdater.runForVehicle` post-first-frame from `app_initializer.dart`. The hook NEVER re-throws — a failing aggregator routes through `errorLogger.log(ErrorLayer.background, ...)` so observability picks it up without derailing the trip-stop flow.
- Threshold rules per the issue: trip count < 5 nulls every aggregate field; per-bucket trip count < 3 nulls that bucket; per-band sample count < 50 omits the band from `SpeedConsumptionHistogram.bands`.
- Background-safety: when the flattened sample list crosses 1000, the aggregation pass hops to a worker isolate via `compute()`. Smaller datasets stay inline because the hop costs ~10 ms.
- Documents the Welford fold's across-threshold lossiness explicitly — `updateForVehicle` remains the source of truth.

Phase 3 (vehicle-profile UI section) follows.

## Files added / modified

- `lib/features/vehicle/data/vehicle_aggregate_updater.dart` — service + pure functions.
- `lib/features/vehicle/providers/vehicle_aggregate_updater_provider.dart` — Riverpod wiring + `wireAggregatorIntoTripHistory(container)`.
- `lib/features/consumption/data/trip_history_repository.dart` — adds `onSavedHook`.
- `lib/app/app_initializer.dart` — installs the hook post-first-frame.
- `test/features/vehicle/data/vehicle_aggregate_updater_test.dart` — 15 new tests.
- `test/features/consumption/data/trip_history_repository_test.dart` — 4 new tests for the hook.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/features/vehicle/data/vehicle_aggregate_updater_test.dart` — 15/15 pass
- [x] `flutter test test/features/consumption/data/trip_history_repository_test.dart` — 10/10 pass
- [x] `flutter test test/features/vehicle/` — 413/413 pass (no regression)
- [x] `flutter test test/features/consumption/` — 1790/1790 pass (no regression)
- [ ] CI green