### PR TITLE
feat(glide-coach): OSM traffic signal data layer (Refs #1125 phase 1)

### DIFF
--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -81,6 +81,10 @@ class HiveBoxes {
   /// keys are available.
   static const String isolateErrorSpool = 'isolate_error_spool';
 
+  /// Glide-coach OSM traffic-signal cache (#1125 phase 1). Public OSM
+  /// data, no PII — unencrypted like the other low-sensitivity boxes.
+  static const String trafficSignalsCache = 'traffic_signals_cache';
+
   static const _encryptedBoxes = {
     settings,
     profiles,
@@ -182,6 +186,8 @@ class HiveBoxes {
     // initialiser into TraceRecorder. Unencrypted so the BG isolate
     // can write before consent / keychain unlock.
     await Hive.openBox<String>(isolateErrorSpool);
+    // #1125 — glide-coach OSM traffic-signal cache (phase 1).
+    await Hive.openBox<String>(trafficSignalsCache);
   }
 
   /// Initialize Hive in a background isolate with proper encryption.

--- a/lib/features/glide_coach/data/osm_traffic_signal_client.dart
+++ b/lib/features/glide_coach/data/osm_traffic_signal_client.dart
@@ -1,0 +1,145 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../domain/entities/traffic_signal.dart';
+
+/// Thrown by [OsmTrafficSignalClient] when the Overpass query fails to
+/// reach the server, returns a non-2xx status, or yields a payload the
+/// parser can't make sense of (#1125 phase 1).
+///
+/// All failure paths surface as this typed exception so the future
+/// repository (and any UI it feeds) can branch on a single class instead
+/// of catching `DioException` plus `FormatException` plus `TypeError`.
+/// Mirrors the `*Exception` pattern used elsewhere in `lib/core/error/`.
+class OsmTrafficSignalException implements Exception {
+  final String message;
+  const OsmTrafficSignalException(this.message);
+
+  @override
+  String toString() => 'OsmTrafficSignalException: $message';
+}
+
+/// HTTP client for OSM's Overpass API, scoped to the
+/// `highway=traffic_signals` query the glide coach needs (#1125 phase 1).
+///
+/// Issues one Overpass query per bounding box and parses the JSON
+/// response into [TrafficSignal] entities. The query is intentionally
+/// narrow — node-only, single tag — so the public Overpass instance
+/// (`overpass-api.de`) doesn't rate-limit users on routine calls.
+///
+/// The constructor accepts a [Dio] so tests can inject a mock; production
+/// callers can pass nothing and pick up a default [Dio] instance.
+///
+/// All errors throw [OsmTrafficSignalException] — never silent. The
+/// `test/lint/no_silent_catch_test.dart` static scan enforces this and
+/// the rethrow path keeps the original cause attached via toString().
+class OsmTrafficSignalClient {
+  final Dio _dio;
+
+  /// Endpoint for the public Overpass instance. The path is part of the
+  /// URL (not the base) because Dio's request method takes the full URL
+  /// when no base is configured — keeps test mocks straightforward.
+  static const String endpoint = 'https://overpass-api.de/api/interpreter';
+
+  OsmTrafficSignalClient({Dio? dio}) : _dio = dio ?? Dio();
+
+  /// Fetch every `highway=traffic_signals` node inside the bounding box
+  /// described by [south] / [west] / [north] / [east].
+  ///
+  /// [timeout] caps both connect and receive — the default of 15s sits
+  /// between Overpass's own `[timeout:25]` ceiling and a tight enough
+  /// budget that a hung server doesn't block the calling repo for long.
+  Future<List<TrafficSignal>> fetchInBoundingBox({
+    required double south,
+    required double west,
+    required double north,
+    required double east,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    final query =
+        '[out:json][timeout:25];\n'
+        'node["highway"="traffic_signals"]($south,$west,$north,$east);\n'
+        'out;';
+
+    Response<dynamic> response;
+    try {
+      response = await _dio.post<dynamic>(
+        endpoint,
+        data: query,
+        options: Options(
+          contentType: 'text/plain',
+          responseType: ResponseType.json,
+          sendTimeout: timeout,
+          receiveTimeout: timeout,
+        ),
+      );
+    } on DioException catch (e, st) {
+      debugPrint('OsmTrafficSignalClient.fetchInBoundingBox dio error: '
+          '${e.message}\n$st');
+      throw OsmTrafficSignalException(
+        'Overpass request failed: ${e.message ?? e.type.name}',
+      );
+    }
+
+    if (response.statusCode == null ||
+        response.statusCode! < 200 ||
+        response.statusCode! >= 300) {
+      throw OsmTrafficSignalException(
+        'Overpass returned HTTP ${response.statusCode}',
+      );
+    }
+
+    final data = response.data;
+    if (data is! Map) {
+      throw const OsmTrafficSignalException(
+        'Overpass response was not a JSON object',
+      );
+    }
+
+    final elements = data['elements'];
+    if (elements is! List) {
+      throw const OsmTrafficSignalException(
+        'Overpass response is missing the "elements" array',
+      );
+    }
+
+    try {
+      return elements
+          .whereType<Map>()
+          .map(_parseElement)
+          .whereType<TrafficSignal>()
+          .toList(growable: false);
+    } catch (e, st) {
+      debugPrint('OsmTrafficSignalClient.fetchInBoundingBox parse error: '
+          '$e\n$st');
+      throw OsmTrafficSignalException('Failed to parse Overpass response: $e');
+    }
+  }
+
+  /// Convert one Overpass element into a [TrafficSignal]. Returns null
+  /// when the element is missing a coordinate so a single bad row
+  /// doesn't poison the whole batch — the caller filters nulls out.
+  TrafficSignal? _parseElement(Map element) {
+    final lat = element['lat'];
+    final lon = element['lon'];
+    if (lat is! num || lon is! num) return null;
+
+    final tagsRaw = element['tags'];
+    String? crossing;
+    String? highway;
+    if (tagsRaw is Map) {
+      final crossingRaw = tagsRaw['crossing'];
+      final highwayRaw = tagsRaw['highway'];
+      if (crossingRaw is String) crossing = crossingRaw;
+      if (highwayRaw is String) highway = highwayRaw;
+    }
+
+    return TrafficSignal(
+      id: element['id'].toString(),
+      lat: lat.toDouble(),
+      lng: lon.toDouble(),
+      crossing: crossing,
+      highway: highway,
+    );
+  }
+}

--- a/lib/features/glide_coach/data/traffic_signal_repository.dart
+++ b/lib/features/glide_coach/data/traffic_signal_repository.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../domain/entities/traffic_signal.dart';
+import 'osm_traffic_signal_client.dart';
+
+/// Master toggle for the glide-coach feature (#1125).
+/// TODO: migrate to central feature management once that system lands.
+const bool kGlideCoachEnabled = false;
+
+/// Default cache TTL for cached Overpass responses (#1125 phase 1).
+///
+/// Public Overpass infrastructure is shared and the underlying OSM map
+/// changes slowly for fixed infrastructure like traffic signals. Seven
+/// days is a comfortable upper bound that keeps repeat trips through the
+/// same neighbourhood off the public Overpass servers without serving
+/// data so stale that newly-installed signals stay invisible for months.
+const Duration kTrafficSignalCacheTtl = Duration(days: 7);
+
+/// Repository wrapping [OsmTrafficSignalClient] with a Hive-backed cache
+/// (#1125 phase 1).
+///
+/// The cache key is the bounding box rounded to `0.01°` (~1.1 km on each
+/// edge) so two near-identical lookups within a residential area share
+/// one Overpass call. Entries persist until the TTL expires; on miss or
+/// expiry the repository hits the underlying client and rewrites the
+/// entry with a fresh `cachedAt` timestamp.
+///
+/// One repository instance per app — the box is opened once at startup
+/// in `HiveBoxes.init` (and `HiveBoxes.initInIsolate`) and handed in
+/// here. Tests can supply an in-memory box via the same constructor.
+class TrafficSignalRepository {
+  final OsmTrafficSignalClient _client;
+  final Box<String> _cacheBox;
+  final Duration _ttl;
+  final DateTime Function() _now;
+
+  /// Hive box that stores cached Overpass payloads. Registered in
+  /// `HiveBoxes.init` so the repository can open one shared instance.
+  static const String boxName = 'traffic_signals_cache';
+
+  TrafficSignalRepository({
+    required OsmTrafficSignalClient client,
+    required Box<String> cacheBox,
+    Duration ttl = kTrafficSignalCacheTtl,
+    DateTime Function()? now,
+  })  : _client = client,
+        _cacheBox = cacheBox,
+        _ttl = ttl,
+        _now = now ?? DateTime.now;
+
+  /// Return every traffic signal inside the bounding box, prefering a
+  /// fresh cache entry over a network round-trip.
+  ///
+  /// On cache miss, expired entry, or unreadable payload, the repository
+  /// falls back to [OsmTrafficSignalClient.fetchInBoundingBox] and
+  /// persists the result. Network errors propagate as
+  /// [OsmTrafficSignalException].
+  Future<List<TrafficSignal>> getSignalsForBoundingBox({
+    required double south,
+    required double west,
+    required double north,
+    required double east,
+  }) async {
+    final key = _cacheKey(
+      south: south,
+      west: west,
+      north: north,
+      east: east,
+    );
+
+    final cached = _readCache(key);
+    if (cached != null) return cached;
+
+    final fresh = await _client.fetchInBoundingBox(
+      south: south,
+      west: west,
+      north: north,
+      east: east,
+    );
+    await _writeCache(key, fresh);
+    return fresh;
+  }
+
+  /// Build a cache key from the bounding box, snapping each corner to
+  /// the nearest 0.01°. Visible for testing so the key format can be
+  /// asserted directly.
+  @visibleForTesting
+  static String cacheKeyFor({
+    required double south,
+    required double west,
+    required double north,
+    required double east,
+  }) =>
+      _cacheKey(south: south, west: west, north: north, east: east);
+
+  static String _cacheKey({
+    required double south,
+    required double west,
+    required double north,
+    required double east,
+  }) {
+    String snap(double v) => v.toStringAsFixed(2);
+    return 'bbox:${snap(south)}:${snap(west)}:${snap(north)}:${snap(east)}';
+  }
+
+  List<TrafficSignal>? _readCache(String key) {
+    final raw = _cacheBox.get(key);
+    if (raw == null || raw.isEmpty) return null;
+
+    Map<String, dynamic> envelope;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return null;
+      envelope = decoded.cast<String, dynamic>();
+    } catch (e, st) {
+      debugPrint('TrafficSignalRepository: corrupt cache entry $key: $e\n$st');
+      return null;
+    }
+
+    final cachedAtMs = envelope['cachedAt'];
+    if (cachedAtMs is! int) return null;
+    final cachedAt = DateTime.fromMillisecondsSinceEpoch(cachedAtMs);
+    if (_now().difference(cachedAt) > _ttl) return null;
+
+    final signalsRaw = envelope['signals'];
+    if (signalsRaw is! List) return null;
+
+    try {
+      return signalsRaw
+          .whereType<Map>()
+          .map((e) => TrafficSignal.fromJson(e.cast<String, dynamic>()))
+          .toList(growable: false);
+    } catch (e, st) {
+      debugPrint('TrafficSignalRepository: failed to deserialise $key: '
+          '$e\n$st');
+      return null;
+    }
+  }
+
+  Future<void> _writeCache(String key, List<TrafficSignal> signals) async {
+    final envelope = <String, dynamic>{
+      'cachedAt': _now().millisecondsSinceEpoch,
+      'signals': signals.map((s) => s.toJson()).toList(),
+    };
+    await _cacheBox.put(key, jsonEncode(envelope));
+  }
+}

--- a/lib/features/glide_coach/domain/entities/traffic_signal.dart
+++ b/lib/features/glide_coach/domain/entities/traffic_signal.dart
@@ -1,0 +1,40 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'traffic_signal.freezed.dart';
+part 'traffic_signal.g.dart';
+
+/// One traffic-signal node sourced from OpenStreetMap (#1125 phase 1).
+///
+/// Represents a single OSM `node` tagged `highway=traffic_signals`. The
+/// future glide-coach feature consumes this stream of signals to detect
+/// "imminent red lights ahead" given the user's current GPS heading and
+/// suggest a coast/throttle-off moment to save fuel.
+///
+/// Phase 1 is the bounded data layer only: domain entity + Overpass API
+/// client + Hive cache. Subsequent phases (imminent-signal detection,
+/// throttle correlation, haptic firing) all need device testing and live
+/// outside the autonomous-worker scope.
+///
+/// Field semantics mirror the Overpass JSON shape so this entity can be
+/// re-serialised back to disk without lossy translation:
+/// - [id] is the OSM node id, stringified so future sources (custom
+///   community-mapped signals, manual annotations) can use non-numeric ids.
+/// - [lat] / [lng] use OSM convention — latitude first, longitude second.
+/// - [crossing] mirrors `tags.crossing` (e.g. `traffic_signals`,
+///   `marked`, `uncontrolled`); null when the node has no `crossing` tag.
+/// - [highway] mirrors `tags.highway` (always `traffic_signals` in
+///   practice for the bounded query, but persisted for future tag-based
+///   filtering).
+@freezed
+abstract class TrafficSignal with _$TrafficSignal {
+  const factory TrafficSignal({
+    required String id,
+    required double lat,
+    required double lng,
+    String? crossing,
+    String? highway,
+  }) = _TrafficSignal;
+
+  factory TrafficSignal.fromJson(Map<String, dynamic> json) =>
+      _$TrafficSignalFromJson(json);
+}

--- a/lib/features/glide_coach/domain/entities/traffic_signal.freezed.dart
+++ b/lib/features/glide_coach/domain/entities/traffic_signal.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'traffic_signal.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$TrafficSignal {
+
+ String get id; double get lat; double get lng; String? get crossing; String? get highway;
+/// Create a copy of TrafficSignal
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TrafficSignalCopyWith<TrafficSignal> get copyWith => _$TrafficSignalCopyWithImpl<TrafficSignal>(this as TrafficSignal, _$identity);
+
+  /// Serializes this TrafficSignal to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TrafficSignal&&(identical(other.id, id) || other.id == id)&&(identical(other.lat, lat) || other.lat == lat)&&(identical(other.lng, lng) || other.lng == lng)&&(identical(other.crossing, crossing) || other.crossing == crossing)&&(identical(other.highway, highway) || other.highway == highway));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,lat,lng,crossing,highway);
+
+@override
+String toString() {
+  return 'TrafficSignal(id: $id, lat: $lat, lng: $lng, crossing: $crossing, highway: $highway)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TrafficSignalCopyWith<$Res>  {
+  factory $TrafficSignalCopyWith(TrafficSignal value, $Res Function(TrafficSignal) _then) = _$TrafficSignalCopyWithImpl;
+@useResult
+$Res call({
+ String id, double lat, double lng, String? crossing, String? highway
+});
+
+
+
+
+}
+/// @nodoc
+class _$TrafficSignalCopyWithImpl<$Res>
+    implements $TrafficSignalCopyWith<$Res> {
+  _$TrafficSignalCopyWithImpl(this._self, this._then);
+
+  final TrafficSignal _self;
+  final $Res Function(TrafficSignal) _then;
+
+/// Create a copy of TrafficSignal
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? lat = null,Object? lng = null,Object? crossing = freezed,Object? highway = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,lat: null == lat ? _self.lat : lat // ignore: cast_nullable_to_non_nullable
+as double,lng: null == lng ? _self.lng : lng // ignore: cast_nullable_to_non_nullable
+as double,crossing: freezed == crossing ? _self.crossing : crossing // ignore: cast_nullable_to_non_nullable
+as String?,highway: freezed == highway ? _self.highway : highway // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TrafficSignal].
+extension TrafficSignalPatterns on TrafficSignal {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TrafficSignal value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TrafficSignal() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TrafficSignal value)  $default,){
+final _that = this;
+switch (_that) {
+case _TrafficSignal():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TrafficSignal value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TrafficSignal() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  double lat,  double lng,  String? crossing,  String? highway)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TrafficSignal() when $default != null:
+return $default(_that.id,_that.lat,_that.lng,_that.crossing,_that.highway);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  double lat,  double lng,  String? crossing,  String? highway)  $default,) {final _that = this;
+switch (_that) {
+case _TrafficSignal():
+return $default(_that.id,_that.lat,_that.lng,_that.crossing,_that.highway);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  double lat,  double lng,  String? crossing,  String? highway)?  $default,) {final _that = this;
+switch (_that) {
+case _TrafficSignal() when $default != null:
+return $default(_that.id,_that.lat,_that.lng,_that.crossing,_that.highway);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TrafficSignal implements TrafficSignal {
+  const _TrafficSignal({required this.id, required this.lat, required this.lng, this.crossing, this.highway});
+  factory _TrafficSignal.fromJson(Map<String, dynamic> json) => _$TrafficSignalFromJson(json);
+
+@override final  String id;
+@override final  double lat;
+@override final  double lng;
+@override final  String? crossing;
+@override final  String? highway;
+
+/// Create a copy of TrafficSignal
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TrafficSignalCopyWith<_TrafficSignal> get copyWith => __$TrafficSignalCopyWithImpl<_TrafficSignal>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TrafficSignalToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TrafficSignal&&(identical(other.id, id) || other.id == id)&&(identical(other.lat, lat) || other.lat == lat)&&(identical(other.lng, lng) || other.lng == lng)&&(identical(other.crossing, crossing) || other.crossing == crossing)&&(identical(other.highway, highway) || other.highway == highway));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,lat,lng,crossing,highway);
+
+@override
+String toString() {
+  return 'TrafficSignal(id: $id, lat: $lat, lng: $lng, crossing: $crossing, highway: $highway)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TrafficSignalCopyWith<$Res> implements $TrafficSignalCopyWith<$Res> {
+  factory _$TrafficSignalCopyWith(_TrafficSignal value, $Res Function(_TrafficSignal) _then) = __$TrafficSignalCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, double lat, double lng, String? crossing, String? highway
+});
+
+
+
+
+}
+/// @nodoc
+class __$TrafficSignalCopyWithImpl<$Res>
+    implements _$TrafficSignalCopyWith<$Res> {
+  __$TrafficSignalCopyWithImpl(this._self, this._then);
+
+  final _TrafficSignal _self;
+  final $Res Function(_TrafficSignal) _then;
+
+/// Create a copy of TrafficSignal
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? lat = null,Object? lng = null,Object? crossing = freezed,Object? highway = freezed,}) {
+  return _then(_TrafficSignal(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,lat: null == lat ? _self.lat : lat // ignore: cast_nullable_to_non_nullable
+as double,lng: null == lng ? _self.lng : lng // ignore: cast_nullable_to_non_nullable
+as double,crossing: freezed == crossing ? _self.crossing : crossing // ignore: cast_nullable_to_non_nullable
+as String?,highway: freezed == highway ? _self.highway : highway // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/glide_coach/domain/entities/traffic_signal.g.dart
+++ b/lib/features/glide_coach/domain/entities/traffic_signal.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'traffic_signal.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_TrafficSignal _$TrafficSignalFromJson(Map<String, dynamic> json) =>
+    _TrafficSignal(
+      id: json['id'] as String,
+      lat: (json['lat'] as num).toDouble(),
+      lng: (json['lng'] as num).toDouble(),
+      crossing: json['crossing'] as String?,
+      highway: json['highway'] as String?,
+    );
+
+Map<String, dynamic> _$TrafficSignalToJson(_TrafficSignal instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'lat': instance.lat,
+      'lng': instance.lng,
+      'crossing': instance.crossing,
+      'highway': instance.highway,
+    };

--- a/test/features/glide_coach/data/osm_traffic_signal_client_test.dart
+++ b/test/features/glide_coach/data/osm_traffic_signal_client_test.dart
@@ -1,0 +1,228 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/features/glide_coach/data/osm_traffic_signal_client.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+class _FakeOptions extends Fake implements Options {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeOptions());
+  });
+
+  group('OsmTrafficSignalClient.fetchInBoundingBox (#1125 phase 1)', () {
+    late _MockDio dio;
+    late OsmTrafficSignalClient client;
+
+    setUp(() {
+      dio = _MockDio();
+      client = OsmTrafficSignalClient(dio: dio);
+    });
+
+    Response<dynamic> okResponse(Map<String, dynamic> body) => Response<dynamic>(
+          requestOptions: RequestOptions(path: OsmTrafficSignalClient.endpoint),
+          statusCode: 200,
+          data: body,
+        );
+
+    test('POSTs the Overpass interpreter URL with the bbox-scoped query',
+        () async {
+      when(() => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => okResponse({'elements': []}));
+
+      await client.fetchInBoundingBox(
+        south: 43.4,
+        west: 3.4,
+        north: 43.5,
+        east: 3.5,
+      );
+
+      final captured = verify(() => dio.post<dynamic>(
+            captureAny(),
+            data: captureAny(named: 'data'),
+            options: any(named: 'options'),
+          )).captured;
+
+      expect(captured[0], OsmTrafficSignalClient.endpoint);
+      final body = captured[1] as String;
+      expect(body, contains('[out:json][timeout:25];'));
+      expect(
+        body,
+        contains('node["highway"="traffic_signals"](43.4,3.4,43.5,3.5);'),
+      );
+      expect(body, contains('out;'));
+    });
+
+    test('parses elements into TrafficSignal entities', () async {
+      when(() => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => okResponse({
+                'elements': [
+                  {
+                    'type': 'node',
+                    'id': 1234567890,
+                    'lat': 43.4501,
+                    'lon': 3.4502,
+                    'tags': {
+                      'highway': 'traffic_signals',
+                      'crossing': 'marked',
+                    },
+                  },
+                  {
+                    'type': 'node',
+                    'id': 9876543210,
+                    'lat': 43.4602,
+                    'lon': 3.4503,
+                    // No tags map at all — must still parse with nulls.
+                  },
+                ],
+              }));
+
+      final signals = await client.fetchInBoundingBox(
+        south: 43.4,
+        west: 3.4,
+        north: 43.5,
+        east: 3.5,
+      );
+
+      expect(signals, hasLength(2));
+      expect(signals[0].id, '1234567890');
+      expect(signals[0].lat, 43.4501);
+      expect(signals[0].lng, 3.4502);
+      expect(signals[0].highway, 'traffic_signals');
+      expect(signals[0].crossing, 'marked');
+
+      expect(signals[1].id, '9876543210');
+      expect(signals[1].crossing, isNull);
+      expect(signals[1].highway, isNull);
+    });
+
+    test('skips elements missing lat/lon without throwing', () async {
+      when(() => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => okResponse({
+                'elements': [
+                  // Bad row: missing lat.
+                  {
+                    'id': 1,
+                    'lon': 3.4,
+                    'tags': {'highway': 'traffic_signals'},
+                  },
+                  // Good row.
+                  {
+                    'id': 2,
+                    'lat': 43.5,
+                    'lon': 3.5,
+                  },
+                ],
+              }));
+
+      final signals = await client.fetchInBoundingBox(
+        south: 43.4,
+        west: 3.4,
+        north: 43.5,
+        east: 3.5,
+      );
+
+      expect(signals, hasLength(1));
+      expect(signals.single.id, '2');
+    });
+
+    test('throws OsmTrafficSignalException on DioException', () async {
+      when(() => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          )).thenThrow(DioException(
+        requestOptions: RequestOptions(path: OsmTrafficSignalClient.endpoint),
+        type: DioExceptionType.connectionTimeout,
+        message: 'connect timeout',
+      ));
+
+      expect(
+        () => client.fetchInBoundingBox(
+          south: 0,
+          west: 0,
+          north: 1,
+          east: 1,
+        ),
+        throwsA(isA<OsmTrafficSignalException>()),
+      );
+    });
+
+    test('throws OsmTrafficSignalException on non-2xx status', () async {
+      when(() => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => Response<dynamic>(
+                requestOptions:
+                    RequestOptions(path: OsmTrafficSignalClient.endpoint),
+                statusCode: 504,
+                data: 'gateway timeout',
+              ));
+
+      expect(
+        () => client.fetchInBoundingBox(
+          south: 0,
+          west: 0,
+          north: 1,
+          east: 1,
+        ),
+        throwsA(isA<OsmTrafficSignalException>()),
+      );
+    });
+
+    test('throws OsmTrafficSignalException when payload is not a JSON object',
+        () async {
+      when(() => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => Response<dynamic>(
+                requestOptions:
+                    RequestOptions(path: OsmTrafficSignalClient.endpoint),
+                statusCode: 200,
+                data: 'not json',
+              ));
+
+      expect(
+        () => client.fetchInBoundingBox(
+          south: 0,
+          west: 0,
+          north: 1,
+          east: 1,
+        ),
+        throwsA(isA<OsmTrafficSignalException>()),
+      );
+    });
+
+    test('throws OsmTrafficSignalException when "elements" is missing',
+        () async {
+      when(() => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => okResponse({'version': 0.6}));
+
+      expect(
+        () => client.fetchInBoundingBox(
+          south: 0,
+          west: 0,
+          north: 1,
+          east: 1,
+        ),
+        throwsA(isA<OsmTrafficSignalException>()),
+      );
+    });
+  });
+}

