### PR TITLE
feat(consumption): trip-vs-pump reconciliation domain (Refs #1361 phase 2a)

### DIFF
--- a/lib/features/consumption/domain/entities/fill_up.dart
+++ b/lib/features/consumption/domain/entities/fill_up.dart
@@ -47,6 +47,13 @@ abstract class FillUp with _$FillUp {
     /// Existing fill-ups deserialise with the default so historical
     /// data keeps working as full-tank fills.
     @Default(true) bool isFullTank,
+
+    /// Whether this fill-up is an auto-generated correction entry that
+    /// closes the gap between OBD-recorded trip fuel and pumped liters
+    /// over a plein-to-plein window (#1361). Correction entries are
+    /// rendered orange in the fill-up list and are user-editable.
+    /// Defaults `false` so existing fill-ups deserialise unchanged.
+    @Default(false) bool isCorrection,
   }) = _FillUp;
 
   factory FillUp.fromJson(Map<String, dynamic> json) => _$FillUpFromJson(json);

--- a/lib/features/consumption/domain/entities/fill_up.freezed.dart
+++ b/lib/features/consumption/domain/entities/fill_up.freezed.dart
@@ -35,7 +35,12 @@ mixin _$FillUp {
 /// it uses `previous_level + liters_added` (partial top-up).
 /// Existing fill-ups deserialise with the default so historical
 /// data keeps working as full-tank fills.
- bool get isFullTank;
+ bool get isFullTank;/// Whether this fill-up is an auto-generated correction entry that
+/// closes the gap between OBD-recorded trip fuel and pumped liters
+/// over a plein-to-plein window (#1361). Correction entries are
+/// rendered orange in the fill-up list and are user-editable.
+/// Defaults `false` so existing fill-ups deserialise unchanged.
+ bool get isCorrection;
 /// Create a copy of FillUp
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,16 +53,16 @@ $FillUpCopyWith<FillUp> get copyWith => _$FillUpCopyWithImpl<FillUp>(this as Fil
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is FillUp&&(identical(other.id, id) || other.id == id)&&(identical(other.date, date) || other.date == date)&&(identical(other.liters, liters) || other.liters == liters)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.odometerKm, odometerKm) || other.odometerKm == odometerKm)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.stationName, stationName) || other.stationName == stationName)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&const DeepCollectionEquality().equals(other.linkedTripIds, linkedTripIds)&&(identical(other.isFullTank, isFullTank) || other.isFullTank == isFullTank));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FillUp&&(identical(other.id, id) || other.id == id)&&(identical(other.date, date) || other.date == date)&&(identical(other.liters, liters) || other.liters == liters)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.odometerKm, odometerKm) || other.odometerKm == odometerKm)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.stationName, stationName) || other.stationName == stationName)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&const DeepCollectionEquality().equals(other.linkedTripIds, linkedTripIds)&&(identical(other.isFullTank, isFullTank) || other.isFullTank == isFullTank)&&(identical(other.isCorrection, isCorrection) || other.isCorrection == isCorrection));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,date,liters,totalCost,odometerKm,fuelType,stationId,stationName,notes,vehicleId,const DeepCollectionEquality().hash(linkedTripIds),isFullTank);
+int get hashCode => Object.hash(runtimeType,id,date,liters,totalCost,odometerKm,fuelType,stationId,stationName,notes,vehicleId,const DeepCollectionEquality().hash(linkedTripIds),isFullTank,isCorrection);
 
 @override
 String toString() {
-  return 'FillUp(id: $id, date: $date, liters: $liters, totalCost: $totalCost, odometerKm: $odometerKm, fuelType: $fuelType, stationId: $stationId, stationName: $stationName, notes: $notes, vehicleId: $vehicleId, linkedTripIds: $linkedTripIds, isFullTank: $isFullTank)';
+  return 'FillUp(id: $id, date: $date, liters: $liters, totalCost: $totalCost, odometerKm: $odometerKm, fuelType: $fuelType, stationId: $stationId, stationName: $stationName, notes: $notes, vehicleId: $vehicleId, linkedTripIds: $linkedTripIds, isFullTank: $isFullTank, isCorrection: $isCorrection)';
 }
 
 
@@ -68,7 +73,7 @@ abstract mixin class $FillUpCopyWith<$Res>  {
   factory $FillUpCopyWith(FillUp value, $Res Function(FillUp) _then) = _$FillUpCopyWithImpl;
 @useResult
 $Res call({
- String id, DateTime date, double liters, double totalCost, double odometerKm,@FuelTypeJsonConverter() FuelType fuelType, String? stationId, String? stationName, String? notes, String? vehicleId, List<String> linkedTripIds, bool isFullTank
+ String id, DateTime date, double liters, double totalCost, double odometerKm,@FuelTypeJsonConverter() FuelType fuelType, String? stationId, String? stationName, String? notes, String? vehicleId, List<String> linkedTripIds, bool isFullTank, bool isCorrection
 });
 
 
@@ -85,7 +90,7 @@ class _$FillUpCopyWithImpl<$Res>
 
 /// Create a copy of FillUp
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? date = null,Object? liters = null,Object? totalCost = null,Object? odometerKm = null,Object? fuelType = null,Object? stationId = freezed,Object? stationName = freezed,Object? notes = freezed,Object? vehicleId = freezed,Object? linkedTripIds = null,Object? isFullTank = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? date = null,Object? liters = null,Object? totalCost = null,Object? odometerKm = null,Object? fuelType = null,Object? stationId = freezed,Object? stationName = freezed,Object? notes = freezed,Object? vehicleId = freezed,Object? linkedTripIds = null,Object? isFullTank = null,Object? isCorrection = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
@@ -99,6 +104,7 @@ as String?,notes: freezed == notes ? _self.notes : notes // ignore: cast_nullabl
 as String?,vehicleId: freezed == vehicleId ? _self.vehicleId : vehicleId // ignore: cast_nullable_to_non_nullable
 as String?,linkedTripIds: null == linkedTripIds ? _self.linkedTripIds : linkedTripIds // ignore: cast_nullable_to_non_nullable
 as List<String>,isFullTank: null == isFullTank ? _self.isFullTank : isFullTank // ignore: cast_nullable_to_non_nullable
+as bool,isCorrection: null == isCorrection ? _self.isCorrection : isCorrection // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -184,10 +190,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank,  bool isCorrection)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _FillUp() when $default != null:
-return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank);case _:
+return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank,_that.isCorrection);case _:
   return orElse();
 
 }
@@ -205,10 +211,10 @@ return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerK
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank,  bool isCorrection)  $default,) {final _that = this;
 switch (_that) {
 case _FillUp():
-return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank);case _:
+return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank,_that.isCorrection);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -225,10 +231,10 @@ return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerK
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank,  bool isCorrection)?  $default,) {final _that = this;
 switch (_that) {
 case _FillUp() when $default != null:
-return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank);case _:
+return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank,_that.isCorrection);case _:
   return null;
 
 }
