### PR TITLE
feat(consumption): persist engineLoad + coolantTemp on TripSample (Refs #1262 phase 1)

### DIFF
--- a/lib/features/consumption/data/obd2/elm327_commands.dart
+++ b/lib/features/consumption/data/obd2/elm327_commands.dart
@@ -151,6 +151,13 @@ class Elm327Commands {
   /// Request calculated engine load (%). Mode 01, PID 04. (#717)
   static const engineLoadCommand = '0104\r';
 
+  /// Request engine coolant temperature (°C). Mode 01, PID 05.
+  /// Formula: °C = A − 40 (one-byte response). Used by the cold-start
+  /// surcharge heuristic (#1262) to flag short trips where the engine
+  /// never reached operating temperature and consumed proportionally
+  /// more fuel for warm-up than for forward motion.
+  static const coolantTempCommand = '0105\r';
+
   /// Request absolute throttle position (%). Mode 01, PID 11. (#717)
   static const throttlePositionCommand = '0111\r';
 

--- a/lib/features/consumption/data/obd2/elm327_parsers.dart
+++ b/lib/features/consumption/data/obd2/elm327_parsers.dart
@@ -134,6 +134,17 @@ class Elm327Parsers {
     return bytes[2].toDouble() - 40.0;
   }
 
+  /// Parse engine coolant temperature from Mode 01 PID 05 response
+  /// (#1262). Formula: °C = A − 40 (single byte) — same encoding as
+  /// PID 0F (intake air). Response: "41 05 XX". Range −40 °C to
+  /// 215 °C. Used by the cold-start surcharge heuristic to flag trips
+  /// whose ECT never reached operating temperature.
+  static double? parseCoolantTempCelsius(String raw) {
+    final bytes = _parseModeOneBody(raw, 0x05, minBytes: 3);
+    if (bytes == null) return null;
+    return bytes[2].toDouble() - 40.0;
+  }
+
   /// Parse short-term fuel trim bank 1 from Mode 01 PID 06 response
   /// (#813). Formula: `trim% = (A − 128) × 100 / 128`. Midpoint 128
   /// = 0 % (stoichiometric); <128 means the ECU is leaning the

--- a/lib/features/consumption/data/obd2/elm327_protocol.dart
+++ b/lib/features/consumption/data/obd2/elm327_protocol.dart
@@ -57,6 +57,7 @@ class Elm327Protocol {
       Elm327Commands.distanceSinceDtcClearedCommand;
   static const odometerCommand = Elm327Commands.odometerCommand;
   static const engineLoadCommand = Elm327Commands.engineLoadCommand;
+  static const coolantTempCommand = Elm327Commands.coolantTempCommand;
   static const throttlePositionCommand = Elm327Commands.throttlePositionCommand;
   static const engineFuelRateCommand = Elm327Commands.engineFuelRateCommand;
   static const mafCommand = Elm327Commands.mafCommand;
@@ -107,6 +108,9 @@ class Elm327Protocol {
 
   static double? parseIntakeAirTempCelsius(String raw) =>
       Elm327Parsers.parseIntakeAirTempCelsius(raw);
+
+  static double? parseCoolantTempCelsius(String raw) =>
+      Elm327Parsers.parseCoolantTempCelsius(raw);
 
   static double? parseShortTermFuelTrim(String raw) =>
       Elm327Parsers.parseShortTermFuelTrim(raw);

--- a/lib/features/consumption/data/obd2/trip_live_reading.dart
+++ b/lib/features/consumption/data/obd2/trip_live_reading.dart
@@ -23,6 +23,13 @@ class TripLiveReading {
   /// the engine-load proxy. Null when the adapter hasn't surfaced PID
   /// 11 or the first tick hasn't landed yet.
   final double? throttlePercent;
+
+  /// Engine coolant temperature in °C (PID 0x05). Null when the car
+  /// doesn't surface the PID or the first tick hasn't landed. Persists
+  /// onto [TripSample] so the cold-start surcharge heuristic (#1262
+  /// phase 2) can read it post-trip — engines that never reach
+  /// operating temperature burn proportionally more fuel for warm-up.
+  final double? coolantTempC;
   final double distanceKmSoFar;
   final double? fuelLitersSoFar;
   final Duration elapsed;
@@ -36,6 +43,7 @@ class TripLiveReading {
     this.fuelLevelPercent,
     this.engineLoadPercent,
     this.throttlePercent,
+    this.coolantTempC,
     required this.distanceKmSoFar,
     this.fuelLitersSoFar,
     required this.elapsed,

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -271,6 +271,7 @@ class TripRecordingController {
   double? _latestIatCelsius;
   double? _latestThrottlePercent;
   double? _latestEngineLoadPercent;
+  double? _latestCoolantTempC;
   double? _latestFuelLevelPercent;
   double? _latestStft;
   double? _latestLtft;
@@ -853,6 +854,17 @@ class TripRecordingController {
         if (v != null) _latestIatCelsius = v;
       },
     );
+    // Coolant temp drifts slowly — 1 Hz is more than enough resolution
+    // for the cold-start surcharge heuristic (#1262 phase 2) to detect
+    // whether the trip ever crossed operating temperature.
+    scheduler.subscribe(
+      Elm327Protocol.coolantTempCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseCoolantTempCelsius(r);
+        if (v != null) _latestCoolantTempC = v;
+      },
+    );
     scheduler.subscribe(
       Elm327Protocol.shortTermFuelTrimCommand,
       ScheduledPid(hz: 1.0),
@@ -916,6 +928,8 @@ class TripRecordingController {
         rpm: _latestRpm ?? 0,
         fuelRateLPerHour: fuelRate,
         throttlePercent: _latestThrottlePercent,
+        engineLoadPercent: _latestEngineLoadPercent,
+        coolantTempC: _latestCoolantTempC,
       );
       _recorder.onSample(sample);
       _lastSampleAt = nowTs;
@@ -933,6 +947,7 @@ class TripRecordingController {
       fuelLevelPercent: _latestFuelLevelPercent,
       engineLoadPercent: _latestEngineLoadPercent,
       throttlePercent: _latestThrottlePercent,
+      coolantTempC: _latestCoolantTempC,
       distanceKmSoFar: _recorder.buildSummary().distanceKm,
       fuelLitersSoFar: _fuelRateSeen ? _fuelLitersSoFar : null,
       elapsed: nowTs.difference(_startedAt ?? nowTs),

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -74,18 +74,21 @@ class TripHistoryEntry {
 }
 
 /// Serialise a single [TripSample]. Compact key names
-/// ('t','s','r','f','th') keep per-trip JSON small — a 39-min trip ×
-/// 1 Hz lands around 19 KB compressed at this density. Use
-/// millisecondsSinceEpoch for the timestamp so the JSON parses fast
-/// and round-trips precisely. The `'th'` key (#1261) is only emitted
-/// when throttle % was actually read (cars without PID 0x11 omit it
-/// — legacy trips without `'th'` deserialise with throttle null).
+/// ('t','s','r','f','th','el','ct') keep per-trip JSON small — a
+/// 39-min trip × 1 Hz lands around 19 KB compressed at this density.
+/// Use millisecondsSinceEpoch for the timestamp so the JSON parses
+/// fast and round-trips precisely. The optional `'th'` (#1261),
+/// `'el'` and `'ct'` (#1262) keys are only emitted when the
+/// corresponding PID was actually read — legacy trips written before
+/// each key landed deserialise with the field null.
 Map<String, dynamic> _sampleToJson(TripSample s) => {
       't': s.timestamp.millisecondsSinceEpoch,
       's': s.speedKmh,
       'r': s.rpm,
       if (s.fuelRateLPerHour != null) 'f': s.fuelRateLPerHour,
       if (s.throttlePercent != null) 'th': s.throttlePercent,
+      if (s.engineLoadPercent != null) 'el': s.engineLoadPercent,
+      if (s.coolantTempC != null) 'ct': s.coolantTempC,
     };
 
 TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
@@ -96,6 +99,8 @@ TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
       rpm: (j['r'] as num).toDouble(),
       fuelRateLPerHour: (j['f'] as num?)?.toDouble(),
       throttlePercent: (j['th'] as num?)?.toDouble(),
+      engineLoadPercent: (j['el'] as num?)?.toDouble(),
+      coolantTempC: (j['ct'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _summaryToJson(TripSummary s) => {

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -13,12 +13,27 @@ class TripSample {
   /// histogram falls back to the RPM axis only in that case (#1261).
   final double? throttlePercent;
 
+  /// Calculated engine load in percent (PID 0x04). Null when the car
+  /// doesn't surface the PID. Persisted so post-trip insights can
+  /// distinguish "uphill at 60 km/h" (high load) from "flat at 60 km/h"
+  /// (low load) instead of inferring from RPM alone (#1262).
+  final double? engineLoadPercent;
+
+  /// Engine coolant temperature in °C (PID 0x05). Null when the car
+  /// doesn't surface the PID. Persisted so the cold-start surcharge
+  /// heuristic (#1262 phase 2) can flag trips whose ECT never reached
+  /// operating temperature — those burn proportionally more fuel for
+  /// warm-up.
+  final double? coolantTempC;
+
   const TripSample({
     required this.timestamp,
     required this.speedKmh,
     required this.rpm,
     this.fuelRateLPerHour,
     this.throttlePercent,
+    this.engineLoadPercent,
+    this.coolantTempC,
   });
 }
 

--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -271,4 +271,6 @@ TripDetailSample _toDetailSample(TripSample s) => TripDetailSample(
       rpm: s.rpm,
       fuelRateLPerHour: s.fuelRateLPerHour,
       throttlePercent: s.throttlePercent,
+      engineLoadPercent: s.engineLoadPercent,
+      coolantTempC: s.coolantTempC,
     );

--- a/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
@@ -40,12 +40,27 @@ class TripDetailSample {
   /// RPM histogram on the trip-detail screen.
   final double? throttlePercent;
 
+  /// Calculated engine load % (PID 0x04). Null when the car's PID
+  /// cache flagged 0x04 as unsupported, or when persisted by a build
+  /// before #1262 (legacy trips). Surfaced by the load-aware coaching
+  /// chart in phase 3 of #1262 — distinguishes "uphill at 60 km/h"
+  /// (high load) from "flat at 60 km/h" (low load).
+  final double? engineLoadPercent;
+
+  /// Engine coolant temperature in °C (PID 0x05). Null when the car
+  /// doesn't surface the PID, or when persisted by a build before
+  /// #1262 (legacy trips). Drives the cold-start surcharge chip in
+  /// phase 3 of #1262.
+  final double? coolantTempC;
+
   const TripDetailSample({
     required this.timestamp,
     required this.speedKmh,
     this.rpm,
     this.fuelRateLPerHour,
     this.throttlePercent,
+    this.engineLoadPercent,
+    this.coolantTempC,
   });
 }
 

--- a/test/features/consumption/data/obd2/elm327_commands_test.dart
+++ b/test/features/consumption/data/obd2/elm327_commands_test.dart
@@ -235,6 +235,7 @@ void main() {
         Elm327Commands.distanceSinceDtcClearedCommand,
         Elm327Commands.odometerCommand,
         Elm327Commands.engineLoadCommand,
+        Elm327Commands.coolantTempCommand,
         Elm327Commands.throttlePositionCommand,
         Elm327Commands.engineFuelRateCommand,
         Elm327Commands.mafCommand,
@@ -266,6 +267,10 @@ void main() {
       expect(Elm327Commands.odometerCommand, '01A6\r');
     });
 
+    test('coolantTempCommand asks for PID 05 (#1262)', () {
+      expect(Elm327Commands.coolantTempCommand, '0105\r');
+    });
+
     test('vinCommand asks for Mode 09 PID 02', () {
       expect(Elm327Commands.vinCommand, '0902\r');
     });
@@ -277,6 +282,7 @@ void main() {
         Elm327Commands.distanceSinceDtcClearedCommand,
         Elm327Commands.odometerCommand,
         Elm327Commands.engineLoadCommand,
+        Elm327Commands.coolantTempCommand,
         Elm327Commands.throttlePositionCommand,
         Elm327Commands.engineFuelRateCommand,
         Elm327Commands.mafCommand,
@@ -286,8 +292,8 @@ void main() {
         Elm327Commands.longTermFuelTrimCommand,
         Elm327Commands.fuelTankLevelCommand,
       };
-      // Set length must equal number of unique commands above (13).
-      expect(pids.length, 13);
+      // Set length must equal number of unique commands above (14).
+      expect(pids.length, 14);
     });
   });
 

--- a/test/features/consumption/data/obd2/elm327_parsers_test.dart
+++ b/test/features/consumption/data/obd2/elm327_parsers_test.dart
@@ -367,6 +367,58 @@ void main() {
     });
   });
 
+  group('parseCoolantTempCelsius (PID 05) — #1262', () {
+    test('41 05 28 -> 0 °C (40 - 40)', () {
+      // Same °C = A − 40 encoding as IAT (PID 0F).
+      expect(
+        Elm327Parsers.parseCoolantTempCelsius('41 05 28'),
+        0.0,
+      );
+    });
+
+    test('41 05 00 -> -40 °C (sensor minimum)', () {
+      expect(
+        Elm327Parsers.parseCoolantTempCelsius('41 05 00'),
+        -40.0,
+      );
+    });
+
+    test('41 05 78 -> 80 °C (typical operating temperature)', () {
+      // 0x78 = 120 → 120 − 40 = 80 °C — the cold-start surcharge
+      // heuristic uses ~80 °C as the "warm" threshold.
+      expect(
+        Elm327Parsers.parseCoolantTempCelsius('41 05 78'),
+        80.0,
+      );
+    });
+
+    test('41 05 FF -> 215 °C (sensor maximum)', () {
+      expect(
+        Elm327Parsers.parseCoolantTempCelsius('41 05 FF'),
+        215.0,
+      );
+    });
+
+    test('wrong PID echo (0F) returns null — PID isolation from IAT', () {
+      // Important: parseCoolantTempCelsius must NOT decode PID 0F (IAT)
+      // even though the formula is identical — otherwise a missing
+      // coolant PID would silently masquerade as IAT data.
+      expect(Elm327Parsers.parseCoolantTempCelsius('41 0F 28'), isNull);
+    });
+
+    test('wrong PID echo (04) returns null', () {
+      expect(Elm327Parsers.parseCoolantTempCelsius('41 04 28'), isNull);
+    });
+
+    test('short response returns null', () {
+      expect(Elm327Parsers.parseCoolantTempCelsius('41 05'), isNull);
+    });
+
+    test('NO DATA returns null', () {
+      expect(Elm327Parsers.parseCoolantTempCelsius('NO DATA'), isNull);
+    });
+  });
+
   group('parseFuelRateLPerHour (PID 5E)', () {
     test('41 5E 00 64 -> 5.0 L/h', () {
       // (0*256 + 100) * 0.05 = 5.0

--- a/test/features/consumption/data/obd2/elm327_protocol_test.dart
+++ b/test/features/consumption/data/obd2/elm327_protocol_test.dart
@@ -102,6 +102,30 @@ void main() {
       });
     });
 
+    group('parseCoolantTempCelsius (PID 05) — #1262', () {
+      test('parses 80 °C (operating temperature) at raw 0x78', () {
+        expect(
+          Elm327Protocol.parseCoolantTempCelsius('41 05 78>'),
+          closeTo(80.0, 0.01),
+        );
+      });
+
+      test('parses -40 °C at raw 0x00 (sensor minimum / cold start)', () {
+        expect(
+          Elm327Protocol.parseCoolantTempCelsius('41 05 00>'),
+          closeTo(-40.0, 0.01),
+        );
+      });
+
+      test('returns null on NO DATA', () {
+        expect(Elm327Protocol.parseCoolantTempCelsius('NO DATA>'), isNull);
+      });
+
+      test('coolantTempCommand asks for PID 05', () {
+        expect(Elm327Protocol.coolantTempCommand, '0105\r');
+      });
+    });
+
     group('parseIntakeAirTempCelsius (PID 0F) — #800 speed-density input', () {
       test('parses -40 °C at raw 0x00 (sensor minimum)', () {
         expect(

--- a/test/features/consumption/data/obd2/trip_live_reading_test.dart
+++ b/test/features/consumption/data/obd2/trip_live_reading_test.dart
@@ -17,9 +17,20 @@ void main() {
       expect(reading.fuelLevelPercent, isNull);
       expect(reading.engineLoadPercent, isNull);
       expect(reading.throttlePercent, isNull);
+      expect(reading.coolantTempC, isNull);
       expect(reading.fuelLitersSoFar, isNull);
       expect(reading.odometerStartKm, isNull);
       expect(reading.odometerNowKm, isNull);
+    });
+
+    test('coolantTempC stores the value supplied by the controller (#1262)',
+        () {
+      const reading = TripLiveReading(
+        coolantTempC: 78.5,
+        distanceKmSoFar: 0,
+        elapsed: Duration.zero,
+      );
+      expect(reading.coolantTempC, 78.5);
     });
   });
 

--- a/test/features/consumption/data/obd2/trip_recording_controller_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_test.dart
@@ -408,6 +408,7 @@ void main() {
           '010D': '41 0D 32>', // 50 km/h
           '0111': '41 11 40>',
           '0104': '41 04 33>', // 0x33 = 51 → ~20 %
+          '0105': '41 05 78>', // 0x78 = 120 → 80 °C
           '010F': '41 0F 41>',
           '0106': '41 06 80>',
           '0107': '41 07 80>',
@@ -447,6 +448,8 @@ void main() {
         expect(latest.engineLoadPercent, closeTo(20, 1));
         // Fuel level landed via 012F → ~50 %.
         expect(latest.fuelLevelPercent, closeTo(50, 1));
+        // Coolant temp landed via 0105 → 80 °C (0x78 - 40). #1262.
+        expect(latest.coolantTempC, closeTo(80, 0.1));
       });
     });
   });

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -333,4 +333,112 @@ void main() {
       expect(loaded.first.samples.first.fuelRateLPerHour, 4.2);
     });
   });
