### PR TITLE
fix(map): refresh tiles + price chips on app resume (#1268)

### DIFF
--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -51,6 +53,27 @@ import '../widgets/route_map_view.dart';
 /// guarantees the TileLayer NEVER sees degenerate constraints — its
 /// first layout pass always uses the real post-mount size.
 ///
+/// ## App-resume refresh (#1268)
+///
+/// Backgrounding the app and returning after >10 s leaves both tiles
+/// and price chips frozen in their pre-pause state — none of the
+/// existing defenses ([_mapIncarnation] tab-flip listener,
+/// [LayoutBuilder] gate, first-paint reset stream) fire on lifecycle
+/// resume because no tab-flip happens. The user reports the visible
+/// viewport never recovers and price chips stay on `--` indefinitely.
+///
+/// We hook [WidgetsBindingObserver.didChangeAppLifecycleState] to:
+///   1. Bump [_mapIncarnation] when the app resumes AND Carte is
+///      currently visible — this rebuilds the FlutterMap subtree the
+///      same way a tab-flip does, restoring the tile-fetch loop.
+///   2. Call `searchStateProvider.notifier.repeatLastSearch()` so the
+///      station data (and any prices that the API now reports) is
+///      refreshed. Stations whose previous fetch returned no price for
+///      the selected fuel get a second chance to populate; chips that
+///      legitimately have no upstream data continue to render `--` (the
+///      `priceColor(null,…)` grey signals "no data" — already distinct
+///      from the loading state).
+///
 /// ## App-bar title color (#1164 bug 2)
 ///
 /// `PageScaffold(titleTextStyle: const TextStyle(fontSize: 16))` would
@@ -62,13 +85,21 @@ import '../widgets/route_map_view.dart';
 /// foreground color explicitly so the compact 16pt size still inherits
 /// the proper on-surface contrast.
 class MapScreen extends ConsumerStatefulWidget {
-  const MapScreen({super.key});
+  const MapScreen({super.key, this.clockOverride});
+
+  /// When non-null, overrides `DateTime.now()` for the resume-threshold
+  /// comparison. Tests use this so they can simulate "paused 30 s ago"
+  /// without sleeping wall-clock seconds. Production callers leave it
+  /// `null`.
+  @visibleForTesting
+  final DateTime Function()? clockOverride;
 
   @override
   ConsumerState<MapScreen> createState() => _MapScreenState();
 }
 
-class _MapScreenState extends ConsumerState<MapScreen> {
+class _MapScreenState extends ConsumerState<MapScreen>
+    with WidgetsBindingObserver {
   late MapController _mapController;
 
   /// Bumped every time the Carte tab becomes visible. Used as a
@@ -76,16 +107,94 @@ class _MapScreenState extends ConsumerState<MapScreen> {
   /// destroyed and rebuilt with real post-layout constraints (#709).
   int _mapIncarnation = 0;
 
+  /// Index of the Map branch in the bottom-nav stack. Kept as a named
+  /// constant so the lifecycle handler stays readable.
+  static const int _mapBranchIndex = 1;
+
+  /// Minimum pause-to-resume gap that triggers a refresh on resume
+  /// (#1268). A short blip (notification shade swipe, lock-screen
+  /// peek) does not need to pay the rebuild + search-refresh cost, so
+  /// brief lifecycle bounces are ignored. Ten seconds matches the
+  /// acceptance criterion in the issue.
+  static const Duration _resumeRefreshThreshold = Duration(seconds: 10);
+
+  /// When the app last entered a non-resumed state. Compared against
+  /// the resume timestamp to decide whether to refresh — see
+  /// [_resumeRefreshThreshold].
+  DateTime? _pausedAt;
+
   @override
   void initState() {
     super.initState();
     _mapController = MapController();
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _mapController.dispose();
     super.dispose();
+  }
+
+  DateTime _now() => widget.clockOverride?.call() ?? DateTime.now();
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      _onAppResumed();
+    } else if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.hidden) {
+      // Track the first transition into a non-resumed state. Don't
+      // reset on every flip — repeated `inactive`+`paused` callbacks
+      // during a single backgrounding would otherwise overwrite the
+      // genuine pause moment.
+      _pausedAt ??= _now();
+    }
+  }
+
+  /// Refresh the map when the user returns to the app after >10 s
+  /// AND the Carte tab is currently visible (#1268). Bumping the
+  /// incarnation rebuilds the FlutterMap subtree (the same fix as the
+  /// tab-flip listener); calling `repeatLastSearch` re-fetches station
+  /// data so price chips pick up any newly-available prices.
+  void _onAppResumed() {
+    final pausedAt = _pausedAt;
+    _pausedAt = null;
+    if (!mounted) return;
+    if (pausedAt == null) return;
+    if (_now().difference(pausedAt) < _resumeRefreshThreshold) {
+      return;
+    }
+    final currentBranch = ref.read(currentShellBranchProvider);
+    if (currentBranch != _mapBranchIndex) return;
+
+    final old = _mapController;
+    try {
+      setState(() {
+        _mapController = MapController();
+        _mapIncarnation++;
+      });
+    } catch (e, st) {
+      debugPrint('MapScreen rebuild on app-resume: $e\n$st');
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      try {
+        old.dispose();
+      } catch (e, st) {
+        debugPrint('MapScreen old controller dispose on resume: $e\n$st');
+      }
+    });
+
+    // Fire-and-forget: re-issue the most recent search so the station
+    // data underlying the price chips is refreshed. Failures (no last
+    // search, network error) are surfaced via `searchStateProvider`'s
+    // existing error path.
+    unawaited(
+      ref.read(searchStateProvider.notifier).repeatLastSearch(),
+    );
   }
 
   @override