@@ -240,7 +246,7 @@ return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerK
 @JsonSerializable()
 
 class _FillUp implements FillUp {
-  const _FillUp({required this.id, required this.date, required this.liters, required this.totalCost, required this.odometerKm, @FuelTypeJsonConverter() required this.fuelType, this.stationId, this.stationName, this.notes, this.vehicleId, final  List<String> linkedTripIds = const <String>[], this.isFullTank = true}): _linkedTripIds = linkedTripIds;
+  const _FillUp({required this.id, required this.date, required this.liters, required this.totalCost, required this.odometerKm, @FuelTypeJsonConverter() required this.fuelType, this.stationId, this.stationName, this.notes, this.vehicleId, final  List<String> linkedTripIds = const <String>[], this.isFullTank = true, this.isCorrection = false}): _linkedTripIds = linkedTripIds;
   factory _FillUp.fromJson(Map<String, dynamic> json) => _$FillUpFromJson(json);
 
 @override final  String id;
@@ -288,6 +294,12 @@ class _FillUp implements FillUp {
 /// Existing fill-ups deserialise with the default so historical
 /// data keeps working as full-tank fills.
 @override@JsonKey() final  bool isFullTank;
+/// Whether this fill-up is an auto-generated correction entry that
+/// closes the gap between OBD-recorded trip fuel and pumped liters
+/// over a plein-to-plein window (#1361). Correction entries are
+/// rendered orange in the fill-up list and are user-editable.
+/// Defaults `false` so existing fill-ups deserialise unchanged.
+@override@JsonKey() final  bool isCorrection;
 
 /// Create a copy of FillUp
 /// with the given fields replaced by the non-null parameter values.
@@ -302,16 +314,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FillUp&&(identical(other.id, id) || other.id == id)&&(identical(other.date, date) || other.date == date)&&(identical(other.liters, liters) || other.liters == liters)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.odometerKm, odometerKm) || other.odometerKm == odometerKm)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.stationName, stationName) || other.stationName == stationName)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&const DeepCollectionEquality().equals(other._linkedTripIds, _linkedTripIds)&&(identical(other.isFullTank, isFullTank) || other.isFullTank == isFullTank));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FillUp&&(identical(other.id, id) || other.id == id)&&(identical(other.date, date) || other.date == date)&&(identical(other.liters, liters) || other.liters == liters)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.odometerKm, odometerKm) || other.odometerKm == odometerKm)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.stationName, stationName) || other.stationName == stationName)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&const DeepCollectionEquality().equals(other._linkedTripIds, _linkedTripIds)&&(identical(other.isFullTank, isFullTank) || other.isFullTank == isFullTank)&&(identical(other.isCorrection, isCorrection) || other.isCorrection == isCorrection));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,date,liters,totalCost,odometerKm,fuelType,stationId,stationName,notes,vehicleId,const DeepCollectionEquality().hash(_linkedTripIds),isFullTank);
+int get hashCode => Object.hash(runtimeType,id,date,liters,totalCost,odometerKm,fuelType,stationId,stationName,notes,vehicleId,const DeepCollectionEquality().hash(_linkedTripIds),isFullTank,isCorrection);
 
 @override
 String toString() {
-  return 'FillUp(id: $id, date: $date, liters: $liters, totalCost: $totalCost, odometerKm: $odometerKm, fuelType: $fuelType, stationId: $stationId, stationName: $stationName, notes: $notes, vehicleId: $vehicleId, linkedTripIds: $linkedTripIds, isFullTank: $isFullTank)';
+  return 'FillUp(id: $id, date: $date, liters: $liters, totalCost: $totalCost, odometerKm: $odometerKm, fuelType: $fuelType, stationId: $stationId, stationName: $stationName, notes: $notes, vehicleId: $vehicleId, linkedTripIds: $linkedTripIds, isFullTank: $isFullTank, isCorrection: $isCorrection)';
 }
 
 
