### PR TITLE
feat(trip-detail): show OBD2 adapter id+name in trip summary

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -108,6 +108,15 @@ class Obd2ConnectionService {
     };
     final transport = BluetoothObd2Transport(channel);
     final service = Obd2Service(transport);
+    // #1312 — stamp adapter identity onto the service so the trip
+    // recorder can persist it on the saved [TripHistoryEntry] and the
+    // detail screen can name the device that produced the recording.
+    // The friendly name falls back to the registry's display label
+    // when the BLE advertisement was empty (matches the picker rule).
+    service.adapterMac = candidate.candidate.deviceId;
+    service.adapterName = candidate.candidate.deviceName.isEmpty
+        ? candidate.profile.displayName
+        : candidate.candidate.deviceName;
     final ok = await service.connect();
     if (!ok) {
       await service.disconnect();

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -49,6 +49,30 @@ class Obd2Service {
   /// for the exact semantics).
   Set<int>? _supportedPids;
 
+  /// Stable adapter identifier (BLE remote-id / Classic MAC) for the
+  /// device backing this session (#1312). Stamped by
+  /// [Obd2ConnectionService] on connect so downstream consumers
+  /// (the trip recorder) can attribute a recorded trip to a specific
+  /// hardware adapter without reaching back into the connection
+  /// service. Null when the service was constructed without going
+  /// through the connection layer (test fakes / direct transport
+  /// construction).
+  String? adapterMac;
+
+  /// Friendly device name advertised by the adapter (#1312). Falls
+  /// back to the registry's display name when the BLE advertisement
+  /// is empty. Stamped at the same moment as [adapterMac].
+  String? adapterName;
+
+  /// ELM327 firmware string (whatever `ATI` returned during init), if
+  /// the adapter reported one (#1312). Currently null in production
+  /// because the connect path does not snapshot the response — the
+  /// field is wired so a future enhancement can populate it without
+  /// touching the trip-history schema again. Persisted/round-tripped
+  /// by [TripHistoryEntry] so device-test reports can name the exact
+  /// firmware variant when we eventually capture it.
+  String? adapterFirmware;
+
   Obd2Service(
     this._transport, {
     SupportedPidsCache? pidsCache,

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -40,12 +40,33 @@ class TripHistoryEntry {
   /// well below the rolling-log cap.
   final List<TripSample> samples;
 
+  /// Stable BLE remote-id / Classic MAC of the OBD2 adapter that was
+  /// connected when this trip was recorded (#1312). Lets the trip
+  /// detail summary card name the suspect device when the user files
+  /// a bug report about adapter-specific PID gaps. Null for trips
+  /// recorded before #1312 landed and for any trip whose connect path
+  /// didn't stamp the service (e.g. test fakes).
+  final String? adapterMac;
+  /// Friendly device name advertised by the OBD2 adapter, falling
+  /// back to the registry's display label when the advertisement was
+  /// empty (#1312). Same null-semantics as [adapterMac].
+  final String? adapterName;
+  /// ELM327 firmware string returned by `ATI` during the init
+  /// sequence, when the connect path captured one (#1312). Currently
+  /// always null in production; persisted as a forward-compat field
+  /// so a future enhancement that snapshots `ATI` doesn't have to
+  /// migrate the trip-history schema again.
+  final String? adapterFirmware;
+
   const TripHistoryEntry({
     required this.id,
     required this.vehicleId,
     required this.summary,
     this.automatic = false,
     this.samples = const [],
+    this.adapterMac,
+    this.adapterName,
+    this.adapterFirmware,
   });
 
   Map<String, dynamic> toJson() => {
@@ -55,6 +76,14 @@ class TripHistoryEntry {
         if (automatic) 'automatic': true,
         if (samples.isNotEmpty)
           'samples': samples.map(_sampleToJson).toList(growable: false),
+        // #1312 — adapter identity. Compact keys so the per-trip JSON
+        // payload doesn't balloon (most trips carry one MAC + one
+        // name; firmware stays null until the connect path captures
+        // it). Each key is omitted when null so legacy entries
+        // round-trip unchanged.
+        if (adapterMac != null) 'adapterMac': adapterMac,
+        if (adapterName != null) 'adapterName': adapterName,
+        if (adapterFirmware != null) 'adapterFirmware': adapterFirmware,
       };
 
   static TripHistoryEntry fromJson(Map<String, dynamic> json) =>
@@ -70,6 +99,13 @@ class TripHistoryEntry {
                     (e) => _sampleFromJson((e as Map).cast<String, dynamic>()))
                 .toList(growable: false) ??
             const [],
+        // #1312 — adapter identity. Reads as `String?` so legacy
+        // entries written before this field landed deserialise with
+        // null rather than throwing (mirrors the schema-drift lesson
+        // from #1301).
+        adapterMac: json['adapterMac'] as String?,
+        adapterName: json['adapterName'] as String?,
+        adapterFirmware: json['adapterFirmware'] as String?,
       );
 }
 

--- a/lib/features/consumption/presentation/widgets/trip_summary_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_summary_card.dart
@@ -87,6 +87,24 @@ class TripSummaryCard extends ConsumerWidget {
               label: l?.trajetDetailFieldVehicle ?? 'Vehicle',
               value: vehicleName,
             ),
+            // #1312 — surface the OBD2 adapter identity directly
+            // under Vehicle so device-test bug reports can name the
+            // suspect device (different ELM327 clones expose different
+            // PID subsets). Hidden when no field was captured —
+            // legacy trips, fake-service tests, and any path that
+            // bypassed [Obd2ConnectionService] all carry null
+            // adapter fields and the row collapses cleanly.
+            if (entry.adapterMac != null ||
+                entry.adapterName != null ||
+                entry.adapterFirmware != null)
+              _SummaryRow(
+                label: l?.trajetDetailFieldAdapter ?? 'OBD2 adapter',
+                value: _formatAdapter(
+                  entry.adapterName,
+                  entry.adapterMac,
+                  entry.adapterFirmware,
+                ),
+              ),
             _SummaryRow(
               label: l?.trajetDetailFieldDistance ?? 'Distance',
               value: distance,
@@ -150,6 +168,31 @@ class TripSummaryCard extends ConsumerWidget {
       if (s.speedKmh > maxV) maxV = s.speedKmh;
     }
     return '${maxV.toStringAsFixed(1)} km/h';
+  }
+
+  /// Render the adapter identity as a single-line summary value
+  /// (#1312). Format is `name • mac` when both are present, just
+  /// one when only one is, with the firmware appended in parentheses
+  /// when known. Total length is capped at ~40 chars (head-truncated
+  /// with an ellipsis) so the row doesn't push the summary card into
+  /// a multi-line layout on narrow phones.
+  static String _formatAdapter(
+    String? name,
+    String? mac,
+    String? firmware,
+  ) {
+    final parts = <String>[];
+    if (name != null && name.isNotEmpty) parts.add(name);
+    if (mac != null && mac.isNotEmpty) parts.add(mac);
+    var label = parts.join(' • ');
+    if (firmware != null && firmware.isNotEmpty) {
+      label = label.isEmpty ? firmware : '$label ($firmware)';
+    }
+    const maxLen = 40;
+    if (label.length > maxLen) {
+      label = '${label.substring(0, maxLen - 1)}…';
+    }
+    return label;
   }
 
   static String _fmtDate(DateTime d) {

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -63,6 +63,17 @@ class TripRecording extends _$TripRecording {
   String? _vehicleId;
   ConsumptionFuelFamily _fuelFamily = ConsumptionFuelFamily.gasoline;
 
+  // #1312 — adapter identity captured at trip-start so it survives
+  // into the saved [TripHistoryEntry] even if the [Obd2Service] has
+  // been disconnected by the time `_saveToHistory` runs (`stop`
+  // disconnects the service before saving). Sourced from the service
+  // fields stamped by [Obd2ConnectionService] on connect; null when
+  // the service was constructed without going through the connection
+  // layer (test fakes).
+  String? _adapterMac;
+  String? _adapterName;
+  String? _adapterFirmware;
+
   /// Tests count haptic fires via these instead of hooking the
   /// platform channel. The production path also still calls
   /// [HapticFeedback], so counting here doesn't short-circuit the
@@ -210,6 +221,14 @@ class TripRecording extends _$TripRecording {
     if (state.isActive) return;
     _lastTripStartedAt ??= DateTime.now();
     _service = service;
+    // #1312 — snapshot adapter identity NOW. The service is
+    // disconnected during `stop` before `_saveToHistory` runs, so we
+    // can't read these off the live service at save time. Best-effort
+    // — a null reading just means the trip detail card will hide the
+    // adapter row.
+    _adapterMac = service.adapterMac;
+    _adapterName = service.adapterName;
+    _adapterFirmware = service.adapterFirmware;
     // #812 phase 3 — snapshot the active vehicle so the controller
     // can hand it to `readFuelRateLPerHour` on every tick. The
     // speed-density fallback reads engineDisplacementCc +
@@ -530,6 +549,12 @@ class TripRecording extends _$TripRecording {
     }
     _store = null;
     _vehicleId = null;
+    // #1312 — clear the captured adapter identity once the trip has
+    // been persisted; the next [start] call snapshots fresh values
+    // from whichever service it receives.
+    _adapterMac = null;
+    _adapterName = null;
+    _adapterFirmware = null;
     try {
       await svc.disconnect();
     } catch (e, st) {
@@ -952,6 +977,12 @@ class TripRecording extends _$TripRecording {
         summary: summary,
         automatic: automatic,
         samples: samples,
+        // #1312 — adapter identity snapshotted at [start] time. Null
+        // for legacy / fake-service code paths; the detail card hides
+        // the row entirely in that case.
+        adapterMac: _adapterMac,
+        adapterName: _adapterName,
+        adapterFirmware: _adapterFirmware,
       ));
       ref.read(tripHistoryListProvider.notifier).refresh();
       // Phase 5 (#1004): bump the launcher-icon badge so the user sees

--- a/lib/l10n/_fragments/trajets_de.arb
+++ b/lib/l10n/_fragments/trajets_de.arb
@@ -13,6 +13,7 @@
   "trajetDetailSummaryTitle": "Zusammenfassung",
   "trajetDetailFieldDate": "Datum",
   "trajetDetailFieldVehicle": "Fahrzeug",
+  "trajetDetailFieldAdapter": "OBD2-Adapter",
   "trajetDetailFieldDistance": "Strecke",
   "trajetDetailFieldDuration": "Dauer",
   "trajetDetailFieldAvgConsumption": "Ø Verbrauch",

--- a/lib/l10n/_fragments/trajets_en.arb
+++ b/lib/l10n/_fragments/trajets_en.arb
@@ -73,6 +73,10 @@
   "@trajetDetailFieldVehicle": {
     "description": "Label for the vehicle-name row in the Trip detail summary card (#890)."
   },
+  "trajetDetailFieldAdapter": "OBD2 adapter",
+  "@trajetDetailFieldAdapter": {
+    "description": "Label for the OBD2-adapter identity row in the Trip detail summary card (#1312). Shown immediately under the Vehicle row when the trip carries any adapter MAC, name, or firmware so device-test bug reports can name the suspect device. Hidden when none of the three fields were captured."
+  },
   "trajetDetailFieldDistance": "Distance",
   "@trajetDetailFieldDistance": {
     "description": "Label for the distance row in the Trip detail summary card (#890)."

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1575,6 +1575,7 @@
   "trajetDetailSummaryTitle": "Zusammenfassung",
   "trajetDetailFieldDate": "Datum",
   "trajetDetailFieldVehicle": "Fahrzeug",
+  "trajetDetailFieldAdapter": "OBD2-Adapter",
   "trajetDetailFieldDistance": "Strecke",
   "trajetDetailFieldDuration": "Dauer",
   "trajetDetailFieldAvgConsumption": "Ø Verbrauch",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2586,6 +2586,10 @@
   "@trajetDetailFieldVehicle": {
     "description": "Label for the vehicle-name row in the Trip detail summary card (#890)."
   },
+  "trajetDetailFieldAdapter": "OBD2 adapter",
+  "@trajetDetailFieldAdapter": {
+    "description": "Label for the OBD2-adapter identity row in the Trip detail summary card (#1312). Shown immediately under the Vehicle row when the trip carries any adapter MAC, name, or firmware so device-test bug reports can name the suspect device. Hidden when none of the three fields were captured."
+  },
   "trajetDetailFieldDistance": "Distance",
   "@trajetDetailFieldDistance": {
     "description": "Label for the distance row in the Trip detail summary card (#890)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -935,6 +935,7 @@
   "tripStartProgressReadingVehicleData": "Lecture des données du véhicule…",
   "tripStartProgressStartingRecording": "Démarrage de l'enregistrement…",
   "trajetDetailFieldFuelCost": "Coût du carburant",
+  "trajetDetailFieldAdapter": "Adaptateur OBD2",
   "trajetDetailShareAction": "Partager",
   "trajetDetailShareSubject": "Tankstellen — trajet du {date}",
   "trajetDetailShareError": "Impossible de générer l'image à partager",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7394,6 +7394,12 @@ abstract class AppLocalizations {
   /// **'Vehicle'**
   String get trajetDetailFieldVehicle;
 
+  /// Label for the OBD2-adapter identity row in the Trip detail summary card (#1312). Shown immediately under the Vehicle row when the trip carries any adapter MAC, name, or firmware so device-test bug reports can name the suspect device. Hidden when none of the three fields were captured.
+  ///
+  /// In en, this message translates to:
+  /// **'OBD2 adapter'**
+  String get trajetDetailFieldAdapter;
+
   /// Label for the distance row in the Trip detail summary card (#890).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3991,6 +3991,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3991,6 +3991,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3989,6 +3989,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4027,6 +4027,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Fahrzeug';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2-Adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Strecke';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3993,6 +3993,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3984,6 +3984,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3992,6 +3992,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3986,6 +3986,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3989,6 +3989,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4025,6 +4025,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'Adaptateur OBD2';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3988,6 +3988,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3993,6 +3993,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3992,6 +3992,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3990,6 +3990,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3992,6 +3992,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3988,6 +3988,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3993,6 +3993,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3991,6 +3991,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3992,6 +3992,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3991,6 +3991,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3992,6 +3992,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3986,6 +3986,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3990,6 +3990,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get trajetDetailFieldVehicle => 'Vehicle';
 
   @override
+  String get trajetDetailFieldAdapter => 'OBD2 adapter';
+
+  @override
   String get trajetDetailFieldDistance => 'Distance';
 
   @override

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -510,6 +510,105 @@ void main() {
     });
   });
 
+  group('TripHistoryEntry adapter identity persistence (#1312)', () {
+    test(
+        'entry with all three adapter fields round-trips through save / '
+        'loadAll', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 4, 29, 12, 0);
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: 'car-a',
+        summary: mkSummary(startedAt: start),
+        adapterMac: 'AA:BB:CC:DD:EE:FF',
+        adapterName: 'Vgate iCar Pro',
+        adapterFirmware: 'ELM327 v2.2',
+      ));
+
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.adapterMac, 'AA:BB:CC:DD:EE:FF');
+      expect(loaded.first.adapterName, 'Vgate iCar Pro');
+      expect(loaded.first.adapterFirmware, 'ELM327 v2.2');
+    });
+
+    test(
+        'entry with all adapter fields null does NOT include the adapter '
+        'keys in stored JSON — matches the parsimony rule the rest of the '
+        'optional summary keys already follow', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 4, 29, 12, 0);
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        // adapterMac / adapterName / adapterFirmware all null
+      ));
+
+      final raw = box.get(start.toIso8601String())!;
+      final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
+      expect(decoded.containsKey('adapterMac'), isFalse);
+      expect(decoded.containsKey('adapterName'), isFalse);
+      expect(decoded.containsKey('adapterFirmware'), isFalse);
+    });
+
+    test(
+        'legacy JSON (pre-#1312) without the adapter keys deserialises with '
+        'all three fields null — backward compat, mirrors the schema-drift '
+        'lesson from #1301 (no fromJson throw on missing optional keys)',
+        () async {
+      final start = DateTime(2026, 4, 29, 12, 0);
+      // Hand-craft a JSON payload as a pre-#1312 build would have
+      // written it: the persisted shape carries id/vehicleId/summary
+      // but none of the new adapter keys.
+      final legacyJson = jsonEncode({
+        'id': start.toIso8601String(),
+        'vehicleId': 'car-a',
+        'summary': {
+          'distanceKm': 10.0,
+          'maxRpm': 2800.0,
+          'highRpmSeconds': 0.0,
+          'idleSeconds': 0.0,
+          'harshBrakes': 0,
+          'harshAccelerations': 0,
+          'startedAt': start.toIso8601String(),
+        },
+        // 'adapterMac' / 'adapterName' / 'adapterFirmware' deliberately absent
+      });
+      await box.put(start.toIso8601String(), legacyJson);
+
+      final repo = TripHistoryRepository(box: box);
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.adapterMac, isNull);
+      expect(loaded.first.adapterName, isNull);
+      expect(loaded.first.adapterFirmware, isNull);
+      // Existing fields still parse — backward compat means the
+      // schema GAINS optional keys without breaking old entries.
+      expect(loaded.first.vehicleId, 'car-a');
+    });
+
+    test(
+        'partial adapter capture (name only, no mac, no firmware) round-trips '
+        '— each field is independently optional so we don\'t enshrine "all '
+        'or nothing" semantics', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 4, 29, 12, 0);
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        adapterName: 'OBDII',
+        // mac + firmware null
+      ));
+
+      final loaded = repo.loadAll();
+      expect(loaded.first.adapterName, 'OBDII');
+      expect(loaded.first.adapterMac, isNull);
+      expect(loaded.first.adapterFirmware, isNull);
+    });
+  });
+
   group('TripSample engineLoad + coolantTemp persistence (#1262 phase 1)', () {
     test(
         'sample with engineLoadPercent and coolantTempC round-trips through '

--- a/test/features/consumption/presentation/widgets/trip_summary_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_summary_card_test.dart
@@ -26,6 +26,9 @@ TripHistoryEntry _entry({
   DateTime? startedAt,
   DateTime? endedAt,
   String distanceSource = 'virtual',
+  String? adapterMac,
+  String? adapterName,
+  String? adapterFirmware,
 }) {
   return TripHistoryEntry(
     id: id,
@@ -43,6 +46,9 @@ TripHistoryEntry _entry({
       endedAt: endedAt,
       distanceSource: distanceSource,
     ),
+    adapterMac: adapterMac,
+    adapterName: adapterName,
+    adapterFirmware: adapterFirmware,
   );
 }
 
@@ -338,6 +344,96 @@ void main() {
       );
       expect(find.text('60.0 km/h'), findsOneWidget);
       expect(find.text('80.0 km/h'), findsOneWidget);
+    });
+  });
+
+  group('TripSummaryCard — OBD2 adapter row (#1312)', () {
+    testWidgets(
+        'renders the adapter row with "name • mac" formatting when both fields '
+        'are populated', (tester) async {
+      await pumpApp(
+        tester,
+        TripSummaryCard(
+          entry: _entry(
+            adapterMac: 'AA:BB:CC:DD:EE:FF',
+            adapterName: 'Vgate iCar Pro',
+          ),
+          vehicle: _vehicle,
+          samples: const [],
+          isEv: false,
+        ),
+      );
+
+      // Label rendered from the en ARB key.
+      expect(find.text('OBD2 adapter'), findsOneWidget);
+      // Value formatted with the • separator.
+      expect(
+        find.text('Vgate iCar Pro • AA:BB:CC:DD:EE:FF'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'hides the adapter row when all three adapter fields are null '
+        '(legacy trips, fake-service paths)', (tester) async {
+      await pumpApp(
+        tester,
+        TripSummaryCard(
+          entry: _entry(
+            // adapterMac / adapterName / adapterFirmware all null
+          ),
+          vehicle: _vehicle,
+          samples: const [],
+          isEv: false,
+        ),
+      );
+
+      expect(find.text('OBD2 adapter'), findsNothing);
+    });
+
+    testWidgets(
+        'renders just the name when mac is null and firmware is null '
+        '— format collapses cleanly without a stray separator',
+        (tester) async {
+      await pumpApp(
+        tester,
+        TripSummaryCard(
+          entry: _entry(
+            adapterName: 'OBDII',
+          ),
+          vehicle: _vehicle,
+          samples: const [],
+          isEv: false,
+        ),
+      );
+
+      expect(find.text('OBD2 adapter'), findsOneWidget);
+      expect(find.text('OBDII'), findsOneWidget);
+    });
+
+    testWidgets(
+        'appends firmware in parentheses when present, after the '
+        'name • mac value',
+        (tester) async {
+      await pumpApp(
+        tester,
+        TripSummaryCard(
+          entry: _entry(
+            adapterMac: 'AA:BB:CC:DD:EE:FF',
+            adapterName: 'OBDII',
+            adapterFirmware: 'ELM327 v1.5',
+          ),
+          vehicle: _vehicle,
+          samples: const [],
+          isEv: false,
+        ),
+      );
+
+      // ~40-char cap leaves the full value intact here.
+      expect(
+        find.text('OBDII • AA:BB:CC:DD:EE:FF (ELM327 v1.5)'),
+        findsOneWidget,
+      );
     });
   });
 


### PR DESCRIPTION
Closes #1312

## Summary
- Stamp the BLE remote-id (MAC) + advertised name onto `Obd2Service` from `Obd2ConnectionService.connect`, falling back to the registry's display label when the advertisement is empty (`connectByMac` inherits via the shared connect path).
- Persist three optional fields (`adapterMac` / `adapterName` / `adapterFirmware`) on `TripHistoryEntry`. `fromJson` reads them as `String?` so legacy entries written before #1312 deserialise cleanly without throwing — mirrors the schema-drift lesson from #1301.
- Capture adapter identity in `TripRecording.start` (snapshotted into provider-local fields because `stop` disconnects the service before `_saveToHistory` runs) and pass it into the saved `TripHistoryEntry`.
- New `_SummaryRow` directly under Vehicle on `TripSummaryCard`. Hidden when all three fields are null. Format is `name • mac` when both present, with optional `(firmware)` appended; the whole label is capped at 40 chars to keep the card layout stable on narrow phones.
- New ARB key `trajetDetailFieldAdapter` in `_fragments/trajets_{en,de}.arb` plus a French translation in `app_fr.arb`. Generated locale Dart files refreshed via `dart run tool/build_arb.dart` + `flutter gen-l10n`.

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/features/consumption/data/trip_history_repository_test.dart` — added round-trip + parsimony + legacy-JSON-no-throw + partial-capture cases (49 tests pass)
- [x] `flutter test test/features/consumption/presentation/widgets/trip_summary_card_test.dart` — added 4 cases (row visible, row hidden, name-only, firmware appended); all pass
- [x] `flutter test test/i18n/arb_key_parity_test.dart test/lint/arb_fragments_consistency_test.dart test/l10n/localization_completeness_test.dart` — all pass (en/de fragment parity holds; French covers the new key)
- [x] Smoke-tested adjacent suites (`obd2_connection_service_test.dart`, `trip_detail_body_test.dart`, `trip_detail_screen_test.dart`, `trip_recording_provider_test.dart`, `trip_recording_samples_persistence_test.dart`, `trip_history_save_integration_test.dart`) — all green
- [x] Lint (`no_silent_catch`, `catch_block_stacktrace_coverage`, `no_hardcoded_ui_strings`) — all green
- [ ] Full CI suite via push (skipped locally per worker policy)

## Out of scope
- Diagnosing why some adapters return empty PID series (#1312 just exposes the identity).
- Capturing the `ATI` firmware string. Field is wired forward-compat (always null in production today) so a future enhancement can land it without another schema change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>