### PR TITLE
fix(consumption): persist throttle % on TripSample (Closes #1261)

### DIFF
--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -915,6 +915,7 @@ class TripRecordingController {
         speedKmh: _latestSpeedKmh ?? 0,
         rpm: _latestRpm ?? 0,
         fuelRateLPerHour: fuelRate,
+        throttlePercent: _latestThrottlePercent,
       );
       _recorder.onSample(sample);
       _lastSampleAt = nowTs;

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -73,15 +73,19 @@ class TripHistoryEntry {
       );
 }
 
-/// Serialise a single [TripSample]. Compact key names ('t','s','r','f')
-/// keep per-trip JSON small — a 39-min trip × 1 Hz lands around 19 KB
-/// compressed at this density. Use millisecondsSinceEpoch for the
-/// timestamp so the JSON parses fast and round-trips precisely.
+/// Serialise a single [TripSample]. Compact key names
+/// ('t','s','r','f','th') keep per-trip JSON small — a 39-min trip ×
+/// 1 Hz lands around 19 KB compressed at this density. Use
+/// millisecondsSinceEpoch for the timestamp so the JSON parses fast
+/// and round-trips precisely. The `'th'` key (#1261) is only emitted
+/// when throttle % was actually read (cars without PID 0x11 omit it
+/// — legacy trips without `'th'` deserialise with throttle null).
 Map<String, dynamic> _sampleToJson(TripSample s) => {
       't': s.timestamp.millisecondsSinceEpoch,
       's': s.speedKmh,
       'r': s.rpm,
       if (s.fuelRateLPerHour != null) 'f': s.fuelRateLPerHour,
+      if (s.throttlePercent != null) 'th': s.throttlePercent,
     };
 
 TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
@@ -91,6 +95,7 @@ TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
       speedKmh: (j['s'] as num).toDouble(),
       rpm: (j['r'] as num).toDouble(),
       fuelRateLPerHour: (j['f'] as num?)?.toDouble(),
