### PR TITLE
feat(ios): hands-free auto-record Dart scaffolding (Refs #1295 phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ docs/guides/*
 !docs/guides/driving-insights.md
 !docs/guides/auto-record.md
 !docs/guides/SCHEMA-BACKUP-XML.md
+!docs/guides/ios-auto-record.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/ios-auto-record.md
+++ b/docs/guides/ios-auto-record.md
@@ -1,0 +1,249 @@
+# iOS hands-free trip auto-record (port from #1004)
+
+Status: phase 2 — Dart-side scaffolding shipped. Native iOS layer
+NOT YET applied or verified — see "How to verify on a Mac" below.
+
+This document explains the iOS port of the hands-free trip
+auto-record flow tracked in #1295 (sibling of the Android flow in
+#1004), and the platform-side changes a Mac-equipped developer must
+apply before the iOS path can be exercised end-to-end.
+
+## Why this scaffolding ships before iOS verification
+
+The autonomous worker that produced this PR has no Mac. The Dart
+layer is **platform-safe** — every public method on
+`IosStateRestorationService` is a no-op on Android (and on the
+Linux / Windows headless runners that drive CI). Wiring Phase 2's
+classes does not break the Android build, does not change Android
+behaviour, and lands no untestable iOS code into the tree.
+
+The actual iOS verification — the Phase 1 spike per #1295 that
+proves `centralManager:willRestoreState:` fires after a real
+background relaunch — requires a Mac, an iPhone, and an ELM327 BLE
+adapter. That work is a human-driven phase, not autonomous-worker
+territory.
+
+## Info.plist changes the developer must apply on a Mac
+
+The values below are quoted **verbatim** from the issue body of
+#1295:
+
+> **Info.plist.** Declare `UIBackgroundModes = ["bluetooth-central",
+> "location"]`. Add `NSBluetoothAlwaysUsageDescription`,
+> `NSLocationAlwaysAndWhenInUseUsageDescription`,
+> `NSLocationWhenInUseUsageDescription`. The two BG modes are the
+> App-Store-reviewable claims that gate everything.
+
+Open `ios/Runner/Info.plist` in Xcode (or any plist editor; do NOT
+edit it from Windows since the worker tooling does not preserve
+plist whitespace) and add the following keys. They are reproduced
+in copy-pasteable XML form below — the exact values matter for
+App Store review.
+
+### `UIBackgroundModes`
+
+Two background-mode entitlements: `bluetooth-central` lets iOS
+relaunch us into the background when a BLE peripheral we registered
+for state restoration becomes available; `location` lets the GPS
+fallback for the speed source keep firing while the app is in the
+background.
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>bluetooth-central</string>
+    <string>location</string>
+</array>
+```
+
+Without `bluetooth-central` the entire state-restoration flow is
+dead — iOS will not relaunch the app on a Bluetooth event. Without
+`location` the GPS fallback (used when PID 0x0D stalls) cannot
+update in the background; the user sees a frozen speed reading
+between BLE drop and the 60 s save debounce.
+
+### `NSBluetoothAlwaysUsageDescription`
+
+Mandatory iOS 13+ usage string for any app that touches
+Core Bluetooth. Presented to the user in the system permission
+sheet. Must be a sentence the user understands — Apple rejects
+boilerplate like "for Bluetooth".
+
+```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>Tankstellen connects to your paired OBD2 adapter so it can record your trips automatically when you start driving, even when the app is closed.</string>
+```
+
+### `NSLocationAlwaysAndWhenInUseUsageDescription`
+
+Required when requesting "Always Allow" location authorization.
+iOS shows this string in the second-stage prompt (the one with the
+map of recent locations). The user must explicitly upgrade from
+"While Using" to "Always" — many decline; the PID-0x0D speed
+source mostly avoids this prompt, but the GPS fallback needs it.
+
+```xml
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>Tankstellen uses your location in the background only as a fallback for measuring trip speed when the OBD2 adapter cannot provide it. Trips are saved on your device.</string>
+```
+
+### `NSLocationWhenInUseUsageDescription`
+
+Required for the first-stage "While Using" location prompt. iOS
+will not show the Always prompt unless the app is already authorized
+for While Using.
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>Tankstellen uses your location to measure trip distance when the OBD2 adapter cannot provide it.</string>
+```
+
+## How to verify on a Mac
+
+This is the Phase 1 spike per #1295 — confirm `flutter_blue_plus`
+state restoration actually fires `willRestoreState` on a real
+ELM327 BLE adapter. Acceptance criteria: the app, started cold via
+a BLE event from the OS, runs Dart code without the user ever
+opening it.
+
+1. **Apply the Info.plist keys above.** Open `ios/Runner/Info.plist`
+   in Xcode and paste each `<key>` / value pair into the top-level
+   `<dict>`. Build settings: confirm "Background Modes" capability
+   is ticked in the Signing & Capabilities tab, with both
+   "Uses Bluetooth LE accessories" and "Location updates" checked.
+2. **Refresh CocoaPods.** From the repo root on a Mac:
+   ```bash
+   flutter pub get
+   cd ios && pod install
+   cd ..
+   ```
+   `pod install` regenerates `Podfile.lock` for the
+   `flutter_blue_plus_darwin` 7.x pod. Commit the updated
+   `Podfile.lock`.
+3. **Build for a real iPhone.** State restoration does NOT work on
+   the simulator (Apple TN3115). Connect an iPhone via USB:
+   ```bash
+   flutter build ios --release --no-codesign
+   open ios/Runner.xcworkspace
+   ```
+   Select the connected device, sign with your provisioning
+   profile, and Run.
+4. **Pair the ELM327 once in foreground.** Walk through the
+   existing OBD2 adapter scan + pick flow with the engine running.
+   The `IosStateRestorationService.registerPersistedAdapter(uuid)`
+   call (Phase 3) will issue the long-lived connect that the OS
+   retains across termination.
+5. **Background the app.** Press the home button — do NOT swipe
+   it out of the app switcher. Force-quit permanently disables
+   state restoration until next manual launch (Apple-documented).
+6. **Power-cycle the ELM327.** Disconnect the OBD2 dongle from
+   the OBD-II port and re-insert it. iOS sees the advertisement,
+   completes the pending connect, and relaunches the app in the
+   background.
+7. **Observe `os_log` in Console.app.** Filter to subsystem
+   `com.tankstellen.app` (or "tankstellen" plain text). You must
+   see:
+   * `IosStateRestorationService: setOptions(restoreState: true) ok`
+     — proves Phase 2 wiring ran on cold start.
+   * `centralManager:willRestoreState:` fired on the native side —
+     proves iOS handed restored peripherals back to the plugin.
+   * `IosStateRestorationService: registerPersistedAdapter queued
+     connect for <uuid>` — proves Phase 2's connect kept the
+     pending peripheral pinned across launches.
+8. **Capture findings as a follow-up issue.** Even a successful
+   spike usually surfaces compromises (e.g. "PID 0x0D stalls for
+   3 s after restore" or "Always Location prompt blocks the
+   notification banner"). Open a new issue tagged `area/ios` with
+   the observed sequence.
+
+## Compromises vs Android
+
+Reproduced **verbatim** from the issue body of #1295 (attribution:
+`fdittgen-png` on the original spec):
+
+> - **First open after install is mandatory.** State restoration
+>   cannot register until the user has launched the app at least
+>   once.
+> - **First open after every reboot or BT toggle is mandatory.**
+>   Apple-documented; no workaround.
+> - **Force-quit kills the flow until next manual launch.** Train
+>   the user via onboarding ("don't swipe Tankstellen out of the
+>   app switcher"). No technical fix.
+> - **Classic-Bluetooth ELM327 dongles will not work at all.** Only
+>   BLE adapters or MFi-certified Classic adapters (vLinker FS,
+>   OBDLink MX+). Document this clearly on the iOS install page.
+> - **10-second background budget per wake.** All trip-start/save
+>   logic must be sync-light; defer heavy computation to next
+>   foreground. Driving Insights re-computation needs to be lazy.
+> - **Badge requires a notification.** Cannot silently bump on save
+>   — the user will see a "Trip recorded" banner. Could be a
+>   feature, not a bug; add a setting to mute the banner (but the
+>   badge will still increment because the notification still
+>   delivers).
+> - **Trip may be missed** if iOS terminates the app for memory
+>   pressure between BLE drop and the 60 s debounce timer.
+> - **Location-Always prompt is rough.** iOS shows it as a separate
+>   dialog after a "While Using" grace period, with a map of recent
+>   locations — many users decline. The PID-0x0D speed path mostly
+>   avoids this, but the GPS fallback will not work for users who
+>   said no.
+
+## Known limitations
+
+Reproduced from the issue body, "Compromises vs Android" section
+(also above) — these are the architectural limits the iOS port
+cannot work around:
+
+* No equivalent of the Android foreground service. iOS owns
+  scheduling; the app is woken only via OS-driven events.
+* `connectPeripheral` with no timeout works ONLY if registered via
+  restored state (TN3115).
+* Background launch does NOT survive reboot. Until the user opens
+  the app once after reboot or BT toggle, no relaunch happens.
+* Force-quit (swipe up from app switcher) permanently disables
+  state restoration until next manual launch (Apple-documented).
+* Background CPU budget after wake: ~10 s per wake event before
+  throttle / kill.
+* Launcher badge: only via `UNNotificationContent.badge` on a
+  delivered notification, or from foreground via
+  `UNUserNotificationCenter.setBadgeCount()` (iOS 17+). No
+  silent-bump from background.
+
+## Cross-references
+
+* **Tracking issue:** [#1295](https://github.com/fdittgen-png/tankstellen/issues/1295)
+  — iOS hands-free auto-record port (this guide is the Phase 2
+  deliverable).
+* **iOS platform support epic:** [#9](https://github.com/fdittgen-png/tankstellen/issues/9)
+  — overall iOS port. #1295 depends on #9 for general iOS
+  Bluetooth scaffolding.
+* **Android sibling:** [#1004](https://github.com/fdittgen-png/tankstellen/issues/1004)
+  / `docs/guides/auto-record.md` — the Android foreground-service
+  implementation this port mirrors as closely as iOS will allow.
+
+## Phase plan (from the issue body)
+
+Phase 2 (this PR) ships the Dart-side scaffolding only. The
+remaining phases:
+
+* **Phase 1 — Investigation + plugin spike** (~2 days, **needs
+  Mac**): verify `flutter_blue_plus` `restoreState` actually
+  triggers `willRestoreState` on a real ELM327 BLE. Confirm Dart
+  isolate spins up on background relaunch (build a tiny
+  logging-only test app, observe in `Console.app`). Decision gate:
+  does FBP suffice, or do we need a native iOS channel?
+* **Phase 3 — BLE listener + speed source + trip lifecycle.**
+  Port the 3-sample/5-km/h start trigger and 60 s debounce save.
+  PID-0x0D primary, GPS fallback gated on Always permission.
+* **Phase 4 — Badge via notifications.** Replace Android's
+  `flutter_app_badger` path on iOS with a local
+  `UNNotificationContent.badge`-driven flow. Add ARB keys for the
+  auto-save notification banner. Localize across 23 locales.
+* **Phase 5 — Device-test acceptance.** Real iPhone + real ELM327
+  BLE. Acceptance script: install, pair once, force-close Xcode,
+  drive (or use a 12 V supply + speed simulator), verify wake,
+  trip, badge. Write findings as a follow-up issue if any
+  compromise needs softening.
+
+None of phases 3-5 are autonomous-worker targets either — each
+needs a Mac for at least the verification step.

--- a/lib/features/consumption/data/obd2/ios_restoration_event.dart
+++ b/lib/features/consumption/data/obd2/ios_restoration_event.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+
+/// Sealed event published by [IosStateRestorationService] when iOS
+/// relaunches the app via Core Bluetooth state restoration
+/// (#1295 phase 2).
+///
+/// Modelled as a Dart-3 sealed class — we don't use Freezed here
+/// because the codebase has no precedent for multi-constructor
+/// Freezed unions and a native sealed class gives us exhaustive
+/// `switch` matching without a code-generation step. Equivalent to
+/// the "Freezed sealed class" called for in the issue body — same
+/// shape, fewer moving parts.
+///
+/// ## Variants
+///
+/// * [IosRestorationWillRestore] — emitted on iOS when
+///   `centralManager:willRestoreState:` fires after a background
+///   relaunch. Carries the list of CBPeripheral identifiers (UUID
+///   strings, not MAC addresses — iOS hides the hardware MAC) that
+///   the OS handed back to us. The service consumer (Phase 3 — BLE
+///   listener + speed source + trip lifecycle) will rehydrate these
+///   into `BluetoothDevice` instances and resume reading from the
+///   already-connected peripheral.
+///
+/// * [IosRestorationNotSupported] — emitted on every non-iOS
+///   platform (Android, Linux desktop tests, headless CI). The
+///   sealed-class shape lets the consumer switch on it explicitly
+///   instead of guarding every callsite with `Platform.isIOS`.
+@immutable
+sealed class IosRestorationEvent {
+  const IosRestorationEvent();
+
+  /// Convenience factory mirroring Freezed's named-constructor API
+  /// so callers read `IosRestorationEvent.willRestore([...])`
+  /// instead of the longer `IosRestorationWillRestore([...])`.
+  /// Pure forwarder — no allocation or behaviour beyond that.
+  const factory IosRestorationEvent.willRestore(
+    List<String> peripheralUuids,
+  ) = IosRestorationWillRestore;
+
+  /// Convenience factory mirroring Freezed's named-constructor API
+  /// for the no-op variant. Returns the `const` singleton so
+  /// repeated `notSupported()` calls don't allocate.
+  const factory IosRestorationEvent.notSupported() =
+      IosRestorationNotSupported;
+}
+
+/// "iOS relaunched us via Core Bluetooth state restoration" event.
+///
+/// [peripheralUuids] is the list of `CBPeripheral.identifier.uuidString`
+/// values the OS handed back. Empty list means iOS restored state
+/// but no peripherals were tracked — still a useful signal for
+/// breadcrumb logging in Phase 3.
+final class IosRestorationWillRestore extends IosRestorationEvent {
+  /// Peripheral UUIDs (CBPeripheral.identifier.uuidString) that iOS
+  /// rehydrated for us. Phase 3 maps these to flutter_blue_plus
+  /// `BluetoothDevice.fromId` instances.
+  final List<String> peripheralUuids;
+
+  const IosRestorationWillRestore(this.peripheralUuids);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is IosRestorationWillRestore &&
+          listEquals(other.peripheralUuids, peripheralUuids);
+
+  @override
+  int get hashCode => Object.hashAll(peripheralUuids);
+
+  @override
+  String toString() =>
+      'IosRestorationEvent.willRestore(peripheralUuids: $peripheralUuids)';
+}
+
+/// "This platform doesn't support iOS state restoration" event.
+///
+/// Android emits this as the single value on the
+/// `IosStateRestorationService.events` stream so consumers can
+/// switch exhaustively without a `Platform.isIOS` guard.
+final class IosRestorationNotSupported extends IosRestorationEvent {
+  const IosRestorationNotSupported();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is IosRestorationNotSupported;
+
+  @override
+  int get hashCode => (IosRestorationNotSupported).hashCode;
+
+  @override
+  String toString() => 'IosRestorationEvent.notSupported()';
+}

--- a/lib/features/consumption/data/obd2/ios_state_restoration_provider.dart
+++ b/lib/features/consumption/data/obd2/ios_state_restoration_provider.dart
@@ -1,0 +1,26 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'ios_state_restoration_service.dart';
+
+part 'ios_state_restoration_provider.g.dart';
+
+/// Singleton provider exposing the [IosStateRestorationService]
+/// (#1295 phase 2).
+///
+/// `keepAlive: true` because the service holds a broadcast stream
+/// controller that callers (Phase 3 — BLE listener) subscribe to
+/// for the entire app lifetime. Letting Riverpod recreate it on
+/// dependency churn would silently drop the controller and break
+/// the listener wiring.
+///
+/// Production resolves to [FlutterBluePlusIosStateRestorationService]
+/// — the only implementation. Tests override the provider with a
+/// fake (or instantiate the service directly with
+/// [FlutterBluePlusIosStateRestorationService.debugIsIOSOverride]
+/// to drive both platform branches).
+@Riverpod(keepAlive: true)
+IosStateRestorationService iosStateRestorationService(Ref ref) {
+  final service = FlutterBluePlusIosStateRestorationService();
+  ref.onDispose(service.dispose);
+  return service;
+}

--- a/lib/features/consumption/data/obd2/ios_state_restoration_provider.g.dart
+++ b/lib/features/consumption/data/obd2/ios_state_restoration_provider.g.dart
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ios_state_restoration_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Singleton provider exposing the [IosStateRestorationService]
+/// (#1295 phase 2).
+///
+/// `keepAlive: true` because the service holds a broadcast stream
+/// controller that callers (Phase 3 — BLE listener) subscribe to
+/// for the entire app lifetime. Letting Riverpod recreate it on
+/// dependency churn would silently drop the controller and break
+/// the listener wiring.
+///
+/// Production resolves to [FlutterBluePlusIosStateRestorationService]
+/// — the only implementation. Tests override the provider with a
+/// fake (or instantiate the service directly with
+/// [FlutterBluePlusIosStateRestorationService.debugIsIOSOverride]
+/// to drive both platform branches).
+
+@ProviderFor(iosStateRestorationService)
+final iosStateRestorationServiceProvider =
+    IosStateRestorationServiceProvider._();
+
+/// Singleton provider exposing the [IosStateRestorationService]
+/// (#1295 phase 2).
+///
+/// `keepAlive: true` because the service holds a broadcast stream
+/// controller that callers (Phase 3 — BLE listener) subscribe to
+/// for the entire app lifetime. Letting Riverpod recreate it on
+/// dependency churn would silently drop the controller and break
+/// the listener wiring.
+///
+/// Production resolves to [FlutterBluePlusIosStateRestorationService]
+/// — the only implementation. Tests override the provider with a
+/// fake (or instantiate the service directly with
+/// [FlutterBluePlusIosStateRestorationService.debugIsIOSOverride]
+/// to drive both platform branches).
+
+final class IosStateRestorationServiceProvider
+    extends
+        $FunctionalProvider<
+          IosStateRestorationService,
+          IosStateRestorationService,
+          IosStateRestorationService
+        >
+    with $Provider<IosStateRestorationService> {
+  /// Singleton provider exposing the [IosStateRestorationService]
+  /// (#1295 phase 2).
+  ///
+  /// `keepAlive: true` because the service holds a broadcast stream
+  /// controller that callers (Phase 3 — BLE listener) subscribe to
+  /// for the entire app lifetime. Letting Riverpod recreate it on
+  /// dependency churn would silently drop the controller and break
+  /// the listener wiring.
+  ///
+  /// Production resolves to [FlutterBluePlusIosStateRestorationService]
+  /// — the only implementation. Tests override the provider with a
+  /// fake (or instantiate the service directly with
+  /// [FlutterBluePlusIosStateRestorationService.debugIsIOSOverride]
+  /// to drive both platform branches).
+  IosStateRestorationServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'iosStateRestorationServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$iosStateRestorationServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<IosStateRestorationService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  IosStateRestorationService create(Ref ref) {
+    return iosStateRestorationService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(IosStateRestorationService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<IosStateRestorationService>(value),
+    );
+  }
+}
+
+String _$iosStateRestorationServiceHash() =>
+    r'ecb8a1e8e23fa11371ce36ac58c41c608c2dc68e';

--- a/lib/features/consumption/data/obd2/ios_state_restoration_service.dart
+++ b/lib/features/consumption/data/obd2/ios_state_restoration_service.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import '../../../../core/logging/error_logger.dart';
+import 'ios_restoration_event.dart';
+
+/// Dart-side facade over Core Bluetooth state preservation +
+/// restoration on iOS (#1295 phase 2).
+///
+/// ## What this is for
+///
+/// On iOS, the only way to keep an OBD2 BLE connection alive across
+/// app termination — so the app can be relaunched in the background
+/// when the user enters their car — is Core Bluetooth's State
+/// Preservation and Restoration. The flow is:
+///
+/// 1. Cold-start: call `FlutterBluePlus.setOptions(restoreState: true)`
+///    BEFORE any scan/connect. Under the hood the plugin passes
+///    `CBCentralManagerOptionRestoreIdentifierKey` to the native
+///    `CBCentralManager`, opting us into state restoration.
+/// 2. After first-run pairing: connect to the paired ELM327 BLE
+///    peripheral with no timeout. iOS retains this pending connect
+///    across termination as long as the user has not force-quit.
+/// 3. When the ELM327 powers up later (driver enters the car), iOS
+///    sees the advertisement, completes the connection, and
+///    relaunches the app into the background. The native plugin
+///    receives `centralManager:willRestoreState:` and rehydrates
+///    the peripheral; we surface that event to Dart via [events].
+///
+/// See `docs/guides/ios-auto-record.md` for the platform-side
+/// changes (Info.plist, background modes, usage strings) the
+/// developer must apply on a Mac before the iOS path can be
+/// verified end-to-end.
+///
+/// ## Platform safety
+///
+/// EVERY public method is safe to call on Android (and on Linux /
+/// macOS-desktop test runners). Non-iOS platforms get no-op
+/// implementations:
+///
+/// * [initialize] returns immediately.
+/// * [registerPersistedAdapter] returns immediately.
+/// * [events] emits a single [IosRestorationNotSupported] then
+///   closes.
+///
+/// This means callers can wire the service unconditionally during
+/// app initialization and let the platform gate handle dispatch —
+/// no `if (Platform.isIOS)` sprinkled across the call sites.
+///
+/// ## Phase boundary
+///
+/// This service is Phase 2 of the iOS hands-free auto-record port
+/// per #1295. Phase 1 (the on-device spike that proves
+/// `willRestoreState` actually fires on real hardware) requires a
+/// Mac + iPhone + ELM327 BLE adapter and is NOT autonomous-worker
+/// territory. Phase 3 (BLE listener + speed source + trip
+/// lifecycle) consumes the [events] stream to resume trip
+/// recording after a background relaunch.
+abstract class IosStateRestorationService {
+  /// Configure flutter_blue_plus for state restoration. Idempotent:
+  /// safe to call more than once. Must be called BEFORE any scan
+  /// or connect on a cold start, otherwise iOS will not register
+  /// our central manager for state restoration on this launch.
+  ///
+  /// On non-iOS platforms this is a no-op.
+  Future<void> initialize();
+
+  /// Issue a flutter_blue_plus connect to the paired ELM327 with
+  /// a long-lived pending semantics. iOS retains this pending
+  /// connect across app termination via state restoration as
+  /// long as the user has not force-quit the app.
+  ///
+  /// [peripheralUuid] is the `CBPeripheral.identifier.uuidString`
+  /// captured during first-run pairing. iOS does NOT expose the
+  /// hardware MAC; the UUID is the stable identifier we persist
+  /// in `VehicleProfile.pairedAdapterUuidIos` (Phase 3).
+  ///
+  /// On non-iOS platforms this is a no-op.
+  Future<void> registerPersistedAdapter(String peripheralUuid);
+
+  /// Stream of state-restoration events surfaced from the native
+  /// side. On iOS, emits [IosRestorationWillRestore] each time
+  /// the OS relaunches us via `centralManager:willRestoreState:`.
+  /// On non-iOS platforms, emits a single
+  /// [IosRestorationNotSupported] then closes.
+  ///
+  /// Single-broadcast: multiple listeners are supported.
+  Stream<IosRestorationEvent> get events;
+
+  /// Release resources held by the service. Closes the [events]
+  /// stream. Safe to call more than once.
+  Future<void> dispose();
+}
+
+/// Production implementation. Dispatches every method to a private
+/// platform-specific handler so the dispatcher itself is testable
+/// on the Dart VM (no iOS runtime needed).
+///
+/// The iOS path uses `flutter_blue_plus` 1.35+ which exposes
+/// `setOptions(restoreState: true)` and forwards
+/// `CBCentralManagerOptionRestoreIdentifierKey` under the hood.
+/// The plugin currently has no Dart-side stream for the
+/// `willRestoreState` callback; Phase 3 will add a thin
+/// MethodChannel listener (or upstream a PR to FBP) to surface
+/// the peripheral list. For Phase 2 we publish a single
+/// [IosRestorationNotSupported] event on cold start as a
+/// breadcrumb that the listener wired up correctly — Phase 3
+/// will replace the placeholder with real `willRestore` events.
+class FlutterBluePlusIosStateRestorationService
+    implements IosStateRestorationService {
+  /// Test seam: when set, overrides `Platform.isIOS` for the
+  /// dispatcher branch. Production code leaves it null and the
+  /// real platform check is used.
+  @visibleForTesting
+  final bool? debugIsIOSOverride;
+
+  final StreamController<IosRestorationEvent> _eventsController =
+      StreamController<IosRestorationEvent>.broadcast();
+
+  bool _initialized = false;
+  bool _disposed = false;
+
+  FlutterBluePlusIosStateRestorationService({this.debugIsIOSOverride});
+
+  /// Resolved platform check. Production reads [Platform.isIOS];
+  /// tests pass [debugIsIOSOverride] to drive both branches.
+  bool get _isIOS => debugIsIOSOverride ?? Platform.isIOS;
+
+  @override
+  Future<void> initialize() async {
+    if (_disposed) return;
+    if (_initialized) return;
+    _initialized = true;
+    if (_isIOS) {
+      await _initializeIOS();
+    } else {
+      _initializeNonIOS();
+    }
+  }
+
+  /// iOS path: opt the central manager into state restoration so
+  /// `CBCentralManagerOptionRestoreIdentifierKey` is set on the
+  /// native side. Must run before any scan/connect.
+  Future<void> _initializeIOS() async {
+    try {
+      await FlutterBluePlus.setOptions(restoreState: true);
+      debugPrint(
+        'IosStateRestorationService: setOptions(restoreState: true) ok',
+      );
+    } catch (e, st) {
+      await errorLogger.log(
+        ErrorLayer.services,
+        e,
+        st,
+        context: const {
+          'where': 'IosStateRestorationService.initialize',
+        },
+      );
+      rethrow;
+    }
+  }
+
+  /// Non-iOS path: emit the "not supported" sentinel so listeners
+  /// can switch exhaustively without a Platform check.
+  void _initializeNonIOS() {
+    if (_eventsController.isClosed) return;
+    _eventsController.add(const IosRestorationEvent.notSupported());
+  }
+
+  @override
+  Future<void> registerPersistedAdapter(String peripheralUuid) async {
+    if (_disposed) return;
+    if (!_isIOS) {
+      // Android keeps its paired ELM327 alive via the foreground
+      // service (#1004) — there is nothing to register here.
+      return;
+    }
+    await _registerPersistedAdapterIOS(peripheralUuid);
+  }
+
+  /// iOS path: issue a flutter_blue_plus connect with a long
+  /// timeout (effectively "no timeout"). iOS retains the pending
+  /// connect across app termination via state restoration. We do
+  /// NOT await the future — the call returns once the connect is
+  /// queued, not once the peripheral is reached.
+  Future<void> _registerPersistedAdapterIOS(String peripheralUuid) async {
+    try {
+      final device = BluetoothDevice.fromId(peripheralUuid);
+      // Fire-and-forget: the connect future completes on the next
+      // BLE state change (which may be hours away when the car is
+      // parked). We purposefully drop the returned Future on the
+      // floor — the consumer in Phase 3 listens to
+      // `device.connectionState` for the actual connect signal.
+      // `unawaited` is intentional, not a bug.
+      // ignore: unawaited_futures
+      device.connect(
+        autoConnect: true,
+        // `mtu` must be null when `autoConnect: true` — see the
+        // FBP source: `assert((mtu == null) || !autoConnect)`.
+        mtu: null,
+        // 365 days is the longest reasonable "no timeout" — the
+        // FBP API doesn't accept Duration.zero as "infinite".
+        timeout: const Duration(days: 365),
+      );
+      debugPrint(
+        'IosStateRestorationService: registerPersistedAdapter queued '
+        'connect for $peripheralUuid',
+      );
+    } catch (e, st) {
+      await errorLogger.log(
+        ErrorLayer.services,
+        e,
+        st,
+        context: {
+          'where': 'IosStateRestorationService.registerPersistedAdapter',
+          'peripheralUuid': peripheralUuid,
+        },
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Stream<IosRestorationEvent> get events => _eventsController.stream;
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    if (!_eventsController.isClosed) {
+      await _eventsController.close();
+    }
+  }
+}

--- a/test/features/consumption/data/obd2/ios_state_restoration_service_test.dart
+++ b/test/features/consumption/data/obd2/ios_state_restoration_service_test.dart
@@ -1,0 +1,222 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_restoration_event.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_state_restoration_service.dart';
+
+/// Unit tests for [FlutterBluePlusIosStateRestorationService] (#1295
+/// phase 2).
+///
+/// These tests run on the Dart VM — no iOS runtime. The iOS-specific
+/// path (which actually calls into `flutter_blue_plus`) cannot be
+/// exercised here because:
+///
+/// * `FlutterBluePlus.setOptions` calls a MethodChannel that is
+///   unbound in `flutter_test`.
+/// * `BluetoothDevice.fromId(...).connect(...)` likewise crosses the
+///   platform channel.
+///
+/// We therefore cover the dispatcher (the `Platform.isIOS` gate) by
+/// driving the test seam `debugIsIOSOverride` and asserting that
+/// non-iOS branches are no-ops + that the events stream emits the
+/// expected sentinel. Phase 5 (device-test acceptance) covers the
+/// real iOS path on hardware.
+void main() {
+  group('FlutterBluePlusIosStateRestorationService — non-iOS branch', () {
+    test('initialize() returns without throwing on non-iOS', () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+      );
+      // Must complete without touching FlutterBluePlus (which would
+      // throw MissingPluginException in the test environment).
+      await expectLater(service.initialize(), completes);
+      await service.dispose();
+    });
+
+    test('initialize() is idempotent — repeat calls are no-ops',
+        () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+      );
+      await service.initialize();
+      // Drain the first emission so the second initialize wouldn't
+      // double-emit if it ran twice.
+      await expectLater(service.initialize(), completes);
+      await expectLater(service.initialize(), completes);
+      await service.dispose();
+    });
+
+    test(
+        'registerPersistedAdapter() is a no-op on non-iOS (no FlutterBluePlus call)',
+        () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+      );
+      // If the no-op gate is broken this would throw
+      // MissingPluginException because the test binding has no FBP.
+      await expectLater(
+        service.registerPersistedAdapter('fake-uuid'),
+        completes,
+      );
+      await service.dispose();
+    });
+
+    test(
+        'events stream emits IosRestorationNotSupported then quiets on non-iOS',
+        () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+      );
+
+      // Subscribe BEFORE initialize() so the broadcast controller
+      // delivers the sentinel synchronously to this listener.
+      final received = <IosRestorationEvent>[];
+      final sub = service.events.listen(received.add);
+
+      await service.initialize();
+      // Pump the event queue so the controller delivers.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        received,
+        [const IosRestorationEvent.notSupported()],
+        reason: 'non-iOS must publish exactly one notSupported sentinel '
+            'so callers can switch exhaustively without a Platform check',
+      );
+
+      // After the sentinel, the stream stays quiet — no more events.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(received, hasLength(1));
+
+      await sub.cancel();
+      await service.dispose();
+    });
+
+    test(
+        'events stream stays usable across multiple subscribers '
+        '(broadcast controller)', () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+      );
+
+      final firstReceived = <IosRestorationEvent>[];
+      final firstSub = service.events.listen(firstReceived.add);
+
+      await service.initialize();
+      await Future<void>.delayed(Duration.zero);
+
+      // Late subscriber — broadcast controller does not replay, so
+      // the second listener sees nothing for the already-emitted
+      // sentinel. This is the documented contract; the consumer
+      // (Phase 3) MUST subscribe before initialize().
+      final secondReceived = <IosRestorationEvent>[];
+      final secondSub = service.events.listen(secondReceived.add);
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(firstReceived, hasLength(1),
+          reason: 'first subscriber must receive the sentinel');
+      expect(secondReceived, isEmpty,
+          reason: 'broadcast controller does not replay — late '
+              'subscribers see nothing for past events');
+
+      await firstSub.cancel();
+      await secondSub.cancel();
+      await service.dispose();
+    });
+
+    test('dispose() closes the events stream', () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+      );
+      // Subscribe to the broadcast stream and assert that the
+      // subscription's onDone fires once dispose closes the
+      // controller. We don't initialize() here — disposing without
+      // ever publishing should still terminate the listener cleanly.
+      final completer = Completer<void>();
+      final sub = service.events.listen(
+        (_) {},
+        onDone: completer.complete,
+      );
+
+      await service.dispose();
+      await completer.future.timeout(const Duration(seconds: 1));
+
+      await sub.cancel();
+    });
+
+    test('dispose() is idempotent', () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+      );
+      await service.dispose();
+      await expectLater(service.dispose(), completes);
+    });
+
+    test('initialize() after dispose() is a no-op', () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+      );
+      await service.dispose();
+      await expectLater(service.initialize(), completes);
+    });
+
+    test('registerPersistedAdapter() after dispose() is a no-op',
+        () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+      );
+      await service.dispose();
+      await expectLater(
+        service.registerPersistedAdapter('any-uuid'),
+        completes,
+      );
+    });
+  });
+
+  group('IosRestorationEvent — sealed class semantics', () {
+    test('willRestore equals another willRestore with same UUIDs', () {
+      const a = IosRestorationEvent.willRestore(['u1', 'u2']);
+      const b = IosRestorationEvent.willRestore(['u1', 'u2']);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('willRestore differs by UUID list', () {
+      const a = IosRestorationEvent.willRestore(['u1']);
+      const b = IosRestorationEvent.willRestore(['u2']);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('notSupported is a singleton-equivalent', () {
+      const a = IosRestorationEvent.notSupported();
+      const b = IosRestorationEvent.notSupported();
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('willRestore != notSupported', () {
+      const a = IosRestorationEvent.willRestore([]);
+      const b = IosRestorationEvent.notSupported();
+      expect(a, isNot(equals(b)));
+    });
+
+    test('exhaustive switch compiles (sealed-class proof)', () {
+      // If a new variant is added without updating this switch the
+      // compiler yells. That's the point of the sealed class.
+      const event = IosRestorationEvent.willRestore(['x']);
+      final result = switch (event) {
+        IosRestorationWillRestore(:final peripheralUuids) =>
+          'will:${peripheralUuids.length}',
+        IosRestorationNotSupported() => 'no',
+      };
+      expect(result, 'will:1');
+    });
+
+    test('toString surfaces UUIDs for debugging', () {
+      const event = IosRestorationEvent.willRestore(['abc', 'def']);
+      expect(event.toString(), contains('abc'));
+      expect(event.toString(), contains('def'));
+    });
+  });
+}


### PR DESCRIPTION
Refs #1295 — phase 2 of 5

## What landed

- `lib/features/consumption/data/obd2/ios_state_restoration_service.dart` — `IosStateRestorationService` interface + `FlutterBluePlusIosStateRestorationService` implementation. `initialize()` calls `FlutterBluePlus.setOptions(restoreState: true)` on iOS, no-op on Android. `registerPersistedAdapter(uuid)` queues the long-lived FBP connect on iOS, no-op on Android. `events` is a broadcast `Stream<IosRestorationEvent>` — Android emits a single `notSupported` sentinel.
- `lib/features/consumption/data/obd2/ios_restoration_event.dart` — Dart-3 sealed class with `IosRestorationEvent.willRestore(List<String> peripheralUuids)` and `IosRestorationEvent.notSupported()`. Used a native sealed class instead of Freezed (codebase has no precedent for multi-constructor Freezed unions; sealed-class semantics are identical for this use case).
- `lib/features/consumption/data/obd2/ios_state_restoration_provider.dart` — `@Riverpod(keepAlive: true)` provider exposing the service as a singleton. Wires `ref.onDispose` to the service's `dispose()`.
- `lib/features/consumption/data/obd2/ios_state_restoration_provider.g.dart` — generated.
- `test/features/consumption/data/obd2/ios_state_restoration_service_test.dart` — 15 tests covering the non-iOS dispatcher branch (initialize / register / events / dispose / idempotency / lifecycle ordering) and the sealed-class semantics (equality, hashCode, exhaustive switch, toString).
- `docs/guides/ios-auto-record.md` — comprehensive guide covering: Info.plist changes (UIBackgroundModes, NSBluetoothAlwaysUsageDescription, NSLocationAlways…, NSLocationWhenInUse… in copy-pasteable XML), why scaffolding ships before iOS verification, how to verify on a Mac (apply Info.plist → `flutter pub get` → `pod install` → build for real iPhone → observe `os_log`), Compromises vs Android (verbatim from issue body), Known limitations, cross-references to #1295 + #9 + #1004 + the Android `auto-record.md`.
- `.gitignore` — added unignore for the new `docs/guides/ios-auto-record.md` entry (existing pattern in the repo).

## Big disclaimer

**iOS build NOT verified in this PR — no Mac available to autonomous worker.** Dart layer is platform-safe (no-op on Android, every public method gated on `Platform.isIOS` / a `debugIsIOSOverride` test seam). Apply Info.plist changes per `docs/guides/ios-auto-record.md` on a Mac, then run Phase 1 spike (verify `willRestoreState` fires on real device).

`ios/Runner/Info.plist` was deliberately NOT edited — Info.plist changes are documented for the Mac-equipped developer instead, since they cannot be tested without iOS CI.

Hot files left untouched: `obd2_service.dart`, `trip_recording_controller.dart`, `adapter_registry.dart`, `app_initializer.dart`, `hive_boxes.dart`, ARB files, `pubspec.yaml`. Build_runner drift (28 unrelated `.g.dart` files refreshed by stale dartdoc on master) was reverted before commit.

## Phase plan

Phase 3 (BLE listener + speed source + trip lifecycle), Phase 4 (notification badge), Phase 5 (device-test acceptance) all remain — none autonomous-worker targets (each needs a Mac + iPhone + ELM327 BLE for the verification step).

## Test plan

- [x] `flutter analyze` — zero issues, zero warnings, zero infos.
- [x] `flutter test test/features/consumption/data/obd2/ios_state_restoration_service_test.dart` — 15/15 green.
- [x] `flutter test test/lint/no_silent_catch_test.dart` — green (the iOS service uses `try/catch` only when followed by `errorLogger.log` + `rethrow`).
- [ ] Mac-equipped developer: apply Info.plist per `docs/guides/ios-auto-record.md`, build for real iPhone, observe `willRestoreState` callback in Console.app (Phase 1 spike).