### PR TITLE
fix(consumption): adapt Trajets CTA + add banner chevron when a trip is active (Closes #1237)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -123,14 +123,26 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
         return bx.compareTo(ax);
       });
 
+    // When a trip is already recording in the background (#1237), the
+    // CTA changes shape: same `_onStartRecording` handler — which
+    // routes through `StartTripOutcome.alreadyActive` and pushes the
+    // existing recording screen — but a different label + icon so the
+    // user understands tapping returns them to the live trip rather
+    // than starting a new one. Without this the recording is hidden
+    // behind a button that looks destructive.
+    final isRecordingActive = ref.watch(tripRecordingProvider).isActive;
     final header = Padding(
       padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
       child: FilledButton.icon(
         key: const Key('trajets_start_recording_button'),
         onPressed: _starting ? null : _onStartRecording,
-        icon: const Icon(Icons.fiber_manual_record),
+        icon: Icon(
+          isRecordingActive ? Icons.visibility : Icons.fiber_manual_record,
+        ),
         label: Text(
-          l?.trajetsStartRecordingButton ?? 'Start recording',
+          isRecordingActive
+              ? (l?.trajetsResumeRecordingButton ?? 'Resume recording')
+              : (l?.trajetsStartRecordingButton ?? 'Start recording'),
         ),
       ),
     );

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -235,6 +235,11 @@ class _Content extends StatelessWidget {
               fontFeatures: const [FontFeature.tabularFigures()],
             ),
           ),
+        // #1237 — chevron makes the banner look tappable. The InkWell
+        // already routes to /trip-recording, but without an affordance
+        // users read the row as decorative AppBar chrome.
+        const SizedBox(width: 6),
+        Icon(Icons.chevron_right, size: 18, color: fg),
       ],
     );
   }

--- a/lib/l10n/_fragments/trajets_de.arb
+++ b/lib/l10n/_fragments/trajets_de.arb
@@ -1,6 +1,7 @@
 {
   "trajetsTabLabel": "Fahrten",
   "trajetsStartRecordingButton": "Aufzeichnung starten",
+  "trajetsResumeRecordingButton": "Aufzeichnung fortsetzen",
   "trajetsEmptyStateTitle": "Noch keine Fahrten",
   "trajetsEmptyStateBody": "Tippe auf „Aufzeichnung starten“, um deine Fahrten zu protokollieren.",
   "trajetsRowDistance": "{km} km",

--- a/lib/l10n/_fragments/trajets_en.arb
+++ b/lib/l10n/_fragments/trajets_en.arb
@@ -7,6 +7,10 @@
   "@trajetsStartRecordingButton": {
     "description": "Primary CTA on the Trips tab that kicks off a new trip recording (#889)."
   },
+  "trajetsResumeRecordingButton": "Resume recording",
+  "@trajetsResumeRecordingButton": {
+    "description": "Primary CTA on the Trips tab when a trip is already being recorded in the background; tapping it brings focus back to the recording screen (#1237)."
+  },
   "trajetsEmptyStateTitle": "No trips yet",
   "@trajetsEmptyStateTitle": {
     "description": "Empty-state title on the Trips tab when no trips have been recorded (#889)."

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1553,6 +1553,7 @@
   "throttleRpmHistogramBarShare": "{pct} %",
   "trajetsTabLabel": "Fahrten",
   "trajetsStartRecordingButton": "Aufzeichnung starten",
+  "trajetsResumeRecordingButton": "Aufzeichnung fortsetzen",
   "trajetsEmptyStateTitle": "Noch keine Fahrten",
   "trajetsEmptyStateBody": "Tippe auf „Aufzeichnung starten“, um deine Fahrten zu protokollieren.",
   "trajetsRowDistance": "{km} km",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2475,6 +2475,10 @@
   "@trajetsStartRecordingButton": {
     "description": "Primary CTA on the Trips tab that kicks off a new trip recording (#889)."
   },
+  "trajetsResumeRecordingButton": "Resume recording",
+  "@trajetsResumeRecordingButton": {
+    "description": "Primary CTA on the Trips tab when a trip is already being recorded in the background; tapping it brings focus back to the recording screen (#1237)."
+  },
   "trajetsEmptyStateTitle": "No trips yet",
   "@trajetsEmptyStateTitle": {
     "description": "Empty-state title on the Trips tab when no trips have been recorded (#889)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -921,6 +921,8 @@
   "consumptionLogTitle": "Consommation",
   "consumptionTabFuel": "Carburant",
   "trajetsTabLabel": "Trajets",
+  "trajetsStartRecordingButton": "Démarrer l'enregistrement",
+  "trajetsResumeRecordingButton": "Reprendre l'enregistrement",
   "trajetDetailFieldFuelCost": "Coût du carburant",
   "trajetDetailShareAction": "Partager",
   "trajetDetailShareSubject": "Tankstellen — trajet du {date}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7262,6 +7262,12 @@ abstract class AppLocalizations {
   /// **'Start recording'**
   String get trajetsStartRecordingButton;
 
+  /// Primary CTA on the Trips tab when a trip is already being recorded in the background; tapping it brings focus back to the recording screen (#1237).
+  ///
+  /// In en, this message translates to:
+  /// **'Resume recording'**
+  String get trajetsResumeRecordingButton;
+
   /// Empty-state title on the Trips tab when no trips have been recorded (#889).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3908,6 +3908,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3908,6 +3908,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3906,6 +3906,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3943,6 +3943,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Aufzeichnung starten';
 
   @override
+  String get trajetsResumeRecordingButton => 'Aufzeichnung fortsetzen';
+
+  @override
   String get trajetsEmptyStateTitle => 'Noch keine Fahrten';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3910,6 +3910,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3901,6 +3901,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3909,6 +3909,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3903,6 +3903,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3906,6 +3906,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3936,7 +3936,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trajetsTabLabel => 'Trajets';
 
   @override
-  String get trajetsStartRecordingButton => 'Start recording';
+  String get trajetsStartRecordingButton => 'Démarrer l\'enregistrement';
+
+  @override
+  String get trajetsResumeRecordingButton => 'Reprendre l\'enregistrement';
 
   @override
   String get trajetsEmptyStateTitle => 'No trips yet';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3905,6 +3905,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3910,6 +3910,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3909,6 +3909,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3907,6 +3907,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3909,6 +3909,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3905,6 +3905,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3910,6 +3910,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3908,6 +3908,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3909,6 +3909,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3908,6 +3908,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3909,6 +3909,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3903,6 +3903,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3907,6 +3907,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get trajetsStartRecordingButton => 'Start recording';
 
   @override
+  String get trajetsResumeRecordingButton => 'Resume recording';
+
+  @override
   String get trajetsEmptyStateTitle => 'No trips yet';
 
   @override

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -677,4 +677,68 @@ void main() {
       expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
     });
   });
