### PR TITLE
fix(map): instrument cold-start tile-grey paths + tighten layout gate (Refs #1316 phase 1)

### DIFF
--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -73,6 +73,32 @@ import '../widgets/route_map_view.dart';
 ///      legitimately have no upstream data continue to render `--` (the
 ///      `priceColor(null,…)` grey signals "no data" — already distinct
 ///      from the loading state).
+///
+/// ## Cold-start one-shot bump (#1316 phase 1)
+///
+/// The 5-fix stack above (#473/#498/#709/#1164/#1268) regressed
+/// because none of the rebuild triggers fire when the user opens the
+/// app DIRECTLY onto the Carte tab (e.g. `last_visited_tab = Carte`
+/// restored from disk). The [currentShellBranchProvider] listener at
+/// the top of [build] only fires on TRANSITIONS to branch 1 — the
+/// initial render at branch 1 is not a transition, so it is silent.
+/// The lifecycle observer only fires on resume from background, not
+/// on first launch. The [LayoutBuilder] gate prevents degenerate
+/// constraints from reaching TileLayer but cannot recover if a 1×1
+/// Android placeholder pass slips through (see the gate threshold
+/// below).
+///
+/// Phase 1 adds a one-shot incarnation bump on the first build that
+/// observes `currentShellBranchProvider == _mapBranchIndex`. This
+/// mirrors the tab-flip rebuild pattern (controller swap, dispose
+/// after next frame) and is guarded by [_coldStartBumpFired] so it
+/// fires exactly once per [_MapScreenState] instance. Phase 1 also
+/// scatters [debugPrint] breadcrumbs across every cold-start path
+/// (tagged `[map-cold-start]`, `[map-layout]`, `[map-incarn]`,
+/// `[map-lifecycle]`, `[map-branch]`) so a `adb logcat | grep map-`
+/// during a repro yields actionable evidence — the issue body
+/// explicitly calls out "a diagnostic logging pass before any 'fix'
+/// is the right move".
 class MapScreen extends ConsumerStatefulWidget {
   const MapScreen({super.key, this.clockOverride});
 
@@ -112,11 +138,24 @@ class _MapScreenState extends ConsumerState<MapScreen>
   /// [_resumeRefreshThreshold].
   DateTime? _pausedAt;
 
+  /// Guard for the cold-start one-shot incarnation bump (#1316 phase
+  /// 1). Set to `true` the first time [build] observes
+  /// `currentShellBranchProvider == _mapBranchIndex`, which schedules
+  /// a single post-frame controller swap so TileLayer re-runs its
+  /// first-layout pass against real constraints. Subsequent builds
+  /// skip the bump — repeat tab visits are covered by the
+  /// [currentShellBranchProvider] listener.
+  bool _coldStartBumpFired = false;
+
   @override
   void initState() {
     super.initState();
     _mapController = MapController();
     WidgetsBinding.instance.addObserver(this);
+    debugPrint(
+      '[map-lifecycle] initState — incarnation=$_mapIncarnation, '
+      'observer attached',
+    );
   }
 
   @override
@@ -131,6 +170,7 @@ class _MapScreenState extends ConsumerState<MapScreen>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
+    debugPrint('[map-lifecycle] state=$state, pausedAt=$_pausedAt');
     if (state == AppLifecycleState.resumed) {
       _onAppResumed();
     } else if (state == AppLifecycleState.paused ||
@@ -153,19 +193,43 @@ class _MapScreenState extends ConsumerState<MapScreen>
     final pausedAt = _pausedAt;
     _pausedAt = null;
     if (!mounted) return;
-    if (pausedAt == null) return;
-    if (_now().difference(pausedAt) < _resumeRefreshThreshold) {
+    if (pausedAt == null) {
+      debugPrint('[map-lifecycle] resume skipped: no pausedAt timestamp');
+      return;
+    }
+    final pauseDuration = _now().difference(pausedAt);
+    if (pauseDuration < _resumeRefreshThreshold) {
+      debugPrint(
+        '[map-lifecycle] resume skipped: pauseDuration=$pauseDuration '
+        '< threshold=$_resumeRefreshThreshold',
+      );
       return;
     }
     final currentBranch = ref.read(currentShellBranchProvider);
-    if (currentBranch != _mapBranchIndex) return;
+    if (currentBranch != _mapBranchIndex) {
+      debugPrint(
+        '[map-lifecycle] resume skipped: currentBranch=$currentBranch '
+        '(not on Carte=$_mapBranchIndex)',
+      );
+      return;
+    }
+    debugPrint(
+      '[map-lifecycle] resume firing refresh: pauseDuration=$pauseDuration, '
+      'incarnation=$_mapIncarnation -> ${_mapIncarnation + 1}',
+    );
 
+    // App-resume rebuild also covers the cold-start case; mark the
+    // one-shot as fired so the next [build] doesn't pile on.
+    _coldStartBumpFired = true;
     final old = _mapController;
     try {
       setState(() {
         _mapController = MapController();
         _mapIncarnation++;
       });
+      debugPrint(
+        '[map-incarn] bumped to $_mapIncarnation (trigger: app-resume)',
+      );
     } catch (e, st) {
       debugPrint('MapScreen rebuild on app-resume: $e\n$st');
     }
@@ -188,9 +252,21 @@ class _MapScreenState extends ConsumerState<MapScreen>
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<int>(currentShellBranchProvider, (_, next) {
-      const mapBranchIndex = 1;
-      if (next != mapBranchIndex) return;
+    ref.listen<int>(currentShellBranchProvider, (previous, next) {
+      debugPrint(
+        '[map-branch] listener fired: $previous -> $next '
+        '(mapBranch=$_mapBranchIndex, incarnation=$_mapIncarnation)',
+      );
+      if (next != _mapBranchIndex) {
+        debugPrint(
+          '[map-branch] skipped rebuild: next=$next is not mapBranch',
+        );
+        return;
+      }
+      // A tab-flip rebuild already covers the cold-start case — mark
+      // the one-shot as fired so the post-flip [build] doesn't pile a
+      // second redundant rebuild on top.
+      _coldStartBumpFired = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         final old = _mapController;
@@ -199,6 +275,9 @@ class _MapScreenState extends ConsumerState<MapScreen>
             _mapController = MapController();
             _mapIncarnation++;
           });
+          debugPrint(
+            '[map-incarn] bumped to $_mapIncarnation (trigger: tab-flip)',
+          );
         } catch (e, st) {
           debugPrint('MapScreen rebuild on tab-flip: $e\n$st');
         }
@@ -213,6 +292,46 @@ class _MapScreenState extends ConsumerState<MapScreen>
         });
       });
     });
