### PR TITLE
fix(vehicle): pair adapter inline from auto-record banner CTA (Closes #1350)

### DIFF
--- a/lib/features/vehicle/presentation/widgets/auto_record_section.dart
+++ b/lib/features/vehicle/presentation/widgets/auto_record_section.dart
@@ -6,6 +6,8 @@ import 'package:permission_handler/permission_handler.dart';
 import '../../../../core/logging/error_logger.dart';
 import '../../../../core/widgets/section_card.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/data/obd2/adapter_registry.dart';
+import '../../../consumption/presentation/widgets/obd2_adapter_picker.dart';
 import '../../domain/entities/vehicle_profile.dart';
 import '../../providers/vehicle_providers.dart';
 
@@ -65,11 +67,21 @@ class AutoRecordSection extends ConsumerWidget {
   final Future<void> Function()? openSettings;
 
   /// Hook invoked when the user taps the "Pair an adapter" CTA on the
-  /// state-aware status banner (#1310). Null defers to the production
-  /// behaviour — push `/setup` (the OBD2 onboarding wizard) via
-  /// [GoRouter]. Tests inject a counter to assert the navigation
-  /// without a router.
+  /// state-aware status banner (#1310). When supplied this hook fully
+  /// owns the CTA — the production picker + persist + `/setup`
+  /// fallback are all skipped. Tests inject a counter to assert the
+  /// CTA dispatched without bringing up the picker. Null defers to
+  /// the production behaviour — open [showObd2AdapterPairer] inline
+  /// and persist the picked adapter onto the current profile (#1350).
   final VoidCallback? onPairAdapter;
+
+  /// Picker seam for [_handlePairAdapter] (#1350). Null defers to the
+  /// production [showObd2AdapterPairer] which mounts the modal sheet
+  /// and resolves with a [ResolvedObd2Candidate] on pick or `null`
+  /// on cancel. Tests inject a stub so the candidate flows into the
+  /// persist path without binding the OBD2 stack.
+  final Future<ResolvedObd2Candidate?> Function(BuildContext)?
+      showAdapterPicker;
 
   const AutoRecordSection({
     super.key,
@@ -78,6 +90,7 @@ class AutoRecordSection extends ConsumerWidget {
     this.requestForegroundLocation,
     this.openSettings,
     this.onPairAdapter,
+    this.showAdapterPicker,
   });
 
   static Future<PermissionStatus> _defaultRequestBackgroundLocation() {
@@ -138,7 +151,11 @@ class AutoRecordSection extends ConsumerWidget {
               state: _statusFor(profile),
               theme: theme,
               l: l,
-              onPairAdapter: () => _handlePairAdapter(context),
+              onPairAdapter: () => _handlePairAdapter(
+                context: context,
+                ref: ref,
+                profile: profile,
+              ),
             ),
             const SizedBox(height: 16),
             _SpeedThresholdSlider(
@@ -211,26 +228,91 @@ class AutoRecordSection extends ConsumerWidget {
   }
 
   /// "Pair an adapter" CTA on the [_AutoRecordStatus.needsPairing]
-  /// banner. Defers to the injected [onPairAdapter] (tests) when
-  /// supplied; falls back to `GoRouter.go('/setup')` so the user
-  /// lands on the OBD2 onboarding wizard. There is no standalone
-  /// "pair an adapter" route — the wizard's OBD2 step is the
-  /// closest reachable surface that runs the picker AND persists
-  /// `pairedAdapterMac` (#1310).
-  void _handlePairAdapter(BuildContext context) {
+  /// banner.
+  ///
+  /// Behaviour (#1350):
+  ///   1. If [onPairAdapter] is injected (tests) it fully owns the
+  ///      tap — invoked and returned, no picker, no fallback.
+  ///   2. Otherwise open [showObd2AdapterPairer] (or the injected
+  ///      [showAdapterPicker] seam) inline. On a non-null result,
+  ///      persist `pairedAdapterMac` + `obd2AdapterMac` +
+  ///      `obd2AdapterName` onto the current profile so the banner
+  ///      flips to `active` (or `needsBackgroundLocation`) on the
+  ///      next rebuild.
+  ///   3. On cancel (null result) OR on picker exception, fall back
+  ///      to `GoRouter.go('/setup')` per the issue spec — the user
+  ///      asked to pair, so route them somewhere that still surfaces
+  ///      the wizard rather than silently dropping the tap.
+  ///
+  /// Pre-#1350 the production fallback ALWAYS routed to `/setup`
+  /// even on a successful pick, sending the user into an unrelated
+  /// onboarding wizard whose result landed on a freshly-saved
+  /// profile rather than the vehicle they were editing. The picker
+  /// is now invoked inline and writes back to the right profile.
+  Future<void> _handlePairAdapter({
+    required BuildContext context,
+    required WidgetRef ref,
+    required VehicleProfile profile,
+  }) async {
     final hook = onPairAdapter;
     if (hook != null) {
       hook();
       return;
     }
-    // Production fallback — push the onboarding wizard. Best-effort:
-    // if the router context is missing (isolated widget pump without
-    // a router) we silently no-op rather than throw, so the surface
-    // remains testable.
+    final picker = showAdapterPicker ?? showObd2AdapterPairer;
+    ResolvedObd2Candidate? result;
+    try {
+      result = await picker(context);
+    } catch (e, st) {
+      // Surface picker failures via debugPrint (cheap, test-safe — the
+      // structured `errorLogger` opens a Hive box that isolated widget
+      // pumps don't initialise). No silent catch — body has a log
+      // statement so `no_silent_catch_test` stays green.
+      debugPrint(
+        'AutoRecordSection: pair-adapter picker failed: $e\n$st',
+      );
+      if (!context.mounted) return;
+      _navigateToSetupFallback(context);
+      return;
+    }
+    if (result == null) {
+      // User cancelled the picker. Per the #1350 spec the `/setup`
+      // fallback fires here so the user has SOMEWHERE to land — the
+      // CTA must never feel like a no-op.
+      if (!context.mounted) return;
+      _navigateToSetupFallback(context);
+      return;
+    }
+    final mac = result.candidate.deviceId;
+    final name = result.candidate.deviceName.isEmpty
+        ? result.profile.displayName
+        : result.candidate.deviceName;
+    await _persist(
+      ref,
+      profile.copyWith(
+        pairedAdapterMac: mac,
+        obd2AdapterMac: mac,
+        obd2AdapterName: name,
+      ),
+    );
+  }
+
+  /// Best-effort `/setup` route push used as the cancel/error
+  /// fallback for [_handlePairAdapter]. A missing router context
+  /// (isolated widget pump) is logged via [debugPrint] rather than
+  /// thrown so the surface stays testable. We deliberately avoid the
+  /// structured [errorLogger] here because it opens a Hive box and
+  /// widget tests that pump this section without initialising Hive
+  /// would fail noisily on what is otherwise a benign test-pump
+  /// shape.
+  void _navigateToSetupFallback(BuildContext context) {
     try {
       GoRouter.of(context).go('/setup');
     } catch (e, st) {
-      debugPrint('AutoRecordSection: pair-adapter navigation failed: $e\n$st');
+      // No silent catch — body logs the failure.
+      debugPrint(
+        'AutoRecordSection: pair-adapter setup-fallback nav failed: $e\n$st',
+      );
     }
   }
 

--- a/test/features/vehicle/presentation/widgets/auto_record_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/auto_record_section_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/presentation/widgets/auto_record_section.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
@@ -42,6 +43,7 @@ Future<_FakeVehicleProfileList> _pumpSection(
   Future<PermissionStatus> Function()? requestForegroundLocation,
   Future<void> Function()? openSettings,
   VoidCallback? onPairAdapter,
+  Future<ResolvedObd2Candidate?> Function(BuildContext)? showAdapterPicker,
 }) async {
   // Tall canvas so the slider/banner stack does not overflow when the
   // master toggle is on. Mirror the size used by the extras section
@@ -60,6 +62,7 @@ Future<_FakeVehicleProfileList> _pumpSection(
         requestForegroundLocation: requestForegroundLocation,
         openSettings: openSettings,
         onPairAdapter: onPairAdapter,
+        showAdapterPicker: showAdapterPicker,
       ),
     ),
     overrides: [
@@ -67,6 +70,28 @@ Future<_FakeVehicleProfileList> _pumpSection(
     ],
   );
   return list;
+}
+
+/// Build a [ResolvedObd2Candidate] for the picker stub. Mirrors the
+/// shape produced by the real BLE/Classic scanner so the persist
+/// path receives the same `(deviceId, deviceName, profile)` tuple
+/// it would in production.
+ResolvedObd2Candidate _candidate({
+  String mac = 'AA:BB:CC:DD:EE:FF',
+  String name = 'vLinker FS 1234',
+}) {
+  return ResolvedObd2Candidate(
+    candidate: Obd2AdapterCandidate(
+      deviceId: mac,
+      deviceName: name,
+      advertisedServiceUuids: const [],
+      rssi: -55,
+    ),
+    profile: const Obd2AdapterProfile(
+      id: 'vlinker-fs-classic',
+      displayName: 'vLinker FS (Classic)',
+    ),
+  );
 }
 
 void main() {
@@ -518,8 +543,8 @@ void main() {
     );
 
     testWidgets(
-      'tapping the "Pair an adapter" CTA navigates to /setup '
-      '(GoRouter wrapper)',
+      'tapping the "Pair an adapter" CTA falls back to /setup when the '
+      'picker is cancelled (GoRouter wrapper) — #1350',
       (tester) async {
         // Tall canvas so the banner + sliders fit without overflow.
         tester.view.physicalSize = const Size(900, 2400);
@@ -531,14 +556,24 @@ void main() {
           const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
         ]);
 
+        // Stub picker that simulates user cancel (null result). Per the
+        // #1350 spec the /setup fallback fires on cancel so the CTA
+        // still has somewhere to land.
+        Future<ResolvedObd2Candidate?> cancelledPicker(BuildContext _) async {
+          return null;
+        }
+
         final router = GoRouter(
           initialLocation: '/edit',
           routes: [
             GoRoute(
               path: '/edit',
-              builder: (_, _) => const Scaffold(
+              builder: (_, _) => Scaffold(
                 body: SingleChildScrollView(
-                  child: AutoRecordSection(vehicleId: 'v1'),
+                  child: AutoRecordSection(
+                    vehicleId: 'v1',
+                    showAdapterPicker: cancelledPicker,
+                  ),
                 ),
               ),
             ),
@@ -587,6 +622,173 @@ void main() {
           router.routerDelegate.currentConfiguration.uri.toString(),
           '/setup',
         );
+        // Cancel must NOT persist anything onto the profile.
+        expect(list.savedProfiles, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'tapping the "Pair an adapter" CTA persists the picked adapter '
+      'onto the current profile (#1350 happy path)',
+      (tester) async {
+        final list = _FakeVehicleProfileList([
+          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
+        ]);
+
+        Future<ResolvedObd2Candidate?> pickerStub(BuildContext _) async {
+          return _candidate(
+            mac: 'DE:AD:BE:EF:00:01',
+            name: 'vLinker FS 9000',
+          );
+        }
+
+        await _pumpSection(
+          tester,
+          vehicleId: 'v1',
+          list: list,
+          showAdapterPicker: pickerStub,
+        );
+
+        // Sanity — needsPairing banner is up before the tap.
+        expect(
+          find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
+          findsOneWidget,
+        );
+
+        await tester.tap(
+          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
+        );
+        // Bounded pumps — the picker stub resolves synchronously but
+        // the persist + rebuild needs at least one frame.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Repository got exactly one save call carrying the picked
+        // adapter's MAC + name on the original profile.
+        expect(list.savedProfiles, hasLength(1));
+        final saved = list.savedProfiles.single;
+        expect(saved.id, 'v1');
+        expect(saved.name, 'Golf');
+        expect(saved.autoRecord, isTrue);
+        expect(saved.pairedAdapterMac, 'DE:AD:BE:EF:00:01');
+        expect(saved.obd2AdapterMac, 'DE:AD:BE:EF:00:01');
+        expect(saved.obd2AdapterName, 'vLinker FS 9000');
+
+        // After persist the banner flips off needsPairing — the
+        // backgroundLocationConsent gate is still missing so we land
+        // on needsBackgroundLocation, not active.
+        expect(
+          find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
+          findsNothing,
+        );
+        expect(
+          find.byKey(const Key('autoRecordStatusBannerNeedsBackgroundLocation')),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'happy path uses the registry display name when the candidate '
+      'advertises an empty deviceName (#1350)',
+      (tester) async {
+        final list = _FakeVehicleProfileList([
+          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
+        ]);
+
+        Future<ResolvedObd2Candidate?> pickerStub(BuildContext _) async {
+          return _candidate(
+            mac: '11:22:33:44:55:66',
+            name: '', // empty advertised name → fall back to profile.displayName
+          );
+        }
+
+        await _pumpSection(
+          tester,
+          vehicleId: 'v1',
+          list: list,
+          showAdapterPicker: pickerStub,
+        );
+
+        await tester.tap(
+          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(list.savedProfiles, hasLength(1));
+        expect(list.savedProfiles.single.obd2AdapterName,
+            'vLinker FS (Classic)');
+        expect(list.savedProfiles.single.pairedAdapterMac,
+            '11:22:33:44:55:66');
+      },
+    );
+
+    testWidgets(
+      'cancel path (picker returns null) does NOT persist anything '
+      '(#1350)',
+      (tester) async {
+        final list = _FakeVehicleProfileList([
+          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
+        ]);
+
+        Future<ResolvedObd2Candidate?> cancelledPicker(BuildContext _) async {
+          return null;
+        }
+
+        await _pumpSection(
+          tester,
+          vehicleId: 'v1',
+          list: list,
+          showAdapterPicker: cancelledPicker,
+        );
+
+        await tester.tap(
+          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(list.savedProfiles, isEmpty);
+        // Banner stays on needsPairing — the user cancelled.
+        expect(
+          find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'onPairAdapter test hook still takes precedence over the picker '
+      'when supplied (#1350)',
+      (tester) async {
+        final list = _FakeVehicleProfileList([
+          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
+        ]);
+        var hookCalls = 0;
+        var pickerCalls = 0;
+
+        await _pumpSection(
+          tester,
+          vehicleId: 'v1',
+          list: list,
+          onPairAdapter: () => hookCalls++,
+          showAdapterPicker: (_) async {
+            pickerCalls++;
+            return null;
+          },
+        );
+
+        await tester.tap(
+          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(hookCalls, 1);
+        expect(pickerCalls, 0,
+            reason: 'onPairAdapter must short-circuit the picker path');
+        expect(list.savedProfiles, isEmpty);
       },
     );
 


### PR DESCRIPTION
## Summary

- `_handlePairAdapter` on the auto-record banner now invokes `showObd2AdapterPairer(context)` inline and persists the picked adapter's MAC + name onto the current `VehicleProfile`. Pre-fix it routed into the OBD2 onboarding wizard, whose result landed on a freshly saved profile rather than the vehicle being edited — so from the user's POV the CTA did nothing.
- The `/setup` fallback now fires only on cancel or picker exception, per the issue spec.
- The injected `onPairAdapter` test hook still short-circuits the picker.
- Adds a `showAdapterPicker` seam so widget tests can stub the picker without binding the OBD2 stack.

## Test plan

- [x] `flutter analyze` — zero warnings
- [x] `flutter test test/features/vehicle/presentation/widgets/auto_record_section_test.dart` — 22/22 pass (4 new #1350 cases: happy path, empty-deviceName fallback, cancel path, hook-precedence)
- [x] `flutter test test/lint/no_silent_catch_test.dart` — green
- [ ] Device-test on a real vehicle-edit screen: tap CTA → pick adapter → banner flips off `needsPairing`

Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)