### PR TITLE
fix(obd2): map BT-off PlatformException to typed Obd2BluetoothOff (Closes #1369)

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_facade.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import 'adapter_registry.dart';
 import 'elm_byte_channel.dart';
 import 'flutter_blue_plus_elm_channel.dart';
+import 'obd2_connection_errors.dart';
 
 /// Thin façade over flutter_blue_plus for the connection service
 /// (#741). Keeps the plugin API pinned to a small surface we can
@@ -45,10 +48,23 @@ class PluginBluetoothFacade implements BluetoothFacade {
     final controller = StreamController<List<Obd2AdapterCandidate>>();
     final accumulated = <String, Obd2AdapterCandidate>{};
 
-    // Start the real plugin scan.
-    FlutterBluePlus.startScan(
-      withServices: serviceUuids.map(Guid.new).toList(),
-      timeout: timeout,
+    // #1369 — `FlutterBluePlus.startScan` is async; previously its
+    // future was unawaited so a `PlatformException(startScan,
+    // "Bluetooth must be turned on", ...)` (BT radio off) leaked to
+    // the zone error handler instead of reaching the consumer's
+    // onError. Route the rejection back through the controller so
+    // the picker / VIN reader sees a typed `Obd2BluetoothOff` (or
+    // the original plugin exception for any unrelated failure).
+    unawaited(
+      FlutterBluePlus.startScan(
+        withServices: serviceUuids.map(Guid.new).toList(),
+        timeout: timeout,
+      ).catchError((Object e, StackTrace st) {
+        if (controller.isClosed) return;
+        final mapped = _looksBluetoothOff(e) ? const Obd2BluetoothOff() : e;
+        controller.addError(mapped, st);
+        unawaited(controller.close());
+      }),
     );
 
     final sub = FlutterBluePlus.scanResults.listen(
@@ -81,6 +97,22 @@ class PluginBluetoothFacade implements BluetoothFacade {
     });
 
     return controller.stream;
+  }
+
+  /// Recognise the platform-channel rejection FlutterBluePlus emits
+  /// when the OS Bluetooth radio is disabled. The exact wording comes
+  /// from `flutter_blue_plus_android`; matched case-insensitively
+  /// against a substring so a future plugin update''s phrasing tweak
+  /// does not silently downgrade us to the generic-error path.
+  @visibleForTesting
+  static bool debugLooksBluetoothOff(Object e) => _looksBluetoothOff(e);
+
+  static bool _looksBluetoothOff(Object e) {
+    if (e is! PlatformException) return false;
+    final msg = (e.message ?? '').toLowerCase();
+    return msg.contains('must be turned on') ||
+        msg.contains('bluetooth must be on') ||
+        msg.contains('bluetooth_off');
   }
 
   @override

--- a/lib/features/consumption/data/obd2/obd2_connection_errors.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_errors.dart
@@ -20,6 +20,19 @@ class Obd2PermissionDenied extends Obd2ConnectionError {
   const Obd2PermissionDenied([super.message = 'Bluetooth permission denied']);
 }
 
+/// The OS Bluetooth radio is turned off (#1369). The user has the
+/// permission but the adapter itself is disabled — `FlutterBluePlus`
+/// rejects `startScan` with `PlatformException(startScan, "Bluetooth
+/// must be turned on", ...)` in this state. Surfaced as its own typed
+/// error so the picker / VIN reader can render a "Turn on Bluetooth
+/// and try again" message instead of leaking the raw plugin exception
+/// through the global error handler.
+class Obd2BluetoothOff extends Obd2ConnectionError {
+  const Obd2BluetoothOff([
+    super.message = 'Turn on Bluetooth and try again',
+  ]);
+}
+
 /// The scan window expired without any known adapter responding.
 /// Usually means the vLinker is off, out of range, or the wrong
 /// service UUID for its firmware variant.

--- a/test/features/consumption/data/obd2/bluetooth_facade_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_facade_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+
+/// Unit tests for the [PluginBluetoothFacade] BT-off classifier
+/// (#1369).
+///
+/// `PluginBluetoothFacade._looksBluetoothOff` is the boundary that
+/// turns a raw `flutter_blue_plus_android` `PlatformException` into a
+/// typed `Obd2BluetoothOff`. The plugin's exact wording has changed
+/// between versions, so the substring match must stay tolerant of
+/// small phrasing tweaks (different capitalisation, "must be on" vs
+/// "must be turned on", explicit `bluetooth_off` codes, etc.).
+void main() {
+  group('PluginBluetoothFacade.debugLooksBluetoothOff (#1369)', () {
+    test('matches the canonical FlutterBluePlus 1.36 phrasing', () {
+      final ex = PlatformException(
+        code: 'startScan',
+        message: 'Bluetooth must be turned on',
+      );
+      expect(PluginBluetoothFacade.debugLooksBluetoothOff(ex), isTrue);
+    });
+
+    test('matches a case-insensitive variant', () {
+      final ex = PlatformException(
+        code: 'startScan',
+        message: 'BLUETOOTH MUST BE TURNED ON',
+      );
+      expect(PluginBluetoothFacade.debugLooksBluetoothOff(ex), isTrue);
+    });
+
+    test('matches the alternate "must be on" phrasing', () {
+      final ex = PlatformException(
+        code: 'startScan',
+        message: 'Bluetooth must be on',
+      );
+      expect(PluginBluetoothFacade.debugLooksBluetoothOff(ex), isTrue);
+    });
+
+    test('matches an explicit bluetooth_off code in the message', () {
+      final ex = PlatformException(
+        code: 'startScan',
+        message: 'BLUETOOTH_OFF: adapter disabled',
+      );
+      expect(PluginBluetoothFacade.debugLooksBluetoothOff(ex), isTrue);
+    });
+
+    test(
+      'rejects unrelated PlatformExceptions so they propagate as-is',
+      () {
+        final ex = PlatformException(
+          code: 'permission_denied',
+          message: 'BLUETOOTH_SCAN permission required',
+        );
+        expect(PluginBluetoothFacade.debugLooksBluetoothOff(ex), isFalse);
+      },
+    );
+
+    test('rejects non-PlatformException objects', () {
+      expect(
+        PluginBluetoothFacade.debugLooksBluetoothOff(
+          ArgumentError('not a platform exception'),
+        ),
+        isFalse,
+      );
+      expect(
+        PluginBluetoothFacade.debugLooksBluetoothOff(
+          'Bluetooth must be turned on',
+        ),
+        isFalse,
+      );
+    });
+
+    test('handles a PlatformException with a null message gracefully', () {
+      final ex = PlatformException(code: 'startScan');
+      expect(PluginBluetoothFacade.debugLooksBluetoothOff(ex), isFalse);
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -21,6 +21,29 @@ void main() {
       await expectLater(svc.scan().toList(), throwsA(isA<Obd2PermissionDenied>()));
     });
 
+    test(
+      'propagates Obd2BluetoothOff from the BLE facade verbatim — the '
+      'service must not catch it as a scan timeout (#1369)',
+      () async {
+        // The facade emits a typed Obd2BluetoothOff once it has
+        // identified that FlutterBluePlus rejected startScan with
+        // "Bluetooth must be turned on". The connection service is a
+        // pass-through; the picker / VIN reader catches the typed
+        // error and renders the "Turn on Bluetooth" message.
+        final svc = _build(
+          permState: Obd2PermissionState.granted,
+          bt: _FakeFacade(
+            batches: const [],
+            error: const Obd2BluetoothOff(),
+          ),
+        );
+        await expectLater(
+          svc.scan().toList(),
+          throwsA(isA<Obd2BluetoothOff>()),
+        );
+      },
+    );
+
     test('throws Obd2ScanTimeout when no known adapter is seen', () async {
       final svc = _build(
         permState: Obd2PermissionState.granted,
@@ -285,7 +308,8 @@ class _FakeClassicFacade implements ClassicBluetoothFacade {
 class _FakeFacade implements BluetoothFacade {
   final List<List<Obd2AdapterCandidate>> batches;
   final ElmByteChannel? channel;
-  _FakeFacade({required this.batches, this.channel});
+  final Object? error;
+  _FakeFacade({required this.batches, this.channel, this.error});
 
   @override
   Stream<List<Obd2AdapterCandidate>> scan({
@@ -294,6 +318,10 @@ class _FakeFacade implements BluetoothFacade {
   }) async* {
     for (final batch in batches) {
       yield batch;
+    }
+    final err = error;
+    if (err != null) {
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary

Field traces (build 5.0.0+7132 — the build that ships #1349 + #1351) showed three crashes when the user tried scan-requiring buttons with Bluetooth disabled:

```
[other] PlatformException(startScan, Bluetooth must be turned on, null, null)
  #4  FlutterBluePlus._invokePlatform
  #5  FlutterBluePlus.startScan
```

The fix uncovered them: the new `connectByMac` path now runs a real scan instead of stale `_lastRanked`, so `FlutterBluePlus.startScan` is reached — and rejects synchronously when BT is off. Previously the rejection was an unawaited future, escaping to the zone error handler.

This PR:
1. Adds an `Obd2BluetoothOff` typed error to the existing `Obd2ConnectionError` hierarchy.
2. In `PluginBluetoothFacade.scan`, awaits the `startScan` future via `.catchError` and routes the rejection through the StreamController. Substring-matches known BT-off phrasings (canonical, case-variant, alternate "must be on", explicit `BLUETOOTH_OFF` code) and emits `Obd2BluetoothOff`; passes every other `PlatformException` through unchanged.
3. The picker's existing `onError: e is Obd2ConnectionError` filter and `_error?.message` rendering then automatically surface "Turn on Bluetooth and try again" — no UI changes needed.
4. The VIN reader's outer try/catch now logs the typed error as `[background] vinReaderService.readVin` instead of leaking to the global handler — still returns `ObdVinFailureReason.io` so the existing snackbar path is unchanged.

Closes #1369

## Test plan
- [x] 7 unit tests for the BT-off classifier (`bluetooth_facade_test.dart`) covering canonical wording, case-insensitivity, "must be on" variant, explicit `BLUETOOTH_OFF` code, unrelated PlatformExceptions, non-PlatformException objects, null message
- [x] 1 integration test on `Obd2ConnectionService.scan` asserting the typed error propagates verbatim instead of being caught as a scan timeout
- [x] `flutter test test/features/consumption/data/obd2/` — 645 tests pass
- [x] `flutter analyze` — no issues
- [ ] Device test — turn off Bluetooth, tap **Lire le VIN depuis la voiture**; confirm a clear "Turn on Bluetooth" snackbar instead of a silent failure or a generic error

## Out of scope (follow-up)

- Auto-prompt BT enablement (Android 13+ requires a separate intent flow)
- Dedicated `ObdVinFailureReason.bluetoothOff` so the VIN snackbar can carry a BT-specific message instead of the generic IO copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)