### PR TITLE
fix(vehicle): consolidate the two adapter-pair CTAs on vehicle edit screen into one (Closes #1400)

### DIFF
--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -34,9 +34,28 @@ class EditVehicleScreen extends ConsumerStatefulWidget {
   ConsumerState<EditVehicleScreen> createState() => _EditVehicleScreenState();
 }
 
-class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
+class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
+    with SingleTickerProviderStateMixin {
   final _formKey = GlobalKey<FormState>();
   final _ctrl = VehicleFormControllers();
+
+  // #1400 — anchors the OBD2 adapter card in the scrollable so the
+  // passive "Pair an adapter in the section below" link on the
+  // auto-record card can `Scrollable.ensureVisible` to it.
+  final GlobalKey _obd2CardKey = GlobalKey();
+
+  // #1400 — scroll controller for the host `ListView`. Owned here
+  // (instead of relying on the implicit primary controller) so the
+  // auto-record link's tap handler can fall back to an `animateTo(0)`
+  // when the OBD2 card has been virtualised out of the tree by
+  // ListView's lazy build, then run `Scrollable.ensureVisible` once
+  // the card remounts.
+  final ScrollController _scrollController = ScrollController();
+
+  // #1400 — drives a brief amber border pulse on the OBD2 card after
+  // the user taps the auto-record link. forward → reverse runs
+  // 1 s end-to-end (500 ms each way).
+  late final AnimationController _obd2HighlightController;
 
   // #710 — combustion default; user can flip to Hybrid/Electric.
   VehicleType _type = VehicleType.combustion;
@@ -75,6 +94,10 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
     super.initState();
     // Rebuild on every name keystroke so the header title tracks input.
     _ctrl.nameController.addListener(_refresh);
+    _obd2HighlightController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 500),
+    );
     if (widget.vehicleId != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _loadExisting());
     }
@@ -120,7 +143,64 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
   void dispose() {
     _ctrl.nameController.removeListener(_refresh);
     _ctrl.dispose();
+    _obd2HighlightController.dispose();
+    _scrollController.dispose();
     super.dispose();
+  }
+
+  /// Scrolls the host `ListView` so the OBD2 adapter card is visible
+  /// near the top of the viewport and pulses an amber border around
+  /// it for ~1 s (#1400). Wired to the passive "Pair an adapter in
+  /// the section below" link on the auto-record card so users have a
+  /// single canonical place to pair an adapter — this method just
+  /// surfaces it.
+  ///
+  /// Two-stage scroll: ListView lazily builds children, so when the
+  /// user has scrolled the auto-record link into view the OBD2 card
+  /// (which lives ABOVE) may have already been virtualised out of
+  /// the tree. In that case `_obd2CardKey.currentContext` is null
+  /// and `Scrollable.ensureVisible` cannot fire. We `animateTo(0)`
+  /// first to pull the OBD2 card back into the tree, then run
+  /// `ensureVisible` so the card lands near the top of the viewport
+  /// regardless of small layout shifts above (header / identity /
+  /// drivetrain cards).
+  ///
+  /// Safe no-op if the OBD2 card isn't in the tree even after the
+  /// pull-back (e.g. brand-new vehicle that hasn't been saved yet —
+  /// the extras section is gated on `_existingId != null`).
+  Future<void> _scrollToAndHighlightObd2Card() async {
+    // Stage 1 — pull the OBD2 card back into the tree. Cheap no-op
+    // when the controller has no clients (e.g. isolated widget
+    // pumps that don't mount a Scrollable) or when offset is
+    // already near zero.
+    if (_scrollController.hasClients && _scrollController.offset > 0) {
+      await _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+      if (!mounted) return;
+    }
+    // Stage 2 — once the card is in the tree, ensure it lands at
+    // alignment 0.1 (near the top, with a small breathing-room
+    // strip above so the user can see we scrolled). The
+    // `currentContext` lookup happens AFTER the previous await so
+    // we always pick up the freshly-mounted element.
+    final ctx = _obd2CardKey.currentContext;
+    if (ctx == null || !ctx.mounted) return;
+    await Scrollable.ensureVisible(
+      ctx,
+      duration: const Duration(milliseconds: 400),
+      alignment: 0.1,
+    );
+    if (!mounted) return;
+    // Run the highlight controller once forward → reverse so the
+    // border fades in over 500 ms then back out over 500 ms (1 s
+    // total). Awaiting forward then reverse keeps the controller
+    // sequence deterministic for tests.
+    await _obd2HighlightController.forward(from: 0.0);
+    if (!mounted) return;
+    await _obd2HighlightController.reverse();
   }
 
   /// Open the VIN explanation sheet (#895). Restores focus on dismiss
@@ -334,6 +414,7 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
       body: Form(
         key: _formKey,
         child: ListView(
+          controller: _scrollController,
           padding: EdgeInsets.fromLTRB(16, 16, 16,
               MediaQuery.of(context).viewPadding.bottom + 96),
           children: [
@@ -405,12 +486,23 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen> {
                 onAdapterForget: () => _onAdapterChanged(null, null),
                 onResetVolumetricEfficiency: _resetVolumetricEfficiency,
                 currentOdometerKm: ref.latestOdometerKm(_existingId!),
+                obd2CardKey: _obd2CardKey,
+                obd2HighlightAnimation: _obd2HighlightController,
               ),
               // Card: hands-free auto-record settings (#1004 phase 6).
               // Spread alongside the extras list so the host ListView
               // owns scroll virtualisation for the row.
+              // #1400 — the auto-record card's "Pair an adapter in the
+              // section below" link calls back into the screen so we
+              // can `Scrollable.ensureVisible` the canonical OBD2 card
+              // and pulse its border. The link replaces the duplicate
+              // orange-tinted "Pair an adapter" button that lived in
+              // the auto-record card before #1400.
               const SizedBox(height: 16),
-              AutoRecordSection(vehicleId: _existingId!),
+              AutoRecordSection(
+                vehicleId: _existingId!,
+                onScrollToObd2Card: _scrollToAndHighlightObd2Card,
+              ),
             ],
           ],
         ),

--- a/lib/features/vehicle/presentation/widgets/auto_record_section.dart
+++ b/lib/features/vehicle/presentation/widgets/auto_record_section.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../../../../core/logging/error_logger.dart';
 import '../../../../core/widgets/section_card.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../consumption/data/obd2/adapter_registry.dart';
-import '../../../consumption/presentation/widgets/obd2_adapter_picker.dart';
 import '../../domain/entities/vehicle_profile.dart';
 import '../../providers/vehicle_providers.dart';
 