@@ -322,7 +334,7 @@ abstract mixin class _$FillUpCopyWith<$Res> implements $FillUpCopyWith<$Res> {
   factory _$FillUpCopyWith(_FillUp value, $Res Function(_FillUp) _then) = __$FillUpCopyWithImpl;
 @override @useResult
 $Res call({
- String id, DateTime date, double liters, double totalCost, double odometerKm,@FuelTypeJsonConverter() FuelType fuelType, String? stationId, String? stationName, String? notes, String? vehicleId, List<String> linkedTripIds, bool isFullTank
+ String id, DateTime date, double liters, double totalCost, double odometerKm,@FuelTypeJsonConverter() FuelType fuelType, String? stationId, String? stationName, String? notes, String? vehicleId, List<String> linkedTripIds, bool isFullTank, bool isCorrection
 });
 
 
@@ -339,7 +351,7 @@ class __$FillUpCopyWithImpl<$Res>
 
 /// Create a copy of FillUp
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? date = null,Object? liters = null,Object? totalCost = null,Object? odometerKm = null,Object? fuelType = null,Object? stationId = freezed,Object? stationName = freezed,Object? notes = freezed,Object? vehicleId = freezed,Object? linkedTripIds = null,Object? isFullTank = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? date = null,Object? liters = null,Object? totalCost = null,Object? odometerKm = null,Object? fuelType = null,Object? stationId = freezed,Object? stationName = freezed,Object? notes = freezed,Object? vehicleId = freezed,Object? linkedTripIds = null,Object? isFullTank = null,Object? isCorrection = null,}) {
   return _then(_FillUp(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
@@ -353,6 +365,7 @@ as String?,notes: freezed == notes ? _self.notes : notes // ignore: cast_nullabl
 as String?,vehicleId: freezed == vehicleId ? _self.vehicleId : vehicleId // ignore: cast_nullable_to_non_nullable
 as String?,linkedTripIds: null == linkedTripIds ? _self._linkedTripIds : linkedTripIds // ignore: cast_nullable_to_non_nullable
 as List<String>,isFullTank: null == isFullTank ? _self.isFullTank : isFullTank // ignore: cast_nullable_to_non_nullable
+as bool,isCorrection: null == isCorrection ? _self.isCorrection : isCorrection // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/lib/features/consumption/domain/entities/fill_up.g.dart
+++ b/lib/features/consumption/domain/entities/fill_up.g.dart
@@ -23,6 +23,7 @@ _FillUp _$FillUpFromJson(Map<String, dynamic> json) => _FillUp(
           .toList() ??
       const <String>[],
   isFullTank: json['isFullTank'] as bool? ?? true,
+  isCorrection: json['isCorrection'] as bool? ?? false,
 );
 
 Map<String, dynamic> _$FillUpToJson(_FillUp instance) => <String, dynamic>{
@@ -38,4 +39,5 @@ Map<String, dynamic> _$FillUpToJson(_FillUp instance) => <String, dynamic>{
   'vehicleId': instance.vehicleId,
   'linkedTripIds': instance.linkedTripIds,
   'isFullTank': instance.isFullTank,
+  'isCorrection': instance.isCorrection,
 };

--- a/lib/features/consumption/domain/services/reconciler.dart
+++ b/lib/features/consumption/domain/services/reconciler.dart
@@ -1,0 +1,282 @@
+import 'package:flutter/foundation.dart';
+
+import '../../data/trip_history_repository.dart';
+import '../entities/fill_up.dart';
+import '../trip_recorder.dart';
+
+/// Outcome bucket for [Reconciler.reconcile] (#1361). Lets the caller
+/// distinguish "no correction needed because the gap was tiny" from
+/// "no correction needed because no trips fell in the window" — both
+/// produce a null [ReconciliationResult.correction] but mean different
+/// things to the breadcrumb log and the user.
+enum ReconciliationAction {
+  /// A correction fill-up was synthesised. [ReconciliationResult.correction]
+  /// is non-null and ready to be persisted alongside the closing plein.
+  created,
+
+  /// `gap` was within the relative + absolute thresholds. No correction
+  /// is produced — the OBD integrator already matched the pump within
+  /// noise, so adding an entry would clutter the list.
+  skippedBelowThreshold,
+
+  /// `gap` was negative, meaning the OBD integrator over-estimated
+  /// fuel use vs. what the pump actually delivered. We don't synthesize
+  /// a "negative correction" entry; that's noise / instrumentation
+  /// drift, not a missed fill-up. Logged so a future η_v audit can
+  /// spot vehicles whose integrator runs hot.
+  clampedNegative,
+
+  /// No trips were found in the window. Without trip data there's no
+  /// reconciliation to perform — every pumped litre maps trivially to
+  /// itself. This is the typical first-fill-after-install case.
+  skippedNoTrips,
+}
+
+/// Result of reconciling a closed plein-to-plein window (#1361).
+///
+/// All numeric fields are populated even when [correction] is null so
+/// the caller can log a useful breadcrumb regardless of outcome.
+@immutable
+class ReconciliationResult {
+  /// Sum of `liters` across every fill-up in the window (including
+  /// the closing plein).
+  final double pumped;
+
+  /// Sum of `summary.fuelLitersConsumed` across every trip in the
+  /// window. Trips with `fuelLitersConsumed == null` contribute zero.
+  final double consumed;
+
+  /// `pumped - consumed`. Positive means the pump delivered more than
+  /// the OBD integrator accounted for — the user likely drove without
+  /// recording (adapter unplugged, off-app drives) and the gap should
+  /// be backfilled as a correction entry.
+  final double gap;
+
+  /// The synthesised correction [FillUp] when [action] is
+  /// [ReconciliationAction.created]; null otherwise.
+  final FillUp? correction;
+
+  /// Bucket explaining why [correction] is or isn't populated.
+  final ReconciliationAction action;
+
+  const ReconciliationResult({
+    required this.pumped,
+    required this.consumed,
+    required this.gap,
+    required this.correction,
+    required this.action,
+  });
+}
+
+/// Pure-logic reconciliation helper for the trip-vs-pump correction
+/// system (#1361). Takes a closing plein, the full fill-up list for
+/// the vehicle, and the full trip list for the vehicle, and either
+/// emits a synthetic correction [FillUp] or a "no correction needed"
+/// outcome. No Riverpod, no Hive — fully unit-testable.
+///
+/// The window semantics are `(previousPlein.date, closingPlein.date]`
+/// when a previous plein exists, and `[firstFill.date, closingPlein.date]`
+/// (closed lower bound) when the closing plein is the first plein in
+/// the data set. `windowFills` always includes the closing plein.
+class Reconciler {
+  /// Don't synthesise a correction unless the absolute gap is at
+  /// least this many litres. Sub-half-litre gaps are within typical
+  /// pump rounding + integrator noise.
+  static const double absoluteThresholdLiters = 0.5;
+
+  /// Don't synthesise a correction unless the relative gap exceeds
+  /// 5 % of pumped volume. Picks up a 1.5 L miss on a 30 L tank, but
+  /// ignores a 0.4 L drift on the same tank.
+  static const double relativeThreshold = 0.05;
+
+  const Reconciler();
+
+  /// Compute the reconciliation outcome for the window CLOSED by
+  /// [closingPlein]. Returns null if [closingPlein.isFullTank] is
+  /// false — windows only close on a full-tank fill, partials extend
+  /// the open window.
+  ReconciliationResult? reconcile({
+    required FillUp closingPlein,
+    required List<FillUp> allFillUpsForVehicle,
+    required List<TripSummary> tripsForVehicle,
+  }) {
+    if (!closingPlein.isFullTank) {
+      return null;
+    }
+
+    final vehicleId = closingPlein.vehicleId;
+
+    // Same-vehicle fills only. Skip already-existing correction
+    // entries — re-running reconciliation must NOT include the
+    // previous correction in the next window's `pumped`.
+    final sameVehicleFills = allFillUpsForVehicle
+        .where(
+          (f) =>
+              f.vehicleId == vehicleId &&
+              !f.isCorrection &&
+              f.id != closingPlein.id,
+        )
+        .toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+
+    // Find the most recent prior plein. Anything strictly older than
+    // [closingPlein] qualifies — we don't care if there are partial
+    // top-ups between the two pleins (those will be folded into the
+    // window via [windowFills]).
+    FillUp? previousPlein;
+    for (final f in sameVehicleFills) {
+      if (!f.date.isBefore(closingPlein.date)) continue;
+      if (!f.isFullTank) continue;
+      if (previousPlein == null || f.date.isAfter(previousPlein.date)) {
+        previousPlein = f;
+      }
+    }
+
+    DateTime windowStart;
+    bool inclusiveLower;
+    if (previousPlein != null) {
+      windowStart = previousPlein.date;
+      inclusiveLower = false;
+    } else {
+      // No prior plein — window starts at the first fill-up. If even
+      // that's missing (closingPlein is the first ever fill-up), the
+      // window is just the closing plein itself.
+      if (sameVehicleFills.isEmpty) {
+        windowStart = closingPlein.date;
+      } else {
+        windowStart = sameVehicleFills.first.date;
+      }
+      inclusiveLower = true;
+    }
+
+    bool inWindow(DateTime when) {
+      final afterStart = inclusiveLower
+          ? !when.isBefore(windowStart)
+          : when.isAfter(windowStart);
+      final beforeEnd = !when.isAfter(closingPlein.date);
+      return afterStart && beforeEnd;
+    }
+
+    // windowFills = same-vehicle fills in the window + the closing
+    // plein. Exclude correction entries so re-running reconciliation
+    // doesn't double-count last cycle's gap.
+    final windowFills = <FillUp>[
+      ...sameVehicleFills.where((f) => inWindow(f.date)),
+      closingPlein,
+    ]..sort((a, b) => a.date.compareTo(b.date));
+
+    final pumped = windowFills.fold<double>(
+      0,
+      (sum, f) => sum + f.liters,
+    );
+
+    final windowTrips = tripsForVehicle.where((t) {
+      final when = t.startedAt;
+      if (when == null) return false;
+      return inWindow(when);
+    }).toList();
+
+    if (windowTrips.isEmpty) {
+      debugPrint(
+        '[reconcile] vehicle=$vehicleId window=${windowStart.toIso8601String()}'
+        '..${closingPlein.date.toIso8601String()} pumped=$pumped consumed=0 '
+        'gap=$pumped action=skippedNoTrips',
+      );
+      return ReconciliationResult(
+        pumped: pumped,
+        consumed: 0,
+        gap: pumped,
+        correction: null,
+        action: ReconciliationAction.skippedNoTrips,
+      );
+    }
+
+    final consumed = windowTrips.fold<double>(
+      0,
+      (sum, t) => sum + (t.fuelLitersConsumed ?? 0),
+    );
+    final gap = pumped - consumed;
+
+    if (gap < 0) {
+      debugPrint(
+        '[reconcile] vehicle=$vehicleId window=${windowStart.toIso8601String()}'
+        '..${closingPlein.date.toIso8601String()} pumped=$pumped '
+        'consumed=$consumed gap=$gap action=clampedNegative',
+      );
+      return ReconciliationResult(
+        pumped: pumped,
+        consumed: consumed,
+        gap: gap,
+        correction: null,
+        action: ReconciliationAction.clampedNegative,
+      );
+    }
+
+    if (gap < absoluteThresholdLiters || gap < pumped * relativeThreshold) {
+      debugPrint(
+        '[reconcile] vehicle=$vehicleId window=${windowStart.toIso8601String()}'
+        '..${closingPlein.date.toIso8601String()} pumped=$pumped '
+        'consumed=$consumed gap=$gap action=skippedBelowThreshold',
+      );
+      return ReconciliationResult(
+        pumped: pumped,
+        consumed: consumed,
+        gap: gap,
+        correction: null,
+        action: ReconciliationAction.skippedBelowThreshold,
+      );
+    }
+
+    // Build a synthetic FillUp at the window midpoint. Date and
+    // odometer midpoints are computed from the window's first fill
+    // (which may be the previous plein, a partial top-up, or the
+    // closing plein itself in degenerate one-fill windows).
+    final firstFill = windowFills.first;
+    final midDateMs = (firstFill.date.millisecondsSinceEpoch +
+            closingPlein.date.millisecondsSinceEpoch) ~/
+        2;
+    final midDate = DateTime.fromMillisecondsSinceEpoch(midDateMs);
+    final midOdo =
+        (firstFill.odometerKm + closingPlein.odometerKm) / 2.0;
+
+    final correction = FillUp(
+      id: 'correction_${closingPlein.id}',
+      date: midDate,
+      liters: gap,
+      totalCost: 0,
+      odometerKm: midOdo,
+      fuelType: closingPlein.fuelType,
+      vehicleId: vehicleId,
+      isFullTank: false,
+      isCorrection: true,
+    );
+
+    debugPrint(
+      '[reconcile] vehicle=$vehicleId window=${windowStart.toIso8601String()}'
+      '..${closingPlein.date.toIso8601String()} pumped=$pumped '
+      'consumed=$consumed gap=$gap action=created',
+    );
+    return ReconciliationResult(
+      pumped: pumped,
+      consumed: consumed,
+      gap: gap,
+      correction: correction,
+      action: ReconciliationAction.created,
+    );
+  }
+}
+
+/// Convenience adapter for callers that hold a list of
+/// [TripHistoryEntry] (the on-disk shape) rather than the raw
+/// [TripSummary]s the [Reconciler] consumes. Keeps the reconciler
+/// repository-agnostic while letting production wiring pass through
+/// the trip history list directly.
+List<TripSummary> tripSummariesForVehicle({
+  required String? vehicleId,
+  required List<TripHistoryEntry> history,
+}) {
+  return history
+      .where((e) => e.vehicleId == vehicleId)
+      .map((e) => e.summary)
+      .toList(growable: false);
+}

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -11,6 +11,7 @@ import '../domain/entities/consumption_stats.dart';
 import '../domain/entities/eco_score.dart';
 import '../domain/entities/fill_up.dart';
 import '../domain/services/eco_score_calculator.dart';
+import '../domain/services/reconciler.dart';
 import 'trip_history_provider.dart';
 
 part 'consumption_providers.g.dart';
@@ -73,70 +74,236 @@ class FillUpList extends _$FillUpList {
   /// After saving, runs the odometer-based service-reminder check
   /// (#584) for the fill-up's vehicle and — when the vehicle has an
   /// OBD2 trip history since the previous fill-up — kicks off the
-  /// η_v reconciliation (#815). Failures in either side-effect path
-  /// are swallowed: logging a fill-up must never fail because a
+  /// η_v reconciliation (#815) and the trip-vs-pump correction
+  /// reconciliation (#1361). Failures in any side-effect path are
+  /// swallowed: logging a fill-up must never fail because a
   /// downstream calibration did.
   ///
-  /// #888 — auto-links OBD2 trajets recorded since the previous
-  /// fill-up for the same vehicle. Populates [FillUp.linkedTripIds]
-  /// before persisting so the derived relationship is durable and
-  /// queryable (per-tank eco-score, trajets list filtering).
+  /// #888 / #1361 — auto-links OBD2 trajets to every fill-up in the
+  /// open plein-to-plein window. Trips recorded inside a window land
+  /// in `linkedTripIds` of every fill in that window (the closing
+  /// plein and any partial top-ups between the previous plein and
+  /// the closing one). When the new fill is itself a plein the
+  /// window closes and we re-link backwards across the closed window
+  /// so the partials see the full trip set.
   Future<void> add(FillUp fillUp) async {
     final repo = ref.read(fillUpRepositoryProvider);
     final previous = _previousFillUpFor(fillUp, repo.getAll());
-    final linkedIds = _linkedTripIdsFor(fillUp, previous);
+    final linkedIds = _linkedTripIdsForWholeWindow(fillUp);
     final linked = fillUp.linkedTripIds.isEmpty
         ? fillUp.copyWith(linkedTripIds: linkedIds)
         : fillUp;
     await repo.save(linked);
+    // Re-link any partials in the open window so they share the
+    // closing plein's trip set. No-op when [linked] is itself a
+    // partial (the next plein will cover this), or when the vehicle
+    // has no trips/partials in the window.
+    await _relinkOpenWindow(linked);
     state = repo.getAll();
     await _evaluateReminders(linked);
     await _reconcileVolumetricEfficiency(linked, previous);
+    // #1361 — trip-vs-pump reconciliation. Only runs on plein fills;
+    // partials extend the open window and don't trigger a closing.
+    await _reconcileTripVsPump(linked);
   }
 
   /// Compute the trip-history ids recorded for [fillUp.vehicleId]
-  /// between [previous] and [fillUp] (inclusive lower, inclusive
-  /// upper). Returns an empty list when the fill-up has no vehicle
-  /// bound, the history repository isn't available, or no trips fall
+  /// in the OPEN plein-to-plein window that ends at [fillUp].
+  ///
+  /// Window semantics (#1361):
+  ///   - upper bound: `fillUp.date` (inclusive).
+  ///   - lower bound: most-recent prior plein (exclusive) for the
+  ///     same vehicle, or — when no prior plein exists — the first
+  ///     same-vehicle fill-up's date (inclusive).
+  ///
+  /// Returns an empty list when the fill-up has no vehicle bound,
+  /// the trip-history repository isn't available, or no trips fall
   /// in the window.
-  List<String> _linkedTripIdsFor(FillUp fillUp, FillUp? previous) {
+  List<String> _linkedTripIdsForWholeWindow(FillUp fillUp) {
     final vehicleId = fillUp.vehicleId;
     if (vehicleId == null) return const <String>[];
     final repo = ref.read(tripHistoryRepositoryProvider);
     if (repo == null) return const <String>[];
     final history = repo.loadAll();
-    final lowerBound = previous?.date;
+    final fillRepo = ref.read(fillUpRepositoryProvider);
+    final allFills = fillRepo
+        .getAll()
+        .where(
+          (f) =>
+              f.vehicleId == vehicleId &&
+              f.id != fillUp.id &&
+              !f.isCorrection,
+        )
+        .toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+
+    FillUp? previousPlein;
+    for (final f in allFills) {
+      if (!f.date.isBefore(fillUp.date)) continue;
+      if (!f.isFullTank) continue;
+      if (previousPlein == null || f.date.isAfter(previousPlein.date)) {
+        previousPlein = f;
+      }
+    }
+
+    // Window lower bound:
+    //   - prior plein → strictly after that plein's date
+    //   - no prior plein but earlier same-vehicle fills exist → at-or-
+    //     after the earliest such fill (inclusive)
+    //   - no prior fills at all → no lower bound (everything before
+    //     this fill qualifies, matching the legacy #888 semantics)
+    DateTime? windowStart;
+    bool inclusiveLower = true;
+    if (previousPlein != null) {
+      windowStart = previousPlein.date;
+      inclusiveLower = false;
+    } else if (allFills.isNotEmpty) {
+      windowStart = allFills.first.date;
+      inclusiveLower = true;
+    }
     final upperBound = fillUp.date;
+
     final matches = <TripHistoryEntry>[];
     for (final entry in history) {
       if (entry.vehicleId != vehicleId) continue;
       final when = entry.summary.startedAt;
       if (when == null) continue;
-      // Strictly after the previous fill-up (or everything older
-      // than this one if there's no prior tank) and at-or-before
-      // the new fill-up timestamp. Dates equal to the previous
-      // fill-up are excluded so the trip that completed the prior
-      // tank isn't double-counted.
-      if (lowerBound != null && !when.isAfter(lowerBound)) continue;
+      if (windowStart != null) {
+        final afterStart = inclusiveLower
+            ? !when.isBefore(windowStart)
+            : when.isAfter(windowStart);
+        if (!afterStart) continue;
+      }
       if (when.isAfter(upperBound)) continue;
       matches.add(entry);
     }
     return matches.map((e) => e.id).toList(growable: false);
   }
 
+  /// After saving [closing], propagate its `linkedTripIds` to every
+  /// other fill in the same open plein-to-plein window so the
+  /// derived relationship is the same on each fill (#1361). This is
+  /// the whole-window semantic the user requested: "the trajets
+  /// since then are related to all fill-ups since then".
+  ///
+  /// The window is the same one [_linkedTripIdsForWholeWindow]
+  /// computed for [closing]; when [closing] is a plein, we cover the
+  /// fills between the previous plein and the closing one (the
+  /// partials), and when [closing] is itself a partial, we still
+  /// cover the open window so the prior partial picks up the new
+  /// trips.
+  Future<void> _relinkOpenWindow(FillUp closing) async {
+    final vehicleId = closing.vehicleId;
+    if (vehicleId == null) return;
+    final repo = ref.read(fillUpRepositoryProvider);
+    final allFills = repo
+        .getAll()
+        .where(
+          (f) =>
+              f.vehicleId == vehicleId &&
+              f.id != closing.id &&
+              !f.isCorrection,
+        )
+        .toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+
+    FillUp? previousPlein;
+    for (final f in allFills) {
+      if (!f.date.isBefore(closing.date)) continue;
+      if (!f.isFullTank) continue;
+      if (previousPlein == null || f.date.isAfter(previousPlein.date)) {
+        previousPlein = f;
+      }
+    }
+
+    DateTime? windowStart;
+    bool inclusiveLower = true;
+    if (previousPlein != null) {
+      windowStart = previousPlein.date;
+      inclusiveLower = false;
+    } else if (allFills.isNotEmpty) {
+      windowStart = allFills.first.date;
+      inclusiveLower = true;
+    }
+    final upperBound = closing.date;
+
+    bool inWindow(DateTime when) {
+      if (windowStart != null) {
+        final afterStart = inclusiveLower
+            ? !when.isBefore(windowStart)
+            : when.isAfter(windowStart);
+        if (!afterStart) return false;
+      }
+      return !when.isAfter(upperBound);
+    }
+
+    final newIds = closing.linkedTripIds;
+    for (final f in allFills) {
+      if (!inWindow(f.date)) continue;
+      // Merge — preserve any pre-existing ids, add the new set.
+      final merged = <String>{...f.linkedTripIds, ...newIds}.toList();
+      if (merged.length == f.linkedTripIds.length &&
+          merged.toSet().difference(f.linkedTripIds.toSet()).isEmpty) {
+        continue;
+      }
+      await repo.save(f.copyWith(linkedTripIds: merged));
+    }
+  }
+
   /// Pick the fill-up with the largest `date` that is strictly older
   /// than [current] for the same vehicle. Ignores fill-ups without a
   /// vehicle id — reconciliation only applies to vehicle-bound fills.
+  /// Skips correction entries — they're synthesised and shouldn't
+  /// anchor the η_v window.
   FillUp? _previousFillUpFor(FillUp current, List<FillUp> all) {
     if (current.vehicleId == null) return null;
     FillUp? best;
     for (final f in all) {
       if (f.id == current.id) continue;
       if (f.vehicleId != current.vehicleId) continue;
+      if (f.isCorrection) continue;
       if (!f.date.isBefore(current.date)) continue;
       if (best == null || f.date.isAfter(best.date)) best = f;
     }
     return best;
+  }
+
+  /// #1361 — synthesise a correction fill-up when the closing plein's
+  /// pumped volume exceeds the OBD-integrated trip fuel by more than
+  /// [Reconciler.absoluteThresholdLiters] and
+  /// [Reconciler.relativeThreshold]. No-op for partial fills, fills
+  /// without a bound vehicle, the synthesised correction itself, or
+  /// when the trip-history repository isn't available. Errors are
+  /// swallowed — a failed reconciliation must not break the save flow.
+  Future<void> _reconcileTripVsPump(FillUp fillUp) async {
+    if (fillUp.isCorrection) return;
+    if (!fillUp.isFullTank) return;
+    final vehicleId = fillUp.vehicleId;
+    if (vehicleId == null) return;
+    try {
+      final tripRepo = ref.read(tripHistoryRepositoryProvider);
+      if (tripRepo == null) return;
+      final fillRepo = ref.read(fillUpRepositoryProvider);
+      final allFills = fillRepo.getAll();
+      final history = tripRepo.loadAll();
+      final trips = tripSummariesForVehicle(
+        vehicleId: vehicleId,
+        history: history,
+      );
+      const reconciler = Reconciler();
+      final result = reconciler.reconcile(
+        closingPlein: fillUp,
+        allFillUpsForVehicle: allFills,
+        tripsForVehicle: trips,
+      );
+      final correction = result?.correction;
+      if (correction != null) {
+        await fillRepo.save(correction);
+        state = fillRepo.getAll();
+      }
+    } catch (e, st) {
+      debugPrint('FillUpList: trip-vs-pump reconciliation failed: $e\n$st');
+    }
   }
 
   Future<void> _evaluateReminders(FillUp fillUp) async {

--- a/test/features/consumption/domain/entities/fill_up_serialization_test.dart
+++ b/test/features/consumption/domain/entities/fill_up_serialization_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// #1361 phase 2a — [FillUp.isCorrection] must round-trip through JSON
+/// and default to `false` when missing from a legacy payload (so
+/// fill-ups persisted before this field landed deserialise as
+/// non-correction entries).
+void main() {
+  group('FillUp.isCorrection', () {
+    test('defaults to false when not provided', () {
+      final f = FillUp(
+        id: '1',
+        date: DateTime(2026, 4, 1),
+        liters: 30,
+        totalCost: 50,
+        odometerKm: 12345,
+        fuelType: FuelType.e10,
+      );
+      expect(f.isCorrection, isFalse);
+    });
+
+    test('preserves the supplied value', () {
+      final f = FillUp(
+        id: '1',
+        date: DateTime(2026, 4, 1),
+        liters: 30,
+        totalCost: 0,
+        odometerKm: 12345,
+        fuelType: FuelType.e10,
+        isCorrection: true,
+      );
+      expect(f.isCorrection, isTrue);
+    });
+
+    test('round-trips through fromJson/toJson', () {
+      final original = FillUp(
+        id: 'correction_p1',
+        date: DateTime.utc(2026, 4, 8, 12),
+        liters: 7.5,
+        totalCost: 0,
+        odometerKm: 12500,
+        fuelType: FuelType.diesel,
+        vehicleId: 'veh-a',
+        isFullTank: false,
+        isCorrection: true,
+      );
+      final decoded = FillUp.fromJson(original.toJson());
+      expect(decoded, equals(original));
+      expect(decoded.isCorrection, isTrue);
+      expect(decoded.isFullTank, isFalse);
+    });
+
+    test('legacy JSON without isCorrection decodes with default false',
+        () {
+      // A fill-up persisted before #1361 won't carry the key.
+      final legacyJson = {
+        'id': '1',
+        'date': DateTime.utc(2026, 4, 1).toIso8601String(),
+        'liters': 42.5,
+        'totalCost': 70,
+        'odometerKm': 100000.0,
+        'fuelType': 'e10',
+      };
+      final decoded = FillUp.fromJson(legacyJson);
+      expect(decoded.isCorrection, isFalse);
+    });
+
+    test(
+        'a non-correction fill round-trip preserves isCorrection=false',
+        () {
+      final original = FillUp(
+        id: '1',
+        date: DateTime.utc(2026, 4, 1),
+        liters: 42.5,
+        totalCost: 70,
+        odometerKm: 100000,
+        fuelType: FuelType.e10,
+      );
+      final decoded = FillUp.fromJson(original.toJson());
+      expect(decoded.isCorrection, isFalse);
+    });
+  });
+}

--- a/test/features/consumption/domain/services/reconciler_test.dart
+++ b/test/features/consumption/domain/services/reconciler_test.dart
@@ -1,0 +1,386 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/services/reconciler.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Unit tests for [Reconciler] (#1361 phase 2a). The reconciler is
+/// pure — every test passes inputs directly and asserts on the
+/// returned [ReconciliationResult] without touching Hive or Riverpod.
+void main() {
+  const reconciler = Reconciler();
+
+  FillUp makePlein({
+    required String id,
+    required DateTime date,
+    required double liters,
+    double odometerKm = 10000,
+    String vehicleId = 'veh-a',
+    bool isFullTank = true,
+  }) =>
+      FillUp(
+        id: id,
+        date: date,
+        liters: liters,
+        totalCost: liters * 1.5,
+        odometerKm: odometerKm,
+        fuelType: FuelType.e10,
+        vehicleId: vehicleId,
+        isFullTank: isFullTank,
+      );
+
+  TripSummary makeTrip({
+    required DateTime startedAt,
+    required double fuel,
+    double distanceKm = 100,
+  }) =>
+      TripSummary(
+        distanceKm: distanceKm,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: fuel,
+        startedAt: startedAt,
+        endedAt: startedAt.add(const Duration(hours: 1)),
+      );
+
+  group('Reconciler.reconcile', () {
+    test('returns null when closing fill is not a plein', () {
+      final partial = makePlein(
+        id: 'partial',
+        date: DateTime(2026, 4, 15),
+        liters: 20,
+        isFullTank: false,
+      );
+      final result = reconciler.reconcile(
+        closingPlein: partial,
+        allFillUpsForVehicle: const [],
+        tripsForVehicle: const [],
+      );
+      expect(result, isNull);
+    });
+
+    test(
+        'single plein with no trips → action skippedNoTrips, no '
+        'correction', () {
+      final plein = makePlein(
+        id: 'p1',
+        date: DateTime(2026, 4, 15),
+        liters: 40,
+      );
+      final result = reconciler.reconcile(
+        closingPlein: plein,
+        allFillUpsForVehicle: [plein],
+        tripsForVehicle: const [],
+      );
+      expect(result, isNotNull);
+      expect(result!.action, ReconciliationAction.skippedNoTrips);
+      expect(result.correction, isNull);
+      expect(result.pumped, 40);
+      expect(result.consumed, 0);
+    });
+
+    test(
+        'plein with trips but gap below absolute threshold → '
+        'skippedBelowThreshold', () {
+      final prevPlein = makePlein(
+        id: 'p0',
+        date: DateTime(2026, 4, 1),
+        liters: 40,
+      );
+      final closingPlein = makePlein(
+        id: 'p1',
+        date: DateTime(2026, 4, 15),
+        liters: 40,
+        odometerKm: 10500,
+      );
+      final trips = [
+        makeTrip(
+          startedAt: DateTime(2026, 4, 5),
+          fuel: 39.7, // gap = 0.3 L (< 0.5 L absolute floor)
+        ),
+      ];
+      final result = reconciler.reconcile(
+        closingPlein: closingPlein,
+        allFillUpsForVehicle: [prevPlein, closingPlein],
+        tripsForVehicle: trips,
+      );
+      expect(result, isNotNull);
+      expect(result!.action, ReconciliationAction.skippedBelowThreshold);
+      expect(result.correction, isNull);
+      expect(result.pumped, 40);
+      expect(result.consumed, closeTo(39.7, 0.001));
+    });
+
+    test(
+        'plein with trips, gap below relative threshold → '
+        'skippedBelowThreshold', () {
+      // pumped = 40, gap must exceed both 0.5 L AND 5 % of 40 = 2.0 L.
+      // gap of 1 L passes the absolute floor but fails the relative
+      // floor.
+      final prevPlein = makePlein(
+        id: 'p0',
+        date: DateTime(2026, 4, 1),
+        liters: 40,
+      );
+      final closingPlein = makePlein(
+        id: 'p1',
+        date: DateTime(2026, 4, 15),
+        liters: 40,
+        odometerKm: 10500,
+      );
+      final trips = [
+        makeTrip(startedAt: DateTime(2026, 4, 5), fuel: 39.0),
+      ];
+      final result = reconciler.reconcile(
+        closingPlein: closingPlein,
+        allFillUpsForVehicle: [prevPlein, closingPlein],
+        tripsForVehicle: trips,
+      );
+      expect(result!.action, ReconciliationAction.skippedBelowThreshold);
+      expect(result.correction, isNull);
+    });
+
+    test(
+        'plein with trips, gap above thresholds → action created with '
+        'correct liters / midpoint odo and date', () {
+      final prevDate = DateTime(2026, 4, 1);
+      final closeDate = DateTime(2026, 4, 15);
+      final prevPlein = makePlein(
+        id: 'p0',
+        date: prevDate,
+        liters: 40,
+        odometerKm: 10000,
+      );
+      final closingPlein = makePlein(
+        id: 'p1',
+        date: closeDate,
+        liters: 40,
+        odometerKm: 10800,
+      );
+      // Trip integrated 30 L, but pump shows 40 L. Gap = 10 L —
+      // well over both floors.
+      final trips = [
+        makeTrip(startedAt: DateTime(2026, 4, 5), fuel: 30),
+      ];
+      final result = reconciler.reconcile(
+        closingPlein: closingPlein,
+        // Note: window starts AFTER prevPlein (exclusive lower
+        // bound), so prevPlein's 40 L don't count toward `pumped`.
+        allFillUpsForVehicle: [prevPlein, closingPlein],
+        tripsForVehicle: trips,
+      );
+      expect(result, isNotNull);
+      expect(result!.action, ReconciliationAction.created);
+      expect(result.pumped, 40);
+      expect(result.consumed, 30);
+      expect(result.gap, 10);
+      final correction = result.correction!;
+      expect(correction.id, 'correction_p1');
+      expect(correction.isCorrection, isTrue);
+      expect(correction.isFullTank, isFalse);
+      expect(correction.liters, 10);
+      expect(correction.totalCost, 0);
+      expect(correction.fuelType, FuelType.e10);
+      expect(correction.vehicleId, 'veh-a');
+      expect(correction.stationName, isNull);
+      expect(correction.stationId, isNull);
+      // Window's first fill (closingPlein itself, since prev is
+      // excluded). Midpoint of [closeDate, closeDate] = closeDate.
+      // BUT — the closing plein is its own first fill in the window,
+      // so the midpoint collapses; that's fine because the spec
+      // explicitly says midpoint of [windowFills.first, closingPlein].
+      // Since both are the same fill, the midpoint equals closeDate.
+      expect(correction.date, closeDate);
+      expect(correction.odometerKm, 10800);
+    });
+
+    test(
+        'midpoint with partials in window — correction date and odo '
+        'fall between the first windowFill and the closing plein', () {
+      final prevPlein = makePlein(
+        id: 'p0',
+        date: DateTime(2026, 4, 1),
+        liters: 40,
+        odometerKm: 10000,
+      );
+      final partial = makePlein(
+        id: 'p-mid',
+        date: DateTime(2026, 4, 8),
+        liters: 20,
+        odometerKm: 10300,
+        isFullTank: false,
+      );
+      final closingPlein = makePlein(
+        id: 'p1',
+        date: DateTime(2026, 4, 15),
+        liters: 25,
+        odometerKm: 10800,
+      );
+      // Pumped in window = 20 (partial) + 25 (closing) = 45.
+      // Trips integrated 30 L → gap = 15 L. Above thresholds.
+      final trips = [
+        makeTrip(startedAt: DateTime(2026, 4, 5), fuel: 15),
+        makeTrip(startedAt: DateTime(2026, 4, 12), fuel: 15),
+      ];
+      final result = reconciler.reconcile(
+        closingPlein: closingPlein,
+        allFillUpsForVehicle: [prevPlein, partial, closingPlein],
+        tripsForVehicle: trips,
+      );
+      expect(result!.action, ReconciliationAction.created);
+      expect(result.pumped, 45);
+      expect(result.consumed, 30);
+      final correction = result.correction!;
+      // First fill in window is the partial (the prev plein is
+      // strictly outside the window). Midpoint date is
+      // (Apr 8 + Apr 15) / 2 = Apr 11 12:00.
+      expect(
+        correction.date,
+        DateTime(2026, 4, 11, 12),
+      );
+      // Midpoint odometer = (10300 + 10800) / 2 = 10550.
+      expect(correction.odometerKm, 10550);
+      expect(correction.liters, 15);
+    });
+
+    test('negative gap → action clampedNegative, no correction', () {
+      // OBD2 integrator over-estimated. Pump delivered 30 L, trips
+      // claimed 40 L. We don't synthesise a "ghost" reverse fill.
+      final prevPlein = makePlein(
+        id: 'p0',
+        date: DateTime(2026, 4, 1),
+        liters: 40,
+      );
+      final closingPlein = makePlein(
+        id: 'p1',
+        date: DateTime(2026, 4, 15),
+        liters: 30,
+        odometerKm: 10500,
+      );
+      final trips = [
+        makeTrip(startedAt: DateTime(2026, 4, 5), fuel: 40),
+      ];
+      final result = reconciler.reconcile(
+        closingPlein: closingPlein,
+        allFillUpsForVehicle: [prevPlein, closingPlein],
+        tripsForVehicle: trips,
+      );
+      expect(result!.action, ReconciliationAction.clampedNegative);
+      expect(result.correction, isNull);
+      expect(result.pumped, 30);
+      expect(result.consumed, 40);
+      expect(result.gap, lessThan(0));
+    });
+
+    test(
+        'no previous plein → window starts (inclusive) at first fill '
+        'of the same vehicle', () {
+      // Closing plein is the first plein for the vehicle but a
+      // partial top-up came earlier. Window is [partial.date,
+      // closing.date], both inclusive.
+      final partial = makePlein(
+        id: 'p-mid',
+        date: DateTime(2026, 4, 8),
+        liters: 20,
+        odometerKm: 10100,
+        isFullTank: false,
+      );
+      final closingPlein = makePlein(
+        id: 'p1',
+        date: DateTime(2026, 4, 15),
+        liters: 30,
+        odometerKm: 10500,
+      );
+      // Pumped = 20 + 30 = 50, integrated trips = 30 → gap = 20.
+      final trips = [
+        makeTrip(startedAt: DateTime(2026, 4, 10), fuel: 30),
+      ];
+      final result = reconciler.reconcile(
+        closingPlein: closingPlein,
+        allFillUpsForVehicle: [partial, closingPlein],
+        tripsForVehicle: trips,
+      );
+      expect(result!.action, ReconciliationAction.created);
+      expect(result.pumped, 50);
+      expect(result.consumed, 30);
+      expect(result.correction!.liters, 20);
+    });
+
+    test('vehicle filtering excludes other-vehicle fills and trips', () {
+      final closingPlein = makePlein(
+        id: 'p1',
+        date: DateTime(2026, 4, 15),
+        liters: 40,
+        vehicleId: 'veh-a',
+      );
+      // Other-vehicle fills should NOT contribute to pumped, even
+      // though the caller passed a mixed list. The reconciler
+      // filters by vehicleId internally.
+      final otherVehicleFill = makePlein(
+        id: 'p-other',
+        date: DateTime(2026, 4, 10),
+        liters: 100,
+        vehicleId: 'veh-b',
+      );
+      // Other-vehicle trips should NOT contribute to consumed.
+      // Caller's responsibility per signature; we test the
+      // helper that pre-filters trips for the wired path.
+      final result = reconciler.reconcile(
+        closingPlein: closingPlein,
+        allFillUpsForVehicle: [otherVehicleFill, closingPlein],
+        tripsForVehicle: const [],
+      );
+      // Pumped should be 40, not 140.
+      expect(result!.pumped, 40);
+      // No trips → skippedNoTrips.
+      expect(result.action, ReconciliationAction.skippedNoTrips);
+    });
+
+    test(
+        're-running over a window that already has a correction does '
+        'NOT double-count the previous correction in `pumped`', () {
+      // First time: gap = 10 L, correction synthesised.
+      final prevPlein = makePlein(
+        id: 'p0',
+        date: DateTime(2026, 4, 1),
+        liters: 40,
+        odometerKm: 10000,
+      );
+      final closingPlein = makePlein(
+        id: 'p1',
+        date: DateTime(2026, 4, 15),
+        liters: 40,
+        odometerKm: 10800,
+      );
+      final trips = [
+        makeTrip(startedAt: DateTime(2026, 4, 5), fuel: 30),
+      ];
+      // Stale correction from a previous run sits in the list.
+      final staleCorrection = FillUp(
+        id: 'correction_p1',
+        date: DateTime(2026, 4, 8),
+        liters: 10,
+        totalCost: 0,
+        odometerKm: 10400,
+        fuelType: FuelType.e10,
+        vehicleId: 'veh-a',
+        isFullTank: false,
+        isCorrection: true,
+      );
+      final result = reconciler.reconcile(
+        closingPlein: closingPlein,
+        allFillUpsForVehicle: [prevPlein, staleCorrection, closingPlein],
+        tripsForVehicle: trips,
+      );
+      // Pumped must still be 40 (closing plein only, prev plein is
+      // outside the window, stale correction is excluded).
+      expect(result!.pumped, 40);
+      expect(result.consumed, 30);
+      expect(result.correction!.liters, 10);
+      expect(result.correction!.id, 'correction_p1');
+    });
+  });
+}

--- a/test/features/consumption/providers/consumption_providers_relinking_test.dart
+++ b/test/features/consumption/providers/consumption_providers_relinking_test.dart
@@ -1,0 +1,278 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// #1361 phase 2a — whole-window trip relinking.
+///
+/// When a closing plein lands, every trip in the open plein-to-plein
+/// window is mirrored across every fill in that window (the prior
+/// partials AND the closing plein). This is a behavioural change from
+/// the pair-to-nearest semantics that #888 originally shipped — the
+/// user wanted "the trajets since then are related to all fill-ups
+/// since then" (#1361 spec).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late TripHistoryRepository historyRepo;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('relinking_test_');
+    Hive.init(tmpDir.path);
+    final box = await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+    historyRepo = TripHistoryRepository(box: box);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2TripHistory).deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Future<void> seedTrip({
+    required String id,
+    required String vehicleId,
+    required DateTime startedAt,
+    double fuel = 5,
+    double distanceKm = 50,
+  }) {
+    return historyRepo.save(TripHistoryEntry(
+      id: id,
+      vehicleId: vehicleId,
+      summary: TripSummary(
+        distanceKm: distanceKm,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: fuel,
+        startedAt: startedAt,
+        endedAt: startedAt.add(const Duration(minutes: 30)),
+      ),
+    ));
+  }
+
+  FillUp mkFillUp({
+    required String id,
+    required DateTime date,
+    String vehicleId = 'veh-a',
+    double liters = 40,
+    double odometerKm = 10000,
+    bool isFullTank = true,
+  }) =>
+      FillUp(
+        id: id,
+        date: date,
+        liters: liters,
+        totalCost: liters * 1.5,
+        odometerKm: odometerKm,
+        fuelType: FuelType.e10,
+        vehicleId: vehicleId,
+        isFullTank: isFullTank,
+      );
+
+  test(
+      '1 opening plein + 2 partials + 5 trips → after closing plein '
+      'lands, every trip id appears in every partial AND the closing '
+      'plein\'s linkedTripIds', () async {
+    // Layout (all veh-a):
+    //   d0 — opening plein A (full)
+    //   d1, d2, d3, d4, d5 — five trips
+    //   d6 — partial top-up P1
+    //   d7 — partial top-up P2
+    //   d8 — closing plein B (full)
+    final d0 = DateTime(2026, 4, 1);
+    final d6 = DateTime(2026, 4, 10);
+    final d7 = DateTime(2026, 4, 12);
+    final d8 = DateTime(2026, 4, 15);
+
+    for (var i = 0; i < 5; i++) {
+      await seedTrip(
+        id: 'trip-$i',
+        vehicleId: 'veh-a',
+        startedAt: d0.add(Duration(days: i + 1)),
+      );
+    }
+
+    final container = makeContainer();
+    final notifier = container.read(fillUpListProvider.notifier);
+    // Sub-litre numbers so reconciliation never fires (all gaps below
+    // floor) — the test focuses on relinking, not on correction.
+    // 5 trips × 5 L = 25 L integrated; opening plein + partials +
+    // closing keep the cumulative pump close to 25 ± 0.5 L over the
+    // window so no correction is synthesised.
+    await notifier.add(mkFillUp(id: 'A', date: d0, liters: 0.1));
+    await notifier.add(mkFillUp(
+      id: 'P1',
+      date: d6,
+      liters: 12.4,
+      isFullTank: false,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'P2',
+      date: d7,
+      liters: 12.4,
+      isFullTank: false,
+    ));
+    await notifier.add(mkFillUp(id: 'B', date: d8, liters: 0.1));
+
+    final all = container.read(fillUpListProvider);
+    final closing = all.firstWhere((f) => f.id == 'B');
+    final partial1 = all.firstWhere((f) => f.id == 'P1');
+    final partial2 = all.firstWhere((f) => f.id == 'P2');
+    final opening = all.firstWhere((f) => f.id == 'A');
+
+    final tripSet = {'trip-0', 'trip-1', 'trip-2', 'trip-3', 'trip-4'};
+    expect(closing.linkedTripIds.toSet(), tripSet,
+        reason: 'closing plein must carry all 5 trip ids');
+    expect(partial1.linkedTripIds.toSet(), tripSet,
+        reason: 'partial 1 must mirror the closing plein\'s links');
+    expect(partial2.linkedTripIds.toSet(), tripSet,
+        reason: 'partial 2 must mirror the closing plein\'s links');
+    // Convention: opening plein is the EXCLUSIVE lower bound, so it
+    // doesn't carry the closed-window trips. (The existing #888 test
+    // relies on this — A's links stay empty.)
+    expect(opening.linkedTripIds, isEmpty,
+        reason: 'opening plein anchors the window from below '
+            '(exclusive); its own links remain whatever they were '
+            'when it was first added');
+  });
+
+  test(
+      'closing plein triggers backwards re-link across the closed '
+      'window even when partials were saved before the trips arrived',
+      () async {
+    // Real-world ordering: user logs the partial first, then drives,
+    // then logs the closing plein. The trip arrives between the two
+    // saves and must propagate to the partial when the closing plein
+    // re-links.
+    final d0 = DateTime(2026, 4, 1);
+    final d6 = DateTime(2026, 4, 10);
+    final d8 = DateTime(2026, 4, 15);
+
+    final container = makeContainer();
+    final notifier = container.read(fillUpListProvider.notifier);
+
+    // Opening plein, then partial — neither sees any trips.
+    await notifier.add(mkFillUp(id: 'A', date: d0, liters: 0.1));
+    await notifier.add(mkFillUp(
+      id: 'P1',
+      date: d6,
+      liters: 12,
+      isFullTank: false,
+    ));
+
+    var partial = container
+        .read(fillUpListProvider)
+        .firstWhere((f) => f.id == 'P1');
+    expect(partial.linkedTripIds, isEmpty);
+
+    // Trip arrives now.
+    await seedTrip(
+      id: 'trip-late',
+      vehicleId: 'veh-a',
+      startedAt: d0.add(const Duration(days: 7)),
+    );
+
+    // Closing plein — should re-link backwards so the partial picks
+    // up the trip too.
+    await notifier.add(mkFillUp(id: 'B', date: d8, liters: 0.1));
+
+    final all = container.read(fillUpListProvider);
+    final closing = all.firstWhere((f) => f.id == 'B');
+    partial = all.firstWhere((f) => f.id == 'P1');
+
+    expect(closing.linkedTripIds, ['trip-late']);
+    expect(partial.linkedTripIds, ['trip-late'],
+        reason: 'partial must inherit the trip via backwards re-link');
+  });
+
+  test(
+      'pre-existing single-plein scenario (#888 fixture parity) — '
+      'no partials, A→B→C still link by per-window trip set', () async {
+    // This mirrors the original #888 trip_linking_test fixture to
+    // prove backward compat. Three pleins, no partials, ids partition
+    // by window.
+    final dateA = DateTime(2026, 4, 1, 8);
+    final dateB = DateTime(2026, 4, 10, 18);
+    final dateC = DateTime(2026, 4, 20, 18);
+
+    await seedTrip(
+      id: 'trip-ab-1',
+      vehicleId: 'veh-a',
+      startedAt: dateA.add(const Duration(days: 1)),
+    );
+    await seedTrip(
+      id: 'trip-ab-2',
+      vehicleId: 'veh-a',
+      startedAt: dateA.add(const Duration(days: 5)),
+    );
+    await seedTrip(
+      id: 'trip-bc-1',
+      vehicleId: 'veh-a',
+      startedAt: dateB.add(const Duration(days: 2)),
+    );
+
+    final container = makeContainer();
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(id: 'A', date: dateA, liters: 0.1));
+    await notifier.add(mkFillUp(id: 'B', date: dateB, liters: 0.1));
+    await notifier.add(mkFillUp(id: 'C', date: dateC, liters: 0.1));
+
+    final all = container.read(fillUpListProvider);
+    final a = all.firstWhere((f) => f.id == 'A');
+    final b = all.firstWhere((f) => f.id == 'B');
+    final c = all.firstWhere((f) => f.id == 'C');
+
+    expect(a.linkedTripIds, isEmpty,
+        reason: 'first plein has no trips before it');
+    expect(b.linkedTripIds.toSet(), {'trip-ab-1', 'trip-ab-2'});
+    expect(c.linkedTripIds, ['trip-bc-1']);
+  });
+}
+
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}


### PR DESCRIPTION
## Summary

- Adds `FillUp.isCorrection` (default `false`, JSON round-trips with backward-compat for legacy fills) and a pure-logic `Reconciler` that synthesises a correction `FillUp` whenever the closing plein's pumped volume exceeds OBD-integrated trip fuel by both 0.5 L AND 5 % of pumped, with deterministic `correction_<plein.id>` ids so re-runs replace cleanly.
- Flips trip-relinking from pair-to-nearest to whole-window: every trip in the open plein-to-plein window writes its id into `linkedTripIds` of every fill in that window; the closing plein re-links backwards so partials inherit the closed-window trip set (matches the user spec "the trajets since then are related to all fill-ups since then").
- Wires the reconciler into `FillUpList.add` — runs only on plein fills, persists the correction next to the closing fill, swallows downstream failures so logging a fill never fails because reconciliation did. No UI changes.

## Phase boundary

Phase 2b (orange UI for correction entries in the fill-up list, edit/correct flow, copy/strings) ships in a separate PR. This PR is domain-only — `lib/features/consumption/presentation/**` and `lib/l10n/**` are untouched. `tank_level_estimator.dart` and the add-fill-up form (sibling worker A's territory under #1360) are also untouched.

## Test plan

- [x] `flutter analyze` — No issues found.
- [x] `flutter test test/features/consumption/` — 2143 tests pass (incl. the existing `trip_linking_test.dart` parity case under the new whole-window semantics).
- [x] New tests:
  - `test/features/consumption/domain/services/reconciler_test.dart` — 9 cases covering all four `ReconciliationAction` outcomes, midpoint odo/date with partials, vehicle filtering, and re-running with a stale correction in the list (must NOT double-count).
  - `test/features/consumption/domain/entities/fill_up_serialization_test.dart` — 5 cases proving `isCorrection` defaults to `false`, round-trips through JSON, and legacy payloads decode cleanly.
  - `test/features/consumption/providers/consumption_providers_relinking_test.dart` — 3 cases proving whole-window relinking (1 plein + 2 partials + 5 trips → all 5 ids in every fill), backwards re-link when trips arrive between partial and closing plein saves, and #888 fixture parity for the no-partial case.

Refs #1361 phase 2a