### PR TITLE
fix(map): re-fire tile reset on programmatic moves during cold-start window (Closes #1316)

### DIFF
--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -45,6 +45,30 @@ import 'station_marker.dart';
 /// pathologies. The KeyedSubtree+incarnation rebuild in [MapScreen]
 /// already destroys this state on tab-flip, so the provider lifetime
 /// is bounded by the visible-tab lifetime.
+///
+/// ## Cold-start tile reset window (#1316 phase 3)
+///
+/// The single `addPostFrameCallback` reset added in #1234 fires
+/// before two later events that also invalidate TileLayer's captured
+/// viewport:
+///   1. `NearbyMapView` schedules its own post-frame `fitCamera` call
+///      every build — that move arrives AFTER the initState reset, so
+///      TileLayer reloads against the bootstrap camera and never
+///      sees the settled camera the user actually wants tiles for.
+///   2. `FlutterMap` only emits `MapEventNonRotatedSizeChange` once
+///      its internal LayoutBuilder lays out — also AFTER the
+///      initState reset. If the bootstrap layout was small (the
+///      <100px LayoutBuilder gate in [MapScreen] only catches the
+///      worst placeholder layouts), TileLayer captured a tiny tile
+///      range that survives the size update.
+/// Both produced the "3 tile patches over a grey background"
+/// symptom the user reported. The fix subscribes to
+/// [MapController.mapEventStream] for [_coldStartResetWindow] (3 s)
+/// and re-emits on the reset stream every time a programmatic move,
+/// `fitCamera`, or `nonRotatedSizeChange` event arrives. After the
+/// window the subscription cancels itself so steady-state pans use
+/// TileLayer's normal load-on-event path (resetting on every pan
+/// would briefly blank the visible tiles).
 class StationMapLayers extends StatefulWidget {
   final MapController mapController;
   final List<Station> stations;
@@ -153,7 +177,29 @@ class _StationMapLayersState extends State<StationMapLayers> {
   /// it once after the first frame to cover the case where TileLayer's
   /// initial `didChangeDependencies` ran against a degenerate camera
   /// and never re-issued requests when the camera settled.
-  final StreamController<void> _resetController = StreamController<void>.broadcast();
+  final StreamController<void> _resetController =
+      StreamController<void>.broadcast();
+
+  /// Subscription on [MapController.mapEventStream] used during the
+  /// cold-start window to force a tile-reset every time the map size
+  /// or camera moves programmatically. Cancelled after
+  /// [_coldStartResetWindow] so steady-state interactions are not
+  /// disturbed (#1316 phase 3 — see class doc).
+  StreamSubscription<MapEvent>? _coldStartEventSub;
+
+  /// Timer that closes the cold-start reset window. Cancelled in
+  /// [dispose] so a late firing cannot touch a disposed state.
+  Timer? _coldStartCloseTimer;
+
+  /// How long to keep firing tile-resets on programmatic
+  /// size/camera changes after init. Three seconds covers the worst
+  /// observed cold-start sequence (offstage IndexedStack pre-mount
+  /// → onstage promotion → LayoutBuilder gate clears → FlutterMap
+  /// internal LayoutBuilder lays out → `fitCamera` post-frame
+  /// callback fires → camera settles). Shorter windows missed the
+  /// late `fitCamera` on slow devices; longer windows risk
+  /// interfering with the user's first deliberate zoom.
+  static const Duration _coldStartResetWindow = Duration(seconds: 3);
 
   @override
   void initState() {
@@ -171,10 +217,51 @@ class _StationMapLayersState extends State<StationMapLayers> {
       if (!mounted || _resetController.isClosed) return;
       _resetController.add(null);
     });
+
+    // #1316 phase 3 — the single first-paint reset above fires before
+    // [NearbyMapView]'s post-frame `fitCamera` runs and before
+    // FlutterMap's own LayoutBuilder finishes propagating the real
+    // viewport size. Result: reset hits TileLayer with the bootstrap
+    // camera, TileLayer fetches a tiny tile set, then `fitCamera`
+    // moves the camera + the size-change event arrives — but
+    // TileLayer's reaction at that point only loads tiles INSIDE the
+    // already-captured (small) viewport, leaving most of the visible
+    // map grey (the "3 patches" symptom in the issue's screenshots).
+    //
+    // Fix: subscribe to the map event stream and re-fire the reset on
+    // every programmatic event that changes either the viewport size
+    // or the camera position during the [_coldStartResetWindow].
+    // After the window, unsubscribe — steady-state pans/zooms do not
+    // need a tile-pipeline reset (TileLayer's normal load-on-event
+    // path handles them just fine, and gratuitous resets would cause
+    // visible tile pop-in on every pan).
+    _coldStartEventSub =
+        widget.mapController.mapEventStream.listen(_onColdStartEvent);
+    _coldStartCloseTimer = Timer(_coldStartResetWindow, () {
+      _coldStartEventSub?.cancel();
+      _coldStartEventSub = null;
+    });
+  }
+
+  /// Fire a tile-reset on programmatic size/camera changes during the
+  /// cold-start window. Filters to events that actually invalidate the
+  /// captured viewport — pure user interaction (drag, scroll-wheel,
+  /// pinch) is ignored because if the user is interacting, the bug
+  /// did not reproduce on this open and we should not interrupt them.
+  void _onColdStartEvent(MapEvent event) {
+    if (!mounted || _resetController.isClosed) return;
+    final src = event.source;
+    final relevant = src == MapEventSource.nonRotatedSizeChange ||
+        src == MapEventSource.fitCamera ||
+        src == MapEventSource.mapController;
+    if (!relevant) return;
+    _resetController.add(null);
   }
 
   @override
   void dispose() {
+    _coldStartCloseTimer?.cancel();
+    _coldStartEventSub?.cancel();
     _resetController.close();
     _tileProvider.dispose();
     super.dispose();

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -199,6 +199,130 @@ void main() {
       },
     );
   });
