### PR TITLE
fix(obd2): EventChannel cancel swallows benign PlatformException (Closes #1323)

### DIFF
--- a/lib/features/consumption/data/obd2/android_background_adapter_listener.dart
+++ b/lib/features/consumption/data/obd2/android_background_adapter_listener.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'background_adapter_listener.dart';
+import 'event_channel_cancel.dart';
 
 /// Production [BackgroundAdapterListener] backed by the native Android
 /// foreground service shipped in #1004 phase 2b-1.
@@ -91,7 +92,7 @@ class AndroidBackgroundAdapterListener implements BackgroundAdapterListener {
   @override
   Future<void> stop() async {
     await _methods.invokeMethod<bool>('stop');
-    await _platformSubscription?.cancel();
+    await _platformSubscription?.safeCancel();
     _platformSubscription = null;
   }
 
@@ -165,7 +166,7 @@ class AndroidBackgroundAdapterListener implements BackgroundAdapterListener {
   /// Test-only hook to drain resources between tests.
   @visibleForTesting
   Future<void> dispose() async {
-    await _platformSubscription?.cancel();
+    await _platformSubscription?.safeCancel();
     _platformSubscription = null;
     if (!_controller.isClosed) {
       await _controller.close();

--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 
 import 'elm327_protocol.dart';
 import 'elm_byte_channel.dart';
+import 'event_channel_cancel.dart';
 import 'obd2_transport.dart';
 
 /// [Obd2Transport] that moves bytes over a generic [ElmByteChannel]
@@ -63,7 +64,7 @@ class BluetoothObd2Transport implements Obd2Transport {
   @override
   Future<void> disconnect() async {
     _connected = false;
-    await _subscription?.cancel();
+    await _subscription?.safeCancel();
     _subscription = null;
     await _channel.close();
     _failPending(StateError('Transport closed'));

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 
 import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
+import 'event_channel_cancel.dart';
 
 /// Standard Bluetooth Serial Port Profile UUID (#761). Every
 /// Classic-SPP ELM327 adapter (vLinker FS, OBDLink LX, generic
@@ -74,7 +75,7 @@ class ClassicElmChannel implements ElmByteChannel {
   @override
   Future<void> close() async {
     _open = false;
-    await _subscription?.cancel();
+    await _subscription?.safeCancel();
     _subscription = null;
     try {
       await _plugin.disconnect();

--- a/lib/features/consumption/data/obd2/event_channel_cancel.dart
+++ b/lib/features/consumption/data/obd2/event_channel_cancel.dart
@@ -22,11 +22,11 @@ extension SafeEventChannelCancel<T> on StreamSubscription<T> {
   Future<void> safeCancel() async {
     try {
       await cancel();
-    } on PlatformException catch (e) {
+    } on PlatformException catch (e, st) {
       if (e.message == 'No active stream to cancel') {
         debugPrint(
           'EventChannel safeCancel: swallowed benign '
-          'PlatformException(${e.code}: ${e.message})',
+          'PlatformException(${e.code}: ${e.message})\n$st',
         );
         return;
       }

--- a/lib/features/consumption/data/obd2/event_channel_cancel.dart
+++ b/lib/features/consumption/data/obd2/event_channel_cancel.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// EventChannel-aware [StreamSubscription.cancel] wrapper.
+///
+/// EventChannel-backed broadcast streams raise a benign
+/// `PlatformException("No active stream to cancel")` when the platform
+/// side has already cleared the broadcast (background foreground-service
+/// kills, lifecycle race during tab navigation). The platform IS already
+/// torn down — there is nothing to do, but Flutter still rethrows the
+/// exception through the cancel future, where it bubbles up into the
+/// privacy-dashboard error log and masks real bugs (#1323).
+///
+/// Use this extension at every call site that cancels an EventChannel
+/// subscription. Every other error type and every other PlatformException
+/// message is rethrown unchanged.
+extension SafeEventChannelCancel<T> on StreamSubscription<T> {
+  /// Cancels this subscription, swallowing the benign EventChannel
+  /// "No active stream to cancel" PlatformException only.
+  Future<void> safeCancel() async {
+    try {
+      await cancel();
+    } on PlatformException catch (e) {
+      if (e.message == 'No active stream to cancel') {
+        debugPrint(
+          'EventChannel safeCancel: swallowed benign '
+          'PlatformException(${e.code}: ${e.message})',
+        );
+        return;
+      }
+      rethrow;
+    }
+  }
+}

--- a/test/features/consumption/data/obd2/event_channel_cancel_test.dart
+++ b/test/features/consumption/data/obd2/event_channel_cancel_test.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/event_channel_cancel.dart';
+
+/// Minimal fake [StreamSubscription] whose only meaningful method is
+/// [cancel]. Every other method throws [UnimplementedError] so a
+/// regression that touches them shows up loudly in the test output.
+///
+/// The cancel behaviour is parametric: pass [cancelError] to make
+/// [cancel] complete with that error, or leave it null for a clean
+/// completion. [cancelCallCount] records how many times cancel was
+/// invoked so tests can assert idempotency.
+class _FakeStreamSubscription<T> implements StreamSubscription<T> {
+  _FakeStreamSubscription({this.cancelError});
+
+  final Object? cancelError;
+  int cancelCallCount = 0;
+
+  @override
+  Future<void> cancel() async {
+    cancelCallCount++;
+    if (cancelError != null) {
+      throw cancelError!;
+    }
+  }
+
+  @override
+  Future<E> asFuture<E>([E? futureValue]) =>
+      throw UnimplementedError('asFuture');
+
+  @override
+  bool get isPaused => throw UnimplementedError('isPaused');
+
+  @override
+  void onData(void Function(T data)? handleData) =>
+      throw UnimplementedError('onData');
+
+  @override
+  void onDone(void Function()? handleDone) =>
+      throw UnimplementedError('onDone');
+
+  @override
+  void onError(Function? handleError) => throw UnimplementedError('onError');
+
+  @override
+  void pause([Future<void>? resumeSignal]) => throw UnimplementedError('pause');
+
+  @override
+  void resume() => throw UnimplementedError('resume');
+}
+
+void main() {
+  group('SafeEventChannelCancel.safeCancel', () {
+    test('completes normally when subscription cancel() succeeds', () async {
+      final sub = _FakeStreamSubscription<int>();
+
+      await sub.safeCancel();
+
+      expect(sub.cancelCallCount, 1);
+    });
+
+    test('swallows benign "No active stream to cancel" PlatformException',
+        () async {
+      final sub = _FakeStreamSubscription<int>(
+        cancelError: PlatformException(
+          code: 'error',
+          message: 'No active stream to cancel',
+        ),
+      );
+
+      // Helper completes without throwing — the whole point of #1323.
+      await sub.safeCancel();
+
+      expect(sub.cancelCallCount, 1);
+    });
+
+    test('rethrows PlatformException with a different message', () async {
+      final sub = _FakeStreamSubscription<int>(
+        cancelError: PlatformException(
+          code: 'error',
+          message: 'Different error',
+        ),
+      );
+
+      await expectLater(
+        sub.safeCancel(),
+        throwsA(
+          isA<PlatformException>().having(
+            (e) => e.message,
+            'message',
+            'Different error',
+          ),
+        ),
+      );
+      expect(sub.cancelCallCount, 1);
+    });
+
+    test('rethrows non-PlatformException errors unchanged', () async {
+      final sub = _FakeStreamSubscription<int>(
+        cancelError: StateError('boom'),
+      );
+
+      await expectLater(
+        sub.safeCancel(),
+        throwsA(
+          isA<StateError>().having((e) => e.message, 'message', 'boom'),
+        ),
+      );
+      expect(sub.cancelCallCount, 1);
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/event_channel_cancel_test.dart
+++ b/test/features/consumption/data/obd2/event_channel_cancel_test.dart
@@ -54,6 +54,7 @@ class _FakeStreamSubscription<T> implements StreamSubscription<T> {
 void main() {
   group('SafeEventChannelCancel.safeCancel', () {
     test('completes normally when subscription cancel() succeeds', () async {
+      // ignore: cancel_subscriptions
       final sub = _FakeStreamSubscription<int>();
 
       await sub.safeCancel();
@@ -63,6 +64,7 @@ void main() {
 
     test('swallows benign "No active stream to cancel" PlatformException',
         () async {
+      // ignore: cancel_subscriptions
       final sub = _FakeStreamSubscription<int>(
         cancelError: PlatformException(
           code: 'error',
@@ -77,6 +79,7 @@ void main() {
     });
 
     test('rethrows PlatformException with a different message', () async {
+      // ignore: cancel_subscriptions
       final sub = _FakeStreamSubscription<int>(
         cancelError: PlatformException(
           code: 'error',
@@ -98,6 +101,7 @@ void main() {
     });
 
     test('rethrows non-PlatformException errors unchanged', () async {
+      // ignore: cancel_subscriptions
       final sub = _FakeStreamSubscription<int>(
         cancelError: StateError('boom'),
       );


### PR DESCRIPTION
## Summary

- **Cause** — Cancelling the last listener of an EventChannel-backed broadcast stream raises `PlatformException("error", "No active stream to cancel")` whenever the platform side has already cleared the broadcast (foreground-service killed by OS, lifecycle race during tab navigation, two cancels racing). The platform IS already torn down; the exception is benign but inflated the `/privacy-dashboard` error log and masked real bugs.
- **Helper** — Adds `SafeEventChannelCancel.safeCancel` extension method in `lib/features/consumption/data/obd2/event_channel_cancel.dart`. Swallows the benign message via `debugPrint` and rethrows every other PlatformException + every non-PlatformException error unchanged.
- **Call sites** — 4 call sites switched to `?.safeCancel()`:
  - `android_background_adapter_listener.dart:stop()` and `dispose()` (auto-record foreground service — most-likely fire site, single subscriber)
  - `classic_elm_channel.dart:close()` (OBD2 classic incoming bytes)
  - `bluetooth_obd2_transport.dart:disconnect()` (OBD2 transport incoming bytes)
- **Tests** — `test/features/consumption/data/obd2/event_channel_cancel_test.dart`: clean cancel path, benign-message swallow, different-message PlatformException rethrow, non-PlatformException (StateError) rethrow.
- **Out of scope** — Other (non-EventChannel) `cancel()` sites are deliberately untouched; helper is private to the OBD2 area, not lifted to `core/`.

Closes #1323

## Test plan

- [x] `flutter analyze` clean (no warnings, no infos)
- [x] `flutter test test/features/consumption/data/obd2/event_channel_cancel_test.dart` — 4/4 pass
- [x] `flutter test test/features/consumption/data/obd2/` — 594/594 pass (regression: directory shares the touched files)
- [x] `flutter test test/lint/no_silent_catch_test.dart` — pass (helper logs + bails on the specific message; not a silent catch)