--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -38,6 +38,12 @@ part 'search_provider.g.dart';
 class SearchState extends _$SearchState {
   CancelToken? _activeCancelToken;
 
+  /// Replays the most recently issued search. `null` until the user has
+  /// run at least one search. Used by [repeatLastSearch], which lets
+  /// observers (e.g. MapScreen's app-resume handler, #1268) refresh
+  /// stale data without knowing which search-by-X variant was invoked.
+  Future<void> Function()? _lastSearchReplay;
+
   /// Cancel any in-flight search and create a fresh [CancelToken].
   CancelToken _newCancelToken() {
     final old = _activeCancelToken;
@@ -54,6 +60,21 @@ class SearchState extends _$SearchState {
       source: ServiceSource.cache,
       fetchedAt: DateTime.now(),
     ));
+  }
+
+  /// Re-runs the most recent search (whichever entry point — GPS, ZIP,
+  /// coordinates) with the same parameters. No-op if no search has run
+  /// yet or one is already in flight.
+  ///
+  /// Used by [MapScreen] to refresh stale tile + price data when the
+  /// app returns from background after >10 s (#1268). Returns the same
+  /// future the underlying search returns, or a completed future when
+  /// no replay is available.
+  Future<void> repeatLastSearch() async {
+    final replay = _lastSearchReplay;
+    if (replay == null) return;
+    if (state.isLoading) return;
+    await replay();
   }
 
   /// Wraps a search closure with standard loading state + error
