### PR TITLE
refactor(obd2): Elm327Adapter abstraction (Refs #1330 phase 1)

### DIFF
--- a/lib/features/consumption/data/obd2/adapter_registry.dart
+++ b/lib/features/consumption/data/obd2/adapter_registry.dart
@@ -1,3 +1,4 @@
+import 'elm327_adapter.dart';
 import 'elm327_protocol.dart';
 
 /// Thin value-object describing one BLE scan result. Kept
@@ -70,12 +71,29 @@ class Obd2AdapterProfile {
   /// Some clones need a few hundred ms between consecutive ELM
   /// init commands — otherwise the chip drops bytes. Default is
   /// 100 ms (what [Obd2Service.connect] already does).
+  ///
+  /// Deprecated in #1330 phase 1 — use [adapter.postResetDelay] /
+  /// [adapter.interCommandDelay] instead. Field stays in place so
+  /// the few historical call sites still compile; will be removed
+  /// in phase 2 once every caller routes through [adapter].
+  @Deprecated('Use adapter.postResetDelay / adapter.interCommandDelay')
   final Duration initDelay;
 
   /// Extra AT commands appended after the shared init sequence
   /// (e.g. `ATSP6\r` to pin ISO 15765-4 on Volvos; `ATST FF\r` for
   /// slow cars that miss the default 200 ms timeout).
+  ///
+  /// Deprecated in #1330 phase 1 — use [adapter.extraInitCommands]
+  /// instead. Removed in phase 2.
+  @Deprecated('Use adapter.extraInitCommands')
   final List<String> extraInitCommands;
+
+  /// Per-adapter ELM327 protocol quirks (#1330): init sequence,
+  /// timing, response pre-parse hook. Phase 1 ships only the
+  /// [GenericElm327Adapter] default — runtime behaviour is identical
+  /// for every profile until phases 2/3 introduce specialised
+  /// adapters.
+  final Elm327Adapter adapter;
 
   const Obd2AdapterProfile({
     required this.id,
@@ -87,6 +105,7 @@ class Obd2AdapterProfile {
     this.nameMatchers = const [],
     this.initDelay = const Duration(milliseconds: 100),
     this.extraInitCommands = const [],
+    this.adapter = const GenericElm327Adapter(),
   });
 
   /// Compares service uuid against the advertised set, case-insensitive.

--- a/lib/features/consumption/data/obd2/elm327_adapter.dart
+++ b/lib/features/consumption/data/obd2/elm327_adapter.dart
@@ -1,0 +1,71 @@
+import 'elm327_commands.dart';
+
+/// Per-adapter ELM327 protocol quirks (#1330).
+///
+/// Phase 1: scaffolding only. The single implementation
+/// [GenericElm327Adapter] reproduces today's hardcoded init sequence +
+/// timing exactly. Phases 2 and 3 add vLinker and SmartOBD profiles
+/// with empirically-tuned values.
+///
+/// The connect path (currently in [Obd2Service.connect] and
+/// [Obd2ConnectionService.connect]) consults this object instead of
+/// hardcoded constants:
+///
+///   * [initSequence] — the AT setup commands sent in order after the
+///     byte channel is open.
+///   * [postResetDelay] — delay applied after the very first init
+///     command (typically `ATZ`). Some clones need extra time to
+///     re-enumerate after a soft reset.
+///   * [interCommandDelay] — delay between subsequent init commands.
+///   * [extraInitCommands] — adapter-specific commands appended to the
+///     [initSequence] (e.g. `ATSP6\r` to pin a protocol).
+///   * [preParse] — hook to massage a raw response BEFORE it reaches
+///     the [Elm327Parsers.cleanResponse] pipeline. Default is identity;
+///     adapter-specific subclasses can strip stray prompts / echoes.
+abstract class Elm327Adapter {
+  /// Stable identifier (`generic`, `vlinker-fs`, `smartobd`) used in
+  /// debug logs and trip-history adapter attribution.
+  String get id;
+
+  /// Init commands sent after the byte channel is open, in order.
+  List<String> get initSequence;
+
+  /// Delay applied after the very first init command (typically `ATZ`).
+  Duration get postResetDelay;
+
+  /// Delay between subsequent init commands.
+  Duration get interCommandDelay;
+
+  /// Optional adapter-specific commands appended to [initSequence].
+  List<String> get extraInitCommands;
+
+  /// Hook to massage a raw response before [Elm327Parsers.cleanResponse].
+  /// Default: identity. Adapter-specific subclasses can strip stray
+  /// echoes etc.
+  String preParse(String raw) => raw;
+}
+
+/// Default adapter — values mirror today's hardcoded behaviour
+/// byte-for-byte (#1330 phase 1). Used for every paired adapter until
+/// phases 2/3 introduce vLinker / SmartOBD specialisations.
+class GenericElm327Adapter implements Elm327Adapter {
+  const GenericElm327Adapter();
+
+  @override
+  String get id => 'generic';
+
+  @override
+  List<String> get initSequence => Elm327Commands.initCommands;
+
+  @override
+  Duration get postResetDelay => const Duration(milliseconds: 100);
+
+  @override
+  Duration get interCommandDelay => const Duration(milliseconds: 100);
+
+  @override
+  List<String> get extraInitCommands => const [];
+
+  @override
+  String preParse(String raw) => raw;
+}

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -117,7 +117,11 @@ class Obd2ConnectionService {
     service.adapterName = candidate.candidate.deviceName.isEmpty
         ? candidate.profile.displayName
         : candidate.candidate.deviceName;
-    final ok = await service.connect();
+    // #1330 — hand the per-adapter ELM327 adapter into [Obd2Service]
+    // so its init sequence + timing matches the connected adapter's
+    // quirks. Phase 1 ships only [GenericElm327Adapter], so runtime
+    // behaviour is unchanged for every paired adapter.
+    final ok = await service.connect(adapter: candidate.profile.adapter);
     if (!ok) {
       await service.disconnect();
       throw const Obd2AdapterUnresponsive();

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import 'elm327_adapter.dart';
 import 'elm327_protocol.dart';
 import 'fuel_rate_estimator.dart' as estimator;
 import 'obd2_transport.dart';
@@ -73,6 +74,19 @@ class Obd2Service {
   /// firmware variant when we eventually capture it.
   String? adapterFirmware;
 
+  /// Per-adapter ELM327 quirks (#1330). Set by [connect] from the
+  /// caller-supplied `adapter` parameter; defaults to the
+  /// [GenericElm327Adapter] which mirrors today's hardcoded init
+  /// sequence + 100 ms delays + identity preParse. Phase 2 will hand
+  /// in vLinker / SmartOBD specialisations from the adapter registry.
+  Elm327Adapter _adapter = const GenericElm327Adapter();
+
+  /// Adapter snapshot used during the most recent [connect]. Exposed
+  /// for tests + diagnostics; production callers should use the typed
+  /// read* methods rather than reaching for the adapter directly.
+  @visibleForTesting
+  Elm327Adapter get adapter => _adapter;
+
   Obd2Service(
     this._transport, {
     SupportedPidsCache? pidsCache,
@@ -95,6 +109,12 @@ class Obd2Service {
 
   /// Connect and initialize the ELM327 adapter.
   ///
+  /// The init sequence + timing is sourced from [adapter] (#1330).
+  /// Default is [GenericElm327Adapter] — same byte-for-byte init
+  /// sequence and 100 ms delays the service has used since the
+  /// feature shipped. Phases 2/3 will hand in vLinker / SmartOBD
+  /// specialisations.
+  ///
   /// After the init sequence, if a [SupportedPidsCache] was wired in
   /// via the constructor (#811) this also:
   ///   1. Reads the VIN from the car (Mode 09 PID 02). Falls back to
@@ -104,19 +124,32 @@ class Obd2Service {
   ///      saves 8 × `01 XX` Bluetooth round-trips every session.
   ///   3. On cache miss, runs [discoverSupportedPids] and persists
   ///      the result under the chosen key for next time.
-  Future<bool> connect() async {
+  Future<bool> connect({
+    Elm327Adapter adapter = const GenericElm327Adapter(),
+  }) async {
     try {
+      _adapter = adapter;
       await _transport.connect();
 
       // Clear the per-connection supported-PIDs cache. A new session
       // may be a different car / different adapter firmware.
       _supportedPids = null;
 
-      // Run initialization sequence
-      for (final cmd in Elm327Protocol.initCommands) {
-        await _transport.sendCommand(cmd);
-        // Brief delay between init commands
-        await Future.delayed(const Duration(milliseconds: 100));
+      // Adapter-driven init sequence (#1330). [GenericElm327Adapter]
+      // matches the legacy hardcoded behaviour byte-for-byte: the
+      // shared ELM init list followed by 100 ms after the first
+      // command (ATZ) and 100 ms between each subsequent command.
+      final sequence = <String>[
+        ...adapter.initSequence,
+        ...adapter.extraInitCommands,
+      ];
+      for (var i = 0; i < sequence.length; i++) {
+        await _transport.sendCommand(sequence[i]);
+        // First command is the ATZ-style reset — its post-delay can
+        // differ from the rest on slow clones.
+        final delay =
+            i == 0 ? adapter.postResetDelay : adapter.interCommandDelay;
+        await Future.delayed(delay);
       }
 
       await _primeSupportedPidsCache();
@@ -168,7 +201,7 @@ class Obd2Service {
   /// available, at which point the cache is skipped this session.
   Future<String?> _resolveVehicleCacheKey() async {
     try {
-      final response = await _transport.sendCommand(Elm327Protocol.vinCommand);
+      final response = await _send(Elm327Protocol.vinCommand);
       final vin = Elm327Protocol.parseVin(response);
       if (vin != null && vin.isNotEmpty) return vin;
     } catch (e, st) {
@@ -230,14 +263,12 @@ class Obd2Service {
 
     try {
       // 1. Direct odometer (standard PID A6)
-      final a6 =
-          await _transport.sendCommand(Elm327Protocol.odometerCommand);
+      final a6 = await _send(Elm327Protocol.odometerCommand);
       final odometer = Elm327Protocol.parseOdometer(a6);
       if (odometer != null) return odometer;
 
       // 2. Distance since DTC cleared (standard PID 31)
-      final pid31 = await _transport
-          .sendCommand(Elm327Protocol.distanceSinceDtcClearedCommand);
+      final pid31 = await _send(Elm327Protocol.distanceSinceDtcClearedCommand);
       final distance = Elm327Protocol.parseDistanceSinceDtcCleared(pid31);
       if (distance != null) return distance.toDouble();
 
@@ -249,8 +280,7 @@ class Obd2Service {
       // Legacy path: identify brand from VIN and iterate catalog.
       // Silent failure on unknown-brand is intentional — we'd rather
       // return null than spam the car with commands it rejects.
-      final vinResponse =
-          await _transport.sendCommand(Elm327Protocol.vinCommand);
+      final vinResponse = await _send(Elm327Protocol.vinCommand);
       final vin = Elm327Protocol.parseVin(vinResponse);
       final brand = vehicleBrandFromVin(vin);
       if (brand == VehicleBrand.unknown) return null;
@@ -293,7 +323,7 @@ class Obd2Service {
   Future<double?> _readOdometerFromCatalogByBrand(VehicleBrand brand) async {
     for (final entry in Elm327Protocol.mfgOdometerCatalog) {
       if (entry.brand != brand) continue;
-      final response = await _transport.sendCommand(entry.command);
+      final response = await _send(entry.command);
       final value = switch (entry.kind) {
         MfgOdometerKind.threeBytesKm =>
           Elm327Protocol.parseMfgOdometer3Byte(
@@ -323,8 +353,7 @@ class Obd2Service {
     if (!_transport.isConnected) return null;
 
     try {
-      final response =
-          await _transport.sendCommand(Elm327Protocol.vehicleSpeedCommand);
+      final response = await _send(Elm327Protocol.vehicleSpeedCommand);
       return Elm327Protocol.parseVehicleSpeed(response);
     } catch (e, st) {
       debugPrint('OBD2 readSpeed failed: $e\n$st');
@@ -363,7 +392,7 @@ class Obd2Service {
       // bases, so we just hex-parse the middle two chars.
       final groupBase = int.parse(command.substring(2, 4), radix: 16);
       try {
-        final response = await _transport.sendCommand(command);
+        final response = await _send(command);
         final bitmap =
             Elm327Protocol.parseSupportedPidsBitmap(response, groupBase);
         if (bitmap == null) break;
@@ -387,8 +416,7 @@ class Obd2Service {
     if (!_transport.isConnected) return null;
 
     try {
-      final response =
-          await _transport.sendCommand(Elm327Protocol.engineRpmCommand);
+      final response = await _send(Elm327Protocol.engineRpmCommand);
       return Elm327Protocol.parseEngineRpm(response);
     } catch (e, st) {
       debugPrint('OBD2 readRpm failed: $e\n$st');
@@ -657,11 +685,22 @@ class Obd2Service {
   }) async {
     if (!_transport.isConnected) return null;
     try {
-      final response = await _transport.sendCommand(command);
+      final response = await _send(command);
       return parser(response);
     } catch (e, st) {
       debugPrint('OBD2 read $label failed: $e\n$st');
       return null;
     }
+  }
+
+  /// Send [command] over the transport and apply the active adapter's
+  /// [Elm327Adapter.preParse] hook before handing the string off to a
+  /// parser (#1330). Phase 1: [GenericElm327Adapter.preParse] is the
+  /// identity function so behaviour matches today's direct
+  /// `_transport.sendCommand` exactly. Adapter-specific subclasses in
+  /// later phases can strip stray prompts / echoes here.
+  Future<String> _send(String command) async {
+    final raw = await _transport.sendCommand(command);
+    return _adapter.preParse(raw);
   }
 }

--- a/test/features/consumption/data/obd2/elm327_adapter_test.dart
+++ b/test/features/consumption/data/obd2/elm327_adapter_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_commands.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+
+/// Transport that records every [sendCommand] invocation along with
+/// the wall-clock timestamp at which the call was received. Used to
+/// verify that the adapter-driven init loop preserves the legacy
+/// hardcoded behaviour byte-for-byte (#1330 phase 1).
+class _RecordingObd2Transport implements Obd2Transport {
+  final Map<String, String> _responses;
+  final List<_RecordedCommand> commands = <_RecordedCommand>[];
+  final Stopwatch _clock = Stopwatch();
+  bool _connected = false;
+
+  _RecordingObd2Transport([Map<String, String>? responses])
+      : _responses = responses ?? const {};
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<void> connect() async {
+    _connected = true;
+    _clock.start();
+  }
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    commands.add(_RecordedCommand(command.trim(), _clock.elapsed));
+    return _responses[command.trim()] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connected = false;
+    _clock.stop();
+  }
+}
+
+class _RecordedCommand {
+  final String command;
+  final Duration at;
+  const _RecordedCommand(this.command, this.at);
+}
+
+void main() {
+  group('GenericElm327Adapter (#1330 phase 1)', () {
+    test('id is "generic"', () {
+      const adapter = GenericElm327Adapter();
+      expect(adapter.id, 'generic');
+    });
+
+    test('initSequence equals Elm327Commands.initCommands byte-for-byte', () {
+      const adapter = GenericElm327Adapter();
+      // Phase 1 contract: the generic adapter MUST mirror the legacy
+      // global init list exactly, otherwise the refactor changes
+      // observed behaviour.
+      expect(adapter.initSequence, Elm327Commands.initCommands);
+      // Spot-check the literal commands so a future edit to
+      // [Elm327Commands.initCommands] surfaces here too.
+      expect(adapter.initSequence, [
+        'ATZ\r',
+        'ATE0\r',
+        'ATL0\r',
+        'ATH0\r',
+        'ATSP0\r',
+      ]);
+    });
+
+    test('postResetDelay and interCommandDelay are both 100 ms', () {
+      const adapter = GenericElm327Adapter();
+      expect(adapter.postResetDelay, const Duration(milliseconds: 100));
+      expect(adapter.interCommandDelay, const Duration(milliseconds: 100));
+    });
+
+    test('extraInitCommands is empty', () {
+      const adapter = GenericElm327Adapter();
+      expect(adapter.extraInitCommands, isEmpty);
+    });
+
+    test('preParse is the identity function', () {
+      const adapter = GenericElm327Adapter();
+      expect(adapter.preParse('foo'), 'foo');
+      expect(adapter.preParse(''), '');
+      expect(
+        adapter.preParse('41 0C 0F A0>'),
+        '41 0C 0F A0>',
+      );
+    });
+  });
+
+  group('Obd2Service.connect with default GenericElm327Adapter (#1330)', () {
+    test(
+      'sends the legacy init sequence in order with a ~100 ms gap '
+      'between commands',
+      () async {
+        final transport = _RecordingObd2Transport({
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+        });
+        final service = Obd2Service(transport);
+
+        final connected = await service.connect();
+
+        expect(connected, isTrue);
+        // Captured commands match the legacy init list exactly.
+        final sent = transport.commands.map((c) => c.command).toList();
+        expect(sent, [
+          'ATZ',
+          'ATE0',
+          'ATL0',
+          'ATH0',
+          'ATSP0',
+        ]);
+
+        // Inter-command intervals are at least the configured 100 ms
+        // delay. Generous upper bound (250 ms) avoids flakiness on
+        // slow CI runners — the assertion that matters is "we DID
+        // wait", not the exact wall-clock value.
+        for (var i = 1; i < transport.commands.length; i++) {
+          final gap = transport.commands[i].at - transport.commands[i - 1].at;
+          expect(
+            gap,
+            greaterThanOrEqualTo(const Duration(milliseconds: 90)),
+            reason: 'gap before command $i (${transport.commands[i].command})',
+          );
+        }
+      },
+    );
+
+    test('the active adapter is exposed as GenericElm327Adapter', () async {
+      final transport = _RecordingObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+      expect(service.adapter, isA<GenericElm327Adapter>());
+      expect(service.adapter.id, 'generic');
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -20,6 +20,34 @@ Future<Obd2Service> _connected(Map<String, String> extra) async {
   return service;
 }
 
+/// Minimal transport that records the order of [sendCommand] calls
+/// into the supplied list. Used by the #1330 regression test that
+/// pins the legacy init sequence.
+class _RecordingTransport implements Obd2Transport {
+  final Map<String, String> _responses;
+  final List<String> _log;
+  bool _connected = false;
+
+  _RecordingTransport(this._responses, this._log);
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    _log.add(cmd);
+    return _responses[cmd] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async => _connected = false;
+}
+
 void main() {
   group('Obd2Service PID expansion (#717)', () {
     test('readEngineLoad parses PID 04', () async {
@@ -613,6 +641,30 @@ void main() {
       expect(connected, isTrue);
       expect(service.isConnected, isTrue);
     });
+
+    test(
+      'connect with default adapter sends legacy init sequence (#1330)',
+      () async {
+        // Phase 1 regression: the default profile MUST drive the
+        // service's connect path with the legacy hardcoded init list.
+        // If [GenericElm327Adapter.initSequence] or the connect loop
+        // diverges, this test fails before any production user does.
+        final sent = <String>[];
+        final transport = _RecordingTransport(
+          {
+            'ATZ': 'ELM327 v1.5>',
+            'ATE0': 'OK>',
+            'ATL0': 'OK>',
+            'ATH0': 'OK>',
+            'ATSP0': 'OK>',
+          },
+          sent,
+        );
+        final service = Obd2Service(transport);
+        await service.connect();
+        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0']);
+      },
+    );
 
     test('readOdometerKm returns odometer from PID A6', () async {
       final transport = FakeObd2Transport({


### PR DESCRIPTION
Refs #1330 phase 1.

Introduces the `Elm327Adapter` abstraction — per-adapter init sequence, post-reset delay, inter-command delay, extra init commands, and a `preParse(raw)` hook for response quirks.

**No behaviour change.** Ships with a single `GenericElm327Adapter` whose values exactly mirror today's hardcoded constants (`Elm327Commands.initCommands` + 100 ms delays). All adapter profiles use the generic adapter, so runtime behaviour for vLinker, SmartOBD, and every other paired adapter is identical to master.

Phase 2 will add `VLinkerFsAdapter` and `SmartObdAdapter` profiles with empirically-tuned delays and a `preParse` override for SmartOBD's stray-`>` echoes. Phase 3 wires silent-failure detection into `trip_recording_controller`.

The deprecated `Obd2AdapterProfile.initDelay` / `.extraInitCommands` fields stay in place for now (with `@Deprecated` annotations) and will be removed in Phase 2 once all callers route through the adapter.

Generated with [Claude Code](https://claude.com/claude-code)