### PR TITLE
fix(obd2): register vLinker BM-Android profile + route VIN read through paired MAC (Closes #1349, Closes #1351)

### DIFF
--- a/lib/features/consumption/data/obd2/adapter_registry.dart
+++ b/lib/features/consumption/data/obd2/adapter_registry.dart
@@ -279,6 +279,23 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
     nameMatchers: ['vlinker bm+', 'vlink bm+'],
   ),
+  // vLinker BM-Android — Classic SPP firmware variant of the vLinker
+  // BM line that ships with an Android-specific advertising name
+  // (#1349). User-reported on a Samsung device 2026-05-02: bonded
+  // device list shows "vLinker BM-Android" and the picker hid it
+  // because no profile carried a matcher for the "-android" suffix
+  // (the BM+ entry above requires the literal "+", and the generic
+  // Classic fallback only catches names containing "obd" / "elm327").
+  // Listed BEFORE the generic-classic fallback so this specific
+  // match wins. The Android-suffixed name is the conservative match —
+  // a plain "vLinker BM" Classic device would still need its own
+  // entry, but evidence in the field is for the -Android variant.
+  Obd2AdapterProfile(
+    id: 'vlinker-bm-android-classic',
+    displayName: 'vLinker BM-Android (Classic)',
+    transport: BluetoothTransport.classic,
+    nameMatchers: ['vlinker bm-android', 'vlink bm-android'],
+  ),
   // Konnwei KW902 — Classic Bluetooth ELM327 v1.5 clone, extremely
   // common on Amazon / AliExpress. Advertises as "KONNWEI" or "KW902"
   // in bonded-device lists (#949).

