### PR TITLE
fix(vehicle): persist calibration mode through form-controller save (Closes #1217)

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -55,6 +55,15 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   int? _engineCylinders;
   int? _curbWeightKg;
 
+  // #1217 — Live calibration mode for the screen-level Save path.
+  // Initialized from the loaded profile in [_loadExisting] and read at
+  // [_save] time so the rebuilt profile keeps whatever value the
+  // [VehicleCalibrationModeSelector] segmented button persisted to the
+  // provider moments earlier. Without this, [_ctrl.buildProfile]
+  // would emit the freezed-default `rule` and overwrite a Fuzzy
+  // selection that the segmented-button widget already saved.
+  VehicleCalibrationMode _calibrationMode = VehicleCalibrationMode.rule;
+
   // True while the vPIC request is in flight → VIN field spinner.
   bool _decodingVin = false;
 
@@ -92,6 +101,7 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
       _engineDisplacementCc = snap.engineDisplacementCc;
       _engineCylinders = snap.engineCylinders;
       _curbWeightKg = snap.curbWeightKg;
+      _calibrationMode = snap.calibrationMode;
     });
   }
 
@@ -122,6 +132,20 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   Future<void> _save() async {
     final form = _formKey.currentState;
     if (form == null || !form.validate()) return;
+    // #1217 — pull the latest persisted calibrationMode from the
+    // provider before rebuilding the profile, so any value the
+    // [VehicleCalibrationModeSelector] saved while this screen was
+    // open is preserved. Falls back to whatever was loaded from the
+    // initial profile (or the freezed default) when no live entry is
+    // found (new vehicle / first save).
+    final liveMode = _existingId == null
+        ? _calibrationMode
+        : ref
+                .read(vehicleProfileListProvider)
+                .where((v) => v.id == _existingId)
+                .firstOrNull
+                ?.calibrationMode ??
+            _calibrationMode;
     final profile = _ctrl.buildProfile(
       existingId: _existingId,
       type: _type,
@@ -131,6 +155,7 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
       engineDisplacementCc: _engineDisplacementCc,
       engineCylinders: _engineCylinders,
       curbWeightKg: _curbWeightKg,
+      calibrationMode: liveMode,
     );
     await ref.read(vehicleProfileListProvider.notifier).save(profile);
     await ref.syncActiveProfile(profile);

--- a/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
@@ -53,11 +53,19 @@ class VehicleFormControllers {
       engineDisplacementCc: profile.engineDisplacementCc,
       engineCylinders: profile.engineCylinders,
       curbWeightKg: profile.curbWeightKg,
+      calibrationMode: profile.calibrationMode,
     );
   }
 
   /// Construct a [VehicleProfile] from the current controller values
   /// combined with the non-controller state passed in by the caller.
+  ///
+  /// [calibrationMode] is threaded through verbatim so the screen-
+  /// level Save path doesn't clobber a value the
+  /// [VehicleCalibrationModeSelector] persisted moments earlier
+  /// (#1217). Defaults to [VehicleCalibrationMode.rule] to match the
+  /// freezed default for new profiles where the caller has no live
+  /// value to pass in.
   VehicleProfile buildProfile({
     required String? existingId,
     required VehicleType type,
@@ -67,6 +75,7 @@ class VehicleFormControllers {
     required int? engineDisplacementCc,
     required int? engineCylinders,
     required int? curbWeightKg,
+    VehicleCalibrationMode calibrationMode = VehicleCalibrationMode.rule,
   }) {
     return VehicleProfile(
       id: existingId ?? _uuid.v4(),
@@ -99,6 +108,7 @@ class VehicleFormControllers {
       engineDisplacementCc: engineDisplacementCc,
       engineCylinders: engineCylinders,
       curbWeightKg: curbWeightKg,
+      calibrationMode: calibrationMode,
     );
   }
 
@@ -143,6 +153,11 @@ class VehicleFormSnapshot {
   final int? engineCylinders;
   final int? curbWeightKg;
 
+  /// Calibration mode (#894) carried out of [VehicleFormControllers.load]
+  /// so the screen can seed its live state and pass the value back
+  /// through [VehicleFormControllers.buildProfile] on save (#1217).
+  final VehicleCalibrationMode calibrationMode;
+
   VehicleFormSnapshot({
     required this.id,
     required this.type,
@@ -153,5 +168,6 @@ class VehicleFormSnapshot {
     required this.engineDisplacementCc,
     required this.engineCylinders,
     required this.curbWeightKg,
+    this.calibrationMode = VehicleCalibrationMode.rule,
   });
 }

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_calibration_mode_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_calibration_mode_test.dart
@@ -131,12 +131,138 @@ void main() {
       expect(segmented.selected, {VehicleCalibrationMode.rule});
     });
   });
