### PR TITLE
ux(settings): cluster vehicles + fuel-club + eco-coach under "Consumption" foldable (Closes #1242)

### DIFF
--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -1,20 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+import '../../../../core/widgets/settings_menu_tile.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/haptic_eco_coach_provider.dart';
 
-/// Driving (wheel-lens) settings section on the profile screen
-/// (#1122).
+/// Consumption / driving settings group on the profile screen.
 ///
-/// Currently surfaces the single real-time eco-coaching toggle. The
-/// section is its own widget so future wheel-lens toggles
-/// (auto-pause-on-drop, voice nudges, etc.) can be added here without
-/// growing `profile_screen.dart` further.
+/// Surfaced under the Conso-tab-aliased "Consumption" foldable, this
+/// section composes everything the user might want to tune for the
+/// vehicle they are currently driving:
+///   1. **My vehicles** (battery, connectors, charging prefs).
+///   2. **Fuel club cards** (per-litre discounts).
+///   3. **Real-time eco coaching** (haptic when over-driving on cruise).
 ///
-/// Default of the toggle is **off** — `HapticEcoCoachEnabled` reads
-/// the persisted Hive setting, which is null for first-launch users
-/// and only flips to true after an explicit tap on this switch.
+/// The first two were standalone `SettingsMenuTile`s on the Settings
+/// page; pulling them inside one foldable that matches the "Conso" tab
+/// label keeps the per-vehicle controls clustered (#1122 follow-up).
+///
+/// Default of the eco-coach toggle is **off** —
+/// `HapticEcoCoachEnabled` reads the persisted Hive setting, which is
+/// null for first-launch users and only flips to true after an
+/// explicit tap.
 class DrivingSettingsSection extends ConsumerWidget {
   const DrivingSettingsSection({super.key});
 
@@ -24,20 +32,42 @@ class DrivingSettingsSection extends ConsumerWidget {
     final theme = Theme.of(context);
     final enabled = ref.watch(hapticEcoCoachEnabledProvider);
 
-    return SwitchListTile(
-      key: const Key('hapticEcoCoachToggle'),
-      value: enabled,
-      title: Text(
-        l?.hapticEcoCoachSettingTitle ?? 'Real-time eco coaching',
-      ),
-      subtitle: Text(
-        l?.hapticEcoCoachSettingSubtitle ??
-            'Gentle haptic when you floor it during cruise',
-        style: theme.textTheme.bodySmall,
-      ),
-      onChanged: (v) =>
-          ref.read(hapticEcoCoachEnabledProvider.notifier).set(v),
-      contentPadding: EdgeInsets.zero,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SettingsMenuTile(
+          key: const Key('consoleVehiclesTile'),
+          icon: Icons.directions_car,
+          title: l?.vehiclesMenuTitle ?? 'My vehicles',
+          subtitle: l?.vehiclesMenuSubtitle ??
+              'Battery, connectors, charging preferences',
+          onTap: () => context.push('/vehicles'),
+        ),
+        const SizedBox(height: 8),
+        SettingsMenuTile(
+          key: const Key('consoleFuelClubCardsTile'),
+          icon: Icons.card_membership,
+          title: l?.loyaltyMenuTitle ?? 'Fuel club cards',
+          subtitle: l?.loyaltyMenuSubtitle ??
+              'Apply per-litre discounts from Total, Aral, Shell, …',
+          onTap: () => context.push('/loyalty-settings'),
+        ),
+        SwitchListTile(
+          key: const Key('hapticEcoCoachToggle'),
+          value: enabled,
+          title: Text(
+            l?.hapticEcoCoachSettingTitle ?? 'Real-time eco coaching',
+          ),
+          subtitle: Text(
+            l?.hapticEcoCoachSettingSubtitle ??
+                'Gentle haptic when you floor it during cruise',
+            style: theme.textTheme.bodySmall,
+          ),
+          onChanged: (v) =>
+              ref.read(hapticEcoCoachEnabledProvider.notifier).set(v),
+          contentPadding: EdgeInsets.zero,
+        ),
+      ],
     );
   }
 }

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -86,16 +86,6 @@ class ProfileScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
 
-          // My vehicles
-          SettingsMenuTile(
-            icon: Icons.directions_car,
-            title: l?.vehiclesMenuTitle ?? 'My vehicles',
-            subtitle: l?.vehiclesMenuSubtitle ??
-                'Battery, connectors, charging preferences',
-            onTap: () => context.push('/vehicles'),
-          ),
-          const SizedBox(height: 8),
-
           // #896 — Consumption log menu tile removed. The consumption
           // screen is already a top-level destination on the bottom
           // navigation bar, so a duplicate menu entry here was
@@ -116,24 +106,15 @@ class ProfileScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
 