+
+    // #1316 phase 1 — cold-start one-shot incarnation bump. Covers the
+    // case where the user opens the app directly onto Carte (no tab
+    // flip → the listener above stays silent → TileLayer keeps any
+    // degenerate constraints captured during the IndexedStack
+    // pre-mount). Mirrors the tab-flip rebuild pattern (controller
+    // swap + dispose on next frame). Guarded by [_coldStartBumpFired]
+    // so it fires exactly once per [_MapScreenState] instance.
+    final currentBranch = ref.read(currentShellBranchProvider);
+    if (!_coldStartBumpFired && currentBranch == _mapBranchIndex) {
+      _coldStartBumpFired = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        debugPrint(
+          '[map-cold-start] firing one-shot incarnation bump on first '
+          'Carte build',
+        );
+        final old = _mapController;
+        try {
+          setState(() {
+            _mapController = MapController();
+            _mapIncarnation++;
+          });
+          debugPrint(
+            '[map-incarn] bumped to $_mapIncarnation (trigger: cold-start)',
+          );
+        } catch (e, st) {
+          debugPrint('MapScreen rebuild on cold-start: $e\n$st');
+        }
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          try {
+            old.dispose();
+          } catch (e, st) {
+            debugPrint(
+              'MapScreen old controller dispose on cold-start: $e\n$st',
+            );
+          }
+        });
+      });
+    }
 
     final searchState = ref.watch(searchStateProvider);
     final selectedFuel = ref.watch(selectedFuelTypeProvider);