+
+  group('TripSample engineLoad + coolantTemp persistence (#1262 phase 1)', () {
+    test(
+        'sample with engineLoadPercent and coolantTempC round-trips through '
+        'save / loadAll', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 4, 21);
+      final ts = start.add(const Duration(seconds: 5));
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        samples: [
+          TripSample(
+            timestamp: ts,
+            speedKmh: 55,
+            rpm: 1800,
+            fuelRateLPerHour: 4.2,
+            throttlePercent: 37.5,
+            engineLoadPercent: 42.5,
+            coolantTempC: 82.0,
+          ),
+        ],
+      ));
+
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.samples, hasLength(1));
+      final s = loaded.first.samples.first;
+      expect(s.engineLoadPercent, 42.5);
+      expect(s.coolantTempC, 82.0);
+      // Throttle still survives — the new keys don't displace the old.
+      expect(s.throttlePercent, 37.5);
+    });
+
+    test(
+        'sample with null engineLoadPercent / coolantTempC does NOT include '
+        '"el" / "ct" keys in stored JSON — matches the parsimony rule the '
+        '"f" / "th" keys already follow', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 4, 21);
+      final ts = start.add(const Duration(seconds: 5));
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        samples: [
+          TripSample(
+            timestamp: ts,
+            speedKmh: 55,
+            rpm: 1800,
+            // engineLoadPercent / coolantTempC both null
+          ),
+        ],
+      ));
+
+      final raw = box.get(start.toIso8601String())!;
+      final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
+      final samples = (decoded['samples'] as List).cast<Map>();
+      expect(samples.first.containsKey('el'), isFalse);
+      expect(samples.first.containsKey('ct'), isFalse);
+    });
+
+    test(
+        'legacy JSON (pre-#1262) without "el" / "ct" keys deserialises with '
+        'engineLoadPercent: null AND coolantTempC: null — backward compat',
+        () async {
+      final start = DateTime(2026, 4, 21);
+      final ts = start.add(const Duration(seconds: 5));
+      // Legacy sample JSON: 't','s','r','f','th' present, but no
+      // 'el' / 'ct' (the trip was recorded before #1262 phase 1).
+      final legacyJson = jsonEncode({
+        'id': start.toIso8601String(),
+        'vehicleId': null,
+        'summary': {
+          'distanceKm': 10.0,
+          'maxRpm': 2800.0,
+          'highRpmSeconds': 0.0,
+          'idleSeconds': 0.0,
+          'harshBrakes': 0,
+          'harshAccelerations': 0,
+          'startedAt': start.toIso8601String(),
+        },
+        'samples': [
+          {
+            't': ts.millisecondsSinceEpoch,
+            's': 55.0,
+            'r': 1800.0,
+            'f': 4.2,
+            'th': 30.0,
+          },
+        ],
+      });
+      await box.put(start.toIso8601String(), legacyJson);
+
+      final repo = TripHistoryRepository(box: box);
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.samples, hasLength(1));
+      final s = loaded.first.samples.first;
+      expect(s.engineLoadPercent, isNull);
+      expect(s.coolantTempC, isNull);
+      // Existing fields still parse — backward compat means "we add to
+      // the schema, we don't break what the old schema persisted."
+      expect(s.throttlePercent, 30.0);
+      expect(s.fuelRateLPerHour, 4.2);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Phase 1 of #1262 — adds PID 0x05 (engine coolant temperature) reader and persists `engineLoadPercent` + `coolantTempC` end-to-end through the trip pipeline. Both fields nullable; legacy trips deserialize with nulls.

## What changed
- New PID 0x05 command + `parseCoolantTempCelsius` parser (formula `°C = A − 40`, mirrors IAT)
- 1 Hz subscriber in TripRecordingController (next to engineLoad / IAT)
- New nullable fields on TripLiveReading, TripSample, TripDetailSample
- JSON persistence keys `'el'` (engineLoadPercent) and `'ct'` (coolantTempC)
- Round-trip test in trip_history_repository_test
- Legacy-JSON deserialization test (missing keys → nulls)

## Out of scope (follow-up phases)
- Phase 2: `TripSummary.coldStartSurcharge` heuristic
- Phase 3: engine-load sparkline + cold-start chip on TripDetailScreen / trip card

## Test plan
- [x] `flutter analyze` clean
- [x] elm327_parsers tests pass (new coolant-temp cases)
- [x] trip_history_repository round-trip test passes (new + legacy)
- [x] trip_recording_controller snapshot test now also asserts coolantTempC
- [ ] CI green on analyze + test