### PR TITLE
feat(obd2): VLinkerFsAdapter + SmartObdAdapter (Refs #1330 phase 2)

### DIFF
--- a/lib/features/consumption/data/obd2/adapter_registry.dart
+++ b/lib/features/consumption/data/obd2/adapter_registry.dart
@@ -1,3 +1,5 @@
+import 'adapters/smart_obd_adapter.dart';
+import 'adapters/v_linker_fs_adapter.dart';
 import 'elm327_adapter.dart';
 import 'elm327_protocol.dart';
 
@@ -68,31 +70,11 @@ class Obd2AdapterProfile {
   /// generic-fallback profile that has no naming signature.
   final List<String> nameMatchers;
 
-  /// Some clones need a few hundred ms between consecutive ELM
-  /// init commands — otherwise the chip drops bytes. Default is
-  /// 100 ms (what [Obd2Service.connect] already does).
-  ///
-  /// Deprecated in #1330 phase 1 — use [adapter.postResetDelay] /
-  /// [adapter.interCommandDelay] instead. Field stays in place so
-  /// the few historical call sites still compile; will be removed
-  /// in phase 2 once every caller routes through [adapter].
-  @Deprecated('Use adapter.postResetDelay / adapter.interCommandDelay')
-  final Duration initDelay;
-
-  /// Extra AT commands appended after the shared init sequence
-  /// (e.g. `ATSP6\r` to pin ISO 15765-4 on Volvos; `ATST FF\r` for
-  /// slow cars that miss the default 200 ms timeout).
-  ///
-  /// Deprecated in #1330 phase 1 — use [adapter.extraInitCommands]
-  /// instead. Removed in phase 2.
-  @Deprecated('Use adapter.extraInitCommands')
-  final List<String> extraInitCommands;
-
   /// Per-adapter ELM327 protocol quirks (#1330): init sequence,
-  /// timing, response pre-parse hook. Phase 1 ships only the
-  /// [GenericElm327Adapter] default — runtime behaviour is identical
-  /// for every profile until phases 2/3 introduce specialised
-  /// adapters.
+  /// timing, response pre-parse hook. Phase 2 ships
+  /// [GenericElm327Adapter] as the default, [VLinkerFsAdapter] for
+  /// vLinker FS-class adapters, and [SmartObdAdapter] for SmartOBD
+  /// clones (which need longer delays + a stray-`>` preParse).
   final Elm327Adapter adapter;
 
   const Obd2AdapterProfile({
@@ -103,8 +85,6 @@ class Obd2AdapterProfile {
     this.writeCharUuid = '',
     this.notifyCharUuid = '',
     this.nameMatchers = const [],
-    this.initDelay = const Duration(milliseconds: 100),
-    this.extraInitCommands = const [],
     this.adapter = const GenericElm327Adapter(),
   });
 
@@ -215,6 +195,7 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     displayName: 'vLinker FS (Classic)',
     transport: BluetoothTransport.classic,
     nameMatchers: ['vlinker fs', 'vlinker ms', 'vlink fs', 'vgate fs'],
+    adapter: VLinkerFsAdapter(),
   ),
   // vLinker FD / MC — the BLE variants. Nordic UART: FFF0 service,
   // FFF2 write, FFF1 notify. Name advertises as "vLinker FD" / "MC".
@@ -267,12 +248,14 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
     notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
     nameMatchers: ['smartobd'],
+    adapter: SmartObdAdapter(),
   ),
   Obd2AdapterProfile(
     id: 'smartobd-classic',
     displayName: 'SmartOBD (Classic)',
     transport: BluetoothTransport.classic,
     nameMatchers: ['smartobd'],
+    adapter: SmartObdAdapter(),
   ),
   // ieGeek Scanner — ELM327 v2.1 BLE clone, advertises as "ieGeek…"
   // (#949). Nordic UART FFF0 family.
@@ -346,7 +329,6 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
     writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
     notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
-    initDelay: Duration(milliseconds: 300),
   ),
   // Generic ELM327 Classic SPP fallback (#761). Matches any bonded
   // device whose name contains "obd" or "elm327" — the common ones
@@ -358,7 +340,6 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     displayName: 'Generic ELM327 (Classic)',
     transport: BluetoothTransport.classic,
     nameMatchers: ['obdii', 'obd-ii', 'obd ii', 'obd2', 'elm327'],
-    initDelay: Duration(milliseconds: 300),
   ),
 ];
 

