### PR TITLE
fix(privacy): resilient error-log copy with parse-vs-raw + share-sheet fallback (Closes #1301)

### DIFF
--- a/lib/core/telemetry/storage/trace_storage.dart
+++ b/lib/core/telemetry/storage/trace_storage.dart
@@ -29,9 +29,16 @@ class TraceStorage {
   List<ErrorTrace> getAll() {
     return _box.values
         .map((raw) {
+          if (raw is! Map) return null;
           try {
-            return ErrorTrace.fromJson(Map<String, dynamic>.from(raw as Map));
-          } on FormatException catch (e, st) {
+            return ErrorTrace.fromJson(Map<String, dynamic>.from(raw));
+          } on Object catch (e, st) {
+            // #1301 — schema migrations can leave entries that throw
+            // TypeError (missing required field) rather than the
+            // narrower FormatException the original code expected.
+            // Catch broadly so a single drift entry doesn't poison
+            // export — `unparsedRaw` in `exportAsJson` ships the raw
+            // payload for offline debugging.
             debugPrint('TraceStorage: trace parse failed: $e\n$st');
             return null;
           }
@@ -43,10 +50,11 @@ class TraceStorage {
 
   ErrorTrace? getById(String id) {
     final raw = _box.get(id);
-    if (raw == null) return null;
+    if (raw is! Map) return null;
     try {
-      return ErrorTrace.fromJson(Map<String, dynamic>.from(raw as Map));
-    } on FormatException catch (e, st) {
+      return ErrorTrace.fromJson(Map<String, dynamic>.from(raw));
+    } on Object catch (e, st) {
+      // See [getAll] for the rationale behind the broad catch (#1301).
       debugPrint('TraceStorage: trace parse failed: $e\n$st');
       return null;
     }
@@ -60,26 +68,79 @@ class TraceStorage {
   /// their first build in environments (tests, headless builds) where
   /// `TraceStorage.init()` hasn't been called — production goes through
   /// AppInitializer which always calls `init()`.
+  ///
+  /// NOTE: This is the RAW box length and includes entries that fail to
+  /// parse via [ErrorTrace.fromJson] after a schema migration. Use
+  /// [parsedCount] to get the count of successfully decoded entries and
+  /// [unparsedCount] to surface drift to the user (see #1301).
   int get count => Hive.isBoxOpen(_boxName) ? _box.length : 0;
+
+  /// Number of stored entries that successfully parse via
+  /// [ErrorTrace.fromJson]. Equals [count] when the schema is current,
+  /// drops to 0 after a breaking schema change. (#1301)
+  int get parsedCount => getAll().length;
+
+  /// Number of stored entries that FAIL to parse — the gap between
+  /// [count] and [parsedCount]. When non-zero the privacy-dashboard
+  /// "copy error log" action surfaces this so users know why the
+  /// payload looks empty after a migration. (#1301)
+  int get unparsedCount {
+    final raw = count;
+    final parsed = parsedCount;
+    return raw > parsed ? raw - parsed : 0;
+  }
+
+  /// Returns the raw Hive maps for entries that fail [ErrorTrace.fromJson].
+  /// Used by [exportAsJson] so a maintainer can debug schema drift even
+  /// when every stored trace is unreadable. Each entry is converted to a
+  /// plain `Map<String, dynamic>` so it round-trips cleanly through
+  /// [JsonEncoder]. (#1301)
+  List<Map<String, dynamic>> getUnparsedRaw() {
+    if (!Hive.isBoxOpen(_boxName)) return const [];
+    final unparsed = <Map<String, dynamic>>[];
+    for (final raw in _box.values) {
+      if (raw is! Map) continue;
+      final asMap = Map<String, dynamic>.from(raw);
+      try {
+        ErrorTrace.fromJson(asMap);
+      } on Object catch (e) {
+        debugPrint('TraceStorage: capturing unparsed entry: $e');
+        unparsed.add(asMap);
+      }
+    }
+    return unparsed;
+  }
 
   /// Serialises every persisted trace into a single JSON document the
   /// user can email or attach to a GitHub issue. Used by the privacy
-  /// dashboard's "Export error log" action (#476).
+  /// dashboard's "Export error log" action (#476, #1301).
   ///
   /// Format:
   /// ```json
   /// {
   ///   "exportedAt": "<iso8601>",
   ///   "traceCount": 12,
-  ///   "traces": [ <ErrorTrace.toJson()>, ... ]
+  ///   "parsedCount": 11,
+  ///   "unparsedCount": 1,
+  ///   "traces": [ <ErrorTrace.toJson()>, ... ],
+  ///   "unparsedRaw": [ <raw Hive map>, ... ]
   /// }
   /// ```
+  ///
+  /// `traceCount` mirrors the raw [count] so the legacy field stays
+  /// stable; `parsedCount` and `unparsedCount` were added in #1301 to
+  /// surface schema-drift to the user (and to keep the unreadable
+  /// payload available under `unparsedRaw` for offline debugging).
   String exportAsJson() {
     final traces = getAll();
+    final unparsed = getUnparsedRaw();
     return const JsonEncoder.withIndent('  ').convert({
       'exportedAt': DateTime.now().toUtc().toIso8601String(),
-      'traceCount': traces.length,
+      'traceCount': traces.length + unparsed.length,
+      'parsedCount': traces.length,
+      'unparsedCount': unparsed.length,
       'traces': traces.map((t) => t.toJson()).toList(),
+      'unparsedRaw': unparsed,
     });
   }
 

--- a/lib/core/telemetry/storage/trace_storage.dart
+++ b/lib/core/telemetry/storage/trace_storage.dart
@@ -103,8 +103,8 @@ class TraceStorage {
       final asMap = Map<String, dynamic>.from(raw);
       try {
         ErrorTrace.fromJson(asMap);
-      } on Object catch (e) {
-        debugPrint('TraceStorage: capturing unparsed entry: $e');
+      } on Object catch (e, st) {
+        debugPrint('TraceStorage: capturing unparsed entry: $e\n$st');
         unparsed.add(asMap);
       }
     }

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -1,8 +1,13 @@
-﻿import 'package:flutter/material.dart';
+﻿import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../../../../core/telemetry/storage/trace_storage.dart';
 import '../../../../core/export/data_exporter.dart';
@@ -16,6 +21,31 @@ import '../widgets/privacy_dashboard/local_data_card.dart';
 import '../widgets/privacy_dashboard/privacy_action_buttons.dart';
 import '../widgets/privacy_dashboard/privacy_banner.dart';
 import '../widgets/privacy_dashboard/synced_data_card.dart';
+
+/// Threshold above which the error-log export switches from clipboard
+/// to the OS share sheet. Some Samsung clipboard managers silently drop
+/// large payloads — see #1301.
+const int _errorLogClipboardThresholdBytes = 64 * 1024;
+
+/// Test-only override for the share-sheet handoff used by
+/// [_PrivacyDashboardScreenState._exportErrorLog]. Production sends
+/// [ShareParams] straight to [SharePlus.instance.share]; widget tests
+/// substitute a fake to assert the outgoing payload without launching
+/// the real OS share sheet. (#1301)
+typedef PrivacyShareSink = Future<void> Function(ShareParams params);
+
+/// See [PrivacyShareSink].
+@visibleForTesting
+PrivacyShareSink? debugPrivacyShareSinkOverride;
+
+/// Test-only override for the temporary-directory lookup used by the
+/// large-log share path. Returns a [Directory] the dashboard is allowed
+/// to write into. (#1301)
+typedef PrivacyTempDirectoryProvider = Future<Directory> Function();
+
+/// See [PrivacyTempDirectoryProvider].
+@visibleForTesting
+PrivacyTempDirectoryProvider? debugPrivacyTempDirectoryOverride;
 
 /// GDPR-compliant privacy dashboard showing all locally stored data
 /// with options to export as JSON or delete everything.
@@ -95,13 +125,85 @@ class _PrivacyDashboardScreenState
   Future<void> _exportErrorLog() async {
     final traces = ref.read(traceStorageProvider);
     final json = traces.exportAsJson();
+    final byteSize = utf8.encode(json).length;
+    final kb = (byteSize / 1024).toStringAsFixed(1);
+    final parsed = traces.parsedCount;
+    final unparsed = traces.unparsedCount;
+    final totalEntries = parsed + unparsed;
+
+    // Large payloads exceed Samsung One UI's clipboard preview budget
+    // (#1301); hand off to the OS share sheet instead so the user can
+    // route the JSON to email / files / a chat reliably.
+    if (byteSize > _errorLogClipboardThresholdBytes) {
+      try {
+        await _shareErrorLogAsFile(json);
+      } on Object catch (e, st) {
+        // If share sheet wiring fails we still want to give the user
+        // something — fall back to clipboard so the bug report doesn't
+        // get blocked on a platform-channel hiccup.
+        debugPrint('privacy: error-log share fallback to clipboard: $e\n$st');
+        await Clipboard.setData(ClipboardData(text: json));
+        if (!mounted) return;
+        SnackBarHelper.showSuccess(
+          context,
+          _formatCopySnackbar(
+            parsed: parsed,
+            unparsed: unparsed,
+            kb: kb,
+          ),
+        );
+        return;
+      }
+      if (!mounted) return;
+      SnackBarHelper.showSuccess(
+        context,
+        'Error log shared ($kb KB, $totalEntries entries)',
+      );
+      return;
+    }
+
     await Clipboard.setData(ClipboardData(text: json));
     if (!mounted) return;
     SnackBarHelper.showSuccess(
       context,
-      'Error log copied to clipboard (${traces.count} entries)',
+      _formatCopySnackbar(
+        parsed: parsed,
+        unparsed: unparsed,
+        kb: kb,
+      ),
     );
   }
+
+  String _formatCopySnackbar({
+    required int parsed,
+    required int unparsed,
+    required String kb,
+  }) {
+    if (unparsed > 0) {
+      return 'Error log copied ($parsed parsed + $unparsed raw entries, '
+          '$kb KB) — some entries failed to parse';
+    }
+    return 'Error log copied to clipboard — $kb KB, $parsed entries';
+  }
+
+  Future<void> _shareErrorLogAsFile(String json) async {
+    final tempDirProvider =
+        debugPrivacyTempDirectoryOverride ?? getTemporaryDirectory;
+    final tempDir = await tempDirProvider();
+    final filePath = '${tempDir.path}/tankstellen-error-log.json';
+    final file = File(filePath);
+    await file.writeAsString(json, flush: true);
+
+    final params = ShareParams(
+      files: [XFile(filePath, mimeType: 'application/json')],
+      subject: 'tankstellen-error-log.json',
+    );
+    final sink = debugPrivacyShareSinkOverride ?? _defaultShareSink;
+    await sink(params);
+  }
+
+  static Future<void> _defaultShareSink(ShareParams params) =>
+      SharePlus.instance.share(params);
 
   Future<void> _exportDataCsv() async {
     final storage = ref.read(storageRepositoryProvider);

--- a/test/core/telemetry/storage/trace_storage_test.dart
+++ b/test/core/telemetry/storage/trace_storage_test.dart
@@ -199,5 +199,93 @@ void main() {
         expect(lines[1], startsWith('  '));
       });
     });
+
+    /// #1301 — surface parse-vs-raw mismatch so the privacy dashboard
+    /// can warn the user (and ship the unreadable payload for offline
+    /// debugging) when a Hive schema migration leaves stale entries the
+    /// current `ErrorTrace.fromJson` can no longer decode.
+    group('parse-vs-raw (#1301)', () {
+      Map<String, dynamic> malformedEntry(String id) => <String, dynamic>{
+            'id': id,
+            // Missing every required field except id — this triggers
+            // FormatException inside ErrorTrace.fromJson.
+            'schemaVersion': 'unknown',
+          };
+
+      test(
+          'count returns the raw box length while parsedCount filters out '
+          'failures', () async {
+        final box = Hive.box('error_traces');
+        await box.put('valid', _makePlainJson(id: 'valid'));
+        await box.put('broken-1', malformedEntry('broken-1'));
+        await box.put('broken-2', malformedEntry('broken-2'));
+
+        expect(storage.count, 3);
+        expect(storage.parsedCount, 1);
+        expect(storage.unparsedCount, 2);
+      });
+
+      test(
+          'when every entry fails to parse, exportAsJson surfaces the raw '
+          'payload under unparsedRaw and traces is empty', () async {
+        final box = Hive.box('error_traces');
+        await box.put('broken-1', malformedEntry('broken-1'));
+        await box.put('broken-2', malformedEntry('broken-2'));
+
+        expect(storage.parsedCount, 0);
+        expect(storage.unparsedCount, storage.count);
+
+        final decoded =
+            jsonDecode(storage.exportAsJson()) as Map<String, dynamic>;
+        expect(decoded['traceCount'], 2);
+        expect(decoded['parsedCount'], 0);
+        expect(decoded['unparsedCount'], 2);
+        expect(decoded['traces'], isEmpty);
+        final unparsed = decoded['unparsedRaw'] as List;
+        expect(unparsed, hasLength(2));
+        // Each raw entry is round-tripped as a plain Map preserving the
+        // original id so a maintainer can correlate it back to the device.
+        final ids = unparsed
+            .map((e) => (e as Map<String, dynamic>)['id'] as String)
+            .toSet();
+        expect(ids, {'broken-1', 'broken-2'});
+      });
+
+      test(
+          'with mixed valid/invalid entries both arrays populate and counts '
+          'add up to the raw box length', () async {
+        final box = Hive.box('error_traces');
+        await box.put('valid-1', _makePlainJson(id: 'valid-1'));
+        await box.put('valid-2', _makePlainJson(id: 'valid-2'));
+        await box.put('broken', malformedEntry('broken'));
+
+        expect(storage.count, 3);
+        expect(storage.parsedCount, 2);
+        expect(storage.unparsedCount, 1);
+
+        final decoded =
+            jsonDecode(storage.exportAsJson()) as Map<String, dynamic>;
+        expect(decoded['traceCount'], 3);
+        expect(decoded['parsedCount'], 2);
+        expect(decoded['unparsedCount'], 1);
+        expect(decoded['traces'], hasLength(2));
+        expect(decoded['unparsedRaw'], hasLength(1));
+        final raw = (decoded['unparsedRaw'] as List).first as Map;
+        expect(raw['id'], 'broken');
+      });
+
+      test('unparsedCount is 0 (never negative) when every entry parses',
+          () async {
+        final box = Hive.box('error_traces');
+        await box.put('a', _makePlainJson(id: 'a'));
+        await box.put('b', _makePlainJson(id: 'b'));
+
+        expect(storage.unparsedCount, 0);
+        final decoded =
+            jsonDecode(storage.exportAsJson()) as Map<String, dynamic>;
+        expect(decoded['unparsedCount'], 0);
+        expect(decoded['unparsedRaw'], isEmpty);
+      });
+    });
   });
 }

--- a/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
+++ b/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
@@ -1,6 +1,10 @@
-﻿import 'package:flutter/widgets.dart';
+﻿import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:tankstellen/core/telemetry/storage/trace_storage.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 import 'package:tankstellen/core/sync/sync_config.dart';
@@ -15,11 +19,29 @@ import '../../../../mocks/mocks.dart';
 /// implementation calls `Hive.box('error_traces')` which fails in
 /// widget tests where Hive isn't initialised.
 class _StubTraceStorage extends TraceStorage {
-  @override
-  int get count => 0;
+  _StubTraceStorage({
+    this.stubCount = 0,
+    this.stubParsedCount = 0,
+    this.stubUnparsedCount = 0,
+    this.stubExport = '{"traceCount":0,"traces":[]}',
+  });
+
+  final int stubCount;
+  final int stubParsedCount;
+  final int stubUnparsedCount;
+  final String stubExport;
 
   @override
-  String exportAsJson() => '{"traceCount":0,"traces":[]}';
+  int get count => stubCount;
+
+  @override
+  int get parsedCount => stubParsedCount;
+
+  @override
+  int get unparsedCount => stubUnparsedCount;
+
+  @override
+  String exportAsJson() => stubExport;
 }
 
 /// #519 — the Privacy Dashboard body grew with the
@@ -258,6 +280,185 @@ void main() {
       expect(find.text('Estimated storage'), findsOneWidget);
       // 35136 bytes = 34.3 KB
       expect(find.text('34.3 KB'), findsOneWidget);
+    });
+
+    /// #1301 — `_exportErrorLog` must (a) write the JSON to the system
+    /// clipboard when the payload is small, (b) hand off via
+    /// share_plus when it's large, and (c) surface unparsed entries in
+    /// the snackbar so users know why a 21-entry log looks empty.
+    group('_exportErrorLog (#1301)', () {
+      Map<String, dynamic>? capturedClipboard;
+      ShareParams? capturedShareParams;
+
+      setUp(() {
+        capturedClipboard = null;
+        capturedShareParams = null;
+      });
+
+      void wireClipboardCapture(WidgetTester tester) {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform,
+                (MethodCall call) async {
+          if (call.method == 'Clipboard.setData') {
+            capturedClipboard = Map<String, dynamic>.from(call.arguments as Map);
+          }
+          return null;
+        });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding
+              .instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null);
+        });
+      }
+
+      void wireShareCapture() {
+        debugPrivacyShareSinkOverride = (params) async {
+          capturedShareParams = params;
+        };
+        debugPrivacyTempDirectoryOverride = () async =>
+            Directory.systemTemp.createTempSync('privacy_dashboard_test_');
+        addTearDown(() {
+          debugPrivacyShareSinkOverride = null;
+          debugPrivacyTempDirectoryOverride = null;
+        });
+      }
+
+      Future<void> tapExportButton(WidgetTester tester) async {
+        await tester.scrollUntilVisible(
+          find.byKey(const ValueKey('privacy-export-error-log-button')),
+          50.0,
+        );
+        // Tap inside runAsync so the export's real-time Futures
+        // (writeAsString + share sink) actually resolve. tester.tap
+        // itself is sync, but the onPressed callback kicks off an
+        // async chain that the fake clock can't pump.
+        await tester.runAsync(() async {
+          await tester.tap(
+            find.byKey(const ValueKey('privacy-export-error-log-button')),
+          );
+          // Give the disk IO + share sink real wall-clock time.
+          await Future<void>.delayed(const Duration(milliseconds: 500));
+        });
+        // Surface the resulting snackbar in the widget tree.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+
+      testWidgets(
+          'small JSON path writes to Clipboard.setData and skips share_plus',
+          (tester) async {
+        wireClipboardCapture(tester);
+        wireShareCapture();
+        await _setTallSurface(tester);
+
+        const smallJson = '{"traceCount":1,"traces":[{"id":"a"}]}';
+        final stub = _StubTraceStorage(
+          stubCount: 1,
+          stubParsedCount: 1,
+          stubExport: smallJson,
+        );
+        await pumpApp(
+          tester,
+          const PrivacyDashboardScreen(),
+          overrides: [
+            storageRepositoryProvider.overrideWithValue(mockStorage),
+            syncStateProvider.overrideWith(() => _DisabledSyncState()),
+            traceStorageProvider.overrideWithValue(stub),
+          ],
+        );
+
+        await tapExportButton(tester);
+
+        expect(capturedClipboard, isNotNull,
+            reason: 'small payload should reach the clipboard channel');
+        expect(capturedClipboard!['text'], smallJson);
+        expect(capturedShareParams, isNull,
+            reason: 'small payload should NOT trigger share_plus');
+        // Snackbar reports byte size + entry count.
+        expect(find.textContaining('Error log copied to clipboard'),
+            findsOneWidget);
+        expect(find.textContaining('1 entries'), findsOneWidget);
+      });
+
+      testWidgets(
+          'large JSON path hands off to share_plus with a JSON file attachment',
+          (tester) async {
+        wireClipboardCapture(tester);
+        wireShareCapture();
+        await _setTallSurface(tester);
+
+        // 80 KB > 64 KB threshold.
+        final bigPayload = '{"traceCount":1,"big":"${'x' * (80 * 1024)}"}';
+        final stub = _StubTraceStorage(
+          stubCount: 1,
+          stubParsedCount: 1,
+          stubExport: bigPayload,
+        );
+        await pumpApp(
+          tester,
+          const PrivacyDashboardScreen(),
+          overrides: [
+            storageRepositoryProvider.overrideWithValue(mockStorage),
+            syncStateProvider.overrideWith(() => _DisabledSyncState()),
+            traceStorageProvider.overrideWithValue(stub),
+          ],
+        );
+
+        await tapExportButton(tester);
+
+        expect(capturedShareParams, isNotNull,
+            reason: 'payload above 64 KB threshold must use share sheet');
+        expect(capturedShareParams!.files, isNotNull);
+        expect(capturedShareParams!.files!, hasLength(1));
+        expect(
+          capturedShareParams!.files!.first.path,
+          endsWith('tankstellen-error-log.json'),
+        );
+        expect(capturedClipboard, isNull,
+            reason: 'large payload skips clipboard');
+        // Snackbar mentions "shared".
+        expect(find.textContaining('Error log shared'), findsOneWidget);
+      });
+
+      testWidgets(
+          'snackbar surfaces parsed-vs-unparsed split when Hive has '
+          'schema drift', (tester) async {
+        wireClipboardCapture(tester);
+        wireShareCapture();
+        await _setTallSurface(tester);
+
+        const mixedJson = '{"traceCount":3,"parsedCount":1,'
+            '"unparsedCount":2,"traces":[],"unparsedRaw":[{"id":"x"}]}';
+        final stub = _StubTraceStorage(
+          stubCount: 3,
+          stubParsedCount: 1,
+          stubUnparsedCount: 2,
+          stubExport: mixedJson,
+        );
+        await pumpApp(
+          tester,
+          const PrivacyDashboardScreen(),
+          overrides: [
+            storageRepositoryProvider.overrideWithValue(mockStorage),
+            syncStateProvider.overrideWith(() => _DisabledSyncState()),
+            traceStorageProvider.overrideWithValue(stub),
+          ],
+        );
+
+        await tapExportButton(tester);
+
+        expect(capturedClipboard, isNotNull);
+        // Snackbar tells the user the breakdown explicitly.
+        expect(
+          find.textContaining(
+              'Error log copied (1 parsed + 2 raw entries'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('some entries failed to parse'),
+          findsOneWidget,
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes the privacy-dashboard "Copy error log" button silently exporting an empty payload after a schema migration and bypassing Samsung's clipboard truncation for large logs.

- `TraceStorage` now exposes `parsedCount` / `unparsedCount` getters and ships unreadable Hive entries under a new `unparsedRaw` key in `exportAsJson()` so a maintainer can debug schema drift offline. Broadened the parse catch in `getAll`/`getById` from `FormatException` to all errors — schema migrations throw `TypeError` (missing required field) too.
- `_exportErrorLog` in the privacy dashboard now (a) computes the UTF-8 byte size, (b) routes payloads above 64 KB through `share_plus` (file attachment via `path_provider`), with a clipboard fallback if share fails, and (c) reports the byte size + entry breakdown in the snackbar (e.g. `Error log copied (1 parsed + 2 raw entries, 0.2 KB) — some entries failed to parse`).
- Test-only `debugPrivacyShareSinkOverride` / `debugPrivacyTempDirectoryOverride` mirror the trip-renderer pattern so widget tests can assert on the outgoing `ShareParams` without launching the OS share sheet.

## Tests

- 4 new `TraceStorage` tests: `count` vs `parsedCount`, all-fail (`unparsedRaw` populated, `traces` empty), mixed valid/invalid, never-negative `unparsedCount`.
- 3 new `PrivacyDashboardScreen` widget tests: small JSON path (clipboard only), large JSON path (`share_plus` file attachment), parsed-vs-unparsed snackbar wording.
- Existing `trace_storage_test.dart` and `privacy_dashboard_screen_test.dart` cases stay green.

## Test plan

- [x] `flutter analyze` — `No issues found!`
- [x] `flutter test test/core/telemetry/storage/trace_storage_test.dart` — 16 tests pass
- [x] `flutter test test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart` — 14 tests pass
- [ ] Device test on Samsung S23 Ultra: trigger >64 KB log → confirm share sheet appears

Closes #1301