### PR TITLE
chore: bump build number to 5122 for Play Store release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 11 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 5.0.0+5112
+version: 5.0.0+5122
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
## Summary
- Bumps `version: 5.0.0+5112` → `5.0.0+5122` (safe +10 jump past any manual uploads)
- AAB already built for Play Store: `app-play-release.aab` (80 MB) in `C:\Users\fditt\OneDrive\Android\`
- Split APKs also built for sideload (arm64-v8a, armeabi-v7a, x86_64)

## Test plan
- [x] `flutter build appbundle --release --flavor play` succeeds
- [x] `flutter build apk --release --split-per-abi --flavor play` succeeds
- [ ] CI: analyze + test green
- [ ] Upload AAB to Play Console open testing track

🤖 Generated with [Claude Code](https://claude.com/claude-code)