### PR TITLE
feat(driving): visual eco-coach + pin/resume help on recording screen (Closes #1273)

### DIFF
--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -54,4 +54,11 @@ class StorageKeys {
   /// fires on sustained-high-throttle / low-Δspeed cruise. Defaults to
   /// off so we never buzz a user who hasn't asked for live feedback.
   static const String hapticEcoCoachEnabled = 'haptic_eco_coach_enabled';
+
+  /// #1273 — flag set the first time the user backs out of the trip
+  /// recording screen WHILE recording, after they've seen the "tap the
+  /// red banner to return" tooltip. Persisted so the tooltip never
+  /// fires twice for the same user.
+  static const String tripRecordingResumeHintShown =
+      'trip_recording_resume_hint_shown';
 }

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -5,8 +5,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/storage/storage_keys.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../driving/haptic_eco_coach.dart';
+import '../../../driving/providers/haptic_eco_coach_provider.dart';
 import '../../domain/trip_recorder.dart';
 import '../../providers/trip_recording_provider.dart';
 import '../../providers/wakelock_facade.dart';
@@ -64,6 +68,24 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
   /// widget is deactivated). Populated the first time the user pins.
   WakelockFacade? _cachedFacade;
 
+  /// #1273 — subscription to [HapticEcoCoachLifecycle.coachEvents]. We
+  /// open this in [initState] and cancel in [dispose] so the visual
+  /// SnackBar surface is bound to THIS screen's lifecycle: navigating
+  /// to the summary, history, or any other route silently stops the
+  /// SnackBar even if the coach keeps firing in the background.
+  StreamSubscription<CoachEvent>? _coachEventsSub;
+
+  @override
+  void initState() {
+    super.initState();
+    // Subscribe to the long-lived coach-events broadcast. The
+    // lifecycle provider's stream is filter-empty when the toggle is
+    // off — no event will be emitted until the user has opted in,
+    // so a `setState`-light listener is fine here.
+    final lifecycle = ref.read(hapticEcoCoachLifecycleProvider.notifier);
+    _coachEventsSub = lifecycle.coachEvents.listen(_onCoachEvent);
+  }
+
   @override
   void dispose() {
     // Auto-release the wake lock + restore system UI if the user
@@ -82,7 +104,41 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         ),
       );
     }
+    _coachEventsSub?.cancel();
+    _coachEventsSub = null;
     super.dispose();
