### PR TITLE
chore(release): v5.0.0+5132 — refresh Play Store listing + bump build

### DIFF
--- a/fastlane/metadata/android/de-DE/changelogs/5132.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/5132.txt
@@ -1,0 +1,9 @@
+v5.0.0 — Major-Release
+• 17 Laender unterstuetzt (neu: Griechenland, Rumaenien, Slowenien, Luxemburg, Suedkorea, Chile)
+• EV-Ladestationen von OpenChargeMap neben den Kraftstoffpreisen
+• Fahrtaufzeichnung via OBD2 (Bluetooth ELM327) — echte Verbrauchsdaten
+• Tank-Historie mit Beleg-OCR (Super U, Carrefour, generisch)
+• Radius- und Geschwindigkeits-Preisalarme mit lokalen Benachrichtigungen
+• Optionale selbst gehostete Supabase-Synchronisation (TankSync)
+• Android Auto, Startbildschirm-Widgets, grenzueberschreitender Preisvergleich
+• 23 Sprachen — Datenschutz an erster Stelle, ohne Werbung, ohne Tracking, MIT-lizenziert

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -2,8 +2,8 @@ Tankstellen ist eine kostenlose Open-Source-App zum Vergleich von Kraftstoff- un
 
 FUNKTIONEN
 
-Preisvergleich in 15 Laendern
-- Echtzeit-Kraftstoffpreise von offiziellen Regierungs-APIs in Deutschland (Tankerkoenig/MTS-K), Frankreich (Prix Carburants), Oesterreich (Spritpreisrechner), Spanien (Geoportal), Italien (MASE/MiSE), Daenemark, Portugal (DGEG), Grossbritannien (GOV.UK), Australien (FuelWatch), Slowenien, Luxemburg, Suedkorea (Opinet), Chile (CNE), Argentinien und Mexiko.
+Preisvergleich in 17 Laendern
+- Echtzeit-Kraftstoffpreise von offiziellen Regierungs-APIs in Deutschland (Tankerkoenig/MTS-K), Frankreich (Prix Carburants), Oesterreich (Spritpreisrechner), Spanien (Geoportal), Italien (MASE/MiSE), Daenemark, Portugal (DGEG), Grossbritannien (CMA Fuel Finder), Australien (FuelCheck NSW), Slowenien (goriva.si), Luxemburg, Suedkorea (Opinet), Chile (CNE Bencina en Linea), Griechenland (Paratiritirio Timon), Rumaenien (Monitorul Preturilor), Argentinien und Mexiko.
 - Interaktive Karte mit OpenStreetMap-Kacheln und Marker-Clustering fuer schnelles Navigieren auch in dichten Stadtgebieten.
 - Suche nach Stadt, Postleitzahl oder GPS-Position mit einstellbarem Radius.
 - EV-Ladestationen von OpenChargeMap mit Stecker- und Leistungsdetails neben den Kraftstoffpreisen.

--- a/fastlane/metadata/android/de-DE/short_description.txt
+++ b/fastlane/metadata/android/de-DE/short_description.txt
@@ -1,1 +1,1 @@
-Kostenlose Kraftstoff- und EV-Ladepreise in 15 Laendern. Werbefrei. Ohne Tracking.
+Kostenlose Kraftstoff- und EV-Ladepreise in 17 Laendern. Werbefrei. Ohne Tracking.

--- a/fastlane/metadata/android/en-US/changelogs/5132.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5132.txt
@@ -1,0 +1,9 @@
+v5.0.0 — Major release
+• 17 countries supported (added Greece, Romania, Slovenia, Luxembourg, South Korea, Chile)
+• EV charging stations from OpenChargeMap alongside fuel prices
+• Trip recording with OBD2 (Bluetooth ELM327) — real consumption data
+• Fill-up history with receipt OCR (Super U, Carrefour, generic)
+• Radius and velocity price alerts with local notifications
+• Optional self-hosted Supabase sync (TankSync)
+• Android Auto, home-screen widgets, cross-border price comparison
+• 23 languages — privacy-first, no ads, no tracking, MIT-licensed

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -2,8 +2,8 @@ Tankstellen is a free, open-source fuel and EV charging price comparison app tha
 
 FEATURES
 
-Price comparison across 15 countries
-- Real-time fuel prices from official government APIs in Germany (Tankerkoenig/MTS-K), France (Prix Carburants), Austria (Spritpreisrechner), Spain (Geoportal), Italy (MASE/MiSE), Denmark, Portugal (DGEG), United Kingdom (GOV.UK), Australia (FuelWatch), Slovenia, Luxembourg, South Korea (Opinet), Chile (CNE), Argentina, and Mexico.
+Price comparison across 17 countries
+- Real-time fuel prices from official government APIs in Germany (Tankerkoenig/MTS-K), France (Prix Carburants), Austria (Spritpreisrechner), Spain (Geoportal), Italy (MASE/MiSE), Denmark, Portugal (DGEG), United Kingdom (CMA Fuel Finder), Australia (FuelCheck NSW), Slovenia (goriva.si), Luxembourg, South Korea (Opinet), Chile (CNE Bencina en Línea), Greece (Paratiritirio Timon), Romania (Monitorul Prețurilor), Argentina, and Mexico.
 - Interactive map with OpenStreetMap tiles and marker clustering for fast browsing even in dense urban areas.
 - Search by city, postal code, or GPS position with a configurable radius.
 - EV charging stations from OpenChargeMap with connector and power details alongside fuel prices.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Free fuel + EV charging prices across 15 countries. No ads. No tracking. No limits.
