### PR TITLE
feat(consumption): pure-logic gear inference module (Refs #1263 phase 1)

### DIFF
--- a/lib/features/consumption/domain/services/gear_inference.dart
+++ b/lib/features/consumption/domain/services/gear_inference.dart
@@ -1,0 +1,391 @@
+/// Pure-logic gear inference for the "labouring in low gear" coaching
+/// signal (#1263 phase 1).
+///
+/// ## Why
+///
+/// A common fuel-economy mistake — driving 60 km/h in 3rd instead of
+/// 5th — is invisible to the driving-insights view today. RPM is
+/// logged, speed is logged, but the *ratio* (which is gear-correlated)
+/// isn't surfaced. This module derives a per-sample gear label from
+/// `engineRpm / wheelRpm` clusters; phase 2 will integrate the labels
+/// into [TripSummary] and surface a coaching line.
+///
+/// ## The math
+///
+/// Given a tyre circumference C (m), a sample's wheel angular velocity
+/// in RPM is:
+///
+/// ```
+///   wheelRpm = (speedKmh / 3.6) / C * 60
+/// ```
+///
+/// The drivetrain ratio (engine RPM / wheel RPM) is:
+///
+/// ```
+///   ratio = rpm / wheelRpm
+///         = rpm / (speedKmh / 3.6 / C * 60)
+/// ```
+///
+/// This is **gear ratio × final-drive ratio**, not the textbook gear
+/// ratio in isolation — but the final-drive constant is the same
+/// across every sample on a given vehicle, so the cluster centroids
+/// still separate cleanly into one per gear.
+///
+/// Higher ratio → more engine revs per wheel rev → lower physical
+/// gear (1st has the highest ratio). When we sort centroids
+/// ascending, **centroid index 0 maps to the top gear** (e.g. 5th in
+/// a 5-speed) and **centroid index `targetGearCount - 1` maps to 1st
+/// gear**. The gear LABEL returned per sample uses the conventional
+/// human-readable numbering: `gear = 1` is 1st (lowest physical
+/// gear), `gear = 5` is 5th (top). So:
+///
+/// ```
+///   gearLabel = targetGearCount - centroidIndex
+/// ```
+///
+/// ## Heuristic thresholds
+///
+/// - **Idle skip** (`speedKmh < 5` OR `rpm < 500`): below 5 km/h the
+///   speed sensor is too noisy to derive a meaningful ratio, and at
+///   <500 RPM the engine is either off or stalling. Both paths
+///   produce huge division-by-near-zero ratios that would dominate
+///   any clustering.
+/// - **Outlier trim** (ratio > 99th × 2 or < 1st / 2 of in-trip
+///   percentiles): clutch transitions and shift events transiently
+///   produce ratios outside the gear band — including them would
+///   smear the centroids. We compute percentiles on the SURVIVING
+///   (post-idle-skip) ratios and trim from there.
+///
+/// ## Algorithm
+///
+/// 1-D k-means with up to 10 iterations, ε = 0.5 % centroid-shift
+/// convergence:
+///
+/// 1. Filter samples by the idle-skip rules → list of valid ratios.
+/// 2. Compute the 1st and 99th percentiles, drop outliers.
+/// 3. Seed centroids: if `priorCentroids` is supplied, use it; else
+///    take the 10th / 30th / 50th / 70th / 90th percentile (for
+///    `targetGearCount = 5`, generalised to `((2i + 1) / (2k))` for
+///    arbitrary k).
+/// 4. Iterate: assign each ratio to its nearest centroid (Euclidean
+///    distance in 1-D = |a - b|), recompute centroid as the mean of
+///    its assigned ratios. Stop when max relative shift < 0.5 % or
+///    after 10 iterations.
+/// 5. Sort centroids ascending. Re-assign every sample (including
+///    the originally-skipped ones, which receive `gear = null`).
+///
+/// ## Degenerate cases
+///
+/// Fewer than `targetGearCount` valid ratios: the algorithm still
+/// runs but the resulting centroids are unreliable. Callers should
+/// only persist centroids from trips with ≥ ~50 valid samples
+/// covering at least 3 distinct ratio bands.
+///
+/// Idle-only fixtures (every sample fails the idle-skip rule): the
+/// function returns an empty centroids list and `gear = null` for
+/// every input sample. No exceptions thrown.
+library;
+
+import 'package:flutter/foundation.dart';
+
+import '../trip_recorder.dart';
+
+/// One sample's inferred gear label, paired with its source timestamp
+/// so the caller can re-align inferred gears with other per-sample
+/// metrics (engine load, throttle, etc.) without re-iterating the
+/// original `Iterable<TripSample>`.
+@immutable
+class InferredGearSample {
+  /// Source sample timestamp.
+  final DateTime timestamp;
+
+  /// Inferred gear label (1 = 1st gear, `targetGearCount` = top
+  /// gear). `null` when the sample was skipped — idle, sub-threshold,
+  /// or an outlier ratio. The caller must treat `null` as "no
+  /// signal" rather than "neutral".
+  final int? gear;
+
+  const InferredGearSample({required this.timestamp, required this.gear});
+}
+
+/// Output of [inferGears] — per-sample gear assignments plus the
+/// cluster centroids that produced them. The centroids are the
+/// caching unit: persist them on the per-vehicle profile so the next
+/// trip seeds with this trip's data and drifts gracefully across the
+/// fleet of trips for that vehicle.
+@immutable
+class GearInferenceResult {
+  /// Per-sample inferred gears, in the same order as the input
+  /// samples. `gear == null` for samples that were skipped (idle,
+  /// outlier, or — when no centroids could be computed — every
+  /// sample).
+  final List<InferredGearSample> samples;
+
+  /// Cluster centroids in ratio space, sorted ascending. Centroid at
+  /// index 0 corresponds to the top gear (e.g. 5th in a 5-speed);
+  /// centroid at index `length - 1` corresponds to 1st gear. Empty
+  /// when no valid samples were found (idle-only / no-data trips).
+  final List<double> centroids;
+
+  const GearInferenceResult({required this.samples, required this.centroids});
+}
+
+/// Internal: minimum speed (km/h) below which a sample is treated as
+/// idle / sub-threshold and skipped from clustering. The wheel-speed
+/// sensor on most cars is unreliable below ~5 km/h, and the resulting
+/// ratio inflates without bound.
+const double _minSpeedKmh = 5.0;
+
+/// Internal: minimum RPM below which a sample is treated as idle /
+/// engine-off and skipped. 500 RPM is well below any production
+/// engine's idle (which sits at 700–900) yet above the noise floor.
+const double _minRpm = 500.0;
+
+/// Internal: maximum k-means iterations. 1-D k-means converges fast;
+/// 10 is generous for trips with ~600 samples.
+const int _maxIterations = 10;
+
+/// Internal: relative centroid-shift threshold for early stopping.
+/// 0.5 % is well below the inter-gear separation on every
+/// transmission we've measured.
+const double _convergenceEpsilon = 0.005;
+
+/// Infer per-sample gears from a sequence of [TripSample]s using the
+/// engine-RPM / wheel-RPM ratio (gear-correlated drivetrain ratio).
+///
+/// See the library docstring for the formula, the heuristic
+/// thresholds (idle skip, outlier trim) and the convention that
+/// maps a centroid index to a human-readable gear label.
+///
+/// [tireCircumferenceMeters] is per-vehicle (≈ 1.95 m for a typical
+/// 195/65R15). [priorCentroids] (optional) seeds the clustering with
+/// centroids learned on a previous trip — the algorithm will allow
+/// drift toward this trip's data, so the cache improves
+/// trip-over-trip without overwriting a stable baseline. When null,
+/// the algorithm cold-starts from this trip's percentiles.
+/// [targetGearCount] is the number of distinct gear clusters to
+/// seek; defaults to 5 for a typical 5-speed manual.
+///
+/// Throws nothing for any well-formed input — degenerate fixtures
+/// (idle-only, < `targetGearCount` valid samples) return as best
+/// they can with empty / partial centroid lists.
+GearInferenceResult inferGears({
+  required Iterable<TripSample> samples,
+  required double tireCircumferenceMeters,
+  List<double>? priorCentroids,
+  int targetGearCount = 5,
+}) {
+  // Materialise the iterable once; we walk it twice (extract ratios,
+  // then re-label every sample including the skipped ones).
+  final sampleList = samples.toList(growable: false);
+
+  // Defensive: a non-positive tyre circumference would invert the
+  // formula. Treat as "no inference possible" — return all-null
+  // gears, no centroids, no exception. The caller (phase 2 trip
+  // recorder) is expected to validate the per-vehicle profile
+  // before calling, but we don't trust upstream.
+  if (tireCircumferenceMeters <= 0 || targetGearCount < 1) {
+    return GearInferenceResult(
+      samples: sampleList
+          .map((s) => InferredGearSample(timestamp: s.timestamp, gear: null))
+          .toList(growable: false),
+      centroids: const <double>[],
+    );
+  }
+
+  // First pass: derive (sampleIndex, ratio) pairs that pass the
+  // idle-skip rule. We keep the index so we can re-label without a
+  // second filter pass later.
+  final validIndices = <int>[];
+  final validRatios = <double>[];
+  for (var i = 0; i < sampleList.length; i++) {
+    final s = sampleList[i];
+    if (s.speedKmh < _minSpeedKmh || s.rpm < _minRpm) {
+      continue;
+    }
+    final wheelRpm = (s.speedKmh / 3.6) / tireCircumferenceMeters * 60.0;
+    if (wheelRpm <= 0) {
+      // Speed passed the threshold but the formula still degenerated;
+      // treat as a skip rather than throw.
+      continue;
+    }
+    final ratio = s.rpm / wheelRpm;
+    if (!ratio.isFinite || ratio <= 0) {
+      continue;
+    }
+    validIndices.add(i);
+    validRatios.add(ratio);
+  }
+
+  // No valid samples → return all-null gears and empty centroids.
+  // Idle-only fixtures (test 4) land here.
+  if (validRatios.isEmpty) {
+    return GearInferenceResult(
+      samples: sampleList
+          .map((s) => InferredGearSample(timestamp: s.timestamp, gear: null))
+          .toList(growable: false),
+      centroids: const <double>[],
+    );
+  }
+
+  // Outlier trim: drop ratios above 99th × 2 or below 1st / 2. We
+  // build the percentile bracket on the surviving ratios so a small
+  // fixture (test 5) doesn't immediately throw away most of its data.
+  final sortedRatios = List<double>.from(validRatios)..sort();
+  final p1 = _percentile(sortedRatios, 0.01);
+  final p99 = _percentile(sortedRatios, 0.99);
+  final lowerBound = p1 / 2.0;
+  final upperBound = p99 * 2.0;
+
+  final keptIndices = <int>[];
+  final keptRatios = <double>[];
+  for (var j = 0; j < validRatios.length; j++) {
+    final r = validRatios[j];
+    if (r < lowerBound || r > upperBound) continue;
+    keptIndices.add(validIndices[j]);
+    keptRatios.add(r);
+  }
+
+  if (keptRatios.isEmpty) {
+    return GearInferenceResult(
+      samples: sampleList
+          .map((s) => InferredGearSample(timestamp: s.timestamp, gear: null))
+          .toList(growable: false),
+      centroids: const <double>[],
+    );
+  }
+
+  // Seed centroids. With priorCentroids → reuse + drift; without →
+  // sample uniform quantiles of the kept ratios so the seeds span
+  // the data evenly.
+  final keptSorted = List<double>.from(keptRatios)..sort();
+  final centroids = <double>[];
+  if (priorCentroids != null && priorCentroids.isNotEmpty) {
+    centroids.addAll(priorCentroids);
+    centroids.sort();
+  } else {
+    for (var k = 0; k < targetGearCount; k++) {
+      // (2k + 1) / (2 * targetGearCount): for targetGearCount = 5
+      // this hits 0.1, 0.3, 0.5, 0.7, 0.9 — i.e. the 10th / 30th /
+      // 50th / 70th / 90th percentiles, as documented.
+      final q = (2.0 * k + 1.0) / (2.0 * targetGearCount);
+      centroids.add(_percentile(keptSorted, q));
+    }
+  }
+
+  // Centroid de-duplication: a degenerate fixture (test 5 — only 5
+  // samples total) will produce repeated quantile picks. K-means
+  // tolerates this — clusters with no assigned points keep their
+  // seed value — but we still return a sorted list so the contract
+  // holds.
+  centroids.sort();
+
+  // K-means iterations.
+  final assignments = List<int>.filled(keptRatios.length, 0);
+  for (var iter = 0; iter < _maxIterations; iter++) {
+    // Assignment step.
+    for (var j = 0; j < keptRatios.length; j++) {
+      assignments[j] = _nearestCentroid(centroids, keptRatios[j]);
+    }
+    // Update step.
+    final newCentroids = List<double>.from(centroids);
+    final sums = List<double>.filled(centroids.length, 0.0);
+    final counts = List<int>.filled(centroids.length, 0);
+    for (var j = 0; j < keptRatios.length; j++) {
+      final c = assignments[j];
+      sums[c] += keptRatios[j];
+      counts[c]++;
+    }
+    for (var c = 0; c < centroids.length; c++) {
+      if (counts[c] > 0) {
+        newCentroids[c] = sums[c] / counts[c];
+      }
+      // counts[c] == 0 → keep the prior seed; the cluster is empty
+      // this iteration.
+    }
+    // Convergence check: max relative shift across the centroids.
+    var maxRelShift = 0.0;
+    for (var c = 0; c < centroids.length; c++) {
+      final base = centroids[c].abs();
+      if (base <= 0) continue;
+      final shift = (newCentroids[c] - centroids[c]).abs() / base;
+      if (shift > maxRelShift) maxRelShift = shift;
+    }
+    for (var c = 0; c < centroids.length; c++) {
+      centroids[c] = newCentroids[c];
+    }
+    if (maxRelShift < _convergenceEpsilon) {
+      break;
+    }
+  }
+
+  // Final assignment after the last update; the loop's last
+  // iteration updated centroids but didn't reassign — re-do it so
+  // the per-sample labels reflect the final centroid positions.
+  centroids.sort();
+  for (var j = 0; j < keptRatios.length; j++) {
+    assignments[j] = _nearestCentroid(centroids, keptRatios[j]);
+  }
+
+  // Build the per-sample output. Skipped samples carry gear=null;
+  // kept samples carry the human-readable gear label
+  // (`targetGearCount - centroidIndex`) — see library docs.
+  final inferredByOriginalIndex = <int, int>{};
+  for (var j = 0; j < keptIndices.length; j++) {
+    final centroidIndex = assignments[j];
+    final gearLabel = targetGearCount - centroidIndex;
+    inferredByOriginalIndex[keptIndices[j]] = gearLabel;
+  }
+
+  final out = <InferredGearSample>[];
+  for (var i = 0; i < sampleList.length; i++) {
+    out.add(InferredGearSample(
+      timestamp: sampleList[i].timestamp,
+      gear: inferredByOriginalIndex[i],
+    ));
+  }
+
+  return GearInferenceResult(
+    samples: List<InferredGearSample>.unmodifiable(out),
+    centroids: List<double>.unmodifiable(centroids),
+  );
+}
+
+/// Internal: linear-interpolation percentile on a pre-sorted list.
+/// `q` in `[0, 1]`. Returns the only element for length-1 inputs and
+/// the boundary element for `q <= 0` / `q >= 1`. Used to seed
+/// centroids and to bracket outliers.
+double _percentile(List<double> sortedAscending, double q) {
+  if (sortedAscending.isEmpty) {
+    return 0.0;
+  }
+  if (sortedAscending.length == 1) {
+    return sortedAscending[0];
+  }
+  if (q <= 0) return sortedAscending.first;
+  if (q >= 1) return sortedAscending.last;
+  final pos = q * (sortedAscending.length - 1);
+  final lo = pos.floor();
+  final hi = pos.ceil();
+  if (lo == hi) return sortedAscending[lo];
+  final frac = pos - lo;
+  return sortedAscending[lo] + (sortedAscending[hi] - sortedAscending[lo]) * frac;
+}
+
+/// Internal: index of the centroid nearest to [value] in 1-D
+/// (Euclidean distance reduces to absolute difference). Ties go to
+/// the lower index — k-means is stable across iterations because
+/// the centroids' positions evolve smoothly and ties occur measure-
+/// zero in practice.
+int _nearestCentroid(List<double> centroids, double value) {
+  var bestIndex = 0;
+  var bestDistance = (centroids[0] - value).abs();
+  for (var c = 1; c < centroids.length; c++) {
+    final d = (centroids[c] - value).abs();
+    if (d < bestDistance) {
+      bestDistance = d;
+      bestIndex = c;
+    }
+  }
+  return bestIndex;
+}

--- a/test/features/consumption/domain/services/gear_inference_test.dart
+++ b/test/features/consumption/domain/services/gear_inference_test.dart
@@ -1,0 +1,432 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/services/gear_inference.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// Pure-logic coverage for the [inferGears] gear-inference module
+/// (#1263 phase 1).
+///
+/// Every test builds a synthetic [TripSample] fixture that simulates
+/// known gear regimes — the tests then assert that the centroids land
+/// where they should and that the per-sample labels match. The
+/// fixtures are deterministic (no randomness) so the assertions can
+/// stay tight.
+
+const double _tireC = 1.95; // 195/65R15 ≈ 1.95 m
+
+/// Helper: build a chronological run of [count] samples at fixed
+/// (speedKmh, rpm), starting at [start] and stepping by 1 second.
+List<TripSample> _steady({
+  required DateTime start,
+  required int count,
+  required double speedKmh,
+  required double rpm,
+}) {
+  return List<TripSample>.generate(
+    count,
+    (i) => TripSample(
+      timestamp: start.add(Duration(seconds: i)),
+      speedKmh: speedKmh,
+      rpm: rpm,
+    ),
+    growable: false,
+  );
+}
+
+/// Helper: build a 5-speed-manual fixture covering all five gears
+/// at plausible cruise points. ~600 samples total — large enough for
+/// k-means to settle, small enough to stay readable.
+///
+/// Gear regimes (each ~120 samples at 1 Hz):
+/// - 1st: 10 km/h @ 1500 RPM
+/// - 2nd: 25 km/h @ 2000 RPM
+/// - 3rd: 50 km/h @ 2500 RPM
+/// - 4th: 80 km/h @ 2500 RPM
+/// - 5th: 110 km/h @ 2500 RPM
+List<TripSample> _fiveSpeedFixture({DateTime? start}) {
+  final t0 = start ?? DateTime(2026, 4, 28, 8, 0, 0);
+  final out = <TripSample>[];
+  out.addAll(_steady(start: t0, count: 120, speedKmh: 10, rpm: 1500));
+  out.addAll(_steady(
+      start: t0.add(const Duration(seconds: 120)),
+      count: 120,
+      speedKmh: 25,
+      rpm: 2000));
+  out.addAll(_steady(
+      start: t0.add(const Duration(seconds: 240)),
+      count: 120,
+      speedKmh: 50,
+      rpm: 2500));
+  out.addAll(_steady(
+      start: t0.add(const Duration(seconds: 360)),
+      count: 120,
+      speedKmh: 80,
+      rpm: 2500));
+  out.addAll(_steady(
+      start: t0.add(const Duration(seconds: 480)),
+      count: 120,
+      speedKmh: 110,
+      rpm: 2500));
+  return out;
+}
+
+/// Helper: compute the expected ratio for a (speedKmh, rpm) pair —
+/// duplicates the formula in the production module so the tests
+/// don't drift if a thinko changes one but not the other.
+double _expectedRatio(double speedKmh, double rpm) {
+  final wheelRpm = (speedKmh / 3.6) / _tireC * 60.0;
+  return rpm / wheelRpm;
+}
+
+void main() {
+  group('inferGears — synthetic 5-speed manual fixture', () {
+    test('returns five monotonically-ordered centroids', () {
+      final samples = _fiveSpeedFixture();
+      final result = inferGears(
+        samples: samples,
+        tireCircumferenceMeters: _tireC,
+      );
+
+      expect(result.centroids.length, equals(5));
+      // Strictly ascending — the module's documented contract.
+      for (var i = 1; i < result.centroids.length; i++) {
+        expect(
+          result.centroids[i],
+          greaterThan(result.centroids[i - 1]),
+          reason: 'Centroids must be sorted ascending — index $i not '
+              '> ${i - 1} (${result.centroids})',
+        );
+      }
+    });
+
+    test('labels each steady-state regime with the expected gear', () {
+      final samples = _fiveSpeedFixture();
+      final result = inferGears(
+        samples: samples,
+        tireCircumferenceMeters: _tireC,
+      );
+
+      // Bin labels per regime. Each regime is 120 samples; we expect
+      // the dominant label to match the gear number.
+      int dominantLabel(List<int?> gears) {
+        final counts = <int, int>{};
+        for (final g in gears) {
+          if (g == null) continue;
+          counts[g] = (counts[g] ?? 0) + 1;
+        }
+        var bestGear = -1;
+        var bestCount = -1;
+        counts.forEach((g, c) {
+          if (c > bestCount) {
+            bestCount = c;
+            bestGear = g;
+          }
+        });
+        return bestGear;
+      }
+
+      // Slice the per-sample output back into the five 120-sample
+      // regimes that the fixture built.
+      final perRegime = <List<int?>>[
+        result.samples.sublist(0, 120).map((s) => s.gear).toList(),
+        result.samples.sublist(120, 240).map((s) => s.gear).toList(),
+        result.samples.sublist(240, 360).map((s) => s.gear).toList(),
+        result.samples.sublist(360, 480).map((s) => s.gear).toList(),
+        result.samples.sublist(480, 600).map((s) => s.gear).toList(),
+      ];
+
+      // Module convention: gear=1 is 1st gear (highest ratio); the
+      // fixture's 1st-gear regime is index 0, and ratios fall as the
+      // car climbs up the box. So expected[0] = 1, ..., expected[4] =
+      // 5.
+      const expectedGears = <int>[1, 2, 3, 4, 5];
+      for (var r = 0; r < 5; r++) {
+        expect(
+          dominantLabel(perRegime[r]),
+          equals(expectedGears[r]),
+          reason: 'Regime $r (${expectedGears[r]}th gear in fixture) '
+              'mislabelled as ${dominantLabel(perRegime[r])}',
+        );
+      }
+    });
+
+    test('returns one InferredGearSample per input sample', () {
+      final samples = _fiveSpeedFixture();
+      final result = inferGears(
+        samples: samples,
+        tireCircumferenceMeters: _tireC,
+      );
+
+      expect(result.samples.length, equals(samples.length));
+      // Timestamps preserved 1:1.
+      for (var i = 0; i < samples.length; i++) {
+        expect(
+          result.samples[i].timestamp,
+          equals(samples[i].timestamp),
+          reason: 'Timestamp at index $i not preserved',
+        );
+      }
+    });
+
+    test('does not throw on the five-speed fixture', () {
+      expect(
+        () => inferGears(
+          samples: _fiveSpeedFixture(),
+          tireCircumferenceMeters: _tireC,
+        ),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('inferGears — cold-start vs prior-centroids parity', () {
+    test('cold-start centroids match prior-centroid run within 5%', () {
+      final samples = _fiveSpeedFixture();
+
+      final coldStart = inferGears(
+        samples: samples,
+        tireCircumferenceMeters: _tireC,
+      );
+
+      // Feed the cold-start result back as the prior. Same input data,
+      // so the second run should converge to (essentially) the same
+      // centroids.
+      final warmStart = inferGears(
+        samples: samples,
+        tireCircumferenceMeters: _tireC,
+        priorCentroids: coldStart.centroids.toList(),
+      );
+
+      expect(warmStart.centroids.length, equals(coldStart.centroids.length));
+      for (var i = 0; i < coldStart.centroids.length; i++) {
+        final relDiff =
+            (warmStart.centroids[i] - coldStart.centroids[i]).abs() /
+                coldStart.centroids[i];
+        expect(
+          relDiff,
+          lessThan(0.05),
+          reason: 'Centroid $i drifted ${(relDiff * 100).toStringAsFixed(2)} '
+              '% between cold-start and warm-start — '
+              'cold=${coldStart.centroids[i]}, warm=${warmStart.centroids[i]}',
+        );
+      }
+    });
+  });
+
+  group('inferGears — drift across trips', () {
+    test('second trip skewed to higher RPM drifts but does not override', () {
+      // Trip 1 — baseline 5-speed fixture.
+      final trip1 = _fiveSpeedFixture();
+      final trip1Result = inferGears(
+        samples: trip1,
+        tireCircumferenceMeters: _tireC,
+      );
+
+      // Trip 2 — same speed regimes, but every RPM is bumped by 15 %
+      // (driver kept it in lower gears than usual). The drivetrain
+      // ratios scale up by the same factor.
+      final t0 = DateTime(2026, 4, 29, 8, 0, 0);
+      final trip2 = <TripSample>[];
+      trip2.addAll(_steady(start: t0, count: 120, speedKmh: 10, rpm: 1725));
+      trip2.addAll(_steady(
+          start: t0.add(const Duration(seconds: 120)),
+          count: 120,
+          speedKmh: 25,
+          rpm: 2300));
+      trip2.addAll(_steady(
+          start: t0.add(const Duration(seconds: 240)),
+          count: 120,
+          speedKmh: 50,
+          rpm: 2875));
+      trip2.addAll(_steady(
+          start: t0.add(const Duration(seconds: 360)),
+          count: 120,
+          speedKmh: 80,
+          rpm: 2875));
+      trip2.addAll(_steady(
+          start: t0.add(const Duration(seconds: 480)),
+          count: 120,
+          speedKmh: 110,
+          rpm: 2875));
+
+      // Pass trip 1's centroids as prior — k-means re-converges on
+      // trip 2's higher-RPM data. Phase 1 doesn't blend the prior
+      // with the new data; it's a SEED, not a regulariser. The drift
+      // expectation below reflects that — centroids will end up
+      // ~15 % higher (the RPM bump fully feeds through).
+      final trip2Result = inferGears(
+        samples: trip2,
+        tireCircumferenceMeters: _tireC,
+        priorCentroids: trip1Result.centroids.toList(),
+      );
+
+      expect(trip2Result.centroids.length, equals(5));
+      // Each centroid should land HIGHER than the trip-1 centroid
+      // (drift in the expected direction)…
+      for (var i = 0; i < 5; i++) {
+        expect(
+          trip2Result.centroids[i],
+          greaterThan(trip1Result.centroids[i]),
+          reason: 'Centroid $i did not drift upward despite higher-RPM '
+              'trip 2 — trip1=${trip1Result.centroids[i]}, '
+              'trip2=${trip2Result.centroids[i]}',
+        );
+      }
+      // …and within 25 % of the trip-1 centroid (drift, not overwrite
+      // — a 15 % RPM bump shouldn't blow past 25 %).
+      for (var i = 0; i < 5; i++) {
+        final relDiff =
+            (trip2Result.centroids[i] - trip1Result.centroids[i]).abs() /
+                trip1Result.centroids[i];
+        expect(
+          relDiff,
+          lessThan(0.25),
+          reason: 'Centroid $i drifted '
+              '${(relDiff * 100).toStringAsFixed(1)}% — trip1='
+              '${trip1Result.centroids[i]}, trip2='
+              '${trip2Result.centroids[i]}',
+        );
+      }
+    });
+  });
+
+  group('inferGears — degenerate fixtures', () {
+    test('idle-only fixture: no centroids, all gear=null, no throw', () {
+      final t0 = DateTime(2026, 4, 28, 8, 0, 0);
+      final samples = _steady(start: t0, count: 60, speedKmh: 0, rpm: 800);
+
+      final result = inferGears(
+        samples: samples,
+        tireCircumferenceMeters: _tireC,
+      );
+
+      expect(result.centroids, isEmpty);
+      expect(result.samples.length, equals(60));
+      for (final s in result.samples) {
+        expect(s.gear, isNull);
+      }
+    });
+
+    test('short fixture (5 samples) does not throw', () {
+      final t0 = DateTime(2026, 4, 28, 8, 0, 0);
+      final samples = <TripSample>[
+        TripSample(timestamp: t0, speedKmh: 25, rpm: 2000),
+        TripSample(
+            timestamp: t0.add(const Duration(seconds: 1)),
+            speedKmh: 50,
+            rpm: 2500),
+        TripSample(
+            timestamp: t0.add(const Duration(seconds: 2)),
+            speedKmh: 80,
+            rpm: 2500),
+        TripSample(
+            timestamp: t0.add(const Duration(seconds: 3)),
+            speedKmh: 110,
+            rpm: 2500),
+        TripSample(
+            timestamp: t0.add(const Duration(seconds: 4)),
+            speedKmh: 10,
+            rpm: 1500),
+      ];
+
+      expect(
+        () => inferGears(
+          samples: samples,
+          tireCircumferenceMeters: _tireC,
+        ),
+        returnsNormally,
+      );
+
+      final result = inferGears(
+        samples: samples,
+        tireCircumferenceMeters: _tireC,
+      );
+
+      // Five samples → up to five distinct kept ratios → centroids
+      // can be 5 (one per sample) or fewer if outlier-trim drops any.
+      // We don't assert on centroid count beyond ≤ 5 — fewer-than-N
+      // fixtures are explicitly documented as degenerate. We DO
+      // assert that every input sample is represented in the output.
+      expect(result.samples.length, equals(5));
+      expect(result.centroids.length, lessThanOrEqualTo(5));
+    });
+
+    test('non-positive tyre circumference returns null gears, no throw', () {
+      final samples = _fiveSpeedFixture();
+
+      expect(
+        () => inferGears(
+          samples: samples,
+          tireCircumferenceMeters: 0.0,
+        ),
+        returnsNormally,
+      );
+
+      final result = inferGears(
+        samples: samples,
+        tireCircumferenceMeters: -1.0,
+      );
+
+      expect(result.centroids, isEmpty);
+      for (final s in result.samples) {
+        expect(s.gear, isNull);
+      }
+    });
+  });
+
+  group('inferGears — outlier robustness', () {
+    test('extreme ratio outliers do not pollute the centroids', () {
+      // Build the 5-speed fixture and prepend / append a handful of
+      // clutch-slipping samples (RPM 5000 at 5.5 km/h → ratio of
+      // ~99 — about 6 × the 1st-gear cluster). The module's
+      // outlier-trim should drop these before clustering.
+      final base = _fiveSpeedFixture();
+      final t0 = DateTime(2026, 4, 28, 7, 59, 0);
+      final outliers = <TripSample>[
+        TripSample(timestamp: t0, speedKmh: 5.5, rpm: 5000),
+        TripSample(
+            timestamp: t0.add(const Duration(seconds: 1)),
+            speedKmh: 5.5,
+            rpm: 6000),
+        TripSample(
+            timestamp: t0.add(const Duration(seconds: 2)),
+            speedKmh: 5.5,
+            rpm: 5500),
+      ];
+      final samples = <TripSample>[...outliers, ...base];
+
+      // Run the clean and the polluted fixture through the same
+      // function — centroids should match within 10 %.
+      final clean = inferGears(
+        samples: base,
+        tireCircumferenceMeters: _tireC,
+      );
+      final dirty = inferGears(
+        samples: samples,
+        tireCircumferenceMeters: _tireC,
+      );
+
+      expect(dirty.centroids.length, equals(clean.centroids.length));
+      for (var i = 0; i < clean.centroids.length; i++) {
+        final relDiff = (dirty.centroids[i] - clean.centroids[i]).abs() /
+            clean.centroids[i];
+        expect(
+          relDiff,
+          lessThan(0.10),
+          reason: 'Outliers shifted centroid $i by '
+              '${(relDiff * 100).toStringAsFixed(2)}% — '
+              'clean=${clean.centroids[i]}, dirty=${dirty.centroids[i]}',
+        );
+      }
+    });
+  });
+
+  group('inferGears — formula sanity', () {
+    test('helper math matches a known regime ratio', () {
+      // Ground-truth check: 50 km/h @ 2500 RPM with 1.95 m tyre ≈
+      // 5.85 ratio. If this drifts, the production module's formula
+      // is wrong.
+      final r = _expectedRatio(50, 2500);
+      expect(r, closeTo(5.85, 0.02));
+    });
+  });
+}


### PR DESCRIPTION
Phase 1 of #1263. Pure-logic 1-D k-means clustering on RPM/speed ratio yielding gear assignments + reusable centroids. Self-contained: no schema change, no UI, no integration with trip recorder yet (phase 2).