### PR TITLE
fix(search): guard SearchState writes with ref.mounted (Closes #1321)

### DIFF
--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -55,6 +55,11 @@ class SearchState extends _$SearchState {
 
   @override
   AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
+    // #1321 — when the provider is disposed mid-flight (e.g. user
+    // navigates away while searchByGps is awaiting), cancel the active
+    // HTTP request so we drop the in-flight DioException via cancel
+    // rather than letting it bubble into a disposed `state =` write.
+    ref.onDispose(() => _activeCancelToken?.cancel('Provider disposed'));
     return AsyncValue.data(ServiceResult(
       data: const [],
       source: ServiceSource.cache,
@@ -81,14 +86,21 @@ class SearchState extends _$SearchState {
   /// handling. Cancellations are silently dropped; every other
   /// exception flows into [AsyncValue.error] via [classifySearchError]
   /// so the UI can surface a fallback summary.
+  ///
+  /// #1321 — every post-await `state =` write is guarded by
+  /// `ref.mounted` to avoid the "set state on disposed provider" crash
+  /// when the user navigates away (e.g. /search → /trip-recording)
+  /// while a search future is in flight.
   Future<void> _runSearch(
     Future<void> Function(CancelToken cancelToken) search,
   ) async {
+    if (!ref.mounted) return;
     state = const AsyncValue.loading();
     final cancelToken = _newCancelToken();
     try {
       await search(cancelToken);
     } catch (e, st) {
+      if (!ref.mounted) return;
       final classified = classifySearchError(e, st);
       if (classified != null) state = classified;
     }
@@ -112,6 +124,7 @@ class SearchState extends _$SearchState {
     await _runSearch((cancelToken) async {
       final position =
           await ref.read(locationServiceProvider).getCurrentPosition();
+      if (!ref.mounted) return;
       ref.read(userPositionProvider.notifier).setFromGps(
             position.latitude, position.longitude,
           );
@@ -124,6 +137,7 @@ class SearchState extends _$SearchState {
         lng: position.longitude,
         radiusKm: resolved.radiusKm,
       );
+      if (!ref.mounted) return;
       if (ev != null) { state = ev; return; }
 
       // Reverse-geocode for a postal code (Prix-Carburants + co).
@@ -132,6 +146,7 @@ class SearchState extends _$SearchState {
         position.latitude, position.longitude,
         cancelToken: cancelToken,
       );
+      if (!ref.mounted) return;
       String? resolvedPostalCode;
       if (addr != null) {
         resolvedPostalCode = extractPostalCode(addr);
@@ -149,6 +164,7 @@ class SearchState extends _$SearchState {
       final result = await ref
           .read(stationServiceProvider)
           .searchStations(params, cancelToken: cancelToken);
+      if (!ref.mounted) return;
       state = AsyncValue.data(wrapFuelResultAsSearchItems(result));
     });
   }
@@ -172,10 +188,12 @@ class SearchState extends _$SearchState {
         );
     await _runSearch((cancelToken) async {
       await autoUpdatePositionIfEnabled(ref);
+      if (!ref.mounted) return;
       final geocoding = ref.read(geocodingChainProvider);
       final coordsResult = await geocoding.zipCodeToCoordinates(
         zipCode, cancelToken: cancelToken,
       );
+      if (!ref.mounted) return;
 
       final resolved = resolveFuelAndRadius(ref, fuelType, radiusKm);
       final ev = await dispatchEvIfNeeded(
@@ -185,12 +203,14 @@ class SearchState extends _$SearchState {
         lng: coordsResult.data.lng,
         radiusKm: resolved.radiusKm,
       );
+      if (!ref.mounted) return;
       if (ev != null) { state = ev; return; }
 
       final cityName = await tryReverseGeocode(
         geocoding, coordsResult.data.lat, coordsResult.data.lng,
         cancelToken: cancelToken,
       );
+      if (!ref.mounted) return;
 
       final locationLabel = '$zipCode ${cityName ?? ''}'.trim();
       ref.read(searchLocationProvider.notifier).set(locationLabel);
@@ -207,6 +227,7 @@ class SearchState extends _$SearchState {
       final result = await ref
           .read(stationServiceProvider)
           .searchStations(params, cancelToken: cancelToken);
+      if (!ref.mounted) return;
 
       final adjustedStations =
           recalcDistancesFrom(result.data, ref.read(userPositionProvider));
@@ -244,6 +265,7 @@ class SearchState extends _$SearchState {
         );
     await _runSearch((cancelToken) async {
       await autoUpdatePositionIfEnabled(ref);
+      if (!ref.mounted) return;
       if (locationName != null) {
         ref.read(searchLocationProvider.notifier).set(locationName);
       }
@@ -256,6 +278,7 @@ class SearchState extends _$SearchState {
         lng: lng,
         radiusKm: resolved.radiusKm,
       );
+      if (!ref.mounted) return;
       if (ev != null) { state = ev; return; }
 
       final params = SearchParams(
@@ -269,6 +292,7 @@ class SearchState extends _$SearchState {
       final result = await ref
           .read(stationServiceProvider)
           .searchStations(params, cancelToken: cancelToken);
+      if (!ref.mounted) return;
       final adjustedStations =
           recalcDistancesFrom(result.data, ref.read(userPositionProvider));
 

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/location/location_service.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/services/geocoding_chain.dart';
 import 'package:tankstellen/core/services/service_providers.dart';
@@ -19,6 +23,8 @@ import '../../../fakes/fake_hive_storage.dart';
 import '../../../mocks/mocks.dart';
 
 class MockGeocodingChain extends Mock implements GeocodingChain {}
+
+class MockLocationService extends Mock implements LocationService {}
 
 class _NullUserPosition extends UserPosition {
   @override
@@ -851,6 +857,197 @@ void main() {
       // (it stays in initial state because EV dispatch returned early)
       final state = container.read(searchStateProvider);
       expect(state.value!.data, isEmpty);
+    });
+  });
+
+  group('dispose-mid-flight (#1321 — ref-not-mounted crash)', () {
+    /// Builds a [Position] without going through geolocator's platform
+    /// channel — `Position` has a public const-ish ctor we can fill.
+    Position fakePosition() => Position(
+          latitude: 52.52,
+          longitude: 13.41,
+          timestamp: DateTime.now(),
+          accuracy: 5.0,
+          altitude: 0.0,
+          altitudeAccuracy: 0.0,
+          heading: 0.0,
+          headingAccuracy: 0.0,
+          speed: 0.0,
+          speedAccuracy: 0.0,
+        );
+
+    test(
+        'GPS dispose mid-flight does not throw when inner future '
+        'completes after dispose', () async {
+      final mockLocation = MockLocationService();
+      // Hold the GPS future open so we can dispose mid-flight, then
+      // complete it AFTER the container is gone.
+      final positionCompleter = Completer<Position>();
+      when(() => mockLocation.getCurrentPosition())
+          .thenAnswer((_) => positionCompleter.future);
+
+      when(() => mockGeocoding.coordinatesToAddress(any(), any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: 'Berlin',
+                source: ServiceSource.nominatimGeocoding,
+                fetchedAt: DateTime.now(),
+              ));
+      when(() => mockStationService.searchStations(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: [testStation],
+                source: ServiceSource.tankerkoenigApi,
+                fetchedAt: DateTime.now(),
+              ));
+
+      final container = ProviderContainer(overrides: [
+        hiveStorageProvider.overrideWithValue(fakeStorage),
+        stationServiceProvider.overrideWithValue(mockStationService),
+        geocodingChainProvider.overrideWithValue(mockGeocoding),
+        locationServiceProvider.overrideWithValue(mockLocation),
+        userPositionProvider.overrideWith(() => _NullUserPosition()),
+      ]);
+
+      // Fire the search but don't await — we need to dispose mid-flight.
+      final searchFuture =
+          container.read(searchStateProvider.notifier).searchByGps();
+
+      // Dispose the container while searchByGps is awaiting GPS.
+      container.dispose();
+
+      // Now complete the GPS future. Without the ref.mounted guards,
+      // every post-await `state =` write would throw on the disposed
+      // provider; with them, the search exits cleanly.
+      positionCompleter.complete(fakePosition());
+
+      await expectLater(searchFuture, completes);
+    });
+
+    test(
+        'GPS dispose mid-await with throw does not propagate '
+        'Ref._throwIfInvalidUsage', () async {
+      final mockLocation = MockLocationService();
+      final positionCompleter = Completer<Position>();
+      when(() => mockLocation.getCurrentPosition())
+          .thenAnswer((_) => positionCompleter.future);
+
+      final container = ProviderContainer(overrides: [
+        hiveStorageProvider.overrideWithValue(fakeStorage),
+        stationServiceProvider.overrideWithValue(mockStationService),
+        geocodingChainProvider.overrideWithValue(mockGeocoding),
+        locationServiceProvider.overrideWithValue(mockLocation),
+        userPositionProvider.overrideWith(() => _NullUserPosition()),
+      ]);
+
+      final searchFuture =
+          container.read(searchStateProvider.notifier).searchByGps();
+
+      container.dispose();
+
+      // Throw AFTER dispose — without the catch-block guard this would
+      // try to `state = classified` on a disposed ref and bubble up
+      // Riverpod's "set state on disposed provider" StateError.
+      positionCompleter.completeError(
+        Exception('Network error after dispose'),
+      );
+
+      await expectLater(searchFuture, completes);
+    });
+
+    test('ZipCode dispose mid-flight does not throw', () async {
+      final geocodeCompleter =
+          Completer<ServiceResult<({double lat, double lng})>>();
+      when(() => mockGeocoding.zipCodeToCoordinates('10115',
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) => geocodeCompleter.future);
+      when(() => mockGeocoding.coordinatesToAddress(any(), any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: 'Berlin',
+                source: ServiceSource.nominatimGeocoding,
+                fetchedAt: DateTime.now(),
+              ));
+      when(() => mockStationService.searchStations(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: [testStation],
+                source: ServiceSource.tankerkoenigApi,
+                fetchedAt: DateTime.now(),
+              ));
+
+      final container = createContainer();
+      final searchFuture = container
+          .read(searchStateProvider.notifier)
+          .searchByZipCode(zipCode: '10115');
+
+      // Dispose while geocoding is still pending.
+      container.dispose();
+
+      // Complete the geocoding result post-dispose. The continuation
+      // would normally write `state = AsyncValue.data(...)` after
+      // each subsequent await — every write must short-circuit on
+      // !ref.mounted.
+      geocodeCompleter.complete(ServiceResult(
+        data: (lat: 52.52, lng: 13.41),
+        source: ServiceSource.nominatimGeocoding,
+        fetchedAt: DateTime.now(),
+      ));
+
+      await expectLater(searchFuture, completes);
+    });
+
+    test(
+        'CancelToken is cancelled on container dispose so in-flight '
+        'HTTP is dropped', () async {
+      // Capture the CancelToken handed to the station service so we
+      // can assert it was cancelled when the container was disposed.
+      CancelToken? capturedToken;
+      final stationCompleter =
+          Completer<ServiceResult<List<Station>>>();
+      when(() => mockStationService.searchStations(any(),
+          cancelToken: any(named: 'cancelToken'))).thenAnswer((inv) {
+        capturedToken =
+            inv.namedArguments[#cancelToken] as CancelToken?;
+        return stationCompleter.future;
+      });
+
+      final container = createContainer();
+      // searchStateProvider is autoDispose; keep it alive across the
+      // read+delay so the autoDispose timer doesn't run our onDispose
+      // before we manually dispose the container.
+      final sub = container.listen(
+        searchStateProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final searchFuture = container
+          .read(searchStateProvider.notifier)
+          .searchByCoordinates(lat: 52.52, lng: 13.41);
+
+      // Yield so the search reaches the station-service await and
+      // the CancelToken is captured.
+      await Future<void>.delayed(Duration.zero);
+      expect(capturedToken, isNotNull,
+          reason: 'station service must be reached before dispose');
+      expect(capturedToken!.isCancelled, isFalse);
+
+      container.dispose();
+
+      expect(capturedToken!.isCancelled, isTrue,
+          reason:
+              'ref.onDispose in build() must cancel the active token '
+              'so the in-flight HTTP request is dropped (#1321).');
+
+      // Complete the station future with a cancel error — the search
+      // must still complete cleanly (no unhandled exception).
+      stationCompleter.completeError(DioException(
+        type: DioExceptionType.cancel,
+        requestOptions: RequestOptions(),
+      ));
+
+      await expectLater(searchFuture, completes);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #1321 — production crash when the user navigates from `/search` to `/trip-recording` while `searchByGps` is in flight: Riverpod disposes the provider, the in-flight future throws, and the `catch` block crashes setting `state = classified` on a disposed ref.

- Guard every post-await `state =` and `ref.read(...).set(...)` write in `_runSearch` and the closures passed by `searchByGps` / `searchByZipCode` / `searchByCoordinates` with `if (!ref.mounted) return;`.
- `ref.onDispose` in `build()` cancels the active `CancelToken` so in-flight HTTP requests are dropped on dispose rather than completing into a disposed provider.
- No silent catches — existing `classifySearchError` path is preserved; the catch-side write is just guarded.

## Test plan

- [x] `flutter analyze` clean (full project, includes `test/`).
- [x] `flutter test test/features/search/providers/search_provider_test.dart` — all 41 tests pass, including 4 new dispose-mid-flight cases:
  - GPS dispose mid-flight, inner future completes after dispose
  - GPS dispose mid-await, future throws after dispose (no `Ref._throwIfInvalidUsage` propagates)
  - ZipCode dispose mid-flight (covers `_runSearch` via `searchByZipCode`)
  - CancelToken transitions to cancelled on container dispose (proves `ref.onDispose` runs)
- [ ] Manual smoke on a build: trigger search-by-GPS, navigate to /trip-recording before results return — no Sentry crash.