### PR TITLE
fix(loyalty): French translations for Fuel Club Cards screen (Closes #1383)

### DIFF
--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1086,5 +1086,20 @@
   "mapDebugOverlayDisabledSnack": "Superposition de débogage de la carte désactivée",
   "mapDebugOverlayClearButton": "Effacer",
   "mapDebugOverlayCloseButton": "Fermer",
-  "mapDebugOverlayTitle": "Traces de la carte"
+  "mapDebugOverlayTitle": "Traces de la carte",
+  "loyaltySettingsTitle": "Mes cartes de fidélité",
+  "loyaltySettingsSubtitle": "Appliquer votre remise fidélité aux prix affichés",
+  "loyaltyMenuTitle": "Cartes de fidélité",
+  "loyaltyMenuSubtitle": "Remises par litre Total, Aral, Shell…",
+  "loyaltyAddCard": "Ajouter une carte",
+  "loyaltyAddCardSheetTitle": "Ajouter une carte de fidélité",
+  "loyaltyBrandLabel": "Enseigne",
+  "loyaltyCardLabelLabel": "Libellé (facultatif)",
+  "loyaltyDiscountLabel": "Remise (par litre)",
+  "loyaltyDiscountInvalid": "Saisissez un nombre positif",
+  "loyaltyDeleteConfirmTitle": "Supprimer la carte ?",
+  "loyaltyDeleteConfirmBody": "Cette carte n'appliquera plus sa remise.",
+  "loyaltyEmptyTitle": "Aucune carte de fidélité",
+  "loyaltyEmptyBody": "Ajoutez une carte pour appliquer automatiquement votre remise par litre aux stations correspondantes.",
+  "loyaltyBadgePrefix": "−"
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3655,50 +3655,49 @@ class AppLocalizationsFr extends AppLocalizations {
       'Easy on the throttle — coasting saves more';
 
   @override
-  String get loyaltySettingsTitle => 'Fuel club cards';
+  String get loyaltySettingsTitle => 'Mes cartes de fidélité';
 
   @override
   String get loyaltySettingsSubtitle =>
-      'Apply your loyalty discount to displayed prices';
+      'Appliquer votre remise fidélité aux prix affichés';
 
   @override
-  String get loyaltyMenuTitle => 'Fuel club cards';
+  String get loyaltyMenuTitle => 'Cartes de fidélité';
 
   @override
-  String get loyaltyMenuSubtitle =>
-      'Apply per-litre discounts from Total, Aral, Shell, …';
+  String get loyaltyMenuSubtitle => 'Remises par litre Total, Aral, Shell…';
 
   @override
-  String get loyaltyAddCard => 'Add card';
+  String get loyaltyAddCard => 'Ajouter une carte';
 
   @override
-  String get loyaltyAddCardSheetTitle => 'Add fuel club card';
+  String get loyaltyAddCardSheetTitle => 'Ajouter une carte de fidélité';
 
   @override
-  String get loyaltyBrandLabel => 'Brand';
+  String get loyaltyBrandLabel => 'Enseigne';
 
   @override
-  String get loyaltyCardLabelLabel => 'Label (optional)';
+  String get loyaltyCardLabelLabel => 'Libellé (facultatif)';
 
   @override
-  String get loyaltyDiscountLabel => 'Discount (per litre)';
+  String get loyaltyDiscountLabel => 'Remise (par litre)';
 
   @override
-  String get loyaltyDiscountInvalid => 'Enter a positive number';
+  String get loyaltyDiscountInvalid => 'Saisissez un nombre positif';
 
   @override
-  String get loyaltyDeleteConfirmTitle => 'Delete card?';
+  String get loyaltyDeleteConfirmTitle => 'Supprimer la carte ?';
 
   @override
   String get loyaltyDeleteConfirmBody =>
-      'This card will stop applying its discount.';
+      'Cette carte n\'appliquera plus sa remise.';
 
   @override
-  String get loyaltyEmptyTitle => 'No fuel club cards yet';
+  String get loyaltyEmptyTitle => 'Aucune carte de fidélité';
 
   @override
   String get loyaltyEmptyBody =>
-      'Add a card to apply your per-litre discount to matching stations automatically.';
+      'Ajoutez une carte pour appliquer automatiquement votre remise par litre aux stations correspondantes.';
 
   @override
   String get loyaltyBadgePrefix => '−';

--- a/test/l10n/localization_completeness_test.dart
+++ b/test/l10n/localization_completeness_test.dart
@@ -124,6 +124,20 @@ void main() {
           reason: 'French (fr) must have every vehicle-edit, calibration, '
               'service-reminder and VIN key — the Edit vehicle screen '
               'must not fall back to English for French users (#1218)');
+
+      // The Fuel Club Cards (loyalty) settings sub-screen shipped with
+      // only `en` + `de` ARB fragments, so French users saw an entirely
+      // English screen — including the menu tile that opens it. Same
+      // rule as onboarding / vehicle-edit: surfaces a French user can
+      // reach must not fall back to English.
+      final frenchMissingLoyalty = frenchMissing
+          .where((k) => k.startsWith('loyalty'))
+          .toList()
+        ..sort();
+      expect(frenchMissingLoyalty, isEmpty,
+          reason: 'French (fr) must have every loyalty* key — the '
+              'Fuel club cards screen and its add-card sheet must not '
+              'fall back to English for French users');
     });
 
     test('no locale has extra keys not in app_en.arb', () {


### PR DESCRIPTION
## Summary

Closes #1383. The Fuel Club Cards settings sub-screen (#1120) was shipping in English to French users — every string from the menu tile down through the add-card form, empty state, and delete dialog. Same root cause as the onboarding (#495) and vehicle-edit (#1218) regressions: the feature only had `en` + `de` ARB fragments, so French fell back.

## Changes

- **`lib/l10n/app_fr.arb`** — 15 new `loyalty*` keys translated to French (`Mes cartes de fidélité`, `Ajouter une carte`, `Enseigne`, `Remise (par litre)`, …)
- **`lib/l10n/app_localizations_fr.dart`** — regenerated from the ARB via `flutter gen-l10n` (no manual edits)
- **`test/l10n/localization_completeness_test.dart`** — new guard mirroring the existing onboarding / vehicle-edit / VIN guards: French must have every `loyalty*` key, or CI fails

## Verified

- [x] `flutter test test/l10n/localization_completeness_test.dart` → 4 tests pass
- [x] `flutter analyze lib/l10n/ test/l10n/` → no issues
- [ ] Spot-check on French device after merge (was the original repro)

## Out of scope (tracked in #1383)

- 22 other locales still missing `loyalty*` keys
- `tool/build_arb.dart` only merges `en`+`de`; orphan `_fr.arb` fragments exist but are unused
- UX-consistency observations across feature settings screens (banner pattern variation, title-style variation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)