+
+  // #1217 — race regression: the screen-level Save button rebuilt the
+  // profile via `_ctrl.buildProfile(...)` without threading the live
+  // calibrationMode, so any value the segmented button persisted was
+  // overwritten with the freezed default `rule` on the very next Save.
+  // These tests guard the form-controller fix end-to-end through the
+  // screen's Save action and across a re-pump round-trip.
+  group('EditVehicleScreen — calibration mode persistence (#1217)', () {
+    testWidgets(
+        'toggling Fuzzy then tapping Save persists fuzzy through the form rebuild',
+        (tester) async {
+      final repo = VehicleProfileRepository(_FakeSettings());
+      await repo.save(const VehicleProfile(id: 'v1', name: 'Car'));
+
+      await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+
+      await tester.dragUntilVisible(
+        find.byKey(const Key('calibrationModeSegmentedButton')),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.ensureVisible(find.text('Fuzzy'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Fuzzy'));
+      await tester.pumpAndSettle();
+
+      // Tap the pinned bottom Save bar — the screen-level path that
+      // rebuilds the profile via _ctrl.buildProfile.
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      // The persisted value must still be Fuzzy. Before the #1217 fix
+      // the screen-level Save would overwrite it with the freezed
+      // default `rule`.
+      expect(repo.getById('v1')!.calibrationMode,
+          VehicleCalibrationMode.fuzzy);
+    });
+
+    testWidgets(
+        'toggling Fuzzy + editing the name + Save persists both changes',
+        (tester) async {
+      final repo = VehicleProfileRepository(_FakeSettings());
+      await repo.save(const VehicleProfile(id: 'v1', name: 'Car'));
+
+      await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+
+      await tester.dragUntilVisible(
+        find.byKey(const Key('calibrationModeSegmentedButton')),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.ensureVisible(find.text('Fuzzy'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Fuzzy'));
+      await tester.pumpAndSettle();
+
+      // Scroll back up so the Name field re-mounts (the screen uses a
+      // ListView which may virtualize the top-of-list field after we
+      // dragged down to reach Fuzzy).
+      await tester.dragUntilVisible(
+        find.byIcon(Icons.directions_car_outlined),
+        find.byType(ListView),
+        const Offset(0, 400),
+      );
+      await tester.pumpAndSettle();
+
+      // Change the name field — covers the worst-case "Save fires for
+      // any field change" path called out in the issue body. The Name
+      // TextFormField is the first one in the form (Identity card top).
+      final nameField = find.byType(TextFormField).first;
+      await tester.enterText(nameField, 'My Renamed Car');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      final saved = repo.getById('v1')!;
+      expect(saved.name, 'My Renamed Car');
+      expect(saved.calibrationMode, VehicleCalibrationMode.fuzzy);
+    });
+
+    testWidgets(
+        're-opening the screen after Save shows Fuzzy as the selected segment',
+        (tester) async {
+      final repo = VehicleProfileRepository(_FakeSettings());
+      await repo.save(const VehicleProfile(id: 'v1', name: 'Car'));
+
+      await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1', appKey: 'A');
+
+      await tester.dragUntilVisible(
+        find.byKey(const Key('calibrationModeSegmentedButton')),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.ensureVisible(find.text('Fuzzy'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Fuzzy'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      // Re-pump the same screen with the now-stored profile; pass a
+      // distinct [appKey] so Flutter rebuilds [MaterialApp]'s
+      // [Navigator] state from scratch (the previous Save popped the
+      // only route, leaving the reused Navigator with an empty
+      // history, which crashes a same-keyed re-pump).
+      await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1', appKey: 'B');
+
+      await tester.dragUntilVisible(
+        find.byKey(const Key('calibrationModeSegmentedButton')),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+
+      final segmented =
+          tester.widget<SegmentedButton<VehicleCalibrationMode>>(
+        find.byKey(const Key('calibrationModeSegmentedButton')),
+      );
+      expect(segmented.selected, {VehicleCalibrationMode.fuzzy});
+    });
+  });
 }
 
 Future<void> _pumpEditScreen(
   WidgetTester tester, {
   required VehicleProfileRepository repo,
   required String vehicleId,
+  String? appKey,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -144,6 +270,7 @@ Future<void> _pumpEditScreen(
         vehicleProfileRepositoryProvider.overrideWithValue(repo),
       ],
       child: MaterialApp(
+        key: appKey == null ? null : ValueKey(appKey),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: EditVehicleScreen(vehicleId: vehicleId),


### PR DESCRIPTION
## Why

User-reported on 2026-04-27: toggling **Calibration mode** on the Edit-vehicle screen flips visually but the chosen value (e.g. Fuzzy) reverts to Rule-based after Save. Repro: change calibration mode, change any other field, tap Save, re-open the screen.

## Root cause — race between two save paths

1. `vehicle_calibration_mode_selector.dart`'s `onSelectionChanged` correctly persists via `vehicleProfileListProvider.notifier.save(profile.copyWith(calibrationMode: next))`.
2. The screen-level `_save()` in `edit_vehicle_screen.dart` rebuilds the profile via `_ctrl.buildProfile(...)`. `VehicleFormControllers` did NOT reference `calibrationMode` in `load()` or `buildProfile()`, so the rebuilt profile got the freezed default (`rule`) and **overwrote** the value the segmented button just persisted.

## Fix

Thread `calibrationMode` through the form-controller load → buildProfile path so the screen-level Save preserves whatever value the segmented button persisted.

- `VehicleFormSnapshot` carries `calibrationMode` (default `rule`).
- `VehicleFormControllers.load` reads `profile.calibrationMode` into the snapshot.
- `VehicleFormControllers.buildProfile` accepts an optional `calibrationMode` parameter and emits it on the rebuilt profile.
- `EditVehicleScreen` initialises `_calibrationMode` from the loaded snapshot and reads the **latest persisted** `calibrationMode` from `vehicleProfileListProvider` at `_save()` time, so any in-screen segmented-button save is honoured by the form rebuild.

The segmented-button immediate save is preserved (issue body marks it "correct"); the fix targets the form-controllers gap that produced the overwrite. Minimal blast radius — no widget interface or provider semantics change.

## Acceptance

- [x] Toggling calibration mode and immediately tapping Save persists the chosen mode.
- [x] Toggling calibration mode, changing any other field, and saving still persists the chosen mode.
- [x] Calibration mode survives an in-test re-pump (Hive round-trip already covered by `vehicle_profile_test.dart`).

## Tests

Three new regression tests in `edit_vehicle_screen_calibration_mode_test.dart`:
1. Toggle Fuzzy + tap Save → repo holds `VehicleCalibrationMode.fuzzy`.
2. Toggle Fuzzy + change name + tap Save → repo holds both new name AND `fuzzy`.
3. Toggle Fuzzy + Save + re-pump screen → segmented button reflects Fuzzy.

## Validation

- `flutter analyze` — 0 issues.
- `flutter test test/features/vehicle/` — 416 / 416 passing.

Closes #1217