### PR TITLE
feat(consumption): show fuel cost on trip detail summary (Closes #1209)

### DIFF
--- a/lib/features/consumption/domain/services/trip_fuel_cost_estimator.dart
+++ b/lib/features/consumption/domain/services/trip_fuel_cost_estimator.dart
@@ -1,0 +1,43 @@
+import '../entities/fill_up.dart';
+import '../../data/trip_history_repository.dart';
+
+/// Estimates the monetary cost of the fuel consumed on a trip (#1209).
+///
+/// Uses the price-per-litre from the most recent fill-up to the
+/// vehicle's tank that occurred on or before the trip's start. The
+/// price is read from [FillUpX.pricePerLiter] (`totalCost / liters`)
+/// in the active country's currency, so the returned cost is in the
+/// same major-unit currency. Multiplied by [TripSummary.fuelLitersConsumed]
+/// to land at a directly-comparable euro / pound / kroner figure.
+///
+/// Returns `null` when:
+/// * the trip has no `fuelLitersConsumed` recorded,
+/// * the trip has no `startedAt`,
+/// * no eligible fill-up has a usable `pricePerLiter` (zero or no
+///   litres recorded — `FillUpX.pricePerLiter` falls back to `0` in
+///   that case, which we treat as "no price" so the row stays hidden
+///   rather than showing a misleading `0,00 €`).
+///
+/// [fillUpsForVehicle] is expected newest-first (matches the order
+/// produced by `FillUpRepository`). The function walks the list and
+/// returns the cost from the first fill-up that satisfies the date
+/// and price-validity gates.
+double? estimateTripFuelCost({
+  required TripHistoryEntry trip,
+  required List<FillUp> fillUpsForVehicle,
+}) {
+  final fuelL = trip.summary.fuelLitersConsumed;
+  if (fuelL == null) return null;
+  final start = trip.summary.startedAt;
+  if (start == null) return null;
+  for (final f in fillUpsForVehicle) {
+    if (f.date.isAfter(start)) continue;
+    final p = f.pricePerLiter;
+    // pricePerLiter is `totalCost / liters` and falls back to 0 when
+    // liters == 0 — treat zero as "no usable price" so the trip
+    // detail row simply hides instead of rendering a misleading 0.
+    if (p <= 0) continue;
+    return fuelL * p;
+  }
+  return null;
+}

--- a/lib/features/consumption/presentation/widgets/trip_summary_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_summary_card.dart
@@ -1,20 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../data/trip_history_repository.dart';
+import '../../providers/trip_fuel_cost_provider.dart';
 import 'trip_detail_charts.dart';
 
 /// Headline summary card on the trip detail screen (#890).
 ///
 /// Shows date, vehicle, distance, duration, average + max speed and —
-/// for fuel vehicles — average consumption (L/100 km) and total fuel
-/// used. EV trips swap the consumption unit to kWh/100 km.
+/// for fuel vehicles — average consumption (L/100 km), total fuel used
+/// and the estimated fuel cost (#1209). EV trips swap the consumption
+/// unit to kWh/100 km and skip the fuel-cost row.
 ///
 /// Per-sample fields (avg/max speed) come from [samples]; the rest is
 /// read straight off [TripSummary]. Missing values fall back to the
 /// localised "unknown" placeholder so the layout stays stable.
-class TripSummaryCard extends StatelessWidget {
+///
+/// The fuel-cost row is only rendered when [tripFuelCostProvider]
+/// returns a non-null value — see the provider for the full edge-case
+/// list (no fill-ups, missing price, EV with no equivalent etc.).
+class TripSummaryCard extends ConsumerWidget {
   final TripHistoryEntry entry;
   final VehicleProfile? vehicle;
   final List<TripDetailSample> samples;
@@ -29,12 +37,18 @@ class TripSummaryCard extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final s = entry.summary;
     final unknown = l?.trajetDetailFieldValueUnknown ?? '—';
     final avgUnit = isEv ? 'kWh/100 km' : 'L/100 km';
+
+    // #1209 — estimated trip cost from the most recent fill-up's
+    // price-per-litre. Hidden on EV trips (the helper still returns
+    // null for fuel-EV mixed setups via the fuelLitersConsumed gate)
+    // and whenever the provider has no usable fill-up data.
+    final fuelCost = isEv ? null : ref.watch(tripFuelCostProvider(entry.id));
 
     final date = s.startedAt == null ? unknown : _fmtDate(s.startedAt!);
     final vehicleName = vehicle?.name ?? unknown;
@@ -89,6 +103,16 @@ class TripSummaryCard extends StatelessWidget {
               label: l?.trajetDetailFieldFuelUsed ?? 'Fuel used',
               value: fuelUsed,
             ),
+            // #1209 — estimated euro/£/$ cost of the fuel used,
+            // derived from the most recent fill-up before this trip.
+            // Hidden when the provider returns null (no fill-ups, no
+            // valid price, or no fuelLitersConsumed) so the row never
+            // shows a misleading "0,00 €" or "—" placeholder.
+            if (fuelCost != null)
+              _SummaryRow(
+                label: l?.trajetDetailFieldFuelCost ?? 'Fuel cost',
+                value: PriceFormatter.formatPrice(fuelCost),
+              ),
             _SummaryRow(
               label: l?.trajetDetailFieldAvgSpeed ?? 'Avg speed',
               value: avgSpeed,

--- a/lib/features/consumption/providers/trip_fuel_cost_provider.dart
+++ b/lib/features/consumption/providers/trip_fuel_cost_provider.dart
@@ -1,0 +1,40 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../domain/services/trip_fuel_cost_estimator.dart';
+import 'consumption_providers.dart';
+import 'trip_history_provider.dart';
+
+part 'trip_fuel_cost_provider.g.dart';
+
+/// Estimated fuel cost for the trip identified by [tripId] (#1209).
+///
+/// Composes the trip history list and the fill-up list filtered to the
+/// trip's vehicle, then delegates to the pure
+/// [estimateTripFuelCost] helper. Returns `null` when the trip is
+/// absent, has no `fuelLitersConsumed` / `startedAt`, has no
+/// `vehicleId`, or no eligible fill-up has a usable price — the trip
+/// detail summary card uses that null to hide the cost row entirely.
+///
+/// Per-screen (no `keepAlive`) — matches the [tankLevel] composition
+/// pattern from #1195.
+@riverpod
+double? tripFuelCost(Ref ref, String tripId) {
+  final trips = ref.watch(tripHistoryListProvider);
+  final trip = trips.where((t) => t.id == tripId).firstOrNull;
+  if (trip == null) return null;
+  final vehicleId = trip.vehicleId;
+  if (vehicleId == null) return null;
+
+  final allFillUps = ref.watch(fillUpListProvider);
+  final fillUpsForVehicle =
+      allFillUps.where((f) => f.vehicleId == vehicleId).toList();
+  if (fillUpsForVehicle.isEmpty) return null;
+  // FillUpRepository returns the list newest-first; defend against
+  // a malformed import handing us a different order.
+  fillUpsForVehicle.sort((a, b) => b.date.compareTo(a.date));
+
+  return estimateTripFuelCost(
+    trip: trip,
+    fillUpsForVehicle: fillUpsForVehicle,
+  );
+}

--- a/lib/features/consumption/providers/trip_fuel_cost_provider.g.dart
+++ b/lib/features/consumption/providers/trip_fuel_cost_provider.g.dart
@@ -1,0 +1,145 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'trip_fuel_cost_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Estimated fuel cost for the trip identified by [tripId] (#1209).
+///
+/// Composes the trip history list and the fill-up list filtered to the
+/// trip's vehicle, then delegates to the pure
+/// [estimateTripFuelCost] helper. Returns `null` when the trip is
+/// absent, has no `fuelLitersConsumed` / `startedAt`, has no
+/// `vehicleId`, or no eligible fill-up has a usable price — the trip
+/// detail summary card uses that null to hide the cost row entirely.
+///
+/// Per-screen (no `keepAlive`) — matches the [tankLevel] composition
+/// pattern from #1195.
+
+@ProviderFor(tripFuelCost)
+final tripFuelCostProvider = TripFuelCostFamily._();
+
+/// Estimated fuel cost for the trip identified by [tripId] (#1209).
+///
+/// Composes the trip history list and the fill-up list filtered to the
+/// trip's vehicle, then delegates to the pure
+/// [estimateTripFuelCost] helper. Returns `null` when the trip is
+/// absent, has no `fuelLitersConsumed` / `startedAt`, has no
+/// `vehicleId`, or no eligible fill-up has a usable price — the trip
+/// detail summary card uses that null to hide the cost row entirely.
+///
+/// Per-screen (no `keepAlive`) — matches the [tankLevel] composition
+/// pattern from #1195.
+
+final class TripFuelCostProvider
+    extends $FunctionalProvider<double?, double?, double?>
+    with $Provider<double?> {
+  /// Estimated fuel cost for the trip identified by [tripId] (#1209).
+  ///
+  /// Composes the trip history list and the fill-up list filtered to the
+  /// trip's vehicle, then delegates to the pure
+  /// [estimateTripFuelCost] helper. Returns `null` when the trip is
+  /// absent, has no `fuelLitersConsumed` / `startedAt`, has no
+  /// `vehicleId`, or no eligible fill-up has a usable price — the trip
+  /// detail summary card uses that null to hide the cost row entirely.
+  ///
+  /// Per-screen (no `keepAlive`) — matches the [tankLevel] composition
+  /// pattern from #1195.
+  TripFuelCostProvider._({
+    required TripFuelCostFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'tripFuelCostProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$tripFuelCostHash();
+
+  @override
+  String toString() {
+    return r'tripFuelCostProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<double?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  double? create(Ref ref) {
+    final argument = this.argument as String;
+    return tripFuelCost(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(double? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<double?>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is TripFuelCostProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$tripFuelCostHash() => r'8345f765d3dc2b9157c6c0727d5e27617fcdf3a4';
+
+/// Estimated fuel cost for the trip identified by [tripId] (#1209).
+///
+/// Composes the trip history list and the fill-up list filtered to the
+/// trip's vehicle, then delegates to the pure
+/// [estimateTripFuelCost] helper. Returns `null` when the trip is
+/// absent, has no `fuelLitersConsumed` / `startedAt`, has no
+/// `vehicleId`, or no eligible fill-up has a usable price — the trip
+/// detail summary card uses that null to hide the cost row entirely.
+///
+/// Per-screen (no `keepAlive`) — matches the [tankLevel] composition
+/// pattern from #1195.
+
+final class TripFuelCostFamily extends $Family
+    with $FunctionalFamilyOverride<double?, String> {
+  TripFuelCostFamily._()
+    : super(
+        retry: null,
+        name: r'tripFuelCostProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Estimated fuel cost for the trip identified by [tripId] (#1209).
+  ///
+  /// Composes the trip history list and the fill-up list filtered to the
+  /// trip's vehicle, then delegates to the pure
+  /// [estimateTripFuelCost] helper. Returns `null` when the trip is
+  /// absent, has no `fuelLitersConsumed` / `startedAt`, has no
+  /// `vehicleId`, or no eligible fill-up has a usable price — the trip
+  /// detail summary card uses that null to hide the cost row entirely.
+  ///
+  /// Per-screen (no `keepAlive`) — matches the [tankLevel] composition
+  /// pattern from #1195.
+
+  TripFuelCostProvider call(String tripId) =>
+      TripFuelCostProvider._(argument: tripId, from: this);
+
+  @override
+  String toString() => r'tripFuelCostProvider';
+}

--- a/lib/l10n/_fragments/trajets_de.arb
+++ b/lib/l10n/_fragments/trajets_de.arb
@@ -13,6 +13,7 @@
   "trajetDetailFieldDuration": "Dauer",
   "trajetDetailFieldAvgConsumption": "Ø Verbrauch",
   "trajetDetailFieldFuelUsed": "Kraftstoff",
+  "trajetDetailFieldFuelCost": "Kraftstoffkosten",
   "trajetDetailFieldAvgSpeed": "Ø Geschwindigkeit",
   "trajetDetailFieldMaxSpeed": "Höchstgeschwindigkeit",
   "trajetDetailFieldValueUnknown": "—",

--- a/lib/l10n/_fragments/trajets_en.arb
+++ b/lib/l10n/_fragments/trajets_en.arb
@@ -73,6 +73,10 @@
   "@trajetDetailFieldFuelUsed": {
     "description": "Label for the total fuel litres row in the Trip detail summary card (#890)."
   },
+  "trajetDetailFieldFuelCost": "Fuel cost",
+  "@trajetDetailFieldFuelCost": {
+    "description": "Label for the estimated fuel cost row in the Trip detail summary card. Shown only when a recent fill-up's price-per-litre is available so we can multiply by fuel-litres-consumed (#1209)."
+  },
   "trajetDetailFieldAvgSpeed": "Avg speed",
   "@trajetDetailFieldAvgSpeed": {
     "description": "Label for the average speed row in the Trip detail summary card (#890)."

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1554,6 +1554,7 @@
   "trajetDetailFieldDuration": "Dauer",
   "trajetDetailFieldAvgConsumption": "Ø Verbrauch",
   "trajetDetailFieldFuelUsed": "Kraftstoff",
+  "trajetDetailFieldFuelCost": "Kraftstoffkosten",
   "trajetDetailFieldAvgSpeed": "Ø Geschwindigkeit",
   "trajetDetailFieldMaxSpeed": "Höchstgeschwindigkeit",
   "trajetDetailFieldValueUnknown": "—",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2492,6 +2492,10 @@
   "@trajetDetailFieldFuelUsed": {
     "description": "Label for the total fuel litres row in the Trip detail summary card (#890)."
   },
+  "trajetDetailFieldFuelCost": "Fuel cost",
+  "@trajetDetailFieldFuelCost": {
+    "description": "Label for the estimated fuel cost row in the Trip detail summary card. Shown only when a recent fill-up's price-per-litre is available so we can multiply by fuel-litres-consumed (#1209)."
+  },
   "trajetDetailFieldAvgSpeed": "Avg speed",
   "@trajetDetailFieldAvgSpeed": {
     "description": "Label for the average speed row in the Trip detail summary card (#890)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -909,6 +909,7 @@
   "consumptionLogTitle": "Consommation",
   "consumptionTabFuel": "Carburant",
   "trajetsTabLabel": "Trajets",
+  "trajetDetailFieldFuelCost": "Coût du carburant",
   "trajetDetailShareAction": "Partager",
   "trajetDetailShareSubject": "Tankstellen — trajet du {date}",
   "trajetDetailShareError": "Impossible de générer l'image à partager",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7268,6 +7268,12 @@ abstract class AppLocalizations {
   /// **'Fuel used'**
   String get trajetDetailFieldFuelUsed;
 
+  /// Label for the estimated fuel cost row in the Trip detail summary card. Shown only when a recent fill-up's price-per-litre is available so we can multiply by fuel-litres-consumed (#1209).
+  ///
+  /// In en, this message translates to:
+  /// **'Fuel cost'**
+  String get trajetDetailFieldFuelCost;
+
   /// Label for the average speed row in the Trip detail summary card (#890).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3914,6 +3914,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3914,6 +3914,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3912,6 +3912,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3949,6 +3949,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Kraftstoff';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Kraftstoffkosten';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Ø Geschwindigkeit';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3916,6 +3916,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3907,6 +3907,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3915,6 +3915,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3909,6 +3909,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3912,6 +3912,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3942,6 +3942,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Coût du carburant';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3911,6 +3911,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3916,6 +3916,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3915,6 +3915,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3913,6 +3913,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3915,6 +3915,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3911,6 +3911,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3916,6 +3916,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3914,6 +3914,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3915,6 +3915,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3914,6 +3914,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3915,6 +3915,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3909,6 +3909,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3913,6 +3913,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get trajetDetailFieldFuelUsed => 'Fuel used';
 
   @override
+  String get trajetDetailFieldFuelCost => 'Fuel cost';
+
+  @override
   String get trajetDetailFieldAvgSpeed => 'Avg speed';
 
   @override

--- a/test/features/consumption/domain/services/trip_fuel_cost_estimator_test.dart
+++ b/test/features/consumption/domain/services/trip_fuel_cost_estimator_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/services/trip_fuel_cost_estimator.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Pure-helper coverage for #1209's trip fuel-cost estimator.
+///
+/// Each test builds the smallest [TripHistoryEntry] / [FillUp] pair
+/// the case requires. No real fixtures, no Riverpod, no Hive — the
+/// helper is intentionally pure so the gates can be verified with
+/// synthetic data.
+void main() {
+  group('estimateTripFuelCost', () {
+    test('multiplies fuelLitersConsumed by the most recent eligible '
+        'fill-up\'s pricePerLiter', () {
+      final trip = _trip(
+        fuelLitersConsumed: 0.27,
+        startedAt: DateTime(2026, 4, 25, 14),
+      );
+      final fillUp = _fillUp(
+        date: DateTime(2026, 4, 24, 9),
+        liters: 40,
+        // pricePerLiter = totalCost / liters = 66 / 40 = 1.65
+        totalCost: 66,
+      );
+
+      final cost = estimateTripFuelCost(
+        trip: trip,
+        fillUpsForVehicle: [fillUp],
+      );
+
+      // 0.27 × 1.65 = 0.4455 — let the test float-compare on a tight
+      // tolerance so a floating-point round-trip doesn't mislead a
+      // future reader chasing a real regression.
+      expect(cost, isNotNull);
+      expect(cost!, closeTo(0.4455, 1e-9));
+    });
+
+    test('returns null when fuelLitersConsumed is null', () {
+      final trip = _trip(
+        fuelLitersConsumed: null,
+        startedAt: DateTime(2026, 4, 25, 14),
+      );
+      final fillUp = _fillUp(
+        date: DateTime(2026, 4, 24, 9),
+        liters: 40,
+        totalCost: 66,
+      );
+
+      expect(
+        estimateTripFuelCost(trip: trip, fillUpsForVehicle: [fillUp]),
+        isNull,
+      );
+    });
+
+    test('returns null when startedAt is null', () {
+      final trip = _trip(fuelLitersConsumed: 0.27, startedAt: null);
+      final fillUp = _fillUp(
+        date: DateTime(2026, 4, 24, 9),
+        liters: 40,
+        totalCost: 66,
+      );
+
+      expect(
+        estimateTripFuelCost(trip: trip, fillUpsForVehicle: [fillUp]),
+        isNull,
+      );
+    });
+
+    test('returns null when there are no fill-ups for the vehicle', () {
+      final trip = _trip(
+        fuelLitersConsumed: 0.27,
+        startedAt: DateTime(2026, 4, 25, 14),
+      );
+
+      expect(
+        estimateTripFuelCost(trip: trip, fillUpsForVehicle: const []),
+        isNull,
+      );
+    });
+
+    test('returns null when every fill-up is dated AFTER the trip start',
+        () {
+      final trip = _trip(
+        fuelLitersConsumed: 0.27,
+        startedAt: DateTime(2026, 4, 25, 14),
+      );
+      // Both fill-ups are strictly after the trip start, so neither
+      // can supply a "what did I pay before this drive?" baseline.
+      final fillUps = [
+        _fillUp(
+          date: DateTime(2026, 4, 25, 18),
+          liters: 40,
+          totalCost: 66,
+        ),
+        _fillUp(
+          date: DateTime(2026, 4, 26, 9),
+          liters: 30,
+          totalCost: 50,
+        ),
+      ];
+
+      expect(
+        estimateTripFuelCost(trip: trip, fillUpsForVehicle: fillUps),
+        isNull,
+      );
+    });
+
+    test(
+        'walks back to the next fill-up when the most recent has no usable '
+        'pricePerLiter (zero litres)', () {
+      final trip = _trip(
+        fuelLitersConsumed: 0.27,
+        startedAt: DateTime(2026, 4, 25, 14),
+      );
+      // Newest first: the recent fill-up has liters == 0, so its
+      // [FillUpX.pricePerLiter] falls back to 0 — the helper must
+      // skip it and use the older one with a real price.
+      final fillUps = [
+        _fillUp(
+          date: DateTime(2026, 4, 25, 8),
+          liters: 0,
+          totalCost: 0,
+        ),
+        _fillUp(
+          date: DateTime(2026, 4, 20, 9),
+          liters: 40,
+          totalCost: 66, // 1.65 €/L
+        ),
+      ];
+
+      final cost = estimateTripFuelCost(
+        trip: trip,
+        fillUpsForVehicle: fillUps,
+      );
+      expect(cost, isNotNull);
+      expect(cost!, closeTo(0.27 * 1.65, 1e-9));
+    });
+
+    test('uses the NEWEST eligible fill-up when several pre-date the trip',
+        () {
+      final trip = _trip(
+        fuelLitersConsumed: 1.0,
+        startedAt: DateTime(2026, 4, 25, 14),
+      );
+      // List is documented "newest first" so the helper must trust
+      // that order — pick the first match it walks to.
+      final fillUps = [
+        _fillUp(
+          date: DateTime(2026, 4, 24, 9),
+          liters: 40,
+          totalCost: 80, // 2.00 €/L — the one we WANT
+        ),
+        _fillUp(
+          date: DateTime(2026, 4, 1, 9),
+          liters: 40,
+          totalCost: 60, // 1.50 €/L — older, must NOT be picked
+        ),
+      ];
+
+      final cost = estimateTripFuelCost(
+        trip: trip,
+        fillUpsForVehicle: fillUps,
+      );
+      expect(cost, isNotNull);
+      expect(cost!, closeTo(2.0, 1e-9));
+    });
+
+    test('treats an exact tie (fill-up date == trip start) as eligible', () {
+      // The helper skips fill-ups that are strictly AFTER the trip
+      // start — equal timestamps still count, so a fill-up logged at
+      // the trip's exact start (e.g. user filled up then immediately
+      // drove away) supplies the price.
+      final start = DateTime(2026, 4, 25, 14);
+      final trip = _trip(fuelLitersConsumed: 0.5, startedAt: start);
+      final fillUp = _fillUp(date: start, liters: 50, totalCost: 75);
+
+      final cost = estimateTripFuelCost(
+        trip: trip,
+        fillUpsForVehicle: [fillUp],
+      );
+      expect(cost, isNotNull);
+      expect(cost!, closeTo(0.5 * 1.50, 1e-9));
+    });
+  });
+}
+
+TripHistoryEntry _trip({
+  required double? fuelLitersConsumed,
+  required DateTime? startedAt,
+  String id = 'trip-1',
+  String? vehicleId = 'v1',
+}) {
+  return TripHistoryEntry(
+    id: id,
+    vehicleId: vehicleId,
+    summary: TripSummary(
+      distanceKm: 10,
+      maxRpm: 0,
+      highRpmSeconds: 0,
+      idleSeconds: 0,
+      harshBrakes: 0,
+      harshAccelerations: 0,
+      fuelLitersConsumed: fuelLitersConsumed,
+      startedAt: startedAt,
+      distanceSource: 'virtual',
+    ),
+  );
+}
+
+FillUp _fillUp({
+  required DateTime date,
+  required double liters,
+  required double totalCost,
+  String id = 'f-1',
+  String vehicleId = 'v1',
+}) {
+  return FillUp(
+    id: id,
+    date: date,
+    liters: liters,
+    totalCost: totalCost,
+    odometerKm: 0,
+    fuelType: FuelType.e10,
+    vehicleId: vehicleId,
+  );
+}

--- a/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
+++ b/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:tankstellen/features/consumption/data/trip_history_repository.da
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/presentation/screens/trip_detail_screen.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_charts.dart';
+import 'package:tankstellen/features/consumption/providers/trip_fuel_cost_provider.dart';
 import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
 import 'package:tankstellen/features/profile/providers/gamification_enabled_provider.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
@@ -142,6 +143,10 @@ Future<({_FixedTripHistoryList tripsNotifier})> _pumpDetail(
       // override here so it doesn't fall through to the (Hive-backed)
       // active profile lookup that these tests don't seed.
       gamificationEnabledProvider.overrideWith((ref) => true),
+      // #1209 — TripSummaryCard now watches tripFuelCostProvider, which
+      // composes fillUpListProvider (Hive-backed). These tests don't
+      // seed Hive; return null so the cost row hides cleanly.
+      tripFuelCostProvider(entry.id).overrideWith((ref) => null),
     ],
   );
   // Push the detail route on top of the stub so `context.pop()` in

--- a/test/features/consumption/presentation/widgets/trip_summary_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_summary_card_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_charts.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_summary_card.dart';
+import 'package:tankstellen/features/consumption/providers/trip_fuel_cost_provider.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 
 import '../../../../helpers/pump_app.dart';
@@ -336,6 +338,91 @@ void main() {
       );
       expect(find.text('60.0 km/h'), findsOneWidget);
       expect(find.text('80.0 km/h'), findsOneWidget);
+    });
+  });
+
+  group('TripSummaryCard — fuel cost row (#1209)', () {
+    setUp(() {
+      // Pin the active currency so the formatted-price assertions
+      // below are deterministic regardless of test ordering.
+      PriceFormatter.setCountry('FR');
+    });
+
+    testWidgets('renders the formatted cost when the provider has data',
+        (tester) async {
+      await pumpApp(
+        tester,
+        TripSummaryCard(
+          entry: _entry(
+            id: 't-cost',
+            fuelLitersConsumed: 0.27,
+            startedAt: DateTime(2026, 4, 25, 14),
+          ),
+          vehicle: _vehicle,
+          samples: const [],
+          isEv: false,
+        ),
+        overrides: [
+          tripFuelCostProvider('t-cost').overrideWithValue(0.4455),
+        ],
+      );
+
+      expect(find.text('Fuel cost'), findsOneWidget);
+      // PriceFormatter.formatPrice with FR locale prints the value
+      // with three decimals and a non-breaking space + €.
+      expect(
+        find.text(PriceFormatter.formatPrice(0.4455)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides the cost row when the provider returns null',
+        (tester) async {
+      await pumpApp(
+        tester,
+        TripSummaryCard(
+          entry: _entry(
+            id: 't-no-cost',
+            fuelLitersConsumed: 0.27,
+            startedAt: DateTime(2026, 4, 25, 14),
+          ),
+          vehicle: _vehicle,
+          samples: const [],
+          isEv: false,
+        ),
+        overrides: [
+          tripFuelCostProvider('t-no-cost').overrideWithValue(null),
+        ],
+      );
+
+      expect(find.text('Fuel cost'), findsNothing);
+    });
+
+    testWidgets('hides the cost row for EV trips even when a value is set',
+        (tester) async {
+      // EV trips never show fuel cost — fuel-litres-consumed semantics
+      // don't apply, and the row should be skipped before the
+      // provider read fires.
+      await pumpApp(
+        tester,
+        TripSummaryCard(
+          entry: _entry(
+            id: 't-ev',
+            fuelLitersConsumed: null,
+            startedAt: DateTime(2026, 4, 25, 14),
+          ),
+          vehicle: _vehicle,
+          samples: const [],
+          isEv: true,
+        ),
+        overrides: [
+          // Even with a non-null override the row must stay hidden
+          // because the EV branch short-circuits before the watch.
+          tripFuelCostProvider('t-ev').overrideWithValue(1.23),
+        ],
+      );
+
+      expect(find.text('Fuel cost'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

Adds a `Fuel cost` row to the Trip Detail Summary card immediately
beneath `Fuel used`. Turns the abstract `0.27 L` figure into a concrete
`0,445 €` the user can directly compare against alternatives — different
driving style, different route, different vehicle.

Computation:

```
cost = fuelLitersConsumed × pricePerLitre(at last fill-up before trip start)
```

Closes #1209.

## What changed

- **Pure helper** `lib/features/consumption/domain/services/trip_fuel_cost_estimator.dart`
  — gates on `null` litres/start, walks the (newest-first) fill-up list
  past any with `liters == 0` (whose `pricePerLiter` falls back to 0)
  and any dated strictly after the trip start. Stays trivially testable
  with synthetic fixtures — no Riverpod, no Hive.
- **Provider** `lib/features/consumption/providers/trip_fuel_cost_provider.dart`
  — derived `@riverpod double?` keyed by `tripId`. Composes
  `tripHistoryListProvider` + `fillUpListProvider` filtered to the trip's
  `vehicleId`, mirrors the `tankLevelProvider` (#1195) pattern.
- **UI** — `TripSummaryCard` becomes a `ConsumerWidget` and watches the
  cost provider. Renders an extra `_SummaryRow` between `Fuel used` and
  `Avg speed` only when the provider returns non-null. EV trips
  short-circuit before the watch.
- **i18n** — new `trajetDetailFieldFuelCost` key via the ARB-fragment
  pattern (EN/DE) + a direct addition to `app_fr.arb` for the
  French-primary user. All 23 `app_localizations_*.dart` regenerated
  via `flutter gen-l10n`.

## Edge cases hidden behind a `null` provider value

- Trip has no `fuelLitersConsumed` recorded
- Trip has no `startedAt`
- Vehicle has no fill-ups logged
- Every fill-up is strictly after the trip start
- Most-recent fill-up has zero litres → walks back to next eligible
- Trip is on an EV (no fuel-cost concept here)

In each case the row is hidden — no `0,00 €` placeholder, no
misleading dash.

## Acceptance checklist

- [x] Trip detail Summary shows `Fuel cost` row in the user's currency
      when fill-up + fuel-used data are available.
- [x] Row hidden in each edge case (5 + EV branch).
- [x] FR / EN / DE translations land via the ARB-fragment pattern + direct fr edit.
- [x] Unit tests cover all 5 edge cases + happy path + tie-on-startedAt.
- [x] Widget test asserts row presence with mocked provider value, absence on `null`, and absence on EV.

## Test plan

- [x] `flutter analyze` — zero warnings, zero infos.
- [x] `flutter test test/features/consumption/domain/services/trip_fuel_cost_estimator_test.dart` — 8 tests pass.
- [x] `flutter test test/features/consumption/presentation/widgets/trip_summary_card_test.dart` — 19 tests pass (16 existing + 3 new).
- [x] `flutter test test/l10n/localization_completeness_test.dart` — DE has every EN key; new FR string present.
- [x] `flutter test test/lint/no_silent_catch_test.dart test/accessibility/icon_button_tooltip_coverage_test.dart` — pass.
- [ ] Smoke-test on device after merge: open a trip with a logged fill-up
      that pre-dates the trip's `startedAt`, confirm `Fuel cost` appears
      formatted in the active country's currency.

## Leitmotiv

Wheel side: makes wasteful driving immediately tangible — a hard
acceleration that wastes 0.3 L now reads as a real-money figure
the user feels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)