### PR TITLE
fix(vehicle): Read-VIN button gates on adapterMac (Closes #1339)

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -55,10 +55,6 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   // first successful load so subsequent provider updates (e.g. from
   // `_save()` writing the freshest profile) don't clobber user edits.
   bool _hasInitiallyLoaded = false;
-  // #1162 — pairedAdapterMac (#1004) gates the "Read VIN from car"
-  // button. Distinct from [_adapterMac] which is the currently-
-  // connected OBD2 picker selection.
-  String? _pairedAdapterMac;
 
   // #812 phase 2 — engine params populated by the VIN decoder;
   // carried through _save for phase-3 OBD2 math.
@@ -112,7 +108,6 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
         ..addAll(snap.connectors);
       _adapterMac = snap.adapterMac;
       _adapterName = snap.adapterName;
-      _pairedAdapterMac = snap.pairedAdapterMac;
       _engineDisplacementCc = snap.engineDisplacementCc;
       _engineCylinders = snap.engineCylinders;
       _curbWeightKg = snap.curbWeightKg;
@@ -240,7 +235,12 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   /// editable.
   Future<void> _readVinFromCar() async {
     final l = AppLocalizations.of(context);
-    final mac = _pairedAdapterMac;
+    // #1339 — gate on the basic adapter-selection field
+    // (`obd2AdapterMac`, surfaced here as `_adapterMac`), NOT the
+    // auto-record `pairedAdapterMac` flag (#1004). VIN reading via
+    // Mode 09 PID 02 only needs an adapter to talk to; auto-record
+    // pairing is unrelated.
+    final mac = _adapterMac;
     if (mac == null || mac.isEmpty) return;
 
     setState(() => _readingVinFromCar = true);
@@ -354,12 +354,18 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
               onDecodeVin: _decodeVin,
               onShowVinInfo: _showVinInfo,
               // #1328 — always show the "Read VIN from car" button. When
-              // no adapter is paired we pass `onReadVinFromCar = null`
+              // no adapter is selected we pass `onReadVinFromCar = null`
               // (which renders the button visibly disabled with a hint)
               // so users discover the feature even before pairing.
-              pairedAdapterMac: _pairedAdapterMac,
+              // #1339 — "selected" here is the basic `obd2AdapterMac`
+              // state (`_adapterMac`), NOT the auto-record
+              // `pairedAdapterMac` flag (#1004); VIN reading only needs
+              // an adapter to talk to.
+              adapterMac: _adapterMac,
               onReadVinFromCar:
-                  _pairedAdapterMac != null ? _readVinFromCar : null,
+                  (_adapterMac != null && _adapterMac!.isNotEmpty)
+                      ? _readVinFromCar
+                      : null,
               readingVinFromCar: _readingVinFromCar,
             ),
             const SizedBox(height: 16),

--- a/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
@@ -181,8 +181,9 @@ class VehicleFormSnapshot {
 
   /// Long-lived "this adapter belongs to this car" marker (#1004).
   /// Distinct from [adapterMac] — that field holds the currently-
-  /// connected adapter from the OBD2 picker. The read-VIN-from-car
-  /// button (#1162) gates on this field.
+  /// connected adapter from the OBD2 picker. The auto-record flow
+  /// (#1004) watches this field for BLE auto-connect; the
+  /// read-VIN-from-car button (#1162) gates on [adapterMac] (#1339).
   final String? pairedAdapterMac;
 
   final int? engineDisplacementCc;

--- a/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
@@ -12,11 +12,13 @@ import '../../../../l10n/app_localizations.dart';
 /// at the screen level where the provider already lives.
 ///
 /// The section also shows a "Read VIN from car" button that triggers a
-/// Mode 09 PID 02 read against the paired OBD2 adapter (#1162). The
-/// button is always rendered (#1328); when no adapter is paired
-/// ([pairedAdapterMac] is null OR [onReadVinFromCar] is null) it is
+/// Mode 09 PID 02 read against the selected OBD2 adapter (#1162). The
+/// button is always rendered (#1328); when no adapter is selected
+/// ([adapterMac] is null OR [onReadVinFromCar] is null) it is
 /// shown visibly disabled with a small helper text, so users discover
-/// the feature even before pairing.
+/// the feature even before pairing. (#1339 — gated on the basic
+/// `obd2AdapterMac` field, NOT the auto-record `pairedAdapterMac`
+/// flag, so the button enables as soon as the user picks an adapter.)
 class VehicleIdentitySection extends StatelessWidget {
   final TextEditingController nameController;
   final TextEditingController vinController;
@@ -26,11 +28,13 @@ class VehicleIdentitySection extends StatelessWidget {
   final VoidCallback onDecodeVin;
   final VoidCallback onShowVinInfo;
 
-  /// The active profile's paired adapter MAC (#1162). When null AND
-  /// [onReadVinFromCar] is null, the "Read VIN from car" button is
-  /// rendered disabled with a helper hint instead of being hidden — see
-  /// #1328 for why discoverability beats minimalism here.
-  final String? pairedAdapterMac;
+  /// The active profile's selected adapter MAC (#1162 / #1339). When
+  /// null AND [onReadVinFromCar] is null, the "Read VIN from car"
+  /// button is rendered disabled with a helper hint instead of being
+  /// hidden — see #1328 for why discoverability beats minimalism here.
+  /// This is the basic `obd2AdapterMac` selection (the bottom adapter-
+  /// picker), NOT the auto-record `pairedAdapterMac` flag (#1004).
+  final String? adapterMac;
 
   /// Callback fired when the user taps the "Read VIN from car" button
   /// (#1162). When null, the button is rendered visibly disabled
@@ -52,7 +56,7 @@ class VehicleIdentitySection extends StatelessWidget {
     required this.decodingVin,
     required this.onDecodeVin,
     required this.onShowVinInfo,
-    this.pairedAdapterMac,
+    this.adapterMac,
     this.onReadVinFromCar,
     this.readingVinFromCar = false,
   });

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_vin_button_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_vin_button_test.dart
@@ -11,29 +11,31 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Widget tests for the "Read VIN from car" button on
-/// [EditVehicleScreen] (#1162).
+/// [EditVehicleScreen] (#1162 / #1339).
 ///
 /// The OBD2 read is faked via a [_FakeVinReaderService] override on
 /// [vinReaderServiceProvider] so no Bluetooth stack is required. The
-/// button is gated on the active profile's `pairedAdapterMac` field;
-/// these tests cover both the hidden (no adapter) and visible (paired)
-/// states plus the success / failure UX branches.
+/// button is gated on the active profile's basic `obd2AdapterMac`
+/// selection (#1339, fixed from the original auto-record
+/// `pairedAdapterMac` gate); these tests cover both the disabled (no
+/// adapter selected) and enabled (adapter selected) states plus the
+/// success / failure UX branches.
 void main() {
-  group('EditVehicleScreen — Read-VIN-from-car button (#1162)', () {
+  group('EditVehicleScreen — Read-VIN-from-car button (#1162 / #1339)', () {
     testWidgets(
       'button is visible but disabled with a hint when the vehicle has '
-      'no paired adapter (#1328)',
+      'no adapter selected (#1328)',
       (tester) async {
-        await _pumpWithProfile(tester, withPairedAdapter: false);
+        await _pumpWithProfile(tester, withAdapterSelected: false);
 
         // #1328 — the button is always rendered so users discover the
-        // feature. With no paired adapter it is disabled (onPressed
+        // feature. With no adapter selected it is disabled (onPressed
         // null) and a small helper text is shown underneath.
         final buttonFinder = find.byKey(const Key('vehicleReadVinFromCar'));
         expect(buttonFinder, findsOneWidget);
         final button = tester.widget<OutlinedButton>(buttonFinder);
         expect(button.onPressed, isNull,
-            reason: 'No paired adapter → button must render disabled');
+            reason: 'No adapter selected → button must render disabled');
         expect(
           find.byKey(const Key('vehicleReadVinNoAdapterHint')),
           findsOneWidget,
@@ -46,22 +48,53 @@ void main() {
     );
 
     testWidgets(
-      'button is visible and enabled with a tooltip when the vehicle '
-      'has a paired adapter',
+      'button is enabled when the basic adapter selection is set even '
+      'though the auto-record pairedAdapterMac flag is null (#1339)',
       (tester) async {
-        await _pumpWithProfile(tester, withPairedAdapter: true);
+        // #1339 regression repro: user picked an adapter via the bottom
+        // OBD2 picker (`obd2AdapterMac` written) but never opted into
+        // the auto-record pairing flow (`pairedAdapterMac` still null).
+        // Before the fix the button was disabled because the gate
+        // confused the two fields.
+        await _pumpWithProfile(
+          tester,
+          withAdapterSelected: true,
+          autoRecordPaired: false,
+        );
 
         final buttonFinder = find.byKey(const Key('vehicleReadVinFromCar'));
         expect(buttonFinder, findsOneWidget);
         final button = tester.widget<OutlinedButton>(buttonFinder);
         expect(button.onPressed, isNotNull,
-            reason: 'Paired adapter → button must be tappable');
+            reason: 'Adapter selected → button must be tappable even when '
+                'auto-record pairing is not configured');
         expect(find.text('Read VIN from car'), findsOneWidget);
         expect(
           find.byTooltip('Read VIN from the paired OBD2 adapter'),
           findsOneWidget,
         );
-        // The "no adapter" hint is gone when paired.
+        // The "no adapter" hint is gone once an adapter is selected.
+        expect(
+          find.byKey(const Key('vehicleReadVinNoAdapterHint')),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'button is enabled when both the adapter selection and the '
+      'auto-record pairing are set',
+      (tester) async {
+        await _pumpWithProfile(
+          tester,
+          withAdapterSelected: true,
+          autoRecordPaired: true,
+        );
+
+        final buttonFinder = find.byKey(const Key('vehicleReadVinFromCar'));
+        expect(buttonFinder, findsOneWidget);
+        final button = tester.widget<OutlinedButton>(buttonFinder);
+        expect(button.onPressed, isNotNull);
         expect(
           find.byKey(const Key('vehicleReadVinNoAdapterHint')),
           findsNothing,
@@ -74,7 +107,7 @@ void main() {
       (tester) async {
         await _pumpWithProfile(
           tester,
-          withPairedAdapter: true,
+          withAdapterSelected: true,
           readerResult: const ObdVinResult.success('VF36B8HZL8R123456'),
         );
 
@@ -99,7 +132,7 @@ void main() {
       (tester) async {
         await _pumpWithProfile(
           tester,
-          withPairedAdapter: true,
+          withAdapterSelected: true,
           readerResult: const ObdVinResult.failure(
             ObdVinFailureReason.unsupported,
           ),
@@ -133,7 +166,7 @@ void main() {
       (tester) async {
         await _pumpWithProfile(
           tester,
-          withPairedAdapter: true,
+          withAdapterSelected: true,
           readerResult: const ObdVinResult.failure(
             ObdVinFailureReason.timeout,
           ),
@@ -154,7 +187,7 @@ void main() {
       'the visible button + surrounding interactive elements meet the '
       'Android tap-target guideline (#566)',
       (tester) async {
-        await _pumpWithProfile(tester, withPairedAdapter: true);
+        await _pumpWithProfile(tester, withAdapterSelected: true);
 
         final handle = tester.ensureSemantics();
         await expectLater(
@@ -167,12 +200,20 @@ void main() {
   });
 }
 
-/// Pumps [EditVehicleScreen] in edit-mode with a stored profile that
-/// either has or does not have a paired adapter. The OBD2 reader is
-/// always faked so the test never touches a real transport.
+/// Pumps [EditVehicleScreen] in edit-mode with a stored profile.
+///
+/// [withAdapterSelected] writes `obd2AdapterMac` (the basic OBD2-picker
+/// selection that gates the Read-VIN-from-car button — #1339).
+/// [autoRecordPaired] is independent: it writes the auto-record
+/// `pairedAdapterMac` flag (#1004). The two were confused before #1339;
+/// the helper exposes both so tests can assert each combination.
+///
+/// The OBD2 reader is always faked so the test never touches a real
+/// transport.
 Future<void> _pumpWithProfile(
   WidgetTester tester, {
-  required bool withPairedAdapter,
+  required bool withAdapterSelected,
+  bool autoRecordPaired = false,
   ObdVinResult? readerResult,
 }) async {
   final repo = VehicleProfileRepository(_FakeSettings());
@@ -180,8 +221,11 @@ Future<void> _pumpWithProfile(
     VehicleProfile(
       id: 'v1',
       name: 'My Test Car',
+      obd2AdapterMac:
+          withAdapterSelected ? 'AA:BB:CC:DD:EE:FF' : null,
+      obd2AdapterName: withAdapterSelected ? 'Test Adapter' : null,
       pairedAdapterMac:
-          withPairedAdapter ? 'AA:BB:CC:DD:EE:FF' : null,
+          autoRecordPaired ? 'AA:BB:CC:DD:EE:FF' : null,
     ),
   );
 
@@ -204,7 +248,7 @@ Future<void> _pumpWithProfile(
     ),
   );
   // The screen loads the existing profile in a post-frame callback;
-  // settle so the paired-adapter UI renders before the test asserts.
+  // settle so the adapter-dependent UI renders before the test asserts.
   await tester.pumpAndSettle();
 }
 


### PR DESCRIPTION
## Root cause

`VehicleProfile` carries two distinct adapter-MAC fields that PR #1331 (the #1328 always-visible button) confused:

- `obd2AdapterMac` — the **basic adapter selection** that the bottom OBD2 picker writes (`_adapterMac` in the screen).
- `pairedAdapterMac` — the long-lived **auto-record pairing flag** (#1004), only set when the user explicitly opts into hands-free recording (`_pairedAdapterMac`).

The "Read VIN from car" button enable-gate was on `_pairedAdapterMac`, so users who paired an adapter via the bottom picker but never enabled auto-record saw the button stuck in its disabled "no adapter" state. Mode 09 PID 02 only needs an adapter to talk to — auto-record pairing is unrelated.

## Fix sites in `lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart`

- `_readVinFromCar` reads `_adapterMac` instead of `_pairedAdapterMac`.
- `VehicleIdentitySection(adapterMac: _adapterMac, ...)` — parameter renamed (was `pairedAdapterMac`, was always dead at the widget level since the gate is driven by `onReadVinFromCar`).
- `onReadVinFromCar` enable-gate switches to `(_adapterMac != null && _adapterMac!.isNotEmpty)`.
- Dead `_pairedAdapterMac` field removed (only consumer was the gate).
- Stale doc comments on `VehicleFormSnapshot.pairedAdapterMac` and `VehicleIdentitySection` updated.

## Tests

`edit_vehicle_screen_vin_button_test.dart`:

- `withAdapterSelected` helper now writes `obd2AdapterMac`; `autoRecordPaired` is a separate flag for `pairedAdapterMac`.
- New: button enabled when adapter is selected but auto-record pairing is null (the #1339 repro).
- New: button enabled when both fields are set.
- Existing: button disabled with hint when no adapter is selected (#1328 regression cover).
- Existing tap/snackbar/tap-target cases re-pointed to `withAdapterSelected: true`.

Closes #1339

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test test/features/vehicle/` — 491 tests pass
- [x] `flutter test test/lint/` — pass