+
+  group('StationMapLayers cold-start tile reset window (#1316 phase 3)', () {
+    testWidgets(
+      'reset stream re-fires on programmatic camera moves during the '
+      'cold-start window so TileLayer reloads after `fitCamera` settles',
+      (tester) async {
+        tester.view.physicalSize = const Size(900, 1600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final mapController = MapController();
+        addTearDown(mapController.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StationMapLayers(
+                mapController: mapController,
+                stations: const [_seedStation],
+                center: const LatLng(52.5210, 13.4100),
+                zoom: 12,
+                searchRadiusKm: 10,
+                selectedFuel: FuelType.diesel,
+              ),
+            ),
+          ),
+        );
+
+        // The initState first-paint reset fired during pumpWidget's
+        // post-frame stage, so a listener attached now misses it
+        // (broadcast streams do not replay). That part is already
+        // covered by the existing "TileLayer.reset stream is wired"
+        // test above. Here we focus on the phase-3 invariant: a
+        // programmatic camera move during the cold-start window must
+        // produce at least one fresh reset.
+        final reset = tester.widget<TileLayer>(find.byType(TileLayer)).reset!;
+        final emissions = <void>[];
+        final sub = reset.listen(emissions.add);
+        addTearDown(sub.cancel);
+
+        // Simulate `NearbyMapView`s post-frame `fitCamera` arriving
+        // AFTER the initState reset already fired. Before #1316
+        // phase 3, this left TileLayer with whatever tile range it
+        // computed at the bootstrap camera — typically only a handful
+        // of tiles around the (possibly stale) initial centre. Now
+        // the cold-start subscriber must catch this event and
+        // re-emit reset so TileLayer reloads against the settled
+        // camera.
+        mapController.move(const LatLng(43.4500, 3.4900), 12);
+        await tester.pump(const Duration(milliseconds: 16));
+
+        expect(
+          emissions,
+          isNotEmpty,
+          reason:
+              '#1316 — programmatic camera moves during the cold-start '
+              'window must re-emit on the reset stream so TileLayer '
+              'recomputes its visible-tile set against the settled '
+              'camera. Previously the initState reset fired against the '
+              'bootstrap camera; if `fitCamera` (or any controller move) '
+              'arrived later, TileLayer kept the small tile set from '
+              'the bootstrap camera, leaving most of the map grey.',
+        );
+      },
+    );
+
+    testWidgets(
+      'after the cold-start window, programmatic moves no longer trigger '
+      'extra resets (steady-state pans must not pop tiles)',
+      (tester) async {
+        tester.view.physicalSize = const Size(900, 1600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final mapController = MapController();
+        addTearDown(mapController.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StationMapLayers(
+                mapController: mapController,
+                stations: const [_seedStation],
+                center: const LatLng(52.5210, 13.4100),
+                zoom: 12,
+                searchRadiusKm: 10,
+                selectedFuel: FuelType.diesel,
+              ),
+            ),
+          ),
+        );
+
+        final reset = tester.widget<TileLayer>(find.byType(TileLayer)).reset!;
+        final emissions = <void>[];
+        final sub = reset.listen(emissions.add);
+        addTearDown(sub.cancel);
+
+        // Burn past the 3-second cold-start window.
+        await tester.pump(const Duration(seconds: 4));
+        final baseline = emissions.length;
+
+        // Programmatic move AFTER the window — must not re-emit on
+        // the reset stream. TileLayer has its own load-on-event
+        // handling for steady-state pans; gratuitous resets pop the
+        // visible tiles back to their loading state.
+        mapController.move(const LatLng(43.4500, 3.4900), 12);
+        await tester.pump(const Duration(milliseconds: 16));
+
+        expect(
+          emissions.length,
+          baseline,
+          reason:
+              'After [_coldStartResetWindow] elapses, programmatic '
+              'camera moves must no longer fire the reset stream — '
+              'TileLayer\'s normal event-driven load path handles '
+              'steady-state pans and an extra reset would briefly '
+              'wipe the visible tiles. The cold-start subscription '
+              'must self-cancel.',
+        );
+      },
+    );
+  });
 }
 
 const _seedStation = Station(


### PR DESCRIPTION
## Summary

Definitive phase-3 fix for #1316. Subscribes to `MapController.mapEventStream` during a 3-second cold-start window and re-fires the tile-reset stream on every programmatic event that invalidates TileLayer's captured viewport — `fitCamera`, `mapController.move`, and `nonRotatedSizeChange`.

## Root cause

The user's screenshot (3 small map fragments at Roujan / Castelnau-de-Guers / Agde over a sea of grey) is the unmistakable signature of TileLayer holding a small captured tile range that never expanded when the real viewport / camera arrived. The single `addPostFrameCallback` reset added in #1234 fires too early:

1. `NearbyMapView.build` schedules its own post-frame `fitCamera` to fit the search-radius bounds. That move arrives AFTER our reset, so TileLayer reloads against the bootstrap camera and never sees the settled camera the user actually wants tiles for.
2. `FlutterMap` only emits `MapEventNonRotatedSizeChange` once its internal `LayoutBuilder` lays out — also AFTER our reset. If the bootstrap layout was small (the `<100px` LayoutBuilder gate in MapScreen catches the worst placeholder layouts but not all intermediate layouts), TileLayer captured a tiny tile range that survives the size update.

Phase 1 (#1354) and phase 2 (#1378) layered defenses around this — the LayoutBuilder threshold, cold-start incarnation bump, delayed retry-bump — but none addressed the actual race: TileLayer's reset arrives before the camera and viewport settle. This phase 3 patch re-fires reset whenever those settling events arrive.

## What changes

`StationMapLayers._StationMapLayersState`:
- Subscribes to `widget.mapController.mapEventStream` in `initState`
- Filters to events with `source` ∈ {`nonRotatedSizeChange`, `fitCamera`, `mapController`} — pure user gestures (drag, pinch, scroll-wheel) are ignored because if the user is interacting, the bug did not reproduce on this open and we should not interrupt them
- Cancels the subscription after `_coldStartResetWindow` (3 s) so steady-state pans use TileLayer's normal load-on-event path. Resetting on every pan would briefly blank the visible tiles.

## Test plan

- [x] `flutter test test/features/map/presentation/widgets/station_map_layers_test.dart` — all 10 pass, including 2 new phase-3 tests covering (a) reset re-fires on programmatic move during the window, (b) reset does NOT re-fire after the window
- [x] `flutter test test/features/map/` — all 150 map tests pass
- [x] `flutter analyze lib/features/map/presentation/widgets/station_map_layers.dart test/features/map/presentation/widgets/station_map_layers_test.dart` — clean
- [ ] Device verification: cold-start the app onto Carte tab, no manual pan/zoom — tiles render fully on first frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)