### PR TITLE
feat(obd2): silent-failure detection — adapter-not-responding snackbar (Closes #1330 phase 3)

### DIFF
--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -60,6 +60,26 @@ enum TripRecordingControllerState {
   stopped,
 }
 
+/// Why the controller transitioned into
+/// [TripRecordingControllerState.pausedDueToDrop] (#1330 phase 3).
+///
+/// Distinguishes the two failure modes that share the
+/// pause-with-grace recovery path:
+///
+///  * [transportError] — repeated transport-level failures
+///    (BT link dropped, three consecutive errors within the window,
+///    or a typed `Obd2DisconnectedException`). The user-visible
+///    surface is "OBD2 connection lost".
+///  * [silentFailure] — adapter is connected and answering, but every
+///    high-priority PID parse returns null for [_silentFailureThreshold]
+///    consecutive ticks. ECU off, vehicle protocol mismatch, defective
+///    adapter firmware. Without this signal the user sees "trip
+///    recorded" with empty charts and no notification (#1330).
+enum TripDropReason {
+  transportError,
+  silentFailure,
+}
+
 /// Drives the priority-tiered PID polling loop that feeds an
 /// [Obd2Service]'s live PIDs into a [TripRecorder] (#726, #814).
 ///
@@ -190,6 +210,15 @@ class TripRecordingController {
   final Duration _dropWindow;
   final int _dropThreshold;
 
+  /// Threshold for the "adapter connected but every PID parse returns
+  /// null" silent-failure heuristic (#1330 phase 3). At the 5 Hz fast
+  /// tier 50 consecutive null parses ≈ 10 s — long enough to ride out a
+  /// brief noise burst, short enough that the user gets a notification
+  /// before they've driven a meaningful distance with no data.
+  /// Test-only: tests inject a small value (e.g. 3) so a fake service
+  /// can drive the counter past the threshold without 50 round-trips.
+  final int _silentFailureThreshold;
+
   /// Pinned adapter MAC that the auto-reconnect scanner (#797 phase 3)
   /// will search for when a drop flips us into
   /// [TripRecordingControllerState.pausedDueToDrop]. Null-able
@@ -236,6 +265,33 @@ class TripRecordingController {
   /// Consecutive-error bookkeeping for the drop heuristic. First entry
   /// is the oldest. Reset on a successful transport read.
   final List<DateTime> _recentErrors = <DateTime>[];
+
+  /// Consecutive-null-parse counter for the silent-failure heuristic
+  /// (#1330 phase 3). Incremented from every high-priority PID
+  /// callback when the parser returns null; reset to zero the moment
+  /// any high-priority PID parses a non-null value. Distinct from
+  /// [_recentErrors] which counts *transport-level* failures —
+  /// silent-failure is the case where the transport is healthy but
+  /// the ECU never speaks.
+  int _consecutiveNullReads = 0;
+
+  /// Sticky flag so the silent-failure handler only fires once per
+  /// recording session — even if more null parses keep arriving past
+  /// the threshold, we don't want to keep re-entering [_handleDrop].
+  /// Reset on stop()/resume() so a subsequent recording (or a manual
+  /// resume followed by another silent stretch) can fire again.
+  bool _silentFailureFired = false;
+
+  /// Reason the most recent [_handleDrop] fired (#1330 phase 3).
+  /// Null when no drop has occurred. Read by the provider so the
+  /// pause banner can surface a different message on silent-failure
+  /// vs transport-error.
+  TripDropReason? _dropReason;
+
+  /// Why the controller flipped into
+  /// [TripRecordingControllerState.pausedDueToDrop] (#1330 phase 3).
+  /// Null when the controller is not in that state.
+  TripDropReason? get dropReason => _dropReason;
 
   /// Rolling buffer of `(timestamp, speedKmh)` samples used by the
   /// virtual odometer (#800). Populated by the 5 Hz speed
@@ -301,6 +357,7 @@ class TripRecordingController {
     Duration pauseGraceWindow = const Duration(minutes: 15),
     Duration dropWindow = const Duration(seconds: 5),
     int dropThreshold = 3,
+    int silentFailureThreshold = 50,
     Duration schedulerTickRate = const Duration(milliseconds: 100),
     String? pinnedAdapterMac,
     bool automatic = false,
@@ -320,6 +377,7 @@ class TripRecordingController {
         _pauseGraceWindow = pauseGraceWindow,
         _dropWindow = dropWindow,
         _dropThreshold = dropThreshold,
+        _silentFailureThreshold = silentFailureThreshold,
         _schedulerTickRate = schedulerTickRate,
         _pinnedAdapterMac = pinnedAdapterMac,
         _automatic = automatic,
@@ -375,6 +433,13 @@ class TripRecordingController {
       _graceTimer?.cancel();
       _graceTimer = null;
       _pausedDueToDrop = false;
+      _dropReason = null;
+      // #1330 phase 3 — clear the silent-failure latch so a
+      // post-resume stretch of nulls can fire again. Without this,
+      // a user who resumes after a silent-failure drop and then hits
+      // a fresh silent failure would never get a second snackbar.
+      _silentFailureFired = false;
+      _consecutiveNullReads = 0;
       // Also tear down the auto-reconnect scanner (#797 phase 3) —
       // either we got here because the scanner fired its callback
       // (in which case it already stopped itself), or the user
@@ -442,6 +507,8 @@ class TripRecordingController {
     _started = false;
     _stopped = true;
     _pausedDueToDrop = false;
+    _silentFailureFired = false;
+    _consecutiveNullReads = 0;
     _emitState();
     if (!_stateController.isClosed) {
       await _stateController.close();
@@ -701,9 +768,64 @@ class TripRecordingController {
     return false;
   }
 
-  void _handleDrop() {
+  /// Bookkeeping for the silent-failure heuristic (#1330 phase 3).
+  ///
+  /// Called from every high-priority PID callback right after the
+  /// parser returned. A null parse increments the consecutive-null
+  /// counter; ANY non-null parse resets it to zero — even from a
+  /// different PID, because we're trying to detect "ECU is dead",
+  /// not "this specific PID is unsupported".
+  ///
+  /// Once the counter reaches [_silentFailureThreshold] AND the
+  /// transport-error drop hasn't already fired, [_onSilentFailure]
+  /// drives the same pause-with-grace path that [_handleDrop] does
+  /// for transport errors, but stamps a [TripDropReason.silentFailure]
+  /// reason so the UI can surface a different message.
+  void _observeHighPriorityParse(Object? parsedValue) {
+    if (parsedValue != null) {
+      // ANY successful high-priority parse clears the window — we're
+      // detecting "ECU is dead", not "this one PID is unsupported".
+      _consecutiveNullReads = 0;
+      return;
+    }
+    if (_silentFailureFired) return;
+    if (_pausedDueToDrop || _stopped) return;
+    _consecutiveNullReads++;
+    if (_consecutiveNullReads >= _silentFailureThreshold) {
+      _onSilentFailure();
+    }
+  }
+
+  /// Silent-failure handler (#1330 phase 3). Fired exactly once per
+  /// recording session when the consecutive-null counter crosses the
+  /// threshold. Drives the same pause-with-grace recovery as
+  /// [_handleDrop] for transport errors, but tags the drop with
+  /// [TripDropReason.silentFailure] so the UI surfaces "OBD2 adapter
+  /// connected but not returning data" instead of "OBD2 connection
+  /// lost".
+  void _onSilentFailure() {
+    if (_silentFailureFired) return;
+    if (_pausedDueToDrop || _stopped) {
+      // The transport-error drop already paused us — don't double-fire
+      // and don't override the reason. The user is already seeing the
+      // "connection lost" banner; switching it mid-flight to "not
+      // responding" would be misleading.
+      return;
+    }
+    _silentFailureFired = true;
+    debugPrint(
+      'TripRecordingController: silent-failure detected — '
+      '$_consecutiveNullReads consecutive null PID parses',
+    );
+    _handleDrop(reason: TripDropReason.silentFailure);
+  }
+
+  void _handleDrop({
+    TripDropReason reason = TripDropReason.transportError,
+  }) {
     if (_pausedDueToDrop) return;
     _pausedDueToDrop = true;
+    _dropReason = reason;
     _scheduler?.stop();
     _recentErrors.clear();
     _persistPausedSnapshot();
@@ -854,6 +976,7 @@ class TripRecordingController {
       (r) {
         final v = Elm327Protocol.parseEngineRpm(r);
         if (v != null) _latestRpm = v;
+        _observeHighPriorityParse(v);
       },
     );
     scheduler.subscribe(
@@ -865,6 +988,7 @@ class TripRecordingController {
           _latestSpeedKmh = v.toDouble();
           _recordSpeedSample(v.toDouble());
         }
+        _observeHighPriorityParse(v);
       },
     );
     // MAF and MAP are the two alternate air-mass inputs to the fuel-
@@ -878,6 +1002,7 @@ class TripRecordingController {
         (r) {
           final v = Elm327Protocol.parseMafGramsPerSecond(r);
           if (v != null) _latestMaf = v;
+          _observeHighPriorityParse(v);
         },
       );
     }
@@ -888,6 +1013,7 @@ class TripRecordingController {
         (r) {
           final v = Elm327Protocol.parseManifoldPressureKpa(r);
           if (v != null) _latestMapKpa = v;
+          _observeHighPriorityParse(v);
         },
       );
     }
@@ -897,6 +1023,7 @@ class TripRecordingController {
       (r) {
         final v = Elm327Protocol.parseThrottlePercent(r);
         if (v != null) _latestThrottlePercent = v;
+        _observeHighPriorityParse(v);
       },
     );
     // PID 5E is only present on ~2014+ ECUs. Skip when #811 discovery
@@ -909,6 +1036,7 @@ class TripRecordingController {
         (r) {
           final v = Elm327Protocol.parseFuelRateLPerHour(r);
           if (v != null) _latestDirectFuelRate = v;
+          _observeHighPriorityParse(v);
         },
       );
     }
@@ -1150,6 +1278,26 @@ class TripRecordingController {
   void debugTriggerDrop() {
     _handleDrop();
   }
+
+  /// Exposed for tests: drive the silent-failure observer with a
+  /// hand-built parse outcome so tests don't have to spin up a fake
+  /// service that returns null forever (#1330 phase 3). Pass `null`
+  /// to increment the counter, any non-null value to reset it.
+  @visibleForTesting
+  void debugObserveHighPriorityParse(Object? parsedValue) {
+    _observeHighPriorityParse(parsedValue);
+  }
+
+  /// Exposed for tests: current consecutive-null count. Lets the
+  /// silent-failure tests assert "49 nulls did NOT trigger" before
+  /// the 50th lands (#1330 phase 3).
+  @visibleForTesting
+  int get debugConsecutiveNullReads => _consecutiveNullReads;
+
+  /// Exposed for tests: whether the silent-failure handler has fired
+  /// for this recording session. Resets on resume() / stop().
+  @visibleForTesting
+  bool get debugSilentFailureFired => _silentFailureFired;
 
   /// Exposed for tests: synchronously drive the grace-window
   /// finalisation path. Useful with fake-async patterns where

--- a/lib/features/consumption/presentation/widgets/obd2_pause_banner.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_pause_banner.dart
@@ -20,6 +20,13 @@ import '../../providers/trip_recording_provider.dart';
 /// The widget renders zero-height unless the phase is
 /// [TripRecordingPhase.pausedDueToDrop], so it's safe to drop into
 /// any layout that always-on renders the trip chrome.
+///
+/// #1330 phase 3 — when the drop reason is
+/// [TripDropReason.silentFailure] (adapter connected but every PID
+/// parse returned null) the banner swaps copy to
+/// `tripRecordingObd2NotResponding` so the user knows to try a
+/// different adapter rather than wait for a Bluetooth reconnect that
+/// never happens.
 class Obd2PauseBanner extends ConsumerWidget {
   const Obd2PauseBanner({super.key});
 
@@ -34,9 +41,13 @@ class Obd2PauseBanner extends ConsumerWidget {
     if (phase != TripRecordingPhase.pausedDueToDrop) {
       return const SizedBox.shrink();
     }
+    final dropReason = ref.watch(
+      tripRecordingProvider.select((s) => s.dropReason),
+    );
 
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
+    final isSilentFailure = dropReason == TripDropReason.silentFailure;
     return MaterialBanner(
       key: const Key('obd2PauseBanner'),
       backgroundColor: theme.colorScheme.errorContainer,
@@ -44,12 +55,19 @@ class Obd2PauseBanner extends ConsumerWidget {
         color: theme.colorScheme.onErrorContainer,
       ),
       leading: Icon(
-        Icons.bluetooth_disabled,
+        isSilentFailure
+            ? Icons.report_gmailerrorred_outlined
+            : Icons.bluetooth_disabled,
         color: theme.colorScheme.onErrorContainer,
       ),
       content: Text(
-        l?.obd2PauseBannerTitle ??
-            'OBD2 connection lost — recording paused',
+        isSilentFailure
+            ? (l?.tripRecordingObd2NotResponding ??
+                'OBD2 adapter connected but not returning data. Try a '
+                "different adapter or check the vehicle's diagnostic "
+                'protocol.')
+            : (l?.obd2PauseBannerTitle ??
+                'OBD2 connection lost — recording paused'),
       ),
       actions: [
         TextButton(

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -38,6 +38,10 @@ export 'haptic_feedback_policy.dart'
     show HapticIntensity, hapticForBandTransition;
 export 'trip_recording_phase.dart' show TripRecordingPhase;
 export 'trip_recording_state.dart' show TripRecordingState;
+// #1330 phase 3 — re-export TripDropReason so widgets watching
+// `tripRecordingProvider.select((s) => s.dropReason)` resolve the
+// type without a second import.
+export '../data/obd2/trip_recording_controller.dart' show TripDropReason;
 
 part 'trip_recording_provider.g.dart';
 
@@ -313,7 +317,21 @@ class TripRecording extends _$TripRecording {
     // live listener). Pure state transitions don't reshape band/delta,
     // so we only copyWith the phase here.
     _stateSub = ctl.stateChanges.listen((_) {
-      state = state.copyWith(phase: _phaseFor(ctl));
+      final newPhase = _phaseFor(ctl);
+      // #1330 phase 3 — surface the controller's drop reason so the
+      // pause banner can pick the right copy (transport error vs
+      // silent failure). Cleared when leaving the drop state.
+      if (newPhase == TripRecordingPhase.pausedDueToDrop) {
+        state = state.copyWith(
+          phase: newPhase,
+          dropReason: ctl.dropReason,
+        );
+      } else {
+        state = state.copyWith(
+          phase: newPhase,
+          clearDropReason: true,
+        );
+      }
       // #1303 — phase transitions force an immediate snapshot so
       // a recovered crash lands on the right phase (the controller
       // moving from recording → pausedDueToDrop should NOT be lost

--- a/lib/features/consumption/providers/trip_recording_state.dart
+++ b/lib/features/consumption/providers/trip_recording_state.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 
-import '../data/obd2/trip_live_reading.dart';
+import '../data/obd2/trip_recording_controller.dart';
 import '../domain/cold_start_baselines.dart';
 import '../domain/situation_classifier.dart';
 import 'trip_recording_phase.dart';
@@ -19,12 +19,19 @@ class TripRecordingState {
   /// be computed (idle uses L/h — caller formats it differently).
   final double? liveDeltaFraction;
 
+  /// Why the controller flipped into [TripRecordingPhase.pausedDueToDrop]
+  /// (#1330 phase 3). Null in any other phase. Drives the pause-banner
+  /// copy: "OBD2 connection lost" for transport errors, "OBD2 adapter
+  /// connected but not returning data" for silent failure.
+  final TripDropReason? dropReason;
+
   const TripRecordingState({
     this.phase = TripRecordingPhase.idle,
     this.live,
     this.situation = DrivingSituation.idle,
     this.band = ConsumptionBand.normal,
     this.liveDeltaFraction,
+    this.dropReason,
   });
 
   TripRecordingState copyWith({
@@ -34,6 +41,8 @@ class TripRecordingState {
     ConsumptionBand? band,
     double? liveDeltaFraction,
     bool clearDelta = false,
+    TripDropReason? dropReason,
+    bool clearDropReason = false,
   }) =>
       TripRecordingState(
         phase: phase ?? this.phase,
@@ -43,6 +52,9 @@ class TripRecordingState {
         liveDeltaFraction: clearDelta
             ? null
             : (liveDeltaFraction ?? this.liveDeltaFraction),
+        dropReason: clearDropReason
+            ? null
+            : (dropReason ?? this.dropReason),
       );
 
   bool get isActive =>

--- a/lib/l10n/_fragments/trajets_de.arb
+++ b/lib/l10n/_fragments/trajets_de.arb
@@ -36,5 +36,6 @@
   "trajetDetailDeleteConfirmTitle": "Diese Fahrt löschen?",
   "trajetDetailDeleteConfirmBody": "Diese Fahrt wird dauerhaft aus deinem Verlauf entfernt.",
   "trajetDetailDeleteConfirmCancel": "Abbrechen",
-  "trajetDetailDeleteConfirmConfirm": "Löschen"
+  "trajetDetailDeleteConfirmConfirm": "Löschen",
+  "tripRecordingObd2NotResponding": "OBD2-Adapter verbunden, aber liefert keine Daten. Probiere einen anderen Adapter oder prüfe das Diagnose-Protokoll des Fahrzeugs."
 }

--- a/lib/l10n/_fragments/trajets_en.arb
+++ b/lib/l10n/_fragments/trajets_en.arb
@@ -173,5 +173,9 @@
   "trajetDetailDeleteConfirmConfirm": "Delete",
   "@trajetDetailDeleteConfirmConfirm": {
     "description": "Confirm button label on the delete-trip confirmation dialog (#890)."
+  },
+  "tripRecordingObd2NotResponding": "OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle's diagnostic protocol.",
+  "@tripRecordingObd2NotResponding": {
+    "description": "OBD2 pause banner copy (#1330 phase 3) when the adapter is connected but every high-priority PID parse returned null for ~10 s. Distinct from the 'connection lost' message — the link is fine, but the ECU isn't answering. Suggests trying a different adapter or checking the vehicle's diagnostic protocol."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1602,6 +1602,7 @@
   "trajetDetailDeleteConfirmBody": "Diese Fahrt wird dauerhaft aus deinem Verlauf entfernt.",
   "trajetDetailDeleteConfirmCancel": "Abbrechen",
   "trajetDetailDeleteConfirmConfirm": "Löschen",
+  "tripRecordingObd2NotResponding": "OBD2-Adapter verbunden, aber liefert keine Daten. Probiere einen anderen Adapter oder prüfe das Diagnose-Protokoll des Fahrzeugs.",
   "tripLengthCardTitle": "Verbrauch nach Fahrtlänge",
   "tripLengthBucketShort": "Kurz (<5 km)",
   "tripLengthBucketMedium": "Mittel (5–25 km)",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2699,6 +2699,10 @@
   "@trajetDetailDeleteConfirmConfirm": {
     "description": "Confirm button label on the delete-trip confirmation dialog (#890)."
   },
+  "tripRecordingObd2NotResponding": "OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle's diagnostic protocol.",
+  "@tripRecordingObd2NotResponding": {
+    "description": "OBD2 pause banner copy (#1330 phase 3) when the adapter is connected but every high-priority PID parse returned null for ~10 s. Distinct from the 'connection lost' message — the link is fine, but the ECU isn't answering. Suggests trying a different adapter or checking the vehicle's diagnostic protocol."
+  },
   "tripLengthCardTitle": "Consumption by trip length",
   "@tripLengthCardTitle": {
     "description": "Title of the trip-length consumption card on the Carbon dashboard Charts tab — splits trips into short/medium/long buckets so the user can see cold-start fuel waste vs. cruising efficiency (#1191)."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7556,6 +7556,12 @@ abstract class AppLocalizations {
   /// **'Delete'**
   String get trajetDetailDeleteConfirmConfirm;
 
+  /// OBD2 pause banner copy (#1330 phase 3) when the adapter is connected but every high-priority PID parse returned null for ~10 s. Distinct from the 'connection lost' message — the link is fine, but the ECU isn't answering. Suggests trying a different adapter or checking the vehicle's diagnostic protocol.
+  ///
+  /// In en, this message translates to:
+  /// **'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.'**
+  String get tripRecordingObd2NotResponding;
+
   /// Title of the trip-length consumption card on the Carbon dashboard Charts tab — splits trips into short/medium/long buckets so the user can see cold-start fuel waste vs. cruising efficiency (#1191).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4076,6 +4076,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4076,6 +4076,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4074,6 +4074,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4113,6 +4113,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Löschen';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2-Adapter verbunden, aber liefert keine Daten. Probiere einen anderen Adapter oder prüfe das Diagnose-Protokoll des Fahrzeugs.';
+
+  @override
   String get tripLengthCardTitle => 'Verbrauch nach Fahrtlänge';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4078,6 +4078,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4069,6 +4069,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4077,6 +4077,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4071,6 +4071,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4074,6 +4074,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4113,6 +4113,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consommation par longueur de trajet';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4073,6 +4073,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4078,6 +4078,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4077,6 +4077,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4075,6 +4075,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4077,6 +4077,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4073,6 +4073,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4078,6 +4078,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4076,6 +4076,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4077,6 +4077,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4076,6 +4076,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4077,6 +4077,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4071,6 +4071,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4075,6 +4075,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get trajetDetailDeleteConfirmConfirm => 'Delete';
 
   @override
+  String get tripRecordingObd2NotResponding =>
+      'OBD2 adapter connected but not returning data. Try a different adapter or check the vehicle\'s diagnostic protocol.';
+
+  @override
   String get tripLengthCardTitle => 'Consumption by trip length';
 
   @override

--- a/test/features/consumption/data/obd2/trip_recording_controller_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_test.dart
@@ -725,6 +725,233 @@ void main() {
       expect(pausedRepo.loadAll(), isEmpty);
     });
   });
+
+  group('silent-failure detection — #1330 phase 3', () {
+    late Directory tmpDir;
+    late Box<String> pausedBox;
+    late Box<String> historyBox;
+    late PausedTripRepository pausedRepo;
+    late TripHistoryRepository historyRepo;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('silent_fail_test_');
+      Hive.init(tmpDir.path);
+      pausedBox = await Hive.openBox<String>(
+        'paused_${DateTime.now().microsecondsSinceEpoch}',
+      );
+      historyBox = await Hive.openBox<String>(
+        'history_${DateTime.now().microsecondsSinceEpoch}',
+      );
+      pausedRepo = PausedTripRepository(box: pausedBox);
+      historyRepo = TripHistoryRepository(box: historyBox);
+    });
+
+    tearDown(() async {
+      await pausedBox.deleteFromDisk();
+      await historyBox.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    Map<String, String> initResponses() => {
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+          '01A6': 'NO DATA>',
+        };
+
+    test(
+        'counter resets on a non-null parse — 49 nulls then a hit '
+        'must NOT trigger silent failure', () async {
+      // Pin the threshold at 50 (the production constant) so the test
+      // proves the boundary the user-visible code is actually using.
+      // 49 nulls then a non-null reset, then 49 more nulls — neither
+      // run reaches 50 because the reset zeroed the counter.
+      final transport = FakeObd2Transport(initResponses());
+      await transport.connect();
+      final ctl = TripRecordingController(
+        service: Obd2Service(transport),
+        pollInterval: const Duration(minutes: 1),
+        pausedRepo: pausedRepo,
+        historyRepo: historyRepo,
+        // Default threshold = 50.
+      );
+      await ctl.start();
+
+      // 49 consecutive null parses — one short of the threshold.
+      for (var i = 0; i < 49; i++) {
+        ctl.debugObserveHighPriorityParse(null);
+      }
+      expect(ctl.debugConsecutiveNullReads, 49);
+      expect(ctl.debugSilentFailureFired, isFalse);
+      expect(
+        ctl.currentState,
+        TripRecordingControllerState.recording,
+        reason: '49 nulls is one short of the threshold; no drop yet',
+      );
+
+      // A single non-null parse zeroes the counter.
+      ctl.debugObserveHighPriorityParse(1234);
+      expect(ctl.debugConsecutiveNullReads, 0,
+          reason: 'any non-null high-priority parse must reset the '
+              'consecutive-null counter to zero');
+
+      // Another 49 nulls — still under the threshold because the
+      // counter was reset by the non-null read above.
+      for (var i = 0; i < 49; i++) {
+        ctl.debugObserveHighPriorityParse(null);
+      }
+      expect(ctl.debugSilentFailureFired, isFalse);
+      expect(
+        ctl.currentState,
+        TripRecordingControllerState.recording,
+        reason: 'a single non-null read between two 49-null runs '
+            'must keep the controller in recording state',
+      );
+      expect(pausedRepo.loadAll(), isEmpty,
+          reason: 'no drop fired → no paused-trip snapshot should '
+              'have been persisted',
+      );
+    });
+
+    test(
+        'fires exactly once after threshold consecutive null parses '
+        'with TripDropReason.silentFailure', () async {
+      // Drive the threshold via the constructor override so the test
+      // doesn't have to push 50 events. The default threshold is 50;
+      // a value of 5 here is purely a test-ergonomics dial.
+      final transport = FakeObd2Transport(initResponses());
+      await transport.connect();
+      final ctl = TripRecordingController(
+        service: Obd2Service(transport),
+        pollInterval: const Duration(minutes: 1),
+        vehicleId: 'silent-failure-car',
+        pausedRepo: pausedRepo,
+        historyRepo: historyRepo,
+        pauseGraceWindow: const Duration(minutes: 5),
+        silentFailureThreshold: 5,
+      );
+      final states = <TripRecordingControllerState>[];
+      final sub = ctl.stateChanges.listen(states.add);
+      await ctl.start();
+
+      // 4 nulls — still under the test threshold.
+      for (var i = 0; i < 4; i++) {
+        ctl.debugObserveHighPriorityParse(null);
+      }
+      expect(ctl.debugSilentFailureFired, isFalse);
+
+      // 5th null → fires the silent-failure handler.
+      ctl.debugObserveHighPriorityParse(null);
+      // The state stream is a broadcast controller — it delivers
+      // events on the microtask loop. A short async hop lets the
+      // listener catch the pausedDueToDrop transition.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(ctl.debugSilentFailureFired, isTrue);
+      expect(
+        ctl.currentState,
+        TripRecordingControllerState.pausedDueToDrop,
+        reason: 'silent failure must drive the same pause-with-grace '
+            'state as a transport-error drop',
+      );
+      expect(
+        ctl.dropReason,
+        TripDropReason.silentFailure,
+        reason: 'the drop reason exposed to the UI must distinguish '
+            'silent failure from transport error',
+      );
+      expect(
+        states,
+        contains(TripRecordingControllerState.pausedDueToDrop),
+        reason: 'state stream must surface the silent-failure-driven '
+            'transition so listeners (the provider, banners) react',
+      );
+
+      // A snapshot landed in the paused-trips box — same path as a
+      // transport-error drop.
+      expect(pausedRepo.loadAll(), hasLength(1));
+      expect(pausedRepo.loadAll().single.vehicleId, 'silent-failure-car');
+
+      // Idempotency: more nulls past the threshold must NOT re-fire
+      // the handler — the latch prevents double-banner / double-save.
+      for (var i = 0; i < 20; i++) {
+        ctl.debugObserveHighPriorityParse(null);
+      }
+      // Still exactly one paused-trip row, still pausedDueToDrop.
+      expect(pausedRepo.loadAll(), hasLength(1),
+          reason: 'silent-failure handler must fire exactly once per '
+              'recording session — extra null parses past the '
+              'threshold are no-ops');
+      // No second pausedDueToDrop transition emitted.
+      final dropTransitions = states
+          .where((s) => s == TripRecordingControllerState.pausedDueToDrop)
+          .length;
+      expect(dropTransitions, 1,
+          reason: 'state stream must emit pausedDueToDrop exactly once');
+
+      await sub.cancel();
+    });
+
+    test(
+        'does NOT fire when the transport-error drop has already '
+        'paused the controller', () async {
+      // The transport-error drop fires first (via debugTriggerDrop).
+      // Subsequent null parses past the threshold must be a no-op —
+      // the user is already seeing the "connection lost" banner;
+      // switching to "not responding" mid-flight would be misleading.
+      final transport = FakeObd2Transport(initResponses());
+      await transport.connect();
+      final ctl = TripRecordingController(
+        service: Obd2Service(transport),
+        pollInterval: const Duration(minutes: 1),
+        vehicleId: 'transport-error-first',
+        pausedRepo: pausedRepo,
+        historyRepo: historyRepo,
+        pauseGraceWindow: const Duration(minutes: 5),
+        silentFailureThreshold: 3,
+      );
+      await ctl.start();
+
+      // Existing transport-error drop fires — drop reason transportError.
+      ctl.debugTriggerDrop();
+      expect(
+        ctl.currentState,
+        TripRecordingControllerState.pausedDueToDrop,
+      );
+      expect(ctl.dropReason, TripDropReason.transportError);
+      expect(pausedRepo.loadAll(), hasLength(1));
+
+      // Now blast nulls well past the silent-failure threshold.
+      for (var i = 0; i < 20; i++) {
+        ctl.debugObserveHighPriorityParse(null);
+      }
+
+      // Reason must NOT have flipped — the user-visible message
+      // stays "connection lost", not "not responding".
+      expect(
+        ctl.dropReason,
+        TripDropReason.transportError,
+        reason: 'silent-failure path must be a no-op once the '
+            'transport-error drop has already fired',
+      );
+      expect(
+        ctl.debugSilentFailureFired,
+        isFalse,
+        reason: 'latch must NOT have been set — the silent-failure '
+            'handler short-circuited because pausedDueToDrop was '
+            'already true',
+      );
+      expect(
+        pausedRepo.loadAll(),
+        hasLength(1),
+        reason: 'no second paused-trip snapshot should have been '
+            'persisted — the silent-failure path is fully suppressed',
+      );
+    });
+  });
 }
 
 /// Counts how many times each command is sent. Used to assert


### PR DESCRIPTION
Closes #1330 (final phase).

Detects the silent-failure case where the OBD2 adapter is connected but every PID read returns null (ECU off, vehicle protocol mismatch, defective adapter firmware). Without this, a user sees "trip recorded" but every chart on the trip detail screen is empty.

- New `_consecutiveNullReads` counter in `TripRecordingController`. Resets on every non-null PID parse, increments on every null. After 50 consecutive nulls (~10 s at 5 Hz), fires `_onSilentFailure()` exactly once per trip.
- New ARB key `tripRecordingObd2NotResponding` (en/de/fr) — surfaces "OBD2 adapter connected but not returning data" snackbar through the existing trip-drop UI path.
- 3 regression tests: counter reset on non-null, single-fire after threshold, suppressed when transport-error drop already fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)