### PR TITLE
feat(features): central feature management engine (Refs #1373 phase 1)

### DIFF
--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -85,6 +85,9 @@ class HiveBoxes {
   /// data, no PII — unencrypted like the other low-sensitivity boxes.
   static const String trafficSignalsCache = 'traffic_signals_cache';
 
+  /// Central feature-flag set (#1373 phase 1).
+  static const String featureFlags = 'feature_flags';
+
   static const _encryptedBoxes = {
     settings,
     profiles,
@@ -188,6 +191,8 @@ class HiveBoxes {
     await Hive.openBox<String>(isolateErrorSpool);
     // #1125 — glide-coach OSM traffic-signal cache (phase 1).
     await Hive.openBox<String>(trafficSignalsCache);
+    // #1373 — central feature-flag set (phase 1).
+    await Hive.openBox<dynamic>(featureFlags);
   }
 
   /// Initialize Hive in a background isolate with proper encryption.

--- a/lib/features/feature_management/application/feature_flags_provider.dart
+++ b/lib/features/feature_management/application/feature_flags_provider.dart
@@ -1,0 +1,109 @@
+import 'package:hive/hive.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../data/feature_flags_repository.dart';
+import '../domain/feature.dart';
+import '../domain/feature_dependency_graph.dart';
+import '../domain/feature_manifest.dart';
+
+part 'feature_flags_provider.g.dart';
+
+/// Default Hive-backed repository (#1373 phase 1).
+///
+/// Returns `null` when the [FeatureFlagsRepository.boxName] box has not
+/// been opened. Tests that don't initialise Hive get a no-op that falls
+/// back to manifest defaults; production opens the box in
+/// [HiveBoxes.init].
+@Riverpod(keepAlive: true)
+FeatureFlagsRepository? featureFlagsRepository(Ref ref) {
+  if (!Hive.isBoxOpen(FeatureFlagsRepository.boxName)) return null;
+  return FeatureFlagsRepository(
+    box: Hive.box<dynamic>(FeatureFlagsRepository.boxName),
+  );
+}
+
+/// Active manifest. Overridable in tests via `ProviderContainer.overrides`
+/// to inject a synthetic manifest (e.g. for cycle-rejection coverage).
+@Riverpod(keepAlive: true)
+FeatureManifest featureManifest(Ref ref) => FeatureManifest.defaultManifest;
+
+/// Central feature-flag store (#1373 phase 1).
+///
+/// State is the set of currently-enabled features. The provider validates
+/// the manifest for cycles on construction, loads the persisted set (or
+/// manifest defaults on first launch), and gates [enable] / [disable]
+/// transitions on the dependency graph.
+///
+/// This phase ships the system in PARALLEL with the existing scattered
+/// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
+/// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
+/// through this provider one feature at a time.
+@Riverpod(keepAlive: true)
+class FeatureFlags extends _$FeatureFlags {
+  @override
+  Set<Feature> build() {
+    final manifest = ref.watch(featureManifestProvider);
+    assertNoCycles(manifest);
+    final repo = ref.watch(featureFlagsRepositoryProvider);
+    if (repo == null) {
+      return manifest.defaultEnabledSet();
+    }
+    // First-frame state: manifest defaults so synchronous reads have a
+    // sensible answer. The async load below replaces it once Hive
+    // returns — the persisted set wins on every subsequent read.
+    final initial = manifest.defaultEnabledSet();
+    repo.loadEnabled().then((persisted) {
+      // ignore: invalid_use_of_protected_member
+      state = persisted;
+    });
+    return initial;
+  }
+
+  /// Enables [feature], throwing [StateError] when a prerequisite is
+  /// disabled. The error message names the missing prerequisites so the
+  /// Phase 2 UI can surface a tooltip without a second lookup.
+  Future<void> enable(Feature feature) async {
+    final manifest = ref.read(featureManifestProvider);
+    if (state.contains(feature)) return;
+    if (!canEnable(feature, manifest, state)) {
+      final entry = manifest.entryFor(feature);
+      final missing = entry.requires
+          .where((f) => !state.contains(f))
+          .map((f) => f.name)
+          .join(', ');
+      throw StateError(
+        'Cannot enable ${feature.name}: requires $missing which is disabled',
+      );
+    }
+    final next = {...state, feature};
+    await _persist(next);
+    state = next;
+  }
+
+  /// Disables [feature], throwing [StateError] when one or more enabled
+  /// features depend on it. The error message names the dependents so
+  /// the Phase 2 UI can prompt the user to disable them first.
+  Future<void> disable(Feature feature) async {
+    final manifest = ref.read(featureManifestProvider);
+    if (!state.contains(feature)) return;
+    final blockers = blockingDisable(feature, manifest, state);
+    if (blockers.isNotEmpty) {
+      final names = blockers.map((f) => f.name).join(', ');
+      throw StateError(
+        'Cannot disable ${feature.name}: $names depend on it',
+      );
+    }
+    final next = {...state}..remove(feature);
+    await _persist(next);
+    state = next;
+  }
+
+  /// True when [feature] is currently enabled.
+  bool isEnabled(Feature feature) => state.contains(feature);
+
+  Future<void> _persist(Set<Feature> next) async {
+    final repo = ref.read(featureFlagsRepositoryProvider);
+    if (repo == null) return;
+    await repo.saveEnabled(next);
+  }
+}

--- a/lib/features/feature_management/application/feature_flags_provider.g.dart
+++ b/lib/features/feature_management/application/feature_flags_provider.g.dart
@@ -1,0 +1,225 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'feature_flags_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Default Hive-backed repository (#1373 phase 1).
+///
+/// Returns `null` when the [FeatureFlagsRepository.boxName] box has not
+/// been opened. Tests that don't initialise Hive get a no-op that falls
+/// back to manifest defaults; production opens the box in
+/// [HiveBoxes.init].
+
+@ProviderFor(featureFlagsRepository)
+final featureFlagsRepositoryProvider = FeatureFlagsRepositoryProvider._();
+
+/// Default Hive-backed repository (#1373 phase 1).
+///
+/// Returns `null` when the [FeatureFlagsRepository.boxName] box has not
+/// been opened. Tests that don't initialise Hive get a no-op that falls
+/// back to manifest defaults; production opens the box in
+/// [HiveBoxes.init].
+
+final class FeatureFlagsRepositoryProvider
+    extends
+        $FunctionalProvider<
+          FeatureFlagsRepository?,
+          FeatureFlagsRepository?,
+          FeatureFlagsRepository?
+        >
+    with $Provider<FeatureFlagsRepository?> {
+  /// Default Hive-backed repository (#1373 phase 1).
+  ///
+  /// Returns `null` when the [FeatureFlagsRepository.boxName] box has not
+  /// been opened. Tests that don't initialise Hive get a no-op that falls
+  /// back to manifest defaults; production opens the box in
+  /// [HiveBoxes.init].
+  FeatureFlagsRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'featureFlagsRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$featureFlagsRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<FeatureFlagsRepository?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  FeatureFlagsRepository? create(Ref ref) {
+    return featureFlagsRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(FeatureFlagsRepository? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<FeatureFlagsRepository?>(value),
+    );
+  }
+}
+
+String _$featureFlagsRepositoryHash() =>
+    r'd80a2b5ab1391191e896d176fbd40e3adba624a7';
+
+/// Active manifest. Overridable in tests via `ProviderContainer.overrides`
+/// to inject a synthetic manifest (e.g. for cycle-rejection coverage).
+
+@ProviderFor(featureManifest)
+final featureManifestProvider = FeatureManifestProvider._();
+
+/// Active manifest. Overridable in tests via `ProviderContainer.overrides`
+/// to inject a synthetic manifest (e.g. for cycle-rejection coverage).
+
+final class FeatureManifestProvider
+    extends
+        $FunctionalProvider<FeatureManifest, FeatureManifest, FeatureManifest>
+    with $Provider<FeatureManifest> {
+  /// Active manifest. Overridable in tests via `ProviderContainer.overrides`
+  /// to inject a synthetic manifest (e.g. for cycle-rejection coverage).
+  FeatureManifestProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'featureManifestProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$featureManifestHash();
+
+  @$internal
+  @override
+  $ProviderElement<FeatureManifest> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  FeatureManifest create(Ref ref) {
+    return featureManifest(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(FeatureManifest value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<FeatureManifest>(value),
+    );
+  }
+}
+
+String _$featureManifestHash() => r'7b67cbf211fcf268808f6c329950be1d4ba91881';
+
+/// Central feature-flag store (#1373 phase 1).
+///
+/// State is the set of currently-enabled features. The provider validates
+/// the manifest for cycles on construction, loads the persisted set (or
+/// manifest defaults on first launch), and gates [enable] / [disable]
+/// transitions on the dependency graph.
+///
+/// This phase ships the system in PARALLEL with the existing scattered
+/// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
+/// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
+/// through this provider one feature at a time.
+
+@ProviderFor(FeatureFlags)
+final featureFlagsProvider = FeatureFlagsProvider._();
+
+/// Central feature-flag store (#1373 phase 1).
+///
+/// State is the set of currently-enabled features. The provider validates
+/// the manifest for cycles on construction, loads the persisted set (or
+/// manifest defaults on first launch), and gates [enable] / [disable]
+/// transitions on the dependency graph.
+///
+/// This phase ships the system in PARALLEL with the existing scattered
+/// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
+/// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
+/// through this provider one feature at a time.
+final class FeatureFlagsProvider
+    extends $NotifierProvider<FeatureFlags, Set<Feature>> {
+  /// Central feature-flag store (#1373 phase 1).
+  ///
+  /// State is the set of currently-enabled features. The provider validates
+  /// the manifest for cycles on construction, loads the persisted set (or
+  /// manifest defaults on first launch), and gates [enable] / [disable]
+  /// transitions on the dependency graph.
+  ///
+  /// This phase ships the system in PARALLEL with the existing scattered
+  /// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
+  /// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
+  /// through this provider one feature at a time.
+  FeatureFlagsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'featureFlagsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$featureFlagsHash();
+
+  @$internal
+  @override
+  FeatureFlags create() => FeatureFlags();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Set<Feature> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Set<Feature>>(value),
+    );
+  }
+}
+
+String _$featureFlagsHash() => r'686570bb567ddffea95eccad14c7aca01253915c';
+
+/// Central feature-flag store (#1373 phase 1).
+///
+/// State is the set of currently-enabled features. The provider validates
+/// the manifest for cycles on construction, loads the persisted set (or
+/// manifest defaults on first launch), and gates [enable] / [disable]
+/// transitions on the dependency graph.
+///
+/// This phase ships the system in PARALLEL with the existing scattered
+/// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
+/// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
+/// through this provider one feature at a time.
+
+abstract class _$FeatureFlags extends $Notifier<Set<Feature>> {
+  Set<Feature> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<Set<Feature>, Set<Feature>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<Set<Feature>, Set<Feature>>,
+              Set<Feature>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/feature_management/data/feature_flags_repository.dart
+++ b/lib/features/feature_management/data/feature_flags_repository.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../domain/feature.dart';
+import '../domain/feature_manifest.dart';
+
+/// Hive-backed persistence for the central feature-flags set (#1373).
+///
+/// Storage layout: ONE entry per [Feature] keyed by [Enum.name] with the
+/// value `true` when enabled and `false` when explicitly disabled.
+/// String keys are forward-compatible — adding new features or removing
+/// stale entries does not need an index migration.
+///
+/// On the very first launch the box is empty, in which case
+/// [loadEnabled] returns the manifest defaults so consumers see the same
+/// initial behaviour they had before the central system existed.
+class FeatureFlagsRepository {
+  final Box<dynamic> _box;
+  final FeatureManifest _manifest;
+
+  FeatureFlagsRepository({
+    required Box<dynamic> box,
+    FeatureManifest manifest = FeatureManifest.defaultManifest,
+  })  : _box = box,
+        _manifest = manifest;
+
+  /// Hive box that holds the persisted feature-flag set.
+  static const String boxName = 'feature_flags';
+
+  /// Returns the currently-enabled feature set.
+  ///
+  /// First launch (empty box) → manifest defaults. Subsequent launches
+  /// → exactly the set persisted by [saveEnabled]. Unknown enum names
+  /// (e.g. a feature removed in a later version) are skipped silently
+  /// so a downgrade-then-upgrade does not crash.
+  Future<Set<Feature>> loadEnabled() async {
+    if (_box.isEmpty) {
+      return _manifest.defaultEnabledSet();
+    }
+    final result = <Feature>{};
+    final byName = {for (final f in Feature.values) f.name: f};
+    for (final key in _box.keys) {
+      final feature = byName[key.toString()];
+      if (feature == null) {
+        debugPrint(
+          'FeatureFlagsRepository.loadEnabled: skipping unknown key $key',
+        );
+        continue;
+      }
+      final raw = _box.get(key);
+      if (raw == true) {
+        result.add(feature);
+      }
+    }
+    return result;
+  }
+
+  /// Persists [enabled] as the new authoritative set. Every known
+  /// [Feature] is written explicitly (true or false) so a future read
+  /// can distinguish "user disabled it" from "first launch".
+  Future<void> saveEnabled(Set<Feature> enabled) async {
+    final updates = <String, bool>{
+      for (final feature in Feature.values)
+        feature.name: enabled.contains(feature),
+    };
+    await _box.putAll(updates);
+  }
+}

--- a/lib/features/feature_management/domain/feature.dart
+++ b/lib/features/feature_management/domain/feature.dart
@@ -1,0 +1,53 @@
+/// Central catalogue of toggleable application features (#1373 phase 1).
+///
+/// This enum is the manifest other systems consult — it does NOT yet drive
+/// runtime behaviour for the existing scattered toggles (`autoRecord`,
+/// `gamificationEnabled`, etc.). Phase 3 migrations of issue #1373 will
+/// route those legacy paths through this enum one feature at a time.
+///
+/// Add a one-line dartdoc above each value naming the issue or area it
+/// gates. Persistence keys use [Enum.name], so values may be reordered or
+/// inserted but MUST NOT be renamed without a migration.
+enum Feature {
+  /// OBD2-driven trip capture (foundation for gamification, eco-coach,
+  /// consumption analytics, glide-coach, GPS path).
+  obd2TripRecording,
+
+  /// Driving scores + badges (#781). Requires [obd2TripRecording].
+  gamification,
+
+  /// Real-time haptic eco-coach feedback during recording (#1194).
+  /// Requires [obd2TripRecording].
+  hapticEcoCoach,
+
+  /// Cross-device sync via Supabase (TankSync).
+  tankSync,
+
+  /// Fill-up / trip analysis tab (#769). Requires [obd2TripRecording].
+  consumptionAnalytics,
+
+  /// Driving-baseline sync over TankSync (#769). Requires [tankSync].
+  baselineSync,
+
+  /// Unified fuel + EV search results.
+  unifiedSearchResults,
+
+  /// Threshold-based price-drop notifications.
+  priceAlerts,
+
+  /// 30-day price history charts.
+  priceHistory,
+
+  /// Along-route cheapest-stop planner.
+  routePlanning,
+
+  /// EV charging stations via OpenChargeMap.
+  evCharging,
+
+  /// Hypermiling glide-coach (#1125, future). Requires [obd2TripRecording].
+  glideCoach,
+
+  /// GPS path persistence on trips (#1374 phase 1, future). Requires
+  /// [obd2TripRecording].
+  gpsTripPath,
+}

--- a/lib/features/feature_management/domain/feature_dependency_graph.dart
+++ b/lib/features/feature_management/domain/feature_dependency_graph.dart
@@ -1,0 +1,96 @@
+import 'feature.dart';
+import 'feature_manifest.dart';
+
+/// Pure helpers over the [FeatureManifest] dependency DAG (#1373 phase 1).
+///
+/// All functions are side-effect-free and operate on the caller-provided
+/// `currentlyEnabled` set so they can be exercised from tests without a
+/// Riverpod container.
+
+/// Returns `true` when [feature] can be enabled given [currentlyEnabled].
+///
+/// A feature can be enabled when every entry in its
+/// [FeatureManifestEntry.requires] is already in [currentlyEnabled]. The
+/// feature itself does not need to be absent — re-enabling an already
+/// enabled feature is a no-op the caller can decide to skip.
+bool canEnable(
+  Feature feature,
+  FeatureManifest manifest,
+  Set<Feature> currentlyEnabled,
+) {
+  final entry = manifest.entryFor(feature);
+  for (final required in entry.requires) {
+    if (!currentlyEnabled.contains(required)) return false;
+  }
+  return true;
+}
+
+/// Returns the set of currently-enabled features that depend on [feature].
+///
+/// When the returned set is empty, [feature] can be safely disabled.
+/// Otherwise the caller must disable each returned feature first (or refuse
+/// the operation).
+Set<Feature> blockingDisable(
+  Feature feature,
+  FeatureManifest manifest,
+  Set<Feature> currentlyEnabled,
+) {
+  final blockers = <Feature>{};
+  for (final entry in manifest.entries.values) {
+    if (entry.feature == feature) continue;
+    if (!currentlyEnabled.contains(entry.feature)) continue;
+    if (entry.requires.contains(feature)) {
+      blockers.add(entry.feature);
+    }
+  }
+  return blockers;
+}
+
+/// Throws [StateError] when [manifest] contains a `requires` cycle.
+///
+/// Called once at provider construction so a malformed manifest fails fast
+/// in tests / debug builds. Uses three-colour DFS so the error message
+/// names the actual cycle chain rather than a generic "cycle detected".
+void assertNoCycles(FeatureManifest manifest) {
+  // White = unvisited, grey = on the current DFS stack, black = fully
+  // explored. A grey-grey edge is a back edge → cycle.
+  const white = 0;
+  const grey = 1;
+  const black = 2;
+  final colour = <Feature, int>{
+    for (final f in manifest.entries.keys) f: white,
+  };
+  final stack = <Feature>[];
+
+  void visit(Feature node) {
+    colour[node] = grey;
+    stack.add(node);
+    final entry = manifest.entries[node];
+    if (entry != null) {
+      for (final next in entry.requires) {
+        final nextColour = colour[next] ?? white;
+        if (nextColour == grey) {
+          // Trim the stack to the start of the cycle so the message is
+          // tight rather than dragging the entire walk into it.
+          final start = stack.indexOf(next);
+          final chain = [
+            ...stack.sublist(start).map((f) => f.name),
+            next.name,
+          ].join(' -> ');
+          throw StateError('Feature dependency cycle: $chain');
+        }
+        if (nextColour == white) {
+          visit(next);
+        }
+      }
+    }
+    stack.removeLast();
+    colour[node] = black;
+  }
+
+  for (final feature in manifest.entries.keys) {
+    if ((colour[feature] ?? white) == white) {
+      visit(feature);
+    }
+  }
+}

--- a/lib/features/feature_management/domain/feature_manifest.dart
+++ b/lib/features/feature_management/domain/feature_manifest.dart
@@ -1,0 +1,170 @@
+import 'feature.dart';
+
+/// Metadata for a single [Feature] in the manifest (#1373 phase 1).
+///
+/// Plain immutable class — the codebase prefers Dart 3 native sealed/enum
+/// + plain classes over Freezed multi-constructor unions for this kind of
+/// declarative descriptor (see #1377 PR notes).
+class FeatureManifestEntry {
+  /// The feature this entry describes.
+  final Feature feature;
+
+  /// Default state for fresh installs and migrated profiles. Mirrors the
+  /// behaviour of the equivalent scattered toggle TODAY so flipping the
+  /// new system on does not silently change anything.
+  final bool defaultEnabled;
+
+  /// Hard prerequisites — every feature here must be enabled before
+  /// [feature] can be enabled. Cycles are rejected by
+  /// `assertNoCycles` at provider construction.
+  final Set<Feature> requires;
+
+  /// Human-readable label used by Phase 2 settings UI. English only;
+  /// localisation is Phase 2's concern.
+  final String displayName;
+
+  /// One-line description shown next to the toggle in Phase 2 UI.
+  /// English only; localisation is Phase 2's concern.
+  final String description;
+
+  const FeatureManifestEntry({
+    required this.feature,
+    required this.defaultEnabled,
+    required this.displayName,
+    required this.description,
+    this.requires = const {},
+  });
+}
+
+/// Declarative registry of every [Feature] the app knows about.
+///
+/// Phase 1 of #1373 ships only [defaultManifest]. Phase 2 / 3 will read
+/// from this manifest to render the settings UI and to migrate the
+/// existing scattered toggles into the central provider.
+class FeatureManifest {
+  final Map<Feature, FeatureManifestEntry> entries;
+
+  const FeatureManifest(this.entries);
+
+  /// Look up a single entry. Throws [StateError] when [feature] has no
+  /// entry — every value in [Feature] must be declared in the active
+  /// manifest, so a missing entry is a programmer error.
+  FeatureManifestEntry entryFor(Feature feature) {
+    final entry = entries[feature];
+    if (entry == null) {
+      throw StateError(
+        'FeatureManifest is missing an entry for $feature. '
+        'Every Feature value must be declared in the manifest.',
+      );
+    }
+    return entry;
+  }
+
+  /// The set of features whose [FeatureManifestEntry.defaultEnabled] is
+  /// `true`. Used by the repository on first launch and as the fallback
+  /// when the persisted set cannot be read.
+  Set<Feature> defaultEnabledSet() {
+    return {
+      for (final e in entries.values)
+        if (e.defaultEnabled) e.feature,
+    };
+  }
+
+  /// Authoritative manifest used at runtime. Defaults match TODAY's
+  /// scattered-toggle behaviour:
+  /// - `obd2TripRecording`: false (matches `VehicleProfile.autoRecord`)
+  /// - `gamification`: true (matches `UserProfile.gamificationEnabled`)
+  /// - `hapticEcoCoach`: false (off by default; explicit opt-in)
+  /// - `tankSync`: false (off until user signs in)
+  /// - `consumptionAnalytics`: false (no trips → no tab)
+  /// - `baselineSync`: false (off until TankSync is enabled)
+  /// - `unifiedSearchResults`: false (kept off pending UX work)
+  /// - `priceAlerts`, `priceHistory`, `routePlanning`, `evCharging`: true
+  /// - `glideCoach`, `gpsTripPath`: false (future features, opt-in)
+  static const FeatureManifest defaultManifest = FeatureManifest({
+    Feature.obd2TripRecording: FeatureManifestEntry(
+      feature: Feature.obd2TripRecording,
+      defaultEnabled: false,
+      displayName: 'OBD2 trip recording',
+      description: 'Capture trips automatically over OBD2.',
+    ),
+    Feature.gamification: FeatureManifestEntry(
+      feature: Feature.gamification,
+      defaultEnabled: true,
+      requires: {Feature.obd2TripRecording},
+      displayName: 'Gamification',
+      description: 'Driving scores and earned badges.',
+    ),
+    Feature.hapticEcoCoach: FeatureManifestEntry(
+      feature: Feature.hapticEcoCoach,
+      defaultEnabled: false,
+      requires: {Feature.obd2TripRecording},
+      displayName: 'Haptic eco-coach',
+      description: 'Real-time haptic feedback during a trip.',
+    ),
+    Feature.tankSync: FeatureManifestEntry(
+      feature: Feature.tankSync,
+      defaultEnabled: false,
+      displayName: 'TankSync',
+      description: 'Cross-device sync via Supabase.',
+    ),
+    Feature.consumptionAnalytics: FeatureManifestEntry(
+      feature: Feature.consumptionAnalytics,
+      defaultEnabled: false,
+      requires: {Feature.obd2TripRecording},
+      displayName: 'Consumption analytics',
+      description: 'Fill-up and trip analysis tab.',
+    ),
+    Feature.baselineSync: FeatureManifestEntry(
+      feature: Feature.baselineSync,
+      defaultEnabled: false,
+      requires: {Feature.tankSync},
+      displayName: 'Baseline sync',
+      description: 'Sync driving baselines via TankSync.',
+    ),
+    Feature.unifiedSearchResults: FeatureManifestEntry(
+      feature: Feature.unifiedSearchResults,
+      defaultEnabled: false,
+      displayName: 'Unified search results',
+      description: 'Single result list combining fuel and EV stations.',
+    ),
+    Feature.priceAlerts: FeatureManifestEntry(
+      feature: Feature.priceAlerts,
+      defaultEnabled: true,
+      displayName: 'Price alerts',
+      description: 'Threshold-based price-drop notifications.',
+    ),
+    Feature.priceHistory: FeatureManifestEntry(
+      feature: Feature.priceHistory,
+      defaultEnabled: true,
+      displayName: 'Price history',
+      description: '30-day price charts on station details.',
+    ),
+    Feature.routePlanning: FeatureManifestEntry(
+      feature: Feature.routePlanning,
+      defaultEnabled: true,
+      displayName: 'Route planning',
+      description: 'Cheapest stop along your route.',
+    ),
+    Feature.evCharging: FeatureManifestEntry(
+      feature: Feature.evCharging,
+      defaultEnabled: true,
+      displayName: 'EV charging',
+      description: 'Charging stations via OpenChargeMap.',
+    ),
+    Feature.glideCoach: FeatureManifestEntry(
+      feature: Feature.glideCoach,
+      defaultEnabled: false,
+      requires: {Feature.obd2TripRecording},
+      displayName: 'Glide-coach',
+      description: 'Hypermiling guidance using OSM traffic signals.',
+    ),
+    Feature.gpsTripPath: FeatureManifestEntry(
+      feature: Feature.gpsTripPath,
+      defaultEnabled: false,
+      requires: {Feature.obd2TripRecording},
+      displayName: 'GPS trip path',
+      description: 'Persist GPS path samples alongside each trip.',
+    ),
+  });
+}

--- a/test/features/feature_management/feature_dependency_graph_test.dart
+++ b/test/features/feature_management/feature_dependency_graph_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_dependency_graph.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+
+void main() {
+  const manifest = FeatureManifest.defaultManifest;
+
+  group('canEnable', () {
+    test('returns false when a prerequisite is disabled', () {
+      // gamification requires obd2TripRecording.
+      expect(
+        canEnable(Feature.gamification, manifest, <Feature>{}),
+        isFalse,
+      );
+    });
+
+    test('returns true when all prerequisites are enabled', () {
+      expect(
+        canEnable(Feature.gamification, manifest, <Feature>{
+          Feature.obd2TripRecording,
+        }),
+        isTrue,
+      );
+    });
+
+    test('returns true for a feature with no prerequisites', () {
+      expect(canEnable(Feature.tankSync, manifest, <Feature>{}), isTrue);
+    });
+  });
+
+  group('blockingDisable', () {
+    test('returns dependents that would break', () {
+      // Disabling obd2TripRecording while gamification + glideCoach are on
+      // must surface BOTH dependents.
+      final blockers = blockingDisable(
+        Feature.obd2TripRecording,
+        manifest,
+        <Feature>{
+          Feature.obd2TripRecording,
+          Feature.gamification,
+          Feature.glideCoach,
+        },
+      );
+      expect(blockers, containsAll(<Feature>[
+        Feature.gamification,
+        Feature.glideCoach,
+      ]));
+    });
+
+    test('returns empty when no enabled feature depends on it', () {
+      final blockers = blockingDisable(
+        Feature.tankSync,
+        manifest,
+        <Feature>{Feature.tankSync},
+      );
+      expect(blockers, isEmpty);
+    });
+
+    test('does not list the feature itself', () {
+      final blockers = blockingDisable(
+        Feature.obd2TripRecording,
+        manifest,
+        <Feature>{Feature.obd2TripRecording},
+      );
+      expect(blockers, isNot(contains(Feature.obd2TripRecording)));
+    });
+  });
+
+  group('assertNoCycles', () {
+    test('does not throw on the default manifest', () {
+      expect(() => assertNoCycles(manifest), returnsNormally);
+    });
+
+    test('throws on a synthetic cycle', () {
+      // a -> b -> a — pick two arbitrary Feature values to wire as a
+      // direct two-node cycle.
+      const cyclic = FeatureManifest({
+        Feature.gamification: FeatureManifestEntry(
+          feature: Feature.gamification,
+          defaultEnabled: false,
+          requires: {Feature.hapticEcoCoach},
+          displayName: 'gamification',
+          description: 'cycle test',
+        ),
+        Feature.hapticEcoCoach: FeatureManifestEntry(
+          feature: Feature.hapticEcoCoach,
+          defaultEnabled: false,
+          requires: {Feature.gamification},
+          displayName: 'hapticEcoCoach',
+          description: 'cycle test',
+        ),
+      });
+      expect(
+        () => assertNoCycles(cyclic),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains('Feature dependency cycle'),
+        )),
+      );
+    });
+  });
+}

