### PR TITLE
fix(consumption): accept OCR-eaten unit char in French thermal-print volume extraction (Closes #1308)

### DIFF
--- a/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
@@ -73,6 +73,27 @@ double? extractLiters(String text) {
     // ℓ because Dart regex treats the character as non-word, so the
     // original word boundary never held anyway.
     RegExp(r'(\d{1,3}[.,]\d{1,3})\s*(?:l(?:itres?)?\b|L\b|ℓ)'),
+    // French thermal-print POS receipts (#1308): the italic lowercase
+    // `l` (litre) glyph after the volume number is so faintly printed
+    // that ML Kit OCR transcribes it as `?`, `|`, `i`, `t`, `j`, `P`,
+    // or `1` — sometimes drops it entirely. Observed across multiple
+    // brands (Super U Pomerols 2026-04-19, enilive Pezenas 2026-04-23)
+    // so this is the French POS template, not brand-specific. The new
+    // pattern fires AFTER the strict l/L/ℓ pattern so anything we can
+    // read confidently is still preferred.
+    //
+    // Constraint: the number must have 2-3 decimals (fuel quantities
+    // aren't printed with 0 or 1 decimal on these receipts). The
+    // `(?!\d)` lookahead pins the decimals so `5.241` doesn't backtrack
+    // to capture `5.24` and consume the trailing `1` as the unit char.
+    // The `(?![A-Za-z0-9.,])` lookahead after the unit char ensures
+    // we didn't grab the `t` from `thanks`, the `i` from `inclus`, or
+    // the leading `1` of an adjacent decimal like `8,29  1,66` from
+    // a Total H.T./TVA column block (real false-positive observed on
+    // the TotalEnergies #801 fixture). The 0.1-300 L range guard at
+    // the bottom of this function prunes the remaining false positives
+    // (TVA percentages stay outside range).
+    RegExp(r'(\d{1,3}[.,]\d{2,3})(?!\d)\s*[?|itjP1](?![A-Za-z0-9.,])'),
     // "VOLUME : 42.35" / "Volume: 42,35" / "Quantité = 5.27"
     RegExp(
       r'(?:volume|quantit[eé])\s*[:=]?\s*(\d{1,3}[.,]\d{1,3})',

--- a/test/features/consumption/data/receipt_parser/fixtures/enilive_pezenas_2026-04-23.txt
+++ b/test/features/consumption/data/receipt_parser/fixtures/enilive_pezenas_2026-04-23.txt
@@ -1,0 +1,14 @@
+enilive france
+PEZENAS CARBURANTS
+18 AVENUE DE VERDUN
+34120 PEZENAS
+
+TICKET CLIENT      TRANSACTION ACCEPTÉE
+Date 23-04-2026 19:02:21
+* Pompe 1                ETHANOL 85
+Volume                    8.93 ?
+Prix                    € 0.899/?
+TOT TTC                  € 8.03
+*
+TVA 20.00 %              € 1.34
+Net                      € 6.69

--- a/test/features/consumption/data/receipt_parser/fixtures/super_u_pomerols_2026-04-19.txt
+++ b/test/features/consumption/data/receipt_parser/fixtures/super_u_pomerols_2026-04-19.txt
@@ -1,0 +1,13 @@
+SUPER U
+CHEMIN DU PORTROU
+34810 POMEROLS
+04 67 00 86 80
+QUITTANCE COPIE      TRANSACTION ACCEPTEE
+Date 19-04-2026 15:19:27
+* Pompe 3                              SP95-E10
+Volume                                 5.24 ?
+Prix                                 € 1.999/?
+TOT TTC                              € 10.47
+*
+TVA 20.00 %                          € 1.74
+Net                                  € 8.73

--- a/test/features/consumption/data/receipt_parser/receipt_field_extractors_test.dart
+++ b/test/features/consumption/data/receipt_parser/receipt_field_extractors_test.dart
@@ -231,6 +231,101 @@ void main() {
     });
   });
 