-          // #1120 — loyalty / fuel-club cards entry point. Pilot
-          // ships with Total Energies; cards apply a per-litre
-          // discount to displayed prices on matching stations.
-          SettingsMenuTile(
-            icon: Icons.card_membership,
-            title: l?.loyaltyMenuTitle ?? 'Fuel club cards',
-            subtitle: l?.loyaltyMenuSubtitle ??
-                'Apply per-litre discounts from Total, Aral, Shell, …',
-            onTap: () => context.push('/loyalty-settings'),
-          ),
-          const SizedBox(height: 8),
-
-          // #1122 — driving (wheel-lens) settings. Foldable so the
-          // section stays out of the way for users who don't want to
-          // toggle the real-time eco-coaching haptic.
+          // Consumption-tab settings group: vehicles, fuel club cards,
+          // and the real-time eco-coaching toggle. Section title matches
+          // the bottom-nav "Conso" tab so users can correlate the two
+          // entry points (#1122 follow-up). The standalone "My vehicles"
+          // and "Fuel club cards" tiles were folded INTO this section
+          // so per-vehicle controls cluster under one heading.
           _FoldableSection(
-            icon: Icons.directions_car_filled,
-            title: l?.hapticEcoCoachSectionTitle ?? 'Driving',
+            icon: Icons.local_gas_station_outlined,
+            title: l?.navConsumption ?? 'Consumption',
             child: const DrivingSettingsSection(),
           ),
           const SizedBox(height: 8),

--- a/test/features/driving/presentation/driving_settings_section_test.dart
+++ b/test/features/driving/presentation/driving_settings_section_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/core/widgets/settings_menu_tile.dart';
 import 'package:tankstellen/features/driving/presentation/widgets/driving_settings_section.dart';
 
 import '../../../helpers/pump_app.dart';
@@ -82,6 +83,47 @@ void main() {
             'A persisted-true value must hydrate the toggle on first '
             'paint — otherwise the user would have to flip it twice on '
             'every cold start.',
+      );
+    },
+  );
+
+  testWidgets(
+    'composes vehicles + fuel-club tiles above the eco-coach toggle '
+    '(#1242 — Console grouping)',
+    (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingSettingsSection(),
+        overrides: [
+          settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+        ],
+      );
+
+      // Both moved-in tiles must render with their canonical keys.
+      expect(
+        find.byKey(const Key('consoleVehiclesTile')),
+        findsOneWidget,
+        reason: 'My vehicles tile is part of the Consumption group.',
+      );
+      expect(
+        find.byKey(const Key('consoleFuelClubCardsTile')),
+        findsOneWidget,
+        reason: 'Fuel club cards tile is part of the Consumption group.',
+      );
+
+      // The eco-coach toggle is the third element, after the two
+      // menu tiles.
+      final children = <Widget>[
+        for (final t in tester
+            .widgetList<SettingsMenuTile>(find.byType(SettingsMenuTile)))
+          t,
+      ];
+      expect(
+        children.length,
+        2,
+        reason: 'Exactly two SettingsMenuTile children: vehicles + fuel '
+            'club. Adding more would risk drift between this section '
+            'and the Conso-tab landing screen.',
       );
     },
   );

