### PR TITLE
fix(consumption): TripRecordingBanner guards GoRouter.maybeOf (Closes #1322)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -73,7 +73,27 @@ class TripRecordingBanner extends ConsumerWidget {
                 bottom: false,
                 child: InkWell(
                   key: const Key('tripRecordingBanner'),
-                  onTap: () => GoRouter.of(context).push('/trip-recording'),
+                  onTap: () {
+                    // #1322 — TripRecordingBanner is wrapped via
+                    // MaterialApp.builder, so its context can sit
+                    // ABOVE the Router/Navigator subtree on certain
+                    // modal paths (e.g. /privacy-dashboard). In those
+                    // cases GoRouter.of throws "No GoRouter found in
+                    // context". Use maybeOf + a ScaffoldMessenger
+                    // fallback so the banner never crashes.
+                    final router = GoRouter.maybeOf(context);
+                    if (router != null) {
+                      router.push('/trip-recording');
+                      return;
+                    }
+                    final messenger = ScaffoldMessenger.maybeOf(context);
+                    messenger?.showSnackBar(SnackBar(
+                      content: Text(
+                        l?.tripBannerOpenFromConsumptionTab ??
+                            'Open the active trip from the Conso tab',
+                      ),
+                    ));
+                  },
                   child: Padding(
                     padding: const EdgeInsets.symmetric(
                         horizontal: 12, vertical: 6),

--- a/lib/l10n/_fragments/trip_recording_pin_de.arb
+++ b/lib/l10n/_fragments/trip_recording_pin_de.arb
@@ -14,5 +14,6 @@
   "tripRecordingPinHelpTooltip": "Was macht das Anpinnen?",
   "tripRecordingPinHelpTitle": "Über das Anpinnen",
   "tripRecordingPinHelpBody": "Anpinnen hält den Bildschirm an und blendet die Systemleisten aus, damit das Formular auf einer Armaturenhalterung lesbar bleibt. Erneut tippen, um zu lösen. Wird automatisch beendet, wenn die Fahrt stoppt.",
-  "tripRecordingResumeHintMessage": "Die Aufnahme läuft im Hintergrund weiter. Tippe oben auf das rote Banner, um zurückzukehren."
+  "tripRecordingResumeHintMessage": "Die Aufnahme läuft im Hintergrund weiter. Tippe oben auf das rote Banner, um zurückzukehren.",
+  "tripBannerOpenFromConsumptionTab": "Aktive Fahrt aus dem Verbrauchs-Tab öffnen"
 }

--- a/lib/l10n/_fragments/trip_recording_pin_en.arb
+++ b/lib/l10n/_fragments/trip_recording_pin_en.arb
@@ -26,5 +26,9 @@
   "tripRecordingResumeHintMessage": "Recording continues in the background. Tap the red banner at the top of any screen to return.",
   "@tripRecordingResumeHintMessage": {
     "description": "One-time tooltip shown the first time the user backs out of the recording screen while a trip is still recording (#1273). Tells them they can tap the persistent banner to return. Persisted dismissal — never fires twice."
+  },
+  "tripBannerOpenFromConsumptionTab": "Open the active trip from the Conso tab",
+  "@tripBannerOpenFromConsumptionTab": {
+    "description": "Snackbar shown when the user taps the trip-recording banner on a screen whose context is above the GoRouter ancestor (#1322). Falls back from a navigation push to a hint pointing the user at the consumption tab."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1624,6 +1624,7 @@
   "tripRecordingPinHelpTitle": "Über das Anpinnen",
   "tripRecordingPinHelpBody": "Anpinnen hält den Bildschirm an und blendet die Systemleisten aus, damit das Formular auf einer Armaturenhalterung lesbar bleibt. Erneut tippen, um zu lösen. Wird automatisch beendet, wenn die Fahrt stoppt.",
   "tripRecordingResumeHintMessage": "Die Aufnahme läuft im Hintergrund weiter. Tippe oben auf das rote Banner, um zurückzukehren.",
+  "tripBannerOpenFromConsumptionTab": "Aktive Fahrt aus dem Verbrauchs-Tab öffnen",
   "vinLabel": "FIN (optional)",
   "vinDecodeTooltip": "FIN entschlüsseln",
   "vinConfirmAction": "Ja, automatisch ausfüllen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2756,6 +2756,10 @@
   "@tripRecordingResumeHintMessage": {
     "description": "One-time tooltip shown the first time the user backs out of the recording screen while a trip is still recording (#1273). Tells them they can tap the persistent banner to return. Persisted dismissal — never fires twice."
   },
+  "tripBannerOpenFromConsumptionTab": "Open the active trip from the Conso tab",
+  "@tripBannerOpenFromConsumptionTab": {
+    "description": "Snackbar shown when the user taps the trip-recording banner on a screen whose context is above the GoRouter ancestor (#1322). Falls back from a navigation push to a hint pointing the user at the consumption tab."
+  },
   "vinLabel": "VIN (optional)",
   "vinDecodeTooltip": "Decode VIN",
   "vinConfirmAction": "Yes, auto-fill",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -785,6 +785,7 @@
   "tripResume": "Reprendre",
   "tripBannerRecording": "Enregistrement en cours",
   "tripBannerPaused": "Trajet en pause — toucher pour reprendre",
+  "tripBannerOpenFromConsumptionTab": "Ouvrez le trajet actif depuis l'onglet Conso",
   "navConsumption": "Conso",
   "vehicleBaselineSectionTitle": "Calibrage de la baseline",
   "vehicleBaselineEmpty": "Aucun échantillon pour l'instant — lancez un trajet OBD2 pour commencer à apprendre le profil de consommation de ce véhicule.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7634,6 +7634,12 @@ abstract class AppLocalizations {
   /// **'Recording continues in the background. Tap the red banner at the top of any screen to return.'**
   String get tripRecordingResumeHintMessage;
 
+  /// Snackbar shown when the user taps the trip-recording banner on a screen whose context is above the GoRouter ancestor (#1322). Falls back from a navigation push to a hint pointing the user at the consumption tab.
+  ///
+  /// In en, this message translates to:
+  /// **'Open the active trip from the Conso tab'**
+  String get tripBannerOpenFromConsumptionTab;
+
   /// No description provided for @vinLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4127,6 +4127,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4127,6 +4127,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4125,6 +4125,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4164,6 +4164,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Die Aufnahme läuft im Hintergrund weiter. Tippe oben auf das rote Banner, um zurückzukehren.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Aktive Fahrt aus dem Verbrauchs-Tab öffnen';
+
+  @override
   String get vinLabel => 'FIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4129,6 +4129,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4120,6 +4120,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4128,6 +4128,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4122,6 +4122,10 @@ class AppLocalizationsEt extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4125,6 +4125,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4164,6 +4164,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Ouvrez le trajet actif depuis l\'onglet Conso';
+
+  @override
   String get vinLabel => 'VIN (optionnel)';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4124,6 +4124,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4129,6 +4129,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4128,6 +4128,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4126,6 +4126,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4128,6 +4128,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4124,6 +4124,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4129,6 +4129,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4127,6 +4127,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4128,6 +4128,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4127,6 +4127,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4128,6 +4128,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4122,6 +4122,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4126,6 +4126,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Recording continues in the background. Tap the red banner at the top of any screen to return.';
 
   @override
+  String get tripBannerOpenFromConsumptionTab =>
+      'Open the active trip from the Conso tab';
+
+  @override
   String get vinLabel => 'VIN (optional)';
 
   @override

--- a/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
 import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
 import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_recording_banner.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -132,6 +135,147 @@ void main() {
       expect(label, contains('-12%'));
       expect(label, isNot(contains('+-12%')));
       handle.dispose();
+    });
+  });
+
+  // #1322 — TripRecordingBanner sits inside MaterialApp.builder, so
+  // its build context can be ABOVE the Router/Navigator subtree on
+  // certain modal paths (e.g. /privacy-dashboard). GoRouter.of throws
+  // "No GoRouter found in context" there. Verify the banner now uses
+  // GoRouter.maybeOf and falls back to a snackbar instead of crashing.
+  group('TripRecordingBanner GoRouter fallback (#1322)', () {
+    testWidgets(
+        'tap with no GoRouter ancestor does not throw — '
+        'falls back gracefully on /privacy-dashboard-style modal paths',
+        (tester) async {
+      // Plain MaterialApp (no .router constructor) means the InheritedWidget
+      // lookup for GoRouter will return null, mirroring the production
+      // crash on /privacy-dashboard.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            tripRecordingProvider.overrideWith(
+              () => _FakeTripRecording(_activeState(
+                band: ConsumptionBand.normal,
+                distance: 1.0,
+              )),
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: TripRecordingBanner(child: SizedBox()),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Sanity: banner is mounted.
+      expect(find.byKey(const Key('tripRecordingBanner')), findsOneWidget);
+
+      // Tapping must not throw — the production trace was a hard crash.
+      await tester.tap(find.byKey(const Key('tripRecordingBanner')));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+        'tap with no GoRouter ancestor surfaces snackbar pointing '
+        'the user at the consumption tab — silent no-op would be worse',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            tripRecordingProvider.overrideWith(
+              () => _FakeTripRecording(_activeState(
+                band: ConsumptionBand.normal,
+                distance: 1.0,
+              )),
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: TripRecordingBanner(child: SizedBox()),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('tripRecordingBanner')));
+      // SnackBar uses a slide animation — pump a few frames to let it
+      // mount, but don't pumpAndSettle (the banner shows no spinner
+      // here, but the SnackBar dismissal timer could otherwise dangle).
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        find.text('Open the active trip from the Conso tab'),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+        'tap with GoRouter ancestor pushes /trip-recording — '
+        'regression for the happy path',
+        (tester) async {
+      final pushedLocations = <String>[];
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => const Scaffold(
+              body: TripRecordingBanner(child: SizedBox()),
+            ),
+          ),
+          GoRoute(
+            path: '/trip-recording',
+            builder: (_, _) {
+              pushedLocations.add('/trip-recording');
+              return const Scaffold(body: Text('trip-recording-screen'));
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            tripRecordingProvider.overrideWith(
+              () => _FakeTripRecording(_activeState(
+                band: ConsumptionBand.normal,
+                distance: 1.0,
+              )),
+            ),
+          ],
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(const Key('tripRecordingBanner')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('tripRecordingBanner')));
+      // GoRouter push triggers a route transition animation. Pump a
+      // bounded number of frames rather than pumpAndSettle (in case
+      // any descendant shows a continuous indicator on transition).
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(pushedLocations, contains('/trip-recording'));
+      expect(find.text('trip-recording-screen'), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #1322 — `TripRecordingBanner` crashed with "No GoRouter found in context" when tapped from `/privacy-dashboard` (and other modal paths). The banner is wrapped via `MaterialApp.builder`, so its build context can sit above the Router/Navigator subtree.

- `GoRouter.maybeOf(context)` instead of `GoRouter.of(context)` at the InkWell tap
- `ScaffoldMessenger.maybeOf` snackbar fallback hint pointing the user at the Conso tab — never silent, never crashing
- New ARB key `tripBannerOpenFromConsumptionTab` (en/de/fr); added via fragment for en+de, directly in `app_fr.arb` for fr

## Test plan

- [x] Widget test: tap with no GoRouter ancestor — no throw
- [x] Widget test: tap with no GoRouter ancestor surfaces the snackbar
- [x] Widget test: tap with GoRouter ancestor still pushes `/trip-recording` (regression)
- [x] `flutter analyze` clean
- [x] All 7 tests pass in `trip_recording_banner_test.dart`

Closes #1322

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>