+      throttlePercent: (j['th'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _summaryToJson(TripSummary s) => {

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -8,11 +8,17 @@ class TripSample {
   final double rpm;
   final double? fuelRateLPerHour;
 
+  /// Throttle position in percent (PID 0x11), if available. Cars
+  /// without PID 11 report null — the trip-detail throttle / RPM
+  /// histogram falls back to the RPM axis only in that case (#1261).
+  final double? throttlePercent;
+
   const TripSample({
     required this.timestamp,
     required this.speedKmh,
     required this.rpm,
     this.fuelRateLPerHour,
+    this.throttlePercent,
   });
 }
 

--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -270,4 +270,5 @@ TripDetailSample _toDetailSample(TripSample s) => TripDetailSample(
       speedKmh: s.speedKmh,
       rpm: s.rpm,
       fuelRateLPerHour: s.fuelRateLPerHour,
+      throttlePercent: s.throttlePercent,
     );

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -71,12 +71,10 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
   /// calculator is O(n), pure, and cheap, but a long trip ticks at
   /// ~1 Hz so re-running on every rebuild adds up.
   ///
-  /// Persisted [TripSample]s currently carry RPM but not throttle %
-  /// (the throttle PID was added to the polling rotation later). We
-  /// still feed every sample through the calculator — the throttle
-  /// axis falls back to its own empty-state caption while the RPM
-  /// bars render normally. Once a future phase persists throttle on
-  /// disk, the card lights up automatically.
+  /// Persisted [TripSample]s carry both RPM and throttle % (#1261).
+  /// Cars without PID 0x11 still emit null throttle on every sample —
+  /// the calculator treats those nulls as "skip on the throttle axis"
+  /// so the RPM bars render alone in that case.
   late final ThrottleRpmHistogram _histogram = _computeHistogram();
 
   /// Lazily-computed composite driving score (#1041 phase 5a — Card A).
@@ -123,11 +121,11 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
         .map(
           (s) => ThrottleRpmSample(
             timestamp: s.timestamp,
-            // TripDetailSample has no throttle field — legacy
-            // persistence didn't carry PID 11. The calculator
+            // #1261: persisted samples now carry throttle %. Cars
+            // without PID 0x11 still emit null and the calculator
             // treats nulls as "skip on the throttle axis" so the
-            // RPM bars still render.
-            throttlePercent: null,
+            // RPM bars render alone for those trips.
+            throttlePercent: s.throttlePercent,
             rpm: s.rpm,
           ),
         )

--- a/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
@@ -34,11 +34,18 @@ class TripDetailSample {
   /// null.
   final double? fuelRateLPerHour;
 
+  /// Throttle position % (PID 0x11). Null when the car's PID cache
+  /// flagged 0x11 as unsupported, or when persisted by a build before
+  /// #1261 (legacy trips). Drives the throttle axis of the throttle /
+  /// RPM histogram on the trip-detail screen.
+  final double? throttlePercent;
+
   const TripDetailSample({
     required this.timestamp,
     required this.speedKmh,
     this.rpm,
     this.fuelRateLPerHour,
+    this.throttlePercent,
   });
 }
 

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -229,6 +230,107 @@ void main() {
         summary: mkSummary(startedAt: start),
       ));
       expect(hookCalls, ['car-b']);
+    });
+  });
+
+  group('TripSample throttle persistence (#1261)', () {
+    test('sample with throttle round-trips through save / loadAll', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 4, 21);
+      final ts = start.add(const Duration(seconds: 5));
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        samples: [
+          TripSample(
+            timestamp: ts,
+            speedKmh: 55,
+            rpm: 1800,
+            fuelRateLPerHour: 4.2,
+            throttlePercent: 37.5,
+          ),
+        ],
+      ));
+
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.samples, hasLength(1));
+      expect(loaded.first.samples.first.throttlePercent, 37.5);
+      // And the other compact-key fields still round-trip cleanly.
+      expect(loaded.first.samples.first.speedKmh, 55);
+      expect(loaded.first.samples.first.rpm, 1800);
+      expect(loaded.first.samples.first.fuelRateLPerHour, 4.2);
+    });
+
+    test(
+        'sample with null throttle does NOT include the "th" key in stored '
+        'JSON — matches the parsimony rule the "f" key already follows',
+        () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 4, 21);
+      final ts = start.add(const Duration(seconds: 5));
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        samples: [
+          TripSample(
+            timestamp: ts,
+            speedKmh: 55,
+            rpm: 1800,
+            // throttlePercent and fuelRateLPerHour both null
+          ),
+        ],
+      ));
+
+      // Read the raw stored JSON and inspect the sample's keys.
+      final raw = box.get(start.toIso8601String())!;
+      final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
+      final samples = (decoded['samples'] as List).cast<Map>();
+      expect(samples.first.containsKey('th'), isFalse);
+      expect(samples.first.containsKey('f'), isFalse);
+    });
+
+    test(
+        'legacy JSON (pre-#1261) without the "th" key deserialises with '
+        'throttlePercent: null — backward compat for trips on disk',
+        () async {
+      final start = DateTime(2026, 4, 21);
+      final ts = start.add(const Duration(seconds: 5));
+      // Hand-craft a JSON payload as a pre-#1261 build would have
+      // written it: every compact key EXCEPT 'th' is present.
+      final legacyJson = jsonEncode({
+        'id': start.toIso8601String(),
+        'vehicleId': null,
+        'summary': {
+          'distanceKm': 10.0,
+          'maxRpm': 2800.0,
+          'highRpmSeconds': 0.0,
+          'idleSeconds': 0.0,
+          'harshBrakes': 0,
+          'harshAccelerations': 0,
+          'startedAt': start.toIso8601String(),
+        },
+        'samples': [
+          {
+            't': ts.millisecondsSinceEpoch,
+            's': 55.0,
+            'r': 1800.0,
+            'f': 4.2,
+          },
+        ],
+      });
+      await box.put(start.toIso8601String(), legacyJson);
+
+      final repo = TripHistoryRepository(box: box);
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.samples, hasLength(1));
+      expect(loaded.first.samples.first.throttlePercent, isNull);
+      // Other fields still parse normally.
+      expect(loaded.first.samples.first.speedKmh, 55);
+      expect(loaded.first.samples.first.fuelRateLPerHour, 4.2);
     });
   });
 }

