### PR TITLE
feat(carbon): consumption-by-trip-length card on dashboard (Closes #1191)

### DIFF
--- a/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
+++ b/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
@@ -7,13 +7,18 @@ import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/section_card.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/data/trip_history_repository.dart';
+import '../../../consumption/domain/services/trip_length_aggregator.dart';
 import '../../../consumption/providers/consumption_providers.dart';
+import '../../../consumption/providers/trip_history_provider.dart';
 import '../../../profile/providers/gamification_enabled_provider.dart';
+import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../domain/milestone.dart';
 import '../../domain/monthly_summary.dart';
 import '../widgets/fuel_vs_ev_card.dart';
 import '../widgets/milestones_card.dart';
 import '../widgets/monthly_bar_chart.dart';
+import '../widgets/trip_length_breakdown_card.dart';
 
 /// Carbon dashboard: tabbed view of monthly charts (#180) and
 /// gamified achievements (#181). Data is derived entirely from the
@@ -116,7 +121,7 @@ class CarbonDashboardScreen extends ConsumerWidget {
   }
 }
 
-class _ChartsTab extends StatelessWidget {
+class _ChartsTab extends ConsumerWidget {
   final List<MonthlySummary> summaries;
   final double totalCost;
   final double totalCo2;
@@ -128,9 +133,23 @@ class _ChartsTab extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
+
+    // #1191 — fold trip-history into the three length buckets, filtered
+    // to the active vehicle (legacy null-vehicleId trips are included
+    // per the trajets-tab convention). Computing the overall avg from
+    // the SAME filtered list keeps the per-tile arrows consistent with
+    // the headline figure on the dashboard.
+    final trips = ref.watch(tripHistoryListProvider);
+    final activeVehicle = ref.watch(activeVehicleProfileProvider);
+    final breakdown = aggregateByTripLength(
+      trips,
+      vehicleId: activeVehicle?.id,
+    );
+    final overallAvg = _overallAvgLPer100Km(trips, activeVehicle?.id);
+
     return ListView(
       padding: EdgeInsets.only(
         top: 16,
@@ -139,6 +158,13 @@ class _ChartsTab extends StatelessWidget {
       children: [
         _SummaryRow(totalCost: totalCost, totalCo2: totalCo2),
         const SizedBox(height: 8),
+        if (l != null && !breakdown.isEmpty)
+          TripLengthBreakdownCard(
+            breakdown: breakdown,
+            overallAvgLPer100Km: overallAvg,
+            l: l,
+            theme: theme,
+          ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: SectionCard(
@@ -168,6 +194,34 @@ class _ChartsTab extends StatelessWidget {
       ],
     );
   }
+}
+
+/// Compute the overall average L/100 km across the same filtered trip
+/// list the [TripLengthBreakdown] was built from. Returns null when no
+/// trip in the filtered set has both a non-null `fuelLitersConsumed`
+/// and a positive distance — the per-tile arrows are suppressed in
+/// that case. Mirrors the same vehicle-id filter as
+/// [aggregateByTripLength] so the figure stays consistent with the
+/// breakdown the user sees right next to it.
+double? _overallAvgLPer100Km(
+  Iterable<TripHistoryEntry> trips,
+  String? vehicleId,
+) {
+  double totalDistanceKm = 0;
+  double totalLitres = 0;
+  for (final entry in trips) {
+    if (vehicleId != null &&
+        entry.vehicleId != null &&
+        entry.vehicleId != vehicleId) {
+      continue;
+    }
+    final litres = entry.summary.fuelLitersConsumed;
+    if (litres == null) continue;
+    totalDistanceKm += entry.summary.distanceKm;
+    totalLitres += litres;
+  }
+  if (totalDistanceKm <= 0) return null;
+  return (totalLitres / totalDistanceKm) * 100.0;
 }
 
 class _AchievementsTab extends StatelessWidget {

--- a/lib/features/carbon/presentation/widgets/trip_length_breakdown_card.dart
+++ b/lib/features/carbon/presentation/widgets/trip_length_breakdown_card.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/domain/services/trip_length_aggregator.dart';
+
+/// Trip-length consumption breakdown card on the Carbon dashboard
+/// Charts tab (#1191).
+///
+/// Renders three horizontally-stacked tiles — Short (<5 km), Medium
+/// (5-25 km), Long (>25 km) — each showing the bucket's avg L/100 km,
+/// trip count, and total distance. When [overallAvgLPer100Km] is
+/// non-null, each tile additionally renders an above/below indicator
+/// arrow against the vehicle-wide average:
+///
+///   * red arrow_upward    → bucket avg is HIGHER than overall (worse
+///                           — the user is burning more in this bucket
+///                           than they do on average)
+///   * green arrow_downward → bucket avg is LOWER than overall (better)
+///
+/// Statistical-floor gates:
+///   * When EVERY bucket has zero trips, the entire card is hidden
+///     (returns [SizedBox.shrink]). The dashboard rendering should
+///     not waste vertical space on an empty 3-tile row.
+///   * When a bucket has between 1 and 4 trips inclusive, that tile
+///     shows the "Need more data" placeholder instead of an average —
+///     averaging two trips' L/100 km is dominated by single-trip
+///     noise. Five was chosen as the minimum for the same reason
+///     `aggregateMonthlyInsights` gates at 3-per-month: it's the
+///     smallest count where a pattern becomes visible without one
+///     outlier swinging the result.
+///
+/// Localised strings flow through [AppLocalizations] — see the
+/// `trip_length_breakdown_<locale>.arb` fragments for the surface.
+class TripLengthBreakdownCard extends StatelessWidget {
+  /// Pre-computed aggregate. Build it via
+  /// `aggregateByTripLength(trips, vehicleId: ...)` from the dashboard
+  /// caller; this widget is purely presentational.
+  final TripLengthBreakdown breakdown;
+
+  /// Vehicle-wide average L/100 km used as the comparison baseline for
+  /// the per-tile up/down arrows. When null (e.g. no overall trips
+  /// have fuel-rate data) the arrows are suppressed. Compute it from
+  /// the same filtered trip list the [breakdown] was built from so the
+  /// per-tile delta is consistent with the headline figure the user
+  /// already sees on the dashboard.
+  final double? overallAvgLPer100Km;
+
+  /// Localizations bundle for the host context. Required so the widget
+  /// can be unit-tested without an inherited [AppLocalizations] (the
+  /// test wraps this in a `MaterialApp` with `AppLocalizations.delegate`
+  /// and reads the bundle there).
+  final AppLocalizations l;
+
+  /// Theme bundle, threaded in from the host so the widget never
+  /// reaches into [Theme.of] directly — keeps it cheap to render
+  /// inside a `ListView` without rebuilding on theme inheritance
+  /// changes.
+  final ThemeData theme;
+
+  const TripLengthBreakdownCard({
+    super.key,
+    required this.breakdown,
+    required this.overallAvgLPer100Km,
+    required this.l,
+    required this.theme,
+  });
+
+  /// Minimum trip count per bucket before the average is shown.
+  /// Below this we render the "Need more data" placeholder — averaging
+  /// two trips swings on every fill-up.
+  static const int minTripsForAverage = 5;
+
+  @override
+  Widget build(BuildContext context) {
+    if (breakdown.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Card(
+      key: const ValueKey('trip_length_breakdown_card'),
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l.tripLengthCardTitle,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            IntrinsicHeight(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(
+                    child: _BucketTile(
+                      key: const Key('trip_length_tile_short'),
+                      label: l.tripLengthBucketShort,
+                      stats: breakdown.short,
+                      overallAvgLPer100Km: overallAvgLPer100Km,
+                      l: l,
+                      theme: theme,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _BucketTile(
+                      key: const Key('trip_length_tile_medium'),
+                      label: l.tripLengthBucketMedium,
+                      stats: breakdown.medium,
+                      overallAvgLPer100Km: overallAvgLPer100Km,
+                      l: l,
+                      theme: theme,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _BucketTile(
+                      key: const Key('trip_length_tile_long'),
+                      label: l.tripLengthBucketLong,
+                      stats: breakdown.long,
+                      overallAvgLPer100Km: overallAvgLPer100Km,
+                      l: l,
+                      theme: theme,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// One bucket tile inside [TripLengthBreakdownCard].
+///
+/// Renders one of three layouts depending on the bucket state:
+///   * `tripCount == 0` → tile shows the bucket label, "—" placeholder
+///     for the average, "no trips" subtitle. No arrow.
+///   * `tripCount in [1, 4]` → tile shows the bucket label, "Need
+///     more data" placeholder, count subtitle. No arrow.
+///   * `tripCount >= 5` → tile shows the bucket label, average
+///     L/100 km, count + distance subtitle, arrow vs. overall avg.
+class _BucketTile extends StatelessWidget {
+  final String label;
+  final TripLengthBucketStats stats;
+  final double? overallAvgLPer100Km;
+  final AppLocalizations l;
+  final ThemeData theme;
+
+  const _BucketTile({
+    super.key,
+    required this.label,
+    required this.stats,
+    required this.overallAvgLPer100Km,
+    required this.l,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final tripCount = stats.tripCount;
+    final hasEnoughData = tripCount >= TripLengthBreakdownCard.minTripsForAverage;
+    final avg = stats.avgLPer100Km;
+
+    final headline = !hasEnoughData
+        ? (tripCount == 0
+            ? '—'
+            : l.tripLengthBucketNeedMoreData)
+        : (avg == null ? '—' : '${avg.toStringAsFixed(1)} L/100');
+
+    final subtitle = tripCount == 0
+        ? l.tripLengthBucketTripCount(0)
+        : '${l.tripLengthBucketTripCount(tripCount)} · '
+            '${stats.totalDistanceKm.toStringAsFixed(0)} km';
+
+    final showArrow = hasEnoughData &&
+        avg != null &&
+        overallAvgLPer100Km != null &&
+        avg != overallAvgLPer100Km;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 6),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Flexible(
+              child: Text(
+                headline,
+                style: hasEnoughData
+                    ? theme.textTheme.titleMedium
+                    : theme.textTheme.bodySmall?.copyWith(
+                        fontStyle: FontStyle.italic,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            if (showArrow) ...[
+              const SizedBox(width: 4),
+              _DeltaArrow(
+                bucketAvg: avg,
+                overallAvg: overallAvgLPer100Km!,
+                theme: theme,
+              ),
+            ],
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          subtitle,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ],
+    );
+  }
+}
+
+/// Up/down arrow on a bucket tile. Rendered only when the bucket has
+/// >=5 trips AND the overall average is known AND they differ.
+///
+/// Sign convention is "lower L/100 km is better":
+///   * bucket avg > overall → red arrow_upward (worse)
+///   * bucket avg < overall → green arrow_downward (better)
+class _DeltaArrow extends StatelessWidget {
+  final double bucketAvg;
+  final double overallAvg;
+  final ThemeData theme;
+
+  const _DeltaArrow({
+    required this.bucketAvg,
+    required this.overallAvg,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final worse = bucketAvg > overallAvg;
+    return Icon(
+      worse ? Icons.arrow_upward : Icons.arrow_downward,
+      size: 16,
+      color: worse ? theme.colorScheme.error : Colors.green.shade700,
+    );
+  }
+}

--- a/lib/features/consumption/domain/services/trip_length_aggregator.dart
+++ b/lib/features/consumption/domain/services/trip_length_aggregator.dart
@@ -1,0 +1,211 @@
+/// Trip-length consumption aggregator (#1191).
+///
+/// Folds a list of [TripHistoryEntry]s into three fixed length buckets
+/// — short (<5 km), medium (5-25 km), long (>25 km) — and returns the
+/// per-bucket trip count, total distance, total litres, and average
+/// L/100 km. The Carbon dashboard's Charts tab renders these as three
+/// horizontally-stacked tiles so the user can see whether their car is
+/// wasting fuel on cold short hops vs. cruising on long voyages.
+///
+/// Why fixed cuts instead of quantiles: a typical European combustion
+/// engine reaches operating temperature around 5 km, and at 25 km the
+/// warm-up effect is fully amortised over the trip. Quantile-based
+/// bucketing would shift over time and confuse users — fixed cuts make
+/// the breakdown comparable across users and over months.
+///
+/// Boundary convention: the upper edge belongs to the upper-side
+/// bucket. A 5.0 km trip falls in MEDIUM, a 25.0 km trip falls in
+/// MEDIUM, a 25.01 km trip falls in LONG. Strict `<` on the lower
+/// bucket and `>` on the upper bucket — the middle bucket is
+/// `[5.0, 25.0]` inclusive on both sides.
+///
+/// Trip filtering:
+///   * When `vehicleId` is non-null, only trips whose
+///     `entry.vehicleId == vehicleId` (exact match) AND trips whose
+///     `entry.vehicleId == null` (legacy data tagging) are included.
+///     Mirrors the convention used by `trajets_tab.dart` line 110-112.
+///   * Trips with `summary.fuelLitersConsumed == null` are dropped
+///     from the bucket totals — silently treating null as 0 would
+///     skew the average. Without the litres figure we cannot honestly
+///     compute L/100 km. (`summary.distanceKm` is non-nullable on the
+///     model, so the only "missing field" gate is on litres.)
+///
+/// Pure function — no Riverpod, no I/O. Mirrors the style of
+/// `monthly_insights_aggregator.dart` in the same directory.
+library;
+
+import '../../data/trip_history_repository.dart';
+
+/// Upper edge of the SHORT bucket, in kilometres. Trips with
+/// `distanceKm < this` fall in [TripLengthBreakdown.short]. Re-exported
+/// so widget tests can verify the boundary value from one source.
+const double tripLengthShortUpperKm = 5.0;
+
+/// Upper edge of the MEDIUM bucket, in kilometres. Trips with
+/// `distanceKm > this` fall in [TripLengthBreakdown.long]; trips with
+/// `distanceKm <= this` (and `>= tripLengthShortUpperKm`) fall in
+/// [TripLengthBreakdown.medium]. The boundary is inclusive on the upper
+/// side per the spec — a 25.0 km trip is still MEDIUM.
+const double tripLengthMediumUpperKm = 25.0;
+
+/// Per-bucket aggregate. Value type, no side effects.
+class TripLengthBucketStats {
+  /// Number of trips that landed in this bucket and contributed to
+  /// the totals (i.e. had both a non-null `distanceKm` and non-null
+  /// `fuelLitersConsumed`). Trips dropped for missing fields are not
+  /// counted here.
+  final int tripCount;
+
+  /// Sum of `summary.distanceKm` across the bucket's qualifying trips.
+  /// Zero when [tripCount] is zero.
+  final double totalDistanceKm;
+
+  /// Sum of `summary.fuelLitersConsumed` across the bucket's
+  /// qualifying trips. Zero when [tripCount] is zero.
+  final double totalLitres;
+
+  /// `(totalLitres / totalDistanceKm) × 100`. Null when [tripCount] is
+  /// zero — averaging zero litres over zero km is undefined and the UI
+  /// renders a placeholder in that case.
+  final double? avgLPer100Km;
+
+  const TripLengthBucketStats({
+    required this.tripCount,
+    required this.totalDistanceKm,
+    required this.totalLitres,
+    required this.avgLPer100Km,
+  });
+
+  /// Empty bucket — used as the default when no qualifying trip lands
+  /// here. `tripCount == 0`, all numeric totals zero, average null.
+  static const TripLengthBucketStats empty = TripLengthBucketStats(
+    tripCount: 0,
+    totalDistanceKm: 0,
+    totalLitres: 0,
+    avgLPer100Km: null,
+  );
+}
+
+/// Result of [aggregateByTripLength] — the three buckets in fixed
+/// order. Value type; consumers render directly.
+class TripLengthBreakdown {
+  /// Trips with `distanceKm < tripLengthShortUpperKm` (cold-engine
+  /// territory).
+  final TripLengthBucketStats short;
+
+  /// Trips with `distanceKm` in `[tripLengthShortUpperKm,
+  /// tripLengthMediumUpperKm]` (engine warm, mostly urban / mixed).
+  final TripLengthBucketStats medium;
+
+  /// Trips with `distanceKm > tripLengthMediumUpperKm` (stable-
+  /// temperature cruising).
+  final TripLengthBucketStats long;
+
+  const TripLengthBreakdown({
+    required this.short,
+    required this.medium,
+    required this.long,
+  });
+
+  /// All-empty breakdown — every bucket has `tripCount == 0`. Returned
+  /// when the input trip list is empty (or every trip was filtered
+  /// out / dropped for missing fields).
+  static const TripLengthBreakdown empty = TripLengthBreakdown(
+    short: TripLengthBucketStats.empty,
+    medium: TripLengthBucketStats.empty,
+    long: TripLengthBucketStats.empty,
+  );
+
+  /// True when every bucket has zero trips. The dashboard hides the
+  /// card entirely when this is true so an empty 3-tile row doesn't
+  /// waste vertical space.
+  bool get isEmpty =>
+      short.tripCount == 0 && medium.tripCount == 0 && long.tripCount == 0;
+}
+
+/// Fold the [trips] iterable into a three-bucket [TripLengthBreakdown].
+///
+/// When [vehicleId] is non-null, the function only considers trips
+/// whose `summary.vehicleId == vehicleId` AND legacy trips whose
+/// `summary.vehicleId == null` (matching the Trajets tab convention).
+/// When null, every trip in [trips] is considered.
+///
+/// Trips with `summary.fuelLitersConsumed == null` are skipped — the
+/// average is undefined without litres. (`summary.distanceKm` is
+/// non-nullable on the model.)
+TripLengthBreakdown aggregateByTripLength(
+  Iterable<TripHistoryEntry> trips, {
+  String? vehicleId,
+}) {
+  final shortBucket = _Bucket();
+  final mediumBucket = _Bucket();
+  final longBucket = _Bucket();
+
+  for (final entry in trips) {
+    if (vehicleId != null &&
+        entry.vehicleId != null &&
+        entry.vehicleId != vehicleId) {
+      continue;
+    }
+
+    final distanceKm = entry.summary.distanceKm;
+    final litres = entry.summary.fuelLitersConsumed;
+    if (litres == null) continue;
+    // distanceKm is non-nullable on TripSummary; a 0 km trip is rare
+    // (synthetic test data) but folds cleanly into the SHORT bucket.
+
+    final bucket = _bucketFor(distanceKm);
+    switch (bucket) {
+      case _BucketKind.shortB:
+        shortBucket.add(distanceKm, litres);
+      case _BucketKind.mediumB:
+        mediumBucket.add(distanceKm, litres);
+      case _BucketKind.longB:
+        longBucket.add(distanceKm, litres);
+    }
+  }
+
+  return TripLengthBreakdown(
+    short: shortBucket.toStats(),
+    medium: mediumBucket.toStats(),
+    long: longBucket.toStats(),
+  );
+}
+
+/// Pick the bucket for [distanceKm]. See the boundary convention in the
+/// library docstring — the short bucket is strict `<5`, medium is
+/// `[5, 25]` inclusive on both sides, long is strict `>25`.
+_BucketKind _bucketFor(double distanceKm) {
+  if (distanceKm < tripLengthShortUpperKm) return _BucketKind.shortB;
+  if (distanceKm > tripLengthMediumUpperKm) return _BucketKind.longB;
+  return _BucketKind.mediumB;
+}
+
+enum _BucketKind { shortB, mediumB, longB }
+
+/// Mutable accumulator. Public surface is the immutable
+/// [TripLengthBucketStats] produced by [toStats].
+class _Bucket {
+  int tripCount = 0;
+  double totalDistanceKm = 0;
+  double totalLitres = 0;
+
+  void add(double distanceKm, double litres) {
+    tripCount++;
+    totalDistanceKm += distanceKm;
+    totalLitres += litres;
+  }
+
+  TripLengthBucketStats toStats() {
+    if (tripCount == 0) return TripLengthBucketStats.empty;
+    final avg = totalDistanceKm > 0
+        ? (totalLitres / totalDistanceKm) * 100.0
+        : null;
+    return TripLengthBucketStats(
+      tripCount: tripCount,
+      totalDistanceKm: totalDistanceKm,
+      totalLitres: totalLitres,
+      avgLPer100Km: avg,
+    );
+  }
+}

--- a/lib/l10n/_fragments/trip_length_breakdown_de.arb
+++ b/lib/l10n/_fragments/trip_length_breakdown_de.arb
@@ -1,0 +1,8 @@
+{
+  "tripLengthCardTitle": "Verbrauch nach Fahrtlänge",
+  "tripLengthBucketShort": "Kurz (<5 km)",
+  "tripLengthBucketMedium": "Mittel (5–25 km)",
+  "tripLengthBucketLong": "Lang (>25 km)",
+  "tripLengthBucketNeedMoreData": "Mehr Daten nötig",
+  "tripLengthBucketTripCount": "{count, plural, =0{keine Fahrten} one{1 Fahrt} other{{count} Fahrten}}"
+}

--- a/lib/l10n/_fragments/trip_length_breakdown_en.arb
+++ b/lib/l10n/_fragments/trip_length_breakdown_en.arb
@@ -1,0 +1,31 @@
+{
+  "tripLengthCardTitle": "Consumption by trip length",
+  "@tripLengthCardTitle": {
+    "description": "Title of the trip-length consumption card on the Carbon dashboard Charts tab — splits trips into short/medium/long buckets so the user can see cold-start fuel waste vs. cruising efficiency (#1191)."
+  },
+  "tripLengthBucketShort": "Short (<5 km)",
+  "@tripLengthBucketShort": {
+    "description": "Label of the short-trip tile on the trip-length breakdown card — trips under 5 km, where cold-engine warmup dominates (#1191)."
+  },
+  "tripLengthBucketMedium": "Medium (5–25 km)",
+  "@tripLengthBucketMedium": {
+    "description": "Label of the medium-trip tile on the trip-length breakdown card — trips between 5 and 25 km, mostly urban / mixed driving (#1191)."
+  },
+  "tripLengthBucketLong": "Long (>25 km)",
+  "@tripLengthBucketLong": {
+    "description": "Label of the long-trip tile on the trip-length breakdown card — trips over 25 km, stable-temperature cruising (#1191)."
+  },
+  "tripLengthBucketNeedMoreData": "Need more data",
+  "@tripLengthBucketNeedMoreData": {
+    "description": "Placeholder shown on a trip-length breakdown tile when the bucket has fewer than 5 trips — statistically meaningless to show an average that thin (#1191)."
+  },
+  "tripLengthBucketTripCount": "{count, plural, =0{no trips} one{1 trip} other{{count} trips}}",
+  "@tripLengthBucketTripCount": {
+    "description": "Trip-count subtitle on each trip-length breakdown tile (#1191).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1570,6 +1570,12 @@
   "trajetDetailDeleteConfirmBody": "Diese Fahrt wird dauerhaft aus deinem Verlauf entfernt.",
   "trajetDetailDeleteConfirmCancel": "Abbrechen",
   "trajetDetailDeleteConfirmConfirm": "Löschen",
+  "tripLengthCardTitle": "Verbrauch nach Fahrtlänge",
+  "tripLengthBucketShort": "Kurz (<5 km)",
+  "tripLengthBucketMedium": "Mittel (5–25 km)",
+  "tripLengthBucketLong": "Lang (>25 km)",
+  "tripLengthBucketNeedMoreData": "Mehr Daten nötig",
+  "tripLengthBucketTripCount": "{count, plural, =0{keine Fahrten} one{1 Fahrt} other{{count} Fahrten}}",
   "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2561,6 +2561,35 @@
   "@trajetDetailDeleteConfirmConfirm": {
     "description": "Confirm button label on the delete-trip confirmation dialog (#890)."
   },
+  "tripLengthCardTitle": "Consumption by trip length",
+  "@tripLengthCardTitle": {
+    "description": "Title of the trip-length consumption card on the Carbon dashboard Charts tab — splits trips into short/medium/long buckets so the user can see cold-start fuel waste vs. cruising efficiency (#1191)."
+  },
+  "tripLengthBucketShort": "Short (<5 km)",
+  "@tripLengthBucketShort": {
+    "description": "Label of the short-trip tile on the trip-length breakdown card — trips under 5 km, where cold-engine warmup dominates (#1191)."
+  },
+  "tripLengthBucketMedium": "Medium (5–25 km)",
+  "@tripLengthBucketMedium": {
+    "description": "Label of the medium-trip tile on the trip-length breakdown card — trips between 5 and 25 km, mostly urban / mixed driving (#1191)."
+  },
+  "tripLengthBucketLong": "Long (>25 km)",
+  "@tripLengthBucketLong": {
+    "description": "Label of the long-trip tile on the trip-length breakdown card — trips over 25 km, stable-temperature cruising (#1191)."
+  },
+  "tripLengthBucketNeedMoreData": "Need more data",
+  "@tripLengthBucketNeedMoreData": {
+    "description": "Placeholder shown on a trip-length breakdown tile when the bucket has fewer than 5 trips — statistically meaningless to show an average that thin (#1191)."
+  },
+  "tripLengthBucketTripCount": "{count, plural, =0{no trips} one{1 trip} other{{count} trips}}",
+  "@tripLengthBucketTripCount": {
+    "description": "Trip-count subtitle on each trip-length breakdown tile (#1191).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1024,5 +1024,11 @@
   "serviceReminderDueTitle": "Entretien à effectuer",
   "serviceReminderDueBody": "{label} à effectuer — {kmOver} km au-delà de l'intervalle.",
   "vehiclesMenuTitle": "Mes véhicules",
-  "vehiclesMenuSubtitle": "Batterie, connecteurs, préférences de recharge"
+  "vehiclesMenuSubtitle": "Batterie, connecteurs, préférences de recharge",
+  "tripLengthCardTitle": "Consommation par longueur de trajet",
+  "tripLengthBucketShort": "Court (<5 km)",
+  "tripLengthBucketMedium": "Moyen (5–25 km)",
+  "tripLengthBucketLong": "Long (>25 km)",
+  "tripLengthBucketNeedMoreData": "Plus de données nécessaires",
+  "tripLengthBucketTripCount": "{count, plural, =0{aucun trajet} one{1 trajet} other{{count} trajets}}"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7364,6 +7364,42 @@ abstract class AppLocalizations {
   /// **'Delete'**
   String get trajetDetailDeleteConfirmConfirm;
 
+  /// Title of the trip-length consumption card on the Carbon dashboard Charts tab — splits trips into short/medium/long buckets so the user can see cold-start fuel waste vs. cruising efficiency (#1191).
+  ///
+  /// In en, this message translates to:
+  /// **'Consumption by trip length'**
+  String get tripLengthCardTitle;
+
+  /// Label of the short-trip tile on the trip-length breakdown card — trips under 5 km, where cold-engine warmup dominates (#1191).
+  ///
+  /// In en, this message translates to:
+  /// **'Short (<5 km)'**
+  String get tripLengthBucketShort;
+
+  /// Label of the medium-trip tile on the trip-length breakdown card — trips between 5 and 25 km, mostly urban / mixed driving (#1191).
+  ///
+  /// In en, this message translates to:
+  /// **'Medium (5–25 km)'**
+  String get tripLengthBucketMedium;
+
+  /// Label of the long-trip tile on the trip-length breakdown card — trips over 25 km, stable-temperature cruising (#1191).
+  ///
+  /// In en, this message translates to:
+  /// **'Long (>25 km)'**
+  String get tripLengthBucketLong;
+
+  /// Placeholder shown on a trip-length breakdown tile when the bucket has fewer than 5 trips — statistically meaningless to show an average that thin (#1191).
+  ///
+  /// In en, this message translates to:
+  /// **'Need more data'**
+  String get tripLengthBucketNeedMoreData;
+
+  /// Trip-count subtitle on each trip-length breakdown tile (#1191).
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{no trips} one{1 trip} other{{count} trips}}'**
+  String tripLengthBucketTripCount(int count);
+
   /// Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3965,6 +3965,33 @@ class AppLocalizationsBg extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3965,6 +3965,33 @@ class AppLocalizationsCs extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3963,6 +3963,33 @@ class AppLocalizationsDa extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4000,6 +4000,33 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Löschen';
 
   @override
+  String get tripLengthCardTitle => 'Verbrauch nach Fahrtlänge';
+
+  @override
+  String get tripLengthBucketShort => 'Kurz (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Mittel (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Lang (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Mehr Daten nötig';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Fahrten',
+      one: '1 Fahrt',
+      zero: 'keine Fahrten',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Anpinnen hält den Bildschirm an — verbraucht mehr Akku';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3967,6 +3967,33 @@ class AppLocalizationsEl extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3958,6 +3958,33 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3966,6 +3966,33 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3960,6 +3960,33 @@ class AppLocalizationsEt extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3963,6 +3963,33 @@ class AppLocalizationsFi extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3997,6 +3997,33 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consommation par longueur de trajet';
+
+  @override
+  String get tripLengthBucketShort => 'Court (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Moyen (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Plus de données nécessaires';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trajets',
+      one: '1 trajet',
+      zero: 'aucun trajet',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3962,6 +3962,33 @@ class AppLocalizationsHr extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3967,6 +3967,33 @@ class AppLocalizationsHu extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3966,6 +3966,33 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3964,6 +3964,33 @@ class AppLocalizationsLt extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3966,6 +3966,33 @@ class AppLocalizationsLv extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3962,6 +3962,33 @@ class AppLocalizationsNb extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3967,6 +3967,33 @@ class AppLocalizationsNl extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3965,6 +3965,33 @@ class AppLocalizationsPl extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3966,6 +3966,33 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3965,6 +3965,33 @@ class AppLocalizationsRo extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3966,6 +3966,33 @@ class AppLocalizationsSk extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3960,6 +3960,33 @@ class AppLocalizationsSl extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3964,6 +3964,33 @@ class AppLocalizationsSv extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripLengthCardTitle => 'Consumption by trip length';
+
+  @override
+  String get tripLengthBucketShort => 'Short (<5 km)';
+
+  @override
+  String get tripLengthBucketMedium => 'Medium (5–25 km)';
+
+  @override
+  String get tripLengthBucketLong => 'Long (>25 km)';
+
+  @override
+  String get tripLengthBucketNeedMoreData => 'Need more data';
+
+  @override
+  String tripLengthBucketTripCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'no trips',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/test/features/carbon/presentation/widgets/trip_length_breakdown_card_test.dart
+++ b/test/features/carbon/presentation/widgets/trip_length_breakdown_card_test.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/trip_length_breakdown_card.dart';
+import 'package:tankstellen/features/consumption/domain/services/trip_length_aggregator.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget-level coverage for [TripLengthBreakdownCard] (#1191).
+///
+/// The card is purely presentational — it renders the aggregate
+/// produced by `aggregateByTripLength`. The aggregator's bucketing +
+/// filter logic is locked down in its own unit-test file; here we
+/// cover the rendering contract:
+///   * three tiles render with localised labels when at least one
+///     bucket has trips
+///   * the card hides entirely when every bucket has zero trips
+///   * a bucket with 1-4 trips shows the "Need more data" placeholder
+///   * arrows render only when the overall avg is provided AND the
+///     bucket has >=5 trips AND the bucket avg differs from overall
+void main() {
+  group('TripLengthBreakdownCard — labels + tile presence', () {
+    testWidgets('renders the localised title + three bucket labels',
+        (tester) async {
+      await _pumpCard(
+        tester,
+        breakdown: const TripLengthBreakdown(
+          short: TripLengthBucketStats(
+            tripCount: 5,
+            totalDistanceKm: 15.0,
+            totalLitres: 1.5,
+            avgLPer100Km: 10.0,
+          ),
+          medium: TripLengthBucketStats.empty,
+          long: TripLengthBucketStats(
+            tripCount: 7,
+            totalDistanceKm: 350.0,
+            totalLitres: 21.0,
+            avgLPer100Km: 6.0,
+          ),
+        ),
+        overallAvgLPer100Km: 7.5,
+      );
+
+      expect(find.text('Consumption by trip length'), findsOneWidget);
+      expect(find.text('Short (<5 km)'), findsOneWidget);
+      expect(find.text('Medium (5–25 km)'), findsOneWidget);
+      expect(find.text('Long (>25 km)'), findsOneWidget);
+
+      // All three tile keys must be present — the card always renders
+      // the 3-tile row when ANY bucket has trips, even if individual
+      // tiles are in their "empty" state.
+      expect(find.byKey(const Key('trip_length_tile_short')), findsOneWidget);
+      expect(find.byKey(const Key('trip_length_tile_medium')), findsOneWidget);
+      expect(find.byKey(const Key('trip_length_tile_long')), findsOneWidget);
+    });
+
+    testWidgets('renders the average L/100 km on tiles with >=5 trips',
+        (tester) async {
+      await _pumpCard(
+        tester,
+        breakdown: const TripLengthBreakdown(
+          short: TripLengthBucketStats(
+            tripCount: 5,
+            totalDistanceKm: 15.0,
+            totalLitres: 1.5,
+            avgLPer100Km: 10.0,
+          ),
+          medium: TripLengthBucketStats.empty,
+          long: TripLengthBucketStats(
+            tripCount: 7,
+            totalDistanceKm: 350.0,
+            totalLitres: 21.0,
+            avgLPer100Km: 6.0,
+          ),
+        ),
+        overallAvgLPer100Km: 7.5,
+      );
+
+      // Short avg 10.0 → "10.0 L/100"; long avg 6.0 → "6.0 L/100".
+      expect(find.text('10.0 L/100'), findsOneWidget);
+      expect(find.text('6.0 L/100'), findsOneWidget);
+    });
+  });
+
+  group('TripLengthBreakdownCard — empty + "need more data"', () {
+    testWidgets(
+      'renders SizedBox.shrink (no card) when all buckets are zero',
+      (tester) async {
+        await _pumpCard(
+          tester,
+          breakdown: TripLengthBreakdown.empty,
+          overallAvgLPer100Km: null,
+        );
+
+        // The title must NOT render when the card is hidden.
+        expect(find.text('Consumption by trip length'), findsNothing);
+        // The internal Card root key must not be in the tree either.
+        expect(
+          find.byKey(const ValueKey('trip_length_breakdown_card')),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'shows "Need more data" on the medium tile when count is between 1 and 4',
+      (tester) async {
+        await _pumpCard(
+          tester,
+          breakdown: const TripLengthBreakdown(
+            short: TripLengthBucketStats(
+              tripCount: 5,
+              totalDistanceKm: 15.0,
+              totalLitres: 1.5,
+              avgLPer100Km: 10.0,
+            ),
+            medium: TripLengthBucketStats(
+              tripCount: 3,
+              totalDistanceKm: 30.0,
+              totalLitres: 1.8,
+              avgLPer100Km: 6.0,
+            ),
+            long: TripLengthBucketStats.empty,
+          ),
+          overallAvgLPer100Km: 8.0,
+        );
+
+        // The placeholder copy renders inside the medium tile.
+        expect(find.text('Need more data'), findsOneWidget);
+        // Belt-and-braces: the actual avg must NOT be rendered for the
+        // medium bucket when below the floor — averaging 3 trips is
+        // exactly the "swing-on-one-outlier" case the placeholder
+        // exists to suppress.
+        expect(find.text('6.0 L/100'), findsNothing);
+      },
+    );
+  });
+
+  group('TripLengthBreakdownCard — above/below arrows', () {
+    testWidgets(
+      'renders red up arrow when bucket avg is above overall avg',
+      (tester) async {
+        await _pumpCard(
+          tester,
+          breakdown: const TripLengthBreakdown(
+            short: TripLengthBucketStats(
+              tripCount: 6,
+              totalDistanceKm: 18.0,
+              totalLitres: 2.0,
+              avgLPer100Km: 11.1, // above overall (7.5)
+            ),
+            medium: TripLengthBucketStats.empty,
+            long: TripLengthBucketStats.empty,
+          ),
+          overallAvgLPer100Km: 7.5,
+        );
+
+        // Up arrow for the worse-than-overall short bucket.
+        expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
+        expect(find.byIcon(Icons.arrow_downward), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'renders green down arrow when bucket avg is below overall avg',
+      (tester) async {
+        await _pumpCard(
+          tester,
+          breakdown: const TripLengthBreakdown(
+            short: TripLengthBucketStats.empty,
+            medium: TripLengthBucketStats.empty,
+            long: TripLengthBucketStats(
+              tripCount: 8,
+              totalDistanceKm: 400.0,
+              totalLitres: 24.0,
+              avgLPer100Km: 6.0, // below overall (7.5)
+            ),
+          ),
+          overallAvgLPer100Km: 7.5,
+        );
+
+        expect(find.byIcon(Icons.arrow_downward), findsOneWidget);
+        expect(find.byIcon(Icons.arrow_upward), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'no arrows render when overallAvgLPer100Km is null',
+      (tester) async {
+        await _pumpCard(
+          tester,
+          breakdown: const TripLengthBreakdown(
+            short: TripLengthBucketStats.empty,
+            medium: TripLengthBucketStats(
+              tripCount: 6,
+              totalDistanceKm: 60.0,
+              totalLitres: 4.0,
+              avgLPer100Km: 6.667,
+            ),
+            long: TripLengthBucketStats.empty,
+          ),
+          overallAvgLPer100Km: null,
+        );
+
+        expect(find.byIcon(Icons.arrow_upward), findsNothing);
+        expect(find.byIcon(Icons.arrow_downward), findsNothing);
+      },
+    );
+  });
+}
+
+/// Pumps [TripLengthBreakdownCard] inside a [MaterialApp] that wires
+/// [AppLocalizations] so the localised strings resolve, and threads the
+/// inherited [ThemeData] / [AppLocalizations] into the widget's
+/// required `l` / `theme` parameters via a [Builder].
+///
+/// The widget intentionally does NOT call [AppLocalizations.of] itself
+/// — it takes the bundle as a parameter so the dashboard can compute
+/// it once and the widget renders deterministically. The Builder here
+/// mirrors the production wire-up in `carbon_dashboard_screen.dart`.
+Future<void> _pumpCard(
+  WidgetTester tester, {
+  required TripLengthBreakdown breakdown,
+  required double? overallAvgLPer100Km,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            final l = AppLocalizations.of(context);
+            final theme = Theme.of(context);
+            // pumpApp would have loaded the delegate by the next pump,
+            // so AppLocalizations.of must resolve before we hand it in.
+            if (l == null) return const SizedBox.shrink();
+            return TripLengthBreakdownCard(
+              breakdown: breakdown,
+              overallAvgLPer100Km: overallAvgLPer100Km,
+              l: l,
+              theme: theme,
+            );
+          },
+        ),
+      ),
+    ),
+  );
+  // Two pumps so the AppLocalizations delegate finishes loading. We
+  // avoid pumpAndSettle on Windows widget tests per the project's
+  // Hive-fire-and-forget guideline.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}

--- a/test/features/consumption/domain/services/trip_length_aggregator_test.dart
+++ b/test/features/consumption/domain/services/trip_length_aggregator_test.dart
@@ -1,0 +1,255 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/services/trip_length_aggregator.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// Pure-logic coverage for `aggregateByTripLength` (#1191).
+///
+/// The aggregator drives `TripLengthBreakdownCard` on the Carbon
+/// dashboard; the widget tests pump pre-built [TripLengthBreakdown]
+/// values, so the bucket boundary + filter + null-handling logic must
+/// be locked down here. Tests cover:
+///   * empty + degenerate input → all-zero breakdown
+///   * one trip per bucket → trip count + total + average per bucket
+///   * boundary at exactly 5.0 km → MEDIUM (lower edge inclusive)
+///   * boundary at exactly 25.0 km → MEDIUM (upper edge inclusive)
+///   * vehicleId filter — other vehicle excluded, legacy null included
+///   * skip when fuelLitersConsumed is null
+///   * average computation correctness over multiple trips per bucket
+void main() {
+  group('aggregateByTripLength — empty / degenerate input', () {
+    test('returns the empty breakdown when trips is empty', () {
+      final breakdown = aggregateByTripLength(const []);
+
+      expect(breakdown.short.tripCount, 0);
+      expect(breakdown.medium.tripCount, 0);
+      expect(breakdown.long.tripCount, 0);
+      expect(breakdown.short.avgLPer100Km, isNull);
+      expect(breakdown.medium.avgLPer100Km, isNull);
+      expect(breakdown.long.avgLPer100Km, isNull);
+      expect(breakdown.isEmpty, isTrue);
+    });
+
+    test('skips trips whose fuelLitersConsumed is null', () {
+      final breakdown = aggregateByTripLength([
+        _entry(id: 't1', distanceKm: 3.0, fuelLitersConsumed: null),
+        _entry(id: 't2', distanceKm: 12.0, fuelLitersConsumed: null),
+        _entry(id: 't3', distanceKm: 40.0, fuelLitersConsumed: null),
+      ]);
+
+      // Every trip dropped — breakdown is all-zero / empty.
+      expect(breakdown.short.tripCount, 0);
+      expect(breakdown.medium.tripCount, 0);
+      expect(breakdown.long.tripCount, 0);
+      expect(breakdown.isEmpty, isTrue);
+    });
+  });
+
+  group('aggregateByTripLength — bucketing', () {
+    test('one trip per bucket lands in the expected slot', () {
+      final breakdown = aggregateByTripLength([
+        _entry(id: 'short', distanceKm: 3.0, fuelLitersConsumed: 0.4),
+        _entry(id: 'medium', distanceKm: 12.0, fuelLitersConsumed: 0.9),
+        _entry(id: 'long', distanceKm: 40.0, fuelLitersConsumed: 2.4),
+      ]);
+
+      expect(breakdown.short.tripCount, 1);
+      expect(breakdown.medium.tripCount, 1);
+      expect(breakdown.long.tripCount, 1);
+
+      // Average L/100 km: 0.4 / 3.0 * 100 = 13.333...
+      expect(breakdown.short.avgLPer100Km!, closeTo(13.333, 0.01));
+      // 0.9 / 12.0 * 100 = 7.5
+      expect(breakdown.medium.avgLPer100Km!, closeTo(7.5, 0.01));
+      // 2.4 / 40.0 * 100 = 6.0
+      expect(breakdown.long.avgLPer100Km!, closeTo(6.0, 0.01));
+      expect(breakdown.isEmpty, isFalse);
+    });
+
+    test('boundary at exactly 5.0 km lands in MEDIUM (lower edge)', () {
+      final breakdown = aggregateByTripLength([
+        _entry(id: 'edge-low', distanceKm: 5.0, fuelLitersConsumed: 0.5),
+      ]);
+
+      expect(breakdown.short.tripCount, 0);
+      expect(breakdown.medium.tripCount, 1);
+      expect(breakdown.long.tripCount, 0);
+    });
+
+    test('boundary at exactly 25.0 km lands in MEDIUM (upper edge)', () {
+      final breakdown = aggregateByTripLength([
+        _entry(id: 'edge-high', distanceKm: 25.0, fuelLitersConsumed: 1.5),
+      ]);
+
+      expect(breakdown.short.tripCount, 0);
+      expect(breakdown.medium.tripCount, 1);
+      expect(breakdown.long.tripCount, 0);
+    });
+
+    test('a value just past 25.0 km lands in LONG', () {
+      final breakdown = aggregateByTripLength([
+        _entry(id: 'just-long', distanceKm: 25.001, fuelLitersConsumed: 1.5),
+      ]);
+
+      expect(breakdown.medium.tripCount, 0);
+      expect(breakdown.long.tripCount, 1);
+    });
+
+    test('a value just under 5.0 km lands in SHORT', () {
+      final breakdown = aggregateByTripLength([
+        _entry(id: 'just-short', distanceKm: 4.999, fuelLitersConsumed: 0.5),
+      ]);
+
+      expect(breakdown.short.tripCount, 1);
+      expect(breakdown.medium.tripCount, 0);
+    });
+
+    test('the boundary constants are 5 km and 25 km', () {
+      // Locks down the public constants imported by the widget so a
+      // future tweak in the aggregator surfaces here AND in the widget
+      // tests, not just on the dashboard at runtime.
+      expect(tripLengthShortUpperKm, 5.0);
+      expect(tripLengthMediumUpperKm, 25.0);
+    });
+  });
+
+  group('aggregateByTripLength — vehicleId filter', () {
+    test('passing a vehicleId excludes trips for other vehicles', () {
+      final breakdown = aggregateByTripLength(
+        [
+          _entry(
+            id: 'mine',
+            vehicleId: 'car-a',
+            distanceKm: 12.0,
+            fuelLitersConsumed: 0.9,
+          ),
+          _entry(
+            id: 'theirs',
+            vehicleId: 'car-b',
+            distanceKm: 18.0,
+            fuelLitersConsumed: 1.4,
+          ),
+        ],
+        vehicleId: 'car-a',
+      );
+
+      // Only the matching trip counted.
+      expect(breakdown.medium.tripCount, 1);
+      expect(breakdown.medium.totalDistanceKm, 12.0);
+    });
+
+    test('passing a vehicleId still includes legacy null-vehicleId trips', () {
+      final breakdown = aggregateByTripLength(
+        [
+          _entry(
+            id: 'tagged',
+            vehicleId: 'car-a',
+            distanceKm: 10.0,
+            fuelLitersConsumed: 0.7,
+          ),
+          _entry(
+            id: 'legacy',
+            vehicleId: null,
+            distanceKm: 14.0,
+            fuelLitersConsumed: 1.0,
+          ),
+        ],
+        vehicleId: 'car-a',
+      );
+
+      // Both trips count — legacy null-vehicleId is treated as "could
+      // be this vehicle" per the trajets-tab convention.
+      expect(breakdown.medium.tripCount, 2);
+      expect(breakdown.medium.totalDistanceKm, closeTo(24.0, 0.001));
+    });
+
+    test('null vehicleId includes every trip regardless of tag', () {
+      final breakdown = aggregateByTripLength([
+        _entry(
+          id: 'a',
+          vehicleId: 'car-a',
+          distanceKm: 10.0,
+          fuelLitersConsumed: 0.7,
+        ),
+        _entry(
+          id: 'b',
+          vehicleId: 'car-b',
+          distanceKm: 14.0,
+          fuelLitersConsumed: 1.0,
+        ),
+        _entry(
+          id: 'legacy',
+          vehicleId: null,
+          distanceKm: 12.0,
+          fuelLitersConsumed: 0.9,
+        ),
+      ]);
+
+      // No filter — every trip lands in medium.
+      expect(breakdown.medium.tripCount, 3);
+    });
+  });
+
+  group('aggregateByTripLength — average correctness', () {
+    test('two medium trips combine into one weighted average', () {
+      final breakdown = aggregateByTripLength([
+        _entry(id: 't1', distanceKm: 10.0, fuelLitersConsumed: 0.5),
+        _entry(id: 't2', distanceKm: 20.0, fuelLitersConsumed: 1.5),
+      ]);
+
+      // Combined: 30 km / 2 L → 6.667 L/100 km.
+      expect(breakdown.medium.tripCount, 2);
+      expect(breakdown.medium.totalDistanceKm, closeTo(30.0, 0.001));
+      expect(breakdown.medium.totalLitres, closeTo(2.0, 0.001));
+      expect(breakdown.medium.avgLPer100Km!, closeTo(6.667, 0.01));
+    });
+
+    test('mixed buckets in one call — no cross-bucket bleed', () {
+      final breakdown = aggregateByTripLength([
+        // Two short trips
+        _entry(id: 's1', distanceKm: 2.0, fuelLitersConsumed: 0.3),
+        _entry(id: 's2', distanceKm: 4.0, fuelLitersConsumed: 0.5),
+        // One long trip
+        _entry(id: 'l1', distanceKm: 100.0, fuelLitersConsumed: 5.0),
+      ]);
+
+      expect(breakdown.short.tripCount, 2);
+      expect(breakdown.short.totalDistanceKm, closeTo(6.0, 0.001));
+      expect(breakdown.short.totalLitres, closeTo(0.8, 0.001));
+      // 0.8 / 6.0 * 100 = 13.333
+      expect(breakdown.short.avgLPer100Km!, closeTo(13.333, 0.01));
+
+      // Medium left empty — short trips MUST not bleed into medium.
+      expect(breakdown.medium.tripCount, 0);
+      expect(breakdown.medium.avgLPer100Km, isNull);
+
+      expect(breakdown.long.tripCount, 1);
+      expect(breakdown.long.avgLPer100Km!, closeTo(5.0, 0.001));
+    });
+  });
+}
+
+/// Convenience constructor for a [TripHistoryEntry] in this file's
+/// tests. Only fields the aggregator reads are exposed; everything
+/// else gets a sensible default that makes the trip parse without
+/// being meaningful for these assertions.
+TripHistoryEntry _entry({
+  required String id,
+  String? vehicleId,
+  required double distanceKm,
+  required double? fuelLitersConsumed,
+}) {
+  return TripHistoryEntry(
+    id: id,
+    vehicleId: vehicleId,
+    summary: TripSummary(
+      distanceKm: distanceKm,
+      maxRpm: 0,
+      highRpmSeconds: 0,
+      idleSeconds: 0,
+      harshBrakes: 0,
+      harshAccelerations: 0,
+      fuelLitersConsumed: fuelLitersConsumed,
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

- New aggregator `aggregateByTripLength` splits trips into short (<5 km), medium (5-25 km), long (>25 km) buckets per the spec — boundary inclusive on both sides of medium so 5.0 km and 25.0 km lands medium.
- New `TripLengthBreakdownCard` widget renders a 3-tile row on the Carbon dashboard's Charts tab. Each tile shows avg L/100 km, trip count, and total distance, with red/green up/down arrows comparing the bucket to the vehicle-wide average.
- Card hides entirely when every bucket has zero trips. Per-tile "Need more data" placeholder when a bucket has 1-4 trips (averaging that few swings on every fill-up).
- Wired into the existing `_ChartsTab` between the summary tiles and the monthly cost chart. Reads `tripHistoryListProvider` + `activeVehicleProfileProvider`, so the card refreshes whenever the trip list updates.
- ARB fragments for EN/DE under `lib/l10n/_fragments/trip_length_breakdown_*.arb`; FR strings added directly to `app_fr.arb` per the project's no-FR-fragment convention.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/features/consumption/domain/services/trip_length_aggregator_test.dart` — 13/13 pass
- [x] `flutter test test/features/carbon/presentation/widgets/trip_length_breakdown_card_test.dart` — 7/7 pass
- [x] `flutter test test/lint/arb_fragments_consistency_test.dart` — fragment rebuild matches committed
- [x] `flutter test test/features/carbon/carbon_dashboard_screen_test.dart` — existing dashboard tests still pass
- [ ] CI runs full suite

## Coverage

- Aggregator: empty input, one trip per bucket, boundary at 5.0 / 25.0 km, just-past boundaries, vehicleId filter (other-vehicle excluded, legacy null included), null-fuel-litres dropped, weighted average across multiple trips, no cross-bucket bleed.
- Widget: 3-tile rendering with localised labels, hidden on empty breakdown, "Need more data" placeholder when count 1-4, red up arrow when worse than overall, green down arrow when better, no arrow when overallAvg null.