### PR TITLE
fix(trip-recording): salvage recovered snapshot when banner Resume/End tapped (Closes #1347)

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -6,6 +6,7 @@ import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/feedback/auto_record_badge_provider.dart';
+import '../../../core/feedback/auto_record_badge_service.dart';
 import '../../../core/storage/hive_boxes.dart';
 import '../../../core/storage/storage_keys.dart';
 import '../../../core/storage/storage_providers.dart';
@@ -493,7 +494,21 @@ class TripRecording extends _$TripRecording {
 
   void resume() {
     final ctl = _controller;
-    if (ctl == null) return;
+    if (ctl == null) {
+      // #1347 — cold-start recovery left us with a snapshot but no
+      // controller. The pause banner's Resume button reaches us
+      // here; without this path the tap is a silent no-op and the
+      // captured samples are stranded in Hive forever. True "continue
+      // recording" requires re-pairing the OBD2 adapter (out of scope
+      // — see the #1347 follow-up issue); the minimum correct
+      // behaviour is to finalise the snapshot into trip history so
+      // the partial drive is preserved.
+      if (_activeSnapshot != null &&
+          state.phase == TripRecordingPhase.pausedDueToDrop) {
+        unawaited(_finalizeRecoveredSnapshot());
+      }
+      return;
+    }
     if (state.phase != TripRecordingPhase.paused &&
         state.phase != TripRecordingPhase.pausedDueToDrop) {
       return;
@@ -517,6 +532,16 @@ class TripRecording extends _$TripRecording {
     final ctl = _controller;
     final svc = _service;
     if (ctl == null || svc == null) {
+      // #1347 — cold-start recovery left us with a snapshot on disk
+      // but no controller / service. The pause banner's End button
+      // reaches us here; without this path the tap silently throws
+      // away the captured samples (`StoppedTripResult.empty()` and a
+      // zero-state reset). Salvage the snapshot into trip history so
+      // the user keeps their partial drive.
+      if (_activeSnapshot != null &&
+          state.phase == TripRecordingPhase.pausedDueToDrop) {
+        return _finalizeRecoveredSnapshot();
+      }
       state = const TripRecordingState();
       return const StoppedTripResult.empty();
     }
@@ -817,6 +842,110 @@ class TripRecording extends _$TripRecording {
     } catch (e, st) {
       debugPrint('TripRecording flush snapshot failed: $e\n$st');
     }
+  }
+
+  /// #1347 — finalise the recovered active-trip snapshot into trip
+  /// history when the user taps Resume / End on the pause banner
+  /// after a cold-start recovery. The controller is null in this
+  /// state (`restoreFromSnapshot` deliberately leaves it that way),
+  /// so [stop] cannot run its normal teardown; this helper writes
+  /// the snapshot's captured samples + summary into the rolling
+  /// trip-history log instead, clears the snapshot from Hive, and
+  /// transitions state to `finished` so the recording screen renders
+  /// the summary view.
+  ///
+  /// True "continue recording" — re-pair the adapter, reattach a
+  /// controller carrying the snapshot's session id + prior samples,
+  /// and resume polling — is intentionally out of scope here. See the
+  /// #1347 follow-up issue. The salvage path's only job is to make
+  /// sure the partial drive isn't silently lost.
+  Future<StoppedTripResult> _finalizeRecoveredSnapshot() async {
+    final snapshot = _activeSnapshot;
+    if (snapshot == null) {
+      state = const TripRecordingState();
+      return const StoppedTripResult.empty();
+    }
+    // Resolve every Riverpod-backed dependency synchronously up
+    // front. Reading `ref` after an `await` is unsafe — the provider
+    // could be disposed by then (rare in production thanks to
+    // `keepAlive: true`, frequent in tests where the container goes
+    // out of scope before the unawaited future settles).
+    TripHistoryRepository? historyRepo;
+    TripHistoryList? historyList;
+    Future<AutoRecordBadgeService>? badgeFuture;
+    try {
+      historyRepo = ref.read(tripHistoryRepositoryProvider);
+    } catch (e, st) {
+      debugPrint(
+          'TripRecording recovered finalise: history repo read failed: $e\n$st');
+    }
+    try {
+      historyList = ref.read(tripHistoryListProvider.notifier);
+    } catch (e, st) {
+      debugPrint(
+          'TripRecording recovered finalise: history list read failed: $e\n$st');
+    }
+    if (snapshot.automatic) {
+      try {
+        badgeFuture = ref.read(autoRecordBadgeServiceProvider.future);
+      } catch (e, st) {
+        debugPrint(
+            'TripRecording recovered finalise: badge service read failed: $e\n$st');
+      }
+    }
+
+    final result = StoppedTripResult(
+      summary: snapshot.summary,
+      odometerStartKm: snapshot.odometerStartKm,
+      odometerLatestKm: snapshot.odometerLatestKm,
+    );
+    // Transition state synchronously so the recording screen flips to
+    // the summary view immediately — even if the Hive writes below
+    // race against provider disposal in a test harness.
+    state = state.copyWith(phase: TripRecordingPhase.finished);
+
+    if (historyRepo != null) {
+      try {
+        await historyRepo.save(TripHistoryEntry(
+          id: snapshot.id,
+          vehicleId: snapshot.vehicleId,
+          summary: snapshot.summary,
+          automatic: snapshot.automatic,
+          samples: snapshot.samples,
+        ));
+      } catch (e, st) {
+        debugPrint(
+            'TripRecording recovered finalise: save failed: $e\n$st');
+      }
+    }
+
+    // Clear the snapshot BEFORE the best-effort observer-refresh and
+    // badge bump below — the recovery service must not resurrect a
+    // finalised trip on next launch even if those follow-up steps
+    // throw or race against provider disposal in a test harness.
+    await _clearActiveSnapshot();
+
+    try {
+      historyList?.refresh();
+    } catch (e, st) {
+      debugPrint(
+          'TripRecording recovered finalise: list refresh failed: $e\n$st');
+    }
+
+    // Mirror the auto-record badge bookkeeping the regular
+    // `_saveToHistory` path applies — a recovered auto-trip is still
+    // an "unseen" trip the user should see in the launcher.
+    if (badgeFuture != null) {
+      try {
+        final badge = await badgeFuture;
+        await badge.increment();
+      } catch (e, st) {
+        debugPrint(
+            'TripRecording recovered finalise: badge bump failed: $e\n$st');
+      }
+    }
+
+    return result;
   }
 
   /// Drop the persisted snapshot + clear in-memory bookkeeping.

--- a/test/features/consumption/providers/trip_recording_provider_active_snapshot_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_active_snapshot_test.dart
@@ -7,6 +7,7 @@ import 'package:tankstellen/core/storage/hive_boxes.dart';
 import 'package:tankstellen/features/consumption/data/obd2/active_trip_repository.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 
@@ -227,6 +228,147 @@ void main() {
       expect(applied, isFalse,
           reason: 'a fresh launch that already started a trip must not '
               'be hijacked by a stale recovery snapshot');
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // #1347 — after cold-start recovery the controller is null. The
+  // banner's Resume + End buttons must not silently no-op; the
+  // captured samples already on disk must be preserved into trip
+  // history so the user does not lose their interrupted drive.
+  // ---------------------------------------------------------------------------
+
+  test(
+    'stop() after restoreFromSnapshot persists snapshot samples to '
+    'history (#1347)',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      notifier.debugSetActiveRepo(activeRepo);
+
+      final start = DateTime.utc(2026, 5, 2, 10, 0);
+      final samples = List<TripSample>.generate(
+        6,
+        (i) => _sampleFor(start, i),
+      );
+      final snap = ActiveTripSnapshot(
+        id: start.toIso8601String(),
+        vehicleId: 'veh-recovered',
+        vin: 'VIN-RECOVERED',
+        automatic: false,
+        phase: 'pausedDueToDrop',
+        summary: const TripSummary(
+          distanceKm: 5.5,
+          maxRpm: 3500,
+          highRpmSeconds: 2,
+          idleSeconds: 30,
+          harshBrakes: 1,
+          harshAccelerations: 0,
+        ),
+        samples: samples,
+        odometerStartKm: 1000.0,
+        odometerLatestKm: 1010.0,
+        startedAt: start,
+        lastFlushedAt: start.add(const Duration(minutes: 30)),
+      );
+      // Persist the snapshot to disk too — the salvage path must clear
+      // the box, otherwise the recovery service would resurrect the
+      // already-finalised trip on next launch.
+      await activeRepo.saveSnapshot(snap);
+      final restored = notifier.restoreFromSnapshot(snap);
+      expect(restored, isTrue);
+      expect(notifier.debugController, isNull,
+          reason: 'restoreFromSnapshot deliberately leaves _controller '
+              'null — that is the bug surface #1347 patches');
+
+      // The user taps "End recording" on the OBD2 pause banner.
+      final result = await notifier.stop();
+
+      final historyRepo = TripHistoryRepository(box: historyBox);
+      final entries = historyRepo.loadAll();
+      expect(entries, hasLength(1),
+          reason: 'stop() in the recovered-no-controller state must '
+              'finalise the snapshot into trip history so the user does '
+              'not silently lose their partial drive (#1347)');
+      expect(entries.first.id, snap.id);
+      expect(entries.first.vehicleId, 'veh-recovered');
+      expect(entries.first.samples, hasLength(6));
+      expect(entries.first.summary.distanceKm, closeTo(5.5, 0.001));
+
+      expect(activeRepo.loadSnapshot(), isNull,
+          reason: 'finalised snapshot must be cleared so the recovery '
+              'service does not resurrect it on next launch');
+      expect(notifier.state.phase, TripRecordingPhase.finished);
+      expect(result.summary.distanceKm, closeTo(5.5, 0.001));
+    },
+  );
+
+  test(
+    'resume() after restoreFromSnapshot also salvages snapshot to '
+    'history (#1347)',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      notifier.debugSetActiveRepo(activeRepo);
+
+      final start = DateTime.utc(2026, 5, 2, 10, 0);
+      final samples = List<TripSample>.generate(
+        4,
+        (i) => _sampleFor(start, i),
+      );
+      final snap = ActiveTripSnapshot(
+        id: start.toIso8601String(),
+        vehicleId: 'veh-resumed',
+        vin: null,
+        automatic: true, // auto-record path
+        phase: 'pausedDueToDrop',
+        summary: const TripSummary(
+          distanceKm: 3.2,
+          maxRpm: 3000,
+          highRpmSeconds: 0,
+          idleSeconds: 10,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+        ),
+        samples: samples,
+        odometerStartKm: null,
+        odometerLatestKm: null,
+        startedAt: start,
+        lastFlushedAt: start.add(const Duration(minutes: 5)),
+      );
+      await activeRepo.saveSnapshot(snap);
+      notifier.restoreFromSnapshot(snap);
+
+      // The user taps "Resume recording" on the OBD2 pause banner. A
+      // true continuation requires re-pairing the OBD2 adapter (out of
+      // scope of #1347 — see follow-up issue); the minimum correct
+      // behaviour is that the captured samples are not silently lost.
+      notifier.resume();
+
+      // resume() is `void` and fires its salvage as an unawaited
+      // future — drain the microtask queue so the chained Hive
+      // writes (save → clearSnapshot) settle before we assert. A
+      // small real-time delay is necessary because Hive's internal
+      // write futures don't all chain off a single microtask.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final historyRepo = TripHistoryRepository(box: historyBox);
+      final entries = historyRepo.loadAll();
+      expect(entries, hasLength(1),
+          reason: 'resume() with no live controller must salvage the '
+              'snapshot into history rather than silently no-op (#1347)');
+      expect(entries.first.id, snap.id);
+      expect(entries.first.automatic, isTrue,
+          reason: 'auto-record provenance must survive the salvage path '
+              'so the unseen-trip badge bookkeeping stays consistent');
+      expect(entries.first.samples, hasLength(4));
+
+      expect(activeRepo.loadSnapshot(), isNull);
+      expect(notifier.state.phase, TripRecordingPhase.finished);
     },
   );
 }


### PR DESCRIPTION
## Summary

- After a cold-start recovery (#1303), the OBD2 pause banner''s **Resume** and **End** buttons silently lost the user''s captured samples — `_controller` is null after `restoreFromSnapshot`, so both `provider.resume()` and `provider.stop()` short-circuited on the null check.
- Add `_finalizeRecoveredSnapshot()` that finalises the snapshot''s samples + summary into the trip-history rolling log, clears the snapshot from Hive, and transitions state to `finished` so the recording screen flips to its summary view.
- Wire both `resume()` and `stop()` to call the salvage helper when `_controller == null && _activeSnapshot != null && phase == pausedDueToDrop`.

True ""continue recording"" (re-pair the adapter, reattach a controller carrying the snapshot''s session id + prior samples, resume polling) is intentionally out of scope and will land in a follow-up issue. This PR''s only job is to make sure the partial drive isn''t silently lost.

Closes #1347

## Test plan
- [x] `flutter test test/features/consumption/providers/trip_recording_provider_active_snapshot_test.dart` — 8 tests pass (6 pre-existing + 2 new)
- [x] `flutter test test/features/consumption/` — 2123 tests pass
- [x] `flutter analyze` — no issues
- [ ] Device test — interrupt a trip mid-drive, force-stop the app, relaunch, tap **End recording** on the banner; confirm a `TripHistoryEntry` appears in the trajets list with the captured samples
- [ ] Device test — same flow but tap **Resume recording**; confirm the same outcome (data preserved, state transitions to summary view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)