### PR TITLE
feat(refuel): unifiedSearchResults foundation + flag (Refs #1116 phase 3a)

### DIFF
--- a/lib/core/refuel/unified_search_results_enabled.dart
+++ b/lib/core/refuel/unified_search_results_enabled.dart
@@ -1,0 +1,58 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../storage/storage_keys.dart';
+import '../storage/storage_providers.dart';
+
+part 'unified_search_results_enabled.g.dart';
+
+/// Feature flag for the #1116 phase-3 unified fuel + EV search results.
+///
+/// Phase 3a (this PR) introduces only the flag and the
+/// [unifiedSearchResultsProvider] foundation; the search screen still
+/// reads `searchStateProvider` directly. Phase 3b ships the mixed
+/// fuel/EV card widgets, and phase 3c rewires the search screen to
+/// consume [unifiedSearchResultsProvider] when this flag is on.
+///
+/// Persisted to the settings box so the user's preference survives
+/// restarts. Defaults to `false` because the unified UI is not yet
+/// shipping — flipping the flag without phase 3b/c installed produces
+/// an empty result list, which is the safer fallback than a partial
+/// rendering.
+///
+/// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
+/// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
+/// mutators.
+@Riverpod(keepAlive: true)
+class UnifiedSearchResultsEnabled extends _$UnifiedSearchResultsEnabled {
+  @override
+  bool build() {
+    final storage = ref.watch(settingsStorageProvider);
+    final raw = storage.getSetting(StorageKeys.unifiedSearchResultsEnabled);
+    return raw is bool ? raw : false;
+  }
+
+  /// Flip the flag. Persists the new value before updating [state] so a
+  /// crash mid-toggle leaves the persisted + observed state consistent.
+  Future<void> toggle() async {
+    final storage = ref.read(settingsStorageProvider);
+    final next = !state;
+    await storage.putSetting(
+      StorageKeys.unifiedSearchResultsEnabled,
+      next,
+    );
+    state = next;
+  }
+
+  /// Set the flag to [value]. Idempotent — calling with the current
+  /// value still rewrites the storage entry (cheap on Hive) so any
+  /// callers that depend on a `putSetting` side-effect (e.g. tests)
+  /// see a deterministic write.
+  Future<void> set(bool value) async {
+    final storage = ref.read(settingsStorageProvider);
+    await storage.putSetting(
+      StorageKeys.unifiedSearchResultsEnabled,
+      value,
+    );
+    state = value;
+  }
+}

--- a/lib/core/refuel/unified_search_results_enabled.g.dart
+++ b/lib/core/refuel/unified_search_results_enabled.g.dart
@@ -1,0 +1,133 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'unified_search_results_enabled.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Feature flag for the #1116 phase-3 unified fuel + EV search results.
+///
+/// Phase 3a (this PR) introduces only the flag and the
+/// [unifiedSearchResultsProvider] foundation; the search screen still
+/// reads `searchStateProvider` directly. Phase 3b ships the mixed
+/// fuel/EV card widgets, and phase 3c rewires the search screen to
+/// consume [unifiedSearchResultsProvider] when this flag is on.
+///
+/// Persisted to the settings box so the user's preference survives
+/// restarts. Defaults to `false` because the unified UI is not yet
+/// shipping — flipping the flag without phase 3b/c installed produces
+/// an empty result list, which is the safer fallback than a partial
+/// rendering.
+///
+/// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
+/// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
+/// mutators.
+
+@ProviderFor(UnifiedSearchResultsEnabled)
+final unifiedSearchResultsEnabledProvider =
+    UnifiedSearchResultsEnabledProvider._();
+
+/// Feature flag for the #1116 phase-3 unified fuel + EV search results.
+///
+/// Phase 3a (this PR) introduces only the flag and the
+/// [unifiedSearchResultsProvider] foundation; the search screen still
+/// reads `searchStateProvider` directly. Phase 3b ships the mixed
+/// fuel/EV card widgets, and phase 3c rewires the search screen to
+/// consume [unifiedSearchResultsProvider] when this flag is on.
+///
+/// Persisted to the settings box so the user's preference survives
+/// restarts. Defaults to `false` because the unified UI is not yet
+/// shipping — flipping the flag without phase 3b/c installed produces
+/// an empty result list, which is the safer fallback than a partial
+/// rendering.
+///
+/// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
+/// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
+/// mutators.
+final class UnifiedSearchResultsEnabledProvider
+    extends $NotifierProvider<UnifiedSearchResultsEnabled, bool> {
+  /// Feature flag for the #1116 phase-3 unified fuel + EV search results.
+  ///
+  /// Phase 3a (this PR) introduces only the flag and the
+  /// [unifiedSearchResultsProvider] foundation; the search screen still
+  /// reads `searchStateProvider` directly. Phase 3b ships the mixed
+  /// fuel/EV card widgets, and phase 3c rewires the search screen to
+  /// consume [unifiedSearchResultsProvider] when this flag is on.
+  ///
+  /// Persisted to the settings box so the user's preference survives
+  /// restarts. Defaults to `false` because the unified UI is not yet
+  /// shipping — flipping the flag without phase 3b/c installed produces
+  /// an empty result list, which is the safer fallback than a partial
+  /// rendering.
+  ///
+  /// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
+  /// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
+  /// mutators.
+  UnifiedSearchResultsEnabledProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'unifiedSearchResultsEnabledProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$unifiedSearchResultsEnabledHash();
+
+  @$internal
+  @override
+  UnifiedSearchResultsEnabled create() => UnifiedSearchResultsEnabled();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$unifiedSearchResultsEnabledHash() =>
+    r'f3861b3c635983e95666508988811f0937a77b15';
+
+/// Feature flag for the #1116 phase-3 unified fuel + EV search results.
+///
+/// Phase 3a (this PR) introduces only the flag and the
+/// [unifiedSearchResultsProvider] foundation; the search screen still
+/// reads `searchStateProvider` directly. Phase 3b ships the mixed
+/// fuel/EV card widgets, and phase 3c rewires the search screen to
+/// consume [unifiedSearchResultsProvider] when this flag is on.
+///
+/// Persisted to the settings box so the user's preference survives
+/// restarts. Defaults to `false` because the unified UI is not yet
+/// shipping — flipping the flag without phase 3b/c installed produces
+/// an empty result list, which is the safer fallback than a partial
+/// rendering.
+///
+/// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
+/// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
+/// mutators.
+
+abstract class _$UnifiedSearchResultsEnabled extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/core/refuel/unified_search_results_provider.dart
+++ b/lib/core/refuel/unified_search_results_provider.dart
@@ -1,0 +1,89 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../features/search/domain/entities/search_result_item.dart';
+import '../../features/search/providers/ev_search_provider.dart';
+import '../../features/search/providers/search_provider.dart';
+import 'charging_station_as_refuel_option.dart';
+import 'refuel_option.dart';
+import 'station_as_refuel_option.dart';
+import 'unified_search_results_enabled.dart';
+
+part 'unified_search_results_provider.g.dart';
+
+/// Combines fuel + EV search results into a single
+/// [List<RefuelOption>] for the #1116 phase-3 unified search list.
+///
+/// Phase 3a (this file) lays the foundation. The search screen still
+/// reads `searchStateProvider` directly today; phase 3b ships the
+/// mixed-card widgets and phase 3c rewires the screen to consume this
+/// provider behind the [unifiedSearchResultsEnabledProvider] flag.
+///
+/// Contract:
+///
+/// * When the flag is off, returns an empty list. Callers fall back to
+///   the legacy fuel-only path. This keeps the no-op semantics until
+///   phase 3b/c land.
+/// * When the flag is on, walks both upstream sources independently:
+///   - the fuel side via [searchStateProvider], mapping
+///     [FuelStationResult]s through [StationAsRefuelOption] using the
+///     currently selected fuel from [selectedFuelTypeProvider];
+///   - the EV side via [eVSearchStateProvider], mapping every
+///     [ChargingStation] through [ChargingStationAsRefuelOption].
+///   The two lists are concatenated (fuel first, EV after) so the
+///   downstream UI can apply its own sort/filter chips deterministically.
+/// * Stations whose price for the active fuel is `null` are skipped on
+///   the fuel side. The phase-2 [StationAsRefuelOption] returns a null
+///   price for those stations, but the unified list is consumed by
+///   price-driven UI (lowest-first sort, savings badges); a price-less
+///   row would render as a placeholder for no useful reason. Callers
+///   that need *every* station regardless of price should keep using
+///   `searchStateProvider`.
+/// * The provider NEVER throws. Loading and error states on either
+///   upstream collapse to an empty contribution from that side; the
+///   other side still surfaces. UI consumers treat an empty result
+///   list as "no results yet" and rely on the upstream
+///   [AsyncValue.isLoading] / `.hasError` flags for spinners + retry
+///   affordances (phase 3b).
+///
+/// Note: this is a synchronous, non-keep-alive provider — Riverpod
+/// re-derives it whenever any of the upstreams update, which is the
+/// behaviour we want so the unified card list refreshes as the fuel +
+/// EV searches land.
+@riverpod
+List<RefuelOption> unifiedSearchResults(Ref ref) {
+  // Flag off → empty. Phase 3b/c will swap the fallback away.
+  if (!ref.watch(unifiedSearchResultsEnabledProvider)) {
+    return const <RefuelOption>[];
+  }
+
+  final fuelOptions = <RefuelOption>[];
+  final evOptions = <RefuelOption>[];
+
+  // Fuel side. The selected fuel drives `RefuelPrice` extraction
+  // through [StationAsRefuelOption]; stations with no price for that
+  // fuel are skipped (see provider doc).
+  final fuelType = ref.watch(selectedFuelTypeProvider);
+  final fuelState = ref.watch(searchStateProvider);
+  final fuelData = fuelState.asData?.value.data;
+  if (fuelData != null) {
+    for (final item in fuelData) {
+      if (item is FuelStationResult) {
+        final adapter = StationAsRefuelOption(item.station, fuelType);
+        if (adapter.price == null) continue;
+        fuelOptions.add(adapter);
+      }
+    }
+  }
+
+  // EV side. The phase-2 adapter computes availability from connector
+  // status internally, so we just wrap each charging station.
+  final evState = ref.watch(eVSearchStateProvider);
+  final evData = evState.asData?.value.data;
+  if (evData != null) {
+    for (final station in evData) {
+      evOptions.add(ChargingStationAsRefuelOption(station));
+    }
+  }
+
+  return [...fuelOptions, ...evOptions];
+}

--- a/lib/core/refuel/unified_search_results_provider.g.dart
+++ b/lib/core/refuel/unified_search_results_provider.g.dart
@@ -1,0 +1,176 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'unified_search_results_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Combines fuel + EV search results into a single
+/// [List<RefuelOption>] for the #1116 phase-3 unified search list.
+///
+/// Phase 3a (this file) lays the foundation. The search screen still
+/// reads `searchStateProvider` directly today; phase 3b ships the
+/// mixed-card widgets and phase 3c rewires the screen to consume this
+/// provider behind the [unifiedSearchResultsEnabledProvider] flag.
+///
+/// Contract:
+///
+/// * When the flag is off, returns an empty list. Callers fall back to
+///   the legacy fuel-only path. This keeps the no-op semantics until
+///   phase 3b/c land.
+/// * When the flag is on, walks both upstream sources independently:
+///   - the fuel side via [searchStateProvider], mapping
+///     [FuelStationResult]s through [StationAsRefuelOption] using the
+///     currently selected fuel from [selectedFuelTypeProvider];
+///   - the EV side via [eVSearchStateProvider], mapping every
+///     [ChargingStation] through [ChargingStationAsRefuelOption].
+///   The two lists are concatenated (fuel first, EV after) so the
+///   downstream UI can apply its own sort/filter chips deterministically.
+/// * Stations whose price for the active fuel is `null` are skipped on
+///   the fuel side. The phase-2 [StationAsRefuelOption] returns a null
+///   price for those stations, but the unified list is consumed by
+///   price-driven UI (lowest-first sort, savings badges); a price-less
+///   row would render as a placeholder for no useful reason. Callers
+///   that need *every* station regardless of price should keep using
+///   `searchStateProvider`.
+/// * The provider NEVER throws. Loading and error states on either
+///   upstream collapse to an empty contribution from that side; the
+///   other side still surfaces. UI consumers treat an empty result
+///   list as "no results yet" and rely on the upstream
+///   [AsyncValue.isLoading] / `.hasError` flags for spinners + retry
+///   affordances (phase 3b).
+///
+/// Note: this is a synchronous, non-keep-alive provider — Riverpod
+/// re-derives it whenever any of the upstreams update, which is the
+/// behaviour we want so the unified card list refreshes as the fuel +
+/// EV searches land.
+
+@ProviderFor(unifiedSearchResults)
+final unifiedSearchResultsProvider = UnifiedSearchResultsProvider._();
+
+/// Combines fuel + EV search results into a single
+/// [List<RefuelOption>] for the #1116 phase-3 unified search list.
+///
+/// Phase 3a (this file) lays the foundation. The search screen still
+/// reads `searchStateProvider` directly today; phase 3b ships the
+/// mixed-card widgets and phase 3c rewires the screen to consume this
+/// provider behind the [unifiedSearchResultsEnabledProvider] flag.
+///
+/// Contract:
+///
+/// * When the flag is off, returns an empty list. Callers fall back to
+///   the legacy fuel-only path. This keeps the no-op semantics until
+///   phase 3b/c land.
+/// * When the flag is on, walks both upstream sources independently:
+///   - the fuel side via [searchStateProvider], mapping
+///     [FuelStationResult]s through [StationAsRefuelOption] using the
+///     currently selected fuel from [selectedFuelTypeProvider];
+///   - the EV side via [eVSearchStateProvider], mapping every
+///     [ChargingStation] through [ChargingStationAsRefuelOption].
+///   The two lists are concatenated (fuel first, EV after) so the
+///   downstream UI can apply its own sort/filter chips deterministically.
+/// * Stations whose price for the active fuel is `null` are skipped on
+///   the fuel side. The phase-2 [StationAsRefuelOption] returns a null
+///   price for those stations, but the unified list is consumed by
+///   price-driven UI (lowest-first sort, savings badges); a price-less
+///   row would render as a placeholder for no useful reason. Callers
+///   that need *every* station regardless of price should keep using
+///   `searchStateProvider`.
+/// * The provider NEVER throws. Loading and error states on either
+///   upstream collapse to an empty contribution from that side; the
+///   other side still surfaces. UI consumers treat an empty result
+///   list as "no results yet" and rely on the upstream
+///   [AsyncValue.isLoading] / `.hasError` flags for spinners + retry
+///   affordances (phase 3b).
+///
+/// Note: this is a synchronous, non-keep-alive provider — Riverpod
+/// re-derives it whenever any of the upstreams update, which is the
+/// behaviour we want so the unified card list refreshes as the fuel +
+/// EV searches land.
+
+final class UnifiedSearchResultsProvider
+    extends
+        $FunctionalProvider<
+          List<RefuelOption>,
+          List<RefuelOption>,
+          List<RefuelOption>
+        >
+    with $Provider<List<RefuelOption>> {
+  /// Combines fuel + EV search results into a single
+  /// [List<RefuelOption>] for the #1116 phase-3 unified search list.
+  ///
+  /// Phase 3a (this file) lays the foundation. The search screen still
+  /// reads `searchStateProvider` directly today; phase 3b ships the
+  /// mixed-card widgets and phase 3c rewires the screen to consume this
+  /// provider behind the [unifiedSearchResultsEnabledProvider] flag.
+  ///
+  /// Contract:
+  ///
+  /// * When the flag is off, returns an empty list. Callers fall back to
+  ///   the legacy fuel-only path. This keeps the no-op semantics until
+  ///   phase 3b/c land.
+  /// * When the flag is on, walks both upstream sources independently:
+  ///   - the fuel side via [searchStateProvider], mapping
+  ///     [FuelStationResult]s through [StationAsRefuelOption] using the
+  ///     currently selected fuel from [selectedFuelTypeProvider];
+  ///   - the EV side via [eVSearchStateProvider], mapping every
+  ///     [ChargingStation] through [ChargingStationAsRefuelOption].
+  ///   The two lists are concatenated (fuel first, EV after) so the
+  ///   downstream UI can apply its own sort/filter chips deterministically.
+  /// * Stations whose price for the active fuel is `null` are skipped on
+  ///   the fuel side. The phase-2 [StationAsRefuelOption] returns a null
+  ///   price for those stations, but the unified list is consumed by
+  ///   price-driven UI (lowest-first sort, savings badges); a price-less
+  ///   row would render as a placeholder for no useful reason. Callers
+  ///   that need *every* station regardless of price should keep using
+  ///   `searchStateProvider`.
+  /// * The provider NEVER throws. Loading and error states on either
+  ///   upstream collapse to an empty contribution from that side; the
+  ///   other side still surfaces. UI consumers treat an empty result
+  ///   list as "no results yet" and rely on the upstream
+  ///   [AsyncValue.isLoading] / `.hasError` flags for spinners + retry
+  ///   affordances (phase 3b).
+  ///
+  /// Note: this is a synchronous, non-keep-alive provider — Riverpod
+  /// re-derives it whenever any of the upstreams update, which is the
+  /// behaviour we want so the unified card list refreshes as the fuel +
+  /// EV searches land.
+  UnifiedSearchResultsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'unifiedSearchResultsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$unifiedSearchResultsHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<RefuelOption>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  List<RefuelOption> create(Ref ref) {
+    return unifiedSearchResults(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<RefuelOption> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<RefuelOption>>(value),
+    );
+  }
+}
+
+String _$unifiedSearchResultsHash() =>
+    r'54035757d018d4552a630dbe75311e74affca4c5';

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -61,4 +61,12 @@ class StorageKeys {
   /// fires twice for the same user.
   static const String tripRecordingResumeHintShown =
       'trip_recording_resume_hint_shown';
+
+  /// #1116 phase 3 — feature flag for the unified fuel + EV search
+  /// results list. Defaults to `false`; flipping it on swaps the
+  /// fuel-only `searchStateProvider` consumption for
+  /// `unifiedSearchResultsProvider`. UI cards land in phase 3b; this
+  /// flag is a no-op until then.
+  static const String unifiedSearchResultsEnabled =
+      'unified_search_results_enabled';
 }

--- a/test/core/refuel/unified_search_results_enabled_test.dart
+++ b/test/core/refuel/unified_search_results_enabled_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/refuel/unified_search_results_enabled.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+
+/// Coverage for the #1116 phase 3a feature flag.
+///
+/// Mirrors the [EvShowOnMap] test pattern in
+/// `test/features/ev/providers/ev_providers_test.dart` — a fake in-memory
+/// [SettingsStorage] is overridden into the container so reads + writes
+/// stay deterministic without a Hive box.
+void main() {
+  group('unifiedSearchResultsEnabledProvider', () {
+    test('defaults to false on a fresh storage', () {
+      final storage = _FakeSettings();
+      final container = ProviderContainer(
+        overrides: [settingsStorageProvider.overrideWithValue(storage)],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
+    });
+
+    test(
+      'reads persisted true value when storage already holds the flag',
+      () {
+        final storage = _FakeSettings()
+          ..putSetting(StorageKeys.unifiedSearchResultsEnabled, true);
+        final container = ProviderContainer(
+          overrides: [settingsStorageProvider.overrideWithValue(storage)],
+        );
+        addTearDown(container.dispose);
+
+        expect(container.read(unifiedSearchResultsEnabledProvider), isTrue);
+      },
+    );
+
+    test('non-bool persisted value falls back to false', () {
+      // Defensive: previous app versions or hand-edited Hive boxes may
+      // store the wrong type. The provider must not throw.
+      final storage = _FakeSettings()
+        ..putSetting(StorageKeys.unifiedSearchResultsEnabled, 'yes');
+      final container = ProviderContainer(
+        overrides: [settingsStorageProvider.overrideWithValue(storage)],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
+    });
+
+    test('toggle flips state and persists the new value', () async {
+      final storage = _FakeSettings();
+      final container = ProviderContainer(
+        overrides: [settingsStorageProvider.overrideWithValue(storage)],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
+
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .toggle();
+
+      expect(container.read(unifiedSearchResultsEnabledProvider), isTrue);
+      expect(
+        storage.getSetting(StorageKeys.unifiedSearchResultsEnabled),
+        isTrue,
+      );
+
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .toggle();
+
+      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
+      expect(
+        storage.getSetting(StorageKeys.unifiedSearchResultsEnabled),
+        isFalse,
+      );
+    });
+
+    test('set(value) writes through and updates state', () async {
+      final storage = _FakeSettings();
+      final container = ProviderContainer(
+        overrides: [settingsStorageProvider.overrideWithValue(storage)],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .set(true);
+      expect(container.read(unifiedSearchResultsEnabledProvider), isTrue);
+      expect(
+        storage.getSetting(StorageKeys.unifiedSearchResultsEnabled),
+        isTrue,
+      );
+
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .set(false);
+      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
+      expect(
+        storage.getSetting(StorageKeys.unifiedSearchResultsEnabled),
+        isFalse,
+      );
+    });
+
+    test('set(true) is idempotent — repeated writes keep state at true',
+        () async {
+      final storage = _FakeSettings();
+      final container = ProviderContainer(
+        overrides: [settingsStorageProvider.overrideWithValue(storage)],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .set(true);
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .set(true);
+      expect(container.read(unifiedSearchResultsEnabledProvider), isTrue);
+    });
+  });
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/core/refuel/unified_search_results_provider_test.dart
+++ b/test/core/refuel/unified_search_results_provider_test.dart
@@ -1,0 +1,384 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/refuel/charging_station_as_refuel_option.dart';
+import 'package:tankstellen/core/refuel/refuel_option.dart';
+import 'package:tankstellen/core/refuel/station_as_refuel_option.dart';
+import 'package:tankstellen/core/refuel/unified_search_results_enabled.dart';
+import 'package:tankstellen/core/refuel/unified_search_results_provider.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/ev_search_provider.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+
+/// Coverage for the #1116 phase 3a unified search results provider.
+///
+/// Each test pre-overrides `searchStateProvider` (fuel side) and
+/// `eVSearchStateProvider` (EV side) with fakes that return a
+/// canned [AsyncValue]. The flag is flipped via the real notifier
+/// against an in-memory [SettingsStorage] so the on/off path is
+/// exercised end-to-end.
+
+class _FakeSearchState extends SearchState {
+  _FakeSearchState(this._value);
+  final AsyncValue<ServiceResult<List<SearchResultItem>>> _value;
+
+  @override
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => _value;
+}
+
+class _FakeEvSearchState extends EVSearchState {
+  _FakeEvSearchState(this._value);
+  final AsyncValue<ServiceResult<List<ChargingStation>>> _value;
+
+  @override
+  AsyncValue<ServiceResult<List<ChargingStation>>> build() => _value;
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+
+AsyncValue<ServiceResult<List<SearchResultItem>>> _fuelData(
+  List<SearchResultItem> items,
+) =>
+    AsyncValue.data(ServiceResult(
+      data: items,
+      source: ServiceSource.cache,
+      fetchedAt: DateTime.now(),
+    ));
+
+AsyncValue<ServiceResult<List<ChargingStation>>> _evData(
+  List<ChargingStation> items,
+) =>
+    AsyncValue.data(ServiceResult(
+      data: items,
+      source: ServiceSource.openChargeMapApi,
+      fetchedAt: DateTime.now(),
+    ));
+
+Station _fuelStation({
+  String id = 'f1',
+  double? e10 = 1.749,
+  double? diesel,
+  String brand = 'Total',
+}) =>
+    Station(
+      id: id,
+      name: 'Station $id',
+      brand: brand,
+      street: 'Teststr.',
+      postCode: '10115',
+      place: 'Testtown',
+      lat: 52.5,
+      lng: 13.4,
+      e10: e10,
+      diesel: diesel,
+      isOpen: true,
+    );
+
+ChargingStation _charger({String id = 'ev1', String? operator = 'Ionity'}) =>
+    ChargingStation(
+      id: id,
+      name: 'Charger $id',
+      operator: operator,
+      latitude: 52.5,
+      longitude: 13.4,
+    );
+
+/// Build a container with the canned fuel + EV upstreams plus an
+/// in-memory settings store. Profile is null by default so
+/// `selectedFuelTypeProvider` falls back to [FuelType.all]; tests that
+/// need a specific fuel type call `select()` on the notifier.
+ProviderContainer _container({
+  required AsyncValue<ServiceResult<List<SearchResultItem>>> fuel,
+  required AsyncValue<ServiceResult<List<ChargingStation>>> ev,
+  bool flagOn = false,
+}) {
+  final storage = _FakeSettings();
+  final container = ProviderContainer(
+    overrides: [
+      settingsStorageProvider.overrideWithValue(storage),
+      activeProfileProvider.overrideWith(_NullProfile.new),
+      searchStateProvider.overrideWith(() => _FakeSearchState(fuel)),
+      eVSearchStateProvider.overrideWith(() => _FakeEvSearchState(ev)),
+    ],
+  );
+  if (flagOn) {
+    // Flip the persisted value before any read; the flag's `build` will
+    // observe `true` on first watch.
+    storage.putSetting(StorageKeys.unifiedSearchResultsEnabled, true);
+  }
+  return container;
+}
+
+class _NullProfile extends ActiveProfile {
+  @override
+  UserProfile? build() => null;
+}
+
+void main() {
+  group('unifiedSearchResultsProvider — flag off', () {
+    test('returns empty list with both upstreams empty', () {
+      final c = _container(fuel: _fuelData(const []), ev: _evData(const []));
+      addTearDown(c.dispose);
+      expect(c.read(unifiedSearchResultsProvider), isEmpty);
+    });
+
+    test('returns empty list even when upstreams have data', () {
+      final c = _container(
+        fuel: _fuelData([FuelStationResult(_fuelStation())]),
+        ev: _evData([_charger()]),
+      );
+      addTearDown(c.dispose);
+      expect(c.read(unifiedSearchResultsProvider), isEmpty);
+    });
+
+    test('returns empty list when upstream fuel is loading', () {
+      final c = _container(
+        fuel: const AsyncValue.loading(),
+        ev: _evData([_charger()]),
+      );
+      addTearDown(c.dispose);
+      expect(c.read(unifiedSearchResultsProvider), isEmpty);
+    });
+  });
+
+  group('unifiedSearchResultsProvider — flag on, fuel side', () {
+    test('returns fuel adapters for the selected fuel type', () {
+      final c = _container(
+        fuel: _fuelData([
+          FuelStationResult(_fuelStation(id: 'f1', e10: 1.749)),
+          FuelStationResult(_fuelStation(id: 'f2', e10: 1.689)),
+        ]),
+        ev: _evData(const []),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+      // Default profile is null → SelectedFuelType.all wildcard, but
+      // StationAsRefuelOption wants a concrete fuel — pick e10.
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      final list = c.read(unifiedSearchResultsProvider);
+      expect(list, hasLength(2));
+      expect(list.every((o) => o is StationAsRefuelOption), isTrue);
+      expect(list.map((o) => o.id).toList(), ['fuel:f1', 'fuel:f2']);
+    });
+
+    test('skips fuel stations whose price for the selected fuel is null',
+        () {
+      final c = _container(
+        fuel: _fuelData([
+          // e10 present → kept.
+          FuelStationResult(_fuelStation(id: 'f-e10', e10: 1.749)),
+          // e10 missing → dropped.
+          FuelStationResult(_fuelStation(id: 'f-no-e10', e10: null)),
+          // e10 missing but diesel present → still dropped (selected
+          // fuel is e10 in this scenario).
+          FuelStationResult(
+            _fuelStation(id: 'f-diesel-only', e10: null, diesel: 1.589),
+          ),
+        ]),
+        ev: _evData(const []),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      final list = c.read(unifiedSearchResultsProvider);
+      expect(list.map((o) => o.id).toList(), ['fuel:f-e10']);
+    });
+
+    test('drops EVStationResult entries from the fuel-state stream', () {
+      // Mid-flight scenario: the search service returned an EV item
+      // mixed in with fuel — should NOT be double-adapted via the fuel
+      // path (the EV path handles those).
+      final c = _container(
+        fuel: _fuelData([
+          FuelStationResult(_fuelStation(id: 'f1', e10: 1.749)),
+          EVStationResult(_charger(id: 'mixed-ev')),
+        ]),
+        ev: _evData(const []),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      final list = c.read(unifiedSearchResultsProvider);
+      expect(list.map((o) => o.id).toList(), ['fuel:f1']);
+    });
+  });
+
+  group('unifiedSearchResultsProvider — flag on, EV side', () {
+    test('returns EV adapters when only EV results are present', () {
+      final c = _container(
+        fuel: _fuelData(const []),
+        ev: _evData([_charger(id: 'ev1'), _charger(id: 'ev2')]),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+
+      final list = c.read(unifiedSearchResultsProvider);
+      expect(list, hasLength(2));
+      expect(list.every((o) => o is ChargingStationAsRefuelOption), isTrue);
+      expect(list.map((o) => o.id).toList(), ['ev:ev1', 'ev:ev2']);
+    });
+  });
+
+  group('unifiedSearchResultsProvider — flag on, both sides', () {
+    test('combines fuel + EV adapters with fuel first', () {
+      final c = _container(
+        fuel: _fuelData([
+          FuelStationResult(_fuelStation(id: 'f1', e10: 1.749)),
+        ]),
+        ev: _evData([_charger(id: 'ev1')]),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      final list = c.read(unifiedSearchResultsProvider);
+      expect(list.map((o) => o.id).toList(), ['fuel:f1', 'ev:ev1']);
+      expect(list.first, isA<StationAsRefuelOption>());
+      expect(list.last, isA<ChargingStationAsRefuelOption>());
+    });
+  });
+
+  group('unifiedSearchResultsProvider — flag on, async edges', () {
+    test('fuel AsyncLoading + EV data → only EV adapters surface', () {
+      final c = _container(
+        fuel: const AsyncValue.loading(),
+        ev: _evData([_charger(id: 'ev-only')]),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+
+      final list = c.read(unifiedSearchResultsProvider);
+      expect(list.map((o) => o.id).toList(), ['ev:ev-only']);
+    });
+
+    test('fuel AsyncError + EV data → only EV adapters surface (no rethrow)',
+        () {
+      final c = _container(
+        fuel: AsyncValue.error(StateError('boom'), StackTrace.current),
+        ev: _evData([_charger(id: 'ev-still-here')]),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+
+      // The provider must not throw when reading; the error is silently
+      // dropped on the fuel side per the documented contract.
+      expect(
+        () => c.read(unifiedSearchResultsProvider),
+        returnsNormally,
+      );
+      final list = c.read(unifiedSearchResultsProvider);
+      expect(list.map((o) => o.id).toList(), ['ev:ev-still-here']);
+    });
+
+    test('both sides loading → empty list, no throw', () {
+      final c = _container(
+        fuel: const AsyncValue.loading(),
+        ev: const AsyncValue.loading(),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+      expect(c.read(unifiedSearchResultsProvider), isEmpty);
+    });
+
+    test('EV AsyncError + fuel data → only fuel adapters surface', () {
+      final c = _container(
+        fuel: _fuelData([
+          FuelStationResult(_fuelStation(id: 'f-only', e10: 1.749)),
+        ]),
+        ev: AsyncValue.error(StateError('ev-down'), StackTrace.current),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      expect(
+        c.read(unifiedSearchResultsProvider).map((o) => o.id).toList(),
+        ['fuel:f-only'],
+      );
+    });
+  });
+
+  group('unifiedSearchResultsProvider — reactivity', () {
+    test('flipping the flag on/off re-derives the list', () async {
+      final c = _container(
+        fuel: _fuelData([
+          FuelStationResult(_fuelStation(id: 'f1', e10: 1.749)),
+        ]),
+        ev: _evData(const []),
+      );
+      addTearDown(c.dispose);
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      // Flag starts off → empty.
+      expect(c.read(unifiedSearchResultsProvider), isEmpty);
+
+      await c.read(unifiedSearchResultsEnabledProvider.notifier).set(true);
+      expect(
+        c.read(unifiedSearchResultsProvider).map((o) => o.id).toList(),
+        ['fuel:f1'],
+      );
+
+      await c.read(unifiedSearchResultsEnabledProvider.notifier).set(false);
+      expect(c.read(unifiedSearchResultsProvider), isEmpty);
+    });
+  });
+
+  group('unifiedSearchResultsProvider — return type', () {
+    test('all returned options implement RefuelOption', () {
+      final c = _container(
+        fuel: _fuelData([
+          FuelStationResult(_fuelStation(id: 'f1', e10: 1.749)),
+        ]),
+        ev: _evData([_charger(id: 'ev1')]),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      final list = c.read(unifiedSearchResultsProvider);
+      for (final option in list) {
+        expect(option, isA<RefuelOption>());
+        expect(option.coordinates.lat, isNotNull);
+        expect(option.coordinates.lng, isNotNull);
+        expect(option.id, isNotEmpty);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Foundational, no-UI layer for the #1116 phase 3 unified fuel + EV search results list:

- **Feature flag** — Hive-backed `unifiedSearchResultsEnabledProvider` (defaults `false`). Mirrors the `EvShowOnMap` pattern: keep-alive notifier with `toggle` + `set` mutators, persisted via `settingsStorageProvider` under `StorageKeys.unifiedSearchResultsEnabled`.
- **Unified provider** — `unifiedSearchResultsProvider` returns `List<RefuelOption>` by walking `searchStateProvider` (fuel) and `eVSearchStateProvider` (EV) and routing each item through the phase 2 adapters (`StationAsRefuelOption` / `ChargingStationAsRefuelOption`). Flag-off short-circuits to `const []`. Loading / error states on either upstream collapse to an empty contribution from that side; the provider never throws.
- **Tests** — 20 new tests in `test/core/refuel/`: flag persistence + toggle (6) and provider behaviour across flag on/off, fuel-only, EV-only, mixed, null-price skip, and Async loading/error edges (14).

Phases 3b (UI cards) and 3c (search-screen wiring behind the flag) follow.

## Test plan

- [x] `flutter analyze` — `No issues found!`
- [x] `flutter test test/core/refuel/` — 81/81 pass (61 existing + 20 new)
- [x] `flutter test test/lint/` — passes (no_silent_catch, prefer_const_constructors, etc.)
- [ ] CI green on PR

Refs #1116

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)