### PR TITLE
fix(consumption): TripRecordingBanner uses ref.read(routerProvider) for navigation (Closes #1322)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../app/router.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/cold_start_baselines.dart';
 import '../../domain/situation_classifier.dart';
@@ -73,7 +73,15 @@ class TripRecordingBanner extends ConsumerWidget {
                 bottom: false,
                 child: InkWell(
                   key: const Key('tripRecordingBanner'),
-                  onTap: () => GoRouter.of(context).push('/trip-recording'),
+                  // #1322 — read the router from Riverpod instead of
+                  // looking it up in `context`. The banner is mounted
+                  // inside `MaterialApp.router(builder: …)` (see
+                  // `lib/app/app.dart`), so this BuildContext is above
+                  // the GoRouter's widget tree and `GoRouter.of(context)`
+                  // throws "No GoRouter found in context". The Riverpod
+                  // lookup has no InheritedWidget dependency and works
+                  // from anywhere under the ProviderScope.
+                  onTap: () => ref.read(routerProvider).push('/trip-recording'),
                   child: Padding(
                     padding: const EdgeInsets.symmetric(
                         horizontal: 12, vertical: 6),

--- a/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tankstellen/app/router.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
 import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
 import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_recording_banner.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -132,6 +136,88 @@ void main() {
       expect(label, contains('-12%'));
       expect(label, isNot(contains('+-12%')));
       handle.dispose();
+    });
+  });
+
+  group('TripRecordingBanner navigation (#1322)', () {
+    // Regression: the banner is mounted in `MaterialApp.router(builder: …)`
+    // (see `lib/app/app.dart`), so its BuildContext sits ABOVE the GoRouter's
+    // widget tree. `GoRouter.of(context)` therefore throws "No GoRouter
+    // found in context" — reproduced from the privacy-dashboard route.
+    // The fix reads the router via Riverpod, which has no InheritedWidget
+    // dependency. This test pumps the banner inside a plain `MaterialApp`
+    // (NOT `MaterialApp.router`) to exercise the same structural scope.
+    testWidgets(
+        'tap pushes /trip-recording via Riverpod-provided router '
+        '— survives mounting outside the GoRouter widget scope',
+        (tester) async {
+      // Mirror the production wiring exactly: the banner sits in
+      // MaterialApp.router's `builder` (above the GoRouter's widget
+      // tree). `GoRouter.of(context)` would throw "No GoRouter found
+      // in context" from this scope — that's the #1322 bug. The fix
+      // reads the router via Riverpod, which has no InheritedWidget
+      // dependency.
+      String? landedOn;
+      final fakeRouter = GoRouter(
+        initialLocation: '/from',
+        routes: [
+          GoRoute(path: '/from', builder: (_, _) => const Text('from')),
+          GoRoute(
+            path: '/trip-recording',
+            builder: (_, _) {
+              landedOn = '/trip-recording';
+              return const Text('trip-recording');
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            tripRecordingProvider.overrideWith(
+              () => _FakeTripRecording(_activeState()),
+            ),
+            routerProvider.overrideWith((_) => fakeRouter),
+          ],
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: fakeRouter,
+            builder: (context, child) => TripRecordingBanner(
+              child: child ?? const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      // Sanity: we start on /from, banner is mounted ABOVE that route's
+      // widget tree (i.e. outside the InheritedGoRouter scope).
+      expect(find.text('from'), findsOneWidget);
+      expect(find.byKey(const Key('tripRecordingBanner')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('tripRecordingBanner')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(landedOn, '/trip-recording',
+          reason: 'banner should have pushed via the Riverpod-provided '
+              'router; if this fails the GoRouter.of(context) regression '
+              'is back');
+      expect(find.text('trip-recording'), findsOneWidget);
+    });
+
+    testWidgets('idle state renders no banner — no tap target exists',
+        (tester) async {
+      // No provider override: TripRecording.build() throws because it
+      // expects a vehicle/baselines wired up, so we must override with
+      // an idle fake to keep the banner-zero-height path deterministic.
+      await pumpApp(
+        tester,
+        const TripRecordingBanner(child: SizedBox(key: Key('child'))),
+      );
+      expect(find.byKey(const Key('tripRecordingBanner')), findsNothing);
+      expect(find.byKey(const Key('child')), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- **Root cause**: `TripRecordingBanner` is mounted in `MaterialApp.router(builder: …)` in `lib/app/app.dart:111`, which runs ABOVE the GoRouter's widget tree. `GoRouter.of(context)` is an `InheritedWidget` lookup, so calling it from this BuildContext throws "No GoRouter found in context" (reproduced from `/privacy-dashboard`).
- **Fix**: Read the router from Riverpod via `ref.read(routerProvider).push('/trip-recording')`. Riverpod has no InheritedWidget dependency and resolves from anywhere under the `ProviderScope`. Drops the now-unused `go_router` import.
- **Test**: New regression test in `trip_recording_banner_test.dart` pumps the banner inside `MaterialApp.router`'s `builder` callback (mirroring the production wiring) with an active recording state + a fake `routerProvider`; asserts the tap pushes `/trip-recording`. Verified the test FAILS on master without this fix (throws "No GoRouter found in context") and PASSES with it. Idle-state regression case retained.

Closes #1322

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test test/features/consumption/presentation/widgets/trip_recording_banner_test.dart` — 6/6 pass
- [x] `flutter test test/features/consumption/` — 2085/2085 pass
- [x] Regression test confirmed to fail on master (verified by stashing the fix and re-running)