@@ -23,8 +20,10 @@ import '../../providers/vehicle_providers.dart';
 ///
 ///   * Active — both prerequisites satisfied; auto-record arms next
 ///     drive.
-///   * Needs pairing — no `pairedAdapterMac` set; CTA pushes the
-///     OBD2 onboarding wizard.
+///   * Needs pairing — no `pairedAdapterMac` set. #1400 — the card
+///     surfaces a passive informational link pointing the user at
+///     the canonical "OBD2 adapter" card below; the actual pair CTA
+///     lives there to consolidate the two adapter-pair entry points.
 ///   * Needs background location — adapter paired but consent
 ///     missing; the existing background-location row below already
 ///     surfaces the OS prompt.
@@ -66,22 +65,14 @@ class AutoRecordSection extends ConsumerWidget {
   /// real Android intent.
   final Future<void> Function()? openSettings;
 
-  /// Hook invoked when the user taps the "Pair an adapter" CTA on the
-  /// state-aware status banner (#1310). When supplied this hook fully
-  /// owns the CTA — the production picker + persist + `/setup`
-  /// fallback are all skipped. Tests inject a counter to assert the
-  /// CTA dispatched without bringing up the picker. Null defers to
-  /// the production behaviour — open [showObd2AdapterPairer] inline
-  /// and persist the picked adapter onto the current profile (#1350).
-  final VoidCallback? onPairAdapter;
-
-  /// Picker seam for [_handlePairAdapter] (#1350). Null defers to the
-  /// production [showObd2AdapterPairer] which mounts the modal sheet
-  /// and resolves with a [ResolvedObd2Candidate] on pick or `null`
-  /// on cancel. Tests inject a stub so the candidate flows into the
-  /// persist path without binding the OBD2 stack.
-  final Future<ResolvedObd2Candidate?> Function(BuildContext)?
-      showAdapterPicker;
+  /// Hook invoked when the user taps the passive "Pair an adapter in
+  /// the section below" link rendered while the vehicle has no paired
+  /// adapter (#1400). Wired by [EditVehicleScreen] to scroll the host
+  /// `ListView` to the canonical "OBD2 adapter" card and pulse its
+  /// border. Null is permitted (e.g. isolated widget tests that don't
+  /// care about scrolling); the link still renders and tapping it is a
+  /// safe no-op.
+  final VoidCallback? onScrollToObd2Card;
 
   const AutoRecordSection({
     super.key,
@@ -89,8 +80,7 @@ class AutoRecordSection extends ConsumerWidget {
     this.requestBackgroundLocation,
     this.requestForegroundLocation,
     this.openSettings,
-    this.onPairAdapter,
-    this.showAdapterPicker,
+    this.onScrollToObd2Card,
   });
 
   static Future<PermissionStatus> _defaultRequestBackgroundLocation() {
@@ -151,11 +141,7 @@ class AutoRecordSection extends ConsumerWidget {
               state: _statusFor(profile),
               theme: theme,
               l: l,
-              onPairAdapter: () => _handlePairAdapter(
-                context: context,
-                ref: ref,
-                profile: profile,
-              ),
+              onScrollToObd2Card: onScrollToObd2Card,
             ),
             const SizedBox(height: 16),
             _SpeedThresholdSlider(
@@ -225,95 +211,6 @@ class AutoRecordSection extends ConsumerWidget {
       return _AutoRecordStatus.needsBackgroundLocation;
     }
     return _AutoRecordStatus.active;
-  }
-
-  /// "Pair an adapter" CTA on the [_AutoRecordStatus.needsPairing]
-  /// banner.
-  ///
-  /// Behaviour (#1350):
-  ///   1. If [onPairAdapter] is injected (tests) it fully owns the
-  ///      tap — invoked and returned, no picker, no fallback.
-  ///   2. Otherwise open [showObd2AdapterPairer] (or the injected
-  ///      [showAdapterPicker] seam) inline. On a non-null result,
-  ///      persist `pairedAdapterMac` + `obd2AdapterMac` +
-  ///      `obd2AdapterName` onto the current profile so the banner
-  ///      flips to `active` (or `needsBackgroundLocation`) on the
-  ///      next rebuild.
-  ///   3. On cancel (null result) OR on picker exception, fall back
-  ///      to `GoRouter.go('/setup')` per the issue spec — the user
-  ///      asked to pair, so route them somewhere that still surfaces
-  ///      the wizard rather than silently dropping the tap.
-  ///
-  /// Pre-#1350 the production fallback ALWAYS routed to `/setup`
-  /// even on a successful pick, sending the user into an unrelated
-  /// onboarding wizard whose result landed on a freshly-saved
-  /// profile rather than the vehicle they were editing. The picker
-  /// is now invoked inline and writes back to the right profile.
-  Future<void> _handlePairAdapter({
-    required BuildContext context,
-    required WidgetRef ref,
-    required VehicleProfile profile,
-  }) async {
-    final hook = onPairAdapter;
-    if (hook != null) {
-      hook();
-      return;
-    }
-    final picker = showAdapterPicker ?? showObd2AdapterPairer;
-    ResolvedObd2Candidate? result;
-    try {
-      result = await picker(context);
-    } catch (e, st) {
-      // Surface picker failures via debugPrint (cheap, test-safe — the
-      // structured `errorLogger` opens a Hive box that isolated widget
-      // pumps don't initialise). No silent catch — body has a log
-      // statement so `no_silent_catch_test` stays green.
-      debugPrint(
-        'AutoRecordSection: pair-adapter picker failed: $e\n$st',
-      );
-      if (!context.mounted) return;
-      _navigateToSetupFallback(context);
-      return;
-    }
-    if (result == null) {
-      // User cancelled the picker. Per the #1350 spec the `/setup`
-      // fallback fires here so the user has SOMEWHERE to land — the
-      // CTA must never feel like a no-op.
-      if (!context.mounted) return;
-      _navigateToSetupFallback(context);
-      return;
-    }
-    final mac = result.candidate.deviceId;
-    final name = result.candidate.deviceName.isEmpty
-        ? result.profile.displayName
-        : result.candidate.deviceName;
-    await _persist(
-      ref,
-      profile.copyWith(
-        pairedAdapterMac: mac,
-        obd2AdapterMac: mac,
-        obd2AdapterName: name,
-      ),
-    );
-  }
-
-  /// Best-effort `/setup` route push used as the cancel/error
-  /// fallback for [_handlePairAdapter]. A missing router context
-  /// (isolated widget pump) is logged via [debugPrint] rather than
-  /// thrown so the surface stays testable. We deliberately avoid the
-  /// structured [errorLogger] here because it opens a Hive box and
-  /// widget tests that pump this section without initialising Hive
-  /// would fail noisily on what is otherwise a benign test-pump
-  /// shape.
-  void _navigateToSetupFallback(BuildContext context) {
-    try {
-      GoRouter.of(context).go('/setup');
-    } catch (e, st) {
-      // No silent catch — body logs the failure.
-      debugPrint(
-        'AutoRecordSection: pair-adapter setup-fallback nav failed: $e\n$st',
-      );
-    }
   }
 
   /// Two-step background-location grant flow (#1302).
@@ -462,7 +359,10 @@ class AutoRecordSection extends ConsumerWidget {
 
 /// Three real prerequisites the auto-record orchestrator gates on
 /// (#1310). Drives the colour, icon, copy, and presence of the
-/// "Pair an adapter" CTA on [_AutoRecordStatusBanner].
+/// passive "Pair an adapter in the section below" link on
+/// [_AutoRecordStatusBanner] (#1400 — replaces the pre-#1400
+/// orange-tinted "Pair an adapter" CTA that duplicated the canonical
+/// pair button on the OBD2 card directly below).
 enum _AutoRecordStatus {
   /// Adapter paired and background-location consent granted —
   /// orchestrator will arm next time the user enters the car.
@@ -482,17 +382,30 @@ class _AutoRecordStatusBanner extends StatelessWidget {
   final _AutoRecordStatus state;
   final ThemeData theme;
   final AppLocalizations? l;
-  final VoidCallback onPairAdapter;
+  final VoidCallback? onScrollToObd2Card;
 
   const _AutoRecordStatusBanner({
     required this.state,
     required this.theme,
     required this.l,
-    required this.onPairAdapter,
+    required this.onScrollToObd2Card,
   });
 
   @override
   Widget build(BuildContext context) {
+    // #1400 — needsPairing renders a passive informational link
+    // pointing the user at the canonical OBD2 adapter card below
+    // instead of duplicating the pair CTA inline. Other states keep
+    // the pre-#1400 banner shape.
+    if (state == _AutoRecordStatus.needsPairing) {
+      return _PairAdapterLink(
+        key: const Key('autoRecordStatusBannerNeedsPairing'),
+        theme: theme,
+        l: l,
+        onTap: onScrollToObd2Card,
+      );
+    }
+
     final isActive = state == _AutoRecordStatus.active;
     final container = isActive
         ? theme.colorScheme.primaryContainer
@@ -509,38 +422,19 @@ class _AutoRecordStatusBanner extends StatelessWidget {
         color: container,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(icon, color: onContainer, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  _labelFor(state, l),
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: onContainer,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          if (state == _AutoRecordStatus.needsPairing) ...[
-            const SizedBox(height: 8),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: FilledButton.tonalIcon(
-                key: const Key('autoRecordStatusPairAdapterCta'),
-                onPressed: onPairAdapter,
-                icon: const Icon(Icons.bluetooth_searching),
-                label: Text(
-                  l?.autoRecordStatusPairAdapterCta ?? 'Pair an adapter',
-                ),
+          Icon(icon, color: onContainer, size: 20),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              _labelFor(state, l),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: onContainer,
               ),
             ),
-          ],
+          ),
         ],
       ),
     );
@@ -552,6 +446,10 @@ class _AutoRecordStatusBanner extends StatelessWidget {
         return l?.autoRecordStatusActiveLabel ??
             'Auto-record will activate the next time you enter the car.';
       case _AutoRecordStatus.needsPairing:
+        // Unused for needsPairing — the passive link in
+        // [_PairAdapterLink] supplies its own copy. Kept as a fallback
+        // for completeness so a future refactor that re-routes this
+        // helper for needsPairing still gets a sensible string.
         return l?.autoRecordStatusNeedsPairingLabel ??
             'Pair an OBD2 adapter to enable auto-record.';
       case _AutoRecordStatus.needsBackgroundLocation:
@@ -570,6 +468,56 @@ class _AutoRecordStatusBanner extends StatelessWidget {
       case _AutoRecordStatus.needsBackgroundLocation:
         return 'autoRecordStatusBannerNeedsBackgroundLocation';
     }
+  }
+}
+
+/// Passive informational link rendered in the [_AutoRecordStatus.needsPairing]
+/// state (#1400). Replaces the pre-#1400 orange-tinted "Pair an
+/// adapter" button + warning box that duplicated the canonical pair
+/// CTA on the OBD2 adapter card directly below this section. Tapping
+/// the link calls [onTap] (wired by [EditVehicleScreen] to scroll to
+/// and pulse the OBD2 card); a null callback is a safe no-op so
+/// isolated widget tests don't need to wire scroll plumbing.
+class _PairAdapterLink extends StatelessWidget {
+  final ThemeData theme;
+  final AppLocalizations? l;
+  final VoidCallback? onTap;
+
+  const _PairAdapterLink({
+    super.key,
+    required this.theme,
+    required this.l,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = theme.colorScheme.onSurfaceVariant;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: InkWell(
+        key: const Key('autoRecordPairAdapterLink'),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              Icon(Icons.info_outline, size: 18, color: color),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  l?.autoRecordPairAdapterLinkText ??
+                      'Pair an adapter in the section below to enable '
+                          'auto-recording',
+                  style: theme.textTheme.bodySmall,
+                ),
+              ),
+              Icon(Icons.arrow_downward, size: 16, color: color),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/features/vehicle/presentation/widgets/vehicle_extras_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_extras_section.dart
@@ -27,16 +27,26 @@ class VehicleExtrasSection {
     required VoidCallback onAdapterForget,
     required VoidCallback onResetVolumetricEfficiency,
     required double? currentOdometerKm,
+    Key? obd2CardKey,
+    Animation<double>? obd2HighlightAnimation,
   }) {
     final l = AppLocalizations.of(context);
     return [
       // Card 3: OBD2 adapter pairing (#779). Stable vehicle id only.
+      // #1400 — `obd2CardKey` anchors the section so the auto-record
+      // card's "Pair an adapter in the section below" link can
+      // `Scrollable.ensureVisible` to it; `obd2HighlightAnimation`
+      // drives a 1 s amber border pulse on tap.
       const SizedBox(height: 16),
-      VehicleAdapterSection(
-        adapterMac: adapterMac,
-        adapterName: adapterName,
-        onPaired: onAdapterPaired,
-        onForget: onAdapterForget,
+      _Obd2AdapterCardHighlight(
+        key: obd2CardKey,
+        animation: obd2HighlightAnimation,
+        child: VehicleAdapterSection(
+          adapterMac: adapterMac,
+          adapterName: adapterName,
+          onPaired: onAdapterPaired,
+          onForget: onAdapterForget,
+        ),
       ),
       // Baseline calibration section (#779). Only renders once a
       // vehicle is saved — hidden during the Add flow.
@@ -65,5 +75,49 @@ class VehicleExtrasSection {
         currentOdometerKm: currentOdometerKm,
       ),
     ];
+  }
+}
+
+/// Wraps the OBD2 adapter card with an animated amber border that
+/// fades in/out for ~1 s when the auto-record card's "Pair an
+/// adapter in the section below" link is tapped (#1400). The border
+/// is invisible when the controller sits at 0.0, which is the
+/// resting state — so the wrapper is a no-op overhead until the
+/// link tap triggers a forward → reverse cycle.
+///
+/// A null [animation] disables the pulse and renders the child
+/// verbatim — used by isolated widget tests that don't care about
+/// the consolidate-CTA flow.
+class _Obd2AdapterCardHighlight extends StatelessWidget {
+  final Animation<double>? animation;
+  final Widget child;
+
+  const _Obd2AdapterCardHighlight({
+    super.key,
+    required this.animation,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final anim = animation;
+    if (anim == null) return child;
+    return AnimatedBuilder(
+      animation: anim,
+      builder: (context, child) {
+        final t = anim.value.clamp(0.0, 1.0);
+        return Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: Colors.amber.withValues(alpha: t),
+              width: 2,
+            ),
+          ),
+          child: child,
+        );
+      },
+      child: child,
+    );
   }
 }

--- a/lib/l10n/_fragments/auto_record_pair_link_de.arb
+++ b/lib/l10n/_fragments/auto_record_pair_link_de.arb
@@ -1,0 +1,3 @@
+{
+  "autoRecordPairAdapterLinkText": "Adapter im Abschnitt unten koppeln, um automatisches Aufzeichnen zu aktivieren"
+}

--- a/lib/l10n/_fragments/auto_record_pair_link_en.arb
+++ b/lib/l10n/_fragments/auto_record_pair_link_en.arb
@@ -1,0 +1,6 @@
+{
+  "autoRecordPairAdapterLinkText": "Pair an adapter in the section below to enable auto-recording",
+  "@autoRecordPairAdapterLinkText": {
+    "description": "Passive informational link rendered on the auto-record card when no adapter is paired (#1400). Replaces the duplicate orange-tinted 'Pair an adapter' CTA that lived in the auto-record card before #1400; tapping the link scrolls to the canonical 'OBD2 adapter' card below and pulses its border."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1273,6 +1273,7 @@
   "autoRecordBackgroundLocationForegroundDeniedSnackbar": "Standortberechtigung erforderlich",
   "autoRecordBackgroundLocationRequestFailedSnackbar": "Hintergrundstandort konnte nicht angefordert werden",
   "autoRecordBadgeClearTooltip": "Zähler zurücksetzen",
+  "autoRecordPairAdapterLinkText": "Adapter im Abschnitt unten koppeln, um automatisches Aufzeichnen zu aktivieren",
   "exportBackupTooltip": "Sicherung exportieren",
   "exportBackupReady": "Sicherung bereit – Ziel auswählen",
   "exportBackupFailed": "Sicherungsexport fehlgeschlagen – bitte erneut versuchen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1544,6 +1544,10 @@
   "@autoRecordBadgeClearTooltip": {
     "description": "Tooltip on the AppBar action that resets the auto-record unseen-trip badge to zero."
   },
+  "autoRecordPairAdapterLinkText": "Pair an adapter in the section below to enable auto-recording",
+  "@autoRecordPairAdapterLinkText": {
+    "description": "Passive informational link rendered on the auto-record card when no adapter is paired (#1400). Replaces the duplicate orange-tinted 'Pair an adapter' CTA that lived in the auto-record card before #1400; tapping the link scrolls to the canonical 'OBD2 adapter' card below and pulses its border."
+  },
   "exportBackupTooltip": "Export backup",
   "@exportBackupTooltip": {
     "description": "AppBar IconButton tooltip on the consumption screen for the full XML-in-ZIP backup export (#1317)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -930,6 +930,7 @@
   "autoRecordBackgroundLocationForegroundDeniedSnackbar": "L'autorisation de localisation est requise",
   "autoRecordBackgroundLocationRequestFailedSnackbar": "Impossible de demander la localisation en arrière-plan",
   "autoRecordBadgeClearTooltip": "Effacer le compteur",
+  "autoRecordPairAdapterLinkText": "Associez un adaptateur dans la section ci-dessous pour activer l'enregistrement automatique",
   "consumptionLogTitle": "Consommation",
   "consumptionTabFuel": "Carburant",
   "trajetsTabLabel": "Trajets",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5930,6 +5930,12 @@ abstract class AppLocalizations {
   /// **'Clear counter'**
   String get autoRecordBadgeClearTooltip;
 
+  /// Passive informational link rendered on the auto-record card when no adapter is paired (#1400). Replaces the duplicate orange-tinted 'Pair an adapter' CTA that lived in the auto-record card before #1400; tapping the link scrolls to the canonical 'OBD2 adapter' card below and pulses its border.
+  ///
+  /// In en, this message translates to:
+  /// **'Pair an adapter in the section below to enable auto-recording'**
+  String get autoRecordPairAdapterLinkText;
+
   /// AppBar IconButton tooltip on the consumption screen for the full XML-in-ZIP backup export (#1317).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3170,6 +3170,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3170,6 +3170,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3168,6 +3168,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3196,6 +3196,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Zähler zurücksetzen';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Adapter im Abschnitt unten koppeln, um automatisches Aufzeichnen zu aktivieren';
+
+  @override
   String get exportBackupTooltip => 'Sicherung exportieren';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3172,6 +3172,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3163,6 +3163,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3171,6 +3171,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3165,6 +3165,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3168,6 +3168,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3197,6 +3197,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Effacer le compteur';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Associez un adaptateur dans la section ci-dessous pour activer l\'enregistrement automatique';
+
+  @override
   String get exportBackupTooltip => 'Exporter la sauvegarde';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3167,6 +3167,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3172,6 +3172,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3171,6 +3171,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3169,6 +3169,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3171,6 +3171,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3167,6 +3167,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3172,6 +3172,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3170,6 +3170,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3171,6 +3171,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3170,6 +3170,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3171,6 +3171,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3165,6 +3165,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3169,6 +3169,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get autoRecordBadgeClearTooltip => 'Clear counter';
 
   @override
+  String get autoRecordPairAdapterLinkText =>
+      'Pair an adapter in the section below to enable auto-recording';
+
+  @override
   String get exportBackupTooltip => 'Export backup';
 
   @override

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_consolidate_pair_cta_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_consolidate_pair_cta_test.dart
@@ -1,0 +1,283 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/presentation/screens/edit_vehicle_screen.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Integration tests for #1400: the auto-record card's passive
+/// "Pair an adapter in the section below" link must scroll the host
+/// `ListView` to the canonical OBD2 adapter card and pulse its
+/// border. Pre-#1400 the auto-record card carried a duplicate
+/// orange-tinted "Pair an adapter" CTA that opened the picker —
+/// users had two CTAs side by side that did the same thing. After
+/// #1400 there is exactly ONE pair entry point: the OBD2 adapter
+/// card's "Pair adapter" button. The auto-record card just points
+/// users at it.
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp
+        .createTemp('edit_vehicle_consolidate_pair_cta_');
+    Hive.init(tempDir.path);
+    await Hive.openBox<String>(HiveBoxes.serviceReminders);
+    await Hive.openBox<String>(HiveBoxes.obd2Baselines);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('EditVehicleScreen — consolidate pair CTA (#1400)', () {
+    testWidgets(
+      'auto-record card renders the passive link and the OBD2 card '
+      'still renders the canonical pair button (single source of truth)',
+      (tester) async {
+        // Tall canvas so multiple cards fit without overflow during
+        // the test pump.
+        tester.view.physicalSize = const Size(900, 2400);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final repo = VehicleProfileRepository(_FakeSettings());
+        await repo.save(const VehicleProfile(
+          id: 'v1',
+          name: 'Car',
+          autoRecord: true,
+        ));
+
+        await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+
+        // Sanity — the auto-record card is on screen and surfaces the
+        // passive link, NOT the deprecated CTA.
+        await tester.dragUntilVisible(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+          find.byType(ListView),
+          const Offset(0, -200),
+        );
+        expect(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
+          findsNothing,
+          reason:
+              '#1400 — the duplicate orange-tinted CTA on the auto-record '
+              'card must be gone',
+        );
+
+        // The OBD2 adapter card still owns the canonical pair button.
+        await tester.dragUntilVisible(
+          find.byKey(const Key('vehicleAdapterPair')),
+          find.byType(ListView),
+          const Offset(0, -200),
+        );
+        expect(find.byKey(const Key('vehicleAdapterPair')), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping the auto-record link scrolls the host ListView so the '
+      'OBD2 card lands inside the viewport (#1400)',
+      (tester) async {
+        // Phone-sized canvas (taller than wide) so the cards genuinely
+        // live on different pages of the ListView. The OBD2 card is
+        // ABOVE the auto-record link in the layout (extras section
+        // spreads first), so to exercise the scroll we have to land
+        // the OBD2 card OFF-screen above the viewport — only then does
+        // `Scrollable.ensureVisible` have meaningful work to do. Width
+        // 600 keeps the drivetrain dropdowns inside their flex bounds.
+        tester.view.physicalSize = const Size(600, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final repo = VehicleProfileRepository(_FakeSettings());
+        await repo.save(const VehicleProfile(
+          id: 'v1',
+          name: 'Car',
+          autoRecord: true,
+        ));
+
+        await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+
+        // The auto-record link sits below the fold by default. Drag
+        // the ListView until it's mounted in the tree, then anchor it
+        // to the BOTTOM of the viewport so the OBD2 card (which is
+        // above) sits above the top edge — that's the only configuration
+        // where `Scrollable.ensureVisible` has meaningful work to do.
+        await tester.dragUntilVisible(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+          find.byType(ListView),
+          const Offset(0, -200),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final linkCtx = tester.element(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+        );
+        await Scrollable.ensureVisible(
+          linkCtx,
+          alignment: 1.0,
+          duration: Duration.zero,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Snapshot the scroll offset BEFORE the tap so we can prove
+        // the tap moved the viewport.
+        ScrollPosition position() {
+          final state = tester
+              .state<ScrollableState>(find.byType(Scrollable).first);
+          return state.position;
+        }
+
+        final beforeOffset = position().pixels;
+
+        await tester.tap(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+        );
+        // Pump enough frames for the 400 ms ensureVisible scroll plus
+        // the 1 s forward+reverse highlight cycle (500 ms each).
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.pump(const Duration(milliseconds: 600));
+        await tester.pump(const Duration(milliseconds: 600));
+
+        final afterOffset = position().pixels;
+
+        // The OBD2 card lives ABOVE the link in the layout, so the
+        // ensureVisible call scrolls UP — i.e. the offset DECREASES.
+        // We don't pin a specific delta because the exact pixel jump
+        // depends on text-metric layout, but the offset MUST have
+        // moved.
+        expect(
+          afterOffset,
+          lessThan(beforeOffset),
+          reason:
+              'Tapping the auto-record link must scroll up so the OBD2 '
+              'card (which lives above the link) lands inside the '
+              'viewport',
+        );
+      },
+    );
+
+    testWidgets(
+      'tapping the link does not crash if the OBD2 card was already '
+      'visible (#1400)',
+      (tester) async {
+        // Ultra-tall canvas — every card renders in-viewport at once,
+        // so the scroll is a no-op. The tap must still complete
+        // without throwing.
+        tester.view.physicalSize = const Size(900, 4000);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final repo = VehicleProfileRepository(_FakeSettings());
+        await repo.save(const VehicleProfile(
+          id: 'v1',
+          name: 'Car',
+          autoRecord: true,
+        ));
+
+        await _pumpEditScreen(tester, repo: repo, vehicleId: 'v1');
+
+        // Both link and pair button visible without scrolling.
+        expect(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+          findsOneWidget,
+        );
+        expect(find.byKey(const Key('vehicleAdapterPair')), findsOneWidget);
+
+        await tester.tap(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+        );
+        // Pump the highlight cycle to completion so the controller
+        // doesn't leak a pending future into the test.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.pump(const Duration(milliseconds: 600));
+        await tester.pump(const Duration(milliseconds: 600));
+
+        // No exceptions surfaced (the test would already have failed
+        // on a thrown exception). Belt-and-suspender: still find the
+        // tree intact.
+        expect(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+          findsOneWidget,
+        );
+        expect(find.byKey(const Key('vehicleAdapterPair')), findsOneWidget);
+      },
+    );
+  });
+}
+
+Future<void> _pumpEditScreen(
+  WidgetTester tester, {
+  required VehicleProfileRepository repo,
+  required String vehicleId,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        vehicleProfileRepositoryProvider.overrideWithValue(repo),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: EditVehicleScreen(vehicleId: vehicleId),
+      ),
+    ),
+  );
+  // Bounded pump — the screen has a postFrameCallback that hydrates
+  // the form controllers from the provider. Two pumps after the
+  // initial paint is enough; a pumpAndSettle would block on any
+  // background animation in the children (none here, but cheap to
+  // be safe).
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+class _FakeSettings implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  bool get isSetupComplete => false;
+
+  @override
+  bool get isSetupSkipped => false;
+
+  @override
+  Future<void> skipSetup() async {}
+
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/vehicle/presentation/widgets/auto_record_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/auto_record_section_test.dart
@@ -1,13 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/presentation/widgets/auto_record_section.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
-import 'package:tankstellen/l10n/app_localizations.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -42,8 +38,7 @@ Future<_FakeVehicleProfileList> _pumpSection(
   Future<PermissionStatus> Function()? requestBackgroundLocation,
   Future<PermissionStatus> Function()? requestForegroundLocation,
   Future<void> Function()? openSettings,
-  VoidCallback? onPairAdapter,
-  Future<ResolvedObd2Candidate?> Function(BuildContext)? showAdapterPicker,
+  VoidCallback? onScrollToObd2Card,
 }) async {
   // Tall canvas so the slider/banner stack does not overflow when the
   // master toggle is on. Mirror the size used by the extras section
@@ -61,8 +56,7 @@ Future<_FakeVehicleProfileList> _pumpSection(
         requestBackgroundLocation: requestBackgroundLocation,
         requestForegroundLocation: requestForegroundLocation,
         openSettings: openSettings,
-        onPairAdapter: onPairAdapter,
-        showAdapterPicker: showAdapterPicker,
+        onScrollToObd2Card: onScrollToObd2Card,
       ),
     ),
     overrides: [
@@ -70,28 +64,6 @@ Future<_FakeVehicleProfileList> _pumpSection(
     ],
   );
   return list;
-}
-
-/// Build a [ResolvedObd2Candidate] for the picker stub. Mirrors the
-/// shape produced by the real BLE/Classic scanner so the persist
-/// path receives the same `(deviceId, deviceName, profile)` tuple
-/// it would in production.
-ResolvedObd2Candidate _candidate({
-  String mac = 'AA:BB:CC:DD:EE:FF',
-  String name = 'vLinker FS 1234',
-}) {
-  return ResolvedObd2Candidate(
-    candidate: Obd2AdapterCandidate(
-      deviceId: mac,
-      deviceName: name,
-      advertisedServiceUuids: const [],
-      rssi: -55,
-    ),
-    profile: const Obd2AdapterProfile(
-      id: 'vlinker-fs-classic',
-      displayName: 'vLinker FS (Classic)',
-    ),
-  );
 }
 
 void main() {
@@ -114,7 +86,7 @@ void main() {
 
       // Master toggle is rendered.
       expect(find.byKey(const Key('autoRecordToggle')), findsOneWidget);
-      // No sliders, no banner.
+      // No sliders, no banner, no link.
       expect(find.byKey(const Key('autoRecordSpeedThreshold')), findsNothing);
       expect(find.byKey(const Key('autoRecordSaveDelay')), findsNothing);
       expect(
@@ -123,6 +95,10 @@ void main() {
       );
       expect(
         find.byKey(const Key('autoRecordStatusBannerActive')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const Key('autoRecordPairAdapterLink')),
         findsNothing,
       );
     });
@@ -134,9 +110,14 @@ void main() {
       ]);
       await _pumpSection(tester, vehicleId: 'v1', list: list);
 
-      // State-aware banner is visible (no paired adapter → needsPairing).
+      // State-aware banner is visible (no paired adapter → needsPairing
+      // renders the passive link, #1400).
       expect(
         find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('autoRecordPairAdapterLink')),
         findsOneWidget,
       );
 
@@ -425,44 +406,15 @@ void main() {
         find.byKey(const Key('autoRecordStatusBannerActive')),
         findsNothing,
       );
+      expect(
+        find.byKey(const Key('autoRecordPairAdapterLink')),
+        findsNothing,
+      );
     });
 
     testWidgets(
-      'autoRecord ON, no paired MAC — needsPairing banner with the '
-      '"Pair an adapter" CTA',
-      (tester) async {
-        final list = _FakeVehicleProfileList([
-          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
-        ]);
-        await _pumpSection(tester, vehicleId: 'v1', list: list);
-
-        expect(
-          find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
-          findsOneWidget,
-        );
-        expect(
-          find.text('Pair an OBD2 adapter to enable auto-record.'),
-          findsOneWidget,
-        );
-        // Other states must NOT render simultaneously.
-        expect(
-          find.byKey(const Key('autoRecordStatusBannerNeedsBackgroundLocation')),
-          findsNothing,
-        );
-        expect(
-          find.byKey(const Key('autoRecordStatusBannerActive')),
-          findsNothing,
-        );
-      },
-    );
-
-    testWidgets(
       'autoRecord ON, MAC paired, backgroundLocationConsent=false — '
-      'needsBackgroundLocation banner without the pair CTA',
+      'needsBackgroundLocation banner without the pair link (#1400)',
       (tester) async {
         final list = _FakeVehicleProfileList([
           const VehicleProfile(
@@ -479,7 +431,7 @@ void main() {
           findsOneWidget,
         );
         expect(
-          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
+          find.byKey(const Key('autoRecordPairAdapterLink')),
           findsNothing,
         );
         expect(
@@ -521,7 +473,7 @@ void main() {
           findsNothing,
         );
         expect(
-          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
+          find.byKey(const Key('autoRecordPairAdapterLink')),
           findsNothing,
         );
         // The active state shows a check_circle icon (not warning_amber).
@@ -539,256 +491,6 @@ void main() {
               'enter the car.'),
           findsOneWidget,
         );
-      },
-    );
-
-    testWidgets(
-      'tapping the "Pair an adapter" CTA falls back to /setup when the '
-      'picker is cancelled (GoRouter wrapper) — #1350',
-      (tester) async {
-        // Tall canvas so the banner + sliders fit without overflow.
-        tester.view.physicalSize = const Size(900, 2400);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.resetPhysicalSize);
-        addTearDown(tester.view.resetDevicePixelRatio);
-
-        final list = _FakeVehicleProfileList([
-          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
-        ]);
-
-        // Stub picker that simulates user cancel (null result). Per the
-        // #1350 spec the /setup fallback fires on cancel so the CTA
-        // still has somewhere to land.
-        Future<ResolvedObd2Candidate?> cancelledPicker(BuildContext _) async {
-          return null;
-        }
-
-        final router = GoRouter(
-          initialLocation: '/edit',
-          routes: [
-            GoRoute(
-              path: '/edit',
-              builder: (_, _) => Scaffold(
-                body: SingleChildScrollView(
-                  child: AutoRecordSection(
-                    vehicleId: 'v1',
-                    showAdapterPicker: cancelledPicker,
-                  ),
-                ),
-              ),
-            ),
-            GoRoute(
-              path: '/setup',
-              builder: (_, _) => const Scaffold(
-                key: Key('setupScreenStub'),
-                body: Text('OBD2 onboarding'),
-              ),
-            ),
-          ],
-        );
-        addTearDown(router.dispose);
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              vehicleProfileListProvider.overrideWith(() => list),
-            ],
-            child: MaterialApp.router(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              locale: const Locale('en'),
-              routerConfig: router,
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        // Sanity — sitting on /edit with the needsPairing banner.
-        expect(
-          find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
-          findsOneWidget,
-        );
-
-        await tester.tap(
-          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
-        );
-        // Pump twice to allow the route push to settle without
-        // invoking pumpAndSettle (some Flutter versions hold a frame).
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 50));
-
-        expect(find.byKey(const Key('setupScreenStub')), findsOneWidget);
-        expect(
-          router.routerDelegate.currentConfiguration.uri.toString(),
-          '/setup',
-        );
-        // Cancel must NOT persist anything onto the profile.
-        expect(list.savedProfiles, isEmpty);
-      },
-    );
-
-    testWidgets(
-      'tapping the "Pair an adapter" CTA persists the picked adapter '
-      'onto the current profile (#1350 happy path)',
-      (tester) async {
-        final list = _FakeVehicleProfileList([
-          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
-        ]);
-
-        Future<ResolvedObd2Candidate?> pickerStub(BuildContext _) async {
-          return _candidate(
-            mac: 'DE:AD:BE:EF:00:01',
-            name: 'vLinker FS 9000',
-          );
-        }
-
-        await _pumpSection(
-          tester,
-          vehicleId: 'v1',
-          list: list,
-          showAdapterPicker: pickerStub,
-        );
-
-        // Sanity — needsPairing banner is up before the tap.
-        expect(
-          find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
-          findsOneWidget,
-        );
-
-        await tester.tap(
-          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
-        );
-        // Bounded pumps — the picker stub resolves synchronously but
-        // the persist + rebuild needs at least one frame.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 50));
-
-        // Repository got exactly one save call carrying the picked
-        // adapter's MAC + name on the original profile.
-        expect(list.savedProfiles, hasLength(1));
-        final saved = list.savedProfiles.single;
-        expect(saved.id, 'v1');
-        expect(saved.name, 'Golf');
-        expect(saved.autoRecord, isTrue);
-        expect(saved.pairedAdapterMac, 'DE:AD:BE:EF:00:01');
-        expect(saved.obd2AdapterMac, 'DE:AD:BE:EF:00:01');
-        expect(saved.obd2AdapterName, 'vLinker FS 9000');
-
-        // After persist the banner flips off needsPairing — the
-        // backgroundLocationConsent gate is still missing so we land
-        // on needsBackgroundLocation, not active.
-        expect(
-          find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
-          findsNothing,
-        );
-        expect(
-          find.byKey(const Key('autoRecordStatusBannerNeedsBackgroundLocation')),
-          findsOneWidget,
-        );
-      },
-    );
-
-    testWidgets(
-      'happy path uses the registry display name when the candidate '
-      'advertises an empty deviceName (#1350)',
-      (tester) async {
-        final list = _FakeVehicleProfileList([
-          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
-        ]);
-
-        Future<ResolvedObd2Candidate?> pickerStub(BuildContext _) async {
-          return _candidate(
-            mac: '11:22:33:44:55:66',
-            name: '', // empty advertised name → fall back to profile.displayName
-          );
-        }
-
-        await _pumpSection(
-          tester,
-          vehicleId: 'v1',
-          list: list,
-          showAdapterPicker: pickerStub,
-        );
-
-        await tester.tap(
-          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
-        );
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 50));
-
-        expect(list.savedProfiles, hasLength(1));
-        expect(list.savedProfiles.single.obd2AdapterName,
-            'vLinker FS (Classic)');
-        expect(list.savedProfiles.single.pairedAdapterMac,
-            '11:22:33:44:55:66');
-      },
-    );
-
-    testWidgets(
-      'cancel path (picker returns null) does NOT persist anything '
-      '(#1350)',
-      (tester) async {
-        final list = _FakeVehicleProfileList([
-          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
-        ]);
-
-        Future<ResolvedObd2Candidate?> cancelledPicker(BuildContext _) async {
-          return null;
-        }
-
-        await _pumpSection(
-          tester,
-          vehicleId: 'v1',
-          list: list,
-          showAdapterPicker: cancelledPicker,
-        );
-
-        await tester.tap(
-          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
-        );
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 50));
-
-        expect(list.savedProfiles, isEmpty);
-        // Banner stays on needsPairing — the user cancelled.
-        expect(
-          find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
-          findsOneWidget,
-        );
-      },
-    );
-
-    testWidgets(
-      'onPairAdapter test hook still takes precedence over the picker '
-      'when supplied (#1350)',
-      (tester) async {
-        final list = _FakeVehicleProfileList([
-          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
-        ]);
-        var hookCalls = 0;
-        var pickerCalls = 0;
-
-        await _pumpSection(
-          tester,
-          vehicleId: 'v1',
-          list: list,
-          onPairAdapter: () => hookCalls++,
-          showAdapterPicker: (_) async {
-            pickerCalls++;
-            return null;
-          },
-        );
-
-        await tester.tap(
-          find.byKey(const Key('autoRecordStatusPairAdapterCta')),
-        );
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 50));
-
-        expect(hookCalls, 1);
-        expect(pickerCalls, 0,
-            reason: 'onPairAdapter must short-circuit the picker path');
-        expect(list.savedProfiles, isEmpty);
       },
     );
 
