### PR TITLE
feat(trips): GPS sampling on TripSample (Refs #1374 phase 1)

### DIFF
--- a/lib/features/consumption/data/obd2/active_trip_repository.dart
+++ b/lib/features/consumption/data/obd2/active_trip_repository.dart
@@ -202,6 +202,11 @@ Map<String, dynamic> _sampleToJson(TripSample s) => {
       if (s.throttlePercent != null) 'th': s.throttlePercent,
       if (s.engineLoadPercent != null) 'el': s.engineLoadPercent,
       if (s.coolantTempC != null) 'ct': s.coolantTempC,
+      // #1374 phase 1: GPS fix mirror keys. Aligned with
+      // `trip_history_repository.dart` so a recovered active trip's
+      // samples deserialise identically when the user finishes it.
+      if (s.latitude != null) 'la': s.latitude,
+      if (s.longitude != null) 'lo': s.longitude,
     };
 
 TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
@@ -214,6 +219,10 @@ TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
       throttlePercent: (j['th'] as num?)?.toDouble(),
       engineLoadPercent: (j['el'] as num?)?.toDouble(),
       coolantTempC: (j['ct'] as num?)?.toDouble(),
+      // #1374 phase 1: legacy active-trip snapshots written before
+      // this PR carry no GPS keys → null on both fields.
+      latitude: (j['la'] as num?)?.toDouble(),
+      longitude: (j['lo'] as num?)?.toDouble(),
     );
 
 /// Hive-backed singleton store for the live, in-progress trip

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -344,6 +344,21 @@ class TripRecordingController {
   double? _latestDirectFuelRate;
   String? _vin;
 
+  // #1374 phase 1 — most recent GPS fix, pushed in by the provider
+  // when the `Feature.gpsTripPath` flag is enabled. The controller
+  // does NOT subscribe to Geolocator itself — that decision lives at
+  // the provider layer so the controller stays free of plugin
+  // imports and tests can drive the latch with hand-built doubles.
+  // When the flag is off the provider never calls [updateGpsFix],
+  // both fields stay null, and every persisted sample carries
+  // `latitude: null, longitude: null` (matching pre-#1374 behaviour
+  // bit-for-bit). When the flag is on but no fix has landed yet
+  // (cold-start, indoors, permission revoked), the fields are also
+  // null and the corresponding sample is written with both keys
+  // absent — better than failing the trip.
+  double? _latestLatitude;
+  double? _latestLongitude;
+
   TripRecordingController({
     required Obd2Service service,
     TripRecorder? recorder,
@@ -460,6 +475,39 @@ class TripRecordingController {
     _scheduler?.start();
     _emitState();
   }
+
+  /// Push the most recent GPS fix into the per-tick snapshot
+  /// (#1374 phase 1).
+  ///
+  /// Called by the trip-recording provider when the
+  /// `Feature.gpsTripPath` flag is enabled and a Geolocator position
+  /// stream has produced an update. The next [_emit] tick stamps the
+  /// stored values onto the [TripSample] it builds. Pass `null` for
+  /// either coord to clear the latch — the sample is then written
+  /// with that field omitted (legacy-compatible behaviour).
+  ///
+  /// Intentionally takes raw doubles instead of a `Position` so this
+  /// file stays free of `package:geolocator` imports — the GPS plugin
+  /// only lives at the provider seam, which keeps unit-testing the
+  /// controller cheap (no Geolocator mocks required) and lets the
+  /// flag-off path skip the plugin entirely.
+  void updateGpsFix({double? latitude, double? longitude}) {
+    _latestLatitude = latitude;
+    _latestLongitude = longitude;
+  }
+
+  /// Read-only snapshot of the most recent GPS latitude pushed in via
+  /// [updateGpsFix] (#1374 phase 1). Exposed for tests + diagnostics;
+  /// production reads the value through the persisted [TripSample]
+  /// fields, not this getter.
+  @visibleForTesting
+  double? get debugLatestLatitude => _latestLatitude;
+
+  /// Read-only snapshot of the most recent GPS longitude pushed in via
+  /// [updateGpsFix] (#1374 phase 1). Same caveats as
+  /// [debugLatestLatitude].
+  @visibleForTesting
+  double? get debugLatestLongitude => _latestLongitude;
 
   /// Start polling. Reads the odometer and VIN ONCE to pin trip
   /// identity; subsequent ticks are scheduled per-PID by
@@ -1134,6 +1182,12 @@ class TripRecordingController {
         throttlePercent: _latestThrottlePercent,
         engineLoadPercent: _latestEngineLoadPercent,
         coolantTempC: _latestCoolantTempC,
+        // #1374 phase 1 — stamp the most recent GPS fix when the
+        // provider has pushed one in. Both fields stay null when the
+        // feature flag is off (no Geolocator subscription was ever
+        // started) or before the first fix lands.
+        latitude: _latestLatitude,
+        longitude: _latestLongitude,
       );
       _recorder.onSample(sample);
       _lastSampleAt = nowTs;

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -110,13 +110,15 @@ class TripHistoryEntry {
 }
 
 /// Serialise a single [TripSample]. Compact key names
-/// ('t','s','r','f','th','el','ct') keep per-trip JSON small — a
-/// 39-min trip × 1 Hz lands around 19 KB compressed at this density.
-/// Use millisecondsSinceEpoch for the timestamp so the JSON parses
-/// fast and round-trips precisely. The optional `'th'` (#1261),
+/// ('t','s','r','f','th','el','ct','la','lo') keep per-trip JSON small
+/// — a 39-min trip × 1 Hz lands around 19 KB compressed at this
+/// density. Use millisecondsSinceEpoch for the timestamp so the JSON
+/// parses fast and round-trips precisely. The optional `'th'` (#1261),
 /// `'el'` and `'ct'` (#1262) keys are only emitted when the
-/// corresponding PID was actually read — legacy trips written before
-/// each key landed deserialise with the field null.
+/// corresponding PID was actually read; the `'la'` / `'lo'` keys
+/// (#1374 phase 1) are only emitted when the GPS-trip-path feature
+/// flag is enabled AND a fix landed for that tick. Legacy trips
+/// written before each key landed deserialise with the field null.
 Map<String, dynamic> _sampleToJson(TripSample s) => {
       't': s.timestamp.millisecondsSinceEpoch,
       's': s.speedKmh,
@@ -125,6 +127,8 @@ Map<String, dynamic> _sampleToJson(TripSample s) => {
       if (s.throttlePercent != null) 'th': s.throttlePercent,
       if (s.engineLoadPercent != null) 'el': s.engineLoadPercent,
       if (s.coolantTempC != null) 'ct': s.coolantTempC,
+      if (s.latitude != null) 'la': s.latitude,
+      if (s.longitude != null) 'lo': s.longitude,
     };
 
 TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
@@ -137,6 +141,11 @@ TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
       throttlePercent: (j['th'] as num?)?.toDouble(),
       engineLoadPercent: (j['el'] as num?)?.toDouble(),
       coolantTempC: (j['ct'] as num?)?.toDouble(),
+      // #1374 phase 1: GPS fix per sample. Legacy trips written before
+      // this PR carry no key → null on both, which is the right answer
+      // for "we don't know where this sample was taken".
+      latitude: (j['la'] as num?)?.toDouble(),
+      longitude: (j['lo'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _summaryToJson(TripSummary s) => {

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -26,6 +26,20 @@ class TripSample {
   /// warm-up.
   final double? coolantTempC;
 
+  /// GPS latitude in degrees (#1374 phase 1). Null when the
+  /// `Feature.gpsTripPath` flag is disabled (default), when no fix has
+  /// landed yet (cold-start indoors), or when the user revoked the
+  /// location permission. Persisted so a future map overlay (Phase 2)
+  /// and a per-segment heatmap (Phase 3) can render the recorded
+  /// trip's path. Legacy samples from trips recorded before this PR
+  /// deserialise with `latitude: null`.
+  final double? latitude;
+
+  /// GPS longitude in degrees (#1374 phase 1). Same null-semantics as
+  /// [latitude]; the two fields are always written and read together
+  /// — a half-set fix is meaningless on a map.
+  final double? longitude;
+
   const TripSample({
     required this.timestamp,
     required this.speedKmh,
@@ -34,6 +48,8 @@ class TripSample {
     this.throttlePercent,
     this.engineLoadPercent,
     this.coolantTempC,
+    this.latitude,
+    this.longitude,
   });
 }
 

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -2,15 +2,19 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../core/feedback/auto_record_badge_service.dart';
+import '../../../core/location/geolocator_wrapper.dart';
 import '../../../core/storage/hive_boxes.dart';
 import '../../../core/storage/storage_keys.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/baselines_sync.dart';
+import '../../feature_management/application/feature_flags_provider.dart';
+import '../../feature_management/domain/feature.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
@@ -63,6 +67,13 @@ class TripRecording extends _$TripRecording {
   TripRecordingController? _controller;
   StreamSubscription<TripLiveReading>? _liveSub;
   StreamSubscription<TripRecordingControllerState>? _stateSub;
+  // #1374 phase 1 — Geolocator position stream feeding the
+  // controller's per-tick GPS latch. Only created when
+  // `Feature.gpsTripPath` is enabled at trip-start; the flag-off
+  // path leaves this null and never touches the plugin, so the
+  // battery / permission cost is exactly zero for users who haven't
+  // opted in. Cancelled on stop alongside the live + state subs.
+  StreamSubscription<Position>? _gpsSub;
   SituationClassifier? _classifier;
   BaselineStore? _store;
   String? _vehicleId;
@@ -288,6 +299,15 @@ class TripRecording extends _$TripRecording {
     }
 
     await ctl.start();
+    // #1374 phase 1 — opt-in GPS sampling. Only when the user has
+    // explicitly turned the feature on do we open a Geolocator
+    // position stream; the flag-off path skips the plugin entirely so
+    // a default-config user pays no battery cost. Errors on the
+    // stream are logged and swallowed (a permission revoke mid-trip
+    // must not derail the recording) — the controller's per-tick
+    // latch simply stops being refreshed and subsequent samples
+    // carry `latitude: null, longitude: null`.
+    _startGpsSubscriptionIfEnabled(ctl);
     // #1303 — seed the active-trip snapshot identity now that the
     // controller knows its session id + odometer reads. The first
     // flush happens off the live-stream debounce below; if the
@@ -561,6 +581,12 @@ class TripRecording extends _$TripRecording {
     _liveSub = null;
     await _stateSub?.cancel();
     _stateSub = null;
+    // #1374 phase 1 — tear down the Geolocator subscription if one
+    // was opened (flag-on path only). Best-effort: a null sub is the
+    // common case (flag off) and a cancel that throws shouldn't
+    // block trip teardown.
+    await _gpsSub?.cancel();
+    _gpsSub = null;
     _controller = null;
     // #726 — persist to the trip history rolling log. Every trip
     // (including discarded ones) is logged; the fill-up flow is a
@@ -670,6 +696,47 @@ class TripRecording extends _$TripRecording {
     } catch (e, st) {
       debugPrint('TripRecording active repo: $e\n$st');
       return null;
+    }
+  }
+
+  /// Open a Geolocator position stream and route every fix through
+  /// [TripRecordingController.updateGpsFix] (#1374 phase 1).
+  ///
+  /// No-op when [Feature.gpsTripPath] is disabled — that's the
+  /// default for every existing user, so this method must NEVER pull
+  /// on the Geolocator plugin in that case (zero battery cost). When
+  /// the flag is on we open the stream at [LocationAccuracy.high]
+  /// because the eventual heatmap (Phase 3) wants ~10 m precision;
+  /// downgrading to medium / low is a Phase 2 follow-up if device
+  /// testing flags battery as an issue.
+  ///
+  /// Stream errors are logged and swallowed: a permission revoke
+  /// mid-trip, a temporary loss of fix, or the OS killing the
+  /// position service must NOT derail the OBD2 trip recording. The
+  /// controller's per-tick latch simply stops being refreshed and
+  /// subsequent samples carry `latitude: null, longitude: null`.
+  void _startGpsSubscriptionIfEnabled(TripRecordingController ctl) {
+    final flags = ref.read(featureFlagsProvider.notifier);
+    if (!flags.isEnabled(Feature.gpsTripPath)) return;
+    final geolocator = ref.read(geolocatorWrapperProvider);
+    try {
+      _gpsSub = geolocator
+          .getPositionStream(
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.high,
+        ),
+      )
+          .listen(
+        (pos) => ctl.updateGpsFix(
+          latitude: pos.latitude,
+          longitude: pos.longitude,
+        ),
+        onError: (Object error) {
+          debugPrint('TripRecording GPS stream error: $error');
+        },
+      );
+    } catch (e, st) {
+      debugPrint('TripRecording GPS subscribe failed: $e\n$st');
     }
   }
 

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -716,4 +716,135 @@ void main() {
       expect(s.fuelRateLPerHour, 4.2);
     });
   });
+
+  group('TripSample GPS coords persistence (#1374 phase 1)', () {
+    test(
+        'sample with latitude + longitude round-trips through save / loadAll '
+        '— the future heatmap (Phase 2/3) needs every recorded fix to come '
+        'back exactly as it went in', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 5, 1, 9);
+      final ts = start.add(const Duration(seconds: 5));
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        samples: [
+          TripSample(
+            timestamp: ts,
+            speedKmh: 55,
+            rpm: 1800,
+            fuelRateLPerHour: 4.2,
+            throttlePercent: 37.5,
+            engineLoadPercent: 42.5,
+            coolantTempC: 82.0,
+            latitude: 43.4567,
+            longitude: 3.5821,
+          ),
+        ],
+      ));
+
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.samples, hasLength(1));
+      final s = loaded.first.samples.first;
+      // Lock the precision the heatmap will rely on — millidegree
+      // (~110 m at the equator) is the minimum useful resolution.
+      expect(s.latitude, closeTo(43.4567, 1e-9));
+      expect(s.longitude, closeTo(3.5821, 1e-9));
+      // None of the existing keys regressed.
+      expect(s.engineLoadPercent, 42.5);
+      expect(s.coolantTempC, 82.0);
+      expect(s.throttlePercent, 37.5);
+      expect(s.fuelRateLPerHour, 4.2);
+    });
+
+    test(
+        'sample with null latitude / longitude does NOT include "la" / "lo" '
+        'keys in stored JSON — matches the parsimony rule the "f" / "th" / '
+        '"el" / "ct" keys already follow', () async {
+      // Phase-1 default: feature flag off → no Geolocator subscription
+      // → every sample is built with `latitude: null, longitude: null`.
+      // The persisted JSON for such a trip MUST be byte-equivalent to a
+      // pre-#1374 trip; otherwise the storage budget regresses on every
+      // existing user even though they never opted in.
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 5, 1, 9);
+      final ts = start.add(const Duration(seconds: 5));
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        samples: [
+          TripSample(
+            timestamp: ts,
+            speedKmh: 55,
+            rpm: 1800,
+            // latitude / longitude both null
+          ),
+        ],
+      ));
+
+      final raw = box.get(start.toIso8601String())!;
+      final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
+      final samples = (decoded['samples'] as List).cast<Map>();
+      expect(samples.first.containsKey('la'), isFalse,
+          reason: 'flag-off ticks must not bloat the JSON');
+      expect(samples.first.containsKey('lo'), isFalse,
+          reason: 'flag-off ticks must not bloat the JSON');
+    });
+
+    test(
+        'legacy JSON (pre-#1374) without "la" / "lo" keys deserialises with '
+        'latitude: null AND longitude: null — backward compat for the trips '
+        'every existing user already has on disk', () async {
+      // Hand-craft a JSON payload exactly as a pre-#1374 build would
+      // have written it: every existing compact key present, no new
+      // ones. This is the file shape a v5.0 user upgrades onto, so a
+      // regression here would silently drop / corrupt their entire
+      // trip history.
+      final start = DateTime(2026, 4, 21);
+      final ts = start.add(const Duration(seconds: 5));
+      final legacyJson = jsonEncode({
+        'id': start.toIso8601String(),
+        'vehicleId': null,
+        'summary': {
+          'distanceKm': 10.0,
+          'maxRpm': 2800.0,
+          'highRpmSeconds': 0.0,
+          'idleSeconds': 0.0,
+          'harshBrakes': 0,
+          'harshAccelerations': 0,
+          'startedAt': start.toIso8601String(),
+        },
+        'samples': [
+          {
+            't': ts.millisecondsSinceEpoch,
+            's': 55.0,
+            'r': 1800.0,
+            'f': 4.2,
+            'th': 30.0,
+            'el': 42.0,
+            'ct': 82.0,
+          },
+        ],
+      });
+      await box.put(start.toIso8601String(), legacyJson);
+
+      final repo = TripHistoryRepository(box: box);
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.samples, hasLength(1));
+      final s = loaded.first.samples.first;
+      expect(s.latitude, isNull);
+      expect(s.longitude, isNull);
+      // Existing fields still parse cleanly — backward compat means
+      // we add to the schema, we don't break what the old schema
+      // persisted.
+      expect(s.fuelRateLPerHour, 4.2);
+      expect(s.throttlePercent, 30.0);
+      expect(s.engineLoadPercent, 42.0);
+      expect(s.coolantTempC, 82.0);
+    });
+  });
 }

