### PR TITLE
fix(vehicle): persist calibrationMode through form controllers (Closes #1217)

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -49,6 +49,12 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   // connected OBD2 picker selection.
   String? _pairedAdapterMac;
 
+  // #1217 — baseline calibration mode (#894) is initialised from the
+  // loaded profile and threaded back through buildProfile on Save so
+  // the screen-level Save button doesn't clobber whatever the
+  // segmented-button selector just persisted.
+  VehicleCalibrationMode _calibrationMode = VehicleCalibrationMode.rule;
+
   // #812 phase 2 — engine params populated by the VIN decoder;
   // carried through _save for phase-3 OBD2 math.
   int? _engineDisplacementCc;
@@ -92,6 +98,7 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
       _engineDisplacementCc = snap.engineDisplacementCc;
       _engineCylinders = snap.engineCylinders;
       _curbWeightKg = snap.curbWeightKg;
+      _calibrationMode = snap.calibrationMode;
     });
   }
 
@@ -122,6 +129,18 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   Future<void> _save() async {
     final form = _formKey.currentState;
     if (form == null || !form.validate()) return;
+    // #1217 — read the freshest calibrationMode from the provider so
+    // a value the segmented-button selector just persisted survives
+    // this Save. Falls back to the loaded snapshot value when the
+    // profile isn't (yet) in the list (new-vehicle flow).
+    final id = _existingId;
+    final persisted = id == null
+        ? null
+        : ref
+            .read(vehicleProfileListProvider)
+            .where((v) => v.id == id)
+            .firstOrNull;
+    final calibrationMode = persisted?.calibrationMode ?? _calibrationMode;
     final profile = _ctrl.buildProfile(
       existingId: _existingId,
       type: _type,
@@ -131,6 +150,7 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
       engineDisplacementCc: _engineDisplacementCc,
       engineCylinders: _engineCylinders,
       curbWeightKg: _curbWeightKg,
+      calibrationMode: calibrationMode,
     );
     await ref.read(vehicleProfileListProvider.notifier).save(profile);
     await ref.syncActiveProfile(profile);

--- a/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
@@ -53,11 +53,16 @@ class VehicleFormControllers {
       engineDisplacementCc: profile.engineDisplacementCc,
       engineCylinders: profile.engineCylinders,
       curbWeightKg: profile.curbWeightKg,
+      calibrationMode: profile.calibrationMode,
     );
   }
 
   /// Construct a [VehicleProfile] from the current controller values
   /// combined with the non-controller state passed in by the caller.
