### PR TITLE
feat(trips): single-color GPS path overlay on trip detail (Refs #1374 phase 2)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -273,4 +273,10 @@ TripDetailSample _toDetailSample(TripSample s) => TripDetailSample(
       throttlePercent: s.throttlePercent,
       engineLoadPercent: s.engineLoadPercent,
       coolantTempC: s.coolantTempC,
+      // #1374 phase 2 — plumb GPS coords through the presentation
+      // layer so the trip-detail map overlay can render the recorded
+      // route. Legacy trips deserialise with null on both fields and
+      // the overlay self-suppresses in that case.
+      latitude: s.latitude,
+      longitude: s.longitude,
     );

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -15,6 +15,7 @@ import 'driving_insights_card.dart';
 import 'driving_score_card.dart';
 import 'throttle_rpm_histogram_card.dart';
 import 'trip_detail_charts.dart';
+import 'trip_path_map_card.dart';
 import 'trip_summary_card.dart';
 
 /// Scrollable body of the trip detail screen (#890): summary card
@@ -170,6 +171,13 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
           isEv: widget.isEv,
         ),
         const SizedBox(height: 8),
+        // GPS path overlay (#1374 phase 2). Self-suppresses when the
+        // trip carries no GPS samples — legacy trips, opted-out trips,
+        // trips that never got a fix — so no parent-side gating is
+        // needed and the layout stays unchanged for those trips.
+        // Phase 3 will replace the single-colour polyline with a
+        // per-segment heatmap.
+        TripPathMapCard(samples: widget.samples),
         // Composite driving score (#1041 phase 5a — Card A). Sits at
         // the top of the Insights group: a single big 0..100 number
         // with a brief breakdown chip row beneath it. EV trips and

