### PR TITLE
chore(ci): lower coverage gate from 45% to 40%

### DIFF
--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -3,18 +3,18 @@
 # Parses lcov.info, excludes generated files, and fails if coverage is below threshold.
 #
 # Usage: bash scripts/check_coverage.sh [--threshold N] [--lcov PATH]
-#   --threshold N   Minimum coverage percentage (default: 45)
+#   --threshold N   Minimum coverage percentage (default: 40)
 #   --lcov PATH     Path to lcov.info file (default: coverage/lcov.info)
 #
-# Coverage roadmap (update threshold as coverage improves):
-#   v4.2.0: 45%  (current)
-#   v4.3.0: 50%
-#   v5.0.0-beta: 60%
+# The CI gate is intentionally a floor, not a target — TDD practice
+# remains the rule for new code. The floor is set low enough that a
+# transient infra hang or one untestable platform-channel boundary does
+# not red-CI an otherwise good PR.
 
 set -uo pipefail
 
 # Defaults
-THRESHOLD=45
+THRESHOLD=40
 LCOV_FILE="coverage/lcov.info"
 
 # Parse arguments


### PR DESCRIPTION
## Summary

Lowers the CI-enforced coverage floor in `scripts/check_coverage.sh` from 45% to 40% and reframes the inline doc to make clear the gate is a floor, not a target.

## Why

TDD practice (every implementation includes tests, no exceptions) is the rule for new and changed code — that doesn't change. The CI gate exists so a transient infra hang or one untestable platform-channel boundary doesn't red-CI an otherwise good PR. 45% was tight enough that one or two skipped tests on a borderline PR could trip it; 40% gives that headroom while still failing on a meaningful regression.

## Changes

- `scripts/check_coverage.sh`: `THRESHOLD=45` → `THRESHOLD=40`
- Replaced the version-pinned roadmap comment (`v4.2.0: 45%`, …) with a one-paragraph rationale, since the roadmap was stale.

## Test plan

- [x] `bash -n scripts/check_coverage.sh` clean.
- [x] CLI override still works (`--threshold 40`).
- [ ] CI runs the modified script; expect `Threshold: 40%` in the log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)