--- a/lib/features/vehicle/providers/obd2_vin_reader_provider.dart
+++ b/lib/features/vehicle/providers/obd2_vin_reader_provider.dart
@@ -33,17 +33,17 @@ class Obd2VinReaderService implements VinReaderService {
 
   @override
   Future<ObdVinResult> readVin({required String pairedAdapterMac}) async {
-    // Connect to the highest-RSSI candidate from the most recent scan.
-    // The adapter-edit UI runs a scan immediately before tapping the
-    // button, so [connectBest] resolves the paired MAC. If no scan has
-    // run, [connectBest] returns null → io failure.
-    //
-    // We don't currently filter by [pairedAdapterMac] inside
-    // [Obd2ConnectionService] — the parameter is forwarded so a future
-    // refinement can pin the connection to the user's paired adapter
-    // (#1162 follow-up).
+    // #1351 — connect to the *paired* adapter by MAC. The previous
+    // implementation called [Obd2ConnectionService.connectBest] which
+    // depends on a fresh scan having run beforehand and otherwise
+    // either returns null OR connects to the wrong adapter (the
+    // highest-RSSI candidate from a stale [_lastRanked]). The vehicle-
+    // edit screen does NOT run a scan before this button is tapped,
+    // so [connectBest] could not work in practice. [connectByMac]
+    // owns its own short scan window and short-circuits on the first
+    // candidate matching [pairedAdapterMac] — exactly what we want.
     try {
-      final service = await connection.connectBest();
+      final service = await connection.connectByMac(pairedAdapterMac);
       if (service == null) {
         return const ObdVinResult.failure(ObdVinFailureReason.io);
       }

--- a/test/features/consumption/data/obd2/adapter_registry_test.dart
+++ b/test/features/consumption/data/obd2/adapter_registry_test.dart
@@ -135,6 +135,40 @@ void main() {
       expect(profile!.id, 'vlinker-bm-plus');
     });
 
+    test(
+      'vLinker BM-Android (Classic SPP) matches vlinker-bm-android-classic '
+      '(#1349)',
+      () {
+        // User-reported 2026-05-02: bonded device "vLinker BM-Android"
+        // was hidden from the picker entirely because no profile
+        // matched the name. Classic transport — Bluetooth bonded list
+        // carries no advertised services.
+        final hit = _candidate(name: 'vLinker BM-Android', services: []);
+        final profile = registry.resolve(hit);
+        expect(profile, isNotNull,
+            reason: 'BM-Android variant must surface in the picker, '
+                'not be silently dropped because the registry has no '
+                'matcher (#1349)');
+        expect(profile!.id, 'vlinker-bm-android-classic');
+        expect(profile.transport, BluetoothTransport.classic);
+      },
+    );
+
+    test(
+      'vLinker BM+ does not collide with the new BM-Android entry (#1349)',
+      () {
+        // Regression guard: the BM+ matcher requires the literal "+"
+        // and the BM-Android matcher requires the literal "-android".
+        // Neither glyph appears in the other so the entries are
+        // disjoint regardless of profile-list ordering.
+        final hit = _candidate(
+          name: 'vLinker BM+',
+          services: const ['0000fff0-0000-1000-8000-00805f9b34fb'],
+        );
+        expect(registry.resolve(hit)?.id, 'vlinker-bm-plus');
+      },
+    );
+
     test('vLinker BM (no plus) does NOT collide with the BM+ entry', () {
       // Regression guard: a plain "vLinker BM" advert must not be
       // hijacked by the BM+ matcher — the "+" is the distinguishing

--- a/test/features/vehicle/providers/obd2_vin_reader_provider_test.dart
+++ b/test/features/vehicle/providers/obd2_vin_reader_provider_test.dart
@@ -15,19 +15,19 @@ import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
 import 'package:tankstellen/features/vehicle/data/obd2_vin_reader.dart';
 import 'package:tankstellen/features/vehicle/providers/obd2_vin_reader_provider.dart';
 
-/// Unit tests for [Obd2VinReaderService] (#1162, Refs #561).
+/// Unit tests for [Obd2VinReaderService] (#1162, Refs #561, #1351).
 ///
 /// The underlying [Obd2VinReader] already has direct coverage in
 /// `test/features/vehicle/data/obd2_vin_reader_test.dart`. This file
 /// targets the orchestrator wrapper class, which composes
-/// `connectBest` + `Obd2VinReader.read` + `disconnect` and was
+/// `connectByMac` + `Obd2VinReader.read` + `disconnect` and was
 /// previously only exercised through widget-test overrides — the
 /// production `Obd2VinReaderService` itself had zero direct coverage.
 ///
 /// Cases:
-///   1. `connectBest` returns null (no scan run yet) → io failure,
+///   1. `connectByMac` returns null (adapter out of range) → io failure,
 ///      no errorLogger entry (this branch deliberately skips logging).
-///   2. `connectBest` throws (permission denied / scan timeout / ...)
+///   2. `connectByMac` throws (permission denied / scan timeout / ...)
 ///      → io failure AND an errorLogger entry with
 ///      `op: 'vinReaderService.readVin'` + `reason: 'connect'`.
 ///   3. Happy path: a fake `Obd2Service` (real class over a
@@ -37,6 +37,9 @@ import 'package:tankstellen/features/vehicle/providers/obd2_vin_reader_provider.
 ///   4. Read-failure path: the transport returns `NO DATA` → result
 ///      is `unsupported` AND `disconnect` was still called (proves
 ///      the `finally` block runs even when the read fails).
+///   5. The `pairedAdapterMac` argument is forwarded to
+///      `connectByMac` verbatim (#1351 — without this guard the
+///      orchestrator would silently connect to the wrong adapter).
 void main() {
   // Wire the global errorLogger to an in-memory recorder so the
   // failure-path branches don't try to spool through Hive (which is
@@ -56,11 +59,11 @@ void main() {
 
   group('Obd2VinReaderService.readVin', () {
     test(
-      'returns failure(io) when connectBest yields null '
-      '(no scan has run yet) and does NOT log an error',
+      'returns failure(io) when connectByMac yields null '
+      '(adapter out of range) and does NOT log an error',
       () async {
         final connection = _FakeObd2ConnectionService(
-          connectBestResult: null,
+          connectByMacResult: null,
         );
         final service = Obd2VinReaderService(connection: connection);
 
@@ -73,13 +76,13 @@ void main() {
         // The null branch deliberately surfaces a typed failure
         // without logging — only the catch path logs.
         expect(recorder.records, isEmpty);
-        expect(connection.connectBestCalls, 1);
+        expect(connection.connectByMacCalls, 1);
       },
     );
 
     test(
       'returns failure(io) and logs the connect error when '
-      'connectBest throws',
+      'connectByMac throws',
       () async {
         final connection = _FakeObd2ConnectionService(
           throwOnConnect: Exception('bluetooth permission denied'),
@@ -92,7 +95,7 @@ void main() {
 
         expect(result.isSuccess, isFalse);
         expect(result.failure, ObdVinFailureReason.io);
-        expect(connection.connectBestCalls, 1);
+        expect(connection.connectByMacCalls, 1);
         // The catch path MUST log the error so a failing connect is
         // diagnosable. The wrapped error stringifies with the layer
         // and context map (#1104 contract) — assert on those markers.
@@ -101,6 +104,30 @@ void main() {
         expect(logged, contains('background'));
         expect(logged, contains('vinReaderService.readVin'));
         expect(logged, contains('connect'));
+      },
+    );
+
+    test(
+      'forwards pairedAdapterMac verbatim into connectByMac (#1351)',
+      () async {
+        // Regression guard for #1351: the previous implementation
+        // called connectBest(), which ignored pairedAdapterMac and
+        // routed to the highest-RSSI candidate from the most recent
+        // scan. The fix routes through connectByMac with the user's
+        // paired MAC — verify the argument is plumbed through.
+        const mac = 'D4:E9:5E:A8:CD:7E';
+        final connection = _FakeObd2ConnectionService(
+          connectByMacResult: null,
+        );
+        final service = Obd2VinReaderService(connection: connection);
+
+        await service.readVin(pairedAdapterMac: mac);
+
+        expect(connection.connectByMacCalls, 1);
+        expect(connection.lastConnectByMacArg, mac,
+            reason: 'connectByMac must receive the exact MAC the UI '
+                'passed in — anything else risks connecting to the '
+                'wrong adapter');
       },
     );
 
@@ -124,7 +151,7 @@ void main() {
         final obd2Service = Obd2Service(transport);
 
         final connection = _FakeObd2ConnectionService(
-          connectBestResult: obd2Service,
+          connectByMacResult: obd2Service,
         );
         final service = Obd2VinReaderService(connection: connection);
 
@@ -158,7 +185,7 @@ void main() {
         final obd2Service = Obd2Service(transport);
 
         final connection = _FakeObd2ConnectionService(
-          connectBestResult: obd2Service,
+          connectByMacResult: obd2Service,
         );
         final service = Obd2VinReaderService(connection: connection);
 
@@ -203,11 +230,11 @@ class _CapturingTraceRecorder implements TraceRecorder {
 
 /// Fake [Obd2ConnectionService] wired with the minimum-viable
 /// dependencies its non-virtual super-constructor demands. We only
-/// override `connectBest` — every other method is unused by
+/// override `connectByMac` — every other method is unused by
 /// [Obd2VinReaderService] so the inert defaults are safe.
 class _FakeObd2ConnectionService extends Obd2ConnectionService {
   _FakeObd2ConnectionService({
-    this.connectBestResult,
+    this.connectByMacResult,
     this.throwOnConnect,
   }) : super(
           registry: Obd2AdapterRegistry.defaults(),
@@ -215,25 +242,33 @@ class _FakeObd2ConnectionService extends Obd2ConnectionService {
           bluetooth: _UnusedBluetoothFacade(),
         );
 
-  /// Service to return from [connectBest]. Null reproduces the
-  /// "no scan run yet" branch.
-  final Obd2Service? connectBestResult;
+  /// Service to return from [connectByMac]. Null reproduces the
+  /// "adapter out of range" branch.
+  final Obd2Service? connectByMacResult;
 
-  /// When non-null, [connectBest] throws this object instead of
+  /// When non-null, [connectByMac] throws this object instead of
   /// returning a service — used to drive the orchestrator's catch
   /// path.
   final Object? throwOnConnect;
 
-  /// Number of [connectBest] calls; lets tests assert the
+  /// Number of [connectByMac] calls; lets tests assert the
   /// orchestrator actually attempted a connect.
-  int connectBestCalls = 0;
+  int connectByMacCalls = 0;
+
+  /// Last MAC argument passed to [connectByMac] — lets tests verify
+  /// the orchestrator forwards `pairedAdapterMac` verbatim.
+  String? lastConnectByMacArg;
 
   @override
-  Future<Obd2Service?> connectBest() async {
-    connectBestCalls++;
+  Future<Obd2Service?> connectByMac(
+    String mac, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    connectByMacCalls++;
+    lastConnectByMacArg = mac;
     final err = throwOnConnect;
     if (err != null) throw err;
-    return connectBestResult;
+    return connectByMacResult;
   }
 }
 


### PR DESCRIPTION
## Summary

Two related OBD2 bugs reported during 2026-05-02 device testing.

**#1349 — OBD2 picker hid `vLinker BM-Android`.** Registry carried only a `vlinker-bm-plus` profile whose matchers required a literal `+`; the user's BM-Android variant didn''t match any matcher and fell through to "not an OBD2 adapter". Added a `vlinker-bm-android-classic` profile (Classic SPP, matchers `['vlinker bm-android', 'vlink bm-android']`) ordered after `vlinker-bm-plus` so the `+` precedence still wins for BM+ devices.

**#1351 — ""Lire le VIN depuis la voiture"" never connected to the paired adapter.** `Obd2VinReaderService.readVin` called `connectBest()`, which depends on a fresh scan having populated `_lastRanked` AND ignored the `pairedAdapterMac` parameter entirely. Trace export shows the call either returning null (`io` failure) or throwing `Obd2AdapterUnresponsive`. Routed through `connectByMac(pairedAdapterMac)` which owns its own short scan window and short-circuits on the pinned MAC.

Closes #1349
Closes #1351

## Test plan
- [x] `flutter test test/features/consumption/data/obd2/adapter_registry_test.dart` — 31 tests pass (29 pre-existing + 2 new)
- [x] `flutter test test/features/vehicle/providers/obd2_vin_reader_provider_test.dart` — 5 tests pass (4 pre-existing + 1 new MAC-forwarding regression guard)
- [x] `flutter test test/features/consumption/data/obd2/ test/features/vehicle/` — 1135 tests pass
- [x] `flutter analyze` — no issues
- [ ] Device test (#1349) — confirm the picker now lists `vLinker BM-Android` alongside `vLinker FS 14884` and `SmartOBD`
- [ ] Device test (#1351) — with paired vLinker FS 14884 and ignition on, tap **Lire le VIN depuis la voiture**; confirm a VIN string is returned and fills the field

## Out of scope (separate issues)
- #1350 — ""Associer un adaptateur"" CTA on auto-record banner navigates to `/setup` instead of pairing inline (own PR)
- #1352 — recurring `PlatformException(""No active stream to cancel"")` (own PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)