@@ -230,7 +349,19 @@ class _MapScreenState extends ConsumerState<MapScreen>
     // visits.
     final body = LayoutBuilder(
       builder: (context, constraints) {
-        if (constraints.maxWidth <= 0 || constraints.maxHeight <= 0) {
+        // #1316: Some Android layout passes use a 1×1 placeholder before the
+        // real constraints arrive — the prior `<= 0` gate let those through
+        // and TileLayer captured a degenerate viewport. Require at least
+        // 100px on each axis so the gate covers placeholder constraints too.
+        final suppressed = constraints.maxWidth < 100 ||
+            constraints.maxHeight < 100;
+        debugPrint(
+          '[map-layout] LayoutBuilder constraints='
+          '${constraints.maxWidth.toStringAsFixed(1)}x'
+          '${constraints.maxHeight.toStringAsFixed(1)}, '
+          'suppressed=$suppressed, incarnation=$_mapIncarnation',
+        );
+        if (suppressed) {
           return const SizedBox.shrink();
         }
         return KeyedSubtree(

--- a/test/features/map/presentation/screens/map_screen_test.dart
+++ b/test/features/map/presentation/screens/map_screen_test.dart
@@ -447,6 +447,152 @@ void main() {
     );
 
     testWidgets(
+      'cold-start on Carte tab fires a one-shot incarnation bump on first '
+      'frame (#1316 phase 1 — last_visited_tab=Carte path)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const MapScreen(),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+            // Pre-seed the shell branch as Carte (1) — this simulates the
+            // app being relaunched onto its last-visited tab.
+            currentShellBranchProvider.overrideWith(
+              () => _CarteBranchSeed(),
+            ),
+          ],
+        );
+
+        int currentIncarnation() {
+          final subtree = tester
+              .widgetList<KeyedSubtree>(
+                find.descendant(
+                  of: find.byType(MapScreen),
+                  matching: find.byType(KeyedSubtree),
+                ),
+              )
+              .firstWhere((w) => w.key is ValueKey<int>);
+          return (subtree.key as ValueKey<int>).value;
+        }
+
+        // After the initial pumpApp (which calls pumpAndSettle inside),
+        // the one-shot post-frame callback has already fired and the
+        // incarnation should be greater than the initial 0. Without the
+        // cold-start bump, the incarnation would stay at 0 and TileLayer
+        // would never re-run its first-layout pass against real
+        // constraints.
+        expect(
+          currentIncarnation(),
+          greaterThan(0),
+          reason:
+              'On cold-start with currentShellBranchProvider already at the '
+              'Carte branch (no tab-flip transition), MapScreen must still '
+              'fire a one-shot incarnation bump so the FlutterMap subtree '
+              'gets rebuilt with real post-layout constraints (#1316).',
+        );
+      },
+    );
+
+    testWidgets(
+      'cold-start one-shot bump fires only once per State instance '
+      '(#1316 phase 1 — guard against repeated rebuilds)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const MapScreen(),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+            currentShellBranchProvider.overrideWith(
+              () => _CarteBranchSeed(),
+            ),
+          ],
+        );
+
+        int currentIncarnation() {
+          final subtree = tester
+              .widgetList<KeyedSubtree>(
+                find.descendant(
+                  of: find.byType(MapScreen),
+                  matching: find.byType(KeyedSubtree),
+                ),
+              )
+              .firstWhere((w) => w.key is ValueKey<int>);
+          return (subtree.key as ValueKey<int>).value;
+        }
+
+        final afterColdStart = currentIncarnation();
+
+        // Pump a few additional frames — these would re-enter [build]
+        // and, without the [_coldStartBumpFired] guard, fire the
+        // one-shot again (continuously cancelling tile fetches).
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.pump();
+
+        expect(
+          currentIncarnation(),
+          equals(afterColdStart),
+          reason:
+              'The cold-start one-shot must fire exactly once per State '
+              'instance — repeated bumps on every build would cancel the '
+              'tile fetches that the bump itself just kicked off (#1316).',
+        );
+      },
+    );
+
+    testWidgets(
+      'LayoutBuilder gate suppresses FlutterMap when constraints are below '
+      '100px on either axis (#1316 phase 1 — Android placeholder pass)',
+      (tester) async {
+        // Force the body LayoutBuilder to receive constraints well
+        // below the new 100px threshold but keep enough total viewport
+        // height for the AppBar so we are NOT measuring AppBar
+        // overflow. AppBar takes ~56px; with a 130px-tall viewport,
+        // the body's Expanded gets ~74px — below 100 → must be
+        // suppressed. Width is wide enough (600) that the AppBar
+        // chrome fits.
+        tester.view.physicalSize = const Size(600, 130);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const MapScreen(),
+          overrides: [
+            ...test.overrides,
+            userPositionNullOverride(),
+            searchStateProvider.overrideWith(
+              () => _LoadedSearchState(const [_seedStation]),
+            ),
+          ],
+        );
+
+        expect(
+          find.byType(FlutterMap),
+          findsNothing,
+          reason:
+              'LayoutBuilder gate must suppress FlutterMap below the 100px '
+              'threshold so Android placeholder layout passes never reach '
+              'TileLayer with degenerate constraints (#1316). With a 130px '
+              'viewport and a 56px AppBar, the body gets ~74px height — '
+              'below the threshold and therefore suppressed.',
+        );
+      },
+    );
+
+    testWidgets(
       'app-resume on a non-Carte tab does NOT rebuild FlutterMap '
       '(#1268 — only refresh when Carte is visible)',
       (tester) async {
@@ -521,6 +667,15 @@ class _LoadedSearchState extends SearchState {
           fetchedAt: DateTime.now(),
         ),
       );
+}
+
+/// Override that seeds [currentShellBranchProvider] at branch 1 (Carte)
+/// from initial state — simulates the cold-start path where
+/// `last_visited_tab = Carte` is restored from disk and no tab-flip
+/// transition is ever observed.
+class _CarteBranchSeed extends CurrentShellBranch {
+  @override
+  int build() => 1;
 }
 
 const _seedStation = Station(


### PR DESCRIPTION
## Summary
Phase 1 of #1316. Two concrete defenses + diagnostic instrumentation against the recurring cold-start grey-tiles regression that the #473/#498/#709/#1164/#1268 stack hasn't fully resolved.

- **Tighten LayoutBuilder gate** from `<= 0` to `< 100` — catches Android 1×1 placeholder constraints that slipped past the prior `<= 0` check.
- **Force one-shot incarnation bump** on first frame on the Carte tab — covers the cold-start path where the user lands directly on the map without a tab-flip (the prior fix relied on tab-flip to nudge).
- **Diagnostic `debugPrint` breadcrumbs** on every cold-start path so the next user repro produces actionable data instead of "still grey, still no logs".

## Scope
- `lib/features/map/presentation/screens/map_screen.dart` — gate tightening + first-frame incarnation bump + breadcrumbs
- `test/features/map/presentation/screens/map_screen_test.dart` — 155 lines of new tests covering both fixes

Phase 2 (separate PR if breadcrumbs reveal new root cause) will follow once we have a fresh repro.

Refs #1316 — issue stays open for phase 2.

## Test plan
- [ ] CI green (analyze + test)
- [ ] Cold-start app on Samsung device, land directly on Carte → tiles render
- [ ] Watch breadcrumb output via `adb logcat | grep map_screen` if regression returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)