--- a/lib/features/consumption/data/obd2/adapters/smart_obd_adapter.dart
+++ b/lib/features/consumption/data/obd2/adapters/smart_obd_adapter.dart
@@ -1,0 +1,40 @@
+import '../elm327_adapter.dart';
+import '../elm327_commands.dart';
+
+/// SmartOBD-class ELM327 v1.5 clone (#1330 phase 2).
+///
+/// These adapters are slower to settle after `ATZ` and need ≥200 ms between
+/// subsequent AT commands or the response buffer drifts (a previous
+/// command's `OK>` arrives during the next read). Some firmware revisions
+/// also emit stray `>` prompt characters mid-frame; [preParse] strips them
+/// before the global parser sees the response.
+class SmartObdAdapter implements Elm327Adapter {
+  const SmartObdAdapter();
+
+  @override
+  String get id => 'smart-obd';
+
+  @override
+  List<String> get initSequence => Elm327Commands.initCommands;
+
+  @override
+  Duration get postResetDelay => const Duration(milliseconds: 400);
+
+  @override
+  Duration get interCommandDelay => const Duration(milliseconds: 200);
+
+  @override
+  List<String> get extraInitCommands => const [];
+
+  @override
+  String preParse(String raw) {
+    // Strip stray `>` prompt characters that some SmartOBD firmware
+    // emits mid-frame. The terminating `>` is still valid and is removed
+    // by Elm327Parsers.cleanResponse downstream.
+    if (raw.isEmpty) return raw;
+    final lastIdx = raw.lastIndexOf('>');
+    if (lastIdx <= 0) return raw;
+    final body = raw.substring(0, lastIdx).replaceAll('>', '');
+    return body + raw.substring(lastIdx);
+  }
+}

--- a/lib/features/consumption/data/obd2/adapters/v_linker_fs_adapter.dart
+++ b/lib/features/consumption/data/obd2/adapters/v_linker_fs_adapter.dart
@@ -1,0 +1,27 @@
+import '../elm327_adapter.dart';
+import '../elm327_commands.dart';
+
+/// vLinker FS-class adapter (e.g. FS-14884). Faster, cleaner ELM327
+/// implementation; the base init sequence is reliable with shorter
+/// delays than the generic profile (#1330 phase 2).
+class VLinkerFsAdapter implements Elm327Adapter {
+  const VLinkerFsAdapter();
+
+  @override
+  String get id => 'vlinker-fs';
+
+  @override
+  List<String> get initSequence => Elm327Commands.initCommands;
+
+  @override
+  Duration get postResetDelay => const Duration(milliseconds: 200);
+
+  @override
+  Duration get interCommandDelay => const Duration(milliseconds: 50);
+
+  @override
+  List<String> get extraInitCommands => const [];
+
+  @override
+  String preParse(String raw) => raw;
+}

