### PR TITLE
feat(consumption): plein-complet toggle on fill-up form (Closes #1360)

### DIFF
--- a/lib/features/consumption/domain/services/tank_level_estimator.dart
+++ b/lib/features/consumption/domain/services/tank_level_estimator.dart
@@ -88,7 +88,7 @@ class TankLevelEstimate {
 }
 
 /// Compute the current tank level for a vehicle from its fill-up history
-/// and the trips logged since the most recent fill-up (#1195).
+/// and the trips logged since the most recent fill-up (#1195, #1360).
 ///
 /// Inputs:
 /// * [vehicle] — the [VehicleProfile] this tank belongs to. Drives the
@@ -96,23 +96,34 @@ class TankLevelEstimate {
 ///   path. Once #1191 lands the overall avg from
 ///   `tripLengthAggregates` will replace the hard-coded 7.0.
 /// * [fillUps] — every fill-up logged for the vehicle, newest first.
-///   Only the head entry is consulted; older fills don't change the
-///   answer because the tank was reset at the most recent fill.
-/// * [trips] — every trip recorded since the most recent fill-up. The
-///   caller is responsible for the filtering (provider does this); the
-///   estimator additionally drops trips with `startedAt == null` or
-///   `startedAt < lastFillUp.date` as a defensive belt-and-braces
-///   guard so the function stays correct in unit tests that pass a
-///   broader list.
+///   When the most recent fill is a full "plein" the older entries
+///   don't change the answer (the tank was reset at the most recent
+///   fill). When the most recent fill is partial (#1360) the estimator
+///   walks earlier fills + trips between them to derive the level just
+///   before the partial top-up.
+/// * [trips] — trip history for the vehicle. The caller (provider)
+///   filters by vehicle and drops null `startedAt`; this function adds
+///   defensive guards. Trips after the most recent fill subtract from
+///   the level; trips between earlier fills are used to compute the
+///   level just before a partial-fill anchor.
 ///
 /// Returns [TankLevelEstimate.unknown] when [fillUps] is empty.
 ///
-/// v1: assumes every fill-up tops the tank up to capacity (the common
-/// "plein" pattern). The freshly-added [FillUp.isFullTank] flag is
-/// captured but not yet honoured here — once partial-fill UI lands the
-/// branch flips to `previous_level + liters_added` for `isFullTank ==
-/// false`. Today the data is recorded so the estimator can become
-/// flag-aware without a migration.
+/// Partial-fill branch (#1360):
+/// * `lastFillUp.isFullTank == true` → starting level resets to
+///   `vehicle.tankCapacityL` (or `lastFillUp.liters` when no capacity
+///   is configured) — historical behaviour.
+/// * `lastFillUp.isFullTank == false` → starting level is
+///   `previous_level + lastFillUp.liters`, clamped into
+///   `[0, capacityL]`. The "previous level" is computed by walking
+///   earlier fill-ups oldest→newest and subtracting trip consumption
+///   between them, anchored by the most recent prior full fill (or 0
+///   when no full anchor exists, the honest fallback for a tank with
+///   partials only).
+///
+/// `tripsSince`, `method`, and `rangeKm` are derived solely from trips
+/// AFTER the most recent fill-up — partial or full. The "trips since
+/// last fill-up" caption stays meaningful regardless of the toggle.
 TankLevelEstimate estimateTankLevel({
   required VehicleProfile vehicle,
   required List<FillUp> fillUps,
@@ -124,14 +135,21 @@ TankLevelEstimate estimateTankLevel({
 
   final lastFillUp = fillUps.first;
   final capacityL = vehicle.tankCapacityL;
-  // Initial tank level. Capacity wins when known; otherwise we fall
-  // back to "tank held at least the litres the user just pumped in",
-  // which is honest for a partial-fill case where capacity isn't set.
-  final startLevelL = capacityL ?? lastFillUp.liters;
+  final upperBound = capacityL ?? double.infinity;
 
   // TODO(#1191): replace with vehicle.tripLengthAggregates
   //   ?.overallAvgLPer100Km once the carbon-dashboard aggregates land.
   const avgLPer100Km = _defaultAvgLPer100Km;
+
+  // Compute the starting level right after [lastFillUp] (#1360 partial-
+  // fill branch). For full fills this is just capacity; for partials
+  // we walk back through earlier history.
+  final startLevelL = _initialLevelAfterFill(
+    fillUps: fillUps,
+    trips: trips,
+    capacityL: capacityL,
+    avgLPer100Km: avgLPer100Km,
+  );
 
   var consumed = 0.0;
   var consideredTrips = 0;
@@ -157,7 +175,6 @@ TankLevelEstimate estimateTankLevel({
   // tank holds (defensive against a rare negative-consumption write
   // race) or a negative level (consumed > capacity, e.g. user logged
   // a full week of trips without a fill-up).
-  final upperBound = capacityL ?? double.infinity;
   final levelL = (startLevelL - consumed).clamp(0.0, upperBound);
 
   final TankLevelEstimationMethod method;
@@ -186,4 +203,127 @@ TankLevelEstimate estimateTankLevel({
     rangeKm: rangeKm,
     tripsSince: consideredTrips,
   );
+}
+
+/// Compute the level right after the most recent fill (#1360).
+///
+/// `fillUps` is the same input the estimator received: newest first,
+/// for one vehicle. `trips` includes both pre- and post-fill trips —
+/// the post-fill ones are subtracted by the caller, so this helper
+/// only consults trips strictly between earlier fills.
+///
+/// Algorithm:
+///  1. If the most recent fill is full, return `capacityL ?? lastFill.liters`
+///     (no need to walk history — the tank just got reset).
+///  2. Else, find the most recent prior FULL fill, anchor the level at
+///     capacity there, then walk forward applying intermediate partial
+///     fills and trip consumption between them. The result is the level
+///     just before the most recent (partial) fill; add its litres,
+///     clamp into `[0, capacity]`, and return.
+///  3. If no prior full anchor exists, start from 0 — honest worst-
+///     case for a tank whose history is partials only (the user's
+///     starting state is unknown). The clamp keeps the answer within
+///     `[0, capacity]`.
+double _initialLevelAfterFill({
+  required List<FillUp> fillUps,
+  required List<TripHistoryEntry> trips,
+  required double? capacityL,
+  required double avgLPer100Km,
+}) {
+  final upper = capacityL ?? double.infinity;
+  final lastFill = fillUps.first;
+
+  if (lastFill.isFullTank) {
+    // Capacity wins when known; otherwise fall back to "tank held at
+    // least the litres the user just pumped in", which is honest when
+    // capacity isn't configured.
+    return capacityL ?? lastFill.liters;
+  }
+
+  // Build a chronological (oldest→newest) view of every prior fill.
+  final priorFills = fillUps.skip(1).toList(growable: false).reversed.toList();
+
+  // Find the most recent full fill before lastFill — the anchor.
+  int anchorIdx = -1;
+  for (var i = priorFills.length - 1; i >= 0; i--) {
+    if (priorFills[i].isFullTank) {
+      anchorIdx = i;
+      break;
+    }
+  }
+
+  // No anchor → honest fallback: start from 0 and let the partials
+  // accumulate (clamp keeps the answer within capacity). When capacity
+  // is unknown we still return `lastFill.liters` clamped — same shape
+  // as the no-capacity branch above for the full-tank path.
+  double level;
+  int startIdx;
+  if (anchorIdx < 0) {
+    level = 0;
+    startIdx = 0;
+  } else {
+    level = capacityL ?? priorFills[anchorIdx].liters;
+    startIdx = anchorIdx + 1;
+  }
+
+  // Walk forward: for each prior fill from startIdx to the end, apply
+  // trip consumption between the previous boundary and this fill, then
+  // apply the partial top-up.
+  var prevBoundary = anchorIdx >= 0 ? priorFills[anchorIdx].date : null;
+  for (var i = startIdx; i < priorFills.length; i++) {
+    final f = priorFills[i];
+    final consumed = _consumedBetween(
+      trips: trips,
+      from: prevBoundary,
+      to: f.date,
+      avgLPer100Km: avgLPer100Km,
+    );
+    level = (level - consumed).clamp(0.0, upper);
+    // Each partial in the chain adds its litres. (Full fills before
+    // lastFill are also clamped — anchorIdx already pointed at the
+    // most recent one, so any later "full" entries don't appear here
+    // by construction.)
+    level = (level + f.liters).clamp(0.0, upper);
+    prevBoundary = f.date;
+  }
+
+  // Finally, consume between the last prior boundary and lastFill,
+  // then add lastFill.liters (the partial top-up).
+  final consumedToLast = _consumedBetween(
+    trips: trips,
+    from: prevBoundary,
+    to: lastFill.date,
+    avgLPer100Km: avgLPer100Km,
+  );
+  level = (level - consumedToLast).clamp(0.0, upper);
+  level = (level + lastFill.liters).clamp(0.0, upper);
+  return level;
+}
+
+/// Sum trip consumption strictly between [from] (exclusive) and [to]
+/// (exclusive). Null `from` means "since the beginning of time".
+///
+/// Trips with `startedAt == null` are skipped (defensive — the provider
+/// already drops these). OBD2 measurements win when present; otherwise
+/// the distance × avg L/100 km fallback applies.
+double _consumedBetween({
+  required List<TripHistoryEntry> trips,
+  required DateTime? from,
+  required DateTime to,
+  required double avgLPer100Km,
+}) {
+  var total = 0.0;
+  for (final t in trips) {
+    final startedAt = t.summary.startedAt;
+    if (startedAt == null) continue;
+    if (from != null && !startedAt.isAfter(from)) continue;
+    if (!startedAt.isBefore(to)) continue;
+    final measured = t.summary.fuelLitersConsumed;
+    if (measured != null) {
+      total += measured;
+    } else {
+      total += t.summary.distanceKm * avgLPer100Km / 100.0;
+    }
+  }
+  return total;
 }

--- a/lib/features/consumption/presentation/widgets/add_fill_up_form_fields.dart
+++ b/lib/features/consumption/presentation/widgets/add_fill_up_form_fields.dart
@@ -187,17 +187,22 @@ class AddFillUpFormFields extends StatelessWidget {
                 ],
               ),
             ),
-            // #1195 — Full-tank toggle. Defaults ON because the typical
-            // pattern is a "plein". Off = partial top-up so the tank-
-            // level estimator can branch on previous_level + liters_added
-            // once that path is wired (today the data is captured but
-            // the v1 estimator still assumes capacity reset).
+            // #1195 / #1360 — Full-tank toggle. Defaults ON because the
+            // typical pattern is a "plein". Off = partial top-up; the
+            // tank-level estimator now honours the flag and branches
+            // on `previous_level + liters_added` (#1360 lands the
+            // partial-fill path the original v1 left as a TODO).
             FormFieldTile(
               icon: Icons.local_gas_station_outlined,
               content: SwitchListTile(
                 key: const Key('add_fill_up_is_full_tank_toggle'),
                 contentPadding: EdgeInsets.zero,
                 title: Text(l?.addFillUpIsFullTankLabel ?? 'Full tank'),
+                subtitle: Text(
+                  l?.addFillUpIsFullTankSubtitle ??
+                      'Tank filled to the brim — uncheck if this was a '
+                          'partial fill',
+                ),
                 value: isFullTank,
                 onChanged: onIsFullTankChanged,
               ),

--- a/lib/features/consumption/providers/tank_level_provider.dart
+++ b/lib/features/consumption/providers/tank_level_provider.dart
@@ -35,19 +35,22 @@ TankLevelEstimate tankLevel(Ref ref, String vehicleId) {
   // The fill-up list is already newest-first via FillUpRepository, but
   // be defensive: a malformed import could hand us a different order.
   fillUps.sort((a, b) => b.date.compareTo(a.date));
-  final lastFillUpDate = fillUps.first.date;
 
+  // Pass every trip for the vehicle (with a real `startedAt`) — the
+  // estimator needs prior trips to compute "level just before the
+  // most recent partial fill" (#1360). Trips with null `startedAt`
+  // are dropped because they can't be placed on the timeline.
+  // The estimator additionally filters by date for the post-fill
+  // consumption tally, so the broader input is safe.
   final allTrips = ref.watch(tripHistoryListProvider);
-  final tripsSinceLastFillUp = allTrips.where((t) {
+  final vehicleTrips = allTrips.where((t) {
     if (t.vehicleId != vehicleId) return false;
-    final startedAt = t.summary.startedAt;
-    if (startedAt == null) return false;
-    return !startedAt.isBefore(lastFillUpDate);
+    return t.summary.startedAt != null;
   }).toList(growable: false);
 
   return estimateTankLevel(
     vehicle: vehicle,
     fillUps: fillUps,
-    trips: tripsSinceLastFillUp,
+    trips: vehicleTrips,
   );
 }

--- a/lib/l10n/_fragments/tank_level_de.arb
+++ b/lib/l10n/_fragments/tank_level_de.arb
@@ -8,5 +8,6 @@
   "tankLevelMethodMixed": "gemischte Messung",
   "tankLevelEmptyNoFillUp": "Tankvorgang erfassen, um den Tankfüllstand zu sehen",
   "tankLevelDetailSheetTitle": "Fahrten seit dem letzten Tankvorgang",
-  "addFillUpIsFullTankLabel": "Voller Tank"
+  "addFillUpIsFullTankLabel": "Voller Tank",
+  "addFillUpIsFullTankSubtitle": "Tank bis zum Rand gefüllt — abwählen, wenn es eine Teilbetankung war"
 }

--- a/lib/l10n/_fragments/tank_level_en.arb
+++ b/lib/l10n/_fragments/tank_level_en.arb
@@ -56,5 +56,9 @@
   "addFillUpIsFullTankLabel": "Full tank",
   "@addFillUpIsFullTankLabel": {
     "description": "Label of the Full-tank toggle on the Add fill-up screen — defaults on, captures whether the fill-up topped the tank up to capacity (#1195)."
+  },
+  "addFillUpIsFullTankSubtitle": "Tank filled to the brim — uncheck if this was a partial fill",
+  "@addFillUpIsFullTankSubtitle": {
+    "description": "Subtitle of the Full-tank toggle on the Add fill-up screen — explains the partial-fill alternative so users know when to flip the switch off (#1360)."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1521,6 +1521,7 @@
   "tankLevelEmptyNoFillUp": "Tankvorgang erfassen, um den Tankfüllstand zu sehen",
   "tankLevelDetailSheetTitle": "Fahrten seit dem letzten Tankvorgang",
   "addFillUpIsFullTankLabel": "Voller Tank",
+  "addFillUpIsFullTankSubtitle": "Tank bis zum Rand gefüllt — abwählen, wenn es eine Teilbetankung war",
   "themeCardTitle": "Design",
   "themeCardSubtitleSystem": "System",
   "themeCardSubtitleLight": "Hell",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2436,6 +2436,10 @@
   "@addFillUpIsFullTankLabel": {
     "description": "Label of the Full-tank toggle on the Add fill-up screen — defaults on, captures whether the fill-up topped the tank up to capacity (#1195)."
   },
+  "addFillUpIsFullTankSubtitle": "Tank filled to the brim — uncheck if this was a partial fill",
+  "@addFillUpIsFullTankSubtitle": {
+    "description": "Subtitle of the Full-tank toggle on the Add fill-up screen — explains the partial-fill alternative so users know when to flip the switch off (#1360)."
+  },
   "themeCardTitle": "Theme",
   "@themeCardTitle": {
     "description": "Title of the Theme card on the Settings screen (#897). The card matches the Privacy + Storage card pattern and navigates to a dedicated theme picker screen."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -968,6 +968,7 @@
   "tankLevelEmptyNoFillUp": "Enregistrez un plein pour voir le niveau du réservoir",
   "tankLevelDetailSheetTitle": "Trajets depuis le dernier plein",
   "addFillUpIsFullTankLabel": "Plein complet",
+  "addFillUpIsFullTankSubtitle": "Réservoir rempli à ras bord — décochez s'il s'agissait d'un plein partiel",
   "profileGamificationToggleTitle": "Afficher les succès et scores",
   "profileGamificationToggleSubtitle": "Désactivé, les badges, scores et trophées sont masqués dans toute l'app.",
   "vehicleEditTitle": "Modifier le véhicule",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7112,6 +7112,12 @@ abstract class AppLocalizations {
   /// **'Full tank'**
   String get addFillUpIsFullTankLabel;
 
+  /// Subtitle of the Full-tank toggle on the Add fill-up screen — explains the partial-fill alternative so users know when to flip the switch off (#1360).
+  ///
+  /// In en, this message translates to:
+  /// **'Tank filled to the brim — uncheck if this was a partial fill'**
+  String get addFillUpIsFullTankSubtitle;
+
   /// Title of the Theme card on the Settings screen (#897). The card matches the Privacy + Storage card pattern and navigates to a dedicated theme picker screen.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3838,6 +3838,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3838,6 +3838,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3836,6 +3836,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3874,6 +3874,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Voller Tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank bis zum Rand gefüllt — abwählen, wenn es eine Teilbetankung war';
+
+  @override
   String get themeCardTitle => 'Design';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3840,6 +3840,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3831,6 +3831,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3839,6 +3839,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3833,6 +3833,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3836,6 +3836,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3872,6 +3872,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Plein complet';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Réservoir rempli à ras bord — décochez s\'il s\'agissait d\'un plein partiel';
+
+  @override
   String get themeCardTitle => 'Thème';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3835,6 +3835,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3840,6 +3840,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3839,6 +3839,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3837,6 +3837,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3839,6 +3839,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3835,6 +3835,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3840,6 +3840,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3838,6 +3838,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3839,6 +3839,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3838,6 +3838,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3839,6 +3839,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3833,6 +3833,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3837,6 +3837,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get addFillUpIsFullTankLabel => 'Full tank';
 
   @override
+  String get addFillUpIsFullTankSubtitle =>
+      'Tank filled to the brim — uncheck if this was a partial fill';
+
+  @override
   String get themeCardTitle => 'Theme';
 
   @override

--- a/test/features/consumption/domain/entities/fill_up_test.dart
+++ b/test/features/consumption/domain/entities/fill_up_test.dart
@@ -46,6 +46,41 @@ void main() {
     });
   });
 
+  group('FillUp.isFullTank round-trip (#1360)', () {
+    test('defaults to true on construction', () {
+      expect(_makeFillUp().isFullTank, isTrue);
+    });
+
+    test('persists `false` through JSON round-trip', () {
+      final partial = _makeFillUp().copyWith(isFullTank: false);
+      final json = partial.toJson();
+      final back = FillUp.fromJson(json);
+      expect(back.isFullTank, isFalse);
+    });
+
+    test('persists `true` through JSON round-trip', () {
+      final fullTank = _makeFillUp().copyWith(isFullTank: true);
+      final json = fullTank.toJson();
+      final back = FillUp.fromJson(json);
+      expect(back.isFullTank, isTrue);
+    });
+
+    test('older JSON without isFullTank deserialises as true (default)', () {
+      // Existing fill-ups predate the toggle; they must keep working
+      // as full-tank fills so the tank-level estimator stays correct.
+      final legacy = <String, dynamic>{
+        'id': 'legacy',
+        'date': DateTime(2026, 3, 15).toIso8601String(),
+        'liters': 50,
+        'totalCost': 80,
+        'odometerKm': 12345,
+        'fuelType': 'diesel',
+      };
+      final back = FillUp.fromJson(legacy);
+      expect(back.isFullTank, isTrue);
+    });
+  });
+
   group('FillUpX.co2Kg', () {
     test('returns non-zero for diesel', () {
       final f = _makeFillUp(liters: 50, fuelType: FuelType.diesel);

--- a/test/features/consumption/domain/services/tank_level_estimator_test.dart
+++ b/test/features/consumption/domain/services/tank_level_estimator_test.dart
@@ -329,6 +329,213 @@ void main() {
     });
   });
 
+  group('estimateTankLevel — partial-fill branch (#1360)', () {
+    // 40 L tank for a clean walkthrough that maps to the brief's
+    // sequence: [plein 40L → 40L, drive 10L → 30L, partial 5L → 35L,
+    // plein 30L → 40L]. Each test pins one snapshot in that timeline.
+    const smallTank = VehicleProfile(
+      id: 'v1',
+      name: 'Small Tank',
+      type: VehicleType.combustion,
+      tankCapacityL: 40,
+    );
+
+    final pleinT0 = FillUp(
+      id: 'plein-0',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 40,
+      totalCost: 70,
+      odometerKm: 100000,
+      fuelType: FuelType.diesel,
+      vehicleId: 'v1',
+      // isFullTank defaults to true.
+    );
+
+    final tripT1 = trip(
+      id: 'drive-1',
+      startedAt: DateTime(2026, 4, 2, 9),
+      distanceKm: 30,
+      fuelLitersConsumed: 10, // exactly 10 L for the brief's case
+    );
+
+    final partialT2 = FillUp(
+      id: 'partial-2',
+      date: DateTime(2026, 4, 3, 8),
+      liters: 5,
+      totalCost: 9,
+      odometerKm: 100030,
+      fuelType: FuelType.diesel,
+      vehicleId: 'v1',
+      isFullTank: false,
+    );
+
+    final pleinT3 = FillUp(
+      id: 'plein-3',
+      date: DateTime(2026, 4, 4, 8),
+      liters: 30,
+      totalCost: 54,
+      odometerKm: 100050,
+      fuelType: FuelType.diesel,
+      vehicleId: 'v1',
+      // isFullTank defaults to true.
+    );
+
+    test('after plein 40L → level == 40 (capacity reset)', () {
+      final result = estimateTankLevel(
+        vehicle: smallTank,
+        fillUps: [pleinT0],
+        trips: const [],
+      );
+
+      expect(result.levelL, 40);
+    });
+
+    test('after plein 40L + drive 10L → level == 30', () {
+      final result = estimateTankLevel(
+        vehicle: smallTank,
+        fillUps: [pleinT0],
+        trips: [tripT1],
+      );
+
+      expect(result.levelL, closeTo(30, 0.001));
+    });
+
+    test('after plein 40L + drive 10L + partial 5L → level == 35', () {
+      // Newest first: partialT2 then pleinT0. tripT1 sits between.
+      final result = estimateTankLevel(
+        vehicle: smallTank,
+        fillUps: [partialT2, pleinT0],
+        trips: [tripT1],
+      );
+
+      // Anchor at pleinT0 (40 L) → drive 10L (30 L) → +5 L partial = 35.
+      expect(result.levelL, closeTo(35, 0.001));
+      expect(result.lastFillUpDate, partialT2.date);
+      // tripsSince counts trips after the most recent fill (partialT2),
+      // none in this fixture.
+      expect(result.tripsSince, 0);
+    });
+
+    test('after the full plein-30L closer → level resets to capacity (40)',
+        () {
+      final result = estimateTankLevel(
+        vehicle: smallTank,
+        fillUps: [pleinT3, partialT2, pleinT0],
+        trips: [tripT1],
+      );
+
+      // Latest fill is full → reset to capacity. Earlier history doesn't
+      // change the answer.
+      expect(result.levelL, 40);
+      expect(result.lastFillUpDate, pleinT3.date);
+    });
+
+    test('partial fill clamps to capacity when level + liters > capacity',
+        () {
+      // No trips between → level just before partial == 40 (capacity).
+      // Adding 5 L would overflow, so the clamp pins at capacity.
+      final result = estimateTankLevel(
+        vehicle: smallTank,
+        fillUps: [partialT2, pleinT0],
+        trips: const [],
+      );
+
+      expect(result.levelL, 40);
+    });
+
+    test('partial fill on top of trips that drove tank dry → starts at 0 + liters',
+        () {
+      // Drive 100 km × 7.0 / 100 = 7 L between fills, but actual
+      // OBD2 says 50 L (more than capacity). Clamp pins level pre-
+      // partial at 0; partial 5 L bumps to 5.
+      final massiveTrip = trip(
+        id: 'huge',
+        startedAt: DateTime(2026, 4, 2, 9),
+        distanceKm: 1000,
+        fuelLitersConsumed: 50,
+      );
+      final result = estimateTankLevel(
+        vehicle: smallTank,
+        fillUps: [partialT2, pleinT0],
+        trips: [massiveTrip],
+      );
+
+      expect(result.levelL, closeTo(5, 0.001));
+    });
+
+    test('post-partial trips subtract from the partial-derived level', () {
+      // After the partial top-up the level should be 35; a 7 L trip
+      // after that brings it to 28.
+      final postPartialTrip = trip(
+        id: 'after-partial',
+        startedAt: DateTime(2026, 4, 3, 12),
+        distanceKm: 30,
+        fuelLitersConsumed: 7,
+      );
+      final result = estimateTankLevel(
+        vehicle: smallTank,
+        fillUps: [partialT2, pleinT0],
+        trips: [tripT1, postPartialTrip],
+      );
+
+      expect(result.levelL, closeTo(28, 0.001));
+      expect(result.tripsSince, 1);
+    });
+
+    test('chain of partials with no prior plein anchor → starts from 0',
+        () {
+      // Two partials in a row, no plein in history. Honest worst case:
+      // start at 0, add liters as we walk forward.
+      final partialA = FillUp(
+        id: 'part-a',
+        date: DateTime(2026, 4, 1),
+        liters: 10,
+        totalCost: 18,
+        odometerKm: 100000,
+        fuelType: FuelType.diesel,
+        vehicleId: 'v1',
+        isFullTank: false,
+      );
+      final partialB = FillUp(
+        id: 'part-b',
+        date: DateTime(2026, 4, 2),
+        liters: 5,
+        totalCost: 9,
+        odometerKm: 100020,
+        fuelType: FuelType.diesel,
+        vehicleId: 'v1',
+        isFullTank: false,
+      );
+
+      final result = estimateTankLevel(
+        vehicle: smallTank,
+        fillUps: [partialB, partialA],
+        trips: const [],
+      );
+
+      // 0 + 10 (partialA) + 5 (partialB) = 15.
+      expect(result.levelL, closeTo(15, 0.001));
+    });
+
+    test('no capacity configured → partial branch still adds litres', () {
+      const noCap = VehicleProfile(
+        id: 'v3',
+        name: 'No-cap',
+        type: VehicleType.combustion,
+      );
+      final result = estimateTankLevel(
+        vehicle: noCap,
+        fillUps: [partialT2, pleinT0],
+        trips: [tripT1],
+      );
+
+      // Anchor at pleinT0 → start = lastFill-anchor.liters (40, since
+      // capacity is null). drive 10 L → 30. partial 5 L → 35. The
+      // upper clamp is infinite without capacity, so 35 stands.
+      expect(result.levelL, closeTo(35, 0.001));
+    });
+  });
+
   group('estimateTankLevel — vehicle without tankCapacityL', () {
     test('falls back to lastFillUp.liters as start level', () {
       const vehicleNoCap = VehicleProfile(

--- a/test/features/consumption/presentation/screens/add_fill_up_screen_restyle_test.dart
+++ b/test/features/consumption/presentation/screens/add_fill_up_screen_restyle_test.dart
@@ -231,5 +231,22 @@ void main() {
       );
       expect(toggle.value, isFalse);
     });
+
+    testWidgets('renders the partial-fill subtitle (#1360)', (tester) async {
+      await _pumpWithTallView(
+        tester,
+        const AddFillUpScreen(),
+        overrides: _withVehicle,
+      );
+
+      // Subtitle explains when to flip the toggle off — landed by
+      // #1360 alongside the estimator's partial-fill branch.
+      expect(
+        find.text(
+          'Tank filled to the brim — uncheck if this was a partial fill',
+        ),
+        findsOneWidget,
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Lands the standing TODO at `tank_level_estimator.dart:113` — the estimator now branches on `FillUp.isFullTank`. Full fills still reset to capacity (unchanged); partial fills add `liters_added` on top of `previous_level`, clamped to `[0, capacity]`. The previous level is computed by walking earlier fill-ups oldest→newest, anchored at the most recent prior full fill, with trip consumption between fills folded in.
- Updates `tankLevelProvider` to pass every vehicle trip (with a real `startedAt`) so the estimator can resolve the level just before a partial top-up. The estimator's existing date filter keeps the "trips since last fill-up" tally honest.
- Adds an explanatory subtitle to the existing Full-tank toggle on the Add fill-up form so the partial-fill case is self-explaining. `addFillUpIsFullTankSubtitle` shipped in en/de fragments + direct fr; other locales fall back to English.

## Test plan

- [x] `flutter analyze` → `No issues found!`
- [x] `flutter test test/features/consumption/domain/entities/fill_up_test.dart` (12/12 pass — includes 3 new isFullTank JSON round-trip tests)
- [x] `flutter test test/features/consumption/domain/services/tank_level_estimator_test.dart` (25/25 pass — includes 9 new partial-fill branch tests covering the brief's `[plein 40L → drive 10L → partial 5L → plein 30L]` sequence, capacity clamping, dry-tank recovery, post-partial trip subtraction, no-anchor fallback, and no-capacity behaviour)
- [x] `flutter test test/features/consumption/` (2139/2139 pass — pre-existing flaky obd2_speed_stream test passed on re-run)
- [x] Widget test: subtitle renders alongside the existing toggle title + default-on / flip-off assertions

## Notes

- Closes the standing TODO at `tank_level_estimator.dart:113` ("once partial-fill UI lands the branch flips on `isFullTank`"). Drops the corresponding comment.
- The toggle UI itself was already wired by #1195 (defaults true, persists into `FillUp.isFullTank` via the existing entity field). This PR adds the missing estimator wiring + the user-visible subtitle.
- No edit screen exists in the codebase today — fill-ups are created via `AddFillUpScreen` and removed via swipe-to-dismiss. The "edit round-trips" acceptance is satisfied by the JSON round-trip tests on `FillUp.isFullTank` (legacy entries without the key correctly deserialise as `true`, which is the documented behaviour for the freezed default). When an edit screen is added in a future PR the existing toggle widget can be reused as-is.
- Provider change is backward-compatible: existing tank_level_provider tests all still pass because the estimator's internal date filter preserves the prior contract for the dominant full-tank case.