--- a/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -208,8 +208,9 @@ void main() {
     });
 
     testWidgets(
-        '#896/#897/#1120: renders exactly four SettingsMenuTile rows — '
-        'My vehicles, Theme, Fuel club cards, Privacy Dashboard',
+        'Settings screen renders Theme + Privacy Dashboard tiles at top '
+        'level; My vehicles + Fuel club cards live INSIDE the Consumption '
+        'foldable (#1242 — Console grouping)',
         (tester) async {
       await pumpApp(
         tester,
@@ -217,23 +218,13 @@ void main() {
         overrides: overrides,
       );
 
-      // The Settings screen body is a lazily-built `ListView`; tiles
-      // below the viewport are not yet realized. Scroll through the
-      // list so every `SettingsMenuTile` is materialised before we
-      // count them.
+      // Scroll through so every realized tile gets a chance to mount.
       await tester.scrollUntilVisible(
         find.text('Privacy Dashboard'),
         200,
         scrollable: find.byType(Scrollable).first,
       );
 
-      // #896 removed Consumption log. #897 restyled the Theme entry
-      // from a bespoke `ThemeModeTile` (Card + bottom sheet) into a
-      // third `SettingsMenuTile` that matches Privacy + Storage and
-      // pushes to a dedicated `/theme-settings` screen. #1120 adds a
-      // Fuel club cards entry point. The Settings screen now renders
-      // My vehicles, Theme, Fuel club cards, Privacy Dashboard as
-      // SettingsMenuTile rows.
       final observedTitles = <String>{};
       void collect() {
         for (final t in tester
@@ -243,21 +234,13 @@ void main() {
       }
 
       collect();
-      // Scroll back to the top so the first tile is realized again.
       await tester.drag(find.byType(Scrollable).first, const Offset(0, 2000));
       await tester.pumpAndSettle();
       collect();
 
-      expect(
-        observedTitles.contains('My vehicles'),
-        isTrue,
-        reason: 'My vehicles tile should still render after #896',
-      );
-      expect(
-        observedTitles.contains('Privacy Dashboard'),
-        isTrue,
-        reason: 'Privacy Dashboard tile should still render after #896',
-      );
+      // Theme + Privacy Dashboard remain at the screen's top level;
+      // they are not vehicle-specific so they don't belong inside
+      // the Consumption foldable.
       expect(
         observedTitles.contains('Theme'),
         isTrue,
@@ -265,22 +248,96 @@ void main() {
             '(card matching Privacy + Storage pattern)',
       );
       expect(
-        observedTitles.contains('Fuel club cards'),
+        observedTitles.contains('Privacy Dashboard'),
         isTrue,
-        reason: '#1120: Fuel club cards tile must render as a '
-            'SettingsMenuTile entry to /loyalty-settings',
+        reason: 'Privacy Dashboard tile should still render at the '
+            'top level of the Settings screen',
       );
+
+      // My vehicles + Fuel club cards must NOT appear at the top
+      // level — they were folded into the Consumption section.
+      expect(
+        observedTitles.contains('My vehicles'),
+        isFalse,
+        reason: 'My vehicles tile moved INSIDE the Consumption '
+            'foldable; it must not render as a top-level entry too '
+            '(would be a duplicate).',
+      );
+      expect(
+        observedTitles.contains('Fuel club cards'),
+        isFalse,
+        reason: 'Fuel club cards tile moved INSIDE the Consumption '
+            'foldable; it must not render as a top-level entry too.',
+      );
+
       expect(
         observedTitles.contains('Consumption log'),
         isFalse,
         reason: '#896: Consumption log tile must not render any more',
       );
+    });
+
+    testWidgets(
+        'Consumption foldable header uses the same label as the bottom-nav '
+        '"Conso" tab and contains vehicles + fuel-club cards entries '
+        '(#1242)',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const ProfileScreen(),
+        overrides: overrides,
+      );
+
+      // The new section header replaces the old "Driving" copy. We
+      // must find the `navConsumption` label ("Consumption" in
+      // English) on the screen, and tapping it must reveal the
+      // vehicles + fuel-club tiles that were moved inside.
+      final consumptionHeader = find.text('Consumption');
+      await tester.scrollUntilVisible(
+        consumptionHeader,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
       expect(
-        observedTitles.length,
-        4,
-        reason: '#1120: expected exactly four distinct SettingsMenuTile '
-            'titles (My vehicles, Theme, Fuel club cards, Privacy '
-            'Dashboard); found $observedTitles',
+        consumptionHeader,
+        findsOneWidget,
+        reason:
+            'Foldable section title must match navConsumption ("Consumption") '
+            'so users correlate the Settings group with the bottom-nav tab.',
+      );
+
+      // Foldable starts collapsed — child tiles should not be in the
+      // tree yet.
+      expect(
+        find.byKey(const Key('consoleVehiclesTile')),
+        findsNothing,
+        reason: 'Consumption foldable must start collapsed; vehicle '
+            'tile should only mount after the user expands it.',
+      );
+
+      // Expand the foldable.
+      await tester.tap(consumptionHeader);
+      await tester.pumpAndSettle();
+
+      // Now both moved tiles should be present, plus the existing
+      // eco-coaching toggle.
+      expect(
+        find.byKey(const Key('consoleVehiclesTile')),
+        findsOneWidget,
+        reason: 'My vehicles tile must live inside the expanded '
+            'Consumption foldable (was at top level before #1242).',
+      );
+      expect(
+        find.byKey(const Key('consoleFuelClubCardsTile')),
+        findsOneWidget,
+        reason: 'Fuel club cards tile must live inside the expanded '
+            'Consumption foldable (was at top level before #1242).',
+      );
+      expect(
+        find.byKey(const Key('hapticEcoCoachToggle')),
+        findsOneWidget,
+        reason: 'The eco-coach haptic toggle remains in the same '
+            'group, now grouped with vehicles + fuel club cards.',
       );
     });
 


### PR DESCRIPTION
## Summary

- Rename the per-vehicle settings foldable from \`Driving\` → \`Consumption\` (uses the existing \`navConsumption\` ARB key, so the label tracks the bottom-nav "Conso" tab in every locale).
- Fold the standalone \`My vehicles\` and \`Fuel club cards\` SettingsMenuTiles INTO the foldable.
- Switch the section icon \`directions_car_filled\` → \`local_gas_station_outlined\` to visually match the tab.

## Why

User feedback (screenshot review): the per-vehicle controls were scattered as three peers — \`My vehicles\`, \`Fuel club cards\`, \`Driving\` — making the "things I tune for the car I'm driving" relationship invisible. Clustering them under a header that mirrors the bottom-nav tab makes the relationship explicit and aligns the user's mental model with the visual hierarchy.

## Test plan

- [x] \`flutter analyze\` clean
- [x] All driving + profile screen tests green (incl. new tests asserting the new structure)
- [ ] Visual check on device: foldable starts collapsed; tapping it reveals vehicles + fuel-club + eco-coach in that order

🤖 Generated with [Claude Code](https://claude.com/claude-code)