### PR TITLE
feat(driving): low-gear coaching line on insights card (Closes #1263)

### DIFF
--- a/lib/features/consumption/presentation/widgets/driving_insights_card.dart
+++ b/lib/features/consumption/presentation/widgets/driving_insights_card.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import '../../../../l10n/app_localizations.dart';
@@ -34,12 +36,37 @@ class DrivingInsightsCard extends StatelessWidget {
   /// `litersWasted` desc and capped at 3. Empty list → empty-state.
   final List<DrivingInsight> insights;
 
-  const DrivingInsightsCard({super.key, required this.insights});
+  /// Optional time-below-optimal-gear metric from `gear_inference.dart`
+  /// (#1263 phase 1) summed at trip end into
+  /// `TripSummary.secondsBelowOptimalGear` (phase 2). Surfaced here as
+  /// the gear-coaching row when non-null AND > 60s. Null on EV trips
+  /// or when the inference had insufficient samples / no centroids;
+  /// the parent screen also gates the entire card on EV / empty-trip.
+  ///
+  /// Rendered ABOVE the regular insight tiles. When the regular
+  /// `insights` list is empty and this metric fires, the gear row
+  /// renders ALONE — no empty-state — so the user always sees the
+  /// most actionable line.
+  final double? secondsBelowOptimalGear;
+
+  const DrivingInsightsCard({
+    super.key,
+    required this.insights,
+    this.secondsBelowOptimalGear,
+  });
+
+  /// True when the gear-coaching row should render — non-null metric
+  /// strictly greater than 60s (the issue-#1263 acceptance threshold).
+  bool get _showLowGearRow {
+    final s = secondsBelowOptimalGear;
+    return s != null && s > 60;
+  }
 
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
+    final showLowGear = _showLowGearRow;
 
     return Card(
       margin: const EdgeInsets.fromLTRB(12, 8, 12, 8),
@@ -53,7 +80,9 @@ class DrivingInsightsCard extends StatelessWidget {
               style: theme.textTheme.titleMedium,
             ),
             const SizedBox(height: 8),
-            if (insights.isEmpty)
+            if (showLowGear)
+              _LowGearTile(seconds: secondsBelowOptimalGear!),
+            if (insights.isEmpty && !showLowGear)
               _EmptyState(
                 message: l?.insightEmptyState ??
                     'No notable inefficiencies — keep it up!',
@@ -64,6 +93,41 @@ class DrivingInsightsCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Gear-coaching row (#1263 phase 3). Visual style mirrors
+/// [_InsightTile] — leading icon, headline title, no trailing badge
+/// (the metric is a duration, not a litres figure).
+class _LowGearTile extends StatelessWidget {
+  /// Total seconds the trip spent below the optimal-gear ceiling.
+  /// Only ever rendered when caller has confirmed `> 60`.
+  final double seconds;
+
+  const _LowGearTile({required this.seconds});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    // `Math.max(1, round(seconds / 60))` so we never display "0
+    // minutes". The `> 60` guard already ensures `round()` returns
+    // at least 1 (round(60/60) = 1), but clamping defensively keeps
+    // the formatter honest for future callers.
+    final minutes = math.max(1, (seconds / 60).round()).toString();
+    final headline = l?.insightLowGear(minutes) ??
+        'Labouring in low gear ($minutes min)';
+
+    return ListTile(
+      key: const ValueKey('insight_tile_insightLowGear'),
+      contentPadding: EdgeInsets.zero,
+      leading: Icon(
+        Icons.swap_vert,
+        color: theme.colorScheme.error,
+      ),
+      title: Text(headline),
     );
   }
 }
@@ -151,6 +215,13 @@ class _InsightTile extends StatelessWidget {
         return Icons.flash_on;
       case 'insightIdling':
         return Icons.hourglass_empty;
+      case 'insightLowGear':
+        // Gear-coaching row (#1263 phase 3) doesn't go through this
+        // tile builder (it's rendered by [_LowGearTile] directly), but
+        // keep the icon mapping here so future analyzer-emitted
+        // 'insightLowGear' insights would render with the same gear-
+        // shift glyph.
+        return Icons.swap_vert;
       default:
         return Icons.info_outline;
     }

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -180,8 +180,20 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
           DrivingScoreCard(score: _score),
         // Driving insights — combustion trips only. EV trips skip
         // this card; phase 4 will land an EV-aware version.
+        //
+        // #1263 phase 3: also pass the gear-coaching metric
+        // (`secondsBelowOptimalGear`) so the card can render a
+        // "Labouring in low gear (X min)" row when the metric > 60s.
+        // Force null on EV trips defensively — the parent gate above
+        // already hides the card for EVs, but null-passing keeps the
+        // contract clean if that gate ever moves.
         if (!widget.isEv && widget.samples.isNotEmpty)
-          DrivingInsightsCard(insights: _insights),
+          DrivingInsightsCard(
+            insights: _insights,
+            secondsBelowOptimalGear: widget.isEv
+                ? null
+                : widget.entry.summary.secondsBelowOptimalGear,
+          ),
         // Throttle / RPM histogram (#1041 phase 3a — Card C). Slotted
         // right below the insights card so the user reads "what was
         // wasteful" then immediately sees "here's the engine

--- a/lib/l10n/_fragments/driving_insights_de.arb
+++ b/lib/l10n/_fragments/driving_insights_de.arb
@@ -5,5 +5,6 @@
   "insightHardAccel": "{count} starke Beschleunigungen: {liters} L verschwendet",
   "insightIdling": "Leerlauf ({pctTime}% der Fahrt): {liters} L verschwendet",
   "insightSubtitlePctOfTrip": "{pctTime}% der Fahrt",
-  "insightTrailingLitersWasted": "+{liters} L"
+  "insightTrailingLitersWasted": "+{liters} L",
+  "insightLowGear": "Im niedrigen Gang gefahren ({minutes} Min.)"
 }

--- a/lib/l10n/_fragments/driving_insights_en.arb
+++ b/lib/l10n/_fragments/driving_insights_en.arb
@@ -60,5 +60,14 @@
         "type": "String"
       }
     }
+  },
+  "insightLowGear": "Labouring in low gear ({minutes} min)",
+  "@insightLowGear": {
+    "description": "Coaching line on the driving-insights card when secondsBelowOptimalGear > 60 (#1263 phase 3). Tells the driver they spent significant time in too-low a gear, raising fuel consumption. Placeholder is the integer minute count.",
+    "placeholders": {
+      "minutes": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1345,6 +1345,7 @@
   "insightIdling": "Leerlauf ({pctTime}% der Fahrt): {liters} L verschwendet",
   "insightSubtitlePctOfTrip": "{pctTime}% der Fahrt",
   "insightTrailingLitersWasted": "+{liters} L",
+  "insightLowGear": "Im niedrigen Gang gefahren ({minutes} Min.)",
   "drivingScoreCardTitle": "Fahrnote",
   "drivingScoreCardOutOf": "/100",
   "drivingScoreCardSubtitle": "Gesamtnote aus Leerlauf, starken Beschleunigungen, hartem Bremsen und Zeit über 3000 U/min. Ein Vergleich „besser als X% deiner bisherigen Fahrten“ folgt in einem späteren Release.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1711,6 +1711,15 @@
       }
     }
   },
