### PR TITLE
ux(settings): nest gamification toggle inside Conso foldable (Closes #1249)

### DIFF
--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/widgets/settings_menu_tile.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../profile/presentation/widgets/gamification_settings_tile.dart';
 import '../../providers/haptic_eco_coach_provider.dart';
 
 /// Consumption / driving settings group on the profile screen.
@@ -14,6 +15,8 @@ import '../../providers/haptic_eco_coach_provider.dart';
 ///   1. **My vehicles** (battery, connectors, charging prefs).
 ///   2. **Fuel club cards** (per-litre discounts).
 ///   3. **Real-time eco coaching** (haptic when over-driving on cruise).
+///   4. **Show achievements & scores** (master gamification opt-out —
+///      badges, scores, achievement tab).
 ///
 /// The first two were standalone `SettingsMenuTile`s on the Settings
 /// page; pulling them inside one foldable that matches the "Conso" tab
@@ -67,6 +70,7 @@ class DrivingSettingsSection extends ConsumerWidget {
               ref.read(hapticEcoCoachEnabledProvider.notifier).set(v),
           contentPadding: EdgeInsets.zero,
         ),
+        const GamificationSettingsTile(),
       ],
     );
   }

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -11,7 +11,6 @@ import '../../../driving/presentation/widgets/driving_settings_section.dart';
 import '../widgets/about_section.dart';
 import '../widgets/api_key_section.dart';
 import '../widgets/feedback_token_section.dart';
-import '../widgets/gamification_settings_tile.dart';
 import '../widgets/location_section_widget.dart';
 import '../widgets/profile_list_section.dart';
 import '../widgets/storage_section.dart';
@@ -116,20 +115,6 @@ class ProfileScreen extends ConsumerWidget {
             icon: Icons.local_gas_station_outlined,
             title: l?.navConsumption ?? 'Consumption',
             child: const DrivingSettingsSection(),
-          ),
-          const SizedBox(height: 8),
-
-          // #1194 — master gamification opt-out. A flat card next to
-          // the existing toggle-style entries. Default on; flipping it
-          // off hides badges, scores, the achievements tab, and the
-          // driving-score card across the app while keeping the
-          // underlying achievement engine running.
-          const Card(
-            margin: EdgeInsets.zero,
-            child: Padding(
-              padding: EdgeInsets.symmetric(horizontal: 8),
-              child: GamificationSettingsTile(),
-            ),
           ),
           const SizedBox(height: 8),
 

--- a/test/features/driving/presentation/driving_settings_section_test.dart
+++ b/test/features/driving/presentation/driving_settings_section_test.dart
@@ -5,7 +5,9 @@ import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 import 'package:tankstellen/core/widgets/settings_menu_tile.dart';
 import 'package:tankstellen/features/driving/presentation/widgets/driving_settings_section.dart';
+import 'package:tankstellen/features/profile/presentation/widgets/gamification_settings_tile.dart';
 
+import '../../../fakes/fake_storage_repository.dart';
 import '../../../helpers/pump_app.dart';
 
 /// Widget coverage for [DrivingSettingsSection] (#1122).
@@ -30,6 +32,7 @@ void main() {
         const DrivingSettingsSection(),
         overrides: [
           settingsStorageProvider.overrideWithValue(fake),
+          storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
         ],
       );
 
@@ -71,6 +74,7 @@ void main() {
         const DrivingSettingsSection(),
         overrides: [
           settingsStorageProvider.overrideWithValue(fake),
+          storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
         ],
       );
 
@@ -96,6 +100,7 @@ void main() {
         const DrivingSettingsSection(),
         overrides: [
           settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+          storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
         ],
       );
 
@@ -124,6 +129,34 @@ void main() {
         reason: 'Exactly two SettingsMenuTile children: vehicles + fuel '
             'club. Adding more would risk drift between this section '
             'and the Conso-tab landing screen.',
+      );
+    },
+  );
+
+  testWidgets(
+    'nests the gamification opt-out tile inside the Conso section '
+    '(#1249 — moved out of the standalone settings card)',
+    (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingSettingsSection(),
+        overrides: [
+          settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+          storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
+        ],
+      );
+
+      // The gamification toggle now lives as the last child of the
+      // Consumption foldable instead of as a sibling Card on the
+      // Settings page. Asserting it is present here pins that
+      // placement so a future rewrite can't silently move it back.
+      expect(
+        find.byType(GamificationSettingsTile),
+        findsOneWidget,
+        reason:
+            'Exactly one GamificationSettingsTile must render inside '
+            'DrivingSettingsSection — duplication or absence indicates '
+            'the #1249 placement regressed.',
       );
     },
   );


### PR DESCRIPTION
## Summary

- Moved `GamificationSettingsTile` ("Show achievements & scores") from a standalone Card on the Settings page into the last child of the Conso foldable's `DrivingSettingsSection`, so the master gamification opt-out clusters with the other per-driver controls (vehicles, fuel club, eco-coach toggle).
- Updated the `DrivingSettingsSection` docstring to document the new 4-item list, and dropped the now-unused gamification import from `profile_screen.dart`.
- Added a test in `test/features/driving/presentation/driving_settings_section_test.dart` asserting exactly one `GamificationSettingsTile` renders inside the section, plus updated the existing tests with a `storageRepositoryProvider` override now that the section watches `activeProfileProvider` indirectly.

Closes #1249

## Test plan
- [x] `flutter analyze` — zero issues
- [x] `flutter test test/features/driving/presentation/driving_settings_section_test.dart` — 4 tests pass (3 existing + 1 new)
- [x] `flutter test test/features/profile/presentation/widgets/gamification_settings_tile_test.dart test/features/profile/presentation/screens/profile_screen_test.dart` — 18 tests pass
- [ ] CI runs the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)