### PR TITLE
feat(trips): per-segment GPS-path heatmap by L/100km (Refs #1374 phase 3) (Closes #1374)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -3,11 +3,43 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../../../core/constants/app_constants.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import 'trip_detail_charts.dart';
 
+// ---------------------------------------------------------------------------
+// Phase 3 thresholds (#1374) — fixed defaults.
+//
+// The GPS-path heatmap colours each segment by its instantaneous
+// L/100 km, computed from the OBD-II `fuelRateLPerHour` and `speedKmh`
+// at the segment's start sample. Three buckets:
+//
+//   * efficient   < 6.0 L/100 km  → DarkModeColors.success (green)
+//   * borderline  6.0 ≤ x < 10.0  → DarkModeColors.warning (orange)
+//   * wasteful    ≥ 10.0          → DarkModeColors.error   (red)
+//
+// Two safety gates classify a segment as efficient regardless of
+// computed L/100 km:
+//
+//   * `fuelRateLPerHour == null` — legacy / partial samples (no
+//     PID 5E and no MAF fallback) shouldn't paint red just because
+//     fuel rate wasn't measured.
+//   * `speedKmh < 5.0` — too-slow segments produce divide-by-near-
+//     zero L/100 km that's meaningless for coaching (creep, idle).
+//
+// These thresholds are intentionally fixed; a future PR could derive
+// them per-vehicle from the consumption profile (tracked separately).
+// ---------------------------------------------------------------------------
+const double _kEfficientThresholdLPer100Km = 6.0;
+const double _kBorderlineThresholdLPer100Km = 10.0;
+const double _kMinClassifiableSpeedKmh = 5.0;
+
+/// Heatmap bucket assigned to a single segment between two consecutive
+/// GPS samples.
+enum _SegmentBucket { efficient, borderline, wasteful }
+
 /// Trip-detail map card rendering the GPS-recorded path of a trip
-/// (#1374 phase 2).
+/// (#1374 phase 3).
 ///
 /// Reads `(latitude, longitude)` pairs from the supplied
 /// [TripDetailSample]s — Phase 1 plumbed those fields through the
@@ -17,14 +49,12 @@ import 'trip_detail_charts.dart';
 /// never got a fix all fall through to the no-card path so the
 /// trip-detail screen layout stays unchanged for them.
 ///
-/// ## Phase 2 scope
-/// * Single-color polyline (theme `colorScheme.primary`).
+/// ## Phase 3 scope
+/// * Per-segment heatmap polylines coloured by computed L/100 km
+///   (see thresholds above).
 /// * Two markers — first and last GPS sample — for trip start and end.
+/// * Legend below the map showing the three buckets + their labels.
 /// * Auto-fits the viewport to the polyline bounds.
-///
-/// Phase 3 (out of scope here) will replace the single colour with a
-/// per-segment heatmap derived from the speed / RPM / engine-load
-/// telemetry, and add the corresponding colour-bucket legend.
 class TripPathMapCard extends StatelessWidget {
   final List<TripDetailSample> samples;
 
@@ -32,16 +62,19 @@ class TripPathMapCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Build the polyline from samples that carry BOTH lat and lng.
-    // Half-set fixes are dropped — the recorder writes the pair
+    // Build the parallel lists of (LatLng, source-sample) so the inner
+    // map can colour segments by the source sample's telemetry. Half-
+    // set fixes are dropped — the recorder writes the lat/lng pair
     // atomically (see `TripSample` doc) but the type still allows it,
     // so be defensive at the read site.
     final points = <LatLng>[];
+    final pointSamples = <TripDetailSample>[];
     for (final s in samples) {
       final lat = s.latitude;
       final lng = s.longitude;
       if (lat != null && lng != null) {
         points.add(LatLng(lat, lng));
+        pointSamples.add(s);
       }
     }
     if (points.isEmpty) {
@@ -82,8 +115,12 @@ class TripPathMapCard extends StatelessWidget {
             ),
             SizedBox(
               height: 220,
-              child: _TripPathMap(points: points),
+              child: _TripPathMap(
+                points: points,
+                pointSamples: pointSamples,
+              ),
             ),
+            const _TripPathLegend(),
           ],
         ),
       ),