--- a/test/features/consumption/domain/trip_recorder_test.dart
+++ b/test/features/consumption/domain/trip_recorder_test.dart
@@ -151,6 +151,30 @@ void main() {
       expect(summary.avgLPer100Km, closeTo(10.0, 0.1));
     });
 
+    test('throttlePercent on TripSample is preserved (#1261)', () {
+      // The recorder doesn't aggregate throttle today — but the field
+      // must round-trip through TripSample so the persisted samples
+      // can drive the trip-detail throttle / RPM histogram.
+      final ts = DateTime.utc(2026);
+      final sample = TripSample(
+        timestamp: ts,
+        speedKmh: 60,
+        rpm: 2000,
+        throttlePercent: 42.0,
+      );
+      expect(sample.throttlePercent, 42.0);
+      // And the existing fields still pass through unchanged.
+      expect(sample.speedKmh, 60);
+      expect(sample.rpm, 2000);
+      expect(sample.fuelRateLPerHour, isNull);
+    });
+
+    test('throttlePercent defaults to null when omitted (#1261)', () {
+      final ts = DateTime.utc(2026);
+      final sample = TripSample(timestamp: ts, speedKmh: 50, rpm: 1500);
+      expect(sample.throttlePercent, isNull);
+    });
+
     test('configurable thresholds override the defaults', () {
       final strict = TripRecorder(
         highRpmThreshold: 2500,


### PR DESCRIPTION
## Summary

Closes #1261. Throttle PID 0x11 was already polled live and surfaced on `TripLiveReading`, but never landed on `TripSample` — so the trip-detail throttle/RPM histogram fell back to RPM-only via a documented null-fallback. Plumb throttle through the six layers it needs to travel.

### Files touched

- `lib/features/consumption/domain/trip_recorder.dart` — add `TripSample.throttlePercent` (nullable)
- `lib/features/consumption/data/obd2/trip_recording_controller.dart` — populate from `_latestThrottlePercent` in the polling loop
- `lib/features/consumption/data/trip_history_repository.dart` — JSON encode/decode under compact key `'th'`, only emitted when non-null (mirrors the `'f'` parsimony rule)
- `lib/features/consumption/presentation/widgets/trip_detail_charts.dart` — `TripDetailSample.throttlePercent` at the presentation boundary
- `lib/features/consumption/presentation/screens/trip_detail_screen.dart` — `_toDetailSample` converter forwards throttle
- `lib/features/consumption/presentation/widgets/trip_detail_body.dart` — feed `s.throttlePercent` into `ThrottleRpmSample`; drop the legacy "no throttle field" fallback comments

### JSON key

Throttle persists under compact key `'th'`. Legacy trips written before this PR deserialise with `throttlePercent: null` (calculator handles null-on-throttle as "skip on the throttle axis").

## Test plan

- [x] `trip_recorder_test` — throttle field round-trips through `TripSample`; defaults to null when omitted
- [x] `trip_history_repository_test` (`#1261` group): sample-with-throttle round-trips through save/loadAll; null-throttle JSON does NOT include `'th'` key; legacy JSON without `'th'` deserialises with `throttlePercent: null` (backward compat)
- [x] `throttle_rpm_histogram_calculator_test` — existing axis-isolation cases still pass; no edits needed
- [x] `trip_detail_body_test` + `trip_detail_charts_test` + `throttle_rpm_histogram_card_test` still pass
- [x] `flutter analyze` clean (no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)