### PR TITLE
fix(telemetry): coerce nested Hive Map<dynamic,dynamic> before fromJson (Closes #1388)

### DIFF
--- a/lib/core/telemetry/storage/trace_storage.dart
+++ b/lib/core/telemetry/storage/trace_storage.dart
@@ -31,7 +31,7 @@ class TraceStorage {
         .map((raw) {
           if (raw is! Map) return null;
           try {
-            return ErrorTrace.fromJson(Map<String, dynamic>.from(raw));
+            return ErrorTrace.fromJson(_jsonMapFrom(raw));
           } on Object catch (e, st) {
             // #1301 — schema migrations can leave entries that throw
             // TypeError (missing required field) rather than the
@@ -52,7 +52,7 @@ class TraceStorage {
     final raw = _box.get(id);
     if (raw is! Map) return null;
     try {
-      return ErrorTrace.fromJson(Map<String, dynamic>.from(raw));
+      return ErrorTrace.fromJson(_jsonMapFrom(raw));
     } on Object catch (e, st) {
       // See [getAll] for the rationale behind the broad catch (#1301).
       debugPrint('TraceStorage: trace parse failed: $e\n$st');
@@ -100,7 +100,7 @@ class TraceStorage {
     final unparsed = <Map<String, dynamic>>[];
     for (final raw in _box.values) {
       if (raw is! Map) continue;
-      final asMap = Map<String, dynamic>.from(raw);
+      final asMap = _jsonMapFrom(raw);
       try {
         ErrorTrace.fromJson(asMap);
       } on Object catch (e, st) {
@@ -109,6 +109,28 @@ class TraceStorage {
       }
     }
     return unparsed;
+  }
+
+  /// Recursively coerces a Hive-returned [Map] (which is typed
+  /// `Map<dynamic, dynamic>` for every nested map and `List<dynamic>` for
+  /// nested lists) into a JSON-compatible structure where every map is
+  /// `Map<String, dynamic>` and every list of maps is
+  /// `List<Map<String, dynamic>>`. Without this, `_$ErrorTraceFromJson`
+  /// (and every nested `_$XFromJson`) throws `TypeError` on the first
+  /// `as Map<String, dynamic>` cast against a Hive-shaped nested map —
+  /// see #1388.
+  Map<String, dynamic> _jsonMapFrom(Map raw) {
+    final result = <String, dynamic>{};
+    raw.forEach((key, value) {
+      result[key.toString()] = _coerceJsonValue(value);
+    });
+    return result;
+  }
+
+  dynamic _coerceJsonValue(dynamic value) {
+    if (value is Map) return _jsonMapFrom(value);
+    if (value is List) return value.map(_coerceJsonValue).toList();
+    return value;
   }
 
   /// Serialises every persisted trace into a single JSON document the

--- a/test/core/telemetry/storage/trace_storage_test.dart
+++ b/test/core/telemetry/storage/trace_storage_test.dart
@@ -287,5 +287,115 @@ void main() {
         expect(decoded['unparsedRaw'], isEmpty);
       });
     });
+
+    /// #1388 — Hive returns `Map<dynamic, dynamic>` for every nested map
+    /// (deviceInfo, appState, networkState, breadcrumbs entries). The
+    /// generated `_$ErrorTraceFromJson` casts each as `Map<String, dynamic>`
+    /// which throws `TypeError`, the broad catch swallows it, and the
+    /// trace lands in `unparsedRaw`. Result on the user's device: every
+    /// trace fails to parse, parsedCount=0. The fix deep-coerces every
+    /// nested Map / List<Map> into a JSON-compatible structure before
+    /// calling `ErrorTrace.fromJson`.
+    group('Hive nested-map coercion (#1388)', () {
+      /// Build a `Map<dynamic, dynamic>` whose nested values are themselves
+      /// `Map<dynamic, dynamic>` and `List<Map<dynamic, dynamic>>` — the
+      /// EXACT runtime shape Hive returns from `_box.values`. Using the
+      /// fixture from the user's 2026-05-03 export (issue body).
+      Map<dynamic, dynamic> hiveShapedTrace() {
+        final deviceInfo = <dynamic, dynamic>{
+          'os': 'android',
+          'osVersion': 'BP2A.250605.031.A3.S918U1UES7EZCI',
+          'platform': 'mobile',
+          'locale': 'fr_FR',
+          'screenWidth': 384.0,
+          'screenHeight': 823.4666666666667,
+          'appVersion': '5.0.0+5132',
+        };
+        final appState = <dynamic, dynamic>{
+          'activeRoute': '/vehicles/edit',
+          'activeProfileId': 'profile-1',
+          'activeProfileName': 'Standard',
+          'lastApiEndpoint': null,
+          'lastSearchParams': null,
+        };
+        final networkState = <dynamic, dynamic>{
+          'isOnline': false,
+          'connectivityType': 'none',
+        };
+        final breadcrumbs = <dynamic>[
+          <dynamic, dynamic>{
+            'timestamp': '2026-05-02T23:07:23.000000',
+            'action': 'navigate:/vehicles/edit',
+            'detail': null,
+          },
+        ];
+        return <dynamic, dynamic>{
+          'id': '30be7070-8aa2-4f9e-bfc0-e61fa4e486ca',
+          'timestamp': '2026-05-02T23:07:23.808494',
+          'timezoneOffset': '+02:00',
+          'category': 'unknown',
+          'errorType': '_ContextualError',
+          'errorMessage': '[other] Obd2ScanTimeout: No OBD2 adapter found in range',
+          'stackTrace': '#0      Obd2ConnectionService.scan ...',
+          'deviceInfo': deviceInfo,
+          'appState': appState,
+          'serviceChainState': null,
+          'networkState': networkState,
+          'breadcrumbs': breadcrumbs,
+        };
+      }
+
+      test('getAll parses Hive-shaped Map<dynamic, dynamic> trace', () async {
+        final box = Hive.box('error_traces');
+        await box.put('30be7070-8aa2-4f9e-bfc0-e61fa4e486ca', hiveShapedTrace());
+
+        final all = storage.getAll();
+        expect(all, hasLength(1),
+            reason: 'Hive-shaped nested maps must be deep-coerced before fromJson');
+        final t = all.first;
+        expect(t.id, '30be7070-8aa2-4f9e-bfc0-e61fa4e486ca');
+        expect(t.errorType, '_ContextualError');
+        expect(t.deviceInfo.locale, 'fr_FR');
+        expect(t.networkState.isOnline, isFalse);
+        expect(t.breadcrumbs, hasLength(1));
+        expect(t.breadcrumbs.first.action, 'navigate:/vehicles/edit');
+      });
+
+      test('getUnparsedRaw is empty when input is Hive-shaped', () async {
+        final box = Hive.box('error_traces');
+        await box.put('30be7070-8aa2-4f9e-bfc0-e61fa4e486ca', hiveShapedTrace());
+
+        expect(storage.getUnparsedRaw(), isEmpty);
+        expect(storage.parsedCount, 1);
+        expect(storage.unparsedCount, 0);
+      });
+
+      test('getById parses Hive-shaped Map<dynamic, dynamic> trace',
+          () async {
+        final box = Hive.box('error_traces');
+        await box.put('30be7070-8aa2-4f9e-bfc0-e61fa4e486ca', hiveShapedTrace());
+
+        final t = storage.getById('30be7070-8aa2-4f9e-bfc0-e61fa4e486ca');
+        expect(t, isNotNull);
+        expect(t!.deviceInfo.os, 'android');
+      });
+
+      test(
+          'malformed entries still surface in unparsedRaw (regression: #1301 '
+          'broad-catch path is preserved)', () async {
+        final box = Hive.box('error_traces');
+        // Hive-shaped map with the required `id` field removed — schema drift.
+        final broken = hiveShapedTrace()..remove('id');
+        await box.put('broken', broken);
+
+        expect(storage.parsedCount, 0);
+        final unparsed = storage.getUnparsedRaw();
+        expect(unparsed, hasLength(1));
+        // The captured raw entry must round-trip through JsonEncoder cleanly
+        // — i.e. it's already a plain Map<String, dynamic> tree, not a
+        // Hive-shaped Map<dynamic, dynamic> that would blow up on encode.
+        expect(() => jsonEncode(unparsed), returnsNormally);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Every stored `ErrorTrace` was failing `ErrorTrace.fromJson` because Hive returns `Map<dynamic, dynamic>` for nested maps (`deviceInfo`, `appState`, `networkState`, `breadcrumbs[*]`) and the generated `_$XFromJson` casts each as `Map<String, dynamic>`. Result on the user's 2026-05-03 export: `parsedCount: 0, unparsedCount: 15`.
- Fix lives entirely in `trace_storage.dart`. New `_jsonMapFrom` / `_coerceJsonValue` helper pair recursively widens every nested `Map` and `List<Map>` to JSON-compatible shapes before calling `fromJson`. Applied in `getAll()`, `getById()`, `getUnparsedRaw()`.
- No changes to `error_trace.dart` or any `.g.dart` / `.freezed.dart` file.
- Broad catch from #1301 is preserved — real schema drift (missing required fields) still surfaces in `unparsedRaw`.

## Tests added

In `test/core/telemetry/storage/trace_storage_test.dart`, new `group('Hive nested-map coercion (#1388)')` with 4 tests:

1. `getAll parses Hive-shaped Map<dynamic, dynamic> trace` — uses the EXACT fixture from the issue body (id `30be7070-...`, errorType `_ContextualError`, deviceInfo with `locale: fr_FR`, etc.) built as `Map<dynamic, dynamic>` with nested `Map<dynamic, dynamic>` and `List<Map<dynamic, dynamic>>` — fails on master, passes after fix.
2. `getUnparsedRaw is empty when input is Hive-shaped` — confirms parsedCount=1, unparsedCount=0.
3. `getById parses Hive-shaped Map<dynamic, dynamic> trace`.
4. `malformed entries still surface in unparsedRaw (regression)` — proves the broad-catch path from #1301 still works for real schema drift.

## Before / after on the issue fixture

|              | master (broken) | this PR |
| ------------ | --------------- | ------- |
| `parsedCount`   | 0               | 1       |
| `unparsedCount` | 1               | 0       |

(Confirmed by the new tests — first run on master fails 3/4, all 4 pass after fix.)

## Test plan

- [x] `flutter test test/core/telemetry/storage/trace_storage_test.dart` — 20/20 pass
- [x] Plain `flutter analyze` — `No issues found!`
- [x] Regression test confirmed failing on master code before fix applied
- [x] No `.g.dart` / `.freezed.dart` regenerated