+  }
+
+  /// Show the visual eco-coach SnackBar. Lifecycle-gated: this is
+  /// only called while the recording screen is mounted because the
+  /// stream subscription only exists between initState and dispose.
+  /// The provider gates EMISSION on the haptic-eco-coach toggle, so
+  /// no event reaches us when the toggle is off — no need to
+  /// double-gate here.
+  void _onCoachEvent(CoachEvent _) {
+    if (!mounted) return;
+    final l = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        key: const Key('hapticEcoCoachSnackBar'),
+        duration: const Duration(seconds: 4),
+        content: Row(
+          children: [
+            const Icon(Icons.eco, size: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                l?.hapticEcoCoachSnackBarMessage ??
+                    'Easy on the throttle — coasting saves more',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   Future<void> _onStop() async {
@@ -167,6 +223,99 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     Navigator.of(context).pop(null);
   }
 
+  /// #1273 — show a bottom sheet explaining what the pin button does.
+  /// Always visible (NOT gated by any toggle); first-launch users
+  /// need this regardless of opt-ins.
+  void _showPinHelp() {
+    final l = AppLocalizations.of(context);
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (ctx) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Icon(Icons.push_pin, size: 24),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        l?.tripRecordingPinHelpTitle ?? 'About pin',
+                        style: Theme.of(ctx).textTheme.titleLarge,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  l?.tripRecordingPinHelpBody ??
+                      'Pin keeps the screen on and hides system bars '
+                          'so the form stays readable on a dashboard '
+                          'mount. Tap again to release. Auto-releases '
+                          'when the trip stops.',
+                ),
+                const SizedBox(height: 16),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton(
+                    onPressed: () => Navigator.of(ctx).pop(),
+                    child: Text(l?.tooltipBack ?? 'Close'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// #1273 — handle the back-press. If the trip is still recording
+  /// AND the user has never seen the resume hint, show a SnackBar
+  /// with the resume copy, persist the dismissal, then pop. Once the
+  /// flag is set (in Hive) future back-outs pop immediately.
+  Future<void> _onBackPressed() async {
+    final state = ref.read(tripRecordingProvider);
+    final settings = ref.read(settingsStorageProvider);
+    final shown =
+        settings.getSetting(StorageKeys.tripRecordingResumeHintShown) == true;
+    if (state.isActive && !shown) {
+      final l = AppLocalizations.of(context);
+      final messenger = ScaffoldMessenger.maybeOf(context);
+      if (messenger != null) {
+        messenger.hideCurrentSnackBar();
+        messenger.showSnackBar(
+          SnackBar(
+            key: const Key('tripRecordingResumeHintSnackBar'),
+            duration: const Duration(seconds: 5),
+            content: Text(
+              l?.tripRecordingResumeHintMessage ??
+                  'Recording continues in the background. Tap the red '
+                      'banner at the top of any screen to return.',
+            ),
+          ),
+        );
+      }
+      // Persist the dismissal so the hint never fires twice. Awaited
+      // so the test that asserts post-state can read it back without
+      // racing the pop.
+      await settings.putSetting(
+        StorageKeys.tripRecordingResumeHintShown,
+        true,
+      );
+    }
+    if (!mounted) return;
+    if (Navigator.canPop(context)) {
+      Navigator.pop(context);
+    } else {
+      GoRouter.of(context).go('/');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
@@ -187,14 +336,9 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         tooltip: l?.tooltipBack ?? 'Back',
         // Back from the recording screen DOES NOT stop the trip —
         // it stays alive via the provider. The banner is the
-        // user's way back in.
-        onPressed: () {
-          if (Navigator.canPop(context)) {
-            Navigator.pop(context);
-          } else {
-            GoRouter.of(context).go('/');
-          }
-        },
+        // user's way back in. #1273 — first back-out while
+        // recording fires a one-time tooltip pointing at the banner.
+        onPressed: _onBackPressed,
       ),
       actions: stopped != null
           ? null
@@ -225,6 +369,17 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
                   isSelected: _pinned,
                   onPressed: _togglePin,
                 ),
+              ),
+              // #1273 — `?` icon adjacent to the pin button. Always
+              // visible (no toggle gating); first-launch users need
+              // a path to "what does this button do" without leaving
+              // the recording screen.
+              IconButton(
+                key: const Key('tripPinHelpButton'),
+                icon: const Icon(Icons.help_outline),
+                tooltip: l?.tripRecordingPinHelpTooltip ??
+                    'What does pin do?',
+                onPressed: _showPinHelp,
               ),
               IconButton(
                 key: const Key('tripPauseButton'),

--- a/lib/features/driving/haptic_eco_coach.dart
+++ b/lib/features/driving/haptic_eco_coach.dart
@@ -6,6 +6,23 @@ import 'package:flutter/services.dart';
 import '../../core/logging/error_logger.dart';
 import '../consumption/data/obd2/trip_live_reading.dart';
 
+/// One coach fire decision (#1273).
+///
+/// Emitted on the lifecycle provider's `coachEvents` stream every time
+/// the heuristic in [HapticEcoCoach] decides to nudge the driver. The
+/// haptic surface and the visual SnackBar both subscribe to the same
+/// stream so they share the 30 s cooldown — there is exactly one
+/// decision per fire window, never one per surface.
+@immutable
+class CoachEvent {
+  /// Wall-clock instant of the fire decision (matches the value the
+  /// coach used to update its internal cooldown gate). Tests assert on
+  /// this to verify cooldown sequencing without `Future.delayed`.
+  final DateTime triggeredAt;
+
+  const CoachEvent({required this.triggeredAt});
+}
+
 /// Real-time eco-coaching haptic (#1122).
 ///
 /// Pure wheel-lens feature: fires a gentle haptic when the driver is
@@ -44,6 +61,7 @@ class HapticEcoCoach {
   HapticEcoCoach({
     required this.readings,
     Future<void> Function()? haptic,
+    this.onFire,
     this.windowSize = const Duration(seconds: 5),
     this.throttleThresholdPercent = 75.0,
     this.maxSpeedDeltaKmh = 10.0,
@@ -62,6 +80,14 @@ class HapticEcoCoach {
   /// Defaults to [HapticFeedback.mediumImpact]. Tests inject a captor
   /// so they can count fires deterministically.
   final Future<void> Function() haptic;
+
+  /// Fan-out callback fired alongside [haptic] on every fire decision
+  /// (#1273). The lifecycle provider plumbs this into a broadcast
+  /// `Stream<CoachEvent>` that the visual SnackBar subscribes to, so
+  /// the haptic and visual surfaces share the SAME 30 s cooldown — one
+  /// decision per match, never one per surface. Optional: tests that
+  /// only care about the haptic count leave it null.
+  final void Function(CoachEvent event)? onFire;
 
   /// Rolling-window length the heuristic averages over. Bigger windows
   /// smooth out short stabs but lag the user's actual behaviour;
@@ -129,6 +155,12 @@ class HapticEcoCoach {
     if (!_inCooldown(now) && _heuristicMatches()) {
       _lastFireAt = now;
       _fireHaptic();
+      // Fire the visual / event-stream surface AFTER the haptic so a
+      // synchronous subscriber can rely on the cooldown gate having
+      // already advanced. Errors here are swallowed via the same
+      // logger path as the haptic — a SnackBar push must never kill
+      // the live-readings subscription (#1273).
+      _fireEvent(now);
     }
   }
 
@@ -216,6 +248,29 @@ class HapticEcoCoach {
         },
       );
     });
+  }
+
+  /// Fire the visual / event-stream subscriber (#1273). The callback
+  /// is optional — code paths that don't need a visual surface (the
+  /// existing pure-haptic test suite) construct a coach without
+  /// `onFire` and pay nothing. Errors are routed through the same
+  /// logger so a SnackBar push that throws can't kill the readings
+  /// subscription.
+  void _fireEvent(DateTime triggeredAt) {
+    final cb = onFire;
+    if (cb == null) return;
+    try {
+      cb(CoachEvent(triggeredAt: triggeredAt));
+    } catch (e, st) {
+      errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: <String, Object?>{
+          'where': 'HapticEcoCoach.onFire',
+        },
+      );
+    }
   }
 }
 

--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -63,7 +63,8 @@ class DrivingSettingsSection extends ConsumerWidget {
           ),
           subtitle: Text(
             l?.hapticEcoCoachSettingSubtitle ??
-                'Gentle haptic when you floor it during cruise',
+                'Gentle haptic + on-screen tip when you floor it '
+                    'during cruise',
             style: theme.textTheme.bodySmall,
           ),
           onChanged: (v) =>

--- a/lib/features/driving/providers/haptic_eco_coach_provider.dart
+++ b/lib/features/driving/providers/haptic_eco_coach_provider.dart
@@ -60,6 +60,26 @@ class HapticEcoCoachLifecycle extends _$HapticEcoCoachLifecycle {
   StreamSubscription<TripLiveReading>? _coachSub;
   TripLiveReading? _lastForwardedReading;
 
+  /// Long-lived broadcast controller for [CoachEvent]s (#1273). Stays
+  /// open for the app's lifetime — cleaning it up on `_teardown`
+  /// would race the recording screen, which subscribes once in
+  /// `initState` and unsubscribes in `dispose`. Multiple subscribers
+  /// (haptic isn't one — that path is direct in [HapticEcoCoach]) can
+  /// attach safely; today there's exactly one (the trip-recording
+  /// screen).
+  // ignore: close_sinks — broadcast lives for the app's lifetime; see
+  //   the comment on [coachEvents] for why we don't close it on each
+  //   trip teardown.
+  final StreamController<CoachEvent> _coachEventsController =
+      StreamController<CoachEvent>.broadcast();
+
+  /// Public broadcast stream of fire decisions (#1273). The trip
+  /// recording screen subscribes in `initState`, shows a SnackBar per
+  /// event, and cancels in `dispose`. Other routes (summary, history,
+  /// home) DO NOT subscribe — that's how we guarantee the visual
+  /// surface only fires while the user is on the recording screen.
+  Stream<CoachEvent> get coachEvents => _coachEventsController.stream;
+
   @override
   void build() {
     final enabled = ref.watch(hapticEcoCoachEnabledProvider);
@@ -79,7 +99,10 @@ class HapticEcoCoachLifecycle extends _$HapticEcoCoachLifecycle {
     // ignore: close_sinks
     final bridge = StreamController<TripLiveReading>.broadcast();
     _bridge = bridge;
-    final coach = HapticEcoCoach(readings: bridge.stream);
+    final coach = HapticEcoCoach(
+      readings: bridge.stream,
+      onFire: _emitCoachEvent,
+    );
     _coachSub = coach.start();
 
     // Forward state updates into the bridge. `ref.listen` fires once
@@ -94,7 +117,22 @@ class HapticEcoCoachLifecycle extends _$HapticEcoCoachLifecycle {
       bridge.add(reading);
     });
 
-    ref.onDispose(_teardown);
+    ref.onDispose(() {
+      _teardown();
+      // The broadcast controller for coach events stays open across
+      // trip-teardown / re-arm cycles — its lifecycle matches the
+      // provider's `keepAlive: true`. We only close it if the
+      // provider itself is being disposed permanently (e.g. test
+      // ProviderContainer.dispose).
+      if (!_coachEventsController.isClosed) {
+        _coachEventsController.close();
+      }
+    });
+  }
+
+  void _emitCoachEvent(CoachEvent event) {
+    if (_coachEventsController.isClosed) return;
+    _coachEventsController.add(event);
   }
 
   void _teardown() {

--- a/lib/features/driving/providers/haptic_eco_coach_provider.g.dart
+++ b/lib/features/driving/providers/haptic_eco_coach_provider.g.dart
@@ -179,7 +179,7 @@ final class HapticEcoCoachLifecycleProvider
 }
 
 String _$hapticEcoCoachLifecycleHash() =>
-    r'0865ff3eaea0b7b6755bed041cbac5fb965a4ec1';
+    r'71655a3b166a44fe287914f68cab58f66aad70fd';
 
 /// Active subscription that bridges the trip-recording state stream
 /// to a [HapticEcoCoach]. Held by Riverpod for the duration of an

--- a/lib/l10n/_fragments/haptic_eco_coach_de.arb
+++ b/lib/l10n/_fragments/haptic_eco_coach_de.arb
@@ -1,5 +1,6 @@
 {
   "hapticEcoCoachSectionTitle": "Fahrweise",
   "hapticEcoCoachSettingTitle": "Echtzeit-Eco-Coaching",
-  "hapticEcoCoachSettingSubtitle": "Sanfte Vibration bei zu starker Beschleunigung im Reisemodus"
+  "hapticEcoCoachSettingSubtitle": "Sanftes Vibrieren + Hinweis am Bildschirm, wenn du beim Cruisen aufs Pedal trittst",
+  "hapticEcoCoachSnackBarMessage": "Locker vom Pedal — Ausrollen spart mehr"
 }

--- a/lib/l10n/_fragments/haptic_eco_coach_en.arb
+++ b/lib/l10n/_fragments/haptic_eco_coach_en.arb
@@ -7,8 +7,12 @@
   "@hapticEcoCoachSettingTitle": {
     "description": "Title of the haptic-eco-coach toggle on the Settings screen (#1122)."
   },
-  "hapticEcoCoachSettingSubtitle": "Gentle haptic when you floor it during cruise",
+  "hapticEcoCoachSettingSubtitle": "Gentle haptic + on-screen tip when you floor it during cruise",
   "@hapticEcoCoachSettingSubtitle": {
-    "description": "Subtitle/explanation of the haptic-eco-coach toggle on the Settings screen (#1122). Describes the heuristic in user-facing terms."
+    "description": "Subtitle/explanation of the haptic-eco-coach toggle on the Settings screen (#1122). Describes both the haptic and visual surfaces in user-facing terms (#1273)."
+  },
+  "hapticEcoCoachSnackBarMessage": "Easy on the throttle — coasting saves more",
+  "@hapticEcoCoachSnackBarMessage": {
+    "description": "SnackBar copy shown on the trip-recording screen when the eco-coach heuristic fires (#1273). Co-located with the haptic; same toggle gates both surfaces."
   }
 }

--- a/lib/l10n/_fragments/trip_recording_pin_de.arb
+++ b/lib/l10n/_fragments/trip_recording_pin_de.arb
@@ -10,5 +10,9 @@
   "tripRecordingPinSemanticOff": "Aufnahmeformular anpinnen",
   "@tripRecordingPinSemanticOff": {
     "description": "Accessibility label when the pin toggle is currently OFF. Tapping will pin (enable wake lock + immersive mode)."
-  }
+  },
+  "tripRecordingPinHelpTooltip": "Was macht das Anpinnen?",
+  "tripRecordingPinHelpTitle": "Über das Anpinnen",
+  "tripRecordingPinHelpBody": "Anpinnen hält den Bildschirm an und blendet die Systemleisten aus, damit das Formular auf einer Armaturenhalterung lesbar bleibt. Erneut tippen, um zu lösen. Wird automatisch beendet, wenn die Fahrt stoppt.",
+  "tripRecordingResumeHintMessage": "Die Aufnahme läuft im Hintergrund weiter. Tippe oben auf das rote Banner, um zurückzukehren."
 }

--- a/lib/l10n/_fragments/trip_recording_pin_en.arb
+++ b/lib/l10n/_fragments/trip_recording_pin_en.arb
@@ -10,5 +10,21 @@
   "tripRecordingPinSemanticOff": "Pin recording form",
   "@tripRecordingPinSemanticOff": {
     "description": "Accessibility label when the pin toggle is currently OFF. Tapping will pin (enable wake lock + immersive mode)."
+  },
+  "tripRecordingPinHelpTooltip": "What does pin do?",
+  "@tripRecordingPinHelpTooltip": {
+    "description": "Tooltip on the help (?) icon adjacent to the pin button (#1273). Tapping opens a bottom sheet explaining what pin does."
+  },
+  "tripRecordingPinHelpTitle": "About pin",
+  "@tripRecordingPinHelpTitle": {
+    "description": "Title of the bottom sheet explaining the pin button (#1273)."
+  },
+  "tripRecordingPinHelpBody": "Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.",
+  "@tripRecordingPinHelpBody": {
+    "description": "Body text in the bottom sheet explaining the pin button (#1273)."
+  },
+  "tripRecordingResumeHintMessage": "Recording continues in the background. Tap the red banner at the top of any screen to return.",
+  "@tripRecordingResumeHintMessage": {
+    "description": "One-time tooltip shown the first time the user backs out of the recording screen while a trip is still recording (#1273). Tells them they can tap the persistent banner to return. Persisted dismissal — never fires twice."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1446,7 +1446,8 @@
   },
   "hapticEcoCoachSectionTitle": "Fahrweise",
   "hapticEcoCoachSettingTitle": "Echtzeit-Eco-Coaching",
-  "hapticEcoCoachSettingSubtitle": "Sanfte Vibration bei zu starker Beschleunigung im Reisemodus",
+  "hapticEcoCoachSettingSubtitle": "Sanftes Vibrieren + Hinweis am Bildschirm, wenn du beim Cruisen aufs Pedal trittst",
+  "hapticEcoCoachSnackBarMessage": "Locker vom Pedal — Ausrollen spart mehr",
   "loyaltySettingsTitle": "Tankstellen-Kundenkarten",
   "loyaltySettingsSubtitle": "Treuerabatt automatisch auf den angezeigten Preis anwenden",
   "loyaltyMenuTitle": "Tankstellen-Kundenkarten",
@@ -1607,6 +1608,10 @@
   "@tripRecordingPinSemanticOff": {
     "description": "Accessibility label when the pin toggle is currently OFF. Tapping will pin (enable wake lock + immersive mode)."
   },
+  "tripRecordingPinHelpTooltip": "Was macht das Anpinnen?",
+  "tripRecordingPinHelpTitle": "Über das Anpinnen",
+  "tripRecordingPinHelpBody": "Anpinnen hält den Bildschirm an und blendet die Systemleisten aus, damit das Formular auf einer Armaturenhalterung lesbar bleibt. Erneut tippen, um zu lösen. Wird automatisch beendet, wenn die Fahrt stoppt.",
+  "tripRecordingResumeHintMessage": "Die Aufnahme läuft im Hintergrund weiter. Tippe oben auf das rote Banner, um zurückzukehren.",
   "vinLabel": "FIN (optional)",
   "vinDecodeTooltip": "FIN entschlüsseln",
   "vinConfirmAction": "Ja, automatisch ausfüllen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2030,9 +2030,13 @@
   "@hapticEcoCoachSettingTitle": {
     "description": "Title of the haptic-eco-coach toggle on the Settings screen (#1122)."
   },
-  "hapticEcoCoachSettingSubtitle": "Gentle haptic when you floor it during cruise",
+  "hapticEcoCoachSettingSubtitle": "Gentle haptic + on-screen tip when you floor it during cruise",
   "@hapticEcoCoachSettingSubtitle": {
-    "description": "Subtitle/explanation of the haptic-eco-coach toggle on the Settings screen (#1122). Describes the heuristic in user-facing terms."
+    "description": "Subtitle/explanation of the haptic-eco-coach toggle on the Settings screen (#1122). Describes both the haptic and visual surfaces in user-facing terms (#1273)."
+  },
+  "hapticEcoCoachSnackBarMessage": "Easy on the throttle — coasting saves more",
+  "@hapticEcoCoachSnackBarMessage": {
+    "description": "SnackBar copy shown on the trip-recording screen when the eco-coach heuristic fires (#1273). Co-located with the haptic; same toggle gates both surfaces."
   },
   "loyaltySettingsTitle": "Fuel club cards",
   "@loyaltySettingsTitle": {
@@ -2687,6 +2691,22 @@
   "tripRecordingPinSemanticOff": "Pin recording form",
   "@tripRecordingPinSemanticOff": {
     "description": "Accessibility label when the pin toggle is currently OFF. Tapping will pin (enable wake lock + immersive mode)."
+  },
+  "tripRecordingPinHelpTooltip": "What does pin do?",
+  "@tripRecordingPinHelpTooltip": {
+    "description": "Tooltip on the help (?) icon adjacent to the pin button (#1273). Tapping opens a bottom sheet explaining what pin does."
+  },
+  "tripRecordingPinHelpTitle": "About pin",
+  "@tripRecordingPinHelpTitle": {
+    "description": "Title of the bottom sheet explaining the pin button (#1273)."
+  },
+  "tripRecordingPinHelpBody": "Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.",
+  "@tripRecordingPinHelpBody": {
+    "description": "Body text in the bottom sheet explaining the pin button (#1273)."
+  },
+  "tripRecordingResumeHintMessage": "Recording continues in the background. Tap the red banner at the top of any screen to return.",
+  "@tripRecordingResumeHintMessage": {
+    "description": "One-time tooltip shown the first time the user backs out of the recording screen while a trip is still recording (#1273). Tells them they can tap the persistent banner to return. Persisted dismissal — never fires twice."
   },
   "vinLabel": "VIN (optional)",
   "vinDecodeTooltip": "Decode VIN",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6686,11 +6686,17 @@ abstract class AppLocalizations {
   /// **'Real-time eco coaching'**
   String get hapticEcoCoachSettingTitle;
 
-  /// Subtitle/explanation of the haptic-eco-coach toggle on the Settings screen (#1122). Describes the heuristic in user-facing terms.
+  /// Subtitle/explanation of the haptic-eco-coach toggle on the Settings screen (#1122). Describes both the haptic and visual surfaces in user-facing terms (#1273).
   ///
   /// In en, this message translates to:
-  /// **'Gentle haptic when you floor it during cruise'**
+  /// **'Gentle haptic + on-screen tip when you floor it during cruise'**
   String get hapticEcoCoachSettingSubtitle;
+
+  /// SnackBar copy shown on the trip-recording screen when the eco-coach heuristic fires (#1273). Co-located with the haptic; same toggle gates both surfaces.
+  ///
+  /// In en, this message translates to:
+  /// **'Easy on the throttle — coasting saves more'**
+  String get hapticEcoCoachSnackBarMessage;
 
   /// Title of the loyalty settings sub-screen where the user manages fuel-club cards (#1120).
   ///
@@ -7531,6 +7537,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Pin recording form'**
   String get tripRecordingPinSemanticOff;
+
+  /// Tooltip on the help (?) icon adjacent to the pin button (#1273). Tapping opens a bottom sheet explaining what pin does.
+  ///
+  /// In en, this message translates to:
+  /// **'What does pin do?'**
+  String get tripRecordingPinHelpTooltip;
+
+  /// Title of the bottom sheet explaining the pin button (#1273).
+  ///
+  /// In en, this message translates to:
+  /// **'About pin'**
+  String get tripRecordingPinHelpTitle;
+
+  /// Body text in the bottom sheet explaining the pin button (#1273).
+  ///
+  /// In en, this message translates to:
+  /// **'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.'**
+  String get tripRecordingPinHelpBody;
+
+  /// One-time tooltip shown the first time the user backs out of the recording screen while a trip is still recording (#1273). Tells them they can tap the persistent banner to return. Persisted dismissal — never fires twice.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording continues in the background. Tap the red banner at the top of any screen to return.'**
+  String get tripRecordingResumeHintMessage;
 
   /// No description provided for @vinLabel.
   ///

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3587,7 +3587,11 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4065,6 +4069,20 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3587,7 +3587,11 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4065,6 +4069,20 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3585,7 +3585,11 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4063,6 +4067,20 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3619,7 +3619,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Sanfte Vibration bei zu starker Beschleunigung im Reisemodus';
+      'Sanftes Vibrieren + Hinweis am Bildschirm, wenn du beim Cruisen aufs Pedal trittst';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Locker vom Pedal — Ausrollen spart mehr';
 
   @override
   String get loyaltySettingsTitle => 'Tankstellen-Kundenkarten';
@@ -4101,6 +4105,20 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Aufnahmeformular anpinnen';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'Was macht das Anpinnen?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'Über das Anpinnen';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Anpinnen hält den Bildschirm an und blendet die Systemleisten aus, damit das Formular auf einer Armaturenhalterung lesbar bleibt. Erneut tippen, um zu lösen. Wird automatisch beendet, wenn die Fahrt stoppt.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Die Aufnahme läuft im Hintergrund weiter. Tippe oben auf das rote Banner, um zurückzukehren.';
 
   @override
   String get vinLabel => 'FIN (optional)';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3589,7 +3589,11 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4067,6 +4071,20 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3580,7 +3580,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4058,6 +4062,20 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3588,7 +3588,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4066,6 +4070,20 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3582,7 +3582,11 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4060,6 +4064,20 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3585,7 +3585,11 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4063,6 +4067,20 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3615,7 +3615,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4099,6 +4103,20 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optionnel)';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3584,7 +3584,11 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4062,6 +4066,20 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3589,7 +3589,11 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4067,6 +4071,20 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3588,7 +3588,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4066,6 +4070,20 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3586,7 +3586,11 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4064,6 +4068,20 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3588,7 +3588,11 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4066,6 +4070,20 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3584,7 +3584,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4062,6 +4066,20 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3589,7 +3589,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4067,6 +4071,20 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3587,7 +3587,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4065,6 +4069,20 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3588,7 +3588,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4066,6 +4070,20 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3587,7 +3587,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4065,6 +4069,20 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3588,7 +3588,11 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4066,6 +4070,20 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3582,7 +3582,11 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4060,6 +4064,20 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3586,7 +3586,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get hapticEcoCoachSettingSubtitle =>
-      'Gentle haptic when you floor it during cruise';
+      'Gentle haptic + on-screen tip when you floor it during cruise';
+
+  @override
+  String get hapticEcoCoachSnackBarMessage =>
+      'Easy on the throttle — coasting saves more';
 
   @override
   String get loyaltySettingsTitle => 'Fuel club cards';
@@ -4064,6 +4068,20 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get tripRecordingPinSemanticOff => 'Pin recording form';
+
+  @override
+  String get tripRecordingPinHelpTooltip => 'What does pin do?';
+
+  @override
+  String get tripRecordingPinHelpTitle => 'About pin';
+
+  @override
+  String get tripRecordingPinHelpBody =>
+      'Pin keeps the screen on and hides system bars so the form stays readable on a dashboard mount. Tap again to release. Auto-releases when the trip stops.';
+
+  @override
+  String get tripRecordingResumeHintMessage =>
+      'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
@@ -1,0 +1,443 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+import 'package:tankstellen/features/driving/haptic_eco_coach.dart';
+import 'package:tankstellen/features/driving/providers/haptic_eco_coach_provider.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// #1273 — visual eco-coach SnackBar + pin help bottom sheet + one-time
+/// resume tooltip.
+///
+/// These tests pin the screen-side wiring of the three sub-features:
+///
+///   * SnackBar appears when the lifecycle provider emits a [CoachEvent]
+///     while the recording screen is mounted.
+///   * SnackBar does NOT appear after the screen has been disposed
+///     (i.e. user navigated to summary / history / home).
+///   * Tapping the `?` icon adjacent to the pin opens a bottom sheet.
+///   * On the FIRST back-out while recording, the resume tooltip
+///     SnackBar appears AND the dismissal is persisted.
+///   * Subsequent back-outs (Hive flag = true) silently pop with no
+///     tooltip.
+///
+/// To exercise the SnackBar wiring we override the
+/// [hapticEcoCoachLifecycleProvider] with a fake whose `coachEvents`
+/// stream we control directly. The real provider's emission gating
+/// (toggle-off → no events) is covered in the provider-level test;
+/// here we confirm the screen handles whatever the provider hands it.
+
+class _FakeWakelockFacade implements WakelockFacade {
+  @override
+  Future<void> enable() async {}
+
+  @override
+  Future<void> disable() async {}
+}
+
+class _FakeTripRecording extends TripRecording {
+  _FakeTripRecording(this._initial);
+
+  final TripRecordingState _initial;
+
+  @override
+  TripRecordingState build() => _initial;
+
+  @override
+  Future<StoppedTripResult> stop({bool automatic = false}) async {
+    state = state.copyWith(phase: TripRecordingPhase.finished);
+    return const StoppedTripResult(
+      summary: TripSummary(
+        distanceKm: 0,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+      ),
+      odometerStartKm: null,
+      odometerLatestKm: null,
+    );
+  }
+
+  @override
+  void reset() {
+    state = const TripRecordingState();
+  }
+}
+
+/// Fake lifecycle that bypasses Riverpod's `keepAlive` machinery. We
+/// override the public `coachEvents` getter via a controller the test
+/// holds, so the test can pump events at any moment to exercise the
+/// screen subscription.
+class _FakeHapticEcoCoachLifecycle extends HapticEcoCoachLifecycle {
+  _FakeHapticEcoCoachLifecycle(this._controller);
+
+  final StreamController<CoachEvent> _controller;
+
+  @override
+  Stream<CoachEvent> get coachEvents => _controller.stream;
+
+  @override
+  void build() {
+    // Skip the real wiring — we control emission directly through
+    // `_controller` so the screen's subscription runs in isolation.
+  }
+}
+
+TripRecordingState _recordingState() {
+  return const TripRecordingState(
+    phase: TripRecordingPhase.recording,
+    situation: DrivingSituation.highwayCruise,
+    band: ConsumptionBand.normal,
+  );
+}
+
+Future<void> _pumpRecordingScreen(
+  WidgetTester tester, {
+  required StreamController<CoachEvent> coachEventsController,
+  TripRecordingState? state,
+}) async {
+  await pumpApp(
+    tester,
+    const TripRecordingScreen(),
+    overrides: [
+      tripRecordingProvider.overrideWith(
+        () => _FakeTripRecording(state ?? _recordingState()),
+      ),
+      wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+      hapticEcoCoachLifecycleProvider
+          .overrideWith(() => _FakeHapticEcoCoachLifecycle(
+                coachEventsController,
+              )),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TripRecordingScreen visual eco-coach SnackBar (#1273)', () {
+    late StreamController<CoachEvent> events;
+
+    setUp(() {
+      events = StreamController<CoachEvent>.broadcast();
+    });
+
+    tearDown(() async {
+      await events.close();
+    });
+
+    testWidgets('emits SnackBar with the expected copy when the lifecycle '
+        'provider pushes a CoachEvent', (tester) async {
+      await _pumpRecordingScreen(tester, coachEventsController: events);
+
+      // Sanity: no SnackBar before any event.
+      expect(find.byKey(const Key('hapticEcoCoachSnackBar')), findsNothing);
+      expect(
+        find.text('Easy on the throttle — coasting saves more'),
+        findsNothing,
+      );
+
+      // Push a fire decision through the lifecycle stream.
+      events.add(CoachEvent(triggeredAt: DateTime(2026, 4, 28, 12)));
+      // pump+pump(50ms) per Hive widget-test convention; SnackBar
+      // entry animation runs in 250ms so we pump generously.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+
+      expect(
+        find.byKey(const Key('hapticEcoCoachSnackBar')),
+        findsOneWidget,
+        reason: 'SnackBar must appear when the lifecycle stream pushes an '
+            'event while the recording screen is mounted.',
+      );
+      expect(
+        find.text('Easy on the throttle — coasting saves more'),
+        findsOneWidget,
+        reason: 'SnackBar carries the localized eco-coach copy.',
+      );
+    });
+
+    testWidgets('SnackBar disappears after navigating away — events emitted '
+        'after dispose do NOT show on the next route', (tester) async {
+      // Mount inside a Navigator so we can pop the recording screen
+      // and verify a subsequent event doesn't surface anywhere.
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) => ElevatedButton(
+            key: const Key('openRecordingScreen'),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const TripRecordingScreen(),
+                ),
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+        overrides: [
+          tripRecordingProvider.overrideWith(
+            () => _FakeTripRecording(_recordingState()),
+          ),
+          wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+          hapticEcoCoachLifecycleProvider
+              .overrideWith(() => _FakeHapticEcoCoachLifecycle(events)),
+        ],
+      );
+
+      await tester.tap(find.byKey(const Key('openRecordingScreen')));
+      await tester.pumpAndSettle();
+
+      // While mounted: event surfaces.
+      events.add(CoachEvent(triggeredAt: DateTime(2026, 4, 28, 12)));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(find.byKey(const Key('hapticEcoCoachSnackBar')), findsOneWidget);
+
+      // Dismiss the existing SnackBar so the next assertion isn't
+      // confused by lingering state.
+      ScaffoldMessenger.of(
+        tester.element(find.byKey(const Key('hapticEcoCoachSnackBar'))),
+      ).hideCurrentSnackBar();
+      await tester.pumpAndSettle();
+
+      // Pop back to the launcher — disposes the recording screen.
+      Navigator.of(tester.element(find.byKey(const Key('tripPinButton'))))
+          .pop();
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('tripPinButton')), findsNothing,
+          reason: 'recording screen must be off-screen now');
+
+      // Emit another event — nothing should show on the launcher
+      // route. Defense-in-depth: the only subscriber was the
+      // recording-screen state, which is disposed.
+      events.add(CoachEvent(triggeredAt: DateTime(2026, 4, 28, 12, 1)));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(
+        find.byKey(const Key('hapticEcoCoachSnackBar')),
+        findsNothing,
+        reason: 'After dispose, post-dispose events must not surface — '
+            'the subscription is the only path to the SnackBar.',
+      );
+    });
+  });
+
+  group('TripRecordingScreen pin help (#1273)', () {
+    late StreamController<CoachEvent> events;
+
+    setUp(() {
+      events = StreamController<CoachEvent>.broadcast();
+    });
+
+    tearDown(() async {
+      await events.close();
+    });
+
+    testWidgets('tapping the ? icon opens a bottom sheet with the pin help '
+        'copy', (tester) async {
+      await _pumpRecordingScreen(tester, coachEventsController: events);
+
+      final helpButton = find.byKey(const Key('tripPinHelpButton'));
+      expect(helpButton, findsOneWidget,
+          reason: 'pin help button must be in the AppBar actions');
+
+      await tester.tap(helpButton);
+      await tester.pumpAndSettle();
+
+      // Title in the bottom sheet.
+      expect(find.text('About pin'), findsOneWidget);
+      // Body in the bottom sheet — assert via `textContaining` so a
+      // trailing space / line break shift doesn't break the test.
+      expect(
+        find.textContaining('keeps the screen on'),
+        findsOneWidget,
+        reason: 'Body must explain what pin does in user-facing copy.',
+      );
+    });
+
+    testWidgets('? icon is visible regardless of whether the pin is on or off',
+        (tester) async {
+      await _pumpRecordingScreen(tester, coachEventsController: events);
+
+      // Unpinned: help button visible.
+      expect(find.byKey(const Key('tripPinHelpButton')), findsOneWidget);
+
+      // Pin → help still visible.
+      await tester.tap(find.byKey(const Key('tripPinButton')));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('tripPinHelpButton')), findsOneWidget);
+    });
+  });
+
+  group('TripRecordingScreen one-time resume tooltip (#1273)', () {
+    late StreamController<CoachEvent> events;
+
+    setUp(() {
+      events = StreamController<CoachEvent>.broadcast();
+    });
+
+    tearDown(() async {
+      await events.close();
+    });
+
+    testWidgets('first back-out while recording shows the tooltip and '
+        'persists the dismissal', (tester) async {
+      // Use an in-memory fake instead of real Hive to keep the test
+      // hermetic and avoid the well-known Windows hang during Hive
+      // tearDown (feedback_hive_widget_test_teardown.md). The
+      // persistence contract is the same — `getSetting` / `putSetting`
+      // round-trip through whatever the provider hands us.
+      final settings = _FakeSettingsStorage();
+      // Sanity: the flag must start absent.
+      expect(
+        settings.getSetting(StorageKeys.tripRecordingResumeHintShown),
+        isNull,
+      );
+
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) => ElevatedButton(
+            key: const Key('openRecordingScreen'),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const TripRecordingScreen(),
+                ),
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+        overrides: [
+          tripRecordingProvider.overrideWith(
+            () => _FakeTripRecording(_recordingState()),
+          ),
+          wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+          hapticEcoCoachLifecycleProvider
+              .overrideWith(() => _FakeHapticEcoCoachLifecycle(events)),
+          settingsStorageProvider.overrideWithValue(settings),
+        ],
+      );
+
+      await tester.tap(find.byKey(const Key('openRecordingScreen')));
+      await tester.pumpAndSettle();
+
+      // Tap the AppBar back button (the leading IconButton with the
+      // back arrow tooltip).
+      await tester.tap(find.byTooltip('Back'));
+      // Don't `pumpAndSettle` immediately — the SnackBar must surface
+      // before the pop animation completes. Pump a couple of frames.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+
+      expect(
+        find.byKey(const Key('tripRecordingResumeHintSnackBar')),
+        findsAtLeastNWidgets(1),
+        reason: 'First back-out while recording must show the resume hint. '
+            'Use findsAtLeast because the SnackBar can transiently appear '
+            'twice in the widget tree during the pop transition.',
+      );
+      expect(
+        find.textContaining('Tap the red banner'),
+        findsAtLeastNWidgets(1),
+        reason: 'SnackBar carries the localized resume copy.',
+      );
+
+      // Allow the pop animation to finish so the persistence write
+      // settles.
+      await tester.pumpAndSettle();
+      expect(
+        settings.data[StorageKeys.tripRecordingResumeHintShown],
+        isTrue,
+        reason:
+            'Dismissal must be persisted after the first back-out so the '
+            'tooltip never fires twice.',
+      );
+    });
+
+    testWidgets('subsequent back-out (flag = true) does NOT show the tooltip',
+        (tester) async {
+      final settings = _FakeSettingsStorage()
+        ..data[StorageKeys.tripRecordingResumeHintShown] = true;
+
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) => ElevatedButton(
+            key: const Key('openRecordingScreen'),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const TripRecordingScreen(),
+                ),
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+        overrides: [
+          tripRecordingProvider.overrideWith(
+            () => _FakeTripRecording(_recordingState()),
+          ),
+          wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+          hapticEcoCoachLifecycleProvider
+              .overrideWith(() => _FakeHapticEcoCoachLifecycle(events)),
+          settingsStorageProvider.overrideWithValue(settings),
+        ],
+      );
+
+      await tester.tap(find.byKey(const Key('openRecordingScreen')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Back'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+
+      expect(
+        find.byKey(const Key('tripRecordingResumeHintSnackBar')),
+        findsNothing,
+        reason: 'Returning users with the persisted flag must back-out '
+            'without seeing the tooltip again.',
+      );
+    });
+  });
+}
+
+/// In-memory fake of [SettingsStorage] for tests that want to verify
+/// the persistence contract without spinning up Hive (which can hang
+/// on Windows during tearDown — feedback_hive_widget_test_teardown.md).
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> data = {};
+
+  @override
+  dynamic getSetting(String key) => data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    data[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/driving/haptic_eco_coach_test.dart
+++ b/test/features/driving/haptic_eco_coach_test.dart
@@ -177,6 +177,83 @@ void main() {
       );
     });
 