@@ -98,8 +135,12 @@ class TripPathMapCard extends StatelessWidget {
 /// worry about lifecycle.
 class _TripPathMap extends StatefulWidget {
   final List<LatLng> points;
+  final List<TripDetailSample> pointSamples;
 
-  const _TripPathMap({required this.points});
+  const _TripPathMap({
+    required this.points,
+    required this.pointSamples,
+  });
 
   @override
   State<_TripPathMap> createState() => _TripPathMapState();
@@ -160,11 +201,91 @@ class _TripPathMapState extends State<_TripPathMap> {
     super.dispose();
   }
 
+  /// Classify a segment between [start] and the next sample by the
+  /// instantaneous L/100 km at [start]. The gates documented at the
+  /// top of the file (null fuel rate, low speed) collapse to
+  /// [_SegmentBucket.efficient] so legacy / idle samples don't paint
+  /// red.
+  static _SegmentBucket _classify(TripDetailSample start) {
+    final fuelRate = start.fuelRateLPerHour;
+    final speed = start.speedKmh;
+    if (fuelRate == null || speed < _kMinClassifiableSpeedKmh) {
+      return _SegmentBucket.efficient;
+    }
+    final lPer100km = fuelRate / speed * 100.0;
+    if (lPer100km < _kEfficientThresholdLPer100Km) {
+      return _SegmentBucket.efficient;
+    }
+    if (lPer100km < _kBorderlineThresholdLPer100Km) {
+      return _SegmentBucket.borderline;
+    }
+    return _SegmentBucket.wasteful;
+  }
+
+  static Color _bucketColor(BuildContext context, _SegmentBucket bucket) {
+    switch (bucket) {
+      case _SegmentBucket.efficient:
+        return DarkModeColors.success(context);
+      case _SegmentBucket.borderline:
+        return DarkModeColors.warning(context);
+      case _SegmentBucket.wasteful:
+        return DarkModeColors.error(context);
+    }
+  }
+
+  /// Walk consecutive segments and group runs of the same bucket into
+  /// a single polyline. Each polyline's points are the run's start
+  /// sample's coord followed by the end coord of every segment in the
+  /// run, so adjacent runs share the boundary point and the line
+  /// stays visually continuous.
+  List<Polyline> _buildHeatmapPolylines(BuildContext context) {
+    final pts = widget.points;
+    if (pts.length < 2) {
+      // Single-sample edge case — no segments to colour, but the start
+      // marker still anchors the viewport. Returning an empty list
+      // keeps the PolylineLayer harmless.
+      return const <Polyline>[];
+    }
+
+    final polylines = <Polyline>[];
+    var runStartIdx = 0;
+    var runBucket = _classify(widget.pointSamples[0]);
+
+    for (var i = 1; i < pts.length; i++) {
+      // The bucket for the segment ending at `i` is determined by the
+      // sample at `i - 1` (the segment's start). When that bucket
+      // changes, close the run [runStartIdx .. i - 1] and start a new
+      // run at `i - 1` so the runs share the boundary point.
+      final segBucket = _classify(widget.pointSamples[i - 1]);
+      if (segBucket != runBucket) {
+        polylines.add(
+          Polyline(
+            points: pts.sublist(runStartIdx, i),
+            color: _bucketColor(context, runBucket),
+            strokeWidth: 4.0,
+          ),
+        );
+        runStartIdx = i - 1;
+        runBucket = segBucket;
+      }
+    }
+    // Flush the final run all the way through the last point.
+    polylines.add(
+      Polyline(
+        points: pts.sublist(runStartIdx),
+        color: _bucketColor(context, runBucket),
+        strokeWidth: 4.0,
+      ),
+    );
+    return polylines;
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final start = widget.points.first;
     final end = widget.points.last;
+    final polylines = _buildHeatmapPolylines(context);
     return FlutterMap(
       mapController: _mapController,
       options: MapOptions(
@@ -187,19 +308,7 @@ class _TripPathMapState extends State<_TripPathMap> {
           evictErrorTileStrategy:
               EvictErrorTileStrategy.notVisibleRespectMargin,
         ),
-        PolylineLayer(
-          polylines: [
-            Polyline(
-              points: widget.points,
-              // Phase 2 — single colour. Phase 3 swaps this for a
-              // per-segment heatmap derived from the speed / RPM /
-              // engine-load telemetry; do NOT inline a fixed colour
-              // here.
-              color: theme.colorScheme.primary,
-              strokeWidth: 4.0,
-            ),
-          ],
-        ),
+        PolylineLayer(polylines: polylines),
         MarkerLayer(
           markers: [
             Marker(
@@ -227,6 +336,73 @@ class _TripPathMapState extends State<_TripPathMap> {
             TextSourceAttribution('OpenStreetMap contributors'),
           ],
         ),
+      ],
+    );
+  }
+}
+
+/// Three-swatch legend rendered below the heatmap map. The swatches
+/// reuse the same [DarkModeColors] entries the polylines do, so the
+/// legend and overlay stay in sync if a future tweak shifts the
+/// colour palette.
+class _TripPathLegend extends StatelessWidget {
+  const _TripPathLegend();
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final efficient =
+        l?.tripPathLegendEfficient ?? 'Efficient (< 6 L/100km)';
+    final borderline =
+        l?.tripPathLegendBorderline ?? 'Borderline (6–10 L/100km)';
+    final wasteful = l?.tripPathLegendWasteful ?? 'Wasteful (≥ 10 L/100km)';
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 6,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          _LegendSwatch(
+            color: DarkModeColors.success(context),
+            label: efficient,
+          ),
+          _LegendSwatch(
+            color: DarkModeColors.warning(context),
+            label: borderline,
+          ),
+          _LegendSwatch(
+            color: DarkModeColors.error(context),
+            label: wasteful,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LegendSwatch extends StatelessWidget {
+  final Color color;
+  final String label;
+
+  const _LegendSwatch({required this.color, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(2),
+          ),
+        ),
+        const SizedBox(width: 6),
+        Text(label, style: theme.textTheme.bodySmall),
       ],
     );
   }

--- a/lib/l10n/_fragments/trip_path_de.arb
+++ b/lib/l10n/_fragments/trip_path_de.arb
@@ -1,4 +1,8 @@
 {
   "tripPathCardTitle": "Fahrtstrecke",
-  "tripPathCardSubtitle": "Per GPS aufgezeichnete Strecke"
+  "tripPathCardSubtitle": "Per GPS aufgezeichnete Strecke",
+  "tripPathLegendTitle": "Verbrauch",
+  "tripPathLegendEfficient": "Effizient (< 6 L/100km)",
+  "tripPathLegendBorderline": "Grenzwertig (6–10 L/100km)",
+  "tripPathLegendWasteful": "Verschwenderisch (≥ 10 L/100km)"
 }

--- a/lib/l10n/_fragments/trip_path_en.arb
+++ b/lib/l10n/_fragments/trip_path_en.arb
@@ -6,5 +6,21 @@
   "tripPathCardSubtitle": "GPS-recorded route",
   "@tripPathCardSubtitle": {
     "description": "Sub-line beneath the trip-path card title clarifying that the polyline comes from the GPS samples captured during the trip."
+  },
+  "tripPathLegendTitle": "Consumption",
+  "@tripPathLegendTitle": {
+    "description": "Header label above the trip-path heatmap legend (#1374 phase 3) — names the metric the colour coding represents."
+  },
+  "tripPathLegendEfficient": "Efficient (< 6 L/100km)",
+  "@tripPathLegendEfficient": {
+    "description": "Legend entry for the green heatmap bucket on the trip-path card (#1374 phase 3): segments where computed L/100 km is below 6."
+  },
+  "tripPathLegendBorderline": "Borderline (6–10 L/100km)",
+  "@tripPathLegendBorderline": {
+    "description": "Legend entry for the orange heatmap bucket on the trip-path card (#1374 phase 3): segments where computed L/100 km is between 6 and 10."
+  },
+  "tripPathLegendWasteful": "Wasteful (≥ 10 L/100km)",
+  "@tripPathLegendWasteful": {
+    "description": "Legend entry for the red heatmap bucket on the trip-path card (#1374 phase 3): segments where computed L/100 km is at least 10."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1656,6 +1656,10 @@
   "tripLengthBucketTripCount": "{count, plural, =0{keine Fahrten} one{1 Fahrt} other{{count} Fahrten}}",
   "tripPathCardTitle": "Fahrtstrecke",
   "tripPathCardSubtitle": "Per GPS aufgezeichnete Strecke",
+  "tripPathLegendTitle": "Verbrauch",
+  "tripPathLegendEfficient": "Effizient (< 6 L/100km)",
+  "tripPathLegendBorderline": "Grenzwertig (6–10 L/100km)",
+  "tripPathLegendWasteful": "Verschwenderisch (≥ 10 L/100km)",
   "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2971,6 +2971,22 @@
   "@tripPathCardSubtitle": {
     "description": "Sub-line beneath the trip-path card title clarifying that the polyline comes from the GPS samples captured during the trip."
   },
+  "tripPathLegendTitle": "Consumption",
+  "@tripPathLegendTitle": {
+    "description": "Header label above the trip-path heatmap legend (#1374 phase 3) — names the metric the colour coding represents."
+  },
+  "tripPathLegendEfficient": "Efficient (< 6 L/100km)",
+  "@tripPathLegendEfficient": {
+    "description": "Legend entry for the green heatmap bucket on the trip-path card (#1374 phase 3): segments where computed L/100 km is below 6."
+  },
+  "tripPathLegendBorderline": "Borderline (6–10 L/100km)",
+  "@tripPathLegendBorderline": {
+    "description": "Legend entry for the orange heatmap bucket on the trip-path card (#1374 phase 3): segments where computed L/100 km is between 6 and 10."
+  },
+  "tripPathLegendWasteful": "Wasteful (≥ 10 L/100km)",
+  "@tripPathLegendWasteful": {
+    "description": "Legend entry for the red heatmap bucket on the trip-path card (#1374 phase 3): segments where computed L/100 km is at least 10."
+  },
   "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1139,5 +1139,9 @@
   "featureBlockedDisable_obd2TripRecording": "Désactivez d'abord les fonctionnalités dépendantes : {dependents}",
   "featureBlockedDisable_tankSync": "Désactivez d'abord les fonctionnalités dépendantes : {dependents}",
   "tripPathCardTitle": "Trace du trajet",
-  "tripPathCardSubtitle": "Itinéraire enregistré par GPS"
+  "tripPathCardSubtitle": "Itinéraire enregistré par GPS",
+  "tripPathLegendTitle": "Consommation",
+  "tripPathLegendEfficient": "Économe (< 6 L/100km)",
+  "tripPathLegendBorderline": "Modérée (6–10 L/100km)",
+  "tripPathLegendWasteful": "Excessive (≥ 10 L/100km)"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7832,6 +7832,30 @@ abstract class AppLocalizations {
   /// **'GPS-recorded route'**
   String get tripPathCardSubtitle;
 
+  /// Header label above the trip-path heatmap legend (#1374 phase 3) — names the metric the colour coding represents.
+  ///
+  /// In en, this message translates to:
+  /// **'Consumption'**
+  String get tripPathLegendTitle;
+
+  /// Legend entry for the green heatmap bucket on the trip-path card (#1374 phase 3): segments where computed L/100 km is below 6.
+  ///
+  /// In en, this message translates to:
+  /// **'Efficient (< 6 L/100km)'**
+  String get tripPathLegendEfficient;
+
+  /// Legend entry for the orange heatmap bucket on the trip-path card (#1374 phase 3): segments where computed L/100 km is between 6 and 10.
+  ///
+  /// In en, this message translates to:
+  /// **'Borderline (6–10 L/100km)'**
+  String get tripPathLegendBorderline;
+
+  /// Legend entry for the red heatmap bucket on the trip-path card (#1374 phase 3): segments where computed L/100 km is at least 10.
+  ///
+  /// In en, this message translates to:
+  /// **'Wasteful (≥ 10 L/100km)'**
+  String get tripPathLegendWasteful;
+
   /// Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4260,6 +4260,18 @@ class AppLocalizationsBg extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4260,6 +4260,18 @@ class AppLocalizationsCs extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4258,6 +4258,18 @@ class AppLocalizationsDa extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4300,6 +4300,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tripPathCardSubtitle => 'Per GPS aufgezeichnete Strecke';
 
   @override
+  String get tripPathLegendTitle => 'Verbrauch';
+
+  @override
+  String get tripPathLegendEfficient => 'Effizient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Grenzwertig (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Verschwenderisch (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Anpinnen hält den Bildschirm an — verbraucht mehr Akku';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4262,6 +4262,18 @@ class AppLocalizationsEl extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4253,6 +4253,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4261,6 +4261,18 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4255,6 +4255,18 @@ class AppLocalizationsEt extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4258,6 +4258,18 @@ class AppLocalizationsFi extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4303,6 +4303,18 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tripPathCardSubtitle => 'Itinéraire enregistré par GPS';
 
   @override
+  String get tripPathLegendTitle => 'Consommation';
+
+  @override
+  String get tripPathLegendEfficient => 'Économe (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Modérée (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Excessive (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4257,6 +4257,18 @@ class AppLocalizationsHr extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4262,6 +4262,18 @@ class AppLocalizationsHu extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4261,6 +4261,18 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4259,6 +4259,18 @@ class AppLocalizationsLt extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4261,6 +4261,18 @@ class AppLocalizationsLv extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4257,6 +4257,18 @@ class AppLocalizationsNb extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4262,6 +4262,18 @@ class AppLocalizationsNl extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4260,6 +4260,18 @@ class AppLocalizationsPl extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4261,6 +4261,18 @@ class AppLocalizationsPt extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4260,6 +4260,18 @@ class AppLocalizationsRo extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4261,6 +4261,18 @@ class AppLocalizationsSk extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4255,6 +4255,18 @@ class AppLocalizationsSl extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4259,6 +4259,18 @@ class AppLocalizationsSv extends AppLocalizations {
   String get tripPathCardSubtitle => 'GPS-recorded route';
 
   @override
+  String get tripPathLegendTitle => 'Consumption';
+
+  @override
+  String get tripPathLegendEfficient => 'Efficient (< 6 L/100km)';
+
+  @override
+  String get tripPathLegendBorderline => 'Borderline (6–10 L/100km)';
+
+  @override
+  String get tripPathLegendWasteful => 'Wasteful (≥ 10 L/100km)';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 

--- a/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
@@ -1,34 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_charts.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_path_map_card.dart';
 
 import '../../../../helpers/pump_app.dart';
 
-/// #1374 phase 2 — widget coverage for [TripPathMapCard], the
-/// trip-detail card that renders the GPS-recorded route as a single-
-/// colour polyline on an OpenStreetMap tile layer.
+/// #1374 phases 2 + 3 — widget coverage for [TripPathMapCard], the
+/// trip-detail card that renders the GPS-recorded route as a polyline
+/// on an OpenStreetMap tile layer.
 ///
-/// The widget is the user-visible surface of Phase 1's GPS sampling
-/// work; phase 3 will swap the single colour for a per-segment
-/// heatmap. These tests pin the Phase 2 contract:
+/// Phase 2 pinned the render-gating contract (single-colour polyline,
+/// self-suppressing on legacy / opted-out trips). Phase 3 swaps the
+/// single colour for a per-segment heatmap derived from the
+/// instantaneous L/100 km, with a 3-bucket legend below the map. The
+/// tests here cover both phases:
 ///
-///  * Renders the [FlutterMap] + [PolylineLayer] only when the trip
-///    carries at least one fully-coord sample.
-///  * Self-suppresses (returns [SizedBox.shrink]) for legacy /
-///    opted-out trips so the trip-detail layout stays unchanged.
-///  * The polyline points list is the in-order projection of the
-///    samples that have BOTH lat and lng — half-set fixes are dropped.
+///  * Render gating: FlutterMap + PolylineLayer only when at least
+///    one sample carries both lat + lng; SizedBox.shrink otherwise.
+///  * Polyline points: in-order projection of the fully-coord samples,
+///    half-set fixes dropped.
+///  * Phase 3 heatmap: per-segment colours by computed L/100 km,
+///    same-colour runs collapsed into one polyline, low-speed and
+///    null-fuel-rate segments pinned to efficient (green).
+///  * Legend: three labels rendered with the matching swatch colours.
 TripDetailSample _sample({
   required int sec,
   double speed = 60.0,
   double? lat,
   double? lng,
+  double? fuelRate,
 }) {
   return TripDetailSample(
     timestamp: DateTime.utc(2026, 5, 3, 10, 0, sec),
     speedKmh: speed,
+    fuelRateLPerHour: fuelRate,
     latitude: lat,
     longitude: lng,
   );
@@ -84,8 +91,16 @@ void main() {
   });
 
   group('TripPathMapCard — polyline points', () {
-    testWidgets('polyline points match the non-null coord sequence in order',
+    testWidgets(
+        'polyline coverage spans the full non-null coord sequence in order',
         (tester) async {
+      // With Phase 3 the path is split across N polylines (one per
+      // colour bucket run). The full coord sequence still has to be
+      // covered, so flatten all polyline points and assert the
+      // concatenation matches the input order. Same-bucket samples
+      // collapse to a single polyline; here every segment is
+      // efficient (no fuel-rate data), so the layer holds exactly
+      // one polyline of all 3 points.
       final samples = [
         _sample(sec: 0, lat: 43.46, lng: 3.43),
         _sample(sec: 1, lat: 43.47, lng: 3.44),
@@ -124,6 +139,9 @@ void main() {
       await pumpApp(tester, TripPathMapCard(samples: samples));
 
       final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      // All kept samples are efficient (no fuel rate) → one polyline
+      // covering every kept point.
+      expect(layer.polylines, hasLength(1));
       final pts = layer.polylines.single.points;
       expect(pts, hasLength(3));
       expect(pts[0].latitude, closeTo(43.46, 1e-9));
@@ -135,7 +153,9 @@ void main() {
         (tester) async {
       // Edge case: a very short trip with exactly one GPS fix should
       // still surface the card (the user got a fix — that's worth
-      // showing) without throwing on the bounds calculation.
+      // showing) without throwing on the bounds calculation. With
+      // Phase 3 there are zero segments to colour, so the polyline
+      // layer is empty but the map still renders.
       final samples = [
         _sample(sec: 0, lat: 43.46, lng: 3.43),
       ];
@@ -144,17 +164,125 @@ void main() {
 
       expect(find.byType(FlutterMap), findsOneWidget);
       final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
-      expect(layer.polylines.single.points, hasLength(1));
+      expect(layer.polylines, isEmpty);
     });
   });
 
-  group('TripPathMapCard — polyline colour', () {
-    testWidgets('polyline uses theme colorScheme.primary (Phase 2 single colour)',
+  group('TripPathMapCard — phase 3 heatmap', () {
+    testWidgets(
+        'three consecutive bucket transitions yield three coloured polylines',
         (tester) async {
-      // Phase 2 specifies a single theme-driven colour. Phase 3 will
-      // replace this with per-segment heatmap colours; this test
-      // pins the Phase 2 contract so any accidental colour change
-      // (e.g. inlining Colors.green) is caught immediately.
+      // Construct samples whose computed L/100 km lands cleanly in
+      // each bucket. L/100 km = fuelRate / speed * 100.
+      //   * efficient   speed=60, fuel=3.0  → 5.0  (< 6)
+      //   * borderline  speed=60, fuel=4.8  → 8.0  (6 ≤ x < 10)
+      //   * wasteful    speed=60, fuel=7.2  → 12.0 (≥ 10)
+      // Four points → three segments → one polyline per bucket.
+      final samples = [
+        _sample(sec: 0, lat: 43.40, lng: 3.40, speed: 60, fuelRate: 3.0),
+        _sample(sec: 1, lat: 43.41, lng: 3.41, speed: 60, fuelRate: 4.8),
+        _sample(sec: 2, lat: 43.42, lng: 3.42, speed: 60, fuelRate: 7.2),
+        _sample(sec: 3, lat: 43.43, lng: 3.43, speed: 60, fuelRate: 7.2),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      expect(layer.polylines, hasLength(3));
+
+      final ctx = tester.element(find.byType(FlutterMap));
+      expect(layer.polylines[0].color, DarkModeColors.success(ctx));
+      expect(layer.polylines[1].color, DarkModeColors.warning(ctx));
+      expect(layer.polylines[2].color, DarkModeColors.error(ctx));
+    });
+
+    testWidgets('consecutive same-bucket segments collapse into one polyline',
+        (tester) async {
+      // Six samples → five segments. Bucket sequence:
+      //   eff, eff, bord, bord, eff
+      // → three polylines: efficient run (3 pts), borderline run
+      // (3 pts), efficient run (2 pts). Adjacent runs share the
+      // boundary point so the line stays visually continuous.
+      final samples = [
+        _sample(sec: 0, lat: 43.40, lng: 3.40, speed: 60, fuelRate: 3.0),
+        _sample(sec: 1, lat: 43.41, lng: 3.41, speed: 60, fuelRate: 3.0),
+        _sample(sec: 2, lat: 43.42, lng: 3.42, speed: 60, fuelRate: 4.8),
+        _sample(sec: 3, lat: 43.43, lng: 3.43, speed: 60, fuelRate: 4.8),
+        _sample(sec: 4, lat: 43.44, lng: 3.44, speed: 60, fuelRate: 3.0),
+        _sample(sec: 5, lat: 43.45, lng: 3.45, speed: 60, fuelRate: 3.0),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      expect(layer.polylines, hasLength(3));
+
+      final ctx = tester.element(find.byType(FlutterMap));
+      expect(layer.polylines[0].color, DarkModeColors.success(ctx));
+      expect(layer.polylines[1].color, DarkModeColors.warning(ctx));
+      expect(layer.polylines[2].color, DarkModeColors.success(ctx));
+    });
+
+    testWidgets(
+        'samples with null fuel rate render as a single efficient polyline',
+        (tester) async {
+      // Legacy / partial samples (no PID 5E and no MAF fallback)
+      // should NOT paint red just because fuel rate wasn't measured.
+      // The classifier collapses them to efficient (green).
+      final samples = [
+        _sample(sec: 0, lat: 43.40, lng: 3.40, speed: 60),
+        _sample(sec: 1, lat: 43.41, lng: 3.41, speed: 60),
+        _sample(sec: 2, lat: 43.42, lng: 3.42, speed: 60),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      expect(layer.polylines, hasLength(1));
+      final ctx = tester.element(find.byType(FlutterMap));
+      expect(layer.polylines.single.color, DarkModeColors.success(ctx));
+    });
+
+    testWidgets(
+        'low-speed segments classify as efficient regardless of fuel rate',
+        (tester) async {
+      // Speed below 5 km/h produces a divide-by-near-zero L/100 km
+      // that's meaningless for coaching (creep, idle). Lock the
+      // classifier to efficient so idle / parking-lot crawl doesn't
+      // show up red. Even with a high fuel rate (idling engine),
+      // the segments must come back green.
+      final samples = [
+        _sample(sec: 0, lat: 43.40, lng: 3.40, speed: 1.0, fuelRate: 1.5),
+        _sample(sec: 1, lat: 43.40001, lng: 3.40001, speed: 2.0, fuelRate: 1.5),
+        _sample(sec: 2, lat: 43.40002, lng: 3.40002, speed: 3.0, fuelRate: 1.5),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      expect(layer.polylines, hasLength(1));
+      final ctx = tester.element(find.byType(FlutterMap));
+      expect(layer.polylines.single.color, DarkModeColors.success(ctx));
+    });
+
+    testWidgets('single GPS sample renders zero polylines without throwing',
+        (tester) async {
+      // One GPS fix → zero segments → zero polylines, but FlutterMap
+      // still renders so the card surfaces the start marker.
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43, speed: 60, fuelRate: 5.0),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      expect(find.byType(FlutterMap), findsOneWidget);
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      expect(layer.polylines, isEmpty);
+    });
+
+    testWidgets('legend renders the three bucket labels', (tester) async {
+      // The legend must surface all three colour buckets so a user
+      // can decode the heatmap without referring to docs.
       final samples = [
         _sample(sec: 0, lat: 43.46, lng: 3.43),
         _sample(sec: 1, lat: 43.47, lng: 3.44),
@@ -162,11 +290,9 @@ void main() {
 
       await pumpApp(tester, TripPathMapCard(samples: samples));
 
-      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
-      // Resolve the same primary colour the widget would have read.
-      final ctx = tester.element(find.byType(FlutterMap));
-      final expectedColor = Theme.of(ctx).colorScheme.primary;
-      expect(layer.polylines.single.color, expectedColor);
+      expect(find.text('Efficient (< 6 L/100km)'), findsOneWidget);
+      expect(find.text('Borderline (6–10 L/100km)'), findsOneWidget);
+      expect(find.text('Wasteful (≥ 10 L/100km)'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Replaces the single-colour Phase 2 polyline with per-segment colours: green / orange / red by computed L/100km.
- Thresholds: efficient < 6 L/100km, borderline 6-10, wasteful >= 10. Documented as fixed defaults; future PR can derive from vehicle profile.
- Low-speed (< 5 km/h) and null-fuel-rate segments classified efficient - avoids false-red on idle / legacy samples.
- Adjacent same-bucket segments collapse into a single Polyline, sharing boundary points so the line stays visually continuous.
- Adds a 3-swatch legend below the map; localized en/de/fr.
- Closes the #1374 epic.

## Test plan
- [x] flutter analyze (zero warnings)
- [x] trip_path_map_card_test.dart - extended with 6 phase-3 cases (color buckets, run-grouping, null-fuel fallback, low-speed gate, single-sample edge, legend labels)
- [x] localization_completeness_test.dart - French parity enforced for new keys
- [ ] Device-test on a recorded trip with mixed fuel rates (deferred to user)