+  ///
+  /// [calibrationMode] is threaded through verbatim from the loaded
+  /// snapshot so the screen-level Save doesn't clobber a value the
+  /// segmented-button selector (#894) just persisted (#1217).
   VehicleProfile buildProfile({
     required String? existingId,
     required VehicleType type,
@@ -67,6 +72,7 @@ class VehicleFormControllers {
     required int? engineDisplacementCc,
     required int? engineCylinders,
     required int? curbWeightKg,
+    VehicleCalibrationMode calibrationMode = VehicleCalibrationMode.rule,
   }) {
     return VehicleProfile(
       id: existingId ?? _uuid.v4(),
@@ -99,6 +105,7 @@ class VehicleFormControllers {
       engineDisplacementCc: engineDisplacementCc,
       engineCylinders: engineCylinders,
       curbWeightKg: curbWeightKg,
+      calibrationMode: calibrationMode,
     );
   }
 
@@ -143,6 +150,12 @@ class VehicleFormSnapshot {
   final int? engineCylinders;
   final int? curbWeightKg;
 
+  /// Baseline calibration mode (#894) captured from the loaded
+  /// profile so the screen can thread it back into [buildProfile]
+  /// on Save instead of falling through to the constructor default
+  /// (#1217).
+  final VehicleCalibrationMode calibrationMode;
+
   VehicleFormSnapshot({
     required this.id,
     required this.type,
@@ -153,5 +166,6 @@ class VehicleFormSnapshot {
     required this.engineDisplacementCc,
     required this.engineCylinders,
     required this.curbWeightKg,
+    this.calibrationMode = VehicleCalibrationMode.rule,
   });
 }

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_calibration_mode_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_calibration_mode_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/core/storage/hive_boxes.dart';
 import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_form_controllers.dart';
 import 'package:tankstellen/features/vehicle/providers/calibration_mode_providers.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
@@ -129,6 +130,125 @@ void main() {
         find.byKey(const Key('calibrationModeSegmentedButton')),
       );
       expect(segmented.selected, {VehicleCalibrationMode.rule});
+    });
+
+    // #1217 — VehicleFormControllers.buildProfile didn't thread the
+    // calibrationMode through, so the screen-level Save rebuilt the
+    // profile with the constructor default and overwrote whatever
+    // the segmented-button selector had just persisted.
+    testWidgets('Fuzzy + immediate Save persists the chosen mode (#1217)',
+        (tester) async {
+      final repo = VehicleProfileRepository(_FakeSettings());
+      await repo.save(const VehicleProfile(id: 'v1', name: 'Car'));
+
+      await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+
+      await tester.dragUntilVisible(
+        find.byKey(const Key('calibrationModeSegmentedButton')),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.ensureVisible(find.text('Fuzzy'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      await tester.tap(find.text('Fuzzy'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Selector wrote fuzzy. Now tap the screen-level Save (the
+      // pinned bottom bar) and expect Hive still holds fuzzy after.
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(repo.getById('v1')!.calibrationMode,
+          VehicleCalibrationMode.fuzzy);
+    });
+
+    testWidgets(
+        'Fuzzy + edit name + Save still persists the chosen mode (#1217)',
+        (tester) async {
+      final repo = VehicleProfileRepository(_FakeSettings());
+      await repo.save(const VehicleProfile(id: 'v1', name: 'Car'));
+
+      await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+
+      await tester.dragUntilVisible(
+        find.byKey(const Key('calibrationModeSegmentedButton')),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.ensureVisible(find.text('Fuzzy'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      await tester.tap(find.text('Fuzzy'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Edit the name field (any other field's edit must not flip
+      // calibrationMode back to rule on Save).
+      await tester.dragUntilVisible(
+        find.widgetWithText(TextFormField, 'Car'),
+        find.byType(ListView),
+        const Offset(0, 200),
+      );
+      await tester.enterText(
+          find.widgetWithText(TextFormField, 'Car'), 'Polo');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final stored = repo.getById('v1')!;
+      expect(stored.name, 'Polo');
+      expect(stored.calibrationMode, VehicleCalibrationMode.fuzzy);
+    });
+
+    testWidgets(
+        'Fuzzy + Save survives the round-trip through the repo (#1217)',
+        (tester) async {
+      // Persistence-survival proof: after the screen-level Save, the
+      // repository (the same in-memory facade that wraps Hive in
+      // production) holds Fuzzy. Re-loading the controllers from the
+      // repo's record reproduces what an app restart would see. The
+      // actual Hive byte-level round-trip is covered by
+      // `vehicle_profile_test.dart`.
+      final repo = VehicleProfileRepository(_FakeSettings());
+      await repo.save(const VehicleProfile(id: 'v1', name: 'Car'));
+
+      await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+
+      await tester.dragUntilVisible(
+        find.byKey(const Key('calibrationModeSegmentedButton')),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.ensureVisible(find.text('Fuzzy'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      await tester.tap(find.text('Fuzzy'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Fresh controllers loading the persisted profile see Fuzzy —
+      // i.e. the next time the user opens this vehicle's edit screen,
+      // the segmented button will render Fuzzy as selected.
+      final reloaded = repo.getById('v1')!;
+      expect(reloaded.calibrationMode, VehicleCalibrationMode.fuzzy);
+
+      final freshControllers = VehicleFormControllers();
+      addTearDown(freshControllers.dispose);
+      final snap = freshControllers.load(reloaded);
+      expect(snap.calibrationMode, VehicleCalibrationMode.fuzzy);
     });
   });
 }

--- a/test/features/vehicle/presentation/widgets/vehicle_form_controllers_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_form_controllers_test.dart
@@ -131,6 +131,31 @@ void main() {
       expect(snap.curbWeightKg, isNull);
     });
 
+    test('captures calibrationMode from the loaded profile (#1217)', () {
+      final c = VehicleFormControllers();
+      addTearDown(c.dispose);
+
+      const profile = VehicleProfile(
+        id: 'fuzzy-1',
+        name: 'Polo',
+        calibrationMode: VehicleCalibrationMode.fuzzy,
+      );
+
+      final snap = c.load(profile);
+      expect(snap.calibrationMode, VehicleCalibrationMode.fuzzy);
+    });
+
+    test('defaults snapshot calibrationMode to rule for pre-#894 profiles',
+        () {
+      final c = VehicleFormControllers();
+      addTearDown(c.dispose);
+
+      const profile = VehicleProfile(id: 'rule-1', name: 'Polo');
+
+      final snap = c.load(profile);
+      expect(snap.calibrationMode, VehicleCalibrationMode.rule);
+    });
+
     test('connectors snapshot is a defensive copy', () {
       final c = VehicleFormControllers();
       addTearDown(c.dispose);
@@ -380,6 +405,47 @@ void main() {
       expect(profile.batteryKwh, 60.5);
       expect(profile.maxChargingKw, 150.25);
       expect(profile.tankCapacityL, 45.5);
+    });
+
+    test('threads calibrationMode through to the built profile (#1217)', () {
+      final c = VehicleFormControllers();
+      addTearDown(c.dispose);
+
+      c.nameController.text = 'Polo';
+
+      final profile = c.buildProfile(
+        existingId: 'fuzzy-2',
+        type: VehicleType.combustion,
+        connectors: const {},
+        adapterMac: null,
+        adapterName: null,
+        engineDisplacementCc: null,
+        engineCylinders: null,
+        curbWeightKg: null,
+        calibrationMode: VehicleCalibrationMode.fuzzy,
+      );
+
+      expect(profile.calibrationMode, VehicleCalibrationMode.fuzzy);
+    });
+
+    test('omitted calibrationMode falls back to rule (#1217 default)', () {
+      final c = VehicleFormControllers();
+      addTearDown(c.dispose);
+
+      c.nameController.text = 'Polo';
+
+      final profile = c.buildProfile(
+        existingId: 'rule-2',
+        type: VehicleType.combustion,
+        connectors: const {},
+        adapterMac: null,
+        adapterName: null,
+        engineDisplacementCc: null,
+        engineCylinders: null,
+        curbWeightKg: null,
+      );
+
+      expect(profile.calibrationMode, VehicleCalibrationMode.rule);
     });
 
     test('SoC values are clamped to 0..100', () {


### PR DESCRIPTION
## Summary

Fixes #1217 — the Edit-vehicle screen's Rule/Fuzzy segmented toggle flipped visually but reverted on Save.

## Root cause

`VehicleFormControllers.buildProfile()` did not accept a `calibrationMode` argument, so the constructed `VehicleProfile` always took the constructor default (`rule`). The segmented-button selector wrote `fuzzy` to the repo on tap (correctly), but the screen-level Save rebuilt the profile **without** `calibrationMode` and overwrote it. The bug surfaces both when the user taps Save immediately after toggling and when they tap Save after editing any other field.

## Fix

- `VehicleFormControllers.load()` now captures `calibrationMode` into `VehicleFormSnapshot`.
- `VehicleFormControllers.buildProfile()` accepts `calibrationMode` and threads it into the constructed `VehicleProfile` (default `rule` keeps existing call-sites unchanged).
- `EditVehicleScreen._save()` reads the freshest persisted value from `vehicleProfileListProvider` (so a same-frame selector tap survives without waiting for the screen's own `setState`) and passes it into `buildProfile()`.
- `_calibrationMode` state field initialised from `snap.calibrationMode` in `_loadExisting` for completeness / fallback when the profile isn't yet in the list.

## Test plan

- [x] `flutter analyze` — clean (full project, including `test/`).
- [x] `flutter test test/features/vehicle/presentation/widgets/vehicle_form_controllers_test.dart` — 20/20 passing (4 new tests assert load/build round-trip the field).
- [x] `flutter test test/features/vehicle/presentation/screens/edit_vehicle_screen_calibration_mode_test.dart` — 6/6 passing (3 new tests cover the acceptance flows: immediate Save, edit-name-then-Save, repo round-trip after reload).
- [x] `flutter test test/features/vehicle/presentation/widgets/` — 96/96 passing (no regression on sibling widget tests).
- [x] `flutter test test/features/vehicle/presentation/screens/` — 47/47 passing (no regression on sibling screen tests).
- [x] `flutter test test/features/vehicle/providers/ test/features/vehicle/domain/` — 159/159 passing (Hive round-trip already covered by `vehicle_profile_test.dart`).
- [ ] Manual device test on next APK — toggle Fuzzy, tap Save, reopen Edit, expect Fuzzy still selected.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>