### PR TITLE
fix(vehicle): preserve non-form fields across edit-screen Save (Closes #1217)

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -122,8 +122,19 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   Future<void> _save() async {
     final form = _formKey.currentState;
     if (form == null || !form.validate()) return;
+    // #1217 — pass the saved profile through so [buildProfile] can
+    // copyWith on top of it. Otherwise every Save reset every field
+    // not on the form's parameter list (autoRecord, pairedAdapterMac,
+    // learned VE, driving aggregates, reference-catalog ids, ...) to
+    // its freezed `@Default`.
+    final existing = _existingId == null
+        ? null
+        : ref
+            .read(vehicleProfileListProvider)
+            .where((v) => v.id == _existingId)
+            .firstOrNull;
     final profile = _ctrl.buildProfile(
-      existingId: _existingId,
+      existing: existing,
       type: _type,
       connectors: _connectors,
       adapterMac: _adapterMac,

--- a/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
@@ -58,8 +58,21 @@ class VehicleFormControllers {
 
   /// Construct a [VehicleProfile] from the current controller values
   /// combined with the non-controller state passed in by the caller.
+  ///
+  /// When [existing] is non-null, the result starts from
+  /// `existing.copyWith(...)` and only overwrites the fields the form
+  /// actually edits — everything else (e.g. the long-lived
+  /// `pairedAdapterMac`, the auto-record toggle, learned volumetric
+  /// efficiency, the driving aggregates, the reference-catalog ids)
+  /// is preserved automatically. This is the architectural fix for
+  /// #1217: previously, every Save constructed a brand-new profile
+  /// from a fixed parameter list, silently wiping any field that
+  /// wasn't on that list back to its `@Default(...)`.
+  ///
+  /// When [existing] is null (the "Add vehicle" path), the new profile
+  /// is built from defaults with a freshly minted uuid.
   VehicleProfile buildProfile({
-    required String? existingId,
+    required VehicleProfile? existing,
     required VehicleType type,
     required Set<ConnectorType> connectors,
     required String? adapterMac,
@@ -68,34 +81,69 @@ class VehicleFormControllers {
     required int? engineCylinders,
     required int? curbWeightKg,
   }) {
+    // Compute the form-derived values once — they're the same whether
+    // we're creating a new profile or copying an existing one.
+    final name = nameController.text.trim();
+    final isCombustion = type == VehicleType.combustion;
+    final isEv = type == VehicleType.ev;
+    final batteryKwh =
+        isCombustion ? null : _parseDouble(batteryController.text);
+    final maxChargingKw =
+        isCombustion ? null : _parseDouble(maxChargingKwController.text);
+    final supportedConnectors =
+        isCombustion ? <ConnectorType>{} : {...connectors};
+    final tankCapacityL =
+        isEv ? null : _parseDouble(tankController.text);
+    final preferredFuelType = isEv
+        ? null
+        : (fuelTypeController.text.trim().isEmpty
+            ? null
+            : fuelTypeController.text.trim());
+    final chargingPreferences = ChargingPreferences(
+      minSocPercent: _parseIntOr(minSocController.text, 20).clamp(0, 100),
+      maxSocPercent: _parseIntOr(maxSocController.text, 80).clamp(0, 100),
+    );
+    final vin = vinController.text.trim().isEmpty
+        ? null
+        : vinController.text.trim();
+
+    if (existing != null) {
+      // Preserve every non-form field by starting from the saved
+      // profile and only overwriting what the form actually edits.
+      // The EV/combustion type-flip rules (null out battery/tank/etc.
+      // when switching across types) are still applied above and
+      // flow through copyWith here.
+      return existing.copyWith(
+        name: name,
+        type: type,
+        batteryKwh: batteryKwh,
+        maxChargingKw: maxChargingKw,
+        supportedConnectors: supportedConnectors,
+        chargingPreferences: chargingPreferences,
+        tankCapacityL: tankCapacityL,
+        preferredFuelType: preferredFuelType,
+        obd2AdapterMac: adapterMac,
+        obd2AdapterName: adapterName,
+        vin: vin,
+        engineDisplacementCc: engineDisplacementCc,
+        engineCylinders: engineCylinders,
+        curbWeightKg: curbWeightKg,
+      );
+    }
+
     return VehicleProfile(
-      id: existingId ?? _uuid.v4(),
-      name: nameController.text.trim(),
+      id: _uuid.v4(),
+      name: name,
       type: type,
-      batteryKwh: type == VehicleType.combustion
-          ? null
-          : _parseDouble(batteryController.text),
-      maxChargingKw: type == VehicleType.combustion
-          ? null
-          : _parseDouble(maxChargingKwController.text),
-      supportedConnectors:
-          type == VehicleType.combustion ? <ConnectorType>{} : {...connectors},
-      tankCapacityL:
-          type == VehicleType.ev ? null : _parseDouble(tankController.text),
-      preferredFuelType: type == VehicleType.ev
-          ? null
-          : (fuelTypeController.text.trim().isEmpty
-              ? null
-              : fuelTypeController.text.trim()),
-      chargingPreferences: ChargingPreferences(
-        minSocPercent: _parseIntOr(minSocController.text, 20).clamp(0, 100),
-        maxSocPercent: _parseIntOr(maxSocController.text, 80).clamp(0, 100),
-      ),
+      batteryKwh: batteryKwh,
+      maxChargingKw: maxChargingKw,
+      supportedConnectors: supportedConnectors,
+      tankCapacityL: tankCapacityL,
+      preferredFuelType: preferredFuelType,
+      chargingPreferences: chargingPreferences,
       obd2AdapterMac: adapterMac,
       obd2AdapterName: adapterName,
-      vin: vinController.text.trim().isEmpty
-          ? null
-          : vinController.text.trim(),
+      vin: vin,
       engineDisplacementCc: engineDisplacementCc,
       engineCylinders: engineCylinders,
       curbWeightKg: curbWeightKg,

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_persistence_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_persistence_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Regression coverage for #1217 — the bug was that
+/// [VehicleFormControllers.buildProfile] constructed a brand-new
+/// [VehicleProfile] from a fixed parameter list, so any field NOT on
+/// that list (e.g. the long-lived OBD2 pairing, the auto-record
+/// toggle, the learned volumetric efficiency, the calibration mode,
+/// etc.) was silently wiped on every Save.
+///
+/// The fix is architectural: [buildProfile] now takes the saved
+/// profile as `existing:` and uses `copyWith` semantics, so anything
+/// not on the form is preserved automatically. Asserting only on
+/// `calibrationMode` (the field reported in #1217) would not prove
+/// the architectural fix — this test pins down a representative slice
+/// of the larger bug surface so future regressions on similar fields
+/// fail loudly.
+void main() {
+  group('EditVehicleScreen — non-form field persistence (#1217)', () {
+    testWidgets(
+      'saving from the edit screen preserves every field the form '
+      'does not touch',
+      (tester) async {
+        final repo = VehicleProfileRepository(_FakeSettings());
+
+        // A profile that already has a bunch of non-default values
+        // from features that live OUTSIDE the edit form (auto-record,
+        // OBD2 pairing, VE learner, calibration mode segment).
+        const original = VehicleProfile(
+          id: 'v1',
+          name: 'My Peugeot 107',
+          type: VehicleType.combustion,
+          tankCapacityL: 35.0,
+          preferredFuelType: 'e10',
+          // #894 — set by the calibration-mode segmented button.
+          calibrationMode: VehicleCalibrationMode.fuzzy,
+          // #1004 — set by the auto-record / pairing flow.
+          pairedAdapterMac: 'AA:BB:CC:DD:EE:FF',
+          autoRecord: true,
+          movementStartThresholdKmh: 7.5,
+          disconnectSaveDelaySec: 90,
+          backgroundLocationConsent: true,
+          // #815 — written by the η_v learner from real driving.
+          volumetricEfficiency: 0.92,
+          volumetricEfficiencySamples: 50,
+          // #950 — written by the reference-vehicle migrator.
+          referenceVehicleId: 'peugeot-107-2008-',
+        );
+        await repo.save(original);
+
+        final container = ProviderContainer(
+          overrides: [
+            vehicleProfileRepositoryProvider.overrideWithValue(repo),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: EditVehicleScreen(vehicleId: 'v1'),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Edit a user-visible field so the Save path is genuinely
+        // exercised (not a no-op).
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Name'),
+          'My Peugeot 107 (renamed)',
+        );
+
+        // Tap the bottom Save button; ensureVisible scrolls into the
+        // viewport in case the host ListView accretes new sections.
+        final saveButton = find.widgetWithText(FilledButton, 'Save');
+        await tester.ensureVisible(saveButton);
+        await tester.pumpAndSettle();
+        await tester.tap(saveButton);
+        await tester.pumpAndSettle();
+
+        // Reload from the repository — same source of truth the
+        // provider reads from.
+        final saved = repo.getById('v1');
+        expect(saved, isNotNull);
+
+        // The user-edited field changed.
+        expect(saved!.name, 'My Peugeot 107 (renamed)');
+
+        // Every non-form field survives — the architectural fix.
+        expect(
+          saved.calibrationMode,
+          VehicleCalibrationMode.fuzzy,
+          reason: '#894 calibration mode must survive Save',
+        );
+        expect(
+          saved.pairedAdapterMac,
+          'AA:BB:CC:DD:EE:FF',
+          reason: '#1004 long-lived adapter pairing must survive Save',
+        );
+        expect(
+          saved.autoRecord,
+          isTrue,
+          reason: '#1004 auto-record toggle must survive Save',
+        );
+        expect(
+          saved.movementStartThresholdKmh,
+          7.5,
+          reason: '#1004 movement threshold must survive Save',
+        );
+        expect(
+          saved.disconnectSaveDelaySec,
+          90,
+          reason: '#1004 disconnect-save delay must survive Save',
+        );
+        expect(
+          saved.backgroundLocationConsent,
+          isTrue,
+          reason: '#1004 background-location consent must survive Save',
+        );
+        expect(
+          saved.volumetricEfficiency,
+          0.92,
+          reason: '#815 learned VE must survive Save',
+        );
+        expect(
+          saved.volumetricEfficiencySamples,
+          50,
+          reason: '#815 VE sample count must survive Save',
+        );
+        expect(
+          saved.referenceVehicleId,
+          'peugeot-107-2008-',
+          reason: '#950 reference-vehicle id must survive Save',
+        );
+
+        // Sanity: the user-editable combustion fields still round-trip.
+        expect(saved.type, VehicleType.combustion);
+        expect(saved.tankCapacityL, 35.0);
+        expect(saved.preferredFuelType, 'e10');
+      },
+    );
+  });
+}
+
+/// Minimal in-memory [SettingsStorage] so the repository round-trips
+/// without a Hive box.
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_form_controllers_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_form_controllers_test.dart
@@ -163,7 +163,7 @@ void main() {
       c.vinController.text = 'WVWZZZ9NZ7Y000001';
 
       final profile = c.buildProfile(
-        existingId: 'ice-7',
+        existing: const VehicleProfile(id: 'ice-7', name: ''),
         type: VehicleType.combustion,
         connectors: const {ConnectorType.ccs}, // ignored for combustion
         adapterMac: '11:22:33:44:55:66',
@@ -207,7 +207,7 @@ void main() {
       c.maxSocController.text = '90';
 
       final profile = c.buildProfile(
-        existingId: 'ev-7',
+        existing: const VehicleProfile(id: 'ev-7', name: ''),
         type: VehicleType.ev,
         connectors: const {ConnectorType.ccs, ConnectorType.type2},
         adapterMac: null,
@@ -244,7 +244,7 @@ void main() {
       c.maxSocController.text = '80';
 
       final profile = c.buildProfile(
-        existingId: 'hyb-1',
+        existing: const VehicleProfile(id: 'hyb-1', name: ''),
         type: VehicleType.hybrid,
         connectors: const {ConnectorType.type2},
         adapterMac: null,
@@ -264,14 +264,14 @@ void main() {
       expect(profile.engineCylinders, 4);
     });
 
-    test('mints a new uuid when existingId is null', () {
+    test('mints a new uuid when existing is null', () {
       final c = VehicleFormControllers();
       addTearDown(c.dispose);
 
       c.nameController.text = 'New Car';
 
       final p1 = c.buildProfile(
-        existingId: null,
+        existing: null,
         type: VehicleType.combustion,
         connectors: const {},
         adapterMac: null,
@@ -281,7 +281,7 @@ void main() {
         curbWeightKg: null,
       );
       final p2 = c.buildProfile(
-        existingId: null,
+        existing: null,
         type: VehicleType.combustion,
         connectors: const {},
         adapterMac: null,
@@ -310,7 +310,7 @@ void main() {
       c.vinController.text = '   ';
 
       final profile = c.buildProfile(
-        existingId: 'edge-1',
+        existing: const VehicleProfile(id: 'edge-1', name: ''),
         type: VehicleType.hybrid,
         connectors: const {},
         adapterMac: null,
@@ -341,7 +341,7 @@ void main() {
       c.maxSocController.text = 'high'; // -> fallback 80
 
       final profile = c.buildProfile(
-        existingId: 'edge-2',
+        existing: const VehicleProfile(id: 'edge-2', name: ''),
         type: VehicleType.hybrid,
         connectors: const {},
         adapterMac: null,
@@ -367,7 +367,7 @@ void main() {
       c.tankController.text = '45,5';
 
       final profile = c.buildProfile(
-        existingId: 'edge-3',
+        existing: const VehicleProfile(id: 'edge-3', name: ''),
         type: VehicleType.hybrid,
         connectors: const {},
         adapterMac: null,
@@ -390,7 +390,7 @@ void main() {
       c.maxSocController.text = '250';
 
       final profile = c.buildProfile(
-        existingId: 'edge-4',
+        existing: const VehicleProfile(id: 'edge-4', name: ''),
         type: VehicleType.ev,
         connectors: const {ConnectorType.type2},
         adapterMac: null,
@@ -411,7 +411,7 @@ void main() {
       final inputConnectors = <ConnectorType>{ConnectorType.type2};
 
       final profile = c.buildProfile(
-        existingId: 'ev-3',
+        existing: const VehicleProfile(id: 'ev-3', name: ''),
         type: VehicleType.ev,
         connectors: inputConnectors,
         adapterMac: null,


### PR DESCRIPTION
## Summary

`VehicleFormControllers.buildProfile()` constructed a brand-new `VehicleProfile` from a fixed parameter list, so any field on `VehicleProfile` NOT in that list silently fell back to its freezed `@Default(...)` and was wiped on every Save.

Architectural fix: `buildProfile` now takes `existing: VehicleProfile?` and uses `copyWith` semantics when present. The EV/combustion type-flip rules (null out battery/tank/etc. across types) still take effect on top of the copyWith. New profiles still construct from scratch with a freshly minted uuid.

`_save()` on `EditVehicleScreen` now reads the saved profile from `vehicleProfileListProvider` by `_existingId` and passes it through. The redundant `existingId:` parameter is dropped.

## Fields the bug was wiping on every Save (now preserved)

- `calibrationMode` (#894 — the field reported in #1217)
- `pairedAdapterMac` (#1004 — long-lived adapter pairing, very user-visible)
- `autoRecord`, `movementStartThresholdKmh`, `disconnectSaveDelaySec`, `backgroundLocationConsent` (#1004 hands-free toggles)
- `volumetricEfficiency`, `volumetricEfficiencySamples` (#815 — runtime-calibrated η_v)
- `tripLengthAggregates`, `speedConsumptionAggregates`, `aggregatesUpdatedAt`, `aggregatesTripCount` (#1206 / #1212 driving stats)
- `make`, `model`, `year`, `referenceVehicleId` (#950 catalog match)

## Test plan

- [x] New `test/features/vehicle/presentation/screens/edit_vehicle_screen_persistence_test.dart` mounts the real `EditVehicleScreen` with a profile carrying non-default values across a representative slice of the bug surface (calibration mode fuzzy, pairedAdapterMac, autoRecord true, all three auto-record knobs, learned VE 0.92 / 50 samples, referenceVehicleId), edits the name, taps Save, and asserts every non-form field survives the round-trip.
- [x] Existing `vehicle_form_controllers_test.dart` updated to the new `existing:` parameter shape.
- [x] `flutter analyze` clean.
- [x] `flutter test test/features/vehicle/presentation/` — 142 / 142 pass (covers all sibling edit-screen tests, calibration-mode, VIN, save-actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)