### PR TITLE
test(consumption): cover fill-up form sub-widgets (Refs #561 phase: fill_up_form_widgets)

### DIFF
--- a/test/features/consumption/presentation/widgets/fill_up_no_vehicle_cta_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_no_vehicle_cta_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_no_vehicle_cta.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for [FillUpNoVehicleCta] (#706 / #563 extraction).
+/// The CTA owns the whole screen when the vehicle list is empty. It
+/// must:
+///   * render the localised title + body + button text,
+///   * push `/vehicles/edit` when "Add vehicle" is tapped,
+///   * pop the route when the back-arrow leading icon is tapped.
+///
+/// Both navigation paths are exercised through a minimal in-test
+/// [GoRouter] so we catch regressions like #695 (an unregistered
+/// route silently no-op'ing).
+void main() {
+  const ctaLanding = ValueKey('cta-landing');
+  const editStub = ValueKey('vehicle-edit-stub');
+  const senderHome = ValueKey('sender-home');
+
+  GoRouter buildRouter({String initial = '/'}) {
+    return GoRouter(
+      initialLocation: initial,
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const Scaffold(
+            key: senderHome,
+            body: Center(child: Text('SENDER HOME')),
+          ),
+        ),
+        GoRoute(
+          path: '/fill-up/no-vehicle',
+          builder: (_, _) => const Scaffold(
+            key: ctaLanding,
+            body: FillUpNoVehicleCta(),
+          ),
+        ),
+        GoRoute(
+          path: '/vehicles/edit',
+          builder: (_, _) => const Scaffold(
+            key: editStub,
+            body: Center(child: Text('VEHICLE EDIT STUB')),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> pumpCta(
+    WidgetTester tester, {
+    String initial = '/fill-up/no-vehicle',
+  }) {
+    final router = buildRouter(initial: initial);
+    return tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+      ),
+    );
+  }
+
+  testWidgets('renders the localised title, body and Add-vehicle button',
+      (tester) async {
+    await pumpCta(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Add fill-up'), findsOneWidget,
+        reason: 'PageScaffold app-bar title');
+    expect(find.text('Add a vehicle first'), findsOneWidget,
+        reason: 'consumptionNoVehicleTitle');
+    expect(
+      find.textContaining('Fill-ups are attributed to a vehicle'),
+      findsOneWidget,
+      reason: 'consumptionNoVehicleBody intro',
+    );
+    expect(find.widgetWithText(FilledButton, 'Add vehicle'), findsOneWidget);
+    expect(find.byIcon(Icons.directions_car_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsOneWidget);
+  });
+
+  testWidgets('tapping "Add vehicle" pushes /vehicles/edit', (tester) async {
+    await pumpCta(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(editStub), findsNothing);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Add vehicle'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(editStub), findsOneWidget,
+        reason:
+            'Tapping the Add-vehicle FilledButton must push the vehicle '
+            'editor — guards against the #695-class regression where a '
+            'wrong route key silently no-ops');
+    expect(find.text('VEHICLE EDIT STUB'), findsOneWidget);
+  });
+
+  testWidgets(
+      'tapping the leading back-arrow pops the CTA off the navigator',
+      (tester) async {
+    final router = buildRouter(initial: '/');
+    await tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Push the CTA on top of the home so there is something to pop back to.
+    unawaited(router.push('/fill-up/no-vehicle'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(ctaLanding), findsOneWidget);
+
+    // Use the tooltip to disambiguate from any other IconButtons.
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(ctaLanding), findsNothing,
+        reason: 'Back-arrow must pop the CTA off the stack');
+    expect(find.byKey(senderHome), findsOneWidget,
+        reason: 'And we land back on the home route');
+  });
+}

--- a/test/features/consumption/presentation/widgets/fill_up_pinned_save_bar_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_pinned_save_bar_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_pinned_save_bar.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for [FillUpPinnedSaveBar] (#751 phase 2 / #563 extraction).
+/// The bar is a thin shell — a `Material` + `SafeArea` around a single
+/// `FilledButton.icon`. Exists so the Save CTA is always one tap away
+/// regardless of how far the user has scrolled the form. The tests
+/// guard the localised label, the icon, and the callback contract.
+void main() {
+  Future<void> pumpBar(
+    WidgetTester tester, {
+    required VoidCallback onSave,
+    Locale locale = const Locale('en'),
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          // Keep the bottom-bar slot to mirror how the screen mounts it.
+          bottomNavigationBar: FillUpPinnedSaveBar(onSave: onSave),
+          body: const SizedBox.shrink(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders the localised Save label and the save icon',
+      (tester) async {
+    await pumpBar(tester, onSave: () {});
+    await tester.pumpAndSettle();
+
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.byIcon(Icons.save_outlined), findsOneWidget);
+    expect(find.byType(FilledButton), findsOneWidget);
+  });
+
+  testWidgets('tap fires onSave exactly once', (tester) async {
+    var taps = 0;
+    await pumpBar(tester, onSave: () => taps++);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FilledButton));
+    await tester.pumpAndSettle();
+
+    expect(taps, 1,
+        reason:
+            'The pinned bar is a one-shot Save trigger — one tap, one '
+            'callback. Multiple firings would duplicate the fill-up record.');
+  });
+}

--- a/test/features/consumption/presentation/widgets/fill_up_station_pre_fill_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_station_pre_fill_banner_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_station_pre_fill_banner.dart';
+
+/// Widget tests for [FillUpStationPreFillBanner] (#581 affordance,
+/// restyled by #751 phase 2 / #563 extraction).
+///
+/// The banner sits above the form to surface the pre-filled station
+/// without stealing visual weight from the "What you filled" card.
+/// The visible chrome is a labelled icon + label + station name. The
+/// accessibility contract collapses both texts into a single Semantics
+/// container labelled "$label: $stationName" so a screen reader hears
+/// the affordance as one announcement.
+void main() {
+  Future<void> pumpBanner(
+    WidgetTester tester, {
+    String stationName = 'Shell Beziers',
+    String label = 'From station',
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FillUpStationPreFillBanner(
+            stationName: stationName,
+            label: label,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders both the label and the station name plus the icon',
+      (tester) async {
+    await pumpBanner(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.text('From station'), findsOneWidget);
+    expect(find.text('Shell Beziers'), findsOneWidget);
+    expect(find.byIcon(Icons.place_outlined), findsOneWidget);
+  });
+
+  testWidgets(
+      'exposes a single combined "label: stationName" Semantics announcement',
+      (tester) async {
+    final handle = tester.ensureSemantics();
+    await pumpBanner(
+      tester,
+      stationName: 'Total Castelnau',
+      label: 'Pre-filled from',
+    );
+    await tester.pumpAndSettle();
+
+    // The Column children are wrapped in ExcludeSemantics so only the
+    // outer Semantics(label: '$label: $stationName') node is reachable.
+    // A screen reader should hear the merged label as one announcement,
+    // not two adjacent text nodes.
+    expect(
+      find.bySemanticsLabel('Pre-filled from: Total Castelnau'),
+      findsOneWidget,
+      reason:
+          'The banner combines label + station name into a single '
+          'Semantics container so screen readers announce them as one '
+          'affordance rather than two disconnected texts.',
+    );
+
+    handle.dispose();
+  });
+
+  testWidgets('renders even when label or stationName is empty',
+      (tester) async {
+    await pumpBanner(tester, label: '', stationName: '');
+    await tester.pumpAndSettle();
+
+    // Defensive: an empty pre-fill payload must not crash the banner.
+    expect(find.byType(FillUpStationPreFillBanner), findsOneWidget);
+    expect(find.byIcon(Icons.place_outlined), findsOneWidget);
+  });
+}

--- a/test/features/consumption/presentation/widgets/fill_up_vehicle_fuel_picker_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_vehicle_fuel_picker_test.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_vehicle_fuel_picker.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for [FillUpVehicleFuelPicker] (#713 / #563 extraction).
+///
+/// The picker constrains the dropdown options to the vehicle's
+/// compatibility family (a petrol car shows e10/e5/e98/e85, a diesel
+/// shows diesel/dieselPremium, an EV / LPG / CNG / H2 shows only its
+/// single applicable fuel). When the inbound `fuelType` is not in the
+/// compatible set, the picker silently lands on `compatible.first` so
+/// the form never opens with an impossible option pre-selected.
+void main() {
+  const petrolVehicle = VehicleProfile(
+    id: 'veh-petrol',
+    name: 'Peugeot 107',
+    type: VehicleType.combustion,
+    preferredFuelType: 'e10',
+  );
+
+  const dieselVehicle = VehicleProfile(
+    id: 'veh-diesel',
+    name: 'Renault Megane',
+    type: VehicleType.combustion,
+    preferredFuelType: 'diesel',
+  );
+
+  const evVehicle = VehicleProfile(
+    id: 'veh-ev',
+    name: 'Renault Zoe',
+    type: VehicleType.ev,
+  );
+
+  Future<void> pumpPicker(
+    WidgetTester tester, {
+    required List<VehicleProfile> vehicles,
+    required String vehicleId,
+    required FuelType fuelType,
+    ValueChanged<FuelType>? onChanged,
+    VoidCallback? onOpenVehicle,
+    Locale locale = const Locale('en'),
+  }) {
+    return tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          locale: locale,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: FillUpVehicleFuelPicker(
+              vehicles: vehicles,
+              vehicleId: vehicleId,
+              fuelType: fuelType,
+              onChanged: onChanged ?? (_) {},
+              onOpenVehicle: onOpenVehicle ?? () {},
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+      'petrol vehicle exposes only petrol-family options (e10/e5/e98/e85)',
+      (tester) async {
+    await pumpPicker(
+      tester,
+      vehicles: const [petrolVehicle],
+      vehicleId: petrolVehicle.id,
+      fuelType: FuelType.e10,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<FuelType>));
+    await tester.pumpAndSettle();
+
+    // Petrol family — the four interchangeable petrol grades all show.
+    expect(find.text(FuelType.e10.displayName), findsWidgets);
+    expect(find.text(FuelType.e5.displayName), findsWidgets);
+    expect(find.text(FuelType.e98.displayName), findsWidgets);
+    expect(find.text(FuelType.e85.displayName), findsWidgets);
+
+    // Cross-family options must NOT appear — guarding against the
+    // pre-#713 behaviour where the picker offered every fuel.
+    expect(find.text(FuelType.diesel.displayName), findsNothing);
+    expect(find.text(FuelType.electric.displayName), findsNothing);
+    expect(find.text(FuelType.lpg.displayName), findsNothing);
+  });
+
+  testWidgets(
+      'diesel vehicle exposes only diesel-family options '
+      '(diesel + dieselPremium)', (tester) async {
+    await pumpPicker(
+      tester,
+      vehicles: const [dieselVehicle],
+      vehicleId: dieselVehicle.id,
+      fuelType: FuelType.diesel,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<FuelType>));
+    await tester.pumpAndSettle();
+
+    expect(find.text(FuelType.diesel.displayName), findsWidgets);
+    expect(find.text(FuelType.dieselPremium.displayName), findsWidgets);
+
+    // Petrol options must NOT appear on a diesel — physically incompatible.
+    expect(find.text(FuelType.e10.displayName), findsNothing);
+    expect(find.text(FuelType.e85.displayName), findsNothing);
+    expect(find.text(FuelType.electric.displayName), findsNothing);
+  });
+
+  testWidgets(
+      'EV vehicle exposes only the single electric option', (tester) async {
+    await pumpPicker(
+      tester,
+      vehicles: const [evVehicle],
+      vehicleId: evVehicle.id,
+      fuelType: FuelType.electric,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<FuelType>));
+    await tester.pumpAndSettle();
+
+    expect(find.text(FuelType.electric.displayName), findsWidgets);
+    expect(find.text(FuelType.diesel.displayName), findsNothing);
+    expect(find.text(FuelType.e10.displayName), findsNothing);
+  });
+
+  testWidgets(
+      'incompatible inbound fuelType silently falls back to compatible.first',
+      (tester) async {
+    // A diesel vehicle but the form was loaded with a stale petrol pre-fill.
+    // The picker must NOT crash — it just lands on `compatible.first`
+    // (`FuelType.diesel`, since compatibleFuelsFor pins primary first).
+    await pumpPicker(
+      tester,
+      vehicles: const [dieselVehicle],
+      vehicleId: dieselVehicle.id,
+      fuelType: FuelType.e10,
+    );
+    await tester.pumpAndSettle();
+
+    final dropdown = tester.widget<DropdownButtonFormField<FuelType>>(
+      find.byType(DropdownButtonFormField<FuelType>),
+    );
+    expect(
+      dropdown.initialValue,
+      FuelType.diesel,
+      reason:
+          'When the inbound fuel is not in the vehicle\'s compatible '
+          'family, the picker must drop to compatible.first instead of '
+          'showing an impossible option (or crashing).',
+    );
+  });
+
+  testWidgets(
+      'picking a different compatible fuel fires onChanged with the new fuel',
+      (tester) async {
+    FuelType? picked;
+    await pumpPicker(
+      tester,
+      vehicles: const [petrolVehicle],
+      vehicleId: petrolVehicle.id,
+      fuelType: FuelType.e10,
+      onChanged: (f) => picked = f,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<FuelType>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(FuelType.e85.displayName).last);
+    await tester.pumpAndSettle();
+
+    expect(picked, FuelType.e85,
+        reason:
+            'A flex-fuel petrol driver must be able to log E85 even if '
+            'the profile preference is E10 — the override is the whole '
+            'point of #713.');
+  });
+
+  testWidgets('open-in-new IconButton fires onOpenVehicle', (tester) async {
+    var taps = 0;
+    await pumpPicker(
+      tester,
+      vehicles: const [petrolVehicle],
+      vehicleId: petrolVehicle.id,
+      fuelType: FuelType.e10,
+      onOpenVehicle: () => taps++,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.open_in_new));
+    await tester.pumpAndSettle();
+
+    expect(taps, 1,
+        reason:
+            'The trailing IconButton is the deep-link to the vehicle '
+            'editor; the picker must forward the tap verbatim.');
+  });
+
+  testWidgets(
+      'label embeds the resolved vehicle name so multi-vehicle users '
+      'see which one they are configuring', (tester) async {
+    await pumpPicker(
+      tester,
+      vehicles: const [petrolVehicle, dieselVehicle],
+      vehicleId: dieselVehicle.id,
+      fuelType: FuelType.diesel,
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Fuel type • Renault Megane'),
+      findsOneWidget,
+      reason: 'Label is `${'fuelType'} • ${'vehicle.name'}`',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Cover four StatelessWidgets pulled out of `add_fill_up_screen.dart` during the #563 extraction effort that landed without unit tests.
- Adds widget tests for `FillUpPinnedSaveBar`, `FillUpNoVehicleCta`, `FillUpStationPreFillBanner`, `FillUpVehicleFuelPicker`.
- Refs #561 phase: fill_up_form_widgets.

## Test plan
- [x] `flutter analyze` clean.
- [x] `flutter test test/features/consumption/presentation/widgets/fill_up_*_test.dart` green locally.