### PR TITLE
refactor(carbon): extract dashboard tabs into widget files (Refs #563)

### DIFF
--- a/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
+++ b/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
@@ -2,25 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/page_scaffold.dart';
-import '../../../../core/widgets/section_card.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../consumption/data/trip_history_repository.dart';
-import '../../../consumption/domain/services/speed_consumption_histogram.dart';
-import '../../../consumption/domain/services/trip_length_aggregator.dart';
 import '../../../consumption/providers/consumption_providers.dart';
-import '../../../consumption/providers/trip_history_provider.dart';
 import '../../../profile/providers/gamification_enabled_provider.dart';
-import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../domain/milestone.dart';
 import '../../domain/monthly_summary.dart';
-import '../widgets/fuel_vs_ev_card.dart';
-import '../widgets/milestones_card.dart';
-import '../widgets/monthly_bar_chart.dart';
-import '../widgets/speed_consumption_card.dart';
-import '../widgets/trip_length_breakdown_card.dart';
+import '../widgets/achievements_tab.dart';
+import '../widgets/charts_tab.dart';
 
 /// Carbon dashboard: tabbed view of monthly charts (#180) and
 /// gamified achievements (#181). Data is derived entirely from the
@@ -32,6 +22,10 @@ import '../widgets/trip_length_breakdown_card.dart';
 /// and Achievements views, but swapping to [TabSwitcher] is a separate
 /// presentation-layer PR to keep this diff focused on the
 /// scaffold/card migration.
+///
+/// #563 — the two tab bodies live in their own widget files
+/// (`widgets/charts_tab.dart`, `widgets/achievements_tab.dart`) so this
+/// screen stays under the 300-LOC target.
 class CarbonDashboardScreen extends ConsumerWidget {
   const CarbonDashboardScreen({super.key});
 
@@ -54,7 +48,7 @@ class CarbonDashboardScreen extends ConsumerWidget {
     final totalCo2 = MonthlyAggregator.totalCo2(summaries);
     final totalCost = MonthlyAggregator.totalCost(summaries);
 
-    final chartsTab = _ChartsTab(
+    final chartsTab = ChartsTab(
       summaries: last12,
       totalCost: totalCost,
       totalCo2: totalCo2,
@@ -88,7 +82,7 @@ class CarbonDashboardScreen extends ConsumerWidget {
             child: TabBarView(
               children: [
                 chartsTab,
-                _AchievementsTab(
+                AchievementsTab(
                   milestones: milestones,
                   fuelCo2Kg: totalCo2,
                   distanceKm: distanceKm,
@@ -120,229 +114,5 @@ class CarbonDashboardScreen extends ConsumerWidget {
       return scaffold;
     }
     return DefaultTabController(length: 2, child: scaffold);
-  }
-}
-
-class _ChartsTab extends ConsumerWidget {
-  final List<MonthlySummary> summaries;
-  final double totalCost;
-  final double totalCo2;
-
-  const _ChartsTab({
-    required this.summaries,
-    required this.totalCost,
-    required this.totalCo2,
-  });
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-
-    // #1191 — fold trip-history into the three length buckets, filtered
-    // to the active vehicle (legacy null-vehicleId trips are included
-    // per the trajets-tab convention). Computing the overall avg from
-    // the SAME filtered list keeps the per-tile arrows consistent with
-    // the headline figure on the dashboard.
-    final trips = ref.watch(tripHistoryListProvider);
-    final activeVehicle = ref.watch(activeVehicleProfileProvider);
-    final breakdown = aggregateByTripLength(
-      trips,
-      vehicleId: activeVehicle?.id,
-    );
-    final overallAvg = _overallAvgLPer100Km(trips, activeVehicle?.id);
-
-    // #1192 — speed-vs-consumption histogram, fed by per-second OBD2
-    // samples on each TripHistoryEntry. Same vehicle-id filter as the
-    // trip-length card so the two histograms describe the same data
-    // slice — and so the reference line on the speed card matches the
-    // overall avg already computed above.
-    final filteredTrips = _filterTrips(trips, activeVehicle?.id);
-    final speedBins = aggregateSpeedConsumption(
-      filteredTrips.expand((entry) => entry.samples),
-    );
-
-    return ListView(
-      padding: EdgeInsets.only(
-        top: 16,
-        bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
-      ),
-      children: [
-        _SummaryRow(totalCost: totalCost, totalCo2: totalCo2),
-        const SizedBox(height: 8),
-        if (l != null && !breakdown.isEmpty)
-          TripLengthBreakdownCard(
-            breakdown: breakdown,
-            overallAvgLPer100Km: overallAvg,
-            l: l,
-            theme: theme,
-          ),
-        if (l != null)
-          SpeedConsumptionCard(
-            bins: speedBins,
-            overallAvgLPer100Km: overallAvg,
-            l: l,
-            theme: theme,
-          ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: SectionCard(
-            title: l?.monthlyCostsTitle ?? 'Monthly costs',
-            child: MonthlyBarChart(
-              key: const Key('monthly_cost_chart'),
-              summaries: summaries,
-              valueOf: (s) => s.totalCost,
-              color: theme.colorScheme.primary,
-              unitLabel: PriceFormatter.currency,
-            ),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: SectionCard(
-            title: l?.monthlyEmissionsTitle ?? 'Monthly CO2 emissions',
-            child: MonthlyBarChart(
-              key: const Key('monthly_emissions_chart'),
-              summaries: summaries,
-              valueOf: (s) => s.totalCo2Kg,
-              color: theme.colorScheme.tertiary,
-              unitLabel: 'kg',
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-/// Compute the overall average L/100 km across the same filtered trip
-/// list the [TripLengthBreakdown] was built from. Returns null when no
-/// trip in the filtered set has both a non-null `fuelLitersConsumed`
-/// and a positive distance — the per-tile arrows are suppressed in
-/// that case. Mirrors the same vehicle-id filter as
-/// [aggregateByTripLength] so the figure stays consistent with the
-/// breakdown the user sees right next to it.
-double? _overallAvgLPer100Km(
-  Iterable<TripHistoryEntry> trips,
-  String? vehicleId,
-) {
-  double totalDistanceKm = 0;
-  double totalLitres = 0;
-  for (final entry in trips) {
-    if (vehicleId != null &&
-        entry.vehicleId != null &&
-        entry.vehicleId != vehicleId) {
-      continue;
-    }
-    final litres = entry.summary.fuelLitersConsumed;
-    if (litres == null) continue;
-    totalDistanceKm += entry.summary.distanceKm;
-    totalLitres += litres;
-  }
-  if (totalDistanceKm <= 0) return null;
-  return (totalLitres / totalDistanceKm) * 100.0;
-}
-
-/// Filter [trips] to those that match [vehicleId] (or carry a legacy
-/// null vehicleId — same convention used by the trajets tab and
-/// [aggregateByTripLength]). Returns the filtered list eagerly so the
-/// caller can `.expand` over it twice without re-running the predicate
-/// per pass — a small but noticeable saving on long trip lists where
-/// each entry carries hundreds of samples.
-List<TripHistoryEntry> _filterTrips(
-  Iterable<TripHistoryEntry> trips,
-  String? vehicleId,
-) {
-  if (vehicleId == null) return trips.toList(growable: false);
-  return trips
-      .where((entry) =>
-          entry.vehicleId == null || entry.vehicleId == vehicleId)
-      .toList(growable: false);
-}
-
-class _AchievementsTab extends StatelessWidget {
-  final List<MilestoneProgress> milestones;
-  final double fuelCo2Kg;
-  final double distanceKm;
-  final ThemeData theme;
-
-  const _AchievementsTab({
-    required this.milestones,
-    required this.fuelCo2Kg,
-    required this.distanceKm,
-    required this.theme,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return ListView(
-      padding: EdgeInsets.only(
-        top: 8,
-        bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
-      ),
-      children: [
-        MilestonesCard(progress: milestones),
-        FuelVsEvCard(fuelCo2Kg: fuelCo2Kg, distanceKm: distanceKm),
-      ],
-    );
-  }
-}
-
-class _SummaryRow extends StatelessWidget {
-  final double totalCost;
-  final double totalCo2;
-
-  const _SummaryRow({required this.totalCost, required this.totalCo2});
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    return Row(
-      children: [
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.only(left: 16, right: 8),
-            child: SectionCard(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    l?.carbonSummaryTotalCost ?? 'Total cost',
-                    style: theme.textTheme.bodySmall,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    '${totalCost.toStringAsFixed(0)} ${PriceFormatter.currency}',
-                    style: theme.textTheme.titleLarge,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.only(left: 8, right: 16),
-            child: SectionCard(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    l?.carbonSummaryTotalCo2 ?? 'Total CO2',
-                    style: theme.textTheme.bodySmall,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    '${totalCo2.toStringAsFixed(0)} kg',
-                    style: theme.textTheme.titleLarge,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
   }
 }

--- a/lib/features/carbon/presentation/widgets/achievements_tab.dart
+++ b/lib/features/carbon/presentation/widgets/achievements_tab.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/milestone.dart';
+import 'fuel_vs_ev_card.dart';
+import 'milestones_card.dart';
+
+/// Achievements tab of the carbon dashboard. Renders the milestones
+/// progress card and the fuel-vs-EV comparison card.
+///
+/// Extracted from `carbon_dashboard_screen.dart` to keep the screen
+/// file under the 300-LOC target (Refs #563).
+class AchievementsTab extends StatelessWidget {
+  final List<MilestoneProgress> milestones;
+  final double fuelCo2Kg;
+  final double distanceKm;
+  final ThemeData theme;
+
+  const AchievementsTab({
+    super.key,
+    required this.milestones,
+    required this.fuelCo2Kg,
+    required this.distanceKm,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: EdgeInsets.only(
+        top: 8,
+        bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      children: [
+        MilestonesCard(progress: milestones),
+        FuelVsEvCard(fuelCo2Kg: fuelCo2Kg, distanceKm: distanceKm),
+      ],
+    );
+  }
+}

--- a/lib/features/carbon/presentation/widgets/charts_tab.dart
+++ b/lib/features/carbon/presentation/widgets/charts_tab.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/widgets/section_card.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/data/trip_history_repository.dart';
+import '../../../consumption/domain/services/speed_consumption_histogram.dart';
+import '../../../consumption/domain/services/trip_length_aggregator.dart';
+import '../../../consumption/providers/trip_history_provider.dart';
+import '../../../vehicle/providers/vehicle_providers.dart';
+import '../../domain/monthly_summary.dart';
+import 'monthly_bar_chart.dart';
+import 'speed_consumption_card.dart';
+import 'trip_length_breakdown_card.dart';
+
+/// Charts tab of the carbon dashboard. Renders the summary row,
+/// trip-length breakdown, speed-consumption histogram, and the two
+/// monthly bar charts (cost + CO2 emissions).
+///
+/// Extracted from `carbon_dashboard_screen.dart` to keep the screen
+/// file under the 300-LOC target (Refs #563).
+class ChartsTab extends ConsumerWidget {
+  final List<MonthlySummary> summaries;
+  final double totalCost;
+  final double totalCo2;
+
+  const ChartsTab({
+    super.key,
+    required this.summaries,
+    required this.totalCost,
+    required this.totalCo2,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    // #1191 — fold trip-history into the three length buckets, filtered
+    // to the active vehicle (legacy null-vehicleId trips are included
+    // per the trajets-tab convention). Computing the overall avg from
+    // the SAME filtered list keeps the per-tile arrows consistent with
+    // the headline figure on the dashboard.
+    final trips = ref.watch(tripHistoryListProvider);
+    final activeVehicle = ref.watch(activeVehicleProfileProvider);
+    final breakdown = aggregateByTripLength(
+      trips,
+      vehicleId: activeVehicle?.id,
+    );
+    final overallAvg = _overallAvgLPer100Km(trips, activeVehicle?.id);
+
+    // #1192 — speed-vs-consumption histogram, fed by per-second OBD2
+    // samples on each TripHistoryEntry. Same vehicle-id filter as the
+    // trip-length card so the two histograms describe the same data
+    // slice — and so the reference line on the speed card matches the
+    // overall avg already computed above.
+    final filteredTrips = _filterTrips(trips, activeVehicle?.id);
+    final speedBins = aggregateSpeedConsumption(
+      filteredTrips.expand((entry) => entry.samples),
+    );
+
+    return ListView(
+      padding: EdgeInsets.only(
+        top: 16,
+        bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      children: [
+        _SummaryRow(totalCost: totalCost, totalCo2: totalCo2),
+        const SizedBox(height: 8),
+        if (l != null && !breakdown.isEmpty)
+          TripLengthBreakdownCard(
+            breakdown: breakdown,
+            overallAvgLPer100Km: overallAvg,
+            l: l,
+            theme: theme,
+          ),
+        if (l != null)
+          SpeedConsumptionCard(
+            bins: speedBins,
+            overallAvgLPer100Km: overallAvg,
+            l: l,
+            theme: theme,
+          ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: SectionCard(
+            title: l?.monthlyCostsTitle ?? 'Monthly costs',
+            child: MonthlyBarChart(
+              key: const Key('monthly_cost_chart'),
+              summaries: summaries,
+              valueOf: (s) => s.totalCost,
+              color: theme.colorScheme.primary,
+              unitLabel: PriceFormatter.currency,
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: SectionCard(
+            title: l?.monthlyEmissionsTitle ?? 'Monthly CO2 emissions',
+            child: MonthlyBarChart(
+              key: const Key('monthly_emissions_chart'),
+              summaries: summaries,
+              valueOf: (s) => s.totalCo2Kg,
+              color: theme.colorScheme.tertiary,
+              unitLabel: 'kg',
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Compute the overall average L/100 km across the same filtered trip
+/// list the [TripLengthBreakdown] was built from. Returns null when no
+/// trip in the filtered set has both a non-null `fuelLitersConsumed`
+/// and a positive distance — the per-tile arrows are suppressed in
+/// that case. Mirrors the same vehicle-id filter as
+/// [aggregateByTripLength] so the figure stays consistent with the
+/// breakdown the user sees right next to it.
+double? _overallAvgLPer100Km(
+  Iterable<TripHistoryEntry> trips,
+  String? vehicleId,
+) {
+  double totalDistanceKm = 0;
+  double totalLitres = 0;
+  for (final entry in trips) {
+    if (vehicleId != null &&
+        entry.vehicleId != null &&
+        entry.vehicleId != vehicleId) {
+      continue;
+    }
+    final litres = entry.summary.fuelLitersConsumed;
+    if (litres == null) continue;
+    totalDistanceKm += entry.summary.distanceKm;
+    totalLitres += litres;
+  }
+  if (totalDistanceKm <= 0) return null;
+  return (totalLitres / totalDistanceKm) * 100.0;
+}
+
+/// Filter [trips] to those that match [vehicleId] (or carry a legacy
+/// null vehicleId — same convention used by the trajets tab and
+/// [aggregateByTripLength]). Returns the filtered list eagerly so the
+/// caller can `.expand` over it twice without re-running the predicate
+/// per pass — a small but noticeable saving on long trip lists where
+/// each entry carries hundreds of samples.
+List<TripHistoryEntry> _filterTrips(
+  Iterable<TripHistoryEntry> trips,
+  String? vehicleId,
+) {
+  if (vehicleId == null) return trips.toList(growable: false);
+  return trips
+      .where((entry) =>
+          entry.vehicleId == null || entry.vehicleId == vehicleId)
+      .toList(growable: false);
+}
+
+class _SummaryRow extends StatelessWidget {
+  final double totalCost;
+  final double totalCo2;
+
+  const _SummaryRow({required this.totalCost, required this.totalCo2});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(left: 16, right: 8),
+            child: SectionCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l?.carbonSummaryTotalCost ?? 'Total cost',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${totalCost.toStringAsFixed(0)} ${PriceFormatter.currency}',
+                    style: theme.textTheme.titleLarge,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(left: 8, right: 16),
+            child: SectionCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l?.carbonSummaryTotalCo2 ?? 'Total CO2',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${totalCo2.toStringAsFixed(0)} kg',
+                    style: theme.textTheme.titleLarge,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/carbon/presentation/widgets/achievements_tab_test.dart
+++ b/test/features/carbon/presentation/widgets/achievements_tab_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/carbon/domain/milestone.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/achievements_tab.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/fuel_vs_ev_card.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/milestones_card.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+MilestoneProgress _p(
+  String id,
+  MilestoneCategory cat, {
+  double current = 0,
+  double target = 100,
+  bool unlocked = false,
+}) =>
+    MilestoneProgress(
+      milestone: Milestone(
+        id: id,
+        category: cat,
+        target: target,
+        unit: 'L',
+      ),
+      current: current,
+      unlocked: unlocked,
+    );
+
+void main() {
+  group('AchievementsTab', () {
+    testWidgets('renders MilestonesCard + FuelVsEvCard', (tester) async {
+      // Tall viewport so both cards land on-screen.
+      tester.view.physicalSize = const Size(800, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) => AchievementsTab(
+            milestones: [
+              _p('m1', MilestoneCategory.firstFillUp, unlocked: true),
+              _p('m2', MilestoneCategory.litersTracked, current: 40),
+            ],
+            fuelCo2Kg: 120,
+            distanceKm: 1500,
+            theme: Theme.of(context),
+          ),
+        ),
+      );
+
+      expect(
+        find.byType(MilestonesCard, skipOffstage: false),
+        findsOneWidget,
+      );
+      expect(
+        find.byType(FuelVsEvCard, skipOffstage: false),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders without throwing on empty milestones',
+        (tester) async {
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) => AchievementsTab(
+            milestones: const [],
+            fuelCo2Kg: 0,
+            distanceKm: 0,
+            theme: Theme.of(context),
+          ),
+        ),
+      );
+
+      expect(find.byType(MilestonesCard), findsOneWidget);
+      expect(find.byType(FuelVsEvCard), findsOneWidget);
+    });
+  });
+}

--- a/test/features/carbon/presentation/widgets/charts_tab_test.dart
+++ b/test/features/carbon/presentation/widgets/charts_tab_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/carbon/domain/monthly_summary.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/charts_tab.dart';
+import 'package:tankstellen/features/carbon/presentation/widgets/monthly_bar_chart.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+class _FixedTripHistoryList extends TripHistoryList {
+  _FixedTripHistoryList(this._value);
+  final List<TripHistoryEntry> _value;
+
+  @override
+  List<TripHistoryEntry> build() => _value;
+}
+
+class _FixedActiveVehicle extends ActiveVehicleProfile {
+  _FixedActiveVehicle(this._value);
+  final VehicleProfile? _value;
+
+  @override
+  VehicleProfile? build() => _value;
+}
+
+MonthlySummary _s(DateTime month, {double cost = 80, double co2 = 100}) =>
+    MonthlySummary(
+      month: month,
+      totalCost: cost,
+      totalLiters: 50,
+      totalCo2Kg: co2,
+      fillUpCount: 1,
+    );
+
+void main() {
+  group('ChartsTab', () {
+    testWidgets('renders summary row + two monthly bar charts',
+        (tester) async {
+      // Tall viewport so both charts sit on-screen and the ListView
+      // mounts both subtrees on the first frame.
+      tester.view.physicalSize = const Size(800, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final summaries = [
+        _s(DateTime(2026, 1), cost: 60, co2: 80),
+        _s(DateTime(2026, 2), cost: 80, co2: 110),
+        _s(DateTime(2026, 3), cost: 70, co2: 95),
+      ];
+
+      await pumpApp(
+        tester,
+        ChartsTab(
+          summaries: summaries,
+          totalCost: 210,
+          totalCo2: 285,
+        ),
+        overrides: [
+          tripHistoryListProvider
+              .overrideWith(() => _FixedTripHistoryList(const [])),
+          activeVehicleProfileProvider
+              .overrideWith(() => _FixedActiveVehicle(null)),
+        ],
+      );
+
+      // Both bar charts are mounted. skipOffstage: false because
+      // ListView may sliver the second chart out of the initial pass.
+      expect(
+        find.byType(MonthlyBarChart, skipOffstage: false),
+        findsNWidgets(2),
+      );
+      // Summary row labels render.
+      expect(find.text('Total cost'), findsOneWidget);
+      expect(find.text('Total CO2'), findsOneWidget);
+      // Section titles render below the summary.
+      expect(
+        find.text('Monthly costs', skipOffstage: false),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Monthly CO2 emissions', skipOffstage: false),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('builds without throwing when summaries are empty',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const ChartsTab(
+          summaries: [],
+          totalCost: 0,
+          totalCo2: 0,
+        ),
+        overrides: [
+          tripHistoryListProvider
+              .overrideWith(() => _FixedTripHistoryList(const [])),
+          activeVehicleProfileProvider
+              .overrideWith(() => _FixedActiveVehicle(null)),
+        ],
+      );
+
+      // Two charts are still rendered (they handle the empty data
+      // path themselves) and the summary row is present.
+      expect(
+        find.byType(MonthlyBarChart, skipOffstage: false),
+        findsNWidgets(2),
+      );
+      expect(find.text('Total cost'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Extracts `_ChartsTab` and `_AchievementsTab` private classes from `carbon_dashboard_screen.dart` (348 LOC → 118 LOC) into `widgets/charts_tab.dart` and `widgets/achievements_tab.dart`. Pure refactor — no behavior change.

## Summary

- `_ChartsTab` → `ChartsTab extends ConsumerWidget` in `lib/features/carbon/presentation/widgets/charts_tab.dart`. Tab-scoped helpers `_overallAvgLPer100Km` and `_filterTrips` move alongside; `_SummaryRow` private widget moves with them.
- `_AchievementsTab` → `AchievementsTab extends StatelessWidget` in `lib/features/carbon/presentation/widgets/achievements_tab.dart`.
- Screen file imports the two new public classes and instantiates them as `ChartsTab(...)` / `AchievementsTab(...)`. Imports trimmed to drop the now-unused symbols (`PriceFormatter`, `SectionCard`, trip-history / vehicle providers, etc.).
- Smoke tests added for both new widgets at `test/features/carbon/presentation/widgets/{charts_tab,achievements_tab}_test.dart` — render-without-throw + summary row + chart count.

## Test plan
- [x] `flutter analyze` — `No issues found!`
- [x] `flutter test test/features/carbon/` — 74/74 pass (incl. 4 new smoke tests + 5 unchanged dashboard tests)
- [x] `flutter test test/lint/` — 29/29 pass
- [x] `wc -l lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart` → 118 (< 300)

Refs #563 — one phase of the multi-phase oversized-files epic; the issue stays open.