### PR TITLE
feat(obd2): runtime adapter-capability detection from ATI firmware (Refs #1401 phase 1)

### DIFF
--- a/lib/features/consumption/data/obd2/adapter_capability.dart
+++ b/lib/features/consumption/data/obd2/adapter_capability.dart
@@ -1,0 +1,69 @@
+/// Runtime capability tier of the connected ELM327-compatible adapter
+/// (#1401 phase 1).
+///
+/// Orthogonal to [Obd2AdapterCompatibility] in `adapter_registry.dart`,
+/// which classifies hardware MODELS we've verified work end-to-end.
+/// This enum captures what the *current* connected adapter session can
+/// actually do at runtime — derived from the firmware-version string
+/// the adapter returns to `ATI`. Two units of the same physical model
+/// can land on different capability tiers (e.g. a real OBDLink MX+
+/// vs. a counterfeit clone selling under the same name).
+///
+/// Order matters. The comparator semantics are
+///   passiveCanCapable >= oemPidsCapable >= standardOnly
+/// — phases 2-7 of the epic gate behaviour with `>=` checks against
+/// these values, so reordering would silently flip those gates.
+enum Obd2AdapterCapability {
+  /// OBD-II standard mode 01-09 PIDs only. Cheap clones, ELM327 v1.x.
+  standardOnly,
+
+  /// Manufacturer-specific PIDs reachable via header switching + raw
+  /// commands. Genuine ELM327 v2.x and equivalent clones.
+  oemPidsCapable,
+
+  /// Listen-mode CAN bus access (passive sniffing of broadcast frames).
+  /// STN-chip family — OBDLink MX+/LX/CX/EX (STN1110 / STN2120).
+  passiveCanCapable,
+}
+
+/// Pure parser: classify an `ATI` firmware-version response string into
+/// a runtime capability tier.
+///
+/// Matching rules (case-insensitive, leading/trailing whitespace
+/// trimmed before matching):
+///   * Starts with `STN1110` or `STN2120` (any version) →
+///     [Obd2AdapterCapability.passiveCanCapable].
+///   * `ELM327 v2.2`, `v2.3`, ..., `v3.x`, ... (genuine v2.2+) →
+///     [Obd2AdapterCapability.oemPidsCapable].
+///   * Anything else, including `ELM327 v2.0`, `ELM327 v2.1`,
+///     `ELM327 v1.x`, empty, null, garbage →
+///     [Obd2AdapterCapability.standardOnly].
+///
+/// Phase 1 trusts the version string. The well-known
+/// "v2.1 clone claiming v2.2" trap is explicitly out of scope here —
+/// a runtime feature-probe that downgrades lying clones is filed in
+/// the epic (#1401) caveats and lands in a later phase.
+Obd2AdapterCapability detectCapabilityFromFirmwareString(String? ati) {
+  if (ati == null) return Obd2AdapterCapability.standardOnly;
+  final normalized = ati.trim().toUpperCase();
+  if (normalized.isEmpty) return Obd2AdapterCapability.standardOnly;
+
+  // STN-chip family — passive CAN listen-mode capable.
+  if (normalized.startsWith('STN1110') || normalized.startsWith('STN2120')) {
+    return Obd2AdapterCapability.passiveCanCapable;
+  }
+
+  // Genuine ELM327 v2.2+ — OEM-PID capable.
+  // Pattern: `ELM327 v(2.[2-9]|[3-9](\.\d+)?)` — accepts v2.2, v2.3,
+  // ..., v2.9, v3, v3.x, v4, ... but NOT v2.0 / v2.1 / v1.x.
+  final match =
+      RegExp(r'^ELM327\s+V(\d+)(?:\.(\d+))?').firstMatch(normalized);
+  if (match != null) {
+    final major = int.parse(match.group(1)!);
+    final minor = int.tryParse(match.group(2) ?? '0') ?? 0;
+    if (major >= 3) return Obd2AdapterCapability.oemPidsCapable;
+    if (major == 2 && minor >= 2) return Obd2AdapterCapability.oemPidsCapable;
+  }
+
+  return Obd2AdapterCapability.standardOnly;
+}

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import 'adapter_capability.dart';
 import 'elm327_adapter.dart';
 import 'elm327_protocol.dart';
 import 'fuel_rate_estimator.dart' as estimator;
@@ -66,13 +67,24 @@ class Obd2Service {
   String? adapterName;
 
   /// ELM327 firmware string (whatever `ATI` returned during init), if
-  /// the adapter reported one (#1312). Currently null in production
-  /// because the connect path does not snapshot the response — the
-  /// field is wired so a future enhancement can populate it without
-  /// touching the trip-history schema again. Persisted/round-tripped
-  /// by [TripHistoryEntry] so device-test reports can name the exact
-  /// firmware variant when we eventually capture it.
+  /// the adapter reported one (#1312, #1401). Populated by [connect]
+  /// after the init sequence completes — null only when the adapter
+  /// returned an empty / NO-DATA response to `ATI`, or when the test
+  /// fake didn't wire one in. Persisted/round-tripped by
+  /// [TripHistoryEntry] so device-test reports can name the exact
+  /// firmware variant.
   String? adapterFirmware;
+
+  /// Runtime capability tier of the connected adapter (#1401 phase 1).
+  /// Defaults to [Obd2AdapterCapability.standardOnly] before [connect]
+  /// has read the firmware string, and is replaced with the parsed
+  /// value after the init sequence runs. Phase 1 ships read-only —
+  /// no production call site branches on this value yet.
+  Obd2AdapterCapability _capability = Obd2AdapterCapability.standardOnly;
+
+  /// Runtime capability tier of the connected adapter (#1401 phase 1).
+  /// See [_capability] for semantics.
+  Obd2AdapterCapability get capability => _capability;
 
   /// Per-adapter ELM327 quirks (#1330). Set by [connect] from the
   /// caller-supplied `adapter` parameter; defaults to the
@@ -93,6 +105,24 @@ class Obd2Service {
     String? vehicleFallbackKey,
   })  : _pidsCache = pidsCache,
         _vehicleFallbackKey = vehicleFallbackKey;
+
+  /// AT command that asks the ELM327 to identify itself. Returns a
+  /// version string like `ELM327 v1.5` / `ELM327 v2.2` /
+  /// `STN1110 v4.0.4` (#1401 phase 1).
+  static const String _atiCommand = 'ATI\r';
+
+  /// Strip the trailing ELM prompt (`>`) plus any CR/LF noise from a
+  /// raw `ATI` response. Returns null when the response was a
+  /// NO-DATA-style placeholder.
+  static String? _parseFirmwareString(String raw) {
+    var s = raw.replaceAll('\r', ' ').replaceAll('\n', ' ');
+    s = s.replaceAll('>', '').trim();
+    // Collapse runs of whitespace introduced by stripping CR/LF.
+    s = s.replaceAll(RegExp(r'\s+'), ' ');
+    if (s.isEmpty) return null;
+    if (s.toUpperCase().contains('NO DATA')) return null;
+    return s;
+  }
 
   /// `true` when the underlying [Obd2Transport] currently has an open
   /// connection to the vehicle's ELM327 adapter.
@@ -150,6 +180,23 @@ class Obd2Service {
         final delay =
             i == 0 ? adapter.postResetDelay : adapter.interCommandDelay;
         await Future.delayed(delay);
+      }
+
+      // Capture the firmware-version string and derive the runtime
+      // capability tier (#1401 phase 1). Sent after the init sequence
+      // so echo / line-feeds / headers are off and the response is
+      // clean. Failures here are non-fatal — we keep the
+      // [Obd2AdapterCapability.standardOnly] default and let the
+      // connect succeed. No call site branches on `capability` yet.
+      try {
+        final raw = await _transport.sendCommand(_atiCommand);
+        final firmware = _parseFirmwareString(raw);
+        if (firmware != null && firmware.isNotEmpty) {
+          adapterFirmware = firmware;
+        }
+        _capability = detectCapabilityFromFirmwareString(firmware);
+      } catch (e, st) {
+        debugPrint('OBD2 ATI firmware read failed: $e\n$st');
       }
 
       await _primeSupportedPidsCache();

--- a/test/features/consumption/data/obd2/adapter_capability_test.dart
+++ b/test/features/consumption/data/obd2/adapter_capability_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_capability.dart';
+
+void main() {
+  group('detectCapabilityFromFirmwareString (#1401 phase 1)', () {
+    group('STN-chip family → passiveCanCapable', () {
+      test('STN1110 v4.0.4 (OBDLink MX+ stock firmware)', () {
+        expect(
+          detectCapabilityFromFirmwareString('STN1110 v4.0.4'),
+          Obd2AdapterCapability.passiveCanCapable,
+        );
+      });
+
+      test('STN2120 v5.7.1 (newer STN family member)', () {
+        expect(
+          detectCapabilityFromFirmwareString('STN2120 v5.7.1'),
+          Obd2AdapterCapability.passiveCanCapable,
+        );
+      });
+
+      test('lowercase stn1110 still matches (case-insensitive)', () {
+        expect(
+          detectCapabilityFromFirmwareString('stn1110'),
+          Obd2AdapterCapability.passiveCanCapable,
+        );
+      });
+
+      test('whitespace padding is trimmed before matching', () {
+        expect(
+          detectCapabilityFromFirmwareString('  STN1110  '),
+          Obd2AdapterCapability.passiveCanCapable,
+        );
+      });
+    });
+
+    group('genuine ELM327 v2.2+ → oemPidsCapable', () {
+      test('ELM327 v2.2', () {
+        expect(
+          detectCapabilityFromFirmwareString('ELM327 v2.2'),
+          Obd2AdapterCapability.oemPidsCapable,
+        );
+      });
+
+      test('ELM327 v2.3', () {
+        expect(
+          detectCapabilityFromFirmwareString('ELM327 v2.3'),
+          Obd2AdapterCapability.oemPidsCapable,
+        );
+      });
+
+      test('ELM327 v3.0 (future-proofs against a real v3 release)', () {
+        expect(
+          detectCapabilityFromFirmwareString('ELM327 v3.0'),
+          Obd2AdapterCapability.oemPidsCapable,
+        );
+      });
+    });
+
+    group('clones / older firmware → standardOnly', () {
+      test('ELM327 v2.1 — the clone-trap case', () {
+        // Many counterfeit ELM327 clones report v2.1 but only support
+        // the v1.x command set. Phase 1 trusts the version string and
+        // floors the threshold at v2.2; a runtime feature-probe that
+        // downgrades lying clones is filed in the epic caveats.
+        expect(
+          detectCapabilityFromFirmwareString('ELM327 v2.1'),
+          Obd2AdapterCapability.standardOnly,
+        );
+      });
+
+      test('ELM327 v2.0', () {
+        expect(
+          detectCapabilityFromFirmwareString('ELM327 v2.0'),
+          Obd2AdapterCapability.standardOnly,
+        );
+      });
+
+      test('ELM327 v1.5', () {
+        expect(
+          detectCapabilityFromFirmwareString('ELM327 v1.5'),
+          Obd2AdapterCapability.standardOnly,
+        );
+      });
+    });
+
+    group('safe-default cases → standardOnly', () {
+      test('empty string', () {
+        expect(
+          detectCapabilityFromFirmwareString(''),
+          Obd2AdapterCapability.standardOnly,
+        );
+      });
+
+      test('null', () {
+        expect(
+          detectCapabilityFromFirmwareString(null),
+          Obd2AdapterCapability.standardOnly,
+        );
+      });
+
+      test('garbage / unrecognised banner', () {
+        expect(
+          detectCapabilityFromFirmwareString('random garbage'),
+          Obd2AdapterCapability.standardOnly,
+        );
+      });
+
+      test('plausibly-named but unknown firmware', () {
+        expect(
+          detectCapabilityFromFirmwareString('MyCustomFirmware'),
+          Obd2AdapterCapability.standardOnly,
+        );
+      });
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart
+++ b/test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_capability.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapters/smart_obd_adapter.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm327_commands.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
@@ -154,7 +155,10 @@ void main() {
         expect(service.adapter, isA<SmartObdAdapter>());
 
         final sent = transport.commands.map((c) => c.command).toList();
-        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0']);
+        // #1401 phase 1: connect appends a firmware-version probe
+        // (`ATI`) after the init sequence — same interCommandDelay
+        // applies, so it slots into the gap-bound assertions below.
+        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0', 'ATI']);
 
         // Gap before ATE0 reflects the 400 ms postResetDelay.
         final firstGap = transport.commands[1].at - transport.commands[0].at;
@@ -181,6 +185,46 @@ void main() {
                 'not the 400 ms postResetDelay',
           );
         }
+      },
+    );
+  });
+
+  group('Obd2Service capability detection (#1401 phase 1)', () {
+    test('default capability is standardOnly before connect', () {
+      final transport = _RecordingObd2Transport();
+      final service = Obd2Service(transport);
+      // Pre-connect: no firmware string read yet → safe default.
+      expect(service.capability, Obd2AdapterCapability.standardOnly);
+      expect(service.adapterFirmware, isNull);
+    });
+
+    test(
+      'connect captures firmware string and exposes parsed capability '
+      '(STN1110 v4.0.4 → passiveCanCapable)',
+      () async {
+        final transport = _RecordingObd2Transport({
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+          // Real OBDLink MX+ firmware string. Comes back via `ATI`
+          // after the init sequence completes.
+          'ATI': 'STN1110 v4.0.4\r\r>',
+        });
+        final service = Obd2Service(transport);
+
+        // Default before connect — proves the getter is wired and the
+        // value updates only as a result of connect().
+        expect(service.capability, Obd2AdapterCapability.standardOnly);
+
+        final connected = await service.connect();
+        expect(connected, isTrue);
+
+        // After connect: firmware string snapshotted, capability
+        // upgraded to passive CAN.
+        expect(service.adapterFirmware, 'STN1110 v4.0.4');
+        expect(service.capability, Obd2AdapterCapability.passiveCanCapable);
       },
     );
   });

--- a/test/features/consumption/data/obd2/adapters/v_linker_fs_adapter_test.dart
+++ b/test/features/consumption/data/obd2/adapters/v_linker_fs_adapter_test.dart
@@ -110,7 +110,10 @@ void main() {
         expect(service.adapter, isA<VLinkerFsAdapter>());
 
         final sent = transport.commands.map((c) => c.command).toList();
-        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0']);
+        // #1401 phase 1: the connect path now appends an `ATI`
+        // firmware-version probe after the init sequence. Subject to
+        // the same interCommandDelay as the rest of the loop.
+        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0', 'ATI']);
 
         // Gap between cmd[0] (ATZ) and cmd[1] (ATE0) reflects the
         // 200 ms postResetDelay. Generous lower bound (180 ms) avoids

--- a/test/features/consumption/data/obd2/elm327_adapter_test.dart
+++ b/test/features/consumption/data/obd2/elm327_adapter_test.dart
@@ -109,7 +109,8 @@ void main() {
         final connected = await service.connect();
 
         expect(connected, isTrue);
-        // Captured commands match the legacy init list exactly.
+        // Captured commands match the legacy init list exactly,
+        // followed by the #1401 phase 1 firmware-version probe.
         final sent = transport.commands.map((c) => c.command).toList();
         expect(sent, [
           'ATZ',
@@ -117,6 +118,7 @@ void main() {
           'ATL0',
           'ATH0',
           'ATSP0',
+          'ATI',
         ]);
 
         // Inter-command intervals are at least the configured 100 ms

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -649,6 +649,9 @@ void main() {
         // service's connect path with the legacy hardcoded init list.
         // If [GenericElm327Adapter.initSequence] or the connect loop
         // diverges, this test fails before any production user does.
+        // #1401 phase 1 appended a follow-up `ATI` (firmware-version
+        // probe) — included in the expected list but does not change
+        // the init sequence itself.
         final sent = <String>[];
         final transport = _RecordingTransport(
           {
@@ -657,12 +660,13 @@ void main() {
             'ATL0': 'OK>',
             'ATH0': 'OK>',
             'ATSP0': 'OK>',
+            'ATI': 'ELM327 v1.5>',
           },
           sent,
         );
         final service = Obd2Service(transport);
         await service.connect();
-        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0']);
+        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0', 'ATI']);
       },
     );
 


### PR DESCRIPTION
## Summary

Phase 1 of #1401 — pure runtime adapter-capability detection from the ATI firmware string. No behaviour change downstream yet; phases 2-7 will gate behaviour on the new `capability` getter.

- New enum `Obd2AdapterCapability { standardOnly, oemPidsCapable, passiveCanCapable }` in `lib/features/consumption/data/obd2/adapter_capability.dart` (order matters — comparators in later phases use ascending capability).
- Pure parser `detectCapabilityFromFirmwareString(String? ati)` in the same file.
- Wired detection into `Obd2Service.connect`: after the init sequence runs, we now send `ATI`, snapshot the response into the existing `adapterFirmware` field, and expose the parsed tier via a new `capability` getter. Default before the firmware string is read is `standardOnly`. No production call site branches on this yet.

The existing init sequence didn't already send `ATI` (the field was wired with a TODO comment) — the `ATI` send is new in this PR. Three pre-existing init-sequence regression tests had to be updated to expect the appended `ATI` command alongside the legacy 5-command init list.

## Matching rules (case-insensitive, leading/trailing whitespace trimmed)

- `STN1110*` / `STN2120*` (any version) → `passiveCanCapable`
- `ELM327 vX.Y` where `X >= 3` or (`X == 2` and `Y >= 2`) → `oemPidsCapable`
- Anything else, including `ELM327 v2.0`, `ELM327 v2.1`, `ELM327 v1.x`, empty, null, garbage → `standardOnly`

The well-known v2.1-clones-claiming-v2.2 trap is explicitly out of scope per the epic body — phase 1 trusts the version string. A runtime feature-probe is filed for a later phase.

## Test matrix

`test/features/consumption/data/obd2/adapter_capability_test.dart` — 14 unit tests on the parser:

| input | expected |
|---|---|
| `STN1110 v4.0.4` | passive |
| `STN2120 v5.7.1` | passive |
| `stn1110` (lowercase) | passive |
| `  STN1110  ` (whitespace) | passive |
| `ELM327 v2.2` | oemPids |
| `ELM327 v2.3` | oemPids |
| `ELM327 v3.0` | oemPids |
| `ELM327 v2.1` (clone-trap) | standardOnly |
| `ELM327 v2.0` | standardOnly |
| `ELM327 v1.5` | standardOnly |
| `''` (empty) | standardOnly |
| `null` | standardOnly |
| `random garbage` | standardOnly |
| `MyCustomFirmware` | standardOnly |

Plus integration coverage in `test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart` proving (a) `capability` is `standardOnly` before connect, and (b) after `connect()` against a fake transport returning `STN1110 v4.0.4`, `service.adapterFirmware == 'STN1110 v4.0.4'` and `service.capability == passiveCanCapable`.

## Test plan

- [x] `flutter analyze` — zero warnings, zero infos
- [x] `flutter test test/features/consumption/data/obd2/adapter_capability_test.dart` — 14/14 pass
- [x] `flutter test test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart` — capability integration test green
- [x] `flutter test test/features/consumption/data/obd2/obd2_service_test.dart` — 82/82 pass with updated init-sequence regression test
- [x] `flutter test test/features/consumption/data/obd2/elm327_adapter_test.dart` `test/features/consumption/data/obd2/adapters/v_linker_fs_adapter_test.dart` — pre-existing init-list regression tests updated for the appended `ATI` command
- [ ] CI runs full suite

Closes #1402