### PR TITLE
fix(map): hold RetryNetworkTileProvider in state — cure provider churn (Closes #1240)

### DIFF
--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -19,7 +20,32 @@ import 'station_marker.dart';
 ///
 /// Used by both [MapScreen] (full-screen) and [InlineMap] (split-screen)
 /// to eliminate ~130 lines of duplicated map layer code.
-class StationMapLayers extends StatelessWidget {
+///
+/// ## Why this is stateful (#1234 follow-up to #1164)
+///
+/// The earlier grey-tile fix (LayoutBuilder gate + tab-flip incarnation
+/// rebuild) covers the offstage IndexedStack viewport-capture race, but
+/// the screen still rendered grey on cold-start in some scenarios. The
+/// reason: [RetryNetworkTileProvider] was created inside `build()` and
+/// rebuilt on every parent state change. flutter_map's TileLayer
+/// preserves its [TileImage] objects across `didUpdateWidget`, but each
+/// existing TileImage holds a reference to the OLD provider's
+/// [http.Client]; meanwhile the *new* provider's client is what fresh
+/// tile fetches use. The leaked-client churn produced two pathologies:
+///   1. The very first tile fetches went through an http.Client that
+///      was about to be discarded, occasionally racing with the next
+///      build's replacement provider before completing.
+///   2. The default `BuiltInMapCachingProvider` instance — created
+///      lazily inside the image provider — was being asked to cache
+///      tiles whose request was abandoned, leaving holes that only got
+///      backfilled when a later rebuild happened to re-issue the same
+///      coordinates against a stable provider.
+/// Holding a single tile provider per [StationMapLayers] lifetime —
+/// created in `initState`, disposed in `dispose` — eliminates both
+/// pathologies. The KeyedSubtree+incarnation rebuild in [MapScreen]
+/// already destroys this state on tab-flip, so the provider lifetime
+/// is bounded by the visible-tab lifetime.
+class StationMapLayers extends StatefulWidget {
   final MapController mapController;
   final List<Station> stations;
   final LatLng center;
@@ -56,189 +82,7 @@ class StationMapLayers extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final priceRange = _getPriceRange(stations, selectedFuel);
-
-    return Stack(
-      children: [
-        FlutterMap(
-          mapController: mapController,
-          options: MapOptions(
-            initialCenter: center,
-            initialZoom: zoom,
-            interactionOptions: const InteractionOptions(
-              flags: InteractiveFlag.all,
-            ),
-          ),
-          children: [
-            TileLayer(
-              urlTemplate: AppConstants.osmTileUrl,
-              userAgentPackageName: AppConstants.osmUserAgent,
-              maxNativeZoom: 19,
-              maxZoom: 19,
-              // #757 — RetryNetworkTileProvider retries transient
-              // HTTP 429 / 5xx / connection errors with jittered
-              // backoff (200 ms, 800 ms). Combined with
-              // `evictErrorTileStrategy: notVisibleRespectMargin`
-              // below, a failed tile gets retried up to 3× and, if
-              // all attempts fail, is evicted as soon as it scrolls
-              // out of view so the next pan retries cleanly. This
-              // replaces the symptom-level workarounds from #496,
-              // #532, #696, #707, #709, and #711 (zoom-jiggle,
-              // subtree rebuild, ImageCache sizing).
-              //
-              // #930 — flutter_map's default aborts in-flight tile
-              // fetches on pan. Our retry layer must not see those
-              // cancellations as errors, and we prefer the tiny
-              // bandwidth cost of finishing the fetch over
-              // race-induced gray tiles when the user stops panning
-              // with a mid-flight tile still in view. Hence explicit
-              // `abortObsoleteRequests: false` here (belt) plus
-              // cancellation-aware retry logic in the provider
-              // itself (suspenders).
-              tileProvider:
-                  RetryNetworkTileProvider(abortObsoleteRequests: false),
-              evictErrorTileStrategy:
-                  EvictErrorTileStrategy.notVisibleRespectMargin,
-              errorTileCallback: (tile, error, stackTrace) {
-                debugPrint(
-                    'TileLayer error at (z:${tile.coordinates.z} '
-                    'x:${tile.coordinates.x} y:${tile.coordinates.y}): '
-                    '$error');
-              },
-            ),
-            // Route polyline (if in route search mode)
-            if (routePolyline != null && routePolyline!.isNotEmpty)
-              PolylineLayer(
-                polylines: [
-                  Polyline(
-                    points: routePolyline!,
-                    color: theme.colorScheme.primary,
-                    strokeWidth: 4.0,
-                  ),
-                ],
-              ),
-            // Search radius circle
-            if (showSearchRadius)
-              CircleLayer(
-                circles: [
-                  CircleMarker(
-                    point: center,
-                    radius: searchRadiusKm * 1000,
-                    useRadiusInMeter: true,
-                    color: theme.colorScheme.primary.withValues(alpha: 0.08),
-                    borderColor: theme.colorScheme.primary.withValues(alpha: 0.3),
-                    borderStrokeWidth: 2,
-                  ),
-                ],
-              ),
-            // Center marker
-            MarkerLayer(
-              markers: [
-                Marker(
-                  point: center,
-                  width: 20,
-                  height: 20,
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.primary,
-                      shape: BoxShape.circle,
-                      border: Border.all(color: Colors.white, width: 3),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.3),
-                          blurRadius: 4,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            // Station markers with clustering
-            Builder(builder: (ctx) {
-              final hasSelection = selectedStationIds != null && selectedStationIds!.isNotEmpty;
-              final markers = stations.map((station) {
-                final isPastel = hasSelection && !selectedStationIds!.contains(station.id);
-                return StationMarkerBuilder.build(
-                  ctx, station, selectedFuel,
-                  priceRange.$1, priceRange.$2,
-                  pastel: isPastel,
-                );
-              }).toList();
-              if (stations.length > 20) {
-                return MarkerClusterLayerWidget(
-                  options: MarkerClusterLayerOptions(
-                    maxClusterRadius: 80,
-                    markers: markers,
-                    builder: (context, clusterMarkers) => Container(
-                      decoration: BoxDecoration(
-                        color: theme.colorScheme.primaryContainer,
-                        shape: BoxShape.circle,
-                      ),
-                      child: Center(
-                        child: Text(
-                          '${clusterMarkers.length}',
-                          style: const TextStyle(fontWeight: FontWeight.bold),
-                        ),
-                      ),
-                    ),
-                  ),
-                );
-              }
-              return MarkerLayer(markers: markers);
-            }),
-            // Extra layers (e.g. EV overlay)
-            ...extraLayers,
-            // Attribution
-            const RichAttributionWidget(
-              attributions: [
-                TextSourceAttribution('OpenStreetMap contributors'),
-              ],
-            ),
-          ],
-        ),
-        // Zoom controls
-        Positioned(
-          right: 16,
-          top: 16,
-          child: Column(
-            children: [
-              ZoomButton(
-                icon: Icons.add,
-                onPressed: () {
-                  final z = mapController.camera.zoom + 1;
-                  mapController.move(mapController.camera.center, z);
-                },
-              ),
-              const SizedBox(height: 8),
-              ZoomButton(
-                icon: Icons.remove,
-                onPressed: () {
-                  final z = mapController.camera.zoom - 1;
-                  mapController.move(mapController.camera.center, z);
-                },
-              ),
-              if (showRecenterButton) ...[
-                const SizedBox(height: 8),
-                ZoomButton(
-                  icon: Icons.my_location,
-                  onPressed: onRecenter ?? () => mapController.move(center, zoom),
-                ),
-              ],
-            ],
-          ),
-        ),
-        // Price legend
-        const Positioned(
-          left: 16,
-          bottom: 16,
-          child: PriceLegend(),
-        ),
-      ],
-    );
-  }
+  State<StationMapLayers> createState() => _StationMapLayersState();
 
   /// Calculate zoom level from search radius.
   static double zoomForRadius(double radiusKm) {
@@ -294,5 +138,242 @@ class StationMapLayers extends StatelessWidget {
     }
     if (minP == double.infinity) return (0, 0);
     return (minP, maxP);
+  }
+}
+
+class _StationMapLayersState extends State<StationMapLayers> {
+  /// Held in state so a single [http.Client] lives for the entire
+  /// visible lifetime of the map. Recreating the provider on every
+  /// build (the prior bug) churned http.Client instances and produced
+  /// the cold-start grey-tile regression (#1234).
+  late final RetryNetworkTileProvider _tileProvider;
+
+  /// Stream that, when emitted, makes [TileLayer] drop all current
+  /// tile images and re-fetch the visible range from scratch. We fire
+  /// it once after the first frame to cover the case where TileLayer's
+  /// initial `didChangeDependencies` ran against a degenerate camera
+  /// and never re-issued requests when the camera settled.
+  final StreamController<void> _resetController = StreamController<void>.broadcast();
+
+  @override
+  void initState() {
+    super.initState();
+    _tileProvider = RetryNetworkTileProvider(abortObsoleteRequests: false);
+
+    // First-paint reset: kick TileLayer once so any tiles that fetched
+    // against the bootstrap camera are dropped + reissued against the
+    // settled MapController state. Cheap (no-op when tiles are already
+    // loaded for the visible range) and fixes the grey-on-first-open
+    // case where neither the LayoutBuilder gate nor the
+    // _mapIncarnation listener catches the offstage→onstage transition
+    // (#1234).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _resetController.isClosed) return;
+      _resetController.add(null);
+    });
+  }
+
+  @override
+  void dispose() {
+    _resetController.close();
+    _tileProvider.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final priceRange = StationMapLayers._getPriceRange(
+        widget.stations, widget.selectedFuel);
+
+    return Stack(
+      children: [
+        FlutterMap(
+          mapController: widget.mapController,
+          options: MapOptions(
+            initialCenter: widget.center,
+            initialZoom: widget.zoom,
+            interactionOptions: const InteractionOptions(
+              flags: InteractiveFlag.all,
+            ),
+          ),
+          children: [
+            TileLayer(
+              urlTemplate: AppConstants.osmTileUrl,
+              userAgentPackageName: AppConstants.osmUserAgent,
+              maxNativeZoom: 19,
+              maxZoom: 19,
+              // #757 — RetryNetworkTileProvider retries transient
+              // HTTP 429 / 5xx / connection errors with jittered
+              // backoff (200 ms, 800 ms). Combined with
+              // `evictErrorTileStrategy: notVisibleRespectMargin`
+              // below, a failed tile gets retried up to 3× and, if
+              // all attempts fail, is evicted as soon as it scrolls
+              // out of view so the next pan retries cleanly.
+              //
+              // #930 — flutter_map's default aborts in-flight tile
+              // fetches on pan. Our retry layer must not see those
+              // cancellations as errors. Hence explicit
+              // `abortObsoleteRequests: false` (in initState) plus
+              // cancellation-aware retry logic in the provider.
+              //
+              // #1234 — provider is held in state (initState/dispose),
+              // NOT rebuilt every frame. Recreating it churned
+              // http.Client instances and produced a cold-start
+              // grey-tile race the LayoutBuilder gate could not
+              // catch. The reset stream fires once after first paint
+              // to drop any tiles that captured a degenerate viewport.
+              tileProvider: _tileProvider,
+              reset: _resetController.stream,
+              evictErrorTileStrategy:
+                  EvictErrorTileStrategy.notVisibleRespectMargin,
+              errorTileCallback: (tile, error, stackTrace) {
+                debugPrint(
+                    'TileLayer error at (z:${tile.coordinates.z} '
+                    'x:${tile.coordinates.x} y:${tile.coordinates.y}): '
+                    '$error');
+              },
+            ),
+            // Route polyline (if in route search mode)
+            if (widget.routePolyline != null &&
+                widget.routePolyline!.isNotEmpty)
+              PolylineLayer(
+                polylines: [
+                  Polyline(
+                    points: widget.routePolyline!,
+                    color: theme.colorScheme.primary,
+                    strokeWidth: 4.0,
+                  ),
+                ],
+              ),
+            // Search radius circle
+            if (widget.showSearchRadius)
+              CircleLayer(
+                circles: [
+                  CircleMarker(
+                    point: widget.center,
+                    radius: widget.searchRadiusKm * 1000,
+                    useRadiusInMeter: true,
+                    color: theme.colorScheme.primary.withValues(alpha: 0.08),
+                    borderColor:
+                        theme.colorScheme.primary.withValues(alpha: 0.3),
+                    borderStrokeWidth: 2,
+                  ),
+                ],
+              ),
+            // Center marker
+            MarkerLayer(
+              markers: [
+                Marker(
+                  point: widget.center,
+                  width: 20,
+                  height: 20,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.primary,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: Colors.white, width: 3),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.3),
+                          blurRadius: 4,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            // Station markers with clustering
+            Builder(builder: (ctx) {
+              final hasSelection = widget.selectedStationIds != null &&
+                  widget.selectedStationIds!.isNotEmpty;
+              final markers = widget.stations.map((station) {
+                final isPastel = hasSelection &&
+                    !widget.selectedStationIds!.contains(station.id);
+                return StationMarkerBuilder.build(
+                  ctx,
+                  station,
+                  widget.selectedFuel,
+                  priceRange.$1,
+                  priceRange.$2,
+                  pastel: isPastel,
+                );
+              }).toList();
+              if (widget.stations.length > 20) {
+                return MarkerClusterLayerWidget(
+                  options: MarkerClusterLayerOptions(
+                    maxClusterRadius: 80,
+                    markers: markers,
+                    builder: (context, clusterMarkers) => Container(
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primaryContainer,
+                        shape: BoxShape.circle,
+                      ),
+                      child: Center(
+                        child: Text(
+                          '${clusterMarkers.length}',
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              }
+              return MarkerLayer(markers: markers);
+            }),
+            // Extra layers (e.g. EV overlay)
+            ...widget.extraLayers,
+            // Attribution
+            const RichAttributionWidget(
+              attributions: [
+                TextSourceAttribution('OpenStreetMap contributors'),
+              ],
+            ),
+          ],
+        ),
+        // Zoom controls
+        Positioned(
+          right: 16,
+          top: 16,
+          child: Column(
+            children: [
+              ZoomButton(
+                icon: Icons.add,
+                onPressed: () {
+                  final z = widget.mapController.camera.zoom + 1;
+                  widget.mapController
+                      .move(widget.mapController.camera.center, z);
+                },
+              ),
+              const SizedBox(height: 8),
+              ZoomButton(
+                icon: Icons.remove,
+                onPressed: () {
+                  final z = widget.mapController.camera.zoom - 1;
+                  widget.mapController
+                      .move(widget.mapController.camera.center, z);
+                },
+              ),
+              if (widget.showRecenterButton) ...[
+                const SizedBox(height: 8),
+                ZoomButton(
+                  icon: Icons.my_location,
+                  onPressed: widget.onRecenter ??
+                      () => widget.mapController
+                          .move(widget.center, widget.zoom),
+                ),
+              ],
+            ],
+          ),
+        ),
+        // Price legend
+        const Positioned(
+          left: 16,
+          bottom: 16,
+          child: PriceLegend(),
+        ),
+      ],
+    );
   }
 }

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -1,6 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/map/data/retry_network_tile_provider.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
 
 void main() {
   group('StationMapLayers.zoomForRadius', () {
@@ -79,4 +84,136 @@ void main() {
   // `MapOptions.onMapReady != null` no longer holds and should not
   // be resurrected — re-adding the jiggle would cancel in-flight
   // retries (the #709 regression that was itself rolled back).
+
+  group('StationMapLayers tile provider stability (#1234)', () {
+    testWidgets(
+      'TileLayer keeps the same RetryNetworkTileProvider instance across '
+      'parent rebuilds — does NOT re-instantiate on every build',
+      (tester) async {
+        // Wide-enough viewport so the FlutterMap actually mounts.
+        tester.view.physicalSize = const Size(900, 1600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final mapController = MapController();
+        addTearDown(mapController.dispose);
+
+        // Helper to drive a fresh build with a different external key
+        // (the kind of trivial rebuild that, before #1234, churned the
+        // tile provider on every parent setState).
+        Widget pumpAt(int rebuildToken) => MaterialApp(
+              home: Scaffold(
+                body: KeyedSubtree(
+                  // ValueKey changes only the OUTER subtree wrapper —
+                  // it's a no-op on StationMapLayers' own State, which
+                  // is what we want. We only want the parent build()
+                  // to run again.
+                  key: ValueKey('rebuild-$rebuildToken'),
+                  child: StationMapLayers(
+                    mapController: mapController,
+                    stations: const [_seedStation],
+                    center: const LatLng(52.5210, 13.4100),
+                    zoom: 12,
+                    searchRadiusKm: 10,
+                    selectedFuel: FuelType.diesel,
+                  ),
+                ),
+              ),
+            );
+
+        await tester.pumpWidget(pumpAt(0));
+
+        TileLayer findTileLayer() => tester.widget<TileLayer>(
+              find.byType(TileLayer),
+            );
+
+        final providerOnFirstBuild = findTileLayer().tileProvider;
+        expect(
+          providerOnFirstBuild,
+          isA<RetryNetworkTileProvider>(),
+          reason:
+              'StationMapLayers must wire RetryNetworkTileProvider into '
+              'the TileLayer (not the default NetworkTileProvider) — the '
+              '#757 retry policy depends on it.',
+        );
+
+        // Rebuild via a parent setState analogue. Same widget instance
+        // (same State), but the TileLayer widget is re-instantiated.
+        // The State must hand it the SAME tile provider instance.
+        await tester.pumpWidget(pumpAt(0));
+        await tester.pumpWidget(pumpAt(0));
+        await tester.pumpWidget(pumpAt(0));
+
+        final providerAfterRebuilds = findTileLayer().tileProvider;
+        expect(
+          identical(providerOnFirstBuild, providerAfterRebuilds),
+          isTrue,
+          reason:
+              'TileLayer.tileProvider must remain identical across '
+              'StationMapLayers parent rebuilds. Recreating the provider '
+              'every build (the prior bug, #1234) churned http.Client '
+              'instances and produced cold-start grey tiles. Holding it '
+              'in State (initState/dispose) is the fix.',
+        );
+      },
+    );
+
+    testWidgets(
+      'TileLayer.reset stream is wired so a settled-camera kick can drop '
+      'tiles fetched against a degenerate viewport',
+      (tester) async {
+        tester.view.physicalSize = const Size(900, 1600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final mapController = MapController();
+        addTearDown(mapController.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StationMapLayers(
+                mapController: mapController,
+                stations: const [_seedStation],
+                center: const LatLng(52.5210, 13.4100),
+                zoom: 12,
+                searchRadiusKm: 10,
+                selectedFuel: FuelType.diesel,
+              ),
+            ),
+          ),
+        );
+
+        final layer = tester.widget<TileLayer>(find.byType(TileLayer));
+        expect(
+          layer.reset,
+          isNotNull,
+          reason:
+              'TileLayer.reset must be wired so the post-first-frame '
+              'kick can force a tile reload — covers the cold-start case '
+              'where TileLayer captured a degenerate viewport before the '
+              'MapController settled (#1234).',
+        );
+      },
+    );
+  });
 }
+
+const _seedStation = Station(
+  id: 'seed-1',
+  name: 'Seed Station',
+  brand: 'JET',
+  street: 'Berliner Str.',
+  houseNumber: '1',
+  postCode: '10178',
+  place: 'Berlin',
+  lat: 52.5210,
+  lng: 13.4100,
+  dist: 0.8,
+  e5: 1.799,
+  e10: 1.739,
+  diesel: 1.599,
+  isOpen: true,
+);


### PR DESCRIPTION
## Summary

- Convert \`StationMapLayers\` from \`StatelessWidget\` to \`StatefulWidget\` so \`RetryNetworkTileProvider\` lives for the full visible-tab lifetime — no more http.Client churn on every incidental rebuild.
- Wire \`TileLayer.reset\` stream and emit once after first paint, so any tiles fetched against a degenerate viewport are dropped and re-issued.

## Root cause (see #1240 body for the full diagnosis)

flutter_map's \`TileLayer.didUpdateWidget\` does NOT trigger a tile reload when \`tileProvider\` changes (only on URL/options/zoom). Cached \`TileImage\`s keep references to the OLD provider's \`http.Client\` while NEW fetches go through the NEW provider — the user-visible symptom is a grey map until any state change forces convergence.

The earlier #1164 LayoutBuilder gate + tab-flip incarnation rebuild is a necessary but insufficient fix for this distinct provider-churn pathology.

## Test plan

- [x] \`flutter analyze\` clean
- [x] \`flutter test test/features/map/\` all green
- [x] New regression test: \`TileLayer.tileProvider\` stays identical across parent rebuilds
- [x] New regression test: \`TileLayer.reset\` stream is wired
- [ ] Device verification — install built APK and confirm cold-start Carte tab paints tiles immediately, no action required

🤖 Generated with [Claude Code](https://claude.com/claude-code)