### PR TITLE
feat(carbon): consumption-by-speed card on dashboard (Closes #1192)

### DIFF
--- a/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
+++ b/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
@@ -8,6 +8,7 @@ import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/section_card.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../consumption/data/trip_history_repository.dart';
+import '../../../consumption/domain/services/speed_consumption_histogram.dart';
 import '../../../consumption/domain/services/trip_length_aggregator.dart';
 import '../../../consumption/providers/consumption_providers.dart';
 import '../../../consumption/providers/trip_history_provider.dart';
@@ -18,6 +19,7 @@ import '../../domain/monthly_summary.dart';
 import '../widgets/fuel_vs_ev_card.dart';
 import '../widgets/milestones_card.dart';
 import '../widgets/monthly_bar_chart.dart';
+import '../widgets/speed_consumption_card.dart';
 import '../widgets/trip_length_breakdown_card.dart';
 
 /// Carbon dashboard: tabbed view of monthly charts (#180) and
@@ -150,6 +152,16 @@ class _ChartsTab extends ConsumerWidget {
     );
     final overallAvg = _overallAvgLPer100Km(trips, activeVehicle?.id);
 
+    // #1192 — speed-vs-consumption histogram, fed by per-second OBD2
+    // samples on each TripHistoryEntry. Same vehicle-id filter as the
+    // trip-length card so the two histograms describe the same data
+    // slice — and so the reference line on the speed card matches the
+    // overall avg already computed above.
+    final filteredTrips = _filterTrips(trips, activeVehicle?.id);
+    final speedBins = aggregateSpeedConsumption(
+      filteredTrips.expand((entry) => entry.samples),
+    );
+
     return ListView(
       padding: EdgeInsets.only(
         top: 16,
@@ -161,6 +173,13 @@ class _ChartsTab extends ConsumerWidget {
         if (l != null && !breakdown.isEmpty)
           TripLengthBreakdownCard(
             breakdown: breakdown,
+            overallAvgLPer100Km: overallAvg,
+            l: l,
+            theme: theme,
+          ),
+        if (l != null)
+          SpeedConsumptionCard(
+            bins: speedBins,
             overallAvgLPer100Km: overallAvg,
             l: l,
             theme: theme,
@@ -222,6 +241,23 @@ double? _overallAvgLPer100Km(
   }
   if (totalDistanceKm <= 0) return null;
   return (totalLitres / totalDistanceKm) * 100.0;
+}
+
+/// Filter [trips] to those that match [vehicleId] (or carry a legacy
+/// null vehicleId — same convention used by the trajets tab and
+/// [aggregateByTripLength]). Returns the filtered list eagerly so the
+/// caller can `.expand` over it twice without re-running the predicate
+/// per pass — a small but noticeable saving on long trip lists where
+/// each entry carries hundreds of samples.
+List<TripHistoryEntry> _filterTrips(
+  Iterable<TripHistoryEntry> trips,
+  String? vehicleId,
+) {
+  if (vehicleId == null) return trips.toList(growable: false);
+  return trips
+      .where((entry) =>
+          entry.vehicleId == null || entry.vehicleId == vehicleId)
+      .toList(growable: false);
 }
 
 class _AchievementsTab extends StatelessWidget {

--- a/lib/features/carbon/presentation/widgets/speed_consumption_card.dart
+++ b/lib/features/carbon/presentation/widgets/speed_consumption_card.dart
@@ -1,0 +1,371 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/domain/services/speed_consumption_histogram.dart';
+
+/// Consumption-by-speed card on the Carbon dashboard Charts tab (#1192).
+///
+/// Renders one horizontal bar per [SpeedBand], with bar length
+/// proportional to the band's average L/100 km. The user can see at a
+/// glance which speed band is costing them most fuel — and adjust their
+/// motorway cruising speed accordingly. The whole card stays on the
+/// dashboard even when the user has no OBD2 data yet, falling through
+/// to an explanatory empty-state so the feature is discoverable.
+///
+/// ## Empty-state thresholds
+///
+/// * `totalSampleCount == 0` → no OBD2 telemetry recorded yet.
+/// * `totalTimeShareSeconds < 1800` (< 30 min total) → not enough
+///   data for the bar averages to be meaningful.
+///
+/// In either case the card body is replaced by the
+/// [AppLocalizations.speedConsumptionInsufficientData] copy. Keeping
+/// the card itself visible (as opposed to hiding it) makes the
+/// requirement discoverable for the user — the empty-state IS the call
+/// to action ("plug in your OBD2 adapter and drive 30 min").
+///
+/// ## Bar rendering
+///
+/// * `idleJam` band: thin neutral bar with "—" in the right column.
+///   The band exists for time-share only — its `avgLPer100Km` is null
+///   by design.
+/// * Bands with `avgLPer100Km == null` (under the 30-sample floor):
+///   thin bar with the "Need more data" label.
+/// * All other bands: bar length = `avg / maxAvg` of the visible bins,
+///   so the bar with the highest L/100 km fills the available width.
+///   Sub-label shows "23 % of driving" computed from
+///   `timeShareSeconds / totalTimeShareSeconds`.
+/// * Reference vertical line: rendered when [overallAvgLPer100Km] is
+///   non-null AND at least one bar has a non-null avg. Position is
+///   `overallAvg / maxAvg` along the bar's track. Anchors which bands
+///   are above/below the user's vehicle-wide figure.
+class SpeedConsumptionCard extends StatelessWidget {
+  /// Pre-computed bins, in [SpeedBand] declaration order. The widget
+  /// renders them in the order received — the dashboard caller passes
+  /// the result of `aggregateSpeedConsumption(...)` directly.
+  final List<SpeedConsumptionBin> bins;
+
+  /// Vehicle-wide average L/100 km used as the reference line. Compute
+  /// from the same trip set the [bins] were built from so the line
+  /// stays consistent with the bars next to it. Null when no overall
+  /// avg can be computed (e.g. no trips have fuel-rate data) — the
+  /// reference line is then suppressed.
+  final double? overallAvgLPer100Km;
+
+  /// Localizations bundle for the host context. Required so the widget
+  /// can be unit-tested without an inherited [AppLocalizations].
+  final AppLocalizations l;
+
+  /// Theme bundle, threaded in from the host so the widget never
+  /// reaches into [Theme.of] directly — keeps it cheap to render
+  /// inside a `ListView`.
+  final ThemeData theme;
+
+  const SpeedConsumptionCard({
+    super.key,
+    required this.bins,
+    required this.overallAvgLPer100Km,
+    required this.l,
+    required this.theme,
+  });
+
+  /// Minimum total time-share (in seconds) before the bars are
+  /// rendered. 30 min ≈ 1800 s — under that the per-band averages
+  /// swing too much on engine-load noise to be useful.
+  static const double minTotalTimeShareSeconds = 1800.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final totalSampleCount =
+        bins.fold<int>(0, (sum, bin) => sum + bin.sampleCount);
+    final totalTimeShareSeconds =
+        bins.fold<double>(0.0, (sum, bin) => sum + bin.timeShareSeconds);
+
+    final hasInsufficientData = totalSampleCount == 0 ||
+        totalTimeShareSeconds < minTotalTimeShareSeconds;
+
+    return Card(
+      key: const ValueKey('speed_consumption_card'),
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l.speedConsumptionCardTitle,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            if (hasInsufficientData)
+              _InsufficientData(l: l, theme: theme)
+            else
+              _BarList(
+                bins: bins,
+                totalTimeShareSeconds: totalTimeShareSeconds,
+                overallAvgLPer100Km: overallAvgLPer100Km,
+                l: l,
+                theme: theme,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Empty-state shown inside the card when there isn't enough OBD2
+/// telemetry yet. Renders the localised copy with a leading info icon
+/// so the user reads it as guidance, not an error.
+class _InsufficientData extends StatelessWidget {
+  final AppLocalizations l;
+  final ThemeData theme;
+
+  const _InsufficientData({required this.l, required this.theme});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      key: const ValueKey('speed_consumption_insufficient_data'),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.info_outline,
+            size: 18,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              l.speedConsumptionInsufficientData,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Vertical stack of one [_SpeedBar] per band, plus an optional
+/// reference line at the vehicle's overall avg. The list owns the
+/// shared `maxAvg` so every bar in the stack scales against the same
+/// denominator — bar length comparisons are honest.
+class _BarList extends StatelessWidget {
+  final List<SpeedConsumptionBin> bins;
+  final double totalTimeShareSeconds;
+  final double? overallAvgLPer100Km;
+  final AppLocalizations l;
+  final ThemeData theme;
+
+  const _BarList({
+    required this.bins,
+    required this.totalTimeShareSeconds,
+    required this.overallAvgLPer100Km,
+    required this.l,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // Find the max avg across bins that actually have one. Used as the
+    // bar-length denominator so the worst-consumption band fills the
+    // track. Falls back to 1.0 when no bin has an avg (every bin is
+    // null) — bars then render at their floor width.
+    double maxAvg = 0.0;
+    for (final bin in bins) {
+      final avg = bin.avgLPer100Km;
+      if (avg != null && avg > maxAvg) maxAvg = avg;
+    }
+    if (maxAvg <= 0) maxAvg = 1.0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final bin in bins)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: _SpeedBar(
+              key: Key('speed_bar_${bin.band.name}'),
+              bin: bin,
+              maxAvg: maxAvg,
+              overallAvgLPer100Km: overallAvgLPer100Km,
+              totalTimeShareSeconds: totalTimeShareSeconds,
+              l: l,
+              theme: theme,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// One horizontal bar inside the bar list. Renders three pieces:
+///   * leading band label (left-aligned, width-capped so long
+///     translations don't shove the bar offscreen);
+///   * the bar itself, with width proportional to the bin's avg, plus
+///     the optional vertical reference line;
+///   * trailing avg L/100 km figure (or "—" / "Need more data").
+class _SpeedBar extends StatelessWidget {
+  final SpeedConsumptionBin bin;
+  final double maxAvg;
+  final double? overallAvgLPer100Km;
+  final double totalTimeShareSeconds;
+  final AppLocalizations l;
+  final ThemeData theme;
+
+  const _SpeedBar({
+    super.key,
+    required this.bin,
+    required this.maxAvg,
+    required this.overallAvgLPer100Km,
+    required this.totalTimeShareSeconds,
+    required this.l,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final avg = bin.avgLPer100Km;
+    final isIdle = bin.band == SpeedBand.idleJam;
+
+    // Bar fill fraction in [0, 1]. Idle/jam and under-threshold bins
+    // render a thin "floor" bar (3 %) so their label still has visual
+    // presence — a zero-width bar would look like a rendering bug.
+    final fillFraction = avg == null ? 0.03 : (avg / maxAvg).clamp(0.0, 1.0);
+
+    final referenceFraction = (avg != null && overallAvgLPer100Km != null)
+        ? (overallAvgLPer100Km! / maxAvg).clamp(0.0, 1.0)
+        : null;
+
+    final timeShareLabel = totalTimeShareSeconds > 0
+        ? l.speedConsumptionTimeShare(
+            ((bin.timeShareSeconds / totalTimeShareSeconds) * 100).round(),
+          )
+        : l.speedConsumptionTimeShare(0);
+
+    final trailing = avg == null
+        ? (isIdle ? '—' : l.speedConsumptionNeedMoreData)
+        : '${avg.toStringAsFixed(1)} L/100';
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 96,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                _bandLabel(bin.band),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              Text(
+                timeShareLabel,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final trackWidth = constraints.maxWidth;
+              final barWidth = trackWidth * fillFraction;
+              return SizedBox(
+                height: 18,
+                child: Stack(
+                  children: [
+                    Container(
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                    ),
+                    SizedBox(
+                      width: barWidth,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: avg == null
+                              ? theme.colorScheme.outlineVariant
+                              : theme.colorScheme.primary,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                    ),
+                    if (referenceFraction != null)
+                      Positioned(
+                        left: trackWidth * referenceFraction,
+                        top: -2,
+                        bottom: -2,
+                        child: Container(
+                          key: const ValueKey(
+                            'speed_consumption_reference_line',
+                          ),
+                          width: 2,
+                          color: theme.colorScheme.error,
+                        ),
+                      ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 80,
+          child: Text(
+            trailing,
+            textAlign: TextAlign.end,
+            style: avg == null
+                ? theme.textTheme.bodySmall?.copyWith(
+                    fontStyle: FontStyle.italic,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  )
+                : theme.textTheme.bodyMedium,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Map a [SpeedBand] to its localised label. Switch is exhaustive so
+  /// adding a band to the enum without updating the UI is a compile-
+  /// time error — surfaces missing translations the moment the
+  /// aggregator grows.
+  String _bandLabel(SpeedBand band) {
+    switch (band) {
+      case SpeedBand.idleJam:
+        return l.speedBandIdleJam;
+      case SpeedBand.urban:
+        return l.speedBandUrban;
+      case SpeedBand.suburban:
+        return l.speedBandSuburban;
+      case SpeedBand.rural:
+        return l.speedBandRural;
+      case SpeedBand.motorwaySlow:
+        return l.speedBandMotorwaySlow;
+      case SpeedBand.motorway:
+        return l.speedBandMotorway;
+      case SpeedBand.motorwayFast:
+        return l.speedBandMotorwayFast;
+    }
+  }
+}

--- a/lib/features/consumption/domain/services/speed_consumption_histogram.dart
+++ b/lib/features/consumption/domain/services/speed_consumption_histogram.dart
@@ -1,0 +1,253 @@
+/// Speed-vs-consumption histogram aggregator (#1192).
+///
+/// Folds a stream of per-second [TripSample]s into seven fixed
+/// [SpeedBand] bins so the Carbon dashboard's Charts tab can show how
+/// many L/100 km the user actually burns at each cruising speed. The
+/// most actionable lever the driver has is motorway speed: aero drag
+/// rises with v², so dropping 130 km/h to 110 km/h typically cuts
+/// consumption by 15-25 % on the same car. Surfacing the user's own
+/// data is what makes that abstract advice land.
+///
+/// ## Design notes
+///
+/// **Pure function** — no Riverpod, no I/O, no DateTime arithmetic
+/// beyond what the input already carries. Mirrors the style of
+/// `monthly_insights_aggregator.dart` and
+/// `throttle_rpm_histogram_calculator.dart` in the same directory.
+///
+/// **Sample = 1 second.** The OBD2 polling loop runs at ~1 Hz, so we
+/// treat each sample as a one-second tick for the time-share metric.
+/// This is identical to how `throttle_rpm_histogram_calculator` weights
+/// its bins — drift between cadences would matter for sub-second
+/// analysis but not for the "how much of my driving is at 130 km/h"
+/// question this card answers.
+///
+/// **Aggregate L/100 km, not mean of per-sample ratios.** The clean
+/// formula for a bin's average consumption is
+/// `(Σ fuelRateLPerHour) / (Σ speedKmh) * 100`, NOT the arithmetic mean
+/// of `(fuelRate / speed * 100)` across samples. The latter would
+/// double-count slow ticks (where the ratio explodes) and drift away
+/// from the figure the user already sees on the trip-detail screen.
+/// This is the harmonic-vs-arithmetic-mean trap most consumption
+/// dashboards stumble into.
+///
+/// **Idle/jam band has no consumption average.** Below 10 km/h the
+/// fuelRate / speed ratio is dominated by the speed denominator (a car
+/// idling at 2 L/h with `speedKmh = 0.5` reports 400 L/100 km, which
+/// is technically correct but useless on a dashboard). The bin still
+/// counts samples + time-share so the user sees "12 % of driving was in
+/// stop-and-go", but its `avgLPer100Km` is always null.
+///
+/// ## Bin edges
+///
+/// Inclusive lower, exclusive upper — a sample at exactly 10.0 km/h
+/// goes to [SpeedBand.urban], at exactly 50.0 to [SpeedBand.suburban],
+/// at 100.0 to [SpeedBand.motorwaySlow], at 130.0 to
+/// [SpeedBand.motorwayFast]. The 130+ band has no upper bound.
+///
+/// ## Sample skip rules
+///
+/// * `fuelRateLPerHour == null` → sample dropped from EVERY bin (not
+///   counted in time-share either — keeps the time-share comparable to
+///   the consumption metric).
+/// * `speedKmh < 0` → sensor glitch, sample dropped entirely.
+/// * Otherwise the sample is credited to its band's count + time-share,
+///   and (if not idle/jam) to the running fuel + speed sums used to
+///   compute the bin's average.
+library;
+
+import '../trip_recorder.dart';
+
+/// Speed bands the dashboard splits driving into. Order is the
+/// declaration order — the aggregator returns one bin per value in
+/// this order so consumers can render the bars top-to-bottom without
+/// re-sorting.
+enum SpeedBand {
+  /// 0–10 km/h. Stop-and-go, traffic jams. Counted for time-share but
+  /// excluded from the L/100 km average (denominator approaches zero).
+  idleJam,
+
+  /// 10–50 km/h. City driving.
+  urban,
+
+  /// 50–80 km/h. Mixed roads / boulevards.
+  suburban,
+
+  /// 80–100 km/h. Country roads, secondary highways.
+  rural,
+
+  /// 100–115 km/h. Eco-cruise — the sweet spot on most modern engines.
+  motorwaySlow,
+
+  /// 115–130 km/h. Standard motorway / French highway speed limit.
+  motorway,
+
+  /// 130 km/h and above. Above the French limit; German Autobahn fast
+  /// lane. Aero drag is dominant here — surfacing this bin lets the
+  /// driver see the cost of the last 20 km/h.
+  motorwayFast,
+}
+
+/// Lower edge (inclusive) of each speed band, in km/h. The
+/// declaration order matches [SpeedBand]; `idleJam` starts at 0 by
+/// convention and the next band's lower edge is the previous band's
+/// exclusive upper edge.
+const Map<SpeedBand, double> _speedBandLowerKmh = <SpeedBand, double>{
+  SpeedBand.idleJam: 0.0,
+  SpeedBand.urban: 10.0,
+  SpeedBand.suburban: 50.0,
+  SpeedBand.rural: 80.0,
+  SpeedBand.motorwaySlow: 100.0,
+  SpeedBand.motorway: 115.0,
+  SpeedBand.motorwayFast: 130.0,
+};
+
+/// One band's aggregate stats. Value type — the widget reads these
+/// fields directly.
+class SpeedConsumptionBin {
+  /// Which band this bin represents.
+  final SpeedBand band;
+
+  /// Number of samples that landed in this band. Includes idle/jam
+  /// samples (we count time-share even when avg is null).
+  final int sampleCount;
+
+  /// Seconds spent in this band, computed as `sampleCount` (each OBD2
+  /// tick is treated as one second per the design notes). Stored as a
+  /// `double` so future sub-second cadences can be plumbed without a
+  /// type change.
+  final double timeShareSeconds;
+
+  /// Average L/100 km for this band, or null when:
+  ///   * the band is [SpeedBand.idleJam] (denominator-zero);
+  ///   * `sampleCount < minSamplesPerBin` (statistical floor — a 30 s
+  ///     window on a single PID 5E reading isn't meaningful).
+  final double? avgLPer100Km;
+
+  const SpeedConsumptionBin({
+    required this.band,
+    required this.sampleCount,
+    required this.timeShareSeconds,
+    required this.avgLPer100Km,
+  });
+}
+
+/// Default minimum samples per bin before [SpeedConsumptionBin.avgLPer100Km]
+/// is exposed. ~30 s of consistent driving in a band is the smallest
+/// window where the aggregate L/100 km stops swinging on engine-load
+/// noise. Exposed as a parameter so tests can pin the threshold.
+const int defaultMinSamplesPerBin = 30;
+
+/// Pick the band an absolute [speedKmh] belongs to. Inclusive lower,
+/// exclusive upper — a sample at exactly 10.0 km/h goes to
+/// [SpeedBand.urban], at 130.0 to [SpeedBand.motorwayFast].
+SpeedBand _bandFor(double speedKmh) {
+  if (speedKmh < 10.0) return SpeedBand.idleJam;
+  if (speedKmh < 50.0) return SpeedBand.urban;
+  if (speedKmh < 80.0) return SpeedBand.suburban;
+  if (speedKmh < 100.0) return SpeedBand.rural;
+  if (speedKmh < 115.0) return SpeedBand.motorwaySlow;
+  if (speedKmh < 130.0) return SpeedBand.motorway;
+  return SpeedBand.motorwayFast;
+}
+
+/// Fold the [samples] iterable into one [SpeedConsumptionBin] per
+/// [SpeedBand], in declaration order. Returns 7 bins always, including
+/// empty ones (so the chart can render an empty bar with the band
+/// label even when no sample fell in that band).
+///
+/// `minSamplesPerBin` controls the statistical floor below which a
+/// bin's `avgLPer100Km` is reported as null. Defaults to
+/// [defaultMinSamplesPerBin].
+List<SpeedConsumptionBin> aggregateSpeedConsumption(
+  Iterable<TripSample> samples, {
+  int minSamplesPerBin = defaultMinSamplesPerBin,
+}) {
+  return _aggregate(samples, minSamplesPerBin);
+}
+
+/// Multi-trip variant: pass an iterable of per-trip sample lists; the
+/// function flattens internally and returns the same shape. Behaviour
+/// is identical to passing `trips.expand((t) => t)` to
+/// [aggregateSpeedConsumption] — the convenience overload exists so the
+/// dashboard caller doesn't have to do the flatten dance inline.
+List<SpeedConsumptionBin> aggregateSpeedConsumptionMultiTrip(
+  Iterable<List<TripSample>> trips, {
+  int minSamplesPerBin = defaultMinSamplesPerBin,
+}) {
+  return _aggregate(trips.expand((t) => t), minSamplesPerBin);
+}
+
+/// Shared bin-walk used by both single- and multi-trip variants.
+List<SpeedConsumptionBin> _aggregate(
+  Iterable<TripSample> samples,
+  int minSamplesPerBin,
+) {
+  // Per-band running counters. Indexed by SpeedBand.index so the loop
+  // body stays branchless beyond the band lookup.
+  final counts = List<int>.filled(SpeedBand.values.length, 0);
+  final fuelSums = List<double>.filled(SpeedBand.values.length, 0.0);
+  final speedSums = List<double>.filled(SpeedBand.values.length, 0.0);
+
+  for (final sample in samples) {
+    final speed = sample.speedKmh;
+    final fuelRate = sample.fuelRateLPerHour;
+    if (fuelRate == null) continue; // No consumption data → skip entirely.
+    if (speed < 0) continue; // Sensor glitch.
+
+    final band = _bandFor(speed);
+    final idx = band.index;
+    counts[idx]++;
+    if (band != SpeedBand.idleJam) {
+      // Idle/jam samples are counted for time-share only — including
+      // them in the fuel/speed sums would skew the average for any
+      // bin's neighbour at low speed.
+      fuelSums[idx] += fuelRate;
+      speedSums[idx] += speed;
+    }
+  }
+
+  return <SpeedConsumptionBin>[
+    for (final band in SpeedBand.values)
+      _buildBin(
+        band: band,
+        sampleCount: counts[band.index],
+        fuelSum: fuelSums[band.index],
+        speedSum: speedSums[band.index],
+        minSamplesPerBin: minSamplesPerBin,
+      ),
+  ];
+}
+
+/// Construct one [SpeedConsumptionBin] from its accumulated counters.
+/// Encapsulates the avg-null rules so [_aggregate] stays focused on the
+/// per-sample loop.
+SpeedConsumptionBin _buildBin({
+  required SpeedBand band,
+  required int sampleCount,
+  required double fuelSum,
+  required double speedSum,
+  required int minSamplesPerBin,
+}) {
+  double? avg;
+  // Two reasons avg stays null:
+  //   1. The band is idleJam (per spec — division by ~zero is meaningless).
+  //   2. Sample count is below the statistical floor — a thin sliver
+  //      of seconds isn't enough to trust the figure.
+  if (band != SpeedBand.idleJam &&
+      sampleCount >= minSamplesPerBin &&
+      speedSum > 0) {
+    avg = (fuelSum / speedSum) * 100.0;
+  }
+  return SpeedConsumptionBin(
+    band: band,
+    sampleCount: sampleCount,
+    timeShareSeconds: sampleCount.toDouble(),
+    avgLPer100Km: avg,
+  );
+}
+
+/// Lower edge (inclusive) of [band], in km/h. Exposed for the widget's
+/// label-formatting helpers — keeps the band-edge constants in one
+/// place even if the UI changes how they're rendered.
+double speedBandLowerKmh(SpeedBand band) => _speedBandLowerKmh[band]!;

--- a/lib/l10n/_fragments/speed_consumption_de.arb
+++ b/lib/l10n/_fragments/speed_consumption_de.arb
@@ -1,0 +1,13 @@
+{
+  "speedConsumptionCardTitle": "Verbrauch nach Geschwindigkeit",
+  "speedBandIdleJam": "Leerlauf / Stau",
+  "speedBandUrban": "Stadt (10–50)",
+  "speedBandSuburban": "Vorort (50–80)",
+  "speedBandRural": "Landstraße (80–100)",
+  "speedBandMotorwaySlow": "Eco-Tempo (100–115)",
+  "speedBandMotorway": "Autobahn (115–130)",
+  "speedBandMotorwayFast": "Autobahn schnell (130+)",
+  "speedConsumptionInsufficientData": "Zeichnen Sie 30+ Minuten Fahrten mit dem OBD2-Adapter auf, um die Geschwindigkeits-/Verbrauchsanalyse freizuschalten.",
+  "speedConsumptionTimeShare": "{percent} % der Fahrt",
+  "speedConsumptionNeedMoreData": "Mehr Daten nötig"
+}

--- a/lib/l10n/_fragments/speed_consumption_en.arb
+++ b/lib/l10n/_fragments/speed_consumption_en.arb
@@ -1,0 +1,51 @@
+{
+  "speedConsumptionCardTitle": "Consumption by speed",
+  "@speedConsumptionCardTitle": {
+    "description": "Title of the consumption-by-speed card on the Carbon dashboard Charts tab — bins per-second OBD2 samples by speed band so the user can see what motorway speed is costing them per 100 km (#1192)."
+  },
+  "speedBandIdleJam": "Idle / jam",
+  "@speedBandIdleJam": {
+    "description": "Label of the 0-10 km/h speed band on the consumption-by-speed card — stop-and-go and traffic-jam time. Has a time-share figure but no L/100 km average (denominator approaches zero) (#1192)."
+  },
+  "speedBandUrban": "Urban (10–50)",
+  "@speedBandUrban": {
+    "description": "Label of the 10-50 km/h speed band on the consumption-by-speed card — city driving (#1192)."
+  },
+  "speedBandSuburban": "Suburban (50–80)",
+  "@speedBandSuburban": {
+    "description": "Label of the 50-80 km/h speed band on the consumption-by-speed card — boulevards and mixed roads (#1192)."
+  },
+  "speedBandRural": "Rural (80–100)",
+  "@speedBandRural": {
+    "description": "Label of the 80-100 km/h speed band on the consumption-by-speed card — country roads and secondary highways (#1192)."
+  },
+  "speedBandMotorwaySlow": "Eco-cruise (100–115)",
+  "@speedBandMotorwaySlow": {
+    "description": "Label of the 100-115 km/h speed band on the consumption-by-speed card — eco-cruise sweet spot on most modern engines (#1192)."
+  },
+  "speedBandMotorway": "Motorway (115–130)",
+  "@speedBandMotorway": {
+    "description": "Label of the 115-130 km/h speed band on the consumption-by-speed card — standard motorway / French highway speed limit (#1192)."
+  },
+  "speedBandMotorwayFast": "Motorway fast (130+)",
+  "@speedBandMotorwayFast": {
+    "description": "Label of the 130+ km/h speed band on the consumption-by-speed card — above the French limit; German Autobahn fast lane (#1192)."
+  },
+  "speedConsumptionInsufficientData": "Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.",
+  "@speedConsumptionInsufficientData": {
+    "description": "Empty-state copy on the consumption-by-speed card when the user has logged less than 30 min of OBD2 telemetry — explains what's needed to populate the chart (#1192)."
+  },
+  "speedConsumptionTimeShare": "{percent} % of driving",
+  "@speedConsumptionTimeShare": {
+    "description": "Per-bar sub-label on the consumption-by-speed card — share of total driving time spent in this band (#1192).",
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "speedConsumptionNeedMoreData": "Need more data",
+  "@speedConsumptionNeedMoreData": {
+    "description": "Placeholder shown on a speed-band bar when the bin's sample count is under the statistical floor — averaging a thin sliver of seconds isn't meaningful (#1192)."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1502,6 +1502,17 @@
   "radiusAlertCenterFromMap": "Kartenposition",
   "radiusAlertNotificationTitle": "{fuelLabel} in der Nähe von {label}",
   "radiusAlertNotificationBody": "Eine Tankstelle bietet {price} € (Grenze: {threshold} €)",
+  "speedConsumptionCardTitle": "Verbrauch nach Geschwindigkeit",
+  "speedBandIdleJam": "Leerlauf / Stau",
+  "speedBandUrban": "Stadt (10–50)",
+  "speedBandSuburban": "Vorort (50–80)",
+  "speedBandRural": "Landstraße (80–100)",
+  "speedBandMotorwaySlow": "Eco-Tempo (100–115)",
+  "speedBandMotorway": "Autobahn (115–130)",
+  "speedBandMotorwayFast": "Autobahn schnell (130+)",
+  "speedConsumptionInsufficientData": "Zeichnen Sie 30+ Minuten Fahrten mit dem OBD2-Adapter auf, um die Geschwindigkeits-/Verbrauchsanalyse freizuschalten.",
+  "speedConsumptionTimeShare": "{percent} % der Fahrt",
+  "speedConsumptionNeedMoreData": "Mehr Daten nötig",
   "splashLoadingLabel": "Tankstellen wird geladen",
   "@splashLoadingLabel": {
     "description": "Barrierefreiheits-Label, das TalkBack/VoiceOver während des animierten Splash-Screens ansagt. Wird nicht sichtbar gerendert; kurz und sprechbar halten."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2255,6 +2255,55 @@
       }
     }
   },
+  "speedConsumptionCardTitle": "Consumption by speed",
+  "@speedConsumptionCardTitle": {
+    "description": "Title of the consumption-by-speed card on the Carbon dashboard Charts tab — bins per-second OBD2 samples by speed band so the user can see what motorway speed is costing them per 100 km (#1192)."
+  },
+  "speedBandIdleJam": "Idle / jam",
+  "@speedBandIdleJam": {
+    "description": "Label of the 0-10 km/h speed band on the consumption-by-speed card — stop-and-go and traffic-jam time. Has a time-share figure but no L/100 km average (denominator approaches zero) (#1192)."
+  },
+  "speedBandUrban": "Urban (10–50)",
+  "@speedBandUrban": {
+    "description": "Label of the 10-50 km/h speed band on the consumption-by-speed card — city driving (#1192)."
+  },
+  "speedBandSuburban": "Suburban (50–80)",
+  "@speedBandSuburban": {
+    "description": "Label of the 50-80 km/h speed band on the consumption-by-speed card — boulevards and mixed roads (#1192)."
+  },
+  "speedBandRural": "Rural (80–100)",
+  "@speedBandRural": {
+    "description": "Label of the 80-100 km/h speed band on the consumption-by-speed card — country roads and secondary highways (#1192)."
+  },
+  "speedBandMotorwaySlow": "Eco-cruise (100–115)",
+  "@speedBandMotorwaySlow": {
+    "description": "Label of the 100-115 km/h speed band on the consumption-by-speed card — eco-cruise sweet spot on most modern engines (#1192)."
+  },
+  "speedBandMotorway": "Motorway (115–130)",
+  "@speedBandMotorway": {
+    "description": "Label of the 115-130 km/h speed band on the consumption-by-speed card — standard motorway / French highway speed limit (#1192)."
+  },
+  "speedBandMotorwayFast": "Motorway fast (130+)",
+  "@speedBandMotorwayFast": {
+    "description": "Label of the 130+ km/h speed band on the consumption-by-speed card — above the French limit; German Autobahn fast lane (#1192)."
+  },
+  "speedConsumptionInsufficientData": "Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.",
+  "@speedConsumptionInsufficientData": {
+    "description": "Empty-state copy on the consumption-by-speed card when the user has logged less than 30 min of OBD2 telemetry — explains what's needed to populate the chart (#1192)."
+  },
+  "speedConsumptionTimeShare": "{percent} % of driving",
+  "@speedConsumptionTimeShare": {
+    "description": "Per-bar sub-label on the consumption-by-speed card — share of total driving time spent in this band (#1192).",
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "speedConsumptionNeedMoreData": "Need more data",
+  "@speedConsumptionNeedMoreData": {
+    "description": "Placeholder shown on a speed-band bar when the bin's sample count is under the statistical floor — averaging a thin sliver of seconds isn't meaningful (#1192)."
+  },
   "splashLoadingLabel": "Loading Tankstellen",
   "@splashLoadingLabel": {
     "description": "Accessibility label announced by TalkBack/VoiceOver while the animated splash screen is visible. Not rendered visually; keep it concise and speakable."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1030,5 +1030,16 @@
   "tripLengthBucketMedium": "Moyen (5–25 km)",
   "tripLengthBucketLong": "Long (>25 km)",
   "tripLengthBucketNeedMoreData": "Plus de données nécessaires",
-  "tripLengthBucketTripCount": "{count, plural, =0{aucun trajet} one{1 trajet} other{{count} trajets}}"
+  "tripLengthBucketTripCount": "{count, plural, =0{aucun trajet} one{1 trajet} other{{count} trajets}}",
+  "speedConsumptionCardTitle": "Consommation par vitesse",
+  "speedBandIdleJam": "Ralenti / embouteillage",
+  "speedBandUrban": "Urbain (10–50)",
+  "speedBandSuburban": "Périurbain (50–80)",
+  "speedBandRural": "Route (80–100)",
+  "speedBandMotorwaySlow": "Eco-vitesse (100–115)",
+  "speedBandMotorway": "Autoroute (115–130)",
+  "speedBandMotorwayFast": "Autoroute rapide (130+)",
+  "speedConsumptionInsufficientData": "Enregistrez plus de 30 minutes de trajets avec l'adaptateur OBD2 pour débloquer l'analyse vitesse/consommation.",
+  "speedConsumptionTimeShare": "{percent} % de conduite",
+  "speedConsumptionNeedMoreData": "Plus de données nécessaires"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6974,6 +6974,72 @@ abstract class AppLocalizations {
   /// **'A station is at {price} € (target: {threshold} €)'**
   String radiusAlertNotificationBody(String price, String threshold);
 
+  /// Title of the consumption-by-speed card on the Carbon dashboard Charts tab — bins per-second OBD2 samples by speed band so the user can see what motorway speed is costing them per 100 km (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Consumption by speed'**
+  String get speedConsumptionCardTitle;
+
+  /// Label of the 0-10 km/h speed band on the consumption-by-speed card — stop-and-go and traffic-jam time. Has a time-share figure but no L/100 km average (denominator approaches zero) (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Idle / jam'**
+  String get speedBandIdleJam;
+
+  /// Label of the 10-50 km/h speed band on the consumption-by-speed card — city driving (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Urban (10–50)'**
+  String get speedBandUrban;
+
+  /// Label of the 50-80 km/h speed band on the consumption-by-speed card — boulevards and mixed roads (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Suburban (50–80)'**
+  String get speedBandSuburban;
+
+  /// Label of the 80-100 km/h speed band on the consumption-by-speed card — country roads and secondary highways (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Rural (80–100)'**
+  String get speedBandRural;
+
+  /// Label of the 100-115 km/h speed band on the consumption-by-speed card — eco-cruise sweet spot on most modern engines (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Eco-cruise (100–115)'**
+  String get speedBandMotorwaySlow;
+
+  /// Label of the 115-130 km/h speed band on the consumption-by-speed card — standard motorway / French highway speed limit (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Motorway (115–130)'**
+  String get speedBandMotorway;
+
+  /// Label of the 130+ km/h speed band on the consumption-by-speed card — above the French limit; German Autobahn fast lane (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Motorway fast (130+)'**
+  String get speedBandMotorwayFast;
+
+  /// Empty-state copy on the consumption-by-speed card when the user has logged less than 30 min of OBD2 telemetry — explains what's needed to populate the chart (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.'**
+  String get speedConsumptionInsufficientData;
+
+  /// Per-bar sub-label on the consumption-by-speed card — share of total driving time spent in this band (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'{percent} % of driving'**
+  String speedConsumptionTimeShare(int percent);
+
+  /// Placeholder shown on a speed-band bar when the bin's sample count is under the statistical floor — averaging a thin sliver of seconds isn't meaningful (#1192).
+  ///
+  /// In en, this message translates to:
+  /// **'Need more data'**
+  String get speedConsumptionNeedMoreData;
+
   /// Accessibility label announced by TalkBack/VoiceOver while the animated splash screen is visible. Not rendered visually; keep it concise and speakable.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3748,6 +3748,42 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3748,6 +3748,42 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3746,6 +3746,42 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3781,6 +3781,42 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Verbrauch nach Geschwindigkeit';
+
+  @override
+  String get speedBandIdleJam => 'Leerlauf / Stau';
+
+  @override
+  String get speedBandUrban => 'Stadt (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Vorort (50–80)';
+
+  @override
+  String get speedBandRural => 'Landstraße (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-Tempo (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Autobahn (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Autobahn schnell (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Zeichnen Sie 30+ Minuten Fahrten mit dem OBD2-Adapter auf, um die Geschwindigkeits-/Verbrauchsanalyse freizuschalten.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % der Fahrt';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Mehr Daten nötig';
+
+  @override
   String get splashLoadingLabel => 'Tankstellen wird geladen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3750,6 +3750,42 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3741,6 +3741,42 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3749,6 +3749,42 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3743,6 +3743,42 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3746,6 +3746,42 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3777,6 +3777,42 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consommation par vitesse';
+
+  @override
+  String get speedBandIdleJam => 'Ralenti / embouteillage';
+
+  @override
+  String get speedBandUrban => 'Urbain (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Périurbain (50–80)';
+
+  @override
+  String get speedBandRural => 'Route (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-vitesse (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Autoroute (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Autoroute rapide (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Enregistrez plus de 30 minutes de trajets avec l\'adaptateur OBD2 pour débloquer l\'analyse vitesse/consommation.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % de conduite';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Plus de données nécessaires';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3745,6 +3745,42 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3750,6 +3750,42 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3749,6 +3749,42 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3747,6 +3747,42 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3749,6 +3749,42 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3745,6 +3745,42 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3750,6 +3750,42 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3748,6 +3748,42 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3749,6 +3749,42 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3748,6 +3748,42 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3749,6 +3749,42 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3743,6 +3743,42 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3747,6 +3747,42 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get speedConsumptionCardTitle => 'Consumption by speed';
+
+  @override
+  String get speedBandIdleJam => 'Idle / jam';
+
+  @override
+  String get speedBandUrban => 'Urban (10–50)';
+
+  @override
+  String get speedBandSuburban => 'Suburban (50–80)';
+
+  @override
+  String get speedBandRural => 'Rural (80–100)';
+
+  @override
+  String get speedBandMotorwaySlow => 'Eco-cruise (100–115)';
+
+  @override
+  String get speedBandMotorway => 'Motorway (115–130)';
+
+  @override
+  String get speedBandMotorwayFast => 'Motorway fast (130+)';
+
+  @override
+  String get speedConsumptionInsufficientData =>
+      'Record 30+ minutes of trips with the OBD2 adapter to unlock the speed/consumption analysis.';
+
+  @override
+  String speedConsumptionTimeShare(int percent) {
+    return '$percent % of driving';
+  }
+
+  @override
+  String get speedConsumptionNeedMoreData => 'Need more data';
+
+  @override
   String get splashLoadingLabel => 'Loading Tankstellen';
 
   @override

--- a/test/features/carbon/carbon_dashboard_screen_test.dart
+++ b/test/features/carbon/carbon_dashboard_screen_test.dart
@@ -75,10 +75,22 @@ void main() {
         gamificationEnabledProvider.overrideWith((ref) => true),
       ],
     );
-    // Two bar charts on the Charts tab
-    expect(find.byType(MonthlyBarChart), findsNWidgets(2));
-    expect(find.text('Monthly costs'), findsOneWidget);
-    expect(find.text('Monthly CO2 emissions'), findsOneWidget);
+    // Two bar charts on the Charts tab. skipOffstage: false because the
+    // tab is now tall enough that the second chart sits below the 800x600
+    // test viewport — the assertion is "the chart is in the tree", not
+    // "the chart is in the initial scroll window".
+    expect(
+      find.byType(MonthlyBarChart, skipOffstage: false),
+      findsNWidgets(2),
+    );
+    expect(
+      find.text('Monthly costs', skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Monthly CO2 emissions', skipOffstage: false),
+      findsOneWidget,
+    );
   });
 
   testWidgets('switches to achievements tab showing milestones + EV card',
@@ -143,10 +155,21 @@ void main() {
       // No TabBar, no Achievements tab — just the Charts pane.
       expect(find.byType(TabBar), findsNothing);
       expect(find.text('Achievements'), findsNothing);
-      // Charts content is still rendered.
-      expect(find.byType(MonthlyBarChart), findsNWidgets(2));
-      expect(find.text('Monthly costs'), findsOneWidget);
-      expect(find.text('Monthly CO2 emissions'), findsOneWidget);
+      // Charts content is still rendered. skipOffstage: false — the
+      // pane is taller than 600 px since the trip-length and
+      // speed-consumption cards landed.
+      expect(
+        find.byType(MonthlyBarChart, skipOffstage: false),
+        findsNWidgets(2),
+      );
+      expect(
+        find.text('Monthly costs', skipOffstage: false),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Monthly CO2 emissions', skipOffstage: false),
+        findsOneWidget,
+      );
     },
   );
 }

--- a/test/features/carbon/presentation/widgets/speed_consumption_card_test.dart
+++ b/test/features/carbon/presentation/widgets/speed_consumption_card_test.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/speed_consumption_card.dart';
+import 'package:tankstellen/features/consumption/domain/services/speed_consumption_histogram.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget-level coverage for [SpeedConsumptionCard] (#1192).
+///
+/// The aggregator's bin / floor / idle-jam logic is exercised in its
+/// own unit-test file. Here we cover the rendering contract:
+///   * one bar per band when bins carry enough total telemetry
+///   * the insufficient-data placeholder when totals are below the
+///     30-min floor (or zero samples)
+///   * the reference line renders only when overall avg is non-null
+///   * the title + localised band labels resolve through the bundle
+void main() {
+  group('SpeedConsumptionCard — happy path', () {
+    testWidgets('renders one bar per band when telemetry is sufficient',
+        (tester) async {
+      // Build a histogram with 1800+ s of total telemetry so the card
+      // renders the bars instead of the empty-state placeholder.
+      final bins = _binsWithTotalSeconds(2000);
+
+      await _pumpCard(
+        tester,
+        bins: bins,
+        overallAvgLPer100Km: 7.5,
+      );
+
+      // Title must resolve from the localisations bundle.
+      expect(find.text('Consumption by speed'), findsOneWidget);
+
+      // One bar per band — assert each band's key-prefixed widget is
+      // present. (Keys are namespaced so the test doesn't depend on
+      // the bar's internal structure.)
+      for (final band in SpeedBand.values) {
+        expect(find.byKey(Key('speed_bar_${band.name}')), findsOneWidget);
+      }
+
+      // Localised band labels render somewhere in the tree.
+      expect(find.text('Idle / jam'), findsOneWidget);
+      expect(find.text('Urban (10–50)'), findsOneWidget);
+      expect(find.text('Suburban (50–80)'), findsOneWidget);
+      expect(find.text('Rural (80–100)'), findsOneWidget);
+      expect(find.text('Eco-cruise (100–115)'), findsOneWidget);
+      expect(find.text('Motorway (115–130)'), findsOneWidget);
+      expect(find.text('Motorway fast (130+)'), findsOneWidget);
+    });
+
+    testWidgets(
+      'renders the reference line when overallAvgLPer100Km is non-null',
+      (tester) async {
+        final bins = _binsWithTotalSeconds(2000);
+
+        await _pumpCard(
+          tester,
+          bins: bins,
+          overallAvgLPer100Km: 7.5,
+        );
+
+        // The reference line is keyed once per bar that has an avg.
+        // At least one bar in our fixture has an avg → at least one
+        // reference line widget exists.
+        expect(
+          find.byKey(const ValueKey('speed_consumption_reference_line')),
+          findsWidgets,
+        );
+      },
+    );
+  });
+
+  group('SpeedConsumptionCard — insufficient data', () {
+    testWidgets(
+      'shows the placeholder when total time-share is under 30 minutes',
+      (tester) async {
+        // 1500 s = 25 min — under the 1800-s floor.
+        final bins = _binsWithTotalSeconds(1500);
+
+        await _pumpCard(
+          tester,
+          bins: bins,
+          overallAvgLPer100Km: 7.5,
+        );
+
+        // Empty-state copy is visible.
+        expect(
+          find.text(
+            'Record 30+ minutes of trips with the OBD2 adapter to '
+            'unlock the speed/consumption analysis.',
+          ),
+          findsOneWidget,
+        );
+        // No per-band bar widgets render in the empty-state.
+        expect(
+          find.byKey(const Key('speed_bar_${'urban'}')),
+          findsNothing,
+        );
+        // The empty-state widget itself is keyed for stable assertion.
+        expect(
+          find.byKey(const ValueKey('speed_consumption_insufficient_data')),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'shows the placeholder when there are zero OBD2 samples',
+      (tester) async {
+        // Every band empty (0 samples) → 0 s total → placeholder.
+        final bins = <SpeedConsumptionBin>[
+          for (final band in SpeedBand.values)
+            SpeedConsumptionBin(
+              band: band,
+              sampleCount: 0,
+              timeShareSeconds: 0,
+              avgLPer100Km: null,
+            ),
+        ];
+
+        await _pumpCard(
+          tester,
+          bins: bins,
+          overallAvgLPer100Km: null,
+        );
+
+        expect(
+          find.byKey(const ValueKey('speed_consumption_insufficient_data')),
+          findsOneWidget,
+        );
+        // Reference line is suppressed in the empty state — there's no
+        // bar to anchor it against.
+        expect(
+          find.byKey(const ValueKey('speed_consumption_reference_line')),
+          findsNothing,
+        );
+      },
+    );
+  });
+
+  group('SpeedConsumptionCard — reference line suppression', () {
+    testWidgets(
+      'no reference line renders when overallAvgLPer100Km is null',
+      (tester) async {
+        final bins = _binsWithTotalSeconds(2000);
+
+        await _pumpCard(
+          tester,
+          bins: bins,
+          overallAvgLPer100Km: null,
+        );
+
+        expect(
+          find.byKey(const ValueKey('speed_consumption_reference_line')),
+          findsNothing,
+        );
+      },
+    );
+  });
+}
+
+/// Build a histogram whose total time-share equals [totalSeconds]. The
+/// samples are spread across rural + motorway bins so both have
+/// non-null avgLPer100Km — that's all the widget needs to exercise its
+/// bar-rendering branch.
+List<SpeedConsumptionBin> _binsWithTotalSeconds(int totalSeconds) {
+  // Split the time roughly evenly across rural + motorway. The exact
+  // split doesn't matter for the rendering assertions — only the total
+  // crosses the 1800-s threshold or not.
+  final ruralSeconds = (totalSeconds / 2).floor();
+  final motorwaySeconds = totalSeconds - ruralSeconds;
+
+  return <SpeedConsumptionBin>[
+    for (final band in SpeedBand.values)
+      switch (band) {
+        SpeedBand.rural => SpeedConsumptionBin(
+            band: band,
+            sampleCount: ruralSeconds,
+            timeShareSeconds: ruralSeconds.toDouble(),
+            avgLPer100Km: 7.0,
+          ),
+        SpeedBand.motorway => SpeedConsumptionBin(
+            band: band,
+            sampleCount: motorwaySeconds,
+            timeShareSeconds: motorwaySeconds.toDouble(),
+            avgLPer100Km: 8.5,
+          ),
+        _ => SpeedConsumptionBin(
+            band: band,
+            sampleCount: 0,
+            timeShareSeconds: 0,
+            avgLPer100Km: null,
+          ),
+      },
+  ];
+}
+
+/// Pumps [SpeedConsumptionCard] inside a [MaterialApp] that wires
+/// [AppLocalizations] so the localised strings resolve. Mirrors the
+/// helper in `trip_length_breakdown_card_test.dart` for consistency.
+Future<void> _pumpCard(
+  WidgetTester tester, {
+  required List<SpeedConsumptionBin> bins,
+  required double? overallAvgLPer100Km,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: Scaffold(
+        // Wider viewport than the default test surface — the card has
+        // a 96-wide leading column and a fixed-width trailing column.
+        // On the default 800x600 surface the bar track has plenty of
+        // room, but a constrained Center on smaller surfaces would
+        // squeeze the LayoutBuilder into a near-zero width.
+        body: SizedBox(
+          width: 600,
+          child: Builder(
+            builder: (context) {
+              final l = AppLocalizations.of(context);
+              final theme = Theme.of(context);
+              if (l == null) return const SizedBox.shrink();
+              return SpeedConsumptionCard(
+                bins: bins,
+                overallAvgLPer100Km: overallAvgLPer100Km,
+                l: l,
+                theme: theme,
+              );
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+  // Two pumps so the AppLocalizations delegate finishes loading.
+  // pumpAndSettle is avoided per the project's Hive-fire-and-forget
+  // guideline — Windows test runs occasionally hang on it.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}

--- a/test/features/consumption/domain/services/speed_consumption_histogram_test.dart
+++ b/test/features/consumption/domain/services/speed_consumption_histogram_test.dart
@@ -1,0 +1,342 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/services/speed_consumption_histogram.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// Pure-logic coverage for `aggregateSpeedConsumption` (#1192).
+///
+/// Locks down the bin boundaries, sample skip rules, statistical floor,
+/// idle/jam carve-out, and avg-of-aggregates math. The widget pumps
+/// pre-built bins, so this is the only file that exercises the actual
+/// folding behaviour.
+void main() {
+  group('aggregateSpeedConsumption — empty / degenerate input', () {
+    test('returns 7 zero-bins (one per band) when input is empty', () {
+      final bins = aggregateSpeedConsumption(const <TripSample>[]);
+
+      expect(bins.length, SpeedBand.values.length);
+      // Bins land in declaration order so the chart can render
+      // top-to-bottom without re-sorting.
+      for (var i = 0; i < SpeedBand.values.length; i++) {
+        expect(bins[i].band, SpeedBand.values[i]);
+        expect(bins[i].sampleCount, 0);
+        expect(bins[i].timeShareSeconds, 0.0);
+        expect(bins[i].avgLPer100Km, isNull);
+      }
+    });
+
+    test('skips samples with fuelRateLPerHour == null entirely', () {
+      // Three samples, none with fuel rate → no bin sees them.
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: 5.0),
+        _sample(speed: 70.0),
+        _sample(speed: 130.0),
+      ]);
+
+      for (final bin in bins) {
+        expect(bin.sampleCount, 0);
+        expect(bin.timeShareSeconds, 0.0);
+      }
+    });
+
+    test('skips samples with negative speed (sensor glitch)', () {
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: -1.0, fuelRate: 8.0),
+        _sample(speed: -5.0, fuelRate: 6.0),
+      ]);
+
+      for (final bin in bins) {
+        expect(bin.sampleCount, 0);
+      }
+    });
+  });
+
+  group('aggregateSpeedConsumption — bin boundaries', () {
+    test('exactly 10.0 km/h lands in urban (lower edge inclusive)', () {
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: 10.0, fuelRate: 4.0),
+      ]);
+      expect(_binFor(bins, SpeedBand.idleJam).sampleCount, 0);
+      expect(_binFor(bins, SpeedBand.urban).sampleCount, 1);
+    });
+
+    test('exactly 50.0 km/h lands in suburban', () {
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: 50.0, fuelRate: 5.0),
+      ]);
+      expect(_binFor(bins, SpeedBand.urban).sampleCount, 0);
+      expect(_binFor(bins, SpeedBand.suburban).sampleCount, 1);
+    });
+
+    test('exactly 80.0 km/h lands in rural', () {
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: 80.0, fuelRate: 6.0),
+      ]);
+      expect(_binFor(bins, SpeedBand.suburban).sampleCount, 0);
+      expect(_binFor(bins, SpeedBand.rural).sampleCount, 1);
+    });
+
+    test('exactly 100.0 km/h lands in motorwaySlow', () {
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: 100.0, fuelRate: 6.5),
+      ]);
+      expect(_binFor(bins, SpeedBand.rural).sampleCount, 0);
+      expect(_binFor(bins, SpeedBand.motorwaySlow).sampleCount, 1);
+    });
+
+    test('exactly 115.0 km/h lands in motorway', () {
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: 115.0, fuelRate: 7.0),
+      ]);
+      expect(_binFor(bins, SpeedBand.motorwaySlow).sampleCount, 0);
+      expect(_binFor(bins, SpeedBand.motorway).sampleCount, 1);
+    });
+
+    test('exactly 130.0 km/h lands in motorwayFast (top band, no upper)', () {
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: 130.0, fuelRate: 9.0),
+      ]);
+      expect(_binFor(bins, SpeedBand.motorway).sampleCount, 0);
+      expect(_binFor(bins, SpeedBand.motorwayFast).sampleCount, 1);
+    });
+
+    test('a value just under 10.0 lands in idleJam', () {
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: 9.999, fuelRate: 1.5),
+      ]);
+      expect(_binFor(bins, SpeedBand.idleJam).sampleCount, 1);
+    });
+  });
+
+  group('aggregateSpeedConsumption — under-threshold floor', () {
+    test('a single sample under threshold has avgLPer100Km null', () {
+      final bins = aggregateSpeedConsumption([
+        _sample(speed: 70.0, fuelRate: 8.0),
+      ]);
+
+      final suburban = _binFor(bins, SpeedBand.suburban);
+      expect(suburban.sampleCount, 1);
+      expect(suburban.timeShareSeconds, 1.0);
+      // 1 < default 30 → avg suppressed.
+      expect(suburban.avgLPer100Km, isNull);
+    });
+
+    test('30 identical samples reach the floor — avg = fuelRate/speed*100', () {
+      final samples = List<TripSample>.generate(
+        30,
+        (_) => _sample(speed: 70.0, fuelRate: 8.0),
+      );
+      final bins = aggregateSpeedConsumption(samples);
+
+      final suburban = _binFor(bins, SpeedBand.suburban);
+      expect(suburban.sampleCount, 30);
+      expect(suburban.timeShareSeconds, 30.0);
+      // 8.0 / 70.0 * 100 ≈ 11.4286 — same for any number of identical
+      // samples because Σ-fuel / Σ-speed cancels the count.
+      expect(suburban.avgLPer100Km, isNotNull);
+      expect(suburban.avgLPer100Km!, closeTo(11.4286, 0.001));
+    });
+
+    test('29 samples (one shy) keeps avg null', () {
+      final samples = List<TripSample>.generate(
+        29,
+        (_) => _sample(speed: 70.0, fuelRate: 8.0),
+      );
+      final bins = aggregateSpeedConsumption(samples);
+
+      final suburban = _binFor(bins, SpeedBand.suburban);
+      expect(suburban.sampleCount, 29);
+      expect(suburban.avgLPer100Km, isNull);
+    });
+
+    test('custom minSamplesPerBin pins the floor', () {
+      // With minSamplesPerBin=1 a single sample's avg shows up.
+      final bins = aggregateSpeedConsumption(
+        [_sample(speed: 70.0, fuelRate: 8.0)],
+        minSamplesPerBin: 1,
+      );
+      final suburban = _binFor(bins, SpeedBand.suburban);
+      expect(suburban.avgLPer100Km, isNotNull);
+      expect(suburban.avgLPer100Km!, closeTo(11.4286, 0.001));
+    });
+  });
+
+  group('aggregateSpeedConsumption — idle/jam band carve-out', () {
+    test('idleJam: time-share counted, avg always null', () {
+      final samples = List<TripSample>.generate(
+        100,
+        (_) => _sample(speed: 5.0, fuelRate: 2.0),
+      );
+      final bins = aggregateSpeedConsumption(samples);
+
+      final idle = _binFor(bins, SpeedBand.idleJam);
+      expect(idle.sampleCount, 100);
+      expect(idle.timeShareSeconds, 100.0);
+      // Even with 100 samples (well over the 30 floor) the avg stays
+      // null — the band-rule overrides the threshold-rule.
+      expect(idle.avgLPer100Km, isNull);
+    });
+
+    test('idleJam samples do not pollute neighbouring band averages', () {
+      // 30 samples at speed=70/fuel=8 PLUS 50 idle-jam samples.
+      // Without the carve-out the suburban average would be dragged
+      // toward the idle-jam ratio.
+      final samples = <TripSample>[
+        ...List<TripSample>.generate(
+          30,
+          (_) => _sample(speed: 70.0, fuelRate: 8.0),
+        ),
+        ...List<TripSample>.generate(
+          50,
+          (_) => _sample(speed: 5.0, fuelRate: 2.0),
+        ),
+      ];
+      final bins = aggregateSpeedConsumption(samples);
+
+      // Suburban computation is unchanged — idle/jam samples never
+      // entered fuelSum / speedSum for any band.
+      expect(
+        _binFor(bins, SpeedBand.suburban).avgLPer100Km!,
+        closeTo(11.4286, 0.001),
+      );
+      // Idle/jam timeshare is preserved.
+      expect(_binFor(bins, SpeedBand.idleJam).sampleCount, 50);
+    });
+  });
+
+  group('aggregateSpeedConsumption — multi-trip variant', () {
+    test('flattens trips and matches concatenated single-trip input', () {
+      final t1 = List<TripSample>.generate(
+        20,
+        (_) => _sample(speed: 70.0, fuelRate: 8.0),
+      );
+      final t2 = List<TripSample>.generate(
+        20,
+        (_) => _sample(speed: 70.0, fuelRate: 8.0),
+      );
+
+      final viaMulti = aggregateSpeedConsumptionMultiTrip([t1, t2]);
+      final viaConcat = aggregateSpeedConsumption([...t1, ...t2]);
+
+      // Bins are returned in band-declaration order so element-wise
+      // comparison is valid across the two call shapes.
+      for (var i = 0; i < SpeedBand.values.length; i++) {
+        expect(viaMulti[i].band, viaConcat[i].band);
+        expect(viaMulti[i].sampleCount, viaConcat[i].sampleCount);
+        expect(viaMulti[i].timeShareSeconds, viaConcat[i].timeShareSeconds);
+        expect(viaMulti[i].avgLPer100Km, viaConcat[i].avgLPer100Km);
+      }
+    });
+
+    test('single-trip aggregator on flattened iterable matches', () {
+      final t1 = [_sample(speed: 30.0, fuelRate: 4.0)];
+      final t2 = [_sample(speed: 90.0, fuelRate: 6.0)];
+
+      final flat = [...t1, ...t2];
+      final viaSingle = aggregateSpeedConsumption(flat);
+      final viaMulti = aggregateSpeedConsumptionMultiTrip([t1, t2]);
+
+      expect(_binFor(viaSingle, SpeedBand.urban).sampleCount,
+          _binFor(viaMulti, SpeedBand.urban).sampleCount);
+      expect(_binFor(viaSingle, SpeedBand.rural).sampleCount,
+          _binFor(viaMulti, SpeedBand.rural).sampleCount);
+    });
+  });
+
+  group('aggregateSpeedConsumption — Σ/Σ vs mean-of-ratios divergence', () {
+    test(
+      'aggregate uses Σ-fuel / Σ-speed, not arithmetic mean of ratios',
+      () {
+        // Contrived case where the two formulas DO diverge:
+        //   - 30 samples at speed=20 km/h, fuelRate=4.0 L/h
+        //       → ratio = 4.0/20*100 = 20 L/100 km
+        //   - 30 samples at speed=120 km/h, fuelRate=8.0 L/h
+        //       → ratio = 8.0/120*100 ≈ 6.6667 L/100 km
+        //
+        // Mean of ratios: (20 + 6.6667) / 2 = 13.3333 L/100 km
+        // Aggregate: (Σ fuel) / (Σ speed) * 100
+        //          = (30*4.0 + 30*8.0) / (30*20 + 30*120) * 100
+        //          = 360 / 4200 * 100
+        //          = 8.5714 L/100 km
+        //
+        // The aggregate is the honest figure — every km is weighted by
+        // the actual fuel burned over it. Asserting the aggregate
+        // value (8.5714) catches a regression that switches the
+        // implementation to mean-of-ratios.
+        final samples = <TripSample>[
+          ...List<TripSample>.generate(
+            30,
+            (_) => _sample(speed: 20.0, fuelRate: 4.0),
+          ),
+          ...List<TripSample>.generate(
+            30,
+            (_) => _sample(speed: 120.0, fuelRate: 8.0),
+          ),
+        ];
+
+        final bins = aggregateSpeedConsumption(samples);
+
+        // Urban band has 30 samples at 20 km/h.
+        final urban = _binFor(bins, SpeedBand.urban);
+        expect(urban.sampleCount, 30);
+        // 4.0 / 20.0 * 100 = 20.0 — only one rate represented in this
+        // bin so aggregate == per-sample ratio here.
+        expect(urban.avgLPer100Km!, closeTo(20.0, 0.001));
+
+        // Motorway band has 30 samples at 120 km/h.
+        final motorway = _binFor(bins, SpeedBand.motorway);
+        expect(motorway.sampleCount, 30);
+        // 8.0 / 120.0 * 100 ≈ 6.6667 — same reasoning.
+        expect(motorway.avgLPer100Km!, closeTo(6.6667, 0.001));
+
+        // Now combine the two into a single "all samples" check by
+        // dropping minSamplesPerBin=1 and putting them in the same
+        // band. We use a custom band-collapse via two distinct speeds
+        // that BOTH land in suburban (50–80 km/h).
+        // Pick speed=60 (fuel=2) and speed=70 (fuel=10):
+        //   ratios: 2/60*100=3.333, 10/70*100=14.286
+        //   mean of ratios: 8.81
+        //   aggregate: (30*2 + 30*10) / (30*60 + 30*70) * 100
+        //            = 360 / 3900 * 100 = 9.2308
+        final mixedSuburban = <TripSample>[
+          ...List<TripSample>.generate(
+            30,
+            (_) => _sample(speed: 60.0, fuelRate: 2.0),
+          ),
+          ...List<TripSample>.generate(
+            30,
+            (_) => _sample(speed: 70.0, fuelRate: 10.0),
+          ),
+        ];
+        final mixedBins = aggregateSpeedConsumption(mixedSuburban);
+        final suburban = _binFor(mixedBins, SpeedBand.suburban);
+        expect(suburban.sampleCount, 60);
+        // Aggregate Σ/Σ: 360 / 3900 * 100 ≈ 9.2308
+        // Mean-of-ratios would be ≈ 8.8095 — assertion bites if
+        // anyone "fixes" the implementation to arithmetic mean.
+        expect(suburban.avgLPer100Km!, closeTo(9.2308, 0.001));
+      },
+    );
+  });
+}
+
+/// Build a [TripSample] with default safe values and the parameters
+/// we care about overriding. The recorder's downstream metrics (rpm,
+/// timestamp) don't affect the histogram — pinning them to zero keeps
+/// the test fixtures readable.
+TripSample _sample({
+  required double speed,
+  double? fuelRate,
+}) {
+  return TripSample(
+    timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+    speedKmh: speed,
+    rpm: 0.0,
+    fuelRateLPerHour: fuelRate,
+  );
+}
+
+/// Pick the bin for [band] from a histogram result. Bins are stored in
+/// declaration order so this is just a lookup, but the helper makes
+/// the assertions read top-down.
+SpeedConsumptionBin _binFor(List<SpeedConsumptionBin> bins, SpeedBand band) =>
+    bins.firstWhere((b) => b.band == band);


### PR DESCRIPTION
## Summary

- New pure aggregator `aggregateSpeedConsumption` (and multi-trip variant) folds `TripSample` per-second OBD2 ticks into 7 fixed speed bands (idle/jam, urban, suburban, rural, motorwaySlow, motorway, motorwayFast). Bin avg uses Σ-fuel / Σ-speed (the honest aggregate) instead of the arithmetic mean of per-sample L/100 km ratios — avoids the harmonic-vs-arithmetic-mean trap.
- `SpeedConsumptionCard` renders one horizontal bar per band on the Carbon dashboard Charts tab, with bar length proportional to the band's avg L/100 km, a per-bar "% of driving" sub-label, and a vertical reference line at the vehicle's overall avg.
- Empty-state placeholder shown inside the card when total telemetry is under 30 minutes (or zero) — keeps the feature discoverable instead of hiding it.
- Idle/jam band (0–10 km/h): counted for time-share but `avgLPer100Km` is always null (the denominator approaches zero — meaningless figure on a dashboard). Bins under the 30-sample floor likewise expose null avg.
- Wired into `_ChartsTab` between the just-landed `TripLengthBreakdownCard` and the monthly-costs chart, sharing the trip-length card's vehicle-id filter and overall-avg computation so the two cards describe the same data slice.
- EN/DE strings live in new `lib/l10n/_fragments/speed_consumption_<locale>.arb` fragments; FR strings added directly to `app_fr.arb`.

## Test plan

- [x] `flutter analyze` — 0 issues across `lib/` and `test/`
- [x] `flutter test test/features/consumption/domain/services/speed_consumption_histogram_test.dart` — 19 tests pass (boundary checks at 10 / 50 / 80 / 100 / 115 / 130 km/h, negative-speed + null-fuel skip, idle/jam carve-out, threshold floor at 29 vs 30 samples, multi-trip variant, Σ/Σ vs mean-of-ratios divergence with a contrived case).
- [x] `flutter test test/features/carbon/presentation/widgets/speed_consumption_card_test.dart` — 5 tests pass (one bar per band, insufficient-data placeholder under 30 min and at zero samples, reference line renders only when overall avg is non-null).

Closes #1192