+    test('onFire fires alongside the haptic on every fire decision (#1273)',
+        () async {
+      // Both surfaces (haptic + visual SnackBar) share the SAME 30 s
+      // cooldown via a single fire decision per match. Two fire
+      // windows < 30 s apart must fire neither callback the second
+      // time.
+      final clock = _Clock(DateTime(2026, 1, 1, 12, 0, 0));
+      var hapticCount = 0;
+      final events = <CoachEvent>[];
+      final coach = HapticEcoCoach(
+        readings: const Stream<TripLiveReading>.empty(),
+        haptic: () async => hapticCount++,
+        onFire: events.add,
+        clock: clock.now,
+      );
+
+      _feedConstant(
+        coach,
+        clock,
+        durationSeconds: 6,
+        intervalMs: 200,
+        throttle: 85.0,
+        speed: 120.0,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        hapticCount,
+        equals(1),
+        reason: 'Haptic fires once on the matching window.',
+      );
+      expect(
+        events.length,
+        equals(1),
+        reason:
+            'Visual surface event fires alongside the haptic — one '
+            'decision per match, never one per surface.',
+      );
+
+      // Second window inside the cooldown — neither surface fires.
+      clock.advance(const Duration(seconds: 10));
+      _feedConstant(
+        coach,
+        clock,
+        durationSeconds: 6,
+        intervalMs: 200,
+        throttle: 85.0,
+        speed: 120.0,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        hapticCount,
+        equals(1),
+        reason: 'Cooldown still applies to haptic.',
+      );
+      expect(
+        events.length,
+        equals(1),
+        reason:
+            'Cooldown applies to BOTH surfaces — they share one fire '
+            'decision so neither can race the other.',
+      );
+
+      // Past the cooldown — both fire again.
+      clock.advance(const Duration(seconds: 35));
+      _feedConstant(
+        coach,
+        clock,
+        durationSeconds: 6,
+        intervalMs: 200,
+        throttle: 85.0,
+        speed: 120.0,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(hapticCount, equals(2));
+      expect(events.length, equals(2));
+    });
+
     test('start() subscribes to the readings stream and forwards to heuristic',
         () async {
       final clock = _Clock(DateTime(2026, 1, 1, 12, 0, 0));

--- a/test/features/driving/providers/haptic_eco_coach_provider_test.dart
+++ b/test/features/driving/providers/haptic_eco_coach_provider_test.dart
@@ -3,6 +3,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_live_reading.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/driving/haptic_eco_coach.dart';
 import 'package:tankstellen/features/driving/providers/haptic_eco_coach_provider.dart';
 
 /// Provider-layer coverage for the [hapticEcoCoachEnabledProvider]
@@ -98,6 +103,100 @@ void main() {
       expect(container.read(hapticEcoCoachEnabledProvider), isFalse);
     });
   });
