### PR TITLE
feat(vehicle): auto-record config fields + provider (Refs #1004 phase 1)

### DIFF
--- a/lib/features/vehicle/providers/auto_record_config_provider.dart
+++ b/lib/features/vehicle/providers/auto_record_config_provider.dart
@@ -1,0 +1,116 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../domain/entities/vehicle_profile.dart';
+import 'vehicle_providers.dart';
+
+part 'auto_record_config_provider.g.dart';
+
+/// Hands-free auto-record configuration projection for a single
+/// [VehicleProfile] (#1004 phase 1).
+///
+/// Surfaces only the five auto-record fields so phase 2+ consumers
+/// (BT auto-connect listener, movement detector, disconnect-save
+/// timer, badge counter) cannot accidentally read or hold a
+/// reference to the larger [VehicleProfile] state — keeps the
+/// background-isolate API surface minimal.
+///
+/// Defaults mirror the [VehicleProfile] field defaults so a missing
+/// or unknown profile id is indistinguishable from a freshly-saved,
+/// not-yet-opted-in profile from the consumer's perspective.
+class AutoRecordConfig {
+  /// Master toggle. When `false`, phase 2 must not register a
+  /// background BT listener for this vehicle.
+  final bool autoRecord;
+
+  /// MAC of the OBD2 adapter the user paired to this vehicle.
+  /// Null when no adapter has been paired yet — phase 2 must skip
+  /// auto-connect registration in that case.
+  final String? pairedAdapterMac;
+
+  /// Speed threshold (km/h) above which phase 3's movement detector
+  /// fires `startTrip()`.
+  final double movementStartThresholdKmh;
+
+  /// Debounce window (seconds) before a BT disconnect triggers
+  /// phase 4's `stopAndSave()`.
+  final int disconnectSaveDelaySec;
+
+  /// User's stored consent for `ACCESS_BACKGROUND_LOCATION`. Without
+  /// it, phase 3 records BT-only with no GPS metadata.
+  final bool backgroundLocationConsent;
+
+  const AutoRecordConfig({
+    this.autoRecord = false,
+    this.pairedAdapterMac,
+    this.movementStartThresholdKmh = 5.0,
+    this.disconnectSaveDelaySec = 60,
+    this.backgroundLocationConsent = false,
+  });
+
+  /// All-default fallback used when [autoRecordConfig] is queried for
+  /// a profile id that does not exist (e.g. the active profile was
+  /// deleted in another isolate). Equivalent to a freshly-created
+  /// [VehicleProfile] that has not opted in.
+  static const AutoRecordConfig defaults = AutoRecordConfig();
+
+  /// Project a [VehicleProfile] into its auto-record config slice.
+  factory AutoRecordConfig.fromProfile(VehicleProfile profile) {
+    return AutoRecordConfig(
+      autoRecord: profile.autoRecord,
+      pairedAdapterMac: profile.pairedAdapterMac,
+      movementStartThresholdKmh: profile.movementStartThresholdKmh,
+      disconnectSaveDelaySec: profile.disconnectSaveDelaySec,
+      backgroundLocationConsent: profile.backgroundLocationConsent,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AutoRecordConfig &&
+        other.autoRecord == autoRecord &&
+        other.pairedAdapterMac == pairedAdapterMac &&
+        other.movementStartThresholdKmh == movementStartThresholdKmh &&
+        other.disconnectSaveDelaySec == disconnectSaveDelaySec &&
+        other.backgroundLocationConsent == backgroundLocationConsent;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        autoRecord,
+        pairedAdapterMac,
+        movementStartThresholdKmh,
+        disconnectSaveDelaySec,
+        backgroundLocationConsent,
+      );
+
+  @override
+  String toString() =>
+      'AutoRecordConfig(autoRecord: $autoRecord, '
+      'pairedAdapterMac: $pairedAdapterMac, '
+      'movementStartThresholdKmh: $movementStartThresholdKmh, '
+      'disconnectSaveDelaySec: $disconnectSaveDelaySec, '
+      'backgroundLocationConsent: $backgroundLocationConsent)';
+}
+
+/// Per-vehicle auto-record configuration (#1004 phase 1).
+///
+/// Reads the [VehicleProfile] identified by [vehicleProfileId] from
+/// [vehicleProfileListProvider] and projects it into a small
+/// immutable [AutoRecordConfig] value. Returning a narrow projection
+/// (instead of the whole profile) keeps the phase 2+ background-
+/// isolate API minimal and prevents accidental coupling to unrelated
+/// fields like baselines or aggregates.
+///
+/// When the profile id is not found in the list, the provider
+/// returns [AutoRecordConfig.defaults] — that way callers do not
+/// need a separate "is this vehicle known yet?" branch.
+@riverpod
+AutoRecordConfig autoRecordConfig(Ref ref, String vehicleProfileId) {
+  final profile = ref
+      .watch(vehicleProfileListProvider)
+      .where((v) => v.id == vehicleProfileId)
+      .firstOrNull;
+  if (profile == null) return AutoRecordConfig.defaults;
+  return AutoRecordConfig.fromProfile(profile);
+}

--- a/lib/features/vehicle/providers/auto_record_config_provider.g.dart
+++ b/lib/features/vehicle/providers/auto_record_config_provider.g.dart
@@ -1,0 +1,155 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auto_record_config_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Per-vehicle auto-record configuration (#1004 phase 1).
+///
+/// Reads the [VehicleProfile] identified by [vehicleProfileId] from
+/// [vehicleProfileListProvider] and projects it into a small
+/// immutable [AutoRecordConfig] value. Returning a narrow projection
+/// (instead of the whole profile) keeps the phase 2+ background-
+/// isolate API minimal and prevents accidental coupling to unrelated
+/// fields like baselines or aggregates.
+///
+/// When the profile id is not found in the list, the provider
+/// returns [AutoRecordConfig.defaults] — that way callers do not
+/// need a separate "is this vehicle known yet?" branch.
+
+@ProviderFor(autoRecordConfig)
+final autoRecordConfigProvider = AutoRecordConfigFamily._();
+
+/// Per-vehicle auto-record configuration (#1004 phase 1).
+///
+/// Reads the [VehicleProfile] identified by [vehicleProfileId] from
+/// [vehicleProfileListProvider] and projects it into a small
+/// immutable [AutoRecordConfig] value. Returning a narrow projection
+/// (instead of the whole profile) keeps the phase 2+ background-
+/// isolate API minimal and prevents accidental coupling to unrelated
+/// fields like baselines or aggregates.
+///
+/// When the profile id is not found in the list, the provider
+/// returns [AutoRecordConfig.defaults] — that way callers do not
+/// need a separate "is this vehicle known yet?" branch.
+
+final class AutoRecordConfigProvider
+    extends
+        $FunctionalProvider<
+          AutoRecordConfig,
+          AutoRecordConfig,
+          AutoRecordConfig
+        >
+    with $Provider<AutoRecordConfig> {
+  /// Per-vehicle auto-record configuration (#1004 phase 1).
+  ///
+  /// Reads the [VehicleProfile] identified by [vehicleProfileId] from
+  /// [vehicleProfileListProvider] and projects it into a small
+  /// immutable [AutoRecordConfig] value. Returning a narrow projection
+  /// (instead of the whole profile) keeps the phase 2+ background-
+  /// isolate API minimal and prevents accidental coupling to unrelated
+  /// fields like baselines or aggregates.
+  ///
+  /// When the profile id is not found in the list, the provider
+  /// returns [AutoRecordConfig.defaults] — that way callers do not
+  /// need a separate "is this vehicle known yet?" branch.
+  AutoRecordConfigProvider._({
+    required AutoRecordConfigFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'autoRecordConfigProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoRecordConfigHash();
+
+  @override
+  String toString() {
+    return r'autoRecordConfigProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<AutoRecordConfig> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  AutoRecordConfig create(Ref ref) {
+    final argument = this.argument as String;
+    return autoRecordConfig(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AutoRecordConfig value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AutoRecordConfig>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AutoRecordConfigProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$autoRecordConfigHash() => r'e7933f50bf4f726f5a597ba1e1a3de4e7869435e';
+
+/// Per-vehicle auto-record configuration (#1004 phase 1).
+///
+/// Reads the [VehicleProfile] identified by [vehicleProfileId] from
+/// [vehicleProfileListProvider] and projects it into a small
+/// immutable [AutoRecordConfig] value. Returning a narrow projection
+/// (instead of the whole profile) keeps the phase 2+ background-
+/// isolate API minimal and prevents accidental coupling to unrelated
+/// fields like baselines or aggregates.
+///
+/// When the profile id is not found in the list, the provider
+/// returns [AutoRecordConfig.defaults] — that way callers do not
+/// need a separate "is this vehicle known yet?" branch.
+
+final class AutoRecordConfigFamily extends $Family
+    with $FunctionalFamilyOverride<AutoRecordConfig, String> {
+  AutoRecordConfigFamily._()
+    : super(
+        retry: null,
+        name: r'autoRecordConfigProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Per-vehicle auto-record configuration (#1004 phase 1).
+  ///
+  /// Reads the [VehicleProfile] identified by [vehicleProfileId] from
+  /// [vehicleProfileListProvider] and projects it into a small
+  /// immutable [AutoRecordConfig] value. Returning a narrow projection
+  /// (instead of the whole profile) keeps the phase 2+ background-
+  /// isolate API minimal and prevents accidental coupling to unrelated
+  /// fields like baselines or aggregates.
+  ///
+  /// When the profile id is not found in the list, the provider
+  /// returns [AutoRecordConfig.defaults] — that way callers do not
+  /// need a separate "is this vehicle known yet?" branch.
+
+  AutoRecordConfigProvider call(String vehicleProfileId) =>
+      AutoRecordConfigProvider._(argument: vehicleProfileId, from: this);
+
+  @override
+  String toString() => r'autoRecordConfigProvider';
+}

--- a/test/features/vehicle/providers/auto_record_config_provider_test.dart
+++ b/test/features/vehicle/providers/auto_record_config_provider_test.dart
@@ -1,0 +1,317 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/auto_record_config_provider.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+void main() {
+  group('AutoRecordConfig value type (#1004 phase 1)', () {
+    test('default constructor matches VehicleProfile defaults', () {
+      const config = AutoRecordConfig();
+      expect(config.autoRecord, isFalse);
+      expect(config.pairedAdapterMac, isNull);
+      expect(config.movementStartThresholdKmh, 5.0);
+      expect(config.disconnectSaveDelaySec, 60);
+      expect(config.backgroundLocationConsent, isFalse);
+    });
+
+    test('AutoRecordConfig.defaults matches VehicleProfile defaults', () {
+      const profile = VehicleProfile(id: 'fresh', name: 'Fresh');
+      const config = AutoRecordConfig.defaults;
+      expect(config.autoRecord, profile.autoRecord);
+      expect(config.pairedAdapterMac, profile.pairedAdapterMac);
+      expect(config.movementStartThresholdKmh, profile.movementStartThresholdKmh);
+      expect(config.disconnectSaveDelaySec, profile.disconnectSaveDelaySec);
+      expect(config.backgroundLocationConsent, profile.backgroundLocationConsent);
+    });
+
+    test('fromProfile copies the five auto-record fields', () {
+      const profile = VehicleProfile(
+        id: 'opted-in',
+        name: 'Daily',
+        type: VehicleType.combustion,
+        autoRecord: true,
+        pairedAdapterMac: 'AA:BB:CC:DD:EE:FF',
+        movementStartThresholdKmh: 8.5,
+        disconnectSaveDelaySec: 120,
+        backgroundLocationConsent: true,
+      );
+
+      final config = AutoRecordConfig.fromProfile(profile);
+
+      expect(config.autoRecord, isTrue);
+      expect(config.pairedAdapterMac, 'AA:BB:CC:DD:EE:FF');
+      expect(config.movementStartThresholdKmh, closeTo(8.5, 0.001));
+      expect(config.disconnectSaveDelaySec, 120);
+      expect(config.backgroundLocationConsent, isTrue);
+    });
+
+    test('equal instances compare equal and share a hash code', () {
+      const a = AutoRecordConfig(
+        autoRecord: true,
+        pairedAdapterMac: '11:22:33:44:55:66',
+        movementStartThresholdKmh: 6.0,
+        disconnectSaveDelaySec: 75,
+        backgroundLocationConsent: true,
+      );
+      const b = AutoRecordConfig(
+        autoRecord: true,
+        pairedAdapterMac: '11:22:33:44:55:66',
+        movementStartThresholdKmh: 6.0,
+        disconnectSaveDelaySec: 75,
+        backgroundLocationConsent: true,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different field values compare unequal', () {
+      const base = AutoRecordConfig(autoRecord: true);
+      const flippedMac = AutoRecordConfig(
+        autoRecord: true,
+        pairedAdapterMac: '00:00:00:00:00:01',
+      );
+      const flippedThreshold = AutoRecordConfig(
+        autoRecord: true,
+        movementStartThresholdKmh: 12,
+      );
+      expect(base, isNot(equals(flippedMac)));
+      expect(base, isNot(equals(flippedThreshold)));
+    });
+
+    test('toString surfaces all five fields for debug logs', () {
+      const c = AutoRecordConfig(
+        autoRecord: true,
+        pairedAdapterMac: 'CC:DD:EE:FF:00:11',
+        movementStartThresholdKmh: 4.0,
+        disconnectSaveDelaySec: 45,
+        backgroundLocationConsent: true,
+      );
+      final s = c.toString();
+      expect(s, contains('autoRecord: true'));
+      expect(s, contains('pairedAdapterMac: CC:DD:EE:FF:00:11'));
+      expect(s, contains('movementStartThresholdKmh: 4.0'));
+      expect(s, contains('disconnectSaveDelaySec: 45'));
+      expect(s, contains('backgroundLocationConsent: true'));
+    });
+  });
+
+  group('autoRecordConfigProvider (#1004 phase 1)', () {
+    late ProviderContainer container;
+    late VehicleProfileRepository repo;
+
+    setUp(() {
+      repo = VehicleProfileRepository(_FakeSettings());
+      container = ProviderContainer(
+        overrides: [
+          vehicleProfileRepositoryProvider.overrideWithValue(repo),
+        ],
+      );
+      addTearDown(container.dispose);
+    });
+
+    test('looks up the profile and projects its five auto-record fields',
+        () async {
+      const v = VehicleProfile(
+        id: 'v-auto',
+        name: 'Daily Driver',
+        type: VehicleType.combustion,
+        autoRecord: true,
+        pairedAdapterMac: 'AA:BB:CC:DD:EE:FF',
+        movementStartThresholdKmh: 7.5,
+        disconnectSaveDelaySec: 90,
+        backgroundLocationConsent: true,
+      );
+      await container.read(vehicleProfileListProvider.notifier).save(v);
+
+      final config = container.read(autoRecordConfigProvider('v-auto'));
+
+      expect(config.autoRecord, isTrue);
+      expect(config.pairedAdapterMac, 'AA:BB:CC:DD:EE:FF');
+      expect(config.movementStartThresholdKmh, closeTo(7.5, 0.001));
+      expect(config.disconnectSaveDelaySec, 90);
+      expect(config.backgroundLocationConsent, isTrue);
+    });
+
+    test('unknown vehicle id returns AutoRecordConfig.defaults', () async {
+      // Save one vehicle so the underlying list is non-empty — a
+      // truly empty list would mask any short-circuit bug that
+      // accidentally returns the first entry.
+      await container.read(vehicleProfileListProvider.notifier).save(
+            const VehicleProfile(id: 'other', name: 'Other'),
+          );
+
+      final config = container.read(autoRecordConfigProvider('does-not-exist'));
+
+      expect(config, equals(AutoRecordConfig.defaults));
+      expect(config.autoRecord, isFalse);
+      expect(config.pairedAdapterMac, isNull);
+      expect(config.movementStartThresholdKmh, 5.0);
+      expect(config.disconnectSaveDelaySec, 60);
+      expect(config.backgroundLocationConsent, isFalse);
+    });
+
+    test('a freshly-saved profile (never opted in) returns the same defaults '
+        'as an unknown id — phase 2+ consumers cannot distinguish the two',
+        () async {
+      const fresh = VehicleProfile(id: 'fresh', name: 'Fresh');
+      await container.read(vehicleProfileListProvider.notifier).save(fresh);
+
+      final knownConfig = container.read(autoRecordConfigProvider('fresh'));
+      final unknownConfig =
+          container.read(autoRecordConfigProvider('not-saved-yet'));
+
+      expect(knownConfig, equals(unknownConfig));
+    });
+
+    test('mutating the underlying profile rebuilds the provider with the '
+        'new auto-record values', () async {
+      const initial = VehicleProfile(
+        id: 'mut',
+        name: 'Mutable',
+        type: VehicleType.combustion,
+      );
+      await container.read(vehicleProfileListProvider.notifier).save(initial);
+
+      // First read mirrors the not-yet-opted-in defaults.
+      final before = container.read(autoRecordConfigProvider('mut'));
+      expect(before.autoRecord, isFalse);
+      expect(before.pairedAdapterMac, isNull);
+
+      // User opts in via a phase-6 UI surface — saving the updated
+      // profile must invalidate the provider so any phase 2+
+      // consumer sees the new MAC and threshold on the next read.
+      const updated = VehicleProfile(
+        id: 'mut',
+        name: 'Mutable',
+        type: VehicleType.combustion,
+        autoRecord: true,
+        pairedAdapterMac: '11:22:33:44:55:66',
+        movementStartThresholdKmh: 3.0,
+        disconnectSaveDelaySec: 45,
+        backgroundLocationConsent: true,
+      );
+      await container.read(vehicleProfileListProvider.notifier).save(updated);
+
+      final after = container.read(autoRecordConfigProvider('mut'));
+      expect(after.autoRecord, isTrue);
+      expect(after.pairedAdapterMac, '11:22:33:44:55:66');
+      expect(after.movementStartThresholdKmh, 3.0);
+      expect(after.disconnectSaveDelaySec, 45);
+      expect(after.backgroundLocationConsent, isTrue);
+      expect(after, isNot(equals(before)));
+    });
+
+    test('a listener attached before the mutation receives the new value',
+        () async {
+      const initial = VehicleProfile(
+        id: 'mut',
+        name: 'Mutable',
+        type: VehicleType.combustion,
+      );
+      await container.read(vehicleProfileListProvider.notifier).save(initial);
+
+      final emitted = <AutoRecordConfig>[];
+      final sub = container.listen<AutoRecordConfig>(
+        autoRecordConfigProvider('mut'),
+        (previous, next) => emitted.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(sub.close);
+
+      // First read mirrors the not-yet-opted-in defaults.
+      expect(emitted, hasLength(1));
+      expect(emitted.last.autoRecord, isFalse);
+
+      const updated = VehicleProfile(
+        id: 'mut',
+        name: 'Mutable',
+        type: VehicleType.combustion,
+        autoRecord: true,
+        pairedAdapterMac: '11:22:33:44:55:66',
+      );
+      await container.read(vehicleProfileListProvider.notifier).save(updated);
+
+      // Force the dependency chain to materialize the new value —
+      // listeners only fire when the provider is re-evaluated.
+      container.read(autoRecordConfigProvider('mut'));
+
+      expect(emitted.length, greaterThanOrEqualTo(2));
+      expect(emitted.last.autoRecord, isTrue);
+      expect(emitted.last.pairedAdapterMac, '11:22:33:44:55:66');
+    });
+
+    test('deleting the profile flips the provider back to defaults', () async {
+      const v = VehicleProfile(
+        id: 'gone',
+        name: 'Vanishing',
+        type: VehicleType.combustion,
+        autoRecord: true,
+        pairedAdapterMac: 'DE:AD:BE:EF:00:01',
+      );
+      await container.read(vehicleProfileListProvider.notifier).save(v);
+
+      final beforeDelete = container.read(autoRecordConfigProvider('gone'));
+      expect(beforeDelete.autoRecord, isTrue);
+      expect(beforeDelete.pairedAdapterMac, 'DE:AD:BE:EF:00:01');
+
+      await container.read(vehicleProfileListProvider.notifier).remove('gone');
+
+      final afterDelete = container.read(autoRecordConfigProvider('gone'));
+      expect(afterDelete, equals(AutoRecordConfig.defaults));
+    });
+
+    test('config does not leak unrelated VehicleProfile fields', () async {
+      // The whole point of the projection: phase-2 consumers cannot
+      // hold a reference to baselines, aggregates, charging prefs,
+      // etc. that live on the wider profile. We assert by checking
+      // the AutoRecordConfig type surface exposes only the five
+      // documented fields.
+      const v = VehicleProfile(
+        id: 'rich',
+        name: 'Rich',
+        type: VehicleType.ev,
+        batteryKwh: 75,
+        tankCapacityL: 50,
+        autoRecord: true,
+      );
+      await container.read(vehicleProfileListProvider.notifier).save(v);
+
+      final config = container.read(autoRecordConfigProvider('rich'));
+      // The runtime type carries no field accessors beyond the five
+      // documented ones; this assertion mirrors that intent.
+      expect(config.autoRecord, isTrue);
+      expect(config, isA<AutoRecordConfig>());
+    });
+  });
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}


### PR DESCRIPTION
## Summary

- Adds `autoRecordConfigProvider(vehicleProfileId)` and an immutable `AutoRecordConfig` value type that projects a `VehicleProfile` into the five auto-record fields only (`autoRecord`, `pairedAdapterMac`, `movementStartThresholdKmh`, `disconnectSaveDelaySec`, `backgroundLocationConsent`).
- The five `VehicleProfile` fields themselves shipped earlier in #1006; this PR is the missing provider piece of phase 1.
- Migration safety: pre-#1004 Hive profiles deserialize cleanly via the existing `@Default` annotations on `VehicleProfile`; the provider returns `AutoRecordConfig.defaults` for an unknown id, so consumers cannot tell a missing profile from a freshly-saved-but-not-opted-in one.
- Narrow projection keeps phase-2+ background-isolate consumers from accidentally holding references to unrelated profile state (baselines, aggregates, charging prefs).

## Explicitly NOT in this PR

- No background / foreground service, no `MethodChannel`, no Android/iOS native code.
- No `AndroidManifest.xml` / `Info.plist` changes.
- No `flutter_blue_plus` calls, no OBD2 layer changes, no `TripRecordingController` changes.
- No UI (no wizard step, no settings toggle, no badge widget).
- No new pubspec dependencies, no `lib/l10n/` changes.

## Phase roadmap (#1004)

- Phase 2 — Android foreground service + BLE auto-connect listener for `pairedAdapterMac`.
- Phase 3 — `AutoTripCoordinator` consumes the OBD2 / GPS speed stream and fires `startTrip(automatic: true)` once `movementStartThresholdKmh` is crossed.
- Phase 4 — disconnect-debounced `stopAndSave(reason: 'auto-disconnect')` with WAL recovery.
- Phase 5 — launcher icon badge counter for new auto-recordings.
- Phase 6 — vehicle wizard / edit-screen UI for the toggle and advanced fields.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test test/features/vehicle/` — 503 passing (12 new + existing)
- [x] `flutter test test/lint/` — clean
- [x] Provider correctly projects an opted-in profile into all five fields
- [x] Unknown / deleted profile id falls back to `AutoRecordConfig.defaults`
- [x] Mutating the underlying `VehicleProfile` rebuilds the provider with the new auto-record values
- [x] `AutoRecordConfig` defaults match `VehicleProfile` defaults exactly

Refs #1004