### PR TITLE
docs: redefine objective as three-layer cost reduction + v5.0.0 changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,79 @@
 ﻿# Tankstellen
 
-> **Smarter pump. Smarter drive. Save twice.**
+> **The cost of driving, attacked from three sides.**
 >
-> Every litre saved at the pump is a litre not burned on the road — and a kilogram of CO₂ you kept out of the air. Tankstellen is built to help you save both ways: cheaper fuel _and_ leaner driving.
+> A car loses you money in three places: at the pump, on the road, and in everything you forgot to track. Tankstellen tackles all three — pay less per litre, burn fewer of them per kilometre, and see exactly where the money actually went.
 
 [![CI](https://github.com/fdittgen-png/tankstellen/actions/workflows/ci.yml/badge.svg)](https://github.com/fdittgen-png/tankstellen/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Flutter](https://img.shields.io/badge/Flutter-3.41-blue.svg)](https://flutter.dev)
 
-**Free fuel-price comparison for Europe and beyond** — 11 countries, 23 languages, privacy-first.
+**A free, open-source companion app for cutting the running cost of your car.** 11 countries, 23 languages, privacy-first, no ads, no tracking.
 
-Tankstellen helps drivers find the cheapest fuel nearby, along a route, or in a specific city, _and_ track their real consumption so they can drive it down over time. It aggregates real-time prices from official government APIs — no scraping, no tracking, no ads.
+Tankstellen aggregates real-time fuel prices from official government APIs, plugs into your car's OBD-II port to see how it actually drives, and keeps a tidy log of every fill-up and trip so the savings stop being theoretical.
 
-### The two savings lenses
+## The objective: a cheaper kilometre
 
-1. **At the pump.** Live price comparison across countries, along your route, with alerts when prices drop.
-2. **Behind the wheel.** Fill-up log, consumption stats, CO₂ dashboard, and the signals you need to drive more economically over time.
+Every feature ladders up to one goal — **reduce what your car costs you, per kilometre driven** — through three layers, in priority order:
 
-Every feature in the app serves at least one of these two lenses. Features that serve neither don't belong.
+### 1. Buy fuel for less money
+
+Live cross-country price comparison, route-aware "cheapest stop" planning, drop alerts, and 30-day price history with a "best time to fill" model. Cheap fuel is the easiest win — and the one drivers leave on the table the most.
+
+### 2. Burn less of it per kilometre
+
+Plug in any ELM327-compatible OBD-II adapter and the app starts coaching: live haptic eco-feedback, hard-acceleration and idling insights, gear-coaching for the wrong-gear moments, a per-trip driving score, and a throttle/RPM histogram showing where your engine actually lives. Behaviour change is harder than picking a station, but it pays out on every drive instead of every fill-up.
+
+### 3. See what you're really spending
+
+A fill-up log (manual, receipt-OCR, or OBD-II auto-record on disconnect), per-trip cost detail, fuel-cost projections, a CO₂ dashboard, and a maintenance-suggestion engine that watches consumption drift over time. You can't reduce what you don't measure — and most drivers measure nothing.
+
+Features that don't serve at least one of those three layers don't belong.
 
 ## Features
 
-- **Real-time prices** from official government data sources
+### Layer 1 — buying cheaper
+
+- **Real-time prices** from each country's official government data source — no scraping
 - **11 countries** — Germany, France, Austria, Spain, Italy, Denmark, Portugal, UK, Argentina, Australia, Mexico
 - **23 languages** — from Bulgarian to Swedish
-- **Route search** — find the cheapest station along your planned route, with saved itineraries
+- **Route-aware search** — uniform / cheapest / balanced strategies, "best stops" along a planned trip
+- **Cross-border suggestions** — when the next country over is meaningfully cheaper, the app says so
+- **Price alerts** — threshold-based notifications, evaluated by a background job
+- **Price history & predictions** — 30-day charts plus a "best time to fill" model from your local history
+- **Brand filter** — Total / Esso / Shell / Aral, country-aware brand registry
+- **Favorites** — quick access with swipe-to-navigate / swipe-to-remove
+- **Home-screen widget** — current prices and a "predictive" variant without opening the app
 - **EV charging** — OpenChargeMap integration with connector type, max power, and pricing
+
+### Layer 2 — burning less
+
+- **OBD-II support** — any ELM327-compatible adapter (BLE classic + dual-mode, see the adapter registry)
+- **Auto-record** — pair adapter to vehicle, auto-connect on Bluetooth, auto-start on movement, auto-save on disconnect
+- **Trip recorder** — speed, fuel rate, RPM, throttle %, engine load (when supported), GPS path
+- **Trip detail view** — per-trip charts (speed, fuel rate, RPM, engine load) plus shareable PNG report
+- **Driving insights** — hard-accel waste, idling fuel, cold-start surcharge, low-gear coaching
+- **Driving score** — composite 0-100 score per trip with breakdown chips, opt-in
+- **Throttle / RPM histogram** — see the engine zone you actually drive in
+- **Visual eco-coach** — live haptic + on-screen feedback when behaviour costs fuel
 - **Driving mode** — full-screen, in-car friendly map with large markers and voice announcements
-- **Vehicle profiles** — combustion, hybrid, or EV; battery, connectors, tank capacity
-- **Fuel consumption tracking** — log fill-ups manually, by **receipt scan** (OCR), or via **OBD-II** (ELM327)
-- **Calculator** — tank fill cost, cross-station savings, fuel budget projections
-- **Carbon dashboard** — CO₂ emissions per vehicle with 30-day rolling chart
-- **Price alerts** — get notified when prices drop below your threshold
-- **Price history & predictions** — 30-day charts and "best time to fill" analysis
-- **Brand registry & filter** — country-specific brand recognition, filter by Total / Esso / Shell / etc.
-- **Landing screen selection** — open the app to nearest, cheapest, favorites, or map
-- **Favorites** — quick access to your regular stations with swipe actions
-- **Home screen widget** — see prices without opening the app
-- **Offline-capable** — local-first architecture with smart caching
+- **Maintenance analyzer** — watches consumption drift over time, flags MAF deviation, idle creep, sluggish warm-up
+
+### Layer 3 — seeing what you actually spend
+
+- **Fill-up log** — manual entry, receipt OCR scan, pump-display OCR, or OBD-II auto-import on disconnect
+- **Trip history** — every recorded trip with distance, duration, avg consumption, fuel used, fuel cost
+- **Vehicle profiles** — combustion, hybrid, or EV; tank capacity, battery, connectors, multi-vehicle households
+- **Cost calculator** — tank fill cost, cross-station savings, fuel-budget projections
+- **CO₂ dashboard** — emissions per vehicle with 30-day rolling chart
+- **Service reminders** — interval + mileage-driven, configurable per vehicle
+
+### Cross-cutting
+
+- **Local-first** — Hive storage, smart caching, offline-capable
 - **Cross-device sync** — optional TankSync cloud backend (self-hostable via Supabase)
-- **Privacy-first** — no Firebase, no Google Play Services, no tracking, GDPR-compliant
-- **Accessibility** — meets Android tap target guidelines, semantic labels throughout
+- **Privacy** — no Firebase, no Google Play Services, no tracking, no ads, GDPR-compliant
+- **Accessibility** — meets Android tap-target guidelines, semantic labels throughout
 
 ## Screenshots
 
@@ -170,23 +203,16 @@ The app is designed to be easily extensible. Each country has its own service im
 
 ## Contributing
 
-Contributions are welcome! See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for detailed guidelines.
-
-**Quick summary:**
-
-1. Open an issue first — describe the bug or feature before writing code
-2. Branch from `master` — use conventional branch names (`feat/`, `fix/`, `refactor/`)
-3. Write tests — every change needs tests
-4. Run checks — `flutter analyze` and `flutter test` must pass
-5. Keep PRs small — under 400 lines changed (excluding generated files)
-Contributions are welcome! Please follow these guidelines:
+Contributions are welcome — see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for the full version. Quick summary:
 
 1. **Open an issue first** — describe the bug or feature before writing code
-2. **Branch from `master`** — use conventional branch names (`feat/`, `fix/`, `refactor/`)
+2. **Branch from `master`** — conventional branch names (`feat/`, `fix/`, `refactor/`, `test/`)
 3. **Write tests** — every change needs tests (unit, widget, or integration)
-4. **Run checks** — `flutter analyze` and `flutter test` must pass
+4. **Run checks** — `flutter analyze` and `flutter test` must pass with zero warnings
 5. **Keep PRs small** — under 400 lines changed (excluding generated files)
 6. **Conventional commits** — `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+
+A feature that doesn't ladder up to one of the three savings layers above is unlikely to be merged.
 
 ### Commit Messages
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [5.0.0] - 2026-04-28 (Build 5112)
+
+The "cheaper kilometre" release. Where 4.x found you a cheaper litre, 5.x helps you burn fewer of them and shows you exactly what each one cost.
+
+### Added — Layer 2 (drive less consumption)
+
+- **OBD-II auto-record (#1004)** — pair adapter to vehicle, auto-connect on Bluetooth, auto-start on movement, auto-save on disconnect, badge counter on the trips tab. Stale-paused-trip recovery on launch (phase 4-WAL).
+- **Visual eco-coach on recording screen (#1273)** — live haptic + on-screen feedback when behaviour costs fuel. Pin-toggle help sheet and resume-recording hint.
+- **Driving insights card (#1041 phases 1-5)** — hard-accel waste, idling fuel, cold-start surcharge, low-gear coaching (#1263) on the per-trip detail screen.
+- **Composite driving score (#1041 phase 5a, opt-in via gamification toggle)** — single 0-100 number per trip with breakdown chips. Hidden on EV trips.
+- **Throttle / RPM histogram (#1041 phase 3a)** — visualises the engine zone you actually drive in.
+- **Engine-load chart (#1262 phase 3)** — per-sample engine load over the trip, when the car exposes PID 0x04.
+- **Cold-start chip + tooltip (#1262 phase 3)** — surfaces trips where the engine never reached operating temperature.
+- **Gear inference + coaching (#1263)** — 1-D k-means clustering on speed/RPM ratios, with a "labouring in low gear" insight when the metric exceeds 60 s per trip.
+- **Maintenance analyzer (#1124)** — watches consumption drift over time. Pilot heuristics: MAF deviation (cruise fuel-rate drop), idle creep (warm idle drift), sluggish warm-up.
+- **Trip-detail share (#1189)** — render Summary + Insights + charts to a PNG and hand off to the OS share sheet.
+- **Fuel-cost field on trip summary (#1209)** — multiplies trip litres by the most-recent fill-up's price-per-litre when available.
+
+### Added — Layer 3 (transparency)
+
+- **Trips tab on Consumption screen (#889)** — full trip history with distance, duration, avg consumption chips. Resume-recording when a trip is already in progress (#1237).
+- **Pump-display OCR scan handler** — scan the display at the pump as an alternative to receipt OCR.
+- **Driving-insights card on Trip Detail (#1041 phase 2)** — phase 2 wires the insights surface above the charts.
+
+### Added — Layer 1 (cheaper fuel)
+
+- **Daily 18:00 Paris open-testing release (#1066)** — automated AAB → Play Store open-testing track at 18:00 Europe/Paris each day.
+
+### Infrastructure
+
+- **ARB fragment pattern** — `lib/l10n/_fragments/<feature>_<locale>.arb` plus `dart run tool/build_arb.dart` aggregator. Eliminates the multi-coordinator merge conflicts that used to plague `app_en.arb` / `app_de.arb`.
+- **Shell branches refactor** — bottom-nav routes extracted to `lib/app/routes/shell_branches.dart` and `*_routes.dart` files. Drove the file-extraction phase work for #563.
+- **Test coverage drive (#561)** — 7 phase PRs in the 4.3.x → 5.0.0 window covering route configs, route widgets, shell surfaces, loyalty providers, maintenance analyzer heuristics, and the trip-detail body. 100+ new test cases.
+- **Coverage gate lowered to 40 %** (from 45 %, #1292) — temporary while the harder OBD-II / sync paths catch up; will be raised again in 5.1.x.
+- **CI parallelism** — daily-beta job pinned to existing action versions (#1066 follow-up).
+
+### Fixed
+
+- Multi-coordinator race detection on parallel autonomous-loop sessions — first-PR-wins with CI-alive verification before closing the duplicate.
+- Numerous unused-import / `unnecessary_underscores` info-level lint failures that CI started failing on after the analyse-stricter switch (#1168 cycle).
+- Worker compute leaks where isolation worktrees could escape via `cd` — workers now verify `git rev-parse --show-toplevel` before every commit.
+
+### Known limitations / not in this release
+
+- iOS support (#9) is still deferred — code signing, notifications, and background tasks need a paid Apple Developer programme.
+- Auto-import the OBD-II odometer reading into the fill-up form is hidden behind a gate until PID 0xA6 is proven reliable across the supported adapter registry (see [docs/guides/obd2-adapters.md](guides/obd2-adapters.md)).
+- The price-prediction TFLite model (#1117) is on the backlog but not yet shipped.
+
+---
+
 ## [4.3.0] - 2026-03-31 (Build 4001)
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- Reframes README around the goal of cutting per-kilometre cost — three layers in priority order: buy cheaper fuel, burn less per km, see what was actually spent
- Refreshes the feature list against what's actually shipped in 5.0.0 (OBD-II auto-record, eco-coach, driving score, gear coaching, maintenance analyzer, ARB fragment pattern)
- Adds the v5.0.0 changelog entry summarizing this cycle's work

## Wiki

Companion wiki update pushed separately to \`fdittgen-png/tankstellen.wiki.git\` covering Home, User-en/de/fr Home, Dev-Home with the same framing.

User-es / User-it / User-pt / User-da home pages still use the old "Smarter pump. Smarter drive. Save twice." copy and need a separate translation review — flagged inside the wiki commit message.

## Test plan

- [x] No code changes, docs only — \`flutter analyze\` and tests not relevant
- [ ] Verify README renders correctly on github.com/fdittgen-png/tankstellen after merge
- [ ] Verify CHANGELOG link from README still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)