### PR TITLE
fix(vehicle): VIN pre-population race + always show OBD2 fetch button (Closes #1328)

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -44,6 +44,17 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   String? _existingId;
   String? _adapterMac;
   String? _adapterName;
+  // #1328 — `_loadExisting()` runs in a postFrameCallback so it sees a
+  // snapshot of `vehicleProfileListProvider` that may still be empty
+  // while Hive is resolving (the provider is sync but the underlying
+  // settings storage may rebuild). When that happens the VIN field
+  // (and every other controller) stays blank. We belt-and-suspender the
+  // initial path by also listening to provider transitions in `build()`
+  // and re-running the load if the form is editing an existing profile
+  // that hasn't been hydrated yet. This flag flips to true after the
+  // first successful load so subsequent provider updates (e.g. from
+  // `_save()` writing the freshest profile) don't clobber user edits.
+  bool _hasInitiallyLoaded = false;
   // #1162 — pairedAdapterMac (#1004) gates the "Read VIN from car"
   // button. Distinct from [_adapterMac] which is the currently-
   // connected OBD2 picker selection.
@@ -77,8 +88,21 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
 
   void _loadExisting() {
     final list = ref.read(vehicleProfileListProvider);
+    _applyLoadedList(list);
+  }
+
+  /// Copy the matching [VehicleProfile] from [list] into the form's
+  /// controllers and scalar state. Returns true when a profile matched
+  /// and was applied, false when none was found (the provider hasn't
+  /// resolved yet, the id was deleted, etc.).
+  ///
+  /// Used by both the initial postFrameCallback path and the
+  /// `ref.listen` second-chance refill (#1328). The
+  /// [_hasInitiallyLoaded] flag is set on success so subsequent
+  /// rebuilds don't clobber user edits.
+  bool _applyLoadedList(List<VehicleProfile> list) {
     final existing = list.where((v) => v.id == widget.vehicleId).firstOrNull;
-    if (existing == null) return;
+    if (existing == null) return false;
     final snap = _ctrl.load(existing);
     setState(() {
       _existingId = snap.id;
@@ -92,7 +116,9 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
       _engineDisplacementCc = snap.engineDisplacementCc;
       _engineCylinders = snap.engineCylinders;
       _curbWeightKg = snap.curbWeightKg;
+      _hasInitiallyLoaded = true;
     });
+    return true;
   }
 
   @override
@@ -274,6 +300,25 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     final isEdit = _existingId != null || widget.vehicleId != null;
     final accent = _brandAccent(context);
 
+    // #1328 — second-chance refill for the pre-population race. When the
+    // initial postFrameCallback ran before the provider resolved (Hive
+    // box still hydrating, etc.), the form controllers stayed blank.
+    // Listening here re-runs the load the moment the provider produces
+    // a list that contains our target id. Guarded by
+    // `_hasInitiallyLoaded` so user edits aren't clobbered by later
+    // provider updates (e.g. `_save()` writing the persisted profile
+    // back into the list).
+    final targetId = widget.vehicleId;
+    if (targetId != null) {
+      ref.listen<List<VehicleProfile>>(vehicleProfileListProvider,
+          (prev, next) {
+        if (_hasInitiallyLoaded) return;
+        if (next.any((v) => v.id == targetId)) {
+          _applyLoadedList(next);
+        }
+      });
+    }
+
     return PageScaffold(
       title: isEdit
           ? (l?.vehicleEditTitle ?? 'Edit vehicle')
@@ -308,6 +353,10 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
               decodingVin: _decodingVin,
               onDecodeVin: _decodeVin,
               onShowVinInfo: _showVinInfo,
+              // #1328 — always show the "Read VIN from car" button. When
+              // no adapter is paired we pass `onReadVinFromCar = null`
+              // (which renders the button visibly disabled with a hint)
+              // so users discover the feature even before pairing.
               pairedAdapterMac: _pairedAdapterMac,
               onReadVinFromCar:
                   _pairedAdapterMac != null ? _readVinFromCar : null,

--- a/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
@@ -11,10 +11,12 @@ import '../../../../l10n/app_localizations.dart';
 /// this widget is intentionally dumb so all VIN-decoder state stays
 /// at the screen level where the provider already lives.
 ///
-/// When the active profile has a paired OBD2 adapter, the section
-/// also shows a "Read VIN from car" button that triggers a Mode 09
-/// PID 02 read against the adapter (#1162). The button is hidden
-/// otherwise so users without an adapter don't see a no-op control.
+/// The section also shows a "Read VIN from car" button that triggers a
+/// Mode 09 PID 02 read against the paired OBD2 adapter (#1162). The
+/// button is always rendered (#1328); when no adapter is paired
+/// ([pairedAdapterMac] is null OR [onReadVinFromCar] is null) it is
+/// shown visibly disabled with a small helper text, so users discover
+/// the feature even before pairing.
 class VehicleIdentitySection extends StatelessWidget {
   final TextEditingController nameController;
   final TextEditingController vinController;
@@ -24,13 +26,16 @@ class VehicleIdentitySection extends StatelessWidget {
   final VoidCallback onDecodeVin;
   final VoidCallback onShowVinInfo;
 
-  /// Optional — when non-null, render the "Read VIN from car" button
-  /// (#1162). The screen passes the active profile's
-  /// `pairedAdapterMac` here; null hides the button entirely.
+  /// The active profile's paired adapter MAC (#1162). When null AND
+  /// [onReadVinFromCar] is null, the "Read VIN from car" button is
+  /// rendered disabled with a helper hint instead of being hidden — see
+  /// #1328 for why discoverability beats minimalism here.
   final String? pairedAdapterMac;
 
   /// Callback fired when the user taps the "Read VIN from car" button
-  /// (#1162). Required when [pairedAdapterMac] is non-null.
+  /// (#1162). When null, the button is rendered visibly disabled
+  /// (Flutter's stock OutlinedButton handling) with a small helper
+  /// hint underneath telling the user to pair an adapter first.
   final VoidCallback? onReadVinFromCar;
 
   /// True while the OBD2 VIN read is in flight (#1162). Disables the
@@ -123,31 +128,57 @@ class VehicleIdentitySection extends StatelessWidget {
             ),
           ],
         ),
-        // "Read VIN from car" — only visible when a paired adapter is
-        // available (#1162). Renders below the VIN row so the visual
-        // grouping mirrors the relationship: this button writes into
-        // the VIN field above. Disabled while a read is in flight to
-        // prevent double-taps spawning concurrent OBD2 sessions.
-        if (pairedAdapterMac != null && onReadVinFromCar != null) ...[
-          const SizedBox(height: 12),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: OutlinedButton.icon(
-              key: const Key('vehicleReadVinFromCar'),
-              onPressed: readingVinFromCar ? null : onReadVinFromCar,
-              icon: readingVinFromCar
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.bluetooth_searching),
-              label: Tooltip(
-                message: l?.vehicleReadVinFromCarTooltip ??
-                    'Read VIN from the paired OBD2 adapter',
-                child: Text(
-                  l?.vehicleReadVinFromCarButton ?? 'Read VIN from car',
-                ),
+        // "Read VIN from car" — always visible (#1328). When no
+        // adapter is paired, the button is rendered disabled with a
+        // small helper text so users discover the feature even before
+        // pairing. Renders below the VIN row so the visual grouping
+        // mirrors the relationship: this button writes into the VIN
+        // field above. Disabled while a read is in flight to prevent
+        // double-taps spawning concurrent OBD2 sessions.
+        const SizedBox(height: 12),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: OutlinedButton.icon(
+            key: const Key('vehicleReadVinFromCar'),
+            onPressed: (onReadVinFromCar == null || readingVinFromCar)
+                ? null
+                : onReadVinFromCar,
+            icon: readingVinFromCar
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.bluetooth_searching),
+            label: Tooltip(
+              message: l?.vehicleReadVinFromCarTooltip ??
+                  'Read VIN from the paired OBD2 adapter',
+              child: Text(
+                l?.vehicleReadVinFromCarButton ?? 'Read VIN from car',
+              ),
+            ),
+          ),
+        ),
+        // Helper text shown when the button is disabled because no
+        // adapter is paired yet (#1328). Tells the user how to enable
+        // the auto-read flow without forcing them to discover the
+        // pairing screen blindly. Wrapped in `Semantics(container: true)`
+        // so the label doesn't merge with the sibling info-icon
+        // Semantics annotation above (which would break the existing
+        // `bySemanticsLabel('What is a VIN?')` test in #895).
+        if (onReadVinFromCar == null) ...[
+          const SizedBox(height: 4),
+          Semantics(
+            container: true,
+            child: Padding(
+              padding: const EdgeInsets.only(left: 12),
+              child: Text(
+                l?.vehicleReadVinNoAdapterHint ??
+                    'Pair an OBD2 adapter first to read VIN automatically',
+                key: const Key('vehicleReadVinNoAdapterHint'),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
               ),
             ),
           ),

--- a/lib/l10n/_fragments/vehicle_de.arb
+++ b/lib/l10n/_fragments/vehicle_de.arb
@@ -7,5 +7,6 @@
   "vehicleReadVinFromCarButton": "FIN aus dem Auto auslesen",
   "vehicleReadVinFromCarTooltip": "FIN vom gekoppelten OBD2-Adapter auslesen",
   "vehicleReadVinFailedUnsupportedSnackbar": "FIN nicht verfügbar (Modus 09 PID 02 wird vor 2005 nicht unterstützt)",
-  "vehicleReadVinFailedGenericSnackbar": "FIN-Auslesen fehlgeschlagen — bitte manuell eingeben"
+  "vehicleReadVinFailedGenericSnackbar": "FIN-Auslesen fehlgeschlagen — bitte manuell eingeben",
+  "vehicleReadVinNoAdapterHint": "OBD2-Adapter koppeln, um VIN automatisch auszulesen"
 }

--- a/lib/l10n/_fragments/vehicle_en.arb
+++ b/lib/l10n/_fragments/vehicle_en.arb
@@ -22,5 +22,9 @@
   "vehicleReadVinFailedGenericSnackbar": "VIN read failed — please enter manually",
   "@vehicleReadVinFailedGenericSnackbar": {
     "description": "Snackbar shown when reading the VIN failed for a non-unsupported reason (timeout, malformed, IO) (#1162)."
+  },
+  "vehicleReadVinNoAdapterHint": "Pair an OBD2 adapter first to read VIN automatically",
+  "@vehicleReadVinNoAdapterHint": {
+    "description": "Helper text shown under the disabled \"Read VIN from car\" button on the vehicle edit screen when no OBD2 adapter is paired yet (#1328). Tells the user how to enable the auto-read flow."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1634,6 +1634,7 @@
   "vehicleReadVinFromCarTooltip": "FIN vom gekoppelten OBD2-Adapter auslesen",
   "vehicleReadVinFailedUnsupportedSnackbar": "FIN nicht verfügbar (Modus 09 PID 02 wird vor 2005 nicht unterstützt)",
   "vehicleReadVinFailedGenericSnackbar": "FIN-Auslesen fehlgeschlagen — bitte manuell eingeben",
+  "vehicleReadVinNoAdapterHint": "OBD2-Adapter koppeln, um VIN automatisch auszulesen",
   "vinInfoTooltip": "Was ist eine FIN?",
   "vinInfoSectionWhatTitle": "Was ist eine FIN?",
   "vinInfoSectionWhatBody": "Die Fahrzeug-Identifizierungsnummer ist ein 17-stelliger Code, der Ihr Fahrzeug eindeutig kennzeichnet. Sie ist im Chassis eingeprägt und steht in Ihrem Fahrzeugschein.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2784,6 +2784,10 @@
   "@vehicleReadVinFailedGenericSnackbar": {
     "description": "Snackbar shown when reading the VIN failed for a non-unsupported reason (timeout, malformed, IO) (#1162)."
   },
+  "vehicleReadVinNoAdapterHint": "Pair an OBD2 adapter first to read VIN automatically",
+  "@vehicleReadVinNoAdapterHint": {
+    "description": "Helper text shown under the disabled \"Read VIN from car\" button on the vehicle edit screen when no OBD2 adapter is paired yet (#1328). Tells the user how to enable the auto-read flow."
+  },
   "vinInfoTooltip": "What is a VIN?",
   "@vinInfoTooltip": {
     "description": "Tooltip + Semantics label for the info icon next to the VIN field on EditVehicleScreen (#895)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -998,6 +998,7 @@
   "vehicleReadVinFromCarTooltip": "Lire le VIN depuis l'adaptateur OBD2 jumelé",
   "vehicleReadVinFailedGenericSnackbar": "Échec de la lecture du VIN — veuillez le saisir manuellement",
   "vehicleReadVinFailedUnsupportedSnackbar": "VIN indisponible (Mode 09 PID 02 non pris en charge avant 2005)",
+  "vehicleReadVinNoAdapterHint": "Couplez un adaptateur OBD2 pour lire la VIN automatiquement",
   "vinLabel": "VIN (optionnel)",
   "vinDecodeTooltip": "Décoder le VIN",
   "vinDecodeError": "Impossible de décoder ce VIN",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7694,6 +7694,12 @@ abstract class AppLocalizations {
   /// **'VIN read failed — please enter manually'**
   String get vehicleReadVinFailedGenericSnackbar;
 
+  /// Helper text shown under the disabled "Read VIN from car" button on the vehicle edit screen when no OBD2 adapter is paired yet (#1328). Tells the user how to enable the auto-read flow.
+  ///
+  /// In en, this message translates to:
+  /// **'Pair an OBD2 adapter first to read VIN automatically'**
+  String get vehicleReadVinNoAdapterHint;
+
   /// Tooltip + Semantics label for the info icon next to the VIN field on EditVehicleScreen (#895).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4161,6 +4161,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4161,6 +4161,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4159,6 +4159,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4198,6 +4198,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'FIN-Auslesen fehlgeschlagen — bitte manuell eingeben';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'OBD2-Adapter koppeln, um VIN automatisch auszulesen';
+
+  @override
   String get vinInfoTooltip => 'Was ist eine FIN?';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4163,6 +4163,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4154,6 +4154,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4162,6 +4162,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4156,6 +4156,10 @@ class AppLocalizationsEt extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4159,6 +4159,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4198,6 +4198,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Échec de la lecture du VIN — veuillez le saisir manuellement';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Couplez un adaptateur OBD2 pour lire la VIN automatiquement';
+
+  @override
   String get vinInfoTooltip => 'Qu\'est-ce qu\'un VIN ?';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4158,6 +4158,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4163,6 +4163,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4162,6 +4162,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4160,6 +4160,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4162,6 +4162,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4158,6 +4158,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4163,6 +4163,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4161,6 +4161,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4162,6 +4162,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4161,6 +4161,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4162,6 +4162,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4156,6 +4156,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4160,6 +4160,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'VIN read failed — please enter manually';
 
   @override
+  String get vehicleReadVinNoAdapterHint =>
+      'Pair an OBD2 adapter first to read VIN automatically';
+
+  @override
   String get vinInfoTooltip => 'What is a VIN?';
 
   @override

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_prepop_race_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_prepop_race_test.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for the VIN pre-population race fix (#1328).
+///
+/// The original bug: `_loadExisting()` runs in a postFrameCallback and
+/// reads `vehicleProfileListProvider` once — if the provider hasn't
+/// resolved (Hive box still hydrating, settings storage swap, etc.), it
+/// sees an empty list and the VIN textfield (and every other field)
+/// stays blank. The fix wires a `ref.listen` in `build()` that re-runs
+/// the controller load the moment the provider produces a list
+/// containing the target id.
+void main() {
+  group('EditVehicleScreen — VIN pre-population race (#1328)', () {
+    testWidgets(
+      'happy path: a profile with a stored VIN populates the VIN '
+      'textfield within a frame',
+      (tester) async {
+        final repo = VehicleProfileRepository(_FakeSettings());
+        await repo.save(
+          const VehicleProfile(
+            id: 'v1',
+            name: 'My Test Car',
+            vin: 'VF36B8HZL8R123456',
+          ),
+        );
+
+        await _pumpScreen(tester, repo: repo, vehicleId: 'v1');
+
+        // pump a frame for the postFrameCallback, then a second frame
+        // so the setState propagates into the rendered TextField.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final field = tester.widget<TextField>(
+          find.descendant(
+            of: find.widgetWithText(TextFormField, 'VIN (optional)'),
+            matching: find.byType(TextField),
+          ),
+        );
+        expect(field.controller?.text, 'VF36B8HZL8R123456');
+      },
+    );
+
+    testWidgets(
+      'race regression: provider initially returns an empty list, then '
+      'transitions to data; the VIN field gets populated by the second-'
+      'chance refill',
+      (tester) async {
+        // Two repos: an empty one for the initial pump (mimics the
+        // race — Hive hasn't returned the saved profile yet), and a
+        // populated one we swap in mid-flight via container override.
+        final emptyRepo = VehicleProfileRepository(_FakeSettings());
+        final hydratedRepo = VehicleProfileRepository(_FakeSettings());
+        await hydratedRepo.save(
+          const VehicleProfile(
+            id: 'v1',
+            name: 'My Test Car',
+            vin: 'VF36B8HZL8R123456',
+          ),
+        );
+
+        // Use a notifier-style override so we can mutate the list AFTER
+        // the screen mounts — exactly the race the bug describes.
+        final container = ProviderContainer(
+          overrides: [
+            vehicleProfileRepositoryProvider.overrideWithValue(emptyRepo),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: EditVehicleScreen(vehicleId: 'v1'),
+            ),
+          ),
+        );
+        // Initial pump: provider is empty, postFrameCallback runs and
+        // _loadExisting finds nothing → field stays blank.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        var field = tester.widget<TextField>(
+          find.descendant(
+            of: find.widgetWithText(TextFormField, 'VIN (optional)'),
+            matching: find.byType(TextField),
+          ),
+        );
+        expect(field.controller?.text, isEmpty,
+            reason: 'Pre-fix baseline: empty repo → blank field');
+
+        // Mid-flight provider transition: push the hydrated profile
+        // into the notifier. The `ref.listen` in build() must catch
+        // this and re-run the controller load.
+        container.read(vehicleProfileListProvider.notifier).state = [
+          const VehicleProfile(
+            id: 'v1',
+            name: 'My Test Car',
+            vin: 'VF36B8HZL8R123456',
+          ),
+        ];
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        field = tester.widget<TextField>(
+          find.descendant(
+            of: find.widgetWithText(TextFormField, 'VIN (optional)'),
+            matching: find.byType(TextField),
+          ),
+        );
+        expect(
+          field.controller?.text,
+          'VF36B8HZL8R123456',
+          reason: 'After provider resolves the field must populate '
+              '(the #1328 fix).',
+        );
+      },
+    );
+
+    testWidgets(
+      'second-chance refill does not clobber user edits made after the '
+      'initial load',
+      (tester) async {
+        final repo = VehicleProfileRepository(_FakeSettings());
+        await repo.save(
+          const VehicleProfile(
+            id: 'v1',
+            name: 'My Test Car',
+            vin: 'VF36B8HZL8R123456',
+          ),
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            vehicleProfileRepositoryProvider.overrideWithValue(repo),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: EditVehicleScreen(vehicleId: 'v1'),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Initial load completed; user edits the VIN.
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'VIN (optional)'),
+          'USEREDITS123456XX',
+        );
+        await tester.pump();
+
+        // A subsequent provider update fires (e.g. another screen saved
+        // an unrelated change). The `_hasInitiallyLoaded` guard must
+        // prevent the listener from re-loading and stomping on the
+        // user's text.
+        container.read(vehicleProfileListProvider.notifier).state = [
+          const VehicleProfile(
+            id: 'v1',
+            name: 'My Test Car',
+            vin: 'VF36B8HZL8R123456',
+          ),
+        ];
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final field = tester.widget<TextField>(
+          find.descendant(
+            of: find.widgetWithText(TextFormField, 'VIN (optional)'),
+            matching: find.byType(TextField),
+          ),
+        );
+        expect(
+          field.controller?.text,
+          'USEREDITS123456XX',
+          reason: 'User edits must survive subsequent provider rebuilds.',
+        );
+      },
+    );
+  });
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester, {
+  required VehicleProfileRepository repo,
+  required String vehicleId,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        vehicleProfileRepositoryProvider.overrideWithValue(repo),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: EditVehicleScreen(vehicleId: vehicleId),
+      ),
+    ),
+  );
+}
+
+/// Minimal in-memory [SettingsStorage] so the repository can run
+/// without a Hive box.
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_vin_button_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_vin_button_test.dart
@@ -21,28 +21,50 @@ import 'package:tankstellen/l10n/app_localizations.dart';
 void main() {
   group('EditVehicleScreen — Read-VIN-from-car button (#1162)', () {
     testWidgets(
-      'button is hidden when the vehicle has no paired adapter',
+      'button is visible but disabled with a hint when the vehicle has '
+      'no paired adapter (#1328)',
       (tester) async {
         await _pumpWithProfile(tester, withPairedAdapter: false);
 
-        expect(find.byKey(const Key('vehicleReadVinFromCar')), findsNothing);
+        // #1328 — the button is always rendered so users discover the
+        // feature. With no paired adapter it is disabled (onPressed
+        // null) and a small helper text is shown underneath.
+        final buttonFinder = find.byKey(const Key('vehicleReadVinFromCar'));
+        expect(buttonFinder, findsOneWidget);
+        final button = tester.widget<OutlinedButton>(buttonFinder);
+        expect(button.onPressed, isNull,
+            reason: 'No paired adapter → button must render disabled');
+        expect(
+          find.byKey(const Key('vehicleReadVinNoAdapterHint')),
+          findsOneWidget,
+        );
+        expect(
+          find.text('Pair an OBD2 adapter first to read VIN automatically'),
+          findsOneWidget,
+        );
       },
     );
 
     testWidgets(
-      'button is visible with a tooltip when the vehicle has a paired '
-      'adapter',
+      'button is visible and enabled with a tooltip when the vehicle '
+      'has a paired adapter',
       (tester) async {
         await _pumpWithProfile(tester, withPairedAdapter: true);
 
-        expect(
-          find.byKey(const Key('vehicleReadVinFromCar')),
-          findsOneWidget,
-        );
+        final buttonFinder = find.byKey(const Key('vehicleReadVinFromCar'));
+        expect(buttonFinder, findsOneWidget);
+        final button = tester.widget<OutlinedButton>(buttonFinder);
+        expect(button.onPressed, isNotNull,
+            reason: 'Paired adapter → button must be tappable');
         expect(find.text('Read VIN from car'), findsOneWidget);
         expect(
           find.byTooltip('Read VIN from the paired OBD2 adapter'),
           findsOneWidget,
+        );
+        // The "no adapter" hint is gone when paired.
+        expect(
+          find.byKey(const Key('vehicleReadVinNoAdapterHint')),
+          findsNothing,
         );
       },
     );


### PR DESCRIPTION
## Summary

Closes both complaints in #1328:

- **Pre-population race fix.** `_loadExisting()` runs in a postFrameCallback that reads `vehicleProfileListProvider` once. When Hive hasn't resolved yet the list is empty and the VIN field (and every other form field) stays blank. Added a `ref.listen<List<VehicleProfile>>` in `build()` that re-runs the controller load when the provider produces a list containing the target vehicle id. Guarded by `_hasInitiallyLoaded` so subsequent rebuilds (e.g. after `_save()`) don't stomp on user edits. The original postFrameCallback path is kept for the cold-init case — belt-and-suspenders.
- **Always show "Read VIN from car".** Dropped the `pairedAdapterMac != null` guard in `vehicle_identity_section.dart`. The `OutlinedButton` now always renders; when no adapter is paired it's visibly disabled (onPressed null) with helper text "Pair an OBD2 adapter first to read VIN automatically" underneath. Users discover the feature even before pairing.
- **New ARB key** `vehicleReadVinNoAdapterHint` — en + de via fragments (`lib/l10n/_fragments/vehicle_*.arb` + `dart run tool/build_arb.dart`); fr added directly in `app_fr.arb` (the CI localization-completeness test enforces French has every `vehicle*` key per #1218).
- **Tests**:
  - New `edit_vehicle_screen_prepop_race_test.dart` — happy-path pre-population, mid-flight provider transition (the actual #1328 repro: provider starts empty, transitions to data, field gets populated by the second-chance refill), and "user edits survive subsequent provider rebuilds" regression guard.
  - Updated `edit_vehicle_screen_vin_button_test.dart` — replaced the "button is hidden" assertion with "button visible + disabled + helper text", and the "paired" case now asserts the button is enabled.
- The helper text is wrapped in `Semantics(container: true)` so its label doesn't merge with the info-icon's Semantics annotation (which would have broken the `bySemanticsLabel('What is a VIN?')` assertion in the #895 test suite).

Closes #1328.

## Test plan

- [x] `flutter analyze` — clean (no infos, warnings, or errors)
- [x] `flutter test test/features/vehicle/presentation/` — 161 passed
- [x] `flutter test test/l10n/` — pass (French has the new `vehicle*` key)
- [x] `flutter test test/lint/` — pass

## Verifying the race fix

The original `_loadExisting()` was a single shot via `addPostFrameCallback`. The new `ref.listen` in `build()` catches the case where the provider transitions from an empty list (Hive still hydrating) to a populated one, runs `_applyLoadedList()` once, and sets `_hasInitiallyLoaded = true` so the listener no-ops on every later rebuild. The third test in the new suite explicitly asserts user edits survive a follow-up provider mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)