+
+  group('TrajetsTab — active recording CTA discoverability (#1237)', () {
+    testWidgets(
+      'idle state shows "Start recording" with the record-dot icon',
+      (tester) async {
+        await _pumpTab(tester, vehicleId: null, trips: const []);
+
+        expect(find.text('Start recording'), findsOneWidget);
+        expect(find.text('Resume recording'), findsNothing);
+        // FilledButton.icon renders the dot when no trip is active.
+        final button = tester.widget<FilledButton>(
+          find.byKey(const Key('trajets_start_recording_button')),
+        );
+        expect(button.onPressed, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'active recording switches CTA to "Resume recording" + visibility icon',
+      (tester) async {
+        await _pumpTab(
+          tester,
+          vehicleId: null,
+          trips: const [],
+          recordingFactory: () => _ActiveRecordingTrip(),
+        );
+
+        expect(find.text('Resume recording'), findsOneWidget);
+        expect(find.text('Start recording'), findsNothing);
+        expect(
+          find.descendant(
+            of: find.byKey(const Key('trajets_start_recording_button')),
+            matching: find.byIcon(Icons.visibility),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: find.byKey(const Key('trajets_start_recording_button')),
+            matching: find.byIcon(Icons.fiber_manual_record),
+          ),
+          findsNothing,
+        );
+      },
+    );
+  });
+}
+
+/// Returns an [TripRecordingState] whose [TripRecordingState.isActive] is
+/// `true` so the Trajets CTA flips to its "Resume recording" shape
+/// without having to spin up the OBD2 service stack.
+class _ActiveRecordingTrip extends TripRecording {
+  @override
+  TripRecordingState build() => const TripRecordingState(
+        phase: TripRecordingPhase.recording,
+      );
+
+  @override
+  Future<StartTripOutcome> startTrip({
+    String? vehicleId,
+    String? adapterMac,
+    Obd2Service? service,
+  }) async =>
+      StartTripOutcome.alreadyActive;
 }


### PR DESCRIPTION
## Summary

Closes #1237. Two tightly-scoped UX fixes for the "ongoing recording is hidden, can't refocus it" path the user reported:

- `TrajetsTab` reads `tripRecordingProvider` and switches the primary CTA to "Resume recording" + `Icons.visibility` when a trip is active. Handler unchanged — `StartTripOutcome.alreadyActive` already pushed the recording screen, the button just looked like it would start a new trip.
- `TripRecordingBanner` gains a trailing `Icons.chevron_right` so the InkWell looks tappable. Color follows the existing `palette.foreground` so the consumption-band coloring still drives it.
- Added French translations for `trajetsStartRecordingButton` (was bleeding through as English) and the new `trajetsResumeRecordingButton`.

## Test plan

- [x] `flutter analyze` clean (no infos, no warnings).
- [x] `flutter test test/features/consumption/presentation/widgets/trajets_tab_test.dart test/features/consumption/presentation/widgets/trip_recording_banner_test.dart test/lint/arb_fragments_consistency_test.dart` — 22/22 green, including the two new #1237 cases.
- [x] ARB consistency: `dart run tool/build_arb.dart` clean rebuild matches committed app_en/de/fr.arb.
- [ ] Manual verification on device: tap "Start recording", navigate to Conso → Trajets, confirm the CTA flips to "Reprendre l'enregistrement" with the eye icon, tap returns to the active recording screen. Banner shows chevron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)