### PR TITLE
refactor(consumption): extract gear_inference helpers (Refs #563 phase: gear_inference)

### DIFF
--- a/lib/features/consumption/domain/services/_gear_clustering.dart
+++ b/lib/features/consumption/domain/services/_gear_clustering.dart
@@ -1,0 +1,69 @@
+/// Internal clustering helpers for the gear-inference pipeline
+/// (#1263 phase 1).
+///
+/// Split out of `gear_inference.dart` to keep that file under the
+/// 300-LOC budget (Refs #563). Library-private (`part of`) — no public
+/// API surface changes. The helpers here are pure 1-D maths utilities;
+/// the main `inferGears` orchestrator in the parent file owns the
+/// idle-skip / outlier-trim / labelling concerns.
+part of 'gear_inference.dart';
+
+/// Internal: minimum speed (km/h) below which a sample is treated as
+/// idle / sub-threshold and skipped from clustering. The wheel-speed
+/// sensor on most cars is unreliable below ~5 km/h, and the resulting
+/// ratio inflates without bound.
+const double _minSpeedKmh = 5.0;
+
+/// Internal: minimum RPM below which a sample is treated as idle /
+/// engine-off and skipped. 500 RPM is well below any production
+/// engine's idle (which sits at 700–900) yet above the noise floor.
+const double _minRpm = 500.0;
+
+/// Internal: maximum k-means iterations. 1-D k-means converges fast;
+/// 10 is generous for trips with ~600 samples.
+const int _maxIterations = 10;
+
+/// Internal: relative centroid-shift threshold for early stopping.
+/// 0.5 % is well below the inter-gear separation on every
+/// transmission we've measured.
+const double _convergenceEpsilon = 0.005;
+
+/// Internal: linear-interpolation percentile on a pre-sorted list.
+/// `q` in `[0, 1]`. Returns the only element for length-1 inputs and
+/// the boundary element for `q <= 0` / `q >= 1`. Used to seed
+/// centroids and to bracket outliers.
+double _percentile(List<double> sortedAscending, double q) {
+  if (sortedAscending.isEmpty) {
+    return 0.0;
+  }
+  if (sortedAscending.length == 1) {
+    return sortedAscending[0];
+  }
+  if (q <= 0) return sortedAscending.first;
+  if (q >= 1) return sortedAscending.last;
+  final pos = q * (sortedAscending.length - 1);
+  final lo = pos.floor();
+  final hi = pos.ceil();
+  if (lo == hi) return sortedAscending[lo];
+  final frac = pos - lo;
+  return sortedAscending[lo] +
+      (sortedAscending[hi] - sortedAscending[lo]) * frac;
+}
+
+/// Internal: index of the centroid nearest to [value] in 1-D
+/// (Euclidean distance reduces to absolute difference). Ties go to
+/// the lower index — k-means is stable across iterations because
+/// the centroids' positions evolve smoothly and ties occur measure-
+/// zero in practice.
+int _nearestCentroid(List<double> centroids, double value) {
+  var bestIndex = 0;
+  var bestDistance = (centroids[0] - value).abs();
+  for (var c = 1; c < centroids.length; c++) {
+    final d = (centroids[c] - value).abs();
+    if (d < bestDistance) {
+      bestDistance = d;
+      bestIndex = c;
+    }
+  }
+  return bestIndex;
+}

--- a/lib/features/consumption/domain/services/_gear_coaching_metrics.dart
+++ b/lib/features/consumption/domain/services/_gear_coaching_metrics.dart
@@ -1,0 +1,99 @@
+/// Gear-based coaching metrics derived from [inferGears] output
+/// (#1263 phase 2).
+///
+/// Split out of `gear_inference.dart` to keep that file under the
+/// 300-LOC budget (Refs #563). Library-private (`part of`) — no public
+/// API surface changes; existing imports of `gear_inference.dart`
+/// continue to resolve `computeSecondsBelowOptimalGear` without churn.
+part of 'gear_inference.dart';
+
+/// Compute total seconds the trip spent below the optimal gear
+/// (one gear lower than where RPM would drop below
+/// [optimalRpmCeiling]). Pure — does not mutate inputs.
+///
+/// Heuristic: for each consecutive pair of [gearAssignments] where
+/// both have non-null gears AND the current gear is below the top
+/// inferred gear, ask "would the next gear up keep the engine at or
+/// above [optimalRpmCeiling] at the same speed?" If yes, the current
+/// gear is unnecessarily low — count the Δt in seconds. If no, the
+/// driver is already at the lowest gear that keeps RPM above the
+/// ceiling, so the current selection is acceptable.
+///
+/// The next-gear RPM is predicted by the centroid ratio:
+///
+/// ```
+///   nextGearRpm = currentRpm × centroids[gearIdx + 1]
+///                            / centroids[gearIdx]
+/// ```
+///
+/// Recall (see library docs) that centroids are sorted ascending and
+/// `centroidIndex = targetGearCount - gear`, so a higher gear maps to
+/// a lower centroid index. Going UP one gear means going DOWN one
+/// centroid index, and the centroids[lower] / centroids[higher]
+/// ratio is < 1 → predicted RPM drops, as intended.
+///
+/// Returns 0.0 when [gearAssignments] is empty or all gear values
+/// are null. Returns null when fewer than two distinct gears were
+/// inferred (can't compare to "next gear up").
+double? computeSecondsBelowOptimalGear({
+  required List<({DateTime timestamp, int? gear})> gearAssignments,
+  required double optimalRpmCeiling,
+  required List<TripSample> samples,
+  required List<double> centroids,
+}) {
+  // Need at least two distinct centroids to define a "next gear up";
+  // otherwise the heuristic isn't computable.
+  if (centroids.length < 2) return null;
+  if (gearAssignments.isEmpty) return 0.0;
+  if (gearAssignments.length != samples.length) {
+    // Defensive — a length mismatch would silently misalign per-pair
+    // RPM lookups. Return null rather than miscount.
+    return null;
+  }
+
+  // Determine the highest inferred gear we'll see — labels follow
+  // [inferGears]'s convention: gear = targetGearCount - centroidIndex,
+  // so the maximum gear label equals the centroids list length (which
+  // [inferGears] guarantees == targetGearCount on success). Computing
+  // it from the centroid count keeps this helper robust to callers
+  // that pass a shorter list.
+  final maxGear = centroids.length;
+
+  var totalSeconds = 0.0;
+  for (var i = 0; i < gearAssignments.length - 1; i++) {
+    final current = gearAssignments[i];
+    final next = gearAssignments[i + 1];
+    final gear = current.gear;
+    if (gear == null || next.gear == null) continue;
+    if (gear >= maxGear) continue; // already top gear, no "next up"
+
+    final dt =
+        next.timestamp.difference(current.timestamp).inMicroseconds /
+        Duration.microsecondsPerSecond;
+    if (dt <= 0) continue;
+
+    // Map the current gear label back to its centroid index. With
+    // gearLabel = targetGearCount - centroidIndex, the centroid index
+    // for the current gear is `maxGear - gear`, and the index for the
+    // next gear up (one physical gear higher) is `maxGear - (gear + 1)`.
+    final currentIdx = maxGear - gear;
+    final nextIdx = maxGear - (gear + 1);
+    // Defensive bounds — a malformed centroids list could produce
+    // out-of-range indices. Skip the pair rather than throw.
+    if (currentIdx < 0 || currentIdx >= centroids.length) continue;
+    if (nextIdx < 0 || nextIdx >= centroids.length) continue;
+    final currentCentroid = centroids[currentIdx];
+    if (currentCentroid <= 0) continue;
+
+    final currentRpm = samples[i].rpm;
+    final predictedNextGearRpm =
+        currentRpm * centroids[nextIdx] / currentCentroid;
+    if (predictedNextGearRpm >= optimalRpmCeiling) {
+      // The next gear up would still hold RPM above the ceiling, so
+      // the current gear was unnecessarily low — count this interval.
+      totalSeconds += dt;
+    }
+  }
+
+  return totalSeconds;
+}

--- a/lib/features/consumption/domain/services/gear_inference.dart
+++ b/lib/features/consumption/domain/services/gear_inference.dart
@@ -84,71 +84,18 @@
 /// Idle-only fixtures (every sample fails the idle-skip rule): the
 /// function returns an empty centroids list and `gear = null` for
 /// every input sample. No exceptions thrown.
+///
+/// Layout (Refs #563): split via `part` into `_models` (value
+/// classes), `_clustering` (helpers), `_coaching_metrics`. All public
+/// symbols still resolve via this file.
 library;
 
 import 'package:flutter/foundation.dart';
-
 import '../trip_recorder.dart';
 
-/// One sample's inferred gear label, paired with its source timestamp
-/// so the caller can re-align inferred gears with other per-sample
-/// metrics (engine load, throttle, etc.) without re-iterating the
-/// original `Iterable<TripSample>`.
-@immutable
-class InferredGearSample {
-  /// Source sample timestamp.
-  final DateTime timestamp;
-
-  /// Inferred gear label (1 = 1st gear, `targetGearCount` = top
-  /// gear). `null` when the sample was skipped — idle, sub-threshold,
-  /// or an outlier ratio. The caller must treat `null` as "no
-  /// signal" rather than "neutral".
-  final int? gear;
-
-  const InferredGearSample({required this.timestamp, required this.gear});
-}
-
-/// Output of [inferGears] — per-sample gear assignments plus the
-/// cluster centroids that produced them. The centroids are the
-/// caching unit: persist them on the per-vehicle profile so the next
-/// trip seeds with this trip's data and drifts gracefully across the
-/// fleet of trips for that vehicle.
-@immutable
-class GearInferenceResult {
-  /// Per-sample inferred gears, in the same order as the input
-  /// samples. `gear == null` for samples that were skipped (idle,
-  /// outlier, or — when no centroids could be computed — every
-  /// sample).
-  final List<InferredGearSample> samples;
-
-  /// Cluster centroids in ratio space, sorted ascending. Centroid at
-  /// index 0 corresponds to the top gear (e.g. 5th in a 5-speed);
-  /// centroid at index `length - 1` corresponds to 1st gear. Empty
-  /// when no valid samples were found (idle-only / no-data trips).
-  final List<double> centroids;
-
-  const GearInferenceResult({required this.samples, required this.centroids});
-}
-
-/// Internal: minimum speed (km/h) below which a sample is treated as
-/// idle / sub-threshold and skipped from clustering. The wheel-speed
-/// sensor on most cars is unreliable below ~5 km/h, and the resulting
-/// ratio inflates without bound.
-const double _minSpeedKmh = 5.0;
-
-/// Internal: minimum RPM below which a sample is treated as idle /
-/// engine-off and skipped. 500 RPM is well below any production
-/// engine's idle (which sits at 700–900) yet above the noise floor.
-const double _minRpm = 500.0;
-
-/// Internal: maximum k-means iterations. 1-D k-means converges fast;
-/// 10 is generous for trips with ~600 samples.
-const int _maxIterations = 10;
-
-/// Internal: relative centroid-shift threshold for early stopping.
-/// 0.5 % is well below the inter-gear separation on every
-/// transmission we've measured.
-const double _convergenceEpsilon = 0.005;
+part 'gear_inference_models.dart';
+part '_gear_clustering.dart';
+part '_gear_coaching_metrics.dart';
 
 /// Infer per-sample gears from a sequence of [TripSample]s using the
 /// engine-RPM / wheel-RPM ratio (gear-correlated drivetrain ratio).
@@ -273,11 +220,10 @@ GearInferenceResult inferGears({
     }
   }
 
-  // Centroid de-duplication: a degenerate fixture (test 5 — only 5
-  // samples total) will produce repeated quantile picks. K-means
-  // tolerates this — clusters with no assigned points keep their
-  // seed value — but we still return a sorted list so the contract
-  // holds.
+  // Centroid de-duplication: degenerate fixtures (e.g. test 5 with
+  // only 5 samples) produce repeated quantile picks. K-means tolerates
+  // this — empty clusters keep their seed value — but we still return
+  // a sorted list so the contract holds.
   centroids.sort();
 
   // K-means iterations.
@@ -339,143 +285,16 @@ GearInferenceResult inferGears({
 
   final out = <InferredGearSample>[];
   for (var i = 0; i < sampleList.length; i++) {
-    out.add(InferredGearSample(
-      timestamp: sampleList[i].timestamp,
-      gear: inferredByOriginalIndex[i],
-    ));
+    out.add(
+      InferredGearSample(
+        timestamp: sampleList[i].timestamp,
+        gear: inferredByOriginalIndex[i],
+      ),
+    );
   }
 
   return GearInferenceResult(
     samples: List<InferredGearSample>.unmodifiable(out),
     centroids: List<double>.unmodifiable(centroids),
   );
-}
-
-/// Compute total seconds the trip spent below the optimal gear
-/// (one gear lower than where RPM would drop below
-/// [optimalRpmCeiling]). Pure — does not mutate inputs.
-///
-/// Heuristic: for each consecutive pair of [gearAssignments] where
-/// both have non-null gears AND the current gear is below the top
-/// inferred gear, ask "would the next gear up keep the engine at or
-/// above [optimalRpmCeiling] at the same speed?" If yes, the current
-/// gear is unnecessarily low — count the Δt in seconds. If no, the
-/// driver is already at the lowest gear that keeps RPM above the
-/// ceiling, so the current selection is acceptable.
-///
-/// The next-gear RPM is predicted by the centroid ratio:
-///
-/// ```
-///   nextGearRpm = currentRpm × centroids[gearIdx + 1]
-///                            / centroids[gearIdx]
-/// ```
-///
-/// Recall (see library docs) that centroids are sorted ascending and
-/// `centroidIndex = targetGearCount - gear`, so a higher gear maps to
-/// a lower centroid index. Going UP one gear means going DOWN one
-/// centroid index, and the centroids[lower] / centroids[higher]
-/// ratio is < 1 → predicted RPM drops, as intended.
-///
-/// Returns 0.0 when [gearAssignments] is empty or all gear values
-/// are null. Returns null when fewer than two distinct gears were
-/// inferred (can't compare to "next gear up").
-double? computeSecondsBelowOptimalGear({
-  required List<({DateTime timestamp, int? gear})> gearAssignments,
-  required double optimalRpmCeiling,
-  required List<TripSample> samples,
-  required List<double> centroids,
-}) {
-  // Need at least two distinct centroids to define a "next gear up";
-  // otherwise the heuristic isn't computable.
-  if (centroids.length < 2) return null;
-  if (gearAssignments.isEmpty) return 0.0;
-  if (gearAssignments.length != samples.length) {
-    // Defensive — a length mismatch would silently misalign per-pair
-    // RPM lookups. Return null rather than miscount.
-    return null;
-  }
-
-  // Determine the highest inferred gear we'll see — labels follow
-  // [inferGears]'s convention: gear = targetGearCount - centroidIndex,
-  // so the maximum gear label equals the centroids list length (which
-  // [inferGears] guarantees == targetGearCount on success). Computing
-  // it from the centroid count keeps this helper robust to callers
-  // that pass a shorter list.
-  final maxGear = centroids.length;
-
-  var totalSeconds = 0.0;
-  for (var i = 0; i < gearAssignments.length - 1; i++) {
-    final current = gearAssignments[i];
-    final next = gearAssignments[i + 1];
-    final gear = current.gear;
-    if (gear == null || next.gear == null) continue;
-    if (gear >= maxGear) continue; // already top gear, no "next up"
-
-    final dt = next.timestamp.difference(current.timestamp).inMicroseconds /
-        Duration.microsecondsPerSecond;
-    if (dt <= 0) continue;
-
-    // Map the current gear label back to its centroid index. With
-    // gearLabel = targetGearCount - centroidIndex, the centroid index
-    // for the current gear is `maxGear - gear`, and the index for the
-    // next gear up (one physical gear higher) is `maxGear - (gear + 1)`.
-    final currentIdx = maxGear - gear;
-    final nextIdx = maxGear - (gear + 1);
-    // Defensive bounds — a malformed centroids list could produce
-    // out-of-range indices. Skip the pair rather than throw.
-    if (currentIdx < 0 || currentIdx >= centroids.length) continue;
-    if (nextIdx < 0 || nextIdx >= centroids.length) continue;
-    final currentCentroid = centroids[currentIdx];
-    if (currentCentroid <= 0) continue;
-
-    final currentRpm = samples[i].rpm;
-    final predictedNextGearRpm =
-        currentRpm * centroids[nextIdx] / currentCentroid;
-    if (predictedNextGearRpm >= optimalRpmCeiling) {
-      // The next gear up would still hold RPM above the ceiling, so
-      // the current gear was unnecessarily low — count this interval.
-      totalSeconds += dt;
-    }
-  }
-
-  return totalSeconds;
-}
-
-/// Internal: linear-interpolation percentile on a pre-sorted list.
-/// `q` in `[0, 1]`. Returns the only element for length-1 inputs and
-/// the boundary element for `q <= 0` / `q >= 1`. Used to seed
-/// centroids and to bracket outliers.
-double _percentile(List<double> sortedAscending, double q) {
-  if (sortedAscending.isEmpty) {
-    return 0.0;
-  }
-  if (sortedAscending.length == 1) {
-    return sortedAscending[0];
-  }
-  if (q <= 0) return sortedAscending.first;
-  if (q >= 1) return sortedAscending.last;
-  final pos = q * (sortedAscending.length - 1);
-  final lo = pos.floor();
-  final hi = pos.ceil();
-  if (lo == hi) return sortedAscending[lo];
-  final frac = pos - lo;
-  return sortedAscending[lo] + (sortedAscending[hi] - sortedAscending[lo]) * frac;
-}
-
-/// Internal: index of the centroid nearest to [value] in 1-D
-/// (Euclidean distance reduces to absolute difference). Ties go to
-/// the lower index — k-means is stable across iterations because
-/// the centroids' positions evolve smoothly and ties occur measure-
-/// zero in practice.
-int _nearestCentroid(List<double> centroids, double value) {
-  var bestIndex = 0;
-  var bestDistance = (centroids[0] - value).abs();
-  for (var c = 1; c < centroids.length; c++) {
-    final d = (centroids[c] - value).abs();
-    if (d < bestDistance) {
-      bestDistance = d;
-      bestIndex = c;
-    }
-  }
-  return bestIndex;
 }

--- a/lib/features/consumption/domain/services/gear_inference_models.dart
+++ b/lib/features/consumption/domain/services/gear_inference_models.dart
@@ -1,0 +1,48 @@
+/// Value objects for the gear-inference pipeline (#1263 phase 1).
+///
+/// Split out of `gear_inference.dart` to keep that file under the
+/// 300-LOC budget (Refs #563). Both classes remain in the same library
+/// via `part of` — no public API surface changes; existing imports of
+/// `gear_inference.dart` continue to resolve `InferredGearSample` and
+/// `GearInferenceResult` without churn.
+part of 'gear_inference.dart';
+
+/// One sample's inferred gear label, paired with its source timestamp
+/// so the caller can re-align inferred gears with other per-sample
+/// metrics (engine load, throttle, etc.) without re-iterating the
+/// original `Iterable<TripSample>`.
+@immutable
+class InferredGearSample {
+  /// Source sample timestamp.
+  final DateTime timestamp;
+
+  /// Inferred gear label (1 = 1st gear, `targetGearCount` = top
+  /// gear). `null` when the sample was skipped — idle, sub-threshold,
+  /// or an outlier ratio. The caller must treat `null` as "no
+  /// signal" rather than "neutral".
+  final int? gear;
+
+  const InferredGearSample({required this.timestamp, required this.gear});
+}
+
+/// Output of [inferGears] — per-sample gear assignments plus the
+/// cluster centroids that produced them. The centroids are the
+/// caching unit: persist them on the per-vehicle profile so the next
+/// trip seeds with this trip's data and drifts gracefully across the
+/// fleet of trips for that vehicle.
+@immutable
+class GearInferenceResult {
+  /// Per-sample inferred gears, in the same order as the input
+  /// samples. `gear == null` for samples that were skipped (idle,
+  /// outlier, or — when no centroids could be computed — every
+  /// sample).
+  final List<InferredGearSample> samples;
+
+  /// Cluster centroids in ratio space, sorted ascending. Centroid at
+  /// index 0 corresponds to the top gear (e.g. 5th in a 5-speed);
+  /// centroid at index `length - 1` corresponds to 1st gear. Empty
+  /// when no valid samples were found (idle-only / no-data trips).
+  final List<double> centroids;
+
+  const GearInferenceResult({required this.samples, required this.centroids});
+}


### PR DESCRIPTION
## Summary

`lib/features/consumption/domain/services/gear_inference.dart` was 481 LOC, well over the 300-LOC budget tracked by epic #563. Split via `part` into four co-libraried files, same library scope, no public API surface changes, behaviour bit-exact.

### New / changed files

| File | LOC | Role |
|---|---:|---|
| `lib/features/consumption/domain/services/gear_inference.dart` | **300** (was 481) | Library docstring + public `inferGears` orchestrator + `part` directives |
| `lib/features/consumption/domain/services/gear_inference_models.dart` | 48 | `InferredGearSample`, `GearInferenceResult` value classes |
| `lib/features/consumption/domain/services/_gear_clustering.dart` | 69 | k-means tuning constants + `_percentile` / `_nearestCentroid` helpers |
| `lib/features/consumption/domain/services/_gear_coaching_metrics.dart` | 99 | `computeSecondsBelowOptimalGear` coaching-metric helper |

The leading-underscore filenames + `part of` follow the existing `maintenance_analyzer.dart` ↔ `_maf_deviation_detector.dart` precedent in the same directory: same library scope keeps `_percentile` / `_nearestCentroid` library-private without re-exports, while filename convention signals "internal".

### Public API: unchanged

`import 'package:tankstellen/features/consumption/domain/services/gear_inference.dart';` continues to resolve all four public symbols:
- `inferGears(...)` → `GearInferenceResult`
- `computeSecondsBelowOptimalGear(...)` → `double?`
- `InferredGearSample` (class)
- `GearInferenceResult` (class)

Every existing import site (`trip_recording_controller.dart`, the three test files, etc.) compiles unchanged.

### Tests

All 18 cases in `test/features/consumption/domain/services/gear_inference_test.dart` pass **without modification** — the test file is the bit-exact behaviour spec for this refactor.

Verified locally:
- `flutter analyze` → No issues found
- `flutter test test/features/consumption/domain/services/gear_inference_test.dart` → 18/18 green
- Dependent tests also green:
  - `test/features/consumption/data/obd2/trip_recording_controller_gear_inference_test.dart` — 4/4
  - `test/features/consumption/presentation/widgets/driving_insights_card_low_gear_test.dart` — 7/7
- `flutter test test/lint/` → 29/29 green (no_silent_catch, prefer_const_constructors, etc.)

## Test plan

- [ ] CI `analyze` job passes
- [ ] CI `test` job runs the full suite (skipped locally — workers die ~50 % on the 5–7 min suite)
- [ ] No public-API churn: spot-check that `trip_recording_controller.dart` still resolves `inferGears`, `computeSecondsBelowOptimalGear`, `GearInferenceResult`, `InferredGearSample`

## Scope note

`Refs #563 phase: gear_inference` — this is one phase of the oversized-files epic. The epic stays open; the coordinator owns final closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)