### PR TITLE
chore(loyalty): remove redundant Add-card button from empty state (Closes #1329)

### DIFF
--- a/lib/features/loyalty/presentation/loyalty_settings_screen.dart
+++ b/lib/features/loyalty/presentation/loyalty_settings_screen.dart
@@ -36,7 +36,7 @@ class LoyaltySettingsScreen extends ConsumerWidget {
           'Apply your loyalty discount to displayed prices',
       bannerIcon: Icons.card_membership,
       body: cards.isEmpty
-          ? LoyaltyEmptyState(onAdd: () => _openAddSheet(context, ref))
+          ? const LoyaltyEmptyState()
           : ListView.separated(
               padding: const EdgeInsets.only(bottom: 96),
               itemCount: cards.length,

--- a/lib/features/loyalty/presentation/widgets/loyalty_empty_state.dart
+++ b/lib/features/loyalty/presentation/widgets/loyalty_empty_state.dart
@@ -5,18 +5,14 @@ import '../../../../l10n/app_localizations.dart';
 /// Explanatory placeholder shown on the loyalty settings screen when
 /// the user has not registered any fuel-club card yet.
 ///
-/// Renders the brand-membership icon, a short explanation of what a
-/// card buys the user, and a primary "Add card" CTA that delegates to
-/// [onAdd] (the parent screen typically opens the add-card bottom
-/// sheet). Extracted from `loyalty_settings_screen.dart` (#563) to keep
-/// the screen file under the 300-LOC guideline; behaviour and visual
-/// contract are unchanged.
+/// Renders the brand-membership icon and a short explanation of what
+/// a card buys the user. The actual "Add card" action lives on the
+/// parent screen's bottom-right `FloatingActionButton` — duplicating
+/// it inside the empty state was redundant (#1329). Extracted from
+/// `loyalty_settings_screen.dart` (#563) to keep the screen file
+/// under the 300-LOC guideline.
 class LoyaltyEmptyState extends StatelessWidget {
-  /// Invoked when the user taps the empty-state CTA. The parent screen
-  /// is expected to open the add-card sheet (or any equivalent flow).
-  final VoidCallback onAdd;
-
-  const LoyaltyEmptyState({super.key, required this.onAdd});
+  const LoyaltyEmptyState({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -46,12 +42,6 @@ class LoyaltyEmptyState extends StatelessWidget {
                       'matching stations automatically.',
               style: theme.textTheme.bodyMedium,
               textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            FilledButton.icon(
-              onPressed: onAdd,
-              icon: const Icon(Icons.add),
-              label: Text(l?.loyaltyAddCard ?? 'Add card'),
             ),
           ],
         ),

--- a/test/features/loyalty/presentation/loyalty_settings_screen_test.dart
+++ b/test/features/loyalty/presentation/loyalty_settings_screen_test.dart
@@ -70,8 +70,12 @@ void main() {
       await pumpScreen(tester);
 
       expect(find.text('No fuel club cards yet'), findsOneWidget);
-      // Both the empty-state CTA and the FAB expose "Add card".
-      expect(find.text('Add card'), findsAtLeastNWidgets(1));
+      // Exactly one "Add card" surface — the bottom-right FAB (#1329).
+      expect(find.text('Add card'), findsOneWidget);
+      expect(
+        find.widgetWithText(FloatingActionButton, 'Add card'),
+        findsOneWidget,
+      );
     });
 
     testWidgets(

--- a/test/features/loyalty/presentation/widgets/loyalty_empty_state_test.dart
+++ b/test/features/loyalty/presentation/widgets/loyalty_empty_state_test.dart
@@ -6,11 +6,11 @@ import '../../../../helpers/pump_app.dart';
 
 void main() {
   group('LoyaltyEmptyState', () {
-    testWidgets('renders the empty-title, body and "Add card" CTA',
+    testWidgets('renders the empty-title and explanatory body',
         (tester) async {
       await pumpApp(
         tester,
-        LoyaltyEmptyState(onAdd: () {}),
+        const LoyaltyEmptyState(),
       );
 
       expect(find.text('No fuel club cards yet'), findsOneWidget);
@@ -18,38 +18,11 @@ void main() {
         find.textContaining('Add a card to apply your per-litre discount'),
         findsOneWidget,
       );
-      // Primary CTA — the FilledButton.icon variant exposes both an
-      // icon and the "Add card" label.
-      expect(find.widgetWithText(FilledButton, 'Add card'), findsOneWidget);
-      expect(find.byIcon(Icons.add), findsOneWidget);
       // The marquee membership icon at 64px.
       expect(find.byIcon(Icons.card_membership), findsOneWidget);
-    });
-
-    testWidgets('invokes onAdd when the CTA is tapped', (tester) async {
-      var taps = 0;
-      await pumpApp(
-        tester,
-        LoyaltyEmptyState(onAdd: () => taps++),
-      );
-
-      await tester.tap(find.widgetWithText(FilledButton, 'Add card'));
-      await tester.pumpAndSettle();
-
-      expect(taps, 1);
-    });
-
-    testWidgets('CTA hit target meets the Android tap-target guideline',
-        (tester) async {
-      await pumpApp(
-        tester,
-        LoyaltyEmptyState(onAdd: () {}),
-      );
-
-      await expectLater(
-        tester,
-        meetsGuideline(androidTapTargetGuideline),
-      );
+      // No inline CTA — the canonical action is the parent screen's FAB
+      // (#1329).
+      expect(find.byType(FilledButton), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Removes the inline `FilledButton.icon` (and surrounding `SizedBox` spacer) from `LoyaltyEmptyState` and drops the now-unused `onAdd` constructor parameter.
- Drops the matching `onAdd:` argument at the only call site (`LoyaltySettingsScreen`).
- The bottom-right `FloatingActionButton` is untouched: it remains the canonical, always-visible "Add card" action — the inline CTA was visual duplication.
- Tests updated: the empty-state widget test no longer expects a `FilledButton`/tap path, and the screen test now asserts exactly one Add-card surface (the FAB).

## What stays

- `LoyaltyEmptyState` keeps the membership icon, title, and explanatory body so first-time users still understand why the list is empty.
- The `loyaltyAddCard` ARB key is still in use by the FAB — no localisation changes.

Closes #1329