@@ -840,6 +542,156 @@ void main() {
             reason: '"rolled out" must not appear in any state',
           );
         }
+      },
+    );
+  });
+
+  group('AutoRecordSection — pair-adapter link (#1400)', () {
+    testWidgets(
+      'autoRecord ON, no paired MAC — passive informational link is '
+      'rendered with the canonical copy and arrow_downward icon',
+      (tester) async {
+        final list = _FakeVehicleProfileList([
+          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
+        ]);
+        await _pumpSection(tester, vehicleId: 'v1', list: list);
+
+        // The passive link carries the needsPairing banner key so
+        // existing /screen tests that find by banner key still match.
+        expect(
+          find.byKey(const Key('autoRecordStatusBannerNeedsPairing')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+          findsOneWidget,
+        );
+        // Canonical copy from the en ARB fragment.
+        expect(
+          find.text(
+            'Pair an adapter in the section below to enable '
+            'auto-recording',
+          ),
+          findsOneWidget,
+        );
+        // Visual cue — info_outline + arrow_downward icons.
+        expect(
+          find.descendant(
+            of: find.byKey(const Key('autoRecordPairAdapterLink')),
+            matching: find.byIcon(Icons.info_outline),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: find.byKey(const Key('autoRecordPairAdapterLink')),
+            matching: find.byIcon(Icons.arrow_downward),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'no orange-tinted "Pair an adapter" CTA button is rendered '
+      'anywhere on the auto-record card (#1400)',
+      (tester) async {
+        // Cycle through both relevant on-states; the deprecated CTA
+        // pre-#1400 only ever rendered on needsPairing but we cover
+        // needsBackgroundLocation too as a belt-and-suspender.
+        final fixtures = [
+          // needsPairing
+          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
+          // needsBackgroundLocation
+          const VehicleProfile(
+            id: 'v1',
+            name: 'Golf',
+            autoRecord: true,
+            pairedAdapterMac: 'DE:AD:BE:EF:00:01',
+          ),
+        ];
+
+        for (final profile in fixtures) {
+          final list = _FakeVehicleProfileList([profile]);
+          await _pumpSection(tester, vehicleId: 'v1', list: list);
+
+          expect(
+            find.byKey(const Key('autoRecordStatusPairAdapterCta')),
+            findsNothing,
+            reason: 'Pre-#1400 CTA button must not survive consolidation',
+          );
+        }
+      },
+    );
+
+    testWidgets(
+      'tapping the link calls onScrollToObd2Card exactly once (#1400)',
+      (tester) async {
+        final list = _FakeVehicleProfileList([
+          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
+        ]);
+        var taps = 0;
+        await _pumpSection(
+          tester,
+          vehicleId: 'v1',
+          list: list,
+          onScrollToObd2Card: () => taps++,
+        );
+
+        await tester.tap(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+        );
+        await tester.pump();
+
+        expect(taps, 1);
+        // The link is passive — tapping it must NOT persist anything.
+        expect(list.savedProfiles, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'tapping the link with a null callback is a safe no-op (#1400)',
+      (tester) async {
+        final list = _FakeVehicleProfileList([
+          const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
+        ]);
+        // No onScrollToObd2Card — isolated widget pump shape.
+        await _pumpSection(tester, vehicleId: 'v1', list: list);
+
+        // Tap should not throw even though the callback is null —
+        // InkWell with null onTap is a no-op.
+        await tester.tap(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+        );
+        await tester.pump();
+
+        expect(list.savedProfiles, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'paired-adapter state hides the link entirely (#1400)',
+      (tester) async {
+        final list = _FakeVehicleProfileList([
+          const VehicleProfile(
+            id: 'v1',
+            name: 'Golf',
+            autoRecord: true,
+            pairedAdapterMac: 'AA:BB:CC:11:22:33',
+            backgroundLocationConsent: true,
+          ),
+        ]);
+        await _pumpSection(tester, vehicleId: 'v1', list: list);
+
+        expect(
+          find.byKey(const Key('autoRecordPairAdapterLink')),
+          findsNothing,
+        );
+        // Active banner takes its place.
+        expect(
+          find.byKey(const Key('autoRecordStatusBannerActive')),
+          findsOneWidget,
+        );
       },
     );
   });


### PR DESCRIPTION
## Summary

Pre-#1400 the vehicle edit screen surfaced **two parallel pair CTAs**: the orange-tinted "Pair an adapter" button on the auto-record card plus the canonical "Pair adapter" button on the OBD2 adapter card directly below. Both opened the same picker — a confusing duplicate.

This PR consolidates to ONE canonical button (the OBD2 card's) and replaces the auto-record duplicate with a **passive informational link** that scrolls to and briefly highlights the OBD2 card on tap.

## Before / after

**Before** (auto-record card, no adapter paired):
- Orange-tinted Container holding warning text + `FilledButton.tonalIcon("Pair an adapter")` that opened the picker

**After** (auto-record card, no adapter paired):
- Passive `InkWell` row: `info_outline` + `"Pair an adapter in the section below to enable auto-recording"` + `arrow_downward`
- Tapping the link calls `Scrollable.ensureVisible` on a `GlobalKey`-anchored OBD2 card and runs a 1 s amber border pulse via an `AnimationController` + `AnimatedBuilder`

The OBD2 adapter card's existing `"Pair adapter"` CTA is now the **single source of truth** for the pair flow. When an adapter IS paired the auto-record card shows the existing "Adaptateur appairé" status block unchanged — the link only renders in the no-adapter state.

Two-stage scroll handles ListView virtualisation: `ScrollController.animateTo(0)` first to pull the OBD2 card back into the tree if it's been unmounted, then `Scrollable.ensureVisible(alignment: 0.1)` for the final position.

i18n: new key `autoRecordPairAdapterLinkText` added in en/de fragment + fr direct.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test test/features/vehicle/` — 512 / 512 pass
- [x] Widget tests in `auto_record_section_test.dart` extended: link-not-button in no-adapter state; link calls `onScrollToObd2Card`; null callback safe; paired state hides link; deprecated CTA key absent in every state
- [x] New integration test `edit_vehicle_screen_consolidate_pair_cta_test.dart`: structure assertion (link present, CTA gone, OBD2 pair button still present); scroll behaviour (offset moves on tap); no-crash on already-visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)