### PR TITLE
docs(readme): add Google Play badge linking to the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Flutter](https://img.shields.io/badge/Flutter-3.41-blue.svg)](https://flutter.dev)
 
+<a href="https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices">
+  <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" height="80"/>
+</a>
+
 **A free, open-source companion app for cutting the running cost of your car.** 11 countries, 23 languages, privacy-first, no ads, no tracking.
 
 Tankstellen aggregates real-time fuel prices from official government APIs, plugs into your car's OBD-II port to see how it actually drives, and keeps a tidy log of every fill-up and trip so the savings stop being theoretical.


### PR DESCRIPTION
## Summary
Adds the standard "Get it on Google Play" badge under the existing CI/License/Flutter shields, linking to https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices.

Wiki landing pages received the same badge in a separate wiki commit (`Home.md` + 7 per-language `User-{lang}-Home.md` pages).

## Test plan
- [ ] Badge renders on github.com README
- [ ] Click → Play Store listing (open testing track per memory; users may need to opt-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)