+
+  group('hapticEcoCoachLifecycleProvider.coachEvents (#1273)', () {
+    test('emits no events when the toggle is OFF — even with an active trip',
+        () async {
+      final fake = _FakeSettingsStorage();
+      final tripRecording = _ManualTripRecording();
+
+      final container = ProviderContainer(overrides: [
+        settingsStorageProvider.overrideWithValue(fake),
+        tripRecordingProvider.overrideWith(() => tripRecording),
+      ]);
+      addTearDown(container.dispose);
+
+      // Materialize the lifecycle provider so its `build` runs and the
+      // (empty, gated) bridge is created.
+      container.read(hapticEcoCoachLifecycleProvider);
+      final lifecycle =
+          container.read(hapticEcoCoachLifecycleProvider.notifier);
+      final received = <CoachEvent>[];
+      final sub = lifecycle.coachEvents.listen(received.add);
+      addTearDown(sub.cancel);
+
+      // Activate the trip — emission still gated by the toggle.
+      tripRecording.setActive(_recordingState());
+      // Yield so any pending stream events propagate before we assert.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        received,
+        isEmpty,
+        reason:
+            'Toggle OFF must gate the emission path even when a trip is '
+            'active — the visual surface only fires when the user opted '
+            'in via the haptic-eco-coach toggle.',
+      );
+    });
+
+    test('exposes a non-null broadcast stream so multiple subscribers can '
+        'attach', () async {
+      // The contract: `coachEvents` is a broadcast stream — the
+      // recording screen subscribes once, but a multi-subscriber
+      // shape future-proofs us for an additional surface (e.g.
+      // an in-app diagnostics overlay) without redesign.
+      final fake = _FakeSettingsStorage();
+      final tripRecording = _ManualTripRecording();
+      final container = ProviderContainer(overrides: [
+        settingsStorageProvider.overrideWithValue(fake),
+        tripRecordingProvider.overrideWith(() => tripRecording),
+      ]);
+      addTearDown(container.dispose);
+
+      container.read(hapticEcoCoachLifecycleProvider);
+      final lifecycle =
+          container.read(hapticEcoCoachLifecycleProvider.notifier);
+      final stream = lifecycle.coachEvents;
+      expect(stream.isBroadcast, isTrue,
+          reason:
+              'coachEvents must be a broadcast stream — single-subscription '
+              'streams would break multi-surface fan-out.');
+
+      // Verify two listeners can attach without throwing.
+      final a = stream.listen((_) {});
+      final b = stream.listen((_) {});
+      addTearDown(a.cancel);
+      addTearDown(b.cancel);
+    });
+  });
+}
+
+/// Manual `TripRecording` fake that lets the test flip phases without
+/// any OBD2 / Hive dependency. Only what the lifecycle provider's
+/// `build` reads (`isActive`, `live`) is exercised; the rest of the
+/// surface is deliberately untouched.
+class _ManualTripRecording extends TripRecording {
+  @override
+  TripRecordingState build() => const TripRecordingState();
+
+  void setActive(TripRecordingState s) {
+    state = s;
+  }
+}
+
+TripRecordingState _recordingState() {
+  return const TripRecordingState(
+    phase: TripRecordingPhase.recording,
+    situation: DrivingSituation.highwayCruise,
+    band: ConsumptionBand.normal,
+    live: TripLiveReading(
+      throttlePercent: 80,
+      speedKmh: 110,
+      distanceKmSoFar: 0,
+      elapsed: Duration(seconds: 1),
+    ),
+  );
 }
 
 class _FakeSettingsStorage implements SettingsStorage {


### PR DESCRIPTION
## Summary

Lands the three connected recording-screen UX gaps from #1273:

1. **Visual eco-coach** — co-located SnackBar fires alongside the haptic when the same toggle is on; both surfaces share the 30s cooldown via a `CoachEvent` stream exposed from the existing `HapticEcoCoachLifecycle`.
2. **Pin help** — `?` icon next to the pin button opens a brief bottom sheet explaining what pin does.
3. **Resume help** — one-time tooltip on first back-out from the recording screen, anchored at the `TripRecordingBanner`. Persists dismissal in Hive.

## Test plan

- [x] `flutter analyze` clean
- [x] Coach event stream tests (toggle on/off, cooldown shared)
- [x] SnackBar visibility tests (recording screen only)
- [x] Pin help bottom sheet test
- [x] One-time tooltip tests (first vs. second back-out)
- [ ] CI green on `analyze` + `test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)