--- a/test/features/consumption/domain/trip_recorder_test.dart
+++ b/test/features/consumption/domain/trip_recorder_test.dart
@@ -316,6 +316,92 @@ void main() {
       });
     });
 
+    group('GPS fix on TripSample (#1374 phase 1)', () {
+      test('latitude / longitude default to null when omitted', () {
+        // Mirrors the throttle / engineLoad / coolant defaults — a
+        // pre-#1374 build never wrote these fields, so the constructor
+        // MUST accept the legacy two-arg shape (or the four-arg shape
+        // that includes the existing optionals) and surface null.
+        final ts = DateTime.utc(2026);
+        final sample = TripSample(timestamp: ts, speedKmh: 50, rpm: 1500);
+        expect(sample.latitude, isNull);
+        expect(sample.longitude, isNull);
+      });
+
+      test('explicit lat/lng round-trip onto the sample', () {
+        // A flag-on tick: the provider pushed a Position into the
+        // controller, which stamped both coords onto the sample. The
+        // round-trip is trivial (the field is just a final double),
+        // but locking the assertion here flags any future refactor
+        // that accidentally drops one of the two fields.
+        final ts = DateTime.utc(2026);
+        final sample = TripSample(
+          timestamp: ts,
+          speedKmh: 60,
+          rpm: 2000,
+          latitude: 43.4567,
+          longitude: 3.5821,
+        );
+        expect(sample.latitude, closeTo(43.4567, 1e-9));
+        expect(sample.longitude, closeTo(3.5821, 1e-9));
+        // Existing optional fields stay null when not supplied — the
+        // GPS additions must not hijack the slot for any other PID.
+        expect(sample.fuelRateLPerHour, isNull);
+        expect(sample.throttlePercent, isNull);
+        expect(sample.engineLoadPercent, isNull);
+        expect(sample.coolantTempC, isNull);
+      });
+
+      test(
+          'half-set fix is allowed by the type system but discouraged — '
+          'phase 1 records both or neither at the integration site',
+          () {
+        // The phase-1 integration site (provider) only ever calls
+        // `controller.updateGpsFix(latitude: pos.latitude,
+        // longitude: pos.longitude)`, so a half-set TripSample never
+        // appears in production. We still allow the constructor to
+        // build one because keeping the fields independent (rather
+        // than adding a `LatLng?` wrapper) keeps the JSON encoding
+        // symmetric with the existing per-field compact keys.
+        final ts = DateTime.utc(2026);
+        final sample =
+            TripSample(timestamp: ts, speedKmh: 0, rpm: 0, latitude: 50.0);
+        expect(sample.latitude, 50.0);
+        expect(sample.longitude, isNull);
+      });
+
+      test(
+          'recorder.onSample accepts samples with GPS coords without '
+          'changing aggregate metrics — coords are persisted, not '
+          'integrated into distance / RPM / fuel maths', () {
+        // Distance still comes from speed × Δt; the GPS coords are
+        // sample-level metadata for the future heatmap (Phase 2/3),
+        // not an input to the existing virtual-odometer math.
+        // Without this guard, a future change that wires GPS into
+        // distance would silently break every legacy trip's distance
+        // value (their coords are null → division by zero / NaN).
+        final start = DateTime.utc(2026);
+        recorder.onSample(TripSample(
+          timestamp: start,
+          speedKmh: 60,
+          rpm: 2000,
+          latitude: 43.45,
+          longitude: 3.58,
+        ));
+        recorder.onSample(TripSample(
+          timestamp: start.add(const Duration(seconds: 60)),
+          speedKmh: 60,
+          rpm: 2000,
+          latitude: 43.46,
+          longitude: 3.59,
+        ));
+        // Same expected distance as the legacy "60 km/h for 60 s"
+        // case earlier in this file — proves the coord plumbing
+        // doesn't perturb the integration.
+        expect(recorder.buildSummary().distanceKm, closeTo(1.0, 0.01));
+      });
+    });
+
     test('configurable thresholds override the defaults', () {
       final strict = TripRecorder(
         highRpmThreshold: 2500,

--- a/test/features/consumption/providers/trip_recording_provider_gps_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_gps_test.dart
@@ -1,0 +1,257 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/location/geolocator_wrapper.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+
+/// Verifies the [Feature.gpsTripPath]-gated GPS subscription wiring
+/// inside [TripRecording.start] (#1374 phase 1).
+///
+/// Two cases must hold:
+///
+///   1. **flag off (default)** — no Geolocator subscription is ever
+///      opened. Existing users see zero behaviour change: no battery
+///      cost, no location-permission prompt, no plugin call. This is
+///      the foundation of the "inert by default" promise in the
+///      issue body.
+///   2. **flag on** — the provider subscribes to the position
+///      stream and routes each fix into the controller's
+///      [TripRecordingController.updateGpsFix] latch, so the next
+///      [TripSample] the recorder builds carries the coords.
+///
+/// We mock [GeolocatorWrapper] with a controllable stream so we can
+/// drive both arms deterministically without touching the real
+/// platform plugin (which is unavailable in unit tests).
+void main() {
+  group('TripRecording GPS gating (#1374 phase 1)', () {
+    test(
+        'flag OFF (default) — no Geolocator subscription is ever started; '
+        'controller.debugLatestLatitude / debugLatestLongitude stay null '
+        'across the whole trip', () async {
+      final fakeGeo = _RecordingGeolocator();
+      final container = ProviderContainer(overrides: [
+        geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(fakeGeo.dispose);
+
+      // Sanity check on the manifest default — if this ever flips, the
+      // whole "inert by default" guarantee is gone and we want a loud
+      // failure here, not a silent battery regression in production.
+      expect(
+        container.read(featureFlagsProvider.notifier)
+            .isEnabled(Feature.gpsTripPath),
+        isFalse,
+        reason: 'gpsTripPath must default to false per the manifest',
+      );
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+
+      // The provider must NOT have called the plugin even once.
+      expect(fakeGeo.positionStreamCallCount, 0,
+          reason: 'flag-off path must never touch Geolocator');
+
+      // And the controller's latch is still null — every TripSample
+      // emitted on a flag-off recording carries lat/lng = null.
+      final ctl = notifier.debugController;
+      expect(ctl, isNotNull);
+      expect(ctl!.debugLatestLatitude, isNull);
+      expect(ctl.debugLatestLongitude, isNull);
+
+      await notifier.stop();
+    });
+
+    test(
+        'flag ON — provider opens a position stream and pushes each fix '
+        'into the controller via updateGpsFix; subsequent samples carry '
+        'the latest coords', () async {
+      final fakeGeo = _RecordingGeolocator();
+      final container = ProviderContainer(overrides: [
+        geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(fakeGeo.dispose);
+
+      // Flip the flag on for this container BEFORE start() — the
+      // provider only checks the flag at trip-start (the subscription
+      // is born then). Mid-trip toggles are out of scope for phase 1.
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.obd2TripRecording);
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.gpsTripPath);
+      expect(
+        container.read(featureFlagsProvider.notifier)
+            .isEnabled(Feature.gpsTripPath),
+        isTrue,
+      );
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+
+      // The provider must have asked Geolocator for a stream exactly once.
+      expect(fakeGeo.positionStreamCallCount, 1,
+          reason: 'flag-on path opens exactly one position stream');
+      // And asked for HIGH accuracy — the eventual heatmap (Phase 3)
+      // wants ~10 m precision; downgrades are a Phase 2 follow-up.
+      expect(fakeGeo.lastAccuracy, LocationAccuracy.high);
+
+      // Push a fix down the fake stream and let the listener run.
+      fakeGeo.emit(_pos(43.4567, 3.5821));
+      await Future<void>.delayed(Duration.zero);
+
+      final ctl = notifier.debugController;
+      expect(ctl, isNotNull);
+      expect(ctl!.debugLatestLatitude, closeTo(43.4567, 1e-9));
+      expect(ctl.debugLatestLongitude, closeTo(3.5821, 1e-9));
+
+      // A second fix overwrites the first — the latch is "most-recent
+      // wins", which matches the heatmap's per-tick semantics.
+      fakeGeo.emit(_pos(43.4600, 3.5900));
+      await Future<void>.delayed(Duration.zero);
+      expect(ctl.debugLatestLatitude, closeTo(43.4600, 1e-9));
+      expect(ctl.debugLatestLongitude, closeTo(3.5900, 1e-9));
+
+      await notifier.stop();
+      // After stop, the subscription must be cancelled. Pushing more
+      // events to the controller would be silently swallowed — but
+      // more importantly, the provider has nulled out the controller
+      // so a leaked subscription would NPE on the next emit. The
+      // recording counter drops back to zero on the next start().
+      expect(fakeGeo.activeListeners, 0,
+          reason: 'stop() must cancel the GPS subscription');
+    });
+
+    test(
+        'flag ON but Geolocator stream errors mid-trip — error is '
+        'logged + swallowed; the trip recording continues; subsequent '
+        'samples carry whatever was in the latch (or null)', () async {
+      // A permission revoke or platform-side stream death must NOT
+      // derail an in-progress trip. The provider catches stream
+      // errors and lets the OBD2 polling loop keep running — the
+      // user's drive metrics are more important than the optional
+      // GPS overlay.
+      final fakeGeo = _RecordingGeolocator();
+      final container = ProviderContainer(overrides: [
+        geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(fakeGeo.dispose);
+
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.obd2TripRecording);
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.gpsTripPath);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+      // First push a real fix so we know the wiring works…
+      fakeGeo.emit(_pos(50.0, 4.0));
+      await Future<void>.delayed(Duration.zero);
+      final ctl = notifier.debugController;
+      expect(ctl, isNotNull);
+      expect(ctl!.debugLatestLatitude, 50.0);
+
+      // …then drop an error onto the stream. The provider's
+      // onError handler must absorb it without rethrowing into the
+      // trip-recording state machine.
+      fakeGeo.emitError(Exception('permission revoked'));
+      await Future<void>.delayed(Duration.zero);
+      // The trip is still active — no phase regression.
+      expect(container.read(tripRecordingProvider).isActive, isTrue);
+
+      await notifier.stop();
+    });
+  });
+}
+
+Map<String, String> _elmOk() => const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '01A6': '41 A6 00 01 6A 2C>',
+    };
+
+Position _pos(double lat, double lng) => Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: DateTime.now(),
+      accuracy: 5,
+      altitude: 0,
+      altitudeAccuracy: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: 0,
+      speedAccuracy: 0,
+    );
+
+/// Test double for [GeolocatorWrapper] that captures every
+/// `getPositionStream` call AND lets the test push positions / errors
+/// down the returned stream on demand.
+///
+/// Mirrors `test/core/location/location_service_test.dart`'s
+/// `_FakeGeolocator` but adds a controllable broadcast stream — the
+/// production provider listens with a single subscriber, but using a
+/// broadcast controller lets us count active listeners cleanly via
+/// [activeListeners].
+class _RecordingGeolocator extends GeolocatorWrapper {
+  int positionStreamCallCount = 0;
+  LocationAccuracy? lastAccuracy;
+  // Re-created on each getPositionStream call so onListen / onCancel
+  // hooks accurately reflect whether the production code is currently
+  // subscribed (a single shared controller would conflate the two).
+  StreamController<Position>? _controller;
+  int activeListeners = 0;
+
+  @override
+  Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
+    positionStreamCallCount++;
+    lastAccuracy = locationSettings?.accuracy;
+    // Close any prior controller so the analyzer's `close_sinks`
+    // lint stays quiet across re-subscribes.
+    final prev = _controller;
+    if (prev != null && !prev.isClosed) {
+      // Fire-and-forget — tests only re-call getPositionStream when
+      // the previous subscription is already gone.
+      prev.close();
+    }
+    _controller = StreamController<Position>(
+      onListen: () => activeListeners++,
+      onCancel: () => activeListeners--,
+    );
+    return _controller!.stream;
+  }
+
+  void emit(Position p) => _controller?.add(p);
+  void emitError(Object error) => _controller?.addError(error);
+
+  /// Close the underlying controller — call from a test tearDown to
+  /// silence the `close_sinks` lint when the production code is the
+  /// one cancelling the subscription (which leaves the controller
+  /// open on the test side).
+  Future<void> dispose() async {
+    final c = _controller;
+    if (c != null && !c.isClosed) await c.close();
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of #1374 — pure data-layer plumbing for the future trip-path heatmap. **Inert by default**: existing users see zero behavior change because `Feature.gpsTripPath` defaults to `false`.

- `TripSample` gains optional `latitude` / `longitude` doubles; legacy samples deserialize cleanly with both null.
- Compact JSON keys `'la'` / `'lo'` added to both `trip_history_repository.dart` and `active_trip_repository.dart`. Keys are omitted when null so the on-disk shape for flag-off users stays byte-equivalent to the pre-#1374 schema.
- `TripRecordingController.updateGpsFix(...)` is the controller-side seam; the controller stays free of `package:geolocator` imports so unit tests don't need plugin mocks.
- `trip_recording_provider.dart` opens a Geolocator position stream **only when `Feature.gpsTripPath` is enabled**, routes each fix into the controller, and tears the subscription down on `stop()`. Flag-off path never touches the plugin.
- Stream errors (permission revoke, OS killing the position service) are logged and swallowed; the OBD2 trip recording is not derailed by GPS failures.

## Phase scope

| Phase | Scope | This PR |
|-------|-------|---------|
| **1** | Data model + opt-in Geolocator subscription + persistence | yes |
| 2     | Map overlay (`flutter_map` `PolylineLayer`)                | no |
| 3     | Per-segment heatmap colors                                 | no |

`Refs #1374` (NOT `Closes`) — the epic stays open for phases 2 and 3.

## Files touched

**lib/**
- `lib/features/consumption/domain/trip_recorder.dart` — added `latitude` / `longitude` to `TripSample`.
- `lib/features/consumption/data/trip_history_repository.dart` — `'la'` / `'lo'` compact keys, legacy null defaults.
- `lib/features/consumption/data/obd2/active_trip_repository.dart` — same compact keys for the in-progress snapshot.
- `lib/features/consumption/data/obd2/trip_recording_controller.dart` — added `updateGpsFix(...)` + `_latestLatitude` / `_latestLongitude` snapshot fields; `_emit()` stamps them onto every `TripSample`.
- `lib/features/consumption/providers/trip_recording_provider.dart` — gated Geolocator subscription via `featureFlagsProvider.notifier.isEnabled(Feature.gpsTripPath)`; teardown in `stop()`.

**test/**
- `test/features/consumption/domain/trip_recorder_test.dart` — default-null + explicit lat/lng coverage; integration metric does not regress.
- `test/features/consumption/data/trip_history_repository_test.dart` — round-trip + parsimony + pre-#1374 legacy-JSON deserialise tests.
- `test/features/consumption/providers/trip_recording_provider_gps_test.dart` (new) — gating proof: flag off ⇒ zero plugin calls; flag on ⇒ stream opened at `LocationAccuracy.high`, fixes flow into the controller's latch, stream errors are absorbed without aborting the trip.

## Battery acceptance

Phase-1 acceptance for the issue body says "no measurable battery impact when flag off". The flag-off path never touches Geolocator, so this is trivially true at the source-code level — but **device verification on a real Android phone is still pending** and is out of scope for this PR. I'll wire that into the device-test session that follows the next signed APK.

## Test plan

- [x] `flutter analyze` — zero warnings, zero infos
- [x] `flutter test test/features/consumption/domain/trip_recorder_test.dart` — passes
- [x] `flutter test test/features/consumption/data/trip_history_repository_test.dart` — passes
- [x] `flutter test test/features/consumption/providers/trip_recording_provider_gps_test.dart` — passes (3/3)
- [x] Regression: `trip_recording_controller_test.dart`, `trip_recording_provider_test.dart`, `trip_recording_samples_persistence_test.dart`, `active_trip_repository_test.dart`, `active_trip_recovery_service_test.dart`, `trip_recording_controller_gear_inference_test.dart`, `trip_recording_controller_reconnect_test.dart` — all green
- [x] `flutter test test/lint/` — all 29 lint scanners pass (no silent catches, prefer-const, etc.)
- [ ] Device verification: GPS-off battery cost over a 30-min trip on a real phone (Phase 1 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)