+  group('extractLiters — French POS unit-char OCR variants (#1308)', () {
+    // The italic lowercase `l` (litre) glyph after the volume number on
+    // French thermal-print receipts is so faintly printed that ML Kit
+    // OCR transcribes it as `?`, `|`, `i`, `t`, `j`, `P`, or `1`.
+    // Reported across Super U Pomerols + enilive Pezenas; the regex
+    // broadening lives in the GENERIC extractor so every brand benefits.
+
+    test('"5.24 ?" parses as 5.24 (Super U glyph)', () {
+      expect(extractLiters('5.24 ?'), closeTo(5.24, 0.001));
+    });
+
+    test('"5.24 |" parses as 5.24 (pipe-as-l misread)', () {
+      expect(extractLiters('5.24 |'), closeTo(5.24, 0.001));
+    });
+
+    test('"5.24 i" parses as 5.24 (dot-i misread)', () {
+      expect(extractLiters('5.24 i'), closeTo(5.24, 0.001));
+    });
+
+    test('"5.24 t" parses as 5.24 (narrow-glyph t misread)', () {
+      expect(extractLiters('5.24 t'), closeTo(5.24, 0.001));
+    });
+
+    test('"5.24 j" parses as 5.24', () {
+      expect(extractLiters('5.24 j'), closeTo(5.24, 0.001));
+    });
+
+    test('"5.24 P" parses as 5.24 (poor scan)', () {
+      expect(extractLiters('5.24 P'), closeTo(5.24, 0.001));
+    });
+
+    test('"8.93 ?" parses as 8.93 (enilive Pezenas case)', () {
+      expect(extractLiters('8.93 ?'), closeTo(8.93, 0.001));
+    });
+
+    test('"5.24 1" parses as 5.24 (digit-1 misread, with whitespace)', () {
+      // Whitespace before the `1` is the disambiguator: with a space
+      // the `1` is the unit char. Without space (`5.241`) the negative
+      // lookahead `(?!\d)` after the decimals prevents the partial
+      // capture, so `5.241` does NOT yield 5.24 — see boundary test.
+      expect(extractLiters('5.24 1'), closeTo(5.24, 0.001));
+    });
+
+    test('"5.241" does NOT match (no whitespace boundary)', () {
+      // Without whitespace between the decimals and the trailing digit,
+      // the lookahead pins the decimals to the full `5.241` token —
+      // which then has no `[?|itjP1]` unit char after it. No match.
+      // (No other regex picks this up because there's no `volume` /
+      // `quantité` label and no `x FUELCODE` line item either.)
+      expect(extractLiters('5.241'), isNull);
+    });
+
+    test('OCR-eaten char inside larger receipt text parses correctly', () {
+      // Whole-text match, not just the line.
+      const text = 'QUITTANCE COPIE\n* Pompe 3 SP95-E10\n'
+          'Volume                                 5.24 ?\n'
+          'Prix                                 € 1.999/?\n'
+          'TOT TTC                              € 10.47\n';
+      expect(extractLiters(text), closeTo(5.24, 0.001));
+    });
+
+    test('does not match when the unit char would form a longer word', () {
+      // "5,24 thanks" — `t` is in the OCR-eaten class, but it's
+      // followed by `h`, a word char, so the negative lookahead
+      // `(?![A-Za-z0-9])` rejects the partial match.
+      expect(extractLiters('5,24 thanks for your business'), isNull);
+    });
+  });
+
+  group('extractLiters — false-positive guards (#1308)', () {
+    test('"TVA 20.00 %" does NOT match (no OCR-eaten unit char)', () {
+      // The new pattern requires a `[?|itjP1]` after the number, and
+      // `%` is not in the class. Range guard would also reject 20.00.
+      expect(extractLiters('TVA 20.00 %'), isNull);
+    });
+
+    test('"2026-04-29" does NOT match (year fragment, no decimal point)', () {
+      // The `[.,]` separator in the captured group needs a literal
+      // `.` or `,`; the date hyphens defeat this.
+      expect(extractLiters('2026-04-29'), isNull);
+    });
+
+    test('"12.99 €" does NOT match (price, not volume)', () {
+      // The new pattern requires a `[?|itjP1]` unit char, not `€`.
+      expect(extractLiters('12.99 €'), isNull);
+    });
+
+    test('"€ 1.999/?" does NOT match as volume (slash blocks unit char)', () {
+      // The `?` after `1.999` is on the price-per-liter denominator,
+      // not the volume. The `/` between `1.999` and `?` is not
+      // whitespace, so `\s*[?|itjP1]` cannot bridge them.
+      expect(extractLiters('€ 1.999/?'), isNull);
+    });
+  });
+
   group('extractTotalCost', () {
     test('labelled "TOTAL 58.42"', () {
       expect(extractTotalCost('TOTAL 58.42'), closeTo(58.42, 0.001));

--- a/test/features/consumption/data/receipt_parser_test.dart
+++ b/test/features/consumption/data/receipt_parser_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/receipt_parser.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
@@ -454,6 +456,69 @@ Date Heure  Num Ticket
         final result = parser.parse(receiptText);
         expect(result.stationName?.toLowerCase(), contains('total'));
       });
+    });
+
+    // -------------------------------------------------------------------
+    // #1308 — French thermal-print POS receipts where ML Kit OCR
+    // misreads the italic lowercase `l` (litre) glyph as `?`, `|`, `i`,
+    // `t`, `j`, `P`, or `1`. Observed across multiple brands (Super U
+    // Pomerols, enilive Pezenas) so the regex broadening lives in the
+    // generic `extractLiters` and rescues every brand using this POS
+    // template.
+    // -------------------------------------------------------------------
+    group('French thermal-print OCR-eaten unit char (#1308)', () {
+      test(
+        'Super U Pomerols 2026-04-19 fixture: 5.24 L SP95-E10 with `5.24 ?` glyph',
+        () {
+          final receipt = File(
+            'test/features/consumption/data/receipt_parser/'
+            'fixtures/super_u_pomerols_2026-04-19.txt',
+          ).readAsStringSync();
+          final result = parser.parse(receipt);
+          expect(
+            result.liters,
+            closeTo(5.24, 0.01),
+            reason: 'volume should be rescued from the `5.24 ?` line',
+          );
+          expect(result.totalCost, closeTo(10.47, 0.01));
+          // Price-per-liter regex still requires `/L` / `/ℓ`; with the
+          // OCR-eaten `/?` denominator the labelled regex misses, and
+          // reconcile() derives ppl = total / liters = 10.47 / 5.24 ≈
+          // 1.998. Tolerance covers both 1.998 (derived) and 1.999
+          // (OCR-original) outcomes — the load-bearing assertion is
+          // that liters is no longer null.
+          expect(result.pricePerLiter, closeTo(1.999, 0.005));
+          expect(result.date, DateTime(2026, 4, 19));
+          expect(result.stationName, 'SUPER U');
+          expect(result.fuelType, FuelType.e10);
+          expect(result.brandLayout, 'super_u');
+        },
+      );
+
+      test(
+        'enilive Pezenas 2026-04-23 fixture: 8.93 L ETHANOL 85 with `8.93 ?` glyph',
+        () {
+          final receipt = File(
+            'test/features/consumption/data/receipt_parser/'
+            'fixtures/enilive_pezenas_2026-04-23.txt',
+          ).readAsStringSync();
+          final result = parser.parse(receipt);
+          expect(
+            result.liters,
+            closeTo(8.93, 0.01),
+            reason: 'volume should be rescued from the `8.93 ?` line',
+          );
+          expect(result.totalCost, closeTo(8.03, 0.01));
+          // 8.03 / 8.93 = 0.8990 → reconcile rounds to 0.899.
+          expect(result.pricePerLiter, closeTo(0.899, 0.005));
+          expect(result.date, DateTime(2026, 4, 23));
+          // enilive isn't in the brand-detection list, so this falls
+          // through to the generic layout and `ETHANOL 85` doesn't
+          // match the existing fuel-type patterns (no `bio` prefix,
+          // no compound `e85` token). Future work — out of scope here.
+          expect(result.brandLayout, 'generic');
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

Broaden the generic `extractLiters` regex to accept the OCR variants of the italic lowercase `l` (litre) glyph that ML Kit emits when scanning French thermal-print POS receipts. Observed across two unrelated brands (Super U Pomerols, enilive Pezenas) — pattern is the French POS template, not brand-specific.

## Regex — before / after

Before (one strict-only litre clause):
```dart
RegExp(r'(\d{1,3}[.,]\d{1,3})\s*(?:l(?:itres?)?\b|L\b|ℓ)'),
```

After (strict path still tried first; new fallback fires on the OCR-eaten char):
```dart
RegExp(r'(\d{1,3}[.,]\d{1,3})\s*(?:l(?:itres?)?\b|L\b|ℓ)'),
RegExp(r'(\d{1,3}[.,]\d{2,3})(?!\d)\s*[?|itjP1](?![A-Za-z0-9.,])'),
```

The `(?!\d)` lookahead pins decimals so `5.241` doesn't backtrack to capture `5.24` + `1`. The `(?![A-Za-z0-9.,])` after the unit char rejects `t` from `thanks`, `i` from `inclus`, and — crucially — the leading `1` of an adjacent decimal: a real false-positive surfaced when running against the existing TotalEnergies #801 fixture (`8,29   1,66` would otherwise have matched `8.29` as the volume).

## Fixtures

Two real-receipt fixtures were added under `test/features/consumption/data/receipt_parser/fixtures/`:

- `super_u_pomerols_2026-04-19.txt` — 5.24 L SP95-E10 with `Volume 5.24 ?` / `Prix € 1.999/?` / `TOT TTC € 10.47`.
- `enilive_pezenas_2026-04-23.txt` — 8.93 L ETHANOL 85 with `Volume 8.93 ?` / `Prix € 0.899/?` / `TOT TTC € 8.03`.

## Tests

12 new unit tests + 2 parser-level fixture tests:

`extractLiters — French POS unit-char OCR variants (#1308)` (8 tests):
- `5.24 ?` (Super U glyph)
- `5.24 |`, `5.24 i`, `5.24 t`, `5.24 j`, `5.24 P`
- `8.93 ?` (enilive case)
- `5.24 1` parses, `5.241` does NOT (boundary verification)
- OCR-eaten char inside larger receipt text
- does not match when the unit char would form a longer word (e.g. `5,24 thanks`)

`extractLiters — false-positive guards (#1308)` (4 tests):
- `TVA 20.00 %` does NOT match
- `2026-04-29` does NOT match (year fragment)
- `12.99 €` does NOT match (price, not volume)
- `€ 1.999/?` does NOT match (slash blocks unit char — guards against the price-line denominator masquerading as a volume)

`French thermal-print OCR-eaten unit char (#1308)` parser-level (2 tests):
- Super U Pomerols fixture → `liters: 5.24, totalCost: 10.47, pricePerLiter: ~1.999, fuelType: e10, brandLayout: super_u`.
- enilive Pezenas fixture → `liters: 8.93, totalCost: 8.03, pricePerLiter: ~0.899, brandLayout: generic`.

`flutter test test/features/consumption/data/receipt_parser/ test/features/consumption/data/receipt_parser_test.dart` → 245 tests pass (no regressions).

`flutter analyze` → No issues found.

## Out of scope

The position-aware Super U column-layout parser (point 2 of the issue body) is left for a follow-up; the regex broadening is brand-agnostic and rescues every French thermal-print receipt with this pattern in one shot.

## Test plan

- [x] `flutter analyze` clean
- [x] All 245 receipt-parser tests pass (203 existing + 14 new + 28 from sibling test files)
- [x] No regressions on the existing TotalEnergies #801 / Super U #713 / Carrefour #713 fixtures
- [x] Both rescued receipts parse with `liters` populated

Closes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)