### PR TITLE
fix(obd2): bump VIN read default timeout from 3s to 8s (Closes #1365)

### DIFF
--- a/lib/features/vehicle/data/obd2_vin_reader.dart
+++ b/lib/features/vehicle/data/obd2_vin_reader.dart
@@ -50,7 +50,7 @@ enum ObdVinFailureReason {
 /// decoder pipeline (#812 phase 2) can pre-fill make/model/year/engine
 /// without forcing the user to type 17 characters.
 ///
-/// Bounded by [timeout] (3 seconds by default) so a stuck adapter
+/// Bounded by [timeout] (8 seconds by default) so a stuck adapter
 /// can't hang the UI. Never throws — every error path produces an
 /// [ObdVinResult.failure] with a typed reason.
 class Obd2VinReader {
@@ -62,11 +62,18 @@ class Obd2VinReader {
   /// Maximum time to wait for the response. Mirrors the bounded shape
   /// used by [TripRecordingController._readVinOnce] so a failing
   /// adapter degrades the UX rather than blocking it.
+  ///
+  /// #1365 — bumped from 3 s to 8 s after field traces (build 5.0.0+7122)
+  /// showed slow ELM327 clones (SmartOBD: 200 ms inter-command, 400 ms
+  /// post-reset) regularly exceeding 3 s on the multi-frame Mode 09
+  /// response. 8 s covers every adapter currently in the registry with
+  /// headroom; a future iteration could make this adapter-aware via
+  /// [Obd2AdapterProfile.adapter.interCommandDelay].
   final Duration timeout;
 
   Obd2VinReader({
     required this.service,
-    this.timeout = const Duration(seconds: 3),
+    this.timeout = const Duration(seconds: 8),
   });
 
   /// Send Mode 09 PID 02 and decode the response.

--- a/test/features/vehicle/data/obd2_vin_reader_test.dart
+++ b/test/features/vehicle/data/obd2_vin_reader_test.dart
@@ -135,6 +135,28 @@ void main() {
       },
     );
   });
+
+  group('Obd2VinReader default timeout (#1365)', () {
+    test(
+      'default constructor timeout is at least 8 s — slow ELM327 clones '
+      'need the headroom on the multi-frame Mode 09 response',
+      () {
+        // Field traces (build 5.0.0+7122) showed the prior 3 s default
+        // firing on SmartOBD-class adapters with 200 ms inter-command
+        // delay. Guard against accidental regression below 8 s.
+        final reader = Obd2VinReader(service: Obd2Service(_FakeTransport.forCommand(
+          Elm327Protocol.vinCommand,
+          'NO DATA\r\n>',
+        )));
+        expect(
+          reader.timeout,
+          greaterThanOrEqualTo(const Duration(seconds: 8)),
+          reason: 'See #1365 — slow adapters must have enough wall-clock '
+              'budget for the Mode 09 PID 02 multi-frame exchange',
+        );
+      },
+    );
+  });
 }
 
 /// In-memory [TraceRecorder] used to drain `errorLogger.log` calls


### PR DESCRIPTION
## Summary

Field traces (build 5.0.0+7122) showed `Obd2VinReader.read` firing its 3-second hard timeout three times in a 5-hour window during normal vehicle-edit usage. The Mode 09 PID 02 multi-frame response from slow ELM327 clones (SmartOBD: 200 ms inter-command + 400 ms post-reset; vLinker FS Classic; generic v1.5 clones) regularly exceeds 3 s on a cold link.

Bumped `Obd2VinReader` default timeout from 3 s to 8 s — covers every adapter in the registry with headroom. Added a regression test that fails if the default ever drops below 8 s again.

Adapter-aware derivation (`timeout = max(3 s, 8 × interCommandDelay + 2 s)`) is the right follow-up but requires plumbing the resolved profile through `Obd2VinReaderService` into `Obd2VinReader`; the wall-clock bump is the minimal correct fix that ships with the next build.

Closes #1365

## Test plan
- [x] `flutter test test/features/vehicle/data/obd2_vin_reader_test.dart` — 6 tests pass (5 pre-existing + 1 new default-timeout regression guard)
- [x] `flutter test test/features/vehicle/` — 510 tests pass
- [x] `flutter analyze` — no issues
- [ ] Device test on a SmartOBD or generic Classic ELM327 — confirm `Lire le VIN depuis la voiture` returns a VIN within ~5 s instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)