### PR TITLE
fix(telemetry): infer ErrorCategory from ErrorLayer at log time (Closes #1394)

### DIFF
--- a/lib/core/logging/error_logger.dart
+++ b/lib/core/logging/error_logger.dart
@@ -134,7 +134,7 @@ class ErrorLogger {
     try {
       if (testRecorderOverride != null) {
         await testRecorderOverride!.record(
-          _ContextualError(layer: layer, error: error, context: context),
+          ContextualError(layer: layer, error: error, context: context),
           stackTrace,
         );
         return;
@@ -145,10 +145,11 @@ class ErrorLogger {
         // Wrap in a contextual error so the layer + context map land
         // in `error.toString()` (which TraceRecorder serialises to
         // `errorMessage`) without requiring a TraceRecorder API
-        // change.
+        // change. The recorder also unwraps [ContextualError] to
+        // extract the layer for [ErrorCategory] inference (#1394).
         final recorder = container.read(traceRecorderProvider);
         await recorder.record(
-          _ContextualError(layer: layer, error: error, context: context),
+          ContextualError(layer: layer, error: error, context: context),
           stackTrace,
         );
         return;
@@ -190,16 +191,16 @@ class ErrorLogger {
 
 /// Wrapper error that carries the [ErrorLayer] and context map through
 /// [TraceRecorder]'s `errorMessage` field (which is built from
-/// `error.toString()`). This avoids a breaking change to
-/// `TraceRecorder.record` — the recorder still gets a single `Object`
-/// + `StackTrace`, but the rendered message includes the structured
-/// metadata for grep / log triage.
-class _ContextualError implements Exception {
+/// `error.toString()`). The rendered message includes the structured
+/// metadata for grep / log triage, while the recorder also pattern-
+/// matches on the wrapper type to extract the [layer] for category
+/// inference (#1394).
+class ContextualError implements Exception {
   final ErrorLayer layer;
   final Object error;
   final Map<String, Object?>? context;
 
-  _ContextualError({
+  ContextualError({
     required this.layer,
     required this.error,
     required this.context,

--- a/lib/core/telemetry/trace_recorder.dart
+++ b/lib/core/telemetry/trace_recorder.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:uuid/uuid.dart';
 import '../error/exceptions.dart';
+import '../logging/error_logger.dart';
 import '../services/service_result.dart';
 import 'collectors/app_state_collector.dart';
 import 'collectors/breadcrumb_collector.dart';
@@ -41,11 +43,25 @@ class TraceRecorder {
         '${tz.isNegative ? '-' : '+'}${tz.inHours.abs().toString().padLeft(2, '0')}:'
         '${(tz.inMinutes.abs() % 60).toString().padLeft(2, '0')}';
 
+    // Unwrap [ContextualError] so the persisted trace reflects the
+    // ROOT exception type and so we can read the [ErrorLayer] for
+    // category inference (#1394). Direct callers (dio interceptor,
+    // navigation observer) pass real exceptions and skip this branch.
+    final ErrorLayer? layer;
+    final Object effectiveError;
+    if (error is ContextualError) {
+      layer = error.layer;
+      effectiveError = error.inner;
+    } else {
+      layer = null;
+      effectiveError = error;
+    }
+
     // Build chain snapshot from ServiceChainExhaustedException
     var chain = serviceChainState;
-    if (chain == null && error is ServiceChainExhaustedException) {
+    if (chain == null && effectiveError is ServiceChainExhaustedException) {
       chain = ServiceChainSnapshot(
-        attempts: error.errors.map((e) {
+        attempts: effectiveError.errors.map((e) {
           if (e is ServiceError) {
             return ServiceAttempt(
               serviceName: e.source.displayName,
@@ -65,12 +81,27 @@ class TraceRecorder {
       );
     }
 
+    // Category resolution order:
+    //   1. Existing [ErrorClassifier] (recognises Dio, ApiException,
+    //      ServiceChainExhausted, FlutterError, etc.).
+    //   2. If still unknown AND we have a layer (i.e. the call came
+    //      through `errorLogger.log`), fall back to layer-based
+    //      inference so traces stop bucketing as `unknown` (#1394).
+    var category = ErrorClassifier.classify(effectiveError);
+    if (category == ErrorCategory.unknown && layer != null) {
+      category = inferCategoryFromLayer(layer, effectiveError);
+    }
+
     final trace = ErrorTrace(
       id: _uuid.v4(),
       timestamp: now,
       timezoneOffset: tzStr,
-      category: ErrorClassifier.classify(error),
-      errorType: error.runtimeType.toString(),
+      category: category,
+      // Use the original (wrapper) toString so the layer prefix and
+      // context map remain visible in `errorMessage`. The trace's
+      // `errorType` reflects the unwrapped exception class so the
+      // privacy dashboard groups by real type, not `ContextualError`.
+      errorType: effectiveError.runtimeType.toString(),
       errorMessage: error.toString(),
       stackTrace: stackTrace.toString(),
       deviceInfo: DeviceInfoCollector.collect(),
@@ -82,5 +113,52 @@ class TraceRecorder {
 
     await _storage.store(trace);
     await _uploader.uploadIfEnabled(trace);
+  }
+}
+
+/// Map [ErrorLayer] (a code-area indicator) to the user-facing
+/// [ErrorCategory] (root-cause grouping) used in the privacy dashboard
+/// (#1394). [PlatformException] always maps to `platform` regardless
+/// of layer — the layer says where the error BUBBLED UP, but the
+/// platform-channel failure is the ROOT cause and the most actionable
+/// hint for the user. Likewise common network exceptions map to
+/// `network` no matter which layer logged them.
+///
+/// Exposed via [visibleForTesting] so the inference rules can be
+/// asserted without standing up the full Hive + provider stack.
+@visibleForTesting
+ErrorCategory inferCategoryFromLayer(ErrorLayer layer, Object? error) {
+  // PlatformException trumps the layer — the layer says where the
+  // error BUBBLED UP, but the platform-channel failure is the ROOT
+  // cause. Match by runtimeType name to avoid pulling Flutter's
+  // services library (and its bindings) into pure-Dart unit tests.
+  final typeName = error?.runtimeType.toString() ?? '';
+  if (typeName.contains('PlatformException')) {
+    return ErrorCategory.platform;
+  }
+  // Network exceptions usually surface in the services layer but the
+  // category should reflect the failure shape, not the call site.
+  if (typeName.contains('SocketException') ||
+      typeName.contains('TimeoutException') ||
+      typeName.contains('HttpException')) {
+    return ErrorCategory.network;
+  }
+  switch (layer) {
+    case ErrorLayer.ui:
+      return ErrorCategory.ui;
+    case ErrorLayer.providers:
+      return ErrorCategory.provider;
+    case ErrorLayer.services:
+      return ErrorCategory.api;
+    case ErrorLayer.storage:
+      return ErrorCategory.cache;
+    case ErrorLayer.sync:
+      return ErrorCategory.api;
+    case ErrorLayer.background:
+      return ErrorCategory.unknown;
+    case ErrorLayer.isolate:
+      return ErrorCategory.unknown;
+    case ErrorLayer.other:
+      return ErrorCategory.unknown;
   }
 }

--- a/test/core/telemetry/error_category_inference_test.dart
+++ b/test/core/telemetry/error_category_inference_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+
+/// Coverage for #1394 — `ErrorTrace.category` must reflect the
+/// [ErrorLayer] passed through `errorLogger.log`, instead of falling
+/// back to `ErrorCategory.unknown` for every wrapped error.
+///
+/// These tests exercise the pure inference helper directly so they do
+/// NOT need Hive / Riverpod / connectivity-channel mocking. The
+/// recorder-level integration is covered by `trace_recorder_test.dart`.
+void main() {
+  group('inferCategoryFromLayer — layer mapping', () {
+    final genericError = Exception('boom');
+
+    // Each ErrorLayer maps to the ErrorCategory that the privacy
+    // dashboard groups under. `background` / `isolate` / `other`
+    // intentionally map to `unknown` for generic exceptions because
+    // we have no actionable hint about the root cause.
+    final expected = <ErrorLayer, ErrorCategory>{
+      ErrorLayer.ui: ErrorCategory.ui,
+      ErrorLayer.providers: ErrorCategory.provider,
+      ErrorLayer.services: ErrorCategory.api,
+      ErrorLayer.storage: ErrorCategory.cache,
+      ErrorLayer.sync: ErrorCategory.api,
+      ErrorLayer.background: ErrorCategory.unknown,
+      ErrorLayer.isolate: ErrorCategory.unknown,
+      ErrorLayer.other: ErrorCategory.unknown,
+    };
+
+    for (final entry in expected.entries) {
+      test('${entry.key.name} → ${entry.value.name}', () {
+        expect(
+          inferCategoryFromLayer(entry.key, genericError),
+          entry.value,
+          reason: 'layer ${entry.key.name} must map to ${entry.value.name}',
+        );
+      });
+    }
+
+    test('mapping is exhaustive over ErrorLayer', () {
+      // Failsafe: if a new ErrorLayer is added without updating the
+      // inference helper, this assertion catches it before the
+      // privacy dashboard starts bucketing the new layer as
+      // `unknown` again.
+      for (final layer in ErrorLayer.values) {
+        expect(
+          expected.containsKey(layer),
+          isTrue,
+          reason: 'ErrorLayer.${layer.name} missing from inference map',
+        );
+      }
+    });
+  });
+
+  group('inferCategoryFromLayer — PlatformException override', () {
+    // PlatformException is the most actionable hint the user can act
+    // on, so it short-circuits to `platform` regardless of the layer
+    // it bubbled up through.
+    test('every layer maps a PlatformException to platform', () {
+      final platformError = PlatformException(
+        code: 'no_permission',
+        message: 'location denied',
+      );
+      for (final layer in ErrorLayer.values) {
+        expect(
+          inferCategoryFromLayer(layer, platformError),
+          ErrorCategory.platform,
+          reason:
+              'PlatformException must override layer ${layer.name} → platform',
+        );
+      }
+    });
+  });
+
+  group('inferCategoryFromLayer — network exception override', () {
+    // Network failures usually surface in the services layer but a
+    // SocketException is fundamentally a network problem, not an API
+    // contract problem — categorise by failure shape.
+    test('SocketException maps to network for every layer', () {
+      const socketError = SocketException('host unreachable');
+      for (final layer in ErrorLayer.values) {
+        expect(
+          inferCategoryFromLayer(layer, socketError),
+          ErrorCategory.network,
+          reason:
+              'SocketException must override layer ${layer.name} → network',
+        );
+      }
+    });
+
+    test('TimeoutException maps to network for every layer', () {
+      final timeoutError = TimeoutException('upstream stalled');
+      for (final layer in ErrorLayer.values) {
+        expect(
+          inferCategoryFromLayer(layer, timeoutError),
+          ErrorCategory.network,
+          reason:
+              'TimeoutException must override layer ${layer.name} → network',
+        );
+      }
+    });
+
+    test('HttpException maps to network for every layer', () {
+      const httpError = HttpException('connection reset');
+      for (final layer in ErrorLayer.values) {
+        expect(
+          inferCategoryFromLayer(layer, httpError),
+          ErrorCategory.network,
+          reason: 'HttpException must override layer ${layer.name} → network',
+        );
+      }
+    });
+  });
+
+  group('inferCategoryFromLayer — null / unwrapped error', () {
+    test('null error still resolves a category from the layer', () {
+      // A null `error` is unusual but possible from synthetic call
+      // sites; we still want a non-`unknown` category for the layers
+      // that can produce one.
+      expect(inferCategoryFromLayer(ErrorLayer.ui, null), ErrorCategory.ui);
+      expect(
+        inferCategoryFromLayer(ErrorLayer.services, null),
+        ErrorCategory.api,
+      );
+    });
+  });
+
+  group('regression: standard layer/error combos never log unknown', () {
+    // Regression net — if any of these combos ever drift back to
+    // `unknown`, the privacy dashboard's category grouping silently
+    // breaks again.
+    final cases = <(ErrorLayer, Object)>[
+      (ErrorLayer.ui, Exception('layout')),
+      (ErrorLayer.providers, StateError('unbound')),
+      (ErrorLayer.services, Exception('rate limit')),
+      (ErrorLayer.storage, Exception('corrupt box')),
+      (ErrorLayer.sync, Exception('supabase 5xx')),
+    ];
+
+    for (final (layer, error) in cases) {
+      test('${layer.name} + ${error.runtimeType} is not unknown', () {
+        expect(
+          inferCategoryFromLayer(layer, error),
+          isNot(ErrorCategory.unknown),
+          reason: 'standard layer ${layer.name} must produce a real category',
+        );
+      });
+    }
+  });
+}

--- a/test/core/telemetry/trace_recorder_test.dart
+++ b/test/core/telemetry/trace_recorder_test.dart
@@ -8,6 +8,7 @@ import 'package:tankstellen/core/telemetry/upload/trace_uploader.dart';
 import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 
 /// Fake TraceStorage that records calls in memory.
@@ -203,6 +204,45 @@ void main() {
       final trace = storage.stored.first;
       expect(trace.networkState, isNotNull);
       expect(trace.networkState.isOnline, isA<bool>());
+    });
+
+    // #1394 — when the error arrives wrapped in [ContextualError]
+    // (i.e. via `errorLogger.log`), the recorder must unwrap it so the
+    // category reflects the real layer and the errorType reflects the
+    // root exception class — not the wrapper.
+    test('ContextualError is unwrapped: category from layer + type from inner',
+        () async {
+      final wrapped = ContextualError(
+        layer: ErrorLayer.services,
+        error: Exception('boom'),
+        context: null,
+      );
+      await recorder.record(wrapped, StackTrace.current);
+
+      final trace = storage.stored.first;
+      expect(trace.category, ErrorCategory.api,
+          reason: 'services layer must infer api, not unknown');
+      expect(trace.errorType, contains('Exception'),
+          reason: 'errorType must reflect the unwrapped exception, '
+              'not the ContextualError wrapper');
+      expect(trace.errorMessage, contains('[services]'),
+          reason: 'wrapper toString preserves the layer prefix for grep');
+    });
+
+    test('ContextualError preserves classifier match for known types',
+        () async {
+      // ApiException carries enough type info on its own — the
+      // classifier should still win even when the wrapper is present.
+      final wrapped = ContextualError(
+        layer: ErrorLayer.ui,
+        error: const ApiException(message: 'rate limited', statusCode: 429),
+        context: null,
+      );
+      await recorder.record(wrapped, StackTrace.current);
+
+      expect(storage.stored.first.category, ErrorCategory.api,
+          reason: 'ApiException stays api — layer fallback only fires '
+              'when classifier returns unknown');
     });
   });
 }


### PR DESCRIPTION
## Summary
- `ErrorTrace` now carries a meaningful `category` instead of always defaulting to `unknown`. The recorder unwraps the `ContextualError` wrapper produced by `errorLogger.log`, classifies the inner exception with the existing `ErrorClassifier`, and falls back to layer-based inference when the classifier returns `unknown`. `PlatformException` short-circuits to `platform`; `SocketException` / `TimeoutException` / `HttpException` short-circuit to `network` regardless of layer.
- Bonus fix: `errorType` now reflects the unwrapped exception class, so the privacy dashboard groups by real type instead of `ContextualError`.
- New unit tests cover every `ErrorLayer` value plus the `PlatformException` and network-exception override paths, and recorder-level tests prove the wrapper unwrap + classifier-precedence flow.

## Test plan
- [x] flutter analyze (zero warnings)
- [x] new ErrorCategory inference tests (19 cases, all green)
- [x] trace_recorder_test.dart still passes (incl. 2 new ContextualError unwrap cases)
- [x] error_logger_test.dart still passes (ContextualError rename)
- [x] no_silent_catch_test.dart passes
- [ ] Verify on next user telemetry export that traces no longer all read `unknown` (deferred to user)