### PR TITLE
feat(consumption): cold-start surcharge flag on TripSummary (Refs #1262 phase 2)

### DIFF
--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -120,6 +120,10 @@ Map<String, dynamic> _summaryToJson(TripSummary s) => {
       // serialised before this field landed deserialise as `'virtual'`
       // to match the recorder's historical behaviour.
       'distanceSource': s.distanceSource,
+      // #1262 phase 2: cold-start surcharge bit. Compact key 'cs'
+      // because every trip carries this and we'd rather not pay six
+      // bytes per record. Legacy trips without the key default false.
+      'cs': s.coldStartSurcharge,
     };
 
 TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
@@ -141,6 +145,10 @@ TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
       // label for legacy recordings, which integrated speed samples
       // regardless of whether an odometer was available.
       distanceSource: (j['distanceSource'] as String?) ?? 'virtual',
+      // #1262 phase 2: pre-existing trips were persisted before the
+      // cold-start surcharge heuristic landed; default false rather
+      // than retroactively flag them.
+      coldStartSurcharge: (j['cs'] as bool?) ?? false,
     );
 
 /// Hive-backed list of finalised trips (#726).

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -66,6 +66,17 @@ class TripSummary {
   /// trips before this flag landed keep that honest label.
   final String distanceSource;
 
+  /// Whether this trip likely paid a cold-start fuel surcharge
+  /// (#1262 phase 2). Flipped true when the coolant temperature
+  /// telemetry suggests the engine was warming up for a meaningful
+  /// portion of the trip — short trips that never reached operating
+  /// temperature, trips where the coolant max stayed below 70 °C, or
+  /// trips that only crossed 70 °C in the second half. Cars without
+  /// PID 0x05 produce no coolant samples, so the flag stays false to
+  /// avoid false positives on absent data. UI surfaces (Phase 3)
+  /// render a chip on the trip card based on this bit.
+  final bool coldStartSurcharge;
+
   const TripSummary({
     required this.distanceKm,
     required this.maxRpm,
@@ -78,6 +89,7 @@ class TripSummary {
     this.startedAt,
     this.endedAt,
     this.distanceSource = 'virtual',
+    this.coldStartSurcharge = false,
   });
 }
 
@@ -113,6 +125,21 @@ class TripRecorder {
   DateTime? _startedAt;
   DateTime? _endedAt;
 
+  // Cold-start surcharge accumulators (#1262 phase 2). Coolant temp
+  // is per-sample (PID 0x05); the recorder tracks the lifetime
+  // min / max plus the first warm-up timestamp so [buildSummary] can
+  // evaluate three cold-start patterns in one pass.
+  double? _minCoolantTempC;
+  double? _maxCoolantTempC;
+  int _coolantSampleCount = 0;
+  DateTime? _firstCoolantWarmAt;
+
+  /// Coolant temperature (°C) at which the engine is considered to
+  /// have reached operating range. 70 °C matches the canonical
+  /// thermostat-open threshold for typical petrol engines and is the
+  /// value the issue body cites for the cold-start heuristic.
+  static const double _coolantWarmThresholdC = 70.0;
+
   TripRecorder({
     this.highRpmThreshold = 3500,
     this.harshBrakeThresholdMps2 = 3.5,
@@ -125,6 +152,24 @@ class TripRecorder {
     _startedAt ??= sample.timestamp;
     _endedAt = sample.timestamp;
     _maxRpm = math.max(_maxRpm, sample.rpm);
+
+    // Track coolant samples for the cold-start surcharge heuristic
+    // (#1262 phase 2). Cars without PID 0x05 carry coolantTempC ==
+    // null on every sample; the heuristic falls back to "false" in
+    // that case so we never accuse a sensor-less car of a cold start.
+    final coolant = sample.coolantTempC;
+    if (coolant != null) {
+      _coolantSampleCount++;
+      final currentMin = _minCoolantTempC;
+      _minCoolantTempC =
+          currentMin == null ? coolant : math.min(currentMin, coolant);
+      final currentMax = _maxCoolantTempC;
+      _maxCoolantTempC =
+          currentMax == null ? coolant : math.max(currentMax, coolant);
+      if (_firstCoolantWarmAt == null && coolant >= _coolantWarmThresholdC) {
+        _firstCoolantWarmAt = sample.timestamp;
+      }
+    }
 
     final previous = _previous;
     if (previous == null) {
@@ -185,6 +230,43 @@ class TripRecorder {
     if (_hadFuelRate && _distanceKm > 0.001) {
       avgLPer100Km = _fuelLiters / _distanceKm * 100.0;
     }
+
+    // Cold-start surcharge heuristic (#1262 phase 2). Three rules
+    // flip the same bit; we OR them so any pattern triggers the
+    // chip. Skipped entirely when no coolant sample was ever read —
+    // a car without PID 0x05 must NOT be flagged as "cold-started"
+    // every trip; the false-positive rate would make the chip
+    // useless.
+    var coldStartSurcharge = false;
+    if (_coolantSampleCount > 0 && _startedAt != null && _endedAt != null) {
+      final durationSec =
+          _endedAt!.difference(_startedAt!).inMicroseconds / 1e6;
+      final minC = _minCoolantTempC ?? 0.0;
+      final maxC = _maxCoolantTempC ?? 0.0;
+      // Rule A: trip < 10 min AND coolant minimum below operating
+      // temp (the canonical "short cold trip"). Even if it warmed
+      // up by the end, a sub-10-minute trip that started cold paid
+      // the surcharge.
+      final shortColdTrip =
+          durationSec < 600 && minC < _coolantWarmThresholdC;
+      // Rule B: any duration, but engine never reached operating
+      // temp at all. Realistic on very cold ambient + low-load
+      // cruising — the engine burns enrichment fuel for the entire
+      // trip. The issue body's "(< 10 min) OR (didn't cross in 2nd
+      // half)" misses this case.
+      final neverWarmed = maxC < _coolantWarmThresholdC;
+      // Rule C: coolant didn't cross 70 °C until the second half of
+      // the trip. The first half ran rich — the surcharge applies.
+      var warmedLate = false;
+      final warmAt = _firstCoolantWarmAt;
+      if (warmAt != null) {
+        final warmOffsetSec =
+            warmAt.difference(_startedAt!).inMicroseconds / 1e6;
+        warmedLate = durationSec > 0 && warmOffsetSec > durationSec / 2;
+      }
+      coldStartSurcharge = shortColdTrip || neverWarmed || warmedLate;
+    }
+
     return TripSummary(
       distanceKm: _distanceKm,
       maxRpm: _maxRpm,
@@ -196,6 +278,7 @@ class TripRecorder {
       fuelLitersConsumed: _hadFuelRate ? _fuelLiters : null,
       startedAt: _startedAt,
       endedAt: _endedAt,
+      coldStartSurcharge: coldStartSurcharge,
     );
   }
 
@@ -213,5 +296,9 @@ class TripRecorder {
     _hadFuelRate = false;
     _startedAt = null;
     _endedAt = null;
+    _minCoolantTempC = null;
+    _maxCoolantTempC = null;
+    _coolantSampleCount = 0;
+    _firstCoolantWarmAt = null;
   }
 }

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -334,6 +334,94 @@ void main() {
     });
   });
 
+  group('TripSummary.coldStartSurcharge persistence (#1262 phase 2)', () {
+    test(
+        'summary with coldStartSurcharge true round-trips through save / '
+        'loadAll', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 4, 21, 12);
+      final cold = TripSummary(
+        distanceKm: 4,
+        maxRpm: 1800,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        startedAt: start,
+        endedAt: start.add(const Duration(minutes: 5)),
+        coldStartSurcharge: true,
+      );
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: cold,
+      ));
+
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.summary.coldStartSurcharge, isTrue);
+    });
+
+    test(
+        'summary with coldStartSurcharge false round-trips and the stored '
+        'JSON carries an explicit "cs": false (no parsimony rule for '
+        'this key — every trip persists it)', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 4, 21, 12);
+      final warm = TripSummary(
+        distanceKm: 30,
+        maxRpm: 2800,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        startedAt: start,
+        endedAt: start.add(const Duration(minutes: 30)),
+        // coldStartSurcharge defaults false
+      );
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: warm,
+      ));
+
+      final raw = box.get(start.toIso8601String())!;
+      final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
+      final summaryJson = (decoded['summary'] as Map).cast<String, dynamic>();
+      expect(summaryJson['cs'], isFalse);
+
+      final loaded = repo.loadAll();
+      expect(loaded.first.summary.coldStartSurcharge, isFalse);
+    });
+
+    test(
+        'legacy JSON (pre-#1262 phase 2) without the "cs" key '
+        'deserialises with coldStartSurcharge: false — older trips '
+        'were written before the heuristic landed', () async {
+      final start = DateTime(2026, 4, 21, 12);
+      final legacyJson = jsonEncode({
+        'id': start.toIso8601String(),
+        'vehicleId': null,
+        'summary': {
+          'distanceKm': 10.0,
+          'maxRpm': 2800.0,
+          'highRpmSeconds': 0.0,
+          'idleSeconds': 0.0,
+          'harshBrakes': 0,
+          'harshAccelerations': 0,
+          'startedAt': start.toIso8601String(),
+          // 'cs' deliberately absent
+        },
+      });
+      await box.put(start.toIso8601String(), legacyJson);
+
+      final repo = TripHistoryRepository(box: box);
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.summary.coldStartSurcharge, isFalse);
+    });
+  });
+
   group('TripSample engineLoad + coolantTemp persistence (#1262 phase 1)', () {
     test(
         'sample with engineLoadPercent and coolantTempC round-trips through '

--- a/test/features/consumption/domain/trip_recorder_test.dart
+++ b/test/features/consumption/domain/trip_recorder_test.dart
@@ -175,6 +175,147 @@ void main() {
       expect(sample.throttlePercent, isNull);
     });
 
+    group('cold-start surcharge heuristic (#1262 phase 2)', () {
+      test(
+          'short cold trip — 5 min @ 25 °C coolant flips coldStartSurcharge '
+          'true (rule A: < 10 min AND coolant min < 70 °C)', () {
+        final start = DateTime.utc(2026);
+        // Five samples across 5 minutes, coolant pegged at 25 °C —
+        // a typical winter short hop where the engine never warms up.
+        for (var i = 0; i <= 5; i++) {
+          recorder.onSample(TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 30,
+            rpm: 1500,
+            coolantTempC: 25,
+          ));
+        }
+        expect(recorder.buildSummary().coldStartSurcharge, isTrue);
+      });
+
+      test(
+          'warm trip — climbs to 90 °C in first 2 min of a 30-min trip '
+          'stays false (engine reached operating temp early)', () {
+        final start = DateTime.utc(2026);
+        // Minute 0: cold. Minute 2: warm. Stays warm for the rest.
+        recorder.onSample(TripSample(
+          timestamp: start,
+          speedKmh: 50,
+          rpm: 2000,
+          coolantTempC: 25,
+        ));
+        recorder.onSample(TripSample(
+          timestamp: start.add(const Duration(minutes: 2)),
+          speedKmh: 70,
+          rpm: 2200,
+          coolantTempC: 90,
+        ));
+        recorder.onSample(TripSample(
+          timestamp: start.add(const Duration(minutes: 30)),
+          speedKmh: 70,
+          rpm: 2200,
+          coolantTempC: 92,
+        ));
+        expect(recorder.buildSummary().coldStartSurcharge, isFalse);
+      });
+
+      test(
+          'never-warmed long trip — 20 min stuck at 60 °C flips true '
+          '(rule B: max coolant < 70 °C across the whole trip)', () {
+        final start = DateTime.utc(2026);
+        // 20-minute trip, coolant never crosses the 70 °C line — the
+        // engine ran rich the whole time. Rule A doesn't fire (the
+        // trip is > 10 min) but rule B catches this case.
+        for (var i = 0; i <= 20; i++) {
+          recorder.onSample(TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 25,
+            rpm: 1400,
+            coolantTempC: 60,
+          ));
+        }
+        expect(recorder.buildSummary().coldStartSurcharge, isTrue);
+      });
+
+      test(
+          'late-warm trip — coolant only crosses 70 °C at minute 15 of a '
+          '20-min trip flips true (rule C: warmed in second half)', () {
+        final start = DateTime.utc(2026);
+        // 0..14: cold. 15..20: warm. Crossover at minute 15 (75 % of
+        // the trip elapsed) → second half → rule C fires.
+        for (var i = 0; i < 15; i++) {
+          recorder.onSample(TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 40,
+            rpm: 1700,
+            coolantTempC: 50,
+          ));
+        }
+        for (var i = 15; i <= 20; i++) {
+          recorder.onSample(TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 40,
+            rpm: 1700,
+            coolantTempC: 80,
+          ));
+        }
+        expect(recorder.buildSummary().coldStartSurcharge, isTrue);
+      });
+
+      test(
+          'no coolant data — every sample carries coolantTempC: null '
+          'leaves coldStartSurcharge false (no false positives on cars '
+          'without PID 0x05)', () {
+        final start = DateTime.utc(2026);
+        // Short trip — would hit rule A if we had any coolant sample.
+        for (var i = 0; i <= 5; i++) {
+          recorder.onSample(TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 30,
+            rpm: 1500,
+            // coolantTempC omitted → null
+          ));
+        }
+        expect(recorder.buildSummary().coldStartSurcharge, isFalse);
+      });
+
+      test(
+          'reset clears cold-start state — a warm trip after a cold trip '
+          'must NOT inherit the cold flag', () {
+        final start = DateTime.utc(2026);
+        // First trip: short and cold → would flip true.
+        for (var i = 0; i <= 5; i++) {
+          recorder.onSample(TripSample(
+            timestamp: start.add(Duration(minutes: i)),
+            speedKmh: 30,
+            rpm: 1500,
+            coolantTempC: 25,
+          ));
+        }
+        expect(recorder.buildSummary().coldStartSurcharge, isTrue);
+
+        recorder.reset();
+
+        // Second trip: warm from the start, long enough to not be a
+        // short cold trip. Min coolant ≥ 70 means rule A (which keys
+        // off min, not start) won't fire either.
+        final t2 = DateTime.utc(2026, 1, 2);
+        recorder.onSample(TripSample(
+          timestamp: t2,
+          speedKmh: 70,
+          rpm: 2200,
+          coolantTempC: 85,
+        ));
+        recorder.onSample(TripSample(
+          timestamp: t2.add(const Duration(minutes: 30)),
+          speedKmh: 70,
+          rpm: 2200,
+          coolantTempC: 90,
+        ));
+        expect(recorder.buildSummary().coldStartSurcharge, isFalse);
+      });
+    });
+
     test('configurable thresholds override the defaults', () {
       final strict = TripRecorder(
         highRpmThreshold: 2500,


### PR DESCRIPTION
## Summary

Phase 2 of #1262 — adds `TripSummary.coldStartSurcharge` derived from coolant-temp samples now persisted by Phase 1 (#1265).

## Heuristic
The flag flips true on any of three patterns:
- **Short cold trip** — duration < 10 min AND min coolant < 70 °C
- **Never warmed** — max coolant < 70 °C across the whole trip
- **Late warmup** — first sample >= 70 °C didn't appear until the second half of the trip

Cars without PID 0x05 (older ECUs) produce zero coolant samples -> flag stays false (no false positives on absent data).

## What changed
- `TripRecorder` accumulates `_minCoolantTempC`, `_maxCoolantTempC`, `_firstCoolantWarmAt`, `_coolantSampleCount`
- `buildSummary()` evaluates the three rules and threads `coldStartSurcharge` into `TripSummary`
- JSON `'cs'` key in `_summaryToJson` / `_summaryFromJson`; legacy trips default `false`

## Out of scope (Phase 3)
- Cold-start chip on the trip card
- Engine-load sparkline on TripDetailScreen
- ARB strings for the chip

## Test plan
- [x] Cold trip (5 min @ 25 C) flips true (rule A)
- [x] Warm trip (30 min, climbs to 90 C in first 2 min) stays false
- [x] Never-warmed long trip (20 min @ 60 C) flips true (rule B)
- [x] Late-warm trip (warm at min 15/20) flips true (rule C)
- [x] No coolant data -> false
- [x] reset() clears state between trips
- [x] JSON round-trip + legacy-without-`'cs'` deserialization
- [ ] CI green on analyze + test