+Free fuel + EV charging prices across 17 countries. No ads. No tracking. No limits.

--- a/fastlane/metadata/android/fr-FR/changelogs/5132.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/5132.txt
@@ -1,0 +1,9 @@
+v5.0.0 — Version majeure
+• 17 pays pris en charge (nouveaux : Grece, Roumanie, Slovenie, Luxembourg, Coree du Sud, Chili)
+• Bornes de recharge electrique OpenChargeMap a cote des prix des carburants
+• Enregistrement de trajets via OBD2 (Bluetooth ELM327) — donnees de consommation reelles
+• Historique des pleins avec OCR pour les tickets (Super U, Carrefour, generiques)
+• Alertes de prix par rayon et par vitesse avec notifications locales
+• Synchronisation Supabase auto-hebergee optionnelle (TankSync)
+• Android Auto, widgets d'ecran d'accueil, comparaison transfrontaliere
+• 23 langues — vie privee respectee, sans publicite, sans tracage, licence MIT

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -2,8 +2,8 @@ Tankstellen est une application gratuite et open source de comparaison des prix 
 
 FONCTIONNALITES
 
-Comparaison de prix dans 15 pays
-- Prix en temps reel provenant des API gouvernementales officielles en Allemagne (Tankerkoenig/MTS-K), France (Prix Carburants), Autriche (Spritpreisrechner), Espagne (Geoportal), Italie (MASE/MiSE), Danemark, Portugal (DGEG), Royaume-Uni (GOV.UK), Australie (FuelWatch), Slovenie, Luxembourg, Coree du Sud (Opinet), Chili (CNE), Argentine et Mexique.
+Comparaison de prix dans 17 pays
+- Prix en temps reel provenant des API gouvernementales officielles en Allemagne (Tankerkoenig/MTS-K), France (Prix Carburants), Autriche (Spritpreisrechner), Espagne (Geoportal), Italie (MASE/MiSE), Danemark, Portugal (DGEG), Royaume-Uni (CMA Fuel Finder), Australie (FuelCheck NSW), Slovenie (goriva.si), Luxembourg, Coree du Sud (Opinet), Chili (CNE Bencina en Linea), Grece (Paratiritirio Timon), Roumanie (Monitorul Preturilor), Argentine et Mexique.
 - Carte interactive avec tuiles OpenStreetMap et regroupement de marqueurs pour une navigation rapide meme dans les zones urbaines denses.
 - Recherche par nom de ville, code postal ou position GPS avec rayon configurable.
 - Bornes de recharge electrique OpenChargeMap avec details des connecteurs et de la puissance a cote des prix des carburants.

--- a/fastlane/metadata/android/fr-FR/short_description.txt
+++ b/fastlane/metadata/android/fr-FR/short_description.txt
@@ -1,1 +1,1 @@
-Carburants + recharge electrique dans 15 pays. Sans publicite. Sans tracage.
+Carburants + recharge electrique dans 17 pays. Sans publicite. Sans tracage.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tankstellen
-description: "Free fuel price comparison app — 11 countries, 23 languages, privacy-first"
+description: "Free fuel price comparison app — 17 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 5.0.0+5122
+version: 5.0.0+5132
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
## Summary

Release prep for Play Store build **5132** (v5.0.0). Two atomic commits:

1. **`docs(playstore)`** — bring fastlane metadata back in sync with reality
   - 15 → **17 countries** in en/de/fr short + full descriptions
   - Add **Greece** (Paratiritirio Timon) and **Romania** (Monitorul Prețurilor)
   - Correct three drifted provider names: GB → *CMA Fuel Finder* (not GOV.UK), AU → *FuelCheck NSW* (FuelWatch is WA-only), CL → *CNE Bencina en Línea*
   - Add `changelogs/5132.txt` for the new build (en/de/fr); old `14.txt` was a v3.0.0-era stub Play Console had already overridden manually
2. **`chore: bump build`** — pubspec `5.0.0+5122` → `5.0.0+5132` and description string `11 → 17 countries`

The live Play Store description was several generations behind ("7 countries", only DE+FR enumerated, "11 countries" in What's new). This corrects multiple generations of drift.

## Build artifacts

Already built locally and copied to `C:\Users\fditt\OneDrive\Android\`:
- `app-play-release.aab` (79.6 MB) — ready to upload to Play Console
- `tankstellen-5.0.0+5132-{arm64,armv7,x86_64}-*.apk` — sideload splits

## Test plan

- [ ] CI green (analyze + tests)
- [ ] Spot-check fastlane diff renders cleanly in Play Console after fastlane push
- [ ] Confirm 17-country list (no typos, no missing flag)
- [ ] Upload AAB to Play Console internal track and verify versionCode 5132 accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)