### PR TITLE
fix(sync): route SyncSetupScreen auth errors through friendlyAuthError (Closes #1234)

### DIFF
--- a/lib/features/sync/presentation/screens/sync_setup_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_setup_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/sync/sync_config.dart';
 import '../../../../core/sync/sync_provider.dart';
+import '../../data/auth_error_mapper.dart';
 import '../../providers/sync_setup_provider.dart';
 import '../widgets/auth_form_widget.dart';
 import '../widgets/qr_scanner_screen.dart';
@@ -106,7 +107,9 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
       await Future<void>.delayed(const Duration(milliseconds: 1500));
       if (mounted) Navigator.pop(context);
     } catch (e, st) { // ignore: unused_catch_stack
-      if (mounted) ctrl.setError(e.toString());
+      if (mounted) {
+        ctrl.setError(friendlyAuthError(e, AppLocalizations.of(context)));
+      }
     }
   }
 

--- a/test/features/sync/presentation/screens/sync_setup_screen_auth_error_test.dart
+++ b/test/features/sync/presentation/screens/sync_setup_screen_auth_error_test.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/sync_config.dart';
+import 'package:tankstellen/core/sync/sync_provider.dart';
+import 'package:tankstellen/features/sync/presentation/screens/sync_setup_screen.dart';
+import 'package:tankstellen/features/sync/providers/sync_setup_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Regression guard for #1234 (twin of #1186).
+///
+/// `SyncSetupScreen`'s `_onAuthSubmit` catch block was leaking the raw
+/// `e.toString()` — including the supabase URL and the
+/// `AuthRetryableFetchException` type name — straight into the form
+/// error pill. The fix routes the exception through `friendlyAuthError`
+/// the same way `auth_screen.dart` already did.
+///
+/// This test pumps the screen pre-positioned at the auth step with a
+/// fake `SyncState` whose `connectCommunity()` throws a `SocketException`
+/// carrying the exact failure shape the user reported, taps the
+/// "Connect anonymously" button, and asserts the rendered pill is the
+/// friendly localized message — never the raw exception.
+
+class _FakeSyncState extends SyncState {
+  _FakeSyncState(this._throwOnConnect);
+
+  final Object _throwOnConnect;
+
+  @override
+  SyncConfig build() => const SyncConfig();
+
+  @override
+  Future<void> connectCommunity() async {
+    throw _throwOnConnect;
+  }
+}
+
+class _AuthStepSyncSetupController extends SyncSetupController {
+  @override
+  SyncSetupState build() => const SyncSetupState(
+        step: SyncSetupStep.auth,
+        selectedMode: SyncMode.community,
+      );
+}
+
+void main() {
+  group('SyncSetupScreen auth-step error mapping (#1234)', () {
+    Future<void> pumpAtAuth(
+      WidgetTester tester, {
+      required Object thrown,
+    }) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            syncStateProvider.overrideWith(() => _FakeSyncState(thrown)),
+            syncSetupControllerProvider
+                .overrideWith(() => _AuthStepSyncSetupController()),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: Locale('en'),
+            home: SyncSetupScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+      'SocketException with supabase URL renders friendly text, '
+      'never the raw exception or the project URL',
+      (tester) async {
+        const e = SocketException(
+            "Failed host lookup: 'klelxnkzrxlpzuddhpfg.supabase.co' "
+            '(errno = 7)');
+        await pumpAtAuth(tester, thrown: e);
+
+        await tester.tap(find.text('Connect anonymously'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('No network connection. Try again later.'),
+            findsOneWidget);
+        expect(find.textContaining('SocketException'), findsNothing);
+        expect(find.textContaining('klelxnkzrxlpzuddhpfg'), findsNothing);
+        expect(find.textContaining('errno'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'AuthRetryableFetchException-shaped string renders friendly text, '
+      'never the type name',
+      (tester) async {
+        final e = Exception(
+            'AuthRetryableFetchException(message: ClientException with '
+            "SocketException: Failed host lookup: 'klelxnkzrxlpzuddhpfg."
+            "supabase.co' (errno = 7), uri=https://klelxnkzrxlpzuddhpfg."
+            'supabase.co/auth/v1/signup?, statusCode: null)');
+        await pumpAtAuth(tester, thrown: e);
+
+        await tester.tap(find.text('Connect anonymously'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('No network connection. Try again later.'),
+            findsOneWidget);
+        expect(find.textContaining('AuthRetryableFetchException'), findsNothing);
+        expect(find.textContaining('klelxnkzrxlpzuddhpfg'), findsNothing);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Twin of #1186 — that fix landed on `auth_screen.dart` but missed the identical leak in the sync-setup wizard's auth step.
- One-line redirect: `e.toString()` → `friendlyAuthError(e, AppLocalizations.of(context))` so the localized "No network connection…" message renders instead of `AuthRetryableFetchException(message: ClientException… klelxnkzrxlpzuddhpfg.supabase.co…)`.
- Regression test pumps the screen at the auth step with a faked `SyncState` that throws the exact failure shape the user reported, taps Connect anonymously, asserts the friendly text wins and neither the exception type name nor the supabase host appears.

## Test plan
- [x] `flutter test test/features/sync/presentation/screens/sync_setup_screen_auth_error_test.dart` — 2/2 green
- [x] `flutter analyze` clean on touched files
- [ ] Manual: airplane-mode, open Sync setup wizard, tap Connect anonymously — should show "No network connection…" not the raw exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)