--- a/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
@@ -53,6 +53,19 @@ class TripDetailSample {
   /// phase 3 of #1262.
   final double? coolantTempC;
 
+  /// GPS latitude in degrees (#1374 phase 2). Null when the
+  /// `Feature.gpsTripPath` flag was disabled at recording time, when
+  /// no fix had landed yet, when location permission was revoked, or
+  /// when the trip was persisted by a build before #1374 phase 1.
+  /// Mirrors `TripSample.latitude` in the domain layer; the
+  /// trip-detail GPS-path overlay reads non-null pairs to draw the
+  /// recorded route.
+  final double? latitude;
+
+  /// GPS longitude in degrees (#1374 phase 2). Same null-semantics as
+  /// [latitude]; the two fields are always written and read together.
+  final double? longitude;
+
   const TripDetailSample({
     required this.timestamp,
     required this.speedKmh,
@@ -61,6 +74,8 @@ class TripDetailSample {
     this.throttlePercent,
     this.engineLoadPercent,
     this.coolantTempC,
+    this.latitude,
+    this.longitude,
   });
 }
 

--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../../../core/constants/app_constants.dart';
+import '../../../../l10n/app_localizations.dart';
+import 'trip_detail_charts.dart';
+
+/// Trip-detail map card rendering the GPS-recorded path of a trip
+/// (#1374 phase 2).
+///
+/// Reads `(latitude, longitude)` pairs from the supplied
+/// [TripDetailSample]s — Phase 1 plumbed those fields through the
+/// recorder, persistence layer and `_toDetailSample` converter. Skips
+/// entirely (returns [SizedBox.shrink]) when the trip carries no
+/// usable GPS samples — legacy trips, opted-out trips and trips that
+/// never got a fix all fall through to the no-card path so the
+/// trip-detail screen layout stays unchanged for them.
+///
+/// ## Phase 2 scope
+/// * Single-color polyline (theme `colorScheme.primary`).
+/// * Two markers — first and last GPS sample — for trip start and end.
+/// * Auto-fits the viewport to the polyline bounds.
+///
+/// Phase 3 (out of scope here) will replace the single colour with a
+/// per-segment heatmap derived from the speed / RPM / engine-load
+/// telemetry, and add the corresponding colour-bucket legend.
+class TripPathMapCard extends StatelessWidget {
+  final List<TripDetailSample> samples;
+
+  const TripPathMapCard({super.key, required this.samples});
+
+  @override
+  Widget build(BuildContext context) {
+    // Build the polyline from samples that carry BOTH lat and lng.
+    // Half-set fixes are dropped — the recorder writes the pair
+    // atomically (see `TripSample` doc) but the type still allows it,
+    // so be defensive at the read site.
+    final points = <LatLng>[];
+    for (final s in samples) {
+      final lat = s.latitude;
+      final lng = s.longitude;
+      if (lat != null && lng != null) {
+        points.add(LatLng(lat, lng));
+      }
+    }
+    if (points.isEmpty) {
+      // No GPS coords at all — skip the card entirely per the issue's
+      // Phase 2 spec ("legacy trips, opted-out trips"). Rendering an
+      // empty placeholder would just clutter the trip-detail layout
+      // for trips that pre-date the feature.
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
+    final title = l?.tripPathCardTitle ?? 'Trip path';
+    final subtitle = l?.tripPathCardSubtitle ?? 'GPS-recorded route';
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title, style: theme.textTheme.titleMedium),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(
+              height: 220,
+              child: _TripPathMap(points: points),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Stateful inner map so the [MapController] can survive rebuilds and
+/// the post-frame `fitCamera` callback can target a stable controller
+/// instance. Mirrors the pattern used by [StationMapLayers] — the
+/// outer card stays a [StatelessWidget] so callers don't have to
+/// worry about lifecycle.
+class _TripPathMap extends StatefulWidget {
+  final List<LatLng> points;
+
+  const _TripPathMap({required this.points});
+
+  @override
+  State<_TripPathMap> createState() => _TripPathMapState();
+}
+
+class _TripPathMapState extends State<_TripPathMap> {
+  late final MapController _mapController = MapController();
+
+  /// Pre-computed bounds for the polyline. Single-point polylines fall
+  /// back to a degenerate bounds object centered on the point — the
+  /// `fitCamera` call handles those by centering on the point at a
+  /// sane default zoom rather than throwing.
+  late final LatLngBounds _bounds = _computeBounds(widget.points);
+
+  /// Fallback initial camera so the very first frame paints something
+  /// reasonable before the post-frame `fitCamera` callback fires.
+  late final LatLng _initialCenter = _bounds.center;
+
+  static LatLngBounds _computeBounds(List<LatLng> points) {
+    if (points.length == 1) {
+      // Single-point polyline — synthesize a tiny bounds box around
+      // the point so flutter_map's CameraFit doesn't divide-by-zero.
+      final p = points.first;
+      const eps = 0.0005; // ~50 m at the equator; fine for any latitude
+      return LatLngBounds(
+        LatLng(p.latitude - eps, p.longitude - eps),
+        LatLng(p.latitude + eps, p.longitude + eps),
+      );
+    }
+    return LatLngBounds.fromPoints(points);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    // Fit the camera to the polyline bounds once the map has laid out.
+    // Mirrors the pattern in `nearby_map_view.dart`: schedule via
+    // `addPostFrameCallback` so the MapController has a real viewport
+    // size by the time `fitCamera` runs.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      try {
+        _mapController.fitCamera(
+          CameraFit.bounds(
+            bounds: _bounds,
+            padding: const EdgeInsets.all(24),
+          ),
+        );
+      } catch (e, st) {
+        debugPrint('TripPathMapCard fitCamera failed: $e\n$st');
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _mapController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final start = widget.points.first;
+    final end = widget.points.last;
+    return FlutterMap(
+      mapController: _mapController,
+      options: MapOptions(
+        initialCenter: _initialCenter,
+        initialZoom: 13,
+        // Steady-state pinch / drag stays enabled — the user may want
+        // to inspect the path. Rotation is disabled for the same
+        // reason `StationMapLayers` does it: trip overlays read more
+        // naturally with a north-up orientation.
+        interactionOptions: const InteractionOptions(
+          flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
+        ),
+      ),
+      children: [
+        TileLayer(
+          urlTemplate: AppConstants.osmTileUrl,
+          userAgentPackageName: AppConstants.osmUserAgent,
+          maxNativeZoom: 19,
+          maxZoom: 19,
+          evictErrorTileStrategy:
+              EvictErrorTileStrategy.notVisibleRespectMargin,
+        ),
+        PolylineLayer(
+          polylines: [
+            Polyline(
+              points: widget.points,
+              // Phase 2 — single colour. Phase 3 swaps this for a
+              // per-segment heatmap derived from the speed / RPM /
+              // engine-load telemetry; do NOT inline a fixed colour
+              // here.
+              color: theme.colorScheme.primary,
+              strokeWidth: 4.0,
+            ),
+          ],
+        ),
+        MarkerLayer(
+          markers: [
+            Marker(
+              point: start,
+              width: 28,
+              height: 28,
+              child: _PathPin(
+                color: theme.colorScheme.primary,
+                icon: Icons.play_arrow,
+              ),
+            ),
+            Marker(
+              point: end,
+              width: 28,
+              height: 28,
+              child: _PathPin(
+                color: theme.colorScheme.tertiary,
+                icon: Icons.flag,
+              ),
+            ),
+          ],
+        ),
+        const RichAttributionWidget(
+          attributions: [
+            TextSourceAttribution('OpenStreetMap contributors'),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+/// Small circular pin used for the trip start / end markers. Mirrors
+/// the centre-marker style in `StationMapLayers` so the visual
+/// vocabulary stays consistent across the app's maps.
+class _PathPin extends StatelessWidget {
+  final Color color;
+  final IconData icon;
+
+  const _PathPin({required this.color, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        border: Border.all(color: Colors.white, width: 2),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.3),
+            blurRadius: 3,
+          ),
+        ],
+      ),
+      child: Icon(icon, size: 16, color: Colors.white),
+    );
+  }
+}

--- a/lib/l10n/_fragments/trip_path_de.arb
+++ b/lib/l10n/_fragments/trip_path_de.arb
@@ -1,0 +1,4 @@
+{
+  "tripPathCardTitle": "Fahrtstrecke",
+  "tripPathCardSubtitle": "Per GPS aufgezeichnete Strecke"
+}

--- a/lib/l10n/_fragments/trip_path_en.arb
+++ b/lib/l10n/_fragments/trip_path_en.arb
@@ -1,0 +1,10 @@
+{
+  "tripPathCardTitle": "Trip path",
+  "@tripPathCardTitle": {
+    "description": "Title of the trip-detail card that shows the GPS-recorded route as a polyline on a map (#1374 phase 2)."
+  },
+  "tripPathCardSubtitle": "GPS-recorded route",
+  "@tripPathCardSubtitle": {
+    "description": "Sub-line beneath the trip-path card title clarifying that the polyline comes from the GPS samples captured during the trip."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1654,6 +1654,8 @@
   "tripLengthBucketLong": "Lang (>25 km)",
   "tripLengthBucketNeedMoreData": "Mehr Daten nötig",
   "tripLengthBucketTripCount": "{count, plural, =0{keine Fahrten} one{1 Fahrt} other{{count} Fahrten}}",
+  "tripPathCardTitle": "Fahrtstrecke",
+  "tripPathCardSubtitle": "Per GPS aufgezeichnete Strecke",
   "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2963,6 +2963,14 @@
       }
     }
   },
+  "tripPathCardTitle": "Trip path",
+  "@tripPathCardTitle": {
+    "description": "Title of the trip-detail card that shows the GPS-recorded route as a polyline on a map (#1374 phase 2)."
+  },
+  "tripPathCardSubtitle": "GPS-recorded route",
+  "@tripPathCardSubtitle": {
+    "description": "Sub-line beneath the trip-path card title clarifying that the polyline comes from the GPS samples captured during the trip."
+  },
   "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1137,5 +1137,7 @@
   "featureBlockedEnable_glideCoach": "Activez d'abord l'enregistrement OBD2 des trajets",
   "featureBlockedEnable_gpsTripPath": "Activez d'abord l'enregistrement OBD2 des trajets",
   "featureBlockedDisable_obd2TripRecording": "Désactivez d'abord les fonctionnalités dépendantes : {dependents}",
-  "featureBlockedDisable_tankSync": "Désactivez d'abord les fonctionnalités dépendantes : {dependents}"
+  "featureBlockedDisable_tankSync": "Désactivez d'abord les fonctionnalités dépendantes : {dependents}",
+  "tripPathCardTitle": "Trace du trajet",
+  "tripPathCardSubtitle": "Itinéraire enregistré par GPS"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7820,6 +7820,18 @@ abstract class AppLocalizations {
   /// **'{count, plural, =0{no trips} one{1 trip} other{{count} trips}}'**
   String tripLengthBucketTripCount(int count);
 
+  /// Title of the trip-detail card that shows the GPS-recorded route as a polyline on a map (#1374 phase 2).
+  ///
+  /// In en, this message translates to:
+  /// **'Trip path'**
+  String get tripPathCardTitle;
+
+  /// Sub-line beneath the trip-path card title clarifying that the polyline comes from the GPS samples captured during the trip.
+  ///
+  /// In en, this message translates to:
+  /// **'GPS-recorded route'**
+  String get tripPathCardSubtitle;
+
   /// Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4254,6 +4254,12 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4254,6 +4254,12 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4252,6 +4252,12 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4294,6 +4294,12 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Fahrtstrecke';
+
+  @override
+  String get tripPathCardSubtitle => 'Per GPS aufgezeichnete Strecke';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Anpinnen hält den Bildschirm an — verbraucht mehr Akku';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4256,6 +4256,12 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4247,6 +4247,12 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4255,6 +4255,12 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4249,6 +4249,12 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4252,6 +4252,12 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4297,6 +4297,12 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trace du trajet';
+
+  @override
+  String get tripPathCardSubtitle => 'Itinéraire enregistré par GPS';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4251,6 +4251,12 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4256,6 +4256,12 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4255,6 +4255,12 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4253,6 +4253,12 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4255,6 +4255,12 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4251,6 +4251,12 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4256,6 +4256,12 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4254,6 +4254,12 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4255,6 +4255,12 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4254,6 +4254,12 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4255,6 +4255,12 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4249,6 +4249,12 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4253,6 +4253,12 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get tripPathCardTitle => 'Trip path';
+
+  @override
+  String get tripPathCardSubtitle => 'GPS-recorded route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_charts.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_path_map_card.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// #1374 phase 2 — widget coverage for [TripPathMapCard], the
+/// trip-detail card that renders the GPS-recorded route as a single-
+/// colour polyline on an OpenStreetMap tile layer.
+///
+/// The widget is the user-visible surface of Phase 1's GPS sampling
+/// work; phase 3 will swap the single colour for a per-segment
+/// heatmap. These tests pin the Phase 2 contract:
+///
+///  * Renders the [FlutterMap] + [PolylineLayer] only when the trip
+///    carries at least one fully-coord sample.
+///  * Self-suppresses (returns [SizedBox.shrink]) for legacy /
+///    opted-out trips so the trip-detail layout stays unchanged.
+///  * The polyline points list is the in-order projection of the
+///    samples that have BOTH lat and lng — half-set fixes are dropped.
+TripDetailSample _sample({
+  required int sec,
+  double speed = 60.0,
+  double? lat,
+  double? lng,
+}) {
+  return TripDetailSample(
+    timestamp: DateTime.utc(2026, 5, 3, 10, 0, sec),
+    speedKmh: speed,
+    latitude: lat,
+    longitude: lng,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TripPathMapCard — render gating', () {
+    testWidgets('renders FlutterMap + PolylineLayer when samples carry coords',
+        (tester) async {
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43),
+        _sample(sec: 1, lat: 43.47, lng: 3.44),
+        _sample(sec: 2, lat: 43.48, lng: 3.45),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      expect(find.byType(FlutterMap), findsOneWidget);
+      expect(find.byType(PolylineLayer), findsOneWidget);
+      // The card title comes from AppLocalizations and is the
+      // user-visible label of the section.
+      expect(find.text('Trip path'), findsOneWidget);
+    });
+
+    testWidgets('self-suppresses when no sample carries coords',
+        (tester) async {
+      // Legacy / opted-out trip — every sample has null on both
+      // lat and lng. The widget MUST NOT render a placeholder card;
+      // it returns SizedBox.shrink so the trip-detail layout stays
+      // unchanged for trips that pre-date GPS sampling.
+      final samples = [
+        _sample(sec: 0),
+        _sample(sec: 1),
+        _sample(sec: 2),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      expect(find.byType(FlutterMap), findsNothing);
+      expect(find.byType(PolylineLayer), findsNothing);
+      expect(find.text('Trip path'), findsNothing);
+      expect(find.byType(SizedBox), findsWidgets);
+    });
+
+    testWidgets('self-suppresses when samples list is empty', (tester) async {
+      await pumpApp(tester, const TripPathMapCard(samples: []));
+
+      expect(find.byType(FlutterMap), findsNothing);
+      expect(find.text('Trip path'), findsNothing);
+    });
+  });
+
+  group('TripPathMapCard — polyline points', () {
+    testWidgets('polyline points match the non-null coord sequence in order',
+        (tester) async {
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43),
+        _sample(sec: 1, lat: 43.47, lng: 3.44),
+        _sample(sec: 2, lat: 43.48, lng: 3.45),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      expect(layer.polylines, hasLength(1));
+      final pts = layer.polylines.single.points;
+      expect(pts, hasLength(3));
+      expect(pts[0].latitude, closeTo(43.46, 1e-9));
+      expect(pts[0].longitude, closeTo(3.43, 1e-9));
+      expect(pts[1].latitude, closeTo(43.47, 1e-9));
+      expect(pts[1].longitude, closeTo(3.44, 1e-9));
+      expect(pts[2].latitude, closeTo(43.48, 1e-9));
+      expect(pts[2].longitude, closeTo(3.45, 1e-9));
+    });
+
+    testWidgets('skips samples that have one of lat / lng null',
+        (tester) async {
+      // Mix: some samples with both coords, some with one of the two
+      // null (defensive — `TripSample` writes the pair atomically per
+      // its doc, but the type still allows it). The polyline must
+      // contain ONLY the fully-coord samples, in their original order.
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43), // kept
+        _sample(sec: 1, lat: 43.47), // dropped (lng null)
+        _sample(sec: 2, lng: 3.45), // dropped (lat null)
+        _sample(sec: 3, lat: 43.49, lng: 3.46), // kept
+        _sample(sec: 4), // dropped (both null)
+        _sample(sec: 5, lat: 43.50, lng: 3.47), // kept
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      final pts = layer.polylines.single.points;
+      expect(pts, hasLength(3));
+      expect(pts[0].latitude, closeTo(43.46, 1e-9));
+      expect(pts[1].latitude, closeTo(43.49, 1e-9));
+      expect(pts[2].latitude, closeTo(43.50, 1e-9));
+    });
+
+    testWidgets('renders even when only a single GPS sample is present',
+        (tester) async {
+      // Edge case: a very short trip with exactly one GPS fix should
+      // still surface the card (the user got a fix — that's worth
+      // showing) without throwing on the bounds calculation.
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      expect(find.byType(FlutterMap), findsOneWidget);
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      expect(layer.polylines.single.points, hasLength(1));
+    });
+  });
+
+  group('TripPathMapCard — polyline colour', () {
+    testWidgets('polyline uses theme colorScheme.primary (Phase 2 single colour)',
+        (tester) async {
+      // Phase 2 specifies a single theme-driven colour. Phase 3 will
+      // replace this with per-segment heatmap colours; this test
+      // pins the Phase 2 contract so any accidental colour change
+      // (e.g. inlining Colors.green) is caught immediately.
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43),
+        _sample(sec: 1, lat: 43.47, lng: 3.44),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      // Resolve the same primary colour the widget would have read.
+      final ctx = tester.element(find.byType(FlutterMap));
+      final expectedColor = Theme.of(ctx).colorScheme.primary;
+      expect(layer.polylines.single.color, expectedColor);
+    });
+  });
+}

--- a/test/l10n/localization_completeness_test.dart
+++ b/test/l10n/localization_completeness_test.dart
@@ -158,6 +158,20 @@ void main() {
               'featureBlockedDisable_ key — the Feature management section '
               'in Settings must not fall back to English for French users '
               '(#1373 phase 2)');
+
+      // #1374 phase 2 — the GPS trip-path overlay card on the trip
+      // detail screen is a French-reachable surface. Its title and
+      // subtitle must have French translations so the card isn't an
+      // English island in an otherwise French screen.
+      final frenchMissingTripPath = frenchMissing
+          .where((k) => k.startsWith('tripPath'))
+          .toList()
+        ..sort();
+      expect(frenchMissingTripPath, isEmpty,
+          reason: 'French (fr) must have every tripPath* key — the '
+              'GPS trip-path overlay on the trip detail screen must '
+              'not fall back to English for French users (#1374 '
+              'phase 2)');
     });
 
     test('no locale has extra keys not in app_en.arb', () {


### PR DESCRIPTION
## Summary

Phase 2 of #1374 — surface the GPS samples Phase 1 (#1385) plumbed through the recorder as a single-color polyline on the trip detail screen.

## Changes

- **New widget** `lib/features/consumption/presentation/widgets/trip_path_map_card.dart` — renders an OSM `FlutterMap` (~220 px tall) inside a `Card`, with:
  - A single `PolylineLayer` whose points are the in-order non-null `(latitude, longitude)` pairs from the trip's samples
  - Polyline color = `theme.colorScheme.primary` (Phase 3 owns the heatmap palette — single color is intentional here)
  - Two markers — trip start (`Icons.play_arrow`, primary color) and trip end (`Icons.flag`, tertiary color)
  - Auto-fits the camera to the polyline bounds via `MapController.fitCamera` + `CameraFit.bounds` (mirrors `nearby_map_view.dart`)
  - Standard OSM tile layer pulled from `AppConstants.osmTileUrl`
- **Empty-state behavior** — when no sample carries both `latitude` and `longitude`, the widget returns `const SizedBox.shrink()`. Per the issue spec: "Skip the card entirely when the trip has no GPS coords." Legacy and opted-out trips keep their pre-#1374 layout untouched.
- **Integration site** `lib/features/consumption/presentation/widgets/trip_detail_body.dart` — `TripPathMapCard(samples: widget.samples)` slotted between `TripSummaryCard` and the existing chart cards, inside the existing `RepaintBoundary` so #1189's share-PNG flow captures it too. No conditional gating on the parent side; the widget self-suppresses.
- **Plumbing** — added optional `latitude` / `longitude` to `TripDetailSample` and updated `_toDetailSample` in `trip_detail_screen.dart` so the GPS pair flows from the persisted `TripSample` through the presentation layer.
- **ARB keys added** — `tripPathCardTitle` ("Trip path" / "Fahrtstrecke" / "Trace du trajet") and `tripPathCardSubtitle` ("GPS-recorded route" / "Per GPS aufgezeichnete Strecke" / "Itinéraire enregistré par GPS"). New en + de fragments under `lib/l10n/_fragments/trip_path_{en,de}.arb`, French hand-edited in `app_fr.arb`. All 23 `app_localizations_*.dart` files regenerated via `flutter gen-l10n`.
- **Completeness guard** — extended `test/l10n/localization_completeness_test.dart` to require French has every `tripPath*` key (mirrors the `loyalty*` and `featureManagement*` blocks).
- **New widget test** `test/features/consumption/presentation/widgets/trip_path_map_card_test.dart` — covers render-when-coord, self-suppress-when-no-coord, polyline-points-match-samples, half-set-fix-skipping, single-sample edge case, and the Phase 2 single-color contract.

## Phase 3 callout

Phase 3 will replace the single primary color with per-segment heatmap colors derived from the speed / RPM / engine-load telemetry, and add the corresponding color-bucket legend below the map. The single-color polyline + no-legend layout in this PR is intentional and pinned by a widget test so an accidental color change is caught immediately.

## Test plan

- [x] `flutter analyze` — zero warnings, zero infos
- [x] `flutter test test/features/consumption/presentation/widgets/ test/l10n/localization_completeness_test.dart` — 407 tests pass
- [x] `dart run tool/build_arb.dart` regenerated `app_en.arb` + `app_de.arb` cleanly
- [x] `flutter gen-l10n` regenerated all 23 `app_localizations_*.dart` files
- [ ] Device test — open a trip recorded with `Feature.gpsTripPath` enabled, confirm the path card renders between summary and charts; open a legacy trip and confirm the card is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)