--- a/test/features/consumption/data/obd2/adapter_registry_test.dart
+++ b/test/features/consumption/data/obd2/adapter_registry_test.dart
@@ -1,5 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapters/smart_obd_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapters/v_linker_fs_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_adapter.dart';
 
 void main() {
   final registry = Obd2AdapterRegistry.defaults();
@@ -243,25 +246,48 @@ void main() {
   });
 
   group('Obd2AdapterProfile', () {
-    test('vLinker BLE defaults to 100 ms init delay', () {
-      final v =
-          registry.profiles.firstWhere((p) => p.id == 'vlinker-ble');
-      expect(v.initDelay, const Duration(milliseconds: 100));
+    test('vLinker BLE defaults to GenericElm327Adapter (100 ms / 100 ms)', () {
+      final v = registry.profiles.firstWhere((p) => p.id == 'vlinker-ble');
+      expect(v.adapter, isA<GenericElm327Adapter>());
+      expect(v.adapter.postResetDelay, const Duration(milliseconds: 100));
+      expect(v.adapter.interCommandDelay, const Duration(milliseconds: 100));
     });
 
-    test('generic BLE fallback uses a longer init delay for slow clones',
+    test('generic BLE fallback also uses GenericElm327Adapter (#1330 phase 2)',
         () {
-      final g =
-          registry.profiles.firstWhere((p) => p.id == 'generic-fff0');
-      expect(g.initDelay, const Duration(milliseconds: 300));
+      final g = registry.profiles.firstWhere((p) => p.id == 'generic-fff0');
+      expect(g.adapter, isA<GenericElm327Adapter>());
     });
 
-    test('generic-classic fallback also uses the 300 ms init delay (#761)',
+    test('generic-classic fallback uses GenericElm327Adapter (#761, #1330)',
         () {
-      final g =
-          registry.profiles.firstWhere((p) => p.id == 'generic-classic');
-      expect(g.initDelay, const Duration(milliseconds: 300));
+      final g = registry.profiles.firstWhere((p) => p.id == 'generic-classic');
+      expect(g.adapter, isA<GenericElm327Adapter>());
       expect(g.transport, BluetoothTransport.classic);
+    });
+  });
+
+  group('Obd2AdapterProfile.adapter wiring (#1330 phase 2)', () {
+    test('vLinker FS Classic profile is wired to VLinkerFsAdapter', () {
+      final v =
+          registry.profiles.firstWhere((p) => p.id == 'vlinker-fs-classic');
+      expect(v.adapter, isA<VLinkerFsAdapter>());
+      expect(v.adapter.id, 'vlinker-fs');
+      expect(v.adapter.postResetDelay, const Duration(milliseconds: 200));
+      expect(v.adapter.interCommandDelay, const Duration(milliseconds: 50));
+    });
+
+    test('SmartOBD BLE profile is wired to SmartObdAdapter', () {
+      final s = registry.profiles.firstWhere((p) => p.id == 'smartobd-ble');
+      expect(s.adapter, isA<SmartObdAdapter>());
+      expect(s.adapter.id, 'smart-obd');
+      expect(s.adapter.postResetDelay, const Duration(milliseconds: 400));
+      expect(s.adapter.interCommandDelay, const Duration(milliseconds: 200));
+    });
+
+    test('SmartOBD Classic profile is wired to SmartObdAdapter', () {
+      final s = registry.profiles.firstWhere((p) => p.id == 'smartobd-classic');
+      expect(s.adapter, isA<SmartObdAdapter>());
     });
   });
 }

--- a/test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart
+++ b/test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapters/smart_obd_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_commands.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+
+class _RecordingObd2Transport implements Obd2Transport {
+  final Map<String, String> _responses;
+  final List<_RecordedCommand> commands = <_RecordedCommand>[];
+  final Stopwatch _clock = Stopwatch();
+  bool _connected = false;
+
+  _RecordingObd2Transport([Map<String, String>? responses])
+      : _responses = responses ?? const {};
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<void> connect() async {
+    _connected = true;
+    _clock.start();
+  }
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    commands.add(_RecordedCommand(command.trim(), _clock.elapsed));
+    return _responses[command.trim()] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connected = false;
+    _clock.stop();
+  }
+}
+
+class _RecordedCommand {
+  final String command;
+  final Duration at;
+  const _RecordedCommand(this.command, this.at);
+}
+
+void main() {
+  group('SmartObdAdapter (#1330 phase 2)', () {
+    test('id is "smart-obd"', () {
+      const adapter = SmartObdAdapter();
+      expect(adapter.id, 'smart-obd');
+    });
+
+    test('initSequence equals Elm327Commands.initCommands byte-for-byte', () {
+      const adapter = SmartObdAdapter();
+      expect(adapter.initSequence, Elm327Commands.initCommands);
+      expect(adapter.initSequence, [
+        'ATZ\r',
+        'ATE0\r',
+        'ATL0\r',
+        'ATH0\r',
+        'ATSP0\r',
+      ]);
+    });
+
+    test('postResetDelay is 400 ms', () {
+      const adapter = SmartObdAdapter();
+      expect(adapter.postResetDelay, const Duration(milliseconds: 400));
+    });
+
+    test('interCommandDelay is 200 ms', () {
+      const adapter = SmartObdAdapter();
+      expect(adapter.interCommandDelay, const Duration(milliseconds: 200));
+    });
+
+    test('extraInitCommands is empty', () {
+      const adapter = SmartObdAdapter();
+      expect(adapter.extraInitCommands, isEmpty);
+    });
+
+    group('preParse', () {
+      test('returns identity for the empty string', () {
+        const adapter = SmartObdAdapter();
+        expect(adapter.preParse(''), '');
+      });
+
+      test('preserves a clean response with only the terminating prompt', () {
+        const adapter = SmartObdAdapter();
+        // No stray `>` characters in the body — output must equal input.
+        expect(adapter.preParse('41 0D 32\r\r>'), '41 0D 32\r\r>');
+        expect(adapter.preParse('OK>'), 'OK>');
+      });
+
+      test('strips stray mid-frame `>` but preserves the final terminator',
+          () {
+        const adapter = SmartObdAdapter();
+        // Documented quirk: SmartOBD firmware sometimes emits stray
+        // `>` prompts mid-frame. preParse strips them everywhere
+        // except the final terminator (which downstream
+        // Elm327Parsers.cleanResponse expects to remove itself).
+        expect(
+          adapter.preParse('OK>extra>41 0D 32>'),
+          'OKextra41 0D 32>',
+        );
+      });
+
+      test('handles a single trailing `>` with no stray prompts', () {
+        const adapter = SmartObdAdapter();
+        expect(
+          adapter.preParse('41 0C 0F A0>'),
+          '41 0C 0F A0>',
+        );
+      });
+
+      test('strips multiple stray `>` characters before the terminator', () {
+        const adapter = SmartObdAdapter();
+        expect(
+          adapter.preParse('>>>OK>'),
+          'OK>',
+        );
+      });
+
+      test('does not corrupt valid PID payloads with embedded carriage returns',
+          () {
+        const adapter = SmartObdAdapter();
+        // The CR/LF separators that ELM327 emits between frames must
+        // pass through untouched — only `>` is the target.
+        const raw = '41 0D 32\r\r41 0C 0F A0\r\r>';
+        expect(adapter.preParse(raw), raw);
+      });
+
+      test('returns input unchanged when there is no `>` at all', () {
+        const adapter = SmartObdAdapter();
+        expect(adapter.preParse('41 0D 32'), '41 0D 32');
+      });
+    });
+  });
+
+  group('Obd2Service.connect with SmartObdAdapter (#1330 phase 2)', () {
+    test(
+      'waits 400 ms after ATZ and 200 ms between subsequent init commands',
+      () async {
+        final transport = _RecordingObd2Transport({
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+        });
+        final service = Obd2Service(transport);
+
+        final connected =
+            await service.connect(adapter: const SmartObdAdapter());
+
+        expect(connected, isTrue);
+        expect(service.adapter, isA<SmartObdAdapter>());
+
+        final sent = transport.commands.map((c) => c.command).toList();
+        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0']);
+
+        // Gap before ATE0 reflects the 400 ms postResetDelay.
+        final firstGap = transport.commands[1].at - transport.commands[0].at;
+        expect(
+          firstGap,
+          greaterThanOrEqualTo(const Duration(milliseconds: 380)),
+          reason: 'postResetDelay (gap before ATE0)',
+        );
+
+        // Subsequent gaps reflect the 200 ms interCommandDelay.
+        for (var i = 2; i < transport.commands.length; i++) {
+          final gap = transport.commands[i].at - transport.commands[i - 1].at;
+          expect(
+            gap,
+            greaterThanOrEqualTo(const Duration(milliseconds: 180)),
+            reason:
+                'interCommandDelay (gap before command $i = ${transport.commands[i].command})',
+          );
+          expect(
+            gap,
+            lessThan(const Duration(milliseconds: 380)),
+            reason:
+                'gap before command $i should reflect 200 ms interCommandDelay, '
+                'not the 400 ms postResetDelay',
+          );
+        }
+      },
+    );
+  });
+}

--- a/test/features/consumption/data/obd2/adapters/v_linker_fs_adapter_test.dart
+++ b/test/features/consumption/data/obd2/adapters/v_linker_fs_adapter_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapters/v_linker_fs_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_commands.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+
+/// Same Stopwatch-based recording transport pattern Phase 1's
+/// regression test uses (`elm327_adapter_test.dart`). Records every
+/// [sendCommand] call along with the elapsed wall-clock time so we can
+/// assert the adapter's per-command delays are honoured.
+class _RecordingObd2Transport implements Obd2Transport {
+  final Map<String, String> _responses;
+  final List<_RecordedCommand> commands = <_RecordedCommand>[];
+  final Stopwatch _clock = Stopwatch();
+  bool _connected = false;
+
+  _RecordingObd2Transport([Map<String, String>? responses])
+      : _responses = responses ?? const {};
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<void> connect() async {
+    _connected = true;
+    _clock.start();
+  }
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    commands.add(_RecordedCommand(command.trim(), _clock.elapsed));
+    return _responses[command.trim()] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connected = false;
+    _clock.stop();
+  }
+}
+
+class _RecordedCommand {
+  final String command;
+  final Duration at;
+  const _RecordedCommand(this.command, this.at);
+}
+
+void main() {
+  group('VLinkerFsAdapter (#1330 phase 2)', () {
+    test('id is "vlinker-fs"', () {
+      const adapter = VLinkerFsAdapter();
+      expect(adapter.id, 'vlinker-fs');
+    });
+
+    test('initSequence equals Elm327Commands.initCommands byte-for-byte', () {
+      const adapter = VLinkerFsAdapter();
+      // vLinker FS uses the standard ELM327 init list — only the
+      // delays differ from the generic profile.
+      expect(adapter.initSequence, Elm327Commands.initCommands);
+      expect(adapter.initSequence, [
+        'ATZ\r',
+        'ATE0\r',
+        'ATL0\r',
+        'ATH0\r',
+        'ATSP0\r',
+      ]);
+    });
+
+    test('postResetDelay is 200 ms', () {
+      const adapter = VLinkerFsAdapter();
+      expect(adapter.postResetDelay, const Duration(milliseconds: 200));
+    });
+
+    test('interCommandDelay is 50 ms', () {
+      const adapter = VLinkerFsAdapter();
+      expect(adapter.interCommandDelay, const Duration(milliseconds: 50));
+    });
+
+    test('extraInitCommands is empty', () {
+      const adapter = VLinkerFsAdapter();
+      expect(adapter.extraInitCommands, isEmpty);
+    });
+
+    test('preParse is the identity function', () {
+      const adapter = VLinkerFsAdapter();
+      expect(adapter.preParse(''), '');
+      expect(adapter.preParse('foo'), 'foo');
+      expect(adapter.preParse('41 0C 0F A0>'), '41 0C 0F A0>');
+    });
+  });
+
+  group('Obd2Service.connect with VLinkerFsAdapter (#1330 phase 2)', () {
+    test(
+      'waits 200 ms after the first command and 50 ms between subsequent ones',
+      () async {
+        final transport = _RecordingObd2Transport({
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+        });
+        final service = Obd2Service(transport);
+
+        final connected =
+            await service.connect(adapter: const VLinkerFsAdapter());
+
+        expect(connected, isTrue);
+        expect(service.adapter, isA<VLinkerFsAdapter>());
+
+        final sent = transport.commands.map((c) => c.command).toList();
+        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0']);
+
+        // Gap between cmd[0] (ATZ) and cmd[1] (ATE0) reflects the
+        // 200 ms postResetDelay. Generous lower bound (180 ms) avoids
+        // flakiness on slow CI; the assertion that matters is "we DID
+        // wait at least the configured 200 ms".
+        final firstGap = transport.commands[1].at - transport.commands[0].at;
+        expect(
+          firstGap,
+          greaterThanOrEqualTo(const Duration(milliseconds: 180)),
+          reason: 'postResetDelay (gap before ATE0)',
+        );
+
+        // Subsequent gaps reflect the 50 ms interCommandDelay.
+        for (var i = 2; i < transport.commands.length; i++) {
+          final gap = transport.commands[i].at - transport.commands[i - 1].at;
+          expect(
+            gap,
+            greaterThanOrEqualTo(const Duration(milliseconds: 40)),
+            reason:
+                'interCommandDelay (gap before command $i = ${transport.commands[i].command})',
+          );
+          // Generous upper bound: real interCommandDelay should be
+          // ~50ms, well below the 200ms postReset value. This guards
+          // against accidentally swapping the two in the connect loop.
+          expect(
+            gap,
+            lessThan(const Duration(milliseconds: 180)),
+            reason:
+                'gap before command $i should reflect 50 ms interCommandDelay, '
+                'not the 200 ms postResetDelay',
+          );
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
Refs #1330 phase 2.

Ships per-adapter timing and parser-quirks profiles. **This is the user-value phase** — when merged, SmartOBD users will get the same trip-recording quality as vLinker users.

- **VLinkerFsAdapter** (id `vlinker-fs`): 200 ms post-reset, 50 ms inter-command. Empirically reliable on the FS-14884 the user has been driving with.
- **SmartObdAdapter** (id `smart-obd`): 400 ms post-reset, 200 ms inter-command. `preParse` strips stray `>` prompt characters that some firmware revisions emit mid-frame, before the global response parser sees the buffer.
- `adapter_registry.dart` wires SmartOBD profiles to `SmartObdAdapter` and vLinker to `VLinkerFsAdapter`. Other adapters keep `GenericElm327Adapter` (Phase 1 default).
- Removed the `@Deprecated` `initDelay` / `extraInitCommands` fields from `Obd2AdapterProfile` — all init now goes through the adapter.

Phase 3 (silent-failure detection in `trip_recording_controller`: N consecutive null PIDs → user-facing snackbar instead of silently empty trip charts) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)