### PR TITLE
test(core): unit tests for RFC 4180 csv encoder (Refs #561 phase: csv_encoder)

### DIFF
--- a/test/core/export/csv_encoder_test.dart
+++ b/test/core/export/csv_encoder_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/export/_csv_encoder.dart';
+
+void main() {
+  group('encodeCsv', () {
+    test('returns empty string for empty input', () {
+      expect(encodeCsv(const []), '');
+    });
+
+    test('joins simple cells with commas and terminates with CRLF', () {
+      expect(
+        encodeCsv(const [
+          ['a', 'b', 'c'],
+        ]),
+        'a,b,c\r\n',
+      );
+    });
+
+    test('emits CRLF between rows including after the last row', () {
+      expect(
+        encodeCsv(const [
+          ['a', 'b'],
+          ['c', 'd'],
+        ]),
+        'a,b\r\nc,d\r\n',
+      );
+    });
+
+    test('renders null cell as empty', () {
+      expect(
+        encodeCsv(const [
+          ['a', null, 'c'],
+        ]),
+        'a,,c\r\n',
+      );
+    });
+
+    test('quotes a cell that contains a comma', () {
+      expect(
+        encodeCsv(const [
+          ['a,b', 'c'],
+        ]),
+        '"a,b",c\r\n',
+      );
+    });
+
+    test('quotes a cell that contains a double quote and doubles the quote', () {
+      expect(
+        encodeCsv(const [
+          ['he said "hi"', 'next'],
+        ]),
+        '"he said ""hi""",next\r\n',
+      );
+    });
+
+    test('quotes a cell that contains a newline', () {
+      expect(
+        encodeCsv(const [
+          ['line1\nline2'],
+        ]),
+        '"line1\nline2"\r\n',
+      );
+    });
+
+    test('quotes a cell that contains a carriage return', () {
+      expect(
+        encodeCsv(const [
+          ['has\rCR'],
+        ]),
+        '"has\rCR"\r\n',
+      );
+    });
+
+    test('coerces non-string cells via toString', () {
+      expect(
+        encodeCsv(const [
+          [1, 2.5, true, null],
+        ]),
+        '1,2.5,true,\r\n',
+      );
+    });
+
+    test('handles single-cell rows without a separator', () {
+      expect(
+        encodeCsv(const [
+          ['solo'],
+        ]),
+        'solo\r\n',
+      );
+    });
+
+    test('preserves spaces and does not quote them when no special chars', () {
+      expect(
+        encodeCsv(const [
+          ['  leading and trailing  ', 'plain'],
+        ]),
+        '  leading and trailing  ,plain\r\n',
+      );
+    });
+
+    test('handles every quoting trigger combined in one cell', () {
+      expect(
+        encodeCsv(const [
+          ['"quote", comma\nnewline\rcr'],
+        ]),
+        '"""quote"", comma\nnewline\rcr"\r\n',
+      );
+    });
+
+    test('preserves empty string as a non-quoted empty cell', () {
+      expect(
+        encodeCsv(const [
+          ['', 'x'],
+        ]),
+        ',x\r\n',
+      );
+    });
+
+    test('handles ragged rows (different column counts per row)', () {
+      expect(
+        encodeCsv(const [
+          ['a', 'b', 'c'],
+          ['d', 'e'],
+          ['f'],
+        ]),
+        'a,b,c\r\nd,e\r\nf\r\n',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds 14 unit tests for `lib/core/export/_csv_encoder.dart::encodeCsv()`. The function had zero direct test coverage; `data_exporter_test.dart` exercises it indirectly through full-document JSON export but never asserts the CSV-specific edge cases.

## Coverage

- Empty input → empty string
- Simple multi-cell row, CRLF terminator
- Multi-row CRLF separation
- `null` cell → empty
- Comma quoting
- Double-quote quoting + RFC 4180 quote-doubling (`"` → `""`)
- Newline quoting
- Carriage-return quoting
- Non-string cells coerced via `toString()` (int / double / bool / null)
- Single-cell rows
- Whitespace-only cells (no quoting)
- All quoting triggers combined
- Empty string cells
- Ragged rows (varying column counts)

## Why phased

Refs #561 (raise test coverage to 80% — cover 20+ zero-coverage files). Single-file phase, file-disjoint from every open PR. Pure-function target with deterministic spec — no Riverpod, no Hive, no widget mounting needed.

## Verification

- `flutter analyze` — no issues.
- `flutter test test/core/export/csv_encoder_test.dart` — 14 / 14 pass.
- No drift in generated files, ARB, or pubspec.lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)