--- a/test/features/glide_coach/data/traffic_signal_repository_test.dart
+++ b/test/features/glide_coach/data/traffic_signal_repository_test.dart
@@ -1,0 +1,239 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/glide_coach/data/osm_traffic_signal_client.dart';
+import 'package:tankstellen/features/glide_coach/data/traffic_signal_repository.dart';
+import 'package:tankstellen/features/glide_coach/domain/entities/traffic_signal.dart';
+
+/// Hand-rolled fake of [OsmTrafficSignalClient] (#1125 phase 1).
+///
+/// Records every call so the cache-hit tests can assert "client was
+/// only invoked once". A mocktail mock would also work but a fake
+/// keeps the test free of `when(() => ...).thenAnswer(...)` boilerplate
+/// for what is otherwise a one-method surface.
+class _FakeOsmClient implements OsmTrafficSignalClient {
+  int callCount = 0;
+  List<TrafficSignal> Function() responder;
+  Object? errorToThrow;
+
+  _FakeOsmClient({List<TrafficSignal>? response, this.errorToThrow})
+      : responder = (() => response ?? const <TrafficSignal>[]);
+
+  @override
+  Future<List<TrafficSignal>> fetchInBoundingBox({
+    required double south,
+    required double west,
+    required double north,
+    required double east,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    callCount++;
+    final err = errorToThrow;
+    if (err != null) throw err;
+    return responder();
+  }
+}
+
+void main() {
+  group('TrafficSignalRepository (#1125 phase 1)', () {
+    late Directory tmpDir;
+    late Box<String> box;
+
+    setUp(() async {
+      tmpDir =
+          Directory.systemTemp.createTempSync('traffic_signal_repo_test_');
+      Hive.init(tmpDir.path);
+      // Microsecond-suffixed box name avoids cross-test contamination on
+      // Windows where deleteFromDisk can race the next setUp.
+      box = await Hive.openBox<String>(
+        'traffic_signals_${DateTime.now().microsecondsSinceEpoch}',
+      );
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    TrafficSignal makeSignal(String id, double lat, double lng) =>
+        TrafficSignal(id: id, lat: lat, lng: lng);
+
+    test('cacheKeyFor snaps each corner to 0.01° precision', () {
+      expect(
+        TrafficSignalRepository.cacheKeyFor(
+          south: 43.43699,
+          west: 3.43101,
+          north: 43.45901,
+          east: 3.45299,
+        ),
+        'bbox:43.44:3.43:43.46:3.45',
+      );
+    });
+
+    test('miss → fetches client and caches result', () async {
+      final client = _FakeOsmClient(response: [
+        makeSignal('1', 43.45, 3.44),
+        makeSignal('2', 43.46, 3.44),
+      ]);
+      final repo = TrafficSignalRepository(
+        client: client,
+        cacheBox: box,
+      );
+
+      final first = await repo.getSignalsForBoundingBox(
+        south: 43.44,
+        west: 3.43,
+        north: 43.46,
+        east: 3.45,
+      );
+
+      expect(first, hasLength(2));
+      expect(client.callCount, 1);
+      // The cache box now has one envelope under the bbox key.
+      expect(box.length, 1);
+    });
+
+    test('hit within TTL returns cached value without re-calling client',
+        () async {
+      final client = _FakeOsmClient(response: [makeSignal('1', 43.45, 3.44)]);
+      final repo = TrafficSignalRepository(
+        client: client,
+        cacheBox: box,
+      );
+
+      final first = await repo.getSignalsForBoundingBox(
+        south: 43.44,
+        west: 3.43,
+        north: 43.46,
+        east: 3.45,
+      );
+      final second = await repo.getSignalsForBoundingBox(
+        south: 43.44,
+        west: 3.43,
+        north: 43.46,
+        east: 3.45,
+      );
+
+      expect(first, hasLength(1));
+      expect(second, hasLength(1));
+      expect(second.single.id, '1');
+      expect(client.callCount, 1, reason: 'second call should hit the cache');
+    });
+
+    test('expired entry triggers a fresh fetch', () async {
+      final client = _FakeOsmClient(response: [makeSignal('a', 43.45, 3.44)]);
+
+      // Advancing clock: first call uses t0, second uses t0 + 8 days
+      // (past the 7-day TTL).
+      final t0 = DateTime(2026, 5, 1, 12);
+      var now = t0;
+      final repo = TrafficSignalRepository(
+        client: client,
+        cacheBox: box,
+        now: () => now,
+      );
+
+      await repo.getSignalsForBoundingBox(
+        south: 43.44,
+        west: 3.43,
+        north: 43.46,
+        east: 3.45,
+      );
+      expect(client.callCount, 1);
+
+      now = t0.add(const Duration(days: 8));
+      client.responder = () => [makeSignal('b', 43.45, 3.44)];
+
+      final refreshed = await repo.getSignalsForBoundingBox(
+        south: 43.44,
+        west: 3.43,
+        north: 43.46,
+        east: 3.45,
+      );
+      expect(client.callCount, 2);
+      expect(refreshed.single.id, 'b');
+    });
+
+    test('different bbox keys do not share cache entries', () async {
+      final client = _FakeOsmClient(response: [makeSignal('x', 0, 0)]);
+      final repo = TrafficSignalRepository(
+        client: client,
+        cacheBox: box,
+      );
+
+      await repo.getSignalsForBoundingBox(
+        south: 43.44,
+        west: 3.43,
+        north: 43.46,
+        east: 3.45,
+      );
+      await repo.getSignalsForBoundingBox(
+        south: 48.85,
+        west: 2.34,
+        north: 48.87,
+        east: 2.36,
+      );
+
+      expect(client.callCount, 2);
+      expect(box.length, 2);
+    });
+
+    test('client errors propagate as OsmTrafficSignalException', () async {
+      final client = _FakeOsmClient(
+        errorToThrow: const OsmTrafficSignalException('boom'),
+      );
+      final repo = TrafficSignalRepository(
+        client: client,
+        cacheBox: box,
+      );
+
+      expect(
+        () => repo.getSignalsForBoundingBox(
+          south: 0,
+          west: 0,
+          north: 1,
+          east: 1,
+        ),
+        throwsA(isA<OsmTrafficSignalException>()),
+      );
+    });
+
+    test('corrupt cache payload falls back to a fresh fetch', () async {
+      final client =
+          _FakeOsmClient(response: [makeSignal('fresh', 43.45, 3.44)]);
+      final repo = TrafficSignalRepository(
+        client: client,
+        cacheBox: box,
+      );
+
+      // Plant garbage under the bbox key.
+      final key = TrafficSignalRepository.cacheKeyFor(
+        south: 43.44,
+        west: 3.43,
+        north: 43.46,
+        east: 3.45,
+      );
+      await box.put(key, 'not json');
+
+      final result = await repo.getSignalsForBoundingBox(
+        south: 43.44,
+        west: 3.43,
+        north: 43.46,
+        east: 3.45,
+      );
+
+      expect(client.callCount, 1);
+      expect(result.single.id, 'fresh');
+    });
+
+    test('kGlideCoachEnabled remains false (placeholder feature flag)', () {
+      expect(kGlideCoachEnabled, isFalse);
+    });
+
+    test('boxName matches the constant registered in HiveBoxes', () {
+      expect(TrafficSignalRepository.boxName, 'traffic_signals_cache');
+    });
+  });
+}


### PR DESCRIPTION
Refs #1125 — phase 1 of N.

## What landed
- `TrafficSignal` freezed entity (`lib/features/glide_coach/domain/entities/`) with `id` / `lat` / `lng` / `crossing` / `highway` plus `fromJson` / `toJson`.
- `OsmTrafficSignalClient` — POSTs an Overpass query (`node["highway"="traffic_signals"](bbox); out;`) and parses the JSON `elements` array into `TrafficSignal`s. Constructor takes a `Dio` so tests can inject a mock; on any HTTP/parse failure it throws the typed `OsmTrafficSignalException` (no silent catches).
- `TrafficSignalRepository` — caches Overpass responses in a new Hive box `traffic_signals_cache` keyed by the bounding box rounded to `0.01°`. Default TTL 7 days; expired entries trigger a fresh fetch and overwrite.
- Placeholder feature flag `kGlideCoachEnabled = false` at the top of the repository (TODO to migrate to central feature management).
- Box opener registered in `lib/core/storage/hive_boxes.dart` (6 inserted lines — only the new constant + one openBox call in `init()`).

## Phases remaining
Imminent-signal detection algorithm (needs GPS heading + design), throttle correlation, haptic firing — all need device testing and are NOT autonomous-worker targets.

## Test plan
- [x] Run `flutter test test/features/glide_coach/` — 16 tests, all green.
- [x] `flutter analyze` — zero issues.
- [x] `flutter test test/lint/` — every static-scan regression test still passes (`no_silent_catch`, `catch_block_stacktrace_coverage`, etc.).