@@ -83,6 +104,11 @@ class SearchState extends _$SearchState {
     double? radiusKm,
     SortBy? sortBy,
   }) async {
+    _lastSearchReplay = () => searchByGps(
+          fuelType: fuelType,
+          radiusKm: radiusKm,
+          sortBy: sortBy,
+        );
     await _runSearch((cancelToken) async {
       final position =
           await ref.read(locationServiceProvider).getCurrentPosition();
@@ -138,6 +164,12 @@ class SearchState extends _$SearchState {
     double? radiusKm,
     SortBy? sortBy,
   }) async {
+    _lastSearchReplay = () => searchByZipCode(
+          zipCode: zipCode,
+          fuelType: fuelType,
+          radiusKm: radiusKm,
+          sortBy: sortBy,
+        );
     await _runSearch((cancelToken) async {
       await autoUpdatePositionIfEnabled(ref);
       final geocoding = ref.read(geocodingChainProvider);
@@ -202,6 +234,14 @@ class SearchState extends _$SearchState {
     FuelType? fuelType,
     double? radiusKm,
   }) async {
+    _lastSearchReplay = () => searchByCoordinates(
+          lat: lat,
+          lng: lng,
+          postalCode: postalCode,
+          locationName: locationName,
+          fuelType: fuelType,
+          radiusKm: radiusKm,
+        );
     await _runSearch((cancelToken) async {
       await autoUpdatePositionIfEnabled(ref);
       if (locationName != null) {

--- a/lib/features/search/providers/search_provider.g.dart
+++ b/lib/features/search/providers/search_provider.g.dart
@@ -19,8 +19,10 @@ part of 'search_provider.dart';
 ///
 /// Pure helpers (result wrapping, distance recalc, postal-code
 /// extraction, geocoding-error merging) live in
-/// `search_result_helpers.dart`; this file keeps the stateful
-/// orchestration (cancel tokens, profile lookups, state mutation).
+/// `search_result_helpers.dart`; orchestration helpers (EV dispatch,
+/// fuel/radius resolution, error classification, GPS auto-update)
+/// live in `search_provider_orchestration.dart`. This file keeps only
+/// the public search entry points + state mutation.
 
 @ProviderFor(SearchState)
 final searchStateProvider = SearchStateProvider._();
@@ -36,8 +38,10 @@ final searchStateProvider = SearchStateProvider._();
 ///
 /// Pure helpers (result wrapping, distance recalc, postal-code
 /// extraction, geocoding-error merging) live in
-/// `search_result_helpers.dart`; this file keeps the stateful
-/// orchestration (cancel tokens, profile lookups, state mutation).
+/// `search_result_helpers.dart`; orchestration helpers (EV dispatch,
+/// fuel/radius resolution, error classification, GPS auto-update)
+/// live in `search_provider_orchestration.dart`. This file keeps only
+/// the public search entry points + state mutation.
 final class SearchStateProvider
     extends
         $NotifierProvider<
@@ -55,8 +59,10 @@ final class SearchStateProvider
   ///
   /// Pure helpers (result wrapping, distance recalc, postal-code
   /// extraction, geocoding-error merging) live in
-  /// `search_result_helpers.dart`; this file keeps the stateful
-  /// orchestration (cancel tokens, profile lookups, state mutation).
+  /// `search_result_helpers.dart`; orchestration helpers (EV dispatch,
+  /// fuel/radius resolution, error classification, GPS auto-update)
+  /// live in `search_provider_orchestration.dart`. This file keeps only
+  /// the public search entry points + state mutation.
   SearchStateProvider._()
     : super(
         from: null,
@@ -89,7 +95,7 @@ final class SearchStateProvider
   }
 }
 
-String _$searchStateHash() => r'a272f93101baa656572034b8f6d56c113693140d';
+String _$searchStateHash() => r'18b410ecf78dd8b652cac24a5f1e7c235658c0a1';
 
 /// Manages the station search lifecycle and exposes results as [AsyncValue].
 ///
@@ -102,8 +108,10 @@ String _$searchStateHash() => r'a272f93101baa656572034b8f6d56c113693140d';
 ///
 /// Pure helpers (result wrapping, distance recalc, postal-code
 /// extraction, geocoding-error merging) live in
-/// `search_result_helpers.dart`; this file keeps the stateful
-/// orchestration (cancel tokens, profile lookups, state mutation).
+/// `search_result_helpers.dart`; orchestration helpers (EV dispatch,
+/// fuel/radius resolution, error classification, GPS auto-update)
+/// live in `search_provider_orchestration.dart`. This file keeps only
+/// the public search entry points + state mutation.
 
 abstract class _$SearchState
     extends $Notifier<AsyncValue<ServiceResult<List<SearchResultItem>>>> {

--- a/test/features/map/presentation/screens/map_screen_test.dart
+++ b/test/features/map/presentation/screens/map_screen_test.dart
@@ -298,6 +298,183 @@ void main() {
     );
 
     testWidgets(
+      'app-resume after >10s on Carte tab rebuilds FlutterMap subtree '
+      '(#1268 — tile + chip refresh on resume)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        // Inject a controllable clock so the test can simulate
+        // "paused 30 s ago" without wall-clock sleeps.
+        var fakeNow = DateTime(2026, 4, 28, 12);
+        await pumpApp(
+          tester,
+          MapScreen(clockOverride: () => fakeNow),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+          ],
+        );
+
+        int currentIncarnation() {
+          final subtree = tester
+              .widgetList<KeyedSubtree>(
+                find.descendant(
+                  of: find.byType(MapScreen),
+                  matching: find.byType(KeyedSubtree),
+                ),
+              )
+              .firstWhere((w) => w.key is ValueKey<int>);
+          return (subtree.key as ValueKey<int>).value;
+        }
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MapScreen)),
+        );
+        // Carte tab is the active branch.
+        container.read(currentShellBranchProvider.notifier).set(1);
+        await tester.pump();
+        await tester.pump();
+        final initial = currentIncarnation();
+
+        // Background → simulate 30 s passing → resume.
+        final binding = tester.binding;
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        await tester.pump();
+        fakeNow = fakeNow.add(const Duration(seconds: 30));
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          currentIncarnation(),
+          greaterThan(initial),
+          reason:
+              'Resuming the app after >10s with the Carte tab visible '
+              'must rebuild the FlutterMap subtree (same fix as the '
+              'tab-flip listener) so tile fetching restarts and the '
+              'station data underlying the price chips refreshes (#1268).',
+        );
+      },
+    );
+
+    testWidgets(
+      'app-resume after <10s does NOT rebuild FlutterMap subtree '
+      '(#1268 — short blip ignored)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        var fakeNow = DateTime(2026, 4, 28, 12);
+        await pumpApp(
+          tester,
+          MapScreen(clockOverride: () => fakeNow),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+          ],
+        );
+
+        int currentIncarnation() {
+          final subtree = tester
+              .widgetList<KeyedSubtree>(
+                find.descendant(
+                  of: find.byType(MapScreen),
+                  matching: find.byType(KeyedSubtree),
+                ),
+              )
+              .firstWhere((w) => w.key is ValueKey<int>);
+          return (subtree.key as ValueKey<int>).value;
+        }
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MapScreen)),
+        );
+        container.read(currentShellBranchProvider.notifier).set(1);
+        await tester.pump();
+        await tester.pump();
+        final initial = currentIncarnation();
+
+        // Brief blip — notification shade swipe, lock-screen peek, etc.
+        final binding = tester.binding;
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+        await tester.pump();
+        fakeNow = fakeNow.add(const Duration(seconds: 2));
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          currentIncarnation(),
+          equals(initial),
+          reason:
+              'Brief lifecycle bounces (<10s) must not pay the rebuild + '
+              'search-refresh cost — only sustained backgrounding does '
+              '(#1268 acceptance criterion).',
+        );
+      },
+    );
+
+    testWidgets(
+      'app-resume on a non-Carte tab does NOT rebuild FlutterMap '
+      '(#1268 — only refresh when Carte is visible)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        var fakeNow = DateTime(2026, 4, 28, 12);
+        await pumpApp(
+          tester,
+          MapScreen(clockOverride: () => fakeNow),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+          ],
+        );
+
+        int currentIncarnation() {
+          final subtree = tester
+              .widgetList<KeyedSubtree>(
+                find.descendant(
+                  of: find.byType(MapScreen),
+                  matching: find.byType(KeyedSubtree),
+                ),
+              )
+              .firstWhere((w) => w.key is ValueKey<int>);
+          return (subtree.key as ValueKey<int>).value;
+        }
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MapScreen)),
+        );
+        // User is on Search (branch 0), not Carte.
+        container.read(currentShellBranchProvider.notifier).set(0);
+        await tester.pump();
+        await tester.pump();
+        final initial = currentIncarnation();
+
+        final binding = tester.binding;
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        await tester.pump();
+        fakeNow = fakeNow.add(const Duration(seconds: 30));
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          currentIncarnation(),
+          equals(initial),
+          reason:
+              'Resume-driven refresh must only fire when Carte is the '
+              'visible branch — pre-emptively rebuilding offstage maps '
+              'would cancel any tile fetches that would otherwise be '
+              'covered by the standard tab-flip listener when the user '
+              'returns to Carte (#1268).',
+        );
+      },
+    );
+
+    testWidgets(
       'AppBar title color survives a tab round-trip '
       '(#1164 bug 2 regression guard)',
       (tester) async {

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -596,6 +596,171 @@ void main() {
       // Distance from Paris to Berlin should be recalculated
       expect(state.value!.data.first.dist, greaterThan(0));
     });
+
+    test(
+        'repeatLastSearch is a no-op before any search has been issued '
+        '(#1268 — guard against fresh-install resume crash)', () async {
+      final container = createContainer();
+      final notifier = container.read(searchStateProvider.notifier);
+
+      // Must not throw and must leave state untouched.
+      await notifier.repeatLastSearch();
+
+      final state = container.read(searchStateProvider);
+      expect(state, isA<AsyncData>());
+      expect(state.value!.data, isEmpty);
+      verifyNever(() => mockStationService.searchStations(any(),
+          cancelToken: any(named: 'cancelToken')));
+    });
+
+    test(
+        'repeatLastSearch replays the most recent searchByZipCode '
+        'with the same parameters (#1268)', () async {
+      when(() => mockGeocoding.zipCodeToCoordinates('10115',
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: (lat: 52.52, lng: 13.41),
+                source: ServiceSource.nominatimGeocoding,
+                fetchedAt: DateTime.now(),
+              ));
+      when(() => mockGeocoding.coordinatesToAddress(any(), any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: 'Berlin',
+                source: ServiceSource.nominatimGeocoding,
+                fetchedAt: DateTime.now(),
+              ));
+      var stationCalls = 0;
+      when(() => mockStationService.searchStations(any(),
+          cancelToken: any(named: 'cancelToken'))).thenAnswer((inv) async {
+        stationCalls++;
+        return ServiceResult(
+          data: [testStation],
+          source: ServiceSource.tankerkoenigApi,
+          fetchedAt: DateTime.now(),
+        );
+      });
+
+      final container = createContainer();
+      final notifier = container.read(searchStateProvider.notifier);
+
+      await notifier.searchByZipCode(zipCode: '10115', radiusKm: 7.0);
+      expect(stationCalls, 1);
+
+      await notifier.repeatLastSearch();
+      expect(stationCalls, 2,
+          reason:
+              'repeatLastSearch must re-run the most recently issued '
+              'search so the map can refresh stale data on app resume.');
+
+      // The second SearchParams must carry the same radius — i.e. the
+      // replay used the original parameters, not a default.
+      final captured = verify(() => mockStationService.searchStations(
+              captureAny(),
+              cancelToken: any(named: 'cancelToken')))
+          .captured
+          .whereType<SearchParams>()
+          .toList();
+      expect(captured.length, 2);
+      expect(captured.last.radiusKm, 7.0);
+      expect(captured.last.postalCode, '10115');
+    });
+
+    test(
+        'repeatLastSearch replays searchByCoordinates with original '
+        'lat/lng/postalCode (#1268)', () async {
+      var stationCalls = 0;
+      when(() => mockStationService.searchStations(any(),
+          cancelToken: any(named: 'cancelToken'))).thenAnswer((inv) async {
+        stationCalls++;
+        return ServiceResult(
+          data: [testStation],
+          source: ServiceSource.tankerkoenigApi,
+          fetchedAt: DateTime.now(),
+        );
+      });
+
+      final container = createContainer();
+      final notifier = container.read(searchStateProvider.notifier);
+
+      await notifier.searchByCoordinates(
+        lat: 43.45,
+        lng: 3.45,
+        postalCode: '34120',
+        locationName: 'Castelnau-de-Guers',
+        radiusKm: 12.5,
+      );
+      expect(stationCalls, 1);
+
+      await notifier.repeatLastSearch();
+      expect(stationCalls, 2);
+
+      final captured = verify(() => mockStationService.searchStations(
+              captureAny(),
+              cancelToken: any(named: 'cancelToken')))
+          .captured
+          .whereType<SearchParams>()
+          .toList();
+      expect(captured.length, 2);
+      expect(captured.last.lat, 43.45);
+      expect(captured.last.lng, 3.45);
+      expect(captured.last.postalCode, '34120');
+      expect(captured.last.radiusKm, 12.5);
+    });
+
+    test(
+        'repeatLastSearch tracks the LATEST search type, not just the '
+        'first (#1268 — sequential tab-switch + zip-edit scenario)',
+        () async {
+      // First search: by zip code.
+      when(() => mockGeocoding.zipCodeToCoordinates(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: (lat: 52.52, lng: 13.41),
+                source: ServiceSource.nominatimGeocoding,
+                fetchedAt: DateTime.now(),
+              ));
+      when(() => mockGeocoding.coordinatesToAddress(any(), any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: 'Berlin',
+                source: ServiceSource.nominatimGeocoding,
+                fetchedAt: DateTime.now(),
+              ));
+      when(() => mockStationService.searchStations(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: [testStation],
+                source: ServiceSource.tankerkoenigApi,
+                fetchedAt: DateTime.now(),
+              ));
+
+      final container = createContainer();
+      final notifier = container.read(searchStateProvider.notifier);
+
+      await notifier.searchByZipCode(zipCode: '10115');
+      // Then a second, different search by coordinates.
+      await notifier.searchByCoordinates(
+        lat: 43.45,
+        lng: 3.45,
+        radiusKm: 5.0,
+      );
+
+      // Replay must replay the SECOND (coordinates) search.
+      await notifier.repeatLastSearch();
+
+      final captured = verify(() => mockStationService.searchStations(
+              captureAny(),
+              cancelToken: any(named: 'cancelToken')))
+          .captured
+          .whereType<SearchParams>()
+          .toList();
+      // 3 calls: zip, coordinates, replay-coordinates.
+      expect(captured.length, 3);
+      expect(captured.last.lat, 43.45);
+      expect(captured.last.lng, 3.45);
+      expect(captured.last.radiusKm, 5.0);
+    });
   });
 
   group('EV dispatch (unified search trigger)', () {


### PR DESCRIPTION
## Diagnosis

The Carte tab freezes in a half-loaded state when the user returns to the app after a >10 s backgrounding. Tile fetches that paused mid-flight never resume, and station price chips stay on `--` because the underlying station data is whatever the last search returned — there is no per-marker async fetch to retry. None of the existing defenses fire on lifecycle resume: the `_mapIncarnation` tab-flip listener only triggers on tab change, the `LayoutBuilder` gate only matters at first mount, and the first-paint reset stream is a one-shot in `initState`. So returning to a still-mounted Carte tab leaves both tile loading and price data frozen at whatever state they reached before backgrounding.

## Fix

`MapScreen` becomes a `WidgetsBindingObserver`. On `AppLifecycleState.resumed` after >10 s with the Carte tab visible, it bumps `_mapIncarnation` (rebuilding the FlutterMap + TileLayer subtree exactly the way a tab-flip does, restoring the tile-fetch loop with a fresh `RetryNetworkTileProvider`) and calls a new `SearchState.repeatLastSearch()` so station data is re-fetched. `repeatLastSearch` memoizes the most recent search entry point (GPS / ZIP / coordinates) along with its parameters, so observers can refresh stale data without knowing which entry point was last used. It is a no-op before any search has run.

Brief lifecycle bounces (<10 s — notification shade, lock-screen peek) are ignored. Resume on a non-Carte tab does not refresh, so we don't pre-emptively cancel offstage tile fetches that the standard tab-flip listener will handle when the user does return.

Stations whose chips render `--` because the upstream API genuinely has no price for the selected fuel continue to show `--`. The `priceColor(null,…)` grey already signals "no data" and is visually distinct from the loading state — a redesign of that affordance is out of scope.

## Files changed

- `lib/features/map/presentation/screens/map_screen.dart` (+87 LOC) — observer, threshold, `_onAppResumed` handler, injectable clock for tests.
- `lib/features/search/providers/search_provider.dart` (+39 LOC) — `_lastSearchReplay` field, `repeatLastSearch()`, replay registration in all three search-by-X methods.
- Generated `search_provider.g.dart` (hash + doc-string sync).
- `test/features/map/presentation/screens/map_screen_test.dart` (+177 LOC).
- `test/features/search/providers/search_provider_test.dart` (+165 LOC).

## Regression test cases

`map_screen_test`:
- `app-resume after >10s on Carte tab rebuilds FlutterMap subtree`
- `app-resume after <10s does NOT rebuild FlutterMap subtree`
- `app-resume on a non-Carte tab does NOT rebuild FlutterMap`

`search_provider_test`:
- `repeatLastSearch is a no-op before any search has been issued`
- `repeatLastSearch replays the most recent searchByZipCode with the same parameters`
- `repeatLastSearch replays searchByCoordinates with original lat/lng/postalCode`
- `repeatLastSearch tracks the LATEST search type, not just the first`

## Test plan

- [x] `flutter analyze` — clean.
- [x] Targeted tests: 11/11 map_screen, 37/37 search_provider, 20/20 station_map_layers + station_marker.
- [x] `no_silent_catch_test` passes.
- [ ] Device-test on cold-start, then background >10 s, then return to Carte — tiles re-fetch and price chips refresh.

Refs #1268