### PR TITLE
fix(obd2): map scanResults BT-off PlatformException to typed Obd2BluetoothOff (Closes #1392)

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_facade.dart
@@ -61,7 +61,7 @@ class PluginBluetoothFacade implements BluetoothFacade {
         timeout: timeout,
       ).catchError((Object e, StackTrace st) {
         if (controller.isClosed) return;
-        final mapped = _looksBluetoothOff(e) ? const Obd2BluetoothOff() : e;
+        final mapped = _mapBluetoothError(e);
         controller.addError(mapped, st);
         unawaited(controller.close());
       }),
@@ -83,7 +83,17 @@ class PluginBluetoothFacade implements BluetoothFacade {
         }
         controller.add(accumulated.values.toList());
       },
-      onError: controller.addError,
+      // #1392 — mirror the explicit-future catchError above. Without
+      // this mapping the raw `PlatformException(startScan, "Bluetooth
+      // must be turned on", ...)` reaches the consumer (and from there
+      // the global zone error handler as `[other] PlatformException`)
+      // when FlutterBluePlus rejects via the stream rather than the
+      // future. The `isClosed` guard handles the race with the timeout
+      // timer below that may have already closed the controller.
+      onError: (Object e, StackTrace st) {
+        if (controller.isClosed) return;
+        controller.addError(_mapBluetoothError(e), st);
+      },
     );
 
     // Clean up when the caller cancels or the timeout elapses.
@@ -107,6 +117,13 @@ class PluginBluetoothFacade implements BluetoothFacade {
   @visibleForTesting
   static bool debugLooksBluetoothOff(Object e) => _looksBluetoothOff(e);
 
+  /// Test seam for the error mapping used by both the explicit-future
+  /// `catchError` and the `scanResults` stream's `onError` (#1392).
+  /// Both call sites must funnel through this helper so a BT-off
+  /// rejection on either path surfaces as `Obd2BluetoothOff`.
+  @visibleForTesting
+  static Object debugMapBluetoothError(Object e) => _mapBluetoothError(e);
+
   static bool _looksBluetoothOff(Object e) {
     if (e is! PlatformException) return false;
     final msg = (e.message ?? '').toLowerCase();
@@ -114,6 +131,9 @@ class PluginBluetoothFacade implements BluetoothFacade {
         msg.contains('bluetooth must be on') ||
         msg.contains('bluetooth_off');
   }
+
+  static Object _mapBluetoothError(Object e) =>
+      _looksBluetoothOff(e) ? const Obd2BluetoothOff() : e;
 
   @override
   Future<void> stopScan() => FlutterBluePlus.stopScan();

--- a/test/features/consumption/data/obd2/bluetooth_facade_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_facade_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 
 /// Unit tests for the [PluginBluetoothFacade] BT-off classifier
 /// (#1369).
@@ -74,6 +75,54 @@ void main() {
     test('handles a PlatformException with a null message gracefully', () {
       final ex = PlatformException(code: 'startScan');
       expect(PluginBluetoothFacade.debugLooksBluetoothOff(ex), isFalse);
+    });
+  });
+
+  // #1392 — the explicit `startScan` future was wrapped by #1370, but
+  // the `scanResults` stream's `onError` was forwarding the raw
+  // `PlatformException(startScan, "Bluetooth must be turned on", ...)`
+  // straight through. Both code paths must funnel through the same
+  // `_mapBluetoothError` helper so a BT-off rejection on either path
+  // surfaces as `Obd2BluetoothOff`.
+  group('PluginBluetoothFacade.debugMapBluetoothError (#1392)', () {
+    test(
+      'scanResults stream BT-off rejection maps to Obd2BluetoothOff',
+      () {
+        // Same shape as the FlutterBluePlus rejection that previously
+        // leaked through the `scanResults` stream's onError to the
+        // global zone error handler as `[other] PlatformException`.
+        final ex = PlatformException(
+          code: 'startScan',
+          message: 'Bluetooth must be turned on',
+        );
+        final mapped = PluginBluetoothFacade.debugMapBluetoothError(ex);
+        expect(
+          mapped,
+          isA<Obd2BluetoothOff>(),
+          reason:
+              'BT-off PlatformException must be normalised to the typed '
+              'error regardless of which call site (explicit-future or '
+              'scanResults stream) caught it.',
+        );
+      },
+    );
+
+    test(
+      'returns the original error for non-BT-off PlatformExceptions',
+      () {
+        final ex = PlatformException(
+          code: 'permission_denied',
+          message: 'BLUETOOTH_SCAN permission required',
+        );
+        final mapped = PluginBluetoothFacade.debugMapBluetoothError(ex);
+        expect(mapped, same(ex));
+      },
+    );
+
+    test('returns the original error for non-PlatformException objects', () {
+      final err = StateError('transport closed');
+      final mapped = PluginBluetoothFacade.debugMapBluetoothError(err);
+      expect(mapped, same(err));
     });
   });
 }


### PR DESCRIPTION
## Summary

- #1370 wrapped only the explicit `startScan` future. The `scanResults` stream's `onError: controller.addError` was still forwarding the raw `PlatformException(startScan, "Bluetooth must be turned on", ...)` unmapped — the auto-record coordinator logged it as `[other] PlatformException` instead of the typed `Obd2BluetoothOff`.
- Extract a `_mapBluetoothError(Object e)` helper and use it on both the explicit-future `catchError` (line 64) and the stream `onError` (line 86) so a BT-off rejection on either FlutterBluePlus call site funnels through the same mapping.
- Mirror the explicit-future path's `if (controller.isClosed) return;` guard in the new stream `onError` to avoid acting on a controller closed by the timeout timer.

## Test added

`test/features/consumption/data/obd2/bluetooth_facade_test.dart` gains a new `PluginBluetoothFacade.debugMapBluetoothError (#1392)` group:

- `scanResults stream BT-off rejection maps to Obd2BluetoothOff` — feeds the canonical FlutterBluePlus `PlatformException(startScan, "Bluetooth must be turned on")` shape through the new helper and asserts it normalises to `Obd2BluetoothOff`.
- `returns the original error for non-BT-off PlatformExceptions` — sanity check, identity-compares the mapped value.
- `returns the original error for non-PlatformException objects` — proves we don't accidentally swallow unrelated errors.

The new test file fails on master (member not found: `debugMapBluetoothError`) and passes after the fix. `FlutterBluePlus` is a static singleton with no constructor seam in this file's existing test pattern, so per the issue's guidance the test exercises the helper via a `@visibleForTesting` accessor (mirrors the existing `debugLooksBluetoothOff`) rather than a new injection seam.

## Test plan

- [x] `flutter test test/features/consumption/data/obd2/` — 662 tests pass
- [x] `flutter analyze` (plain, includes test/) — `No issues found!`
- [x] New `debugMapBluetoothError` test fails on master and passes after fix
- [ ] CI: full suite + analyze on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)