+  "insightLowGear": "Labouring in low gear ({minutes} min)",
+  "@insightLowGear": {
+    "description": "Coaching line on the driving-insights card when secondsBelowOptimalGear > 60 (#1263 phase 3). Tells the driver they spent significant time in too-low a gear, raising fuel consumption. Placeholder is the integer minute count.",
+    "placeholders": {
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
   "drivingScoreCardTitle": "Driving score",
   "@drivingScoreCardTitle": {
     "description": "Title of the composite driving-score card on the Trip detail screen — sits at the top of the Insights group above the cost-line card (#1041 phase 5a Card A)."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6200,6 +6200,12 @@ abstract class AppLocalizations {
   /// **'+{liters} L'**
   String insightTrailingLitersWasted(String liters);
 
+  /// Coaching line on the driving-insights card when secondsBelowOptimalGear > 60 (#1263 phase 3). Tells the driver they spent significant time in too-low a gear, raising fuel consumption. Placeholder is the integer minute count.
+  ///
+  /// In en, this message translates to:
+  /// **'Labouring in low gear ({minutes} min)'**
+  String insightLowGear(String minutes);
+
   /// Title of the composite driving-score card on the Trip detail screen — sits at the top of the Insights group above the cost-line card (#1041 phase 5a Card A).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3320,6 +3320,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3320,6 +3320,11 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3318,6 +3318,11 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3348,6 +3348,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Im niedrigen Gang gefahren ($minutes Min.)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Fahrnote';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3322,6 +3322,11 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3313,6 +3313,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3321,6 +3321,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3315,6 +3315,11 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3318,6 +3318,11 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3346,6 +3346,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3317,6 +3317,11 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3322,6 +3322,11 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3321,6 +3321,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3319,6 +3319,11 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3321,6 +3321,11 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3317,6 +3317,11 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3322,6 +3322,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3320,6 +3320,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3321,6 +3321,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3320,6 +3320,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3321,6 +3321,11 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3315,6 +3315,11 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3319,6 +3319,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String insightLowGear(String minutes) {
+    return 'Labouring in low gear ($minutes min)';
+  }
+
+  @override
   String get drivingScoreCardTitle => 'Driving score';
 
   @override

--- a/test/features/consumption/presentation/widgets/driving_insights_card_low_gear_test.dart
+++ b/test/features/consumption/presentation/widgets/driving_insights_card_low_gear_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/driving_insight.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/driving_insights_card.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Coverage for the gear-coaching row added to [DrivingInsightsCard]
+/// in #1263 phase 3.
+///
+/// The row surfaces `TripSummary.secondsBelowOptimalGear` (computed by
+/// `gear_inference.dart` in phase 1, persisted in phase 2) when the
+/// metric is non-null and strictly greater than 60s. Below the
+/// threshold, the row stays hidden so noisy short bursts don't dilute
+/// the coaching signal.
+void main() {
+  const lowGearKey = ValueKey('insight_tile_insightLowGear');
+
+  group('DrivingInsightsCard — gear-coaching row visibility', () {
+    testWidgets('hidden when secondsBelowOptimalGear is null',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingInsightsCard(insights: []),
+      );
+
+      expect(find.byKey(lowGearKey), findsNothing);
+      expect(find.textContaining('Labouring'), findsNothing);
+    });
+
+    testWidgets('hidden at the boundary — 60.0 is NOT > 60',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingInsightsCard(
+          insights: [],
+          secondsBelowOptimalGear: 60.0,
+        ),
+      );
+
+      expect(find.byKey(lowGearKey), findsNothing);
+      expect(find.textContaining('Labouring'), findsNothing);
+    });
+
+    testWidgets('rendered when secondsBelowOptimalGear is 65 — shows "1 min"',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingInsightsCard(
+          insights: [],
+          secondsBelowOptimalGear: 65.0,
+        ),
+      );
+
+      expect(find.byKey(lowGearKey), findsOneWidget);
+      expect(
+        find.text('Labouring in low gear (1 min)'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('rendered when secondsBelowOptimalGear is 180 — shows "3 min"',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingInsightsCard(
+          insights: [],
+          secondsBelowOptimalGear: 180.0,
+        ),
+      );
+
+      expect(find.byKey(lowGearKey), findsOneWidget);
+      expect(
+        find.text('Labouring in low gear (3 min)'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'when fired with no other insights, replaces empty-state — no '
+        '"keep it up" copy', (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingInsightsCard(
+          insights: [],
+          secondsBelowOptimalGear: 180.0,
+        ),
+      );
+
+      expect(find.byKey(lowGearKey), findsOneWidget);
+      expect(
+        find.text('No notable inefficiencies — keep it up!'),
+        findsNothing,
+      );
+    });
+
+    testWidgets(
+        'when fired alongside non-empty insights, BOTH render — gear row '
+        'first', (tester) async {
+      const insights = [
+        DrivingInsight(
+          labelKey: 'insightHighRpm',
+          litersWasted: 0.6,
+          percentOfTrip: 12.0,
+        ),
+      ];
+
+      await pumpApp(
+        tester,
+        const DrivingInsightsCard(
+          insights: insights,
+          secondsBelowOptimalGear: 180.0,
+        ),
+      );
+
+      // Both rows present.
+      expect(find.byKey(lowGearKey), findsOneWidget);
+      expect(
+        find.text('Labouring in low gear (3 min)'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Engine over 3000 RPM (12% of trip): wasted 0.6 L'),
+        findsOneWidget,
+      );
+      // ListTile count: gear row + 1 insight tile.
+      expect(find.byType(ListTile), findsNWidgets(2));
+
+      // Gear row precedes the insight tile vertically (smaller dy).
+      final gearTopLeft = tester.getTopLeft(find.byKey(lowGearKey));
+      final insightTopLeft = tester.getTopLeft(
+        find.text('Engine over 3000 RPM (12% of trip): wasted 0.6 L'),
+      );
+      expect(gearTopLeft.dy, lessThan(insightTopLeft.dy));
+    });
+
+    testWidgets('gear row does NOT carry a trailing "+x L" badge',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingInsightsCard(
+          insights: [],
+          secondsBelowOptimalGear: 180.0,
+        ),
+      );
+
+      final tile = tester.widget<ListTile>(find.byKey(lowGearKey));
+      expect(tile.trailing, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the gear-coaching surface for #1263. Phases 1 (gear-inference module) and 2 (persistence) shipped earlier; this PR closes the epic by rendering "Labouring in low gear (X min)" on the driving-insights card when `TripSummary.secondsBelowOptimalGear > 60`.

- `DrivingInsightsCard` takes an optional `secondsBelowOptimalGear` and renders a leading row above the insight tiles when the metric is non-null and > 60s.
- `trip_detail_body.dart` passes the metric from `widget.entry.summary.secondsBelowOptimalGear`. EV gating unchanged — the parent already hides the card for EV trips.
- ARB strings added in `_fragments/driving_insights_en.arb` + `_fragments/driving_insights_de.arb`; `app_en.arb`+`app_de.arb` regenerated.
- Widget tests cover null / boundary (60.0 = no row) / above-threshold / formatting / co-rendering with existing insights.

## Test plan

- [x] flutter analyze clean
- [x] flutter test test/features/consumption/presentation/widgets/ passes
- [ ] CI green on analyze + test

🤖 Generated with [Claude Code](https://claude.com/claude-code)