--- a/test/features/feature_management/feature_flags_provider_test.dart
+++ b/test/features/feature_management/feature_flags_provider_test.dart
@@ -1,0 +1,202 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/data/feature_flags_repository.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late Box<dynamic> box;
+  late FeatureFlagsRepository repo;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('feature_flags_test_');
+    Hive.init(tmpDir.path);
+    box = await Hive.openBox<dynamic>(
+      'feature_flags_${DateTime.now().microsecondsSinceEpoch}',
+    );
+    repo = FeatureFlagsRepository(box: box);
+  });
+
+  tearDown(() async {
+    await box.deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  ProviderContainer makeContainer({FeatureManifest? manifest}) {
+    final c = ProviderContainer(overrides: [
+      featureFlagsRepositoryProvider.overrideWithValue(repo),
+      if (manifest != null)
+        featureManifestProvider.overrideWithValue(manifest),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  /// Drains the post-build async load so reads observe the persisted set
+  /// rather than the synchronous manifest-default placeholder.
+  Future<void> pumpLoad(ProviderContainer c) async {
+    c.read(featureFlagsProvider);
+    // Two microtask drains — one for repo.loadEnabled().then, one for the
+    // setter. A single delay covers both in practice.
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  group('FeatureFlags initial state', () {
+    test('matches defaultManifest defaults on an empty box', () async {
+      final c = makeContainer();
+      await pumpLoad(c);
+      final state = c.read(featureFlagsProvider);
+      expect(state, FeatureManifest.defaultManifest.defaultEnabledSet());
+      // Sanity-check a few that should default true / false respectively.
+      expect(state, contains(Feature.gamification));
+      expect(state, contains(Feature.priceAlerts));
+      expect(state, isNot(contains(Feature.obd2TripRecording)));
+      expect(state, isNot(contains(Feature.tankSync)));
+    });
+  });
+
+  group('FeatureFlags.enable / disable', () {
+    test('enable(gamification) throws when obd2TripRecording is disabled',
+        () async {
+      final c = makeContainer();
+      await pumpLoad(c);
+      // Defaults: gamification is in the set but obd2TripRecording is not.
+      // To trigger the guard we first remove gamification, then attempt to
+      // re-enable it without its prerequisite.
+      await c.read(featureFlagsProvider.notifier).disable(Feature.gamification);
+      expect(
+        () => c.read(featureFlagsProvider.notifier).enable(Feature.gamification),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('Cannot enable gamification'),
+              contains('obd2TripRecording')),
+        )),
+      );
+    });
+
+    test('enable(obd2TripRecording) then enable(gamification) succeeds',
+        () async {
+      final c = makeContainer();
+      await pumpLoad(c);
+      await c
+          .read(featureFlagsProvider.notifier)
+          .disable(Feature.gamification);
+      await c
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.obd2TripRecording);
+      await c
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.gamification);
+
+      final state = c.read(featureFlagsProvider);
+      expect(state, contains(Feature.obd2TripRecording));
+      expect(state, contains(Feature.gamification));
+    });
+
+    test('disable(obd2TripRecording) throws when gamification is enabled',
+        () async {
+      final c = makeContainer();
+      await pumpLoad(c);
+      await c
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.obd2TripRecording);
+      // gamification is on by default; ensure it's still set after the
+      // pre-condition above.
+      expect(c.read(featureFlagsProvider), contains(Feature.gamification));
+
+      expect(
+        () => c
+            .read(featureFlagsProvider.notifier)
+            .disable(Feature.obd2TripRecording),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('Cannot disable obd2TripRecording'),
+              contains('gamification')),
+        )),
+      );
+    });
+
+    test('isEnabled mirrors the current state', () async {
+      final c = makeContainer();
+      await pumpLoad(c);
+      final notifier = c.read(featureFlagsProvider.notifier);
+      expect(notifier.isEnabled(Feature.priceAlerts), isTrue);
+      expect(notifier.isEnabled(Feature.tankSync), isFalse);
+      await notifier.enable(Feature.tankSync);
+      expect(notifier.isEnabled(Feature.tankSync), isTrue);
+    });
+  });
+
+  group('FeatureFlags persistence round-trip', () {
+    test('enable -> save -> reload still enabled', () async {
+      final c1 = makeContainer();
+      await pumpLoad(c1);
+      await c1.read(featureFlagsProvider.notifier).enable(Feature.tankSync);
+      expect(c1.read(featureFlagsProvider), contains(Feature.tankSync));
+
+      // Fresh container, same Hive box → persisted set wins over defaults.
+      final c2 = makeContainer();
+      await pumpLoad(c2);
+      final state = c2.read(featureFlagsProvider);
+      expect(state, contains(Feature.tankSync));
+      // Things on by default that were never touched stay on.
+      expect(state, contains(Feature.priceAlerts));
+    });
+
+    test('disable -> save -> reload stays disabled', () async {
+      final c1 = makeContainer();
+      await pumpLoad(c1);
+      // priceAlerts defaults true; disabling it must survive a reload.
+      await c1
+          .read(featureFlagsProvider.notifier)
+          .disable(Feature.priceAlerts);
+
+      final c2 = makeContainer();
+      await pumpLoad(c2);
+      expect(c2.read(featureFlagsProvider), isNot(contains(Feature.priceAlerts)));
+    });
+  });
+
+  group('FeatureFlags cycle detection', () {
+    test('build throws when the manifest contains a cycle', () async {
+      const cyclic = FeatureManifest({
+        Feature.gamification: FeatureManifestEntry(
+          feature: Feature.gamification,
+          defaultEnabled: false,
+          requires: {Feature.hapticEcoCoach},
+          displayName: 'gamification',
+          description: 'cycle test',
+        ),
+        Feature.hapticEcoCoach: FeatureManifestEntry(
+          feature: Feature.hapticEcoCoach,
+          defaultEnabled: false,
+          requires: {Feature.gamification},
+          displayName: 'hapticEcoCoach',
+          description: 'cycle test',
+        ),
+      });
+      final c = makeContainer(manifest: cyclic);
+      // Riverpod wraps build-time throws inside ProviderException; the
+      // contract we care about is that the StateError surfaces (matched
+      // by message), not the wrapper class.
+      expect(
+        () => c.read(featureFlagsProvider),
+        throwsA(predicate(
+          (e) => e.toString().contains('Feature dependency cycle'),
+          'wraps a StateError naming the cycle',
+        )),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Refs #1373 — phase 1 of 3.

## What landed
- `Feature` enum (13 entries) — declarative manifest of every toggleable feature, one-line dartdoc per value naming the issue/area it gates.
- `FeatureManifest` + `FeatureManifestEntry` — per-feature `defaultEnabled`, `requires`, `displayName`, `description`. `defaultManifest` matches TODAY's scattered-toggle behaviour exactly so this PR ships zero behaviour change.
- `feature_dependency_graph.dart` — pure helpers: `canEnable`, `blockingDisable`, `assertNoCycles` (three-colour DFS that names the cycle chain in the error message).
- `FeatureFlagsRepository` — Hive-backed store on the new `feature_flags` box; string keys (`Feature.name`) for forward compatibility.
- `featureFlagsProvider` (`@riverpod` codegen) — exposes `isEnabled`, `enable`, `disable`. Validates the manifest for cycles on construction. `enable` / `disable` throw `StateError` with a message that names the offending dependency so Phase 2 UI can surface tooltips without a second lookup.
- New Hive box opener `feature_flags` registered in `lib/core/storage/hive_boxes.dart` (5-line addition: const + dartdoc + openBox + comment).
- 16 tests across `feature_dependency_graph_test.dart` (8) + `feature_flags_provider_test.dart` (8) — round-trip, dependency guards both directions, default-state, cycle rejection.

## Phase 2 (settings UI) and Phase 3 migrations remain
Phase 2: collapsible section in `profile_screen.dart` with localized labels (en/de/fr).
Phase 3: migrate `hapticEcoCoachEnabled`, `gamificationEnabled`, `showConsumptionTab` / `showFuel` / `showElectric`, `autoRecord`, `syncBaselinesEnabled`, `unifiedSearchResultsEnabled` one feature per PR for bisectability.

## Note
Existing scattered toggles continue to work — this phase ships the parallel system without consumer migration. No production code path reads `featureFlagsProvider` yet.

## Test plan
- Run ``flutter test test/features/feature_management/``.