### PR TITLE
feat(features): migrate gamificationEnabled to central feature flags (Refs #1373 phase 3b)

### DIFF
--- a/lib/features/feature_management/application/legacy_toggle_migration_provider.dart
+++ b/lib/features/feature_management/application/legacy_toggle_migration_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../profile/providers/profile_provider.dart';
 import '../data/legacy_toggle_migrator.dart';
 import 'feature_flags_provider.dart';
 
@@ -16,31 +17,40 @@ part 'legacy_toggle_migration_provider.g.dart';
 /// box was first introduced.
 const String _settingsBoxName = 'settings';
 
-/// One-shot Riverpod hook that runs [migrateLegacyToggles] once after
-/// app startup (#1373 phase 3a).
+/// One-shot Riverpod hook that runs the legacy-toggle migrators once
+/// after app startup (#1373 phase 3a + 3b).
 ///
-/// Returns a [Future] that completes when the migration finishes (or
+/// Returns a [Future] that completes when both migrations finish (or
 /// resolves immediately to `null` when either the settings box or the
 /// central feature-flags repository is not yet available — in tests
 /// without Hive, or before [HiveBoxes.init] runs in production).
 ///
-/// The migration itself is idempotent and gated on the
-/// [hapticEcoCoachMigratedKey] flag, so re-firing this provider in
-/// tests / hot-reload is safe.
+/// Two migrators run in sequence:
+///   1. [migrateLegacyToggles] — settings-box-backed legacy keys
+///      (currently `hapticEcoCoachEnabled`).
+///   2. [migrateUserProfileToggles] — UserProfile-backed legacy fields
+///      (currently `gamificationEnabled`). This migrator is a no-op
+///      when the active profile has not loaded yet; it re-runs on
+///      subsequent launches until a profile is available, and only
+///      then writes the per-feature `*Migrated` gate flag.
+///
+/// Each migration is idempotent and gated on its own
+/// `*Migrated` flag, so re-firing this provider in tests / hot-reload
+/// is safe.
 ///
 /// `keepAlive: true` so the migration runs at most once per app
 /// lifetime — Riverpod will not rebuild the provider unless one of
-/// its dependencies changes (in this case, `featureFlagsRepository`,
-/// which itself is `keepAlive`).
+/// its dependencies changes (in this case, `featureFlagsRepository`
+/// or `activeProfile`, both of which are `keepAlive`).
 ///
 /// Wiring: any provider / widget can `ref.watch(...)` this to
-/// guarantee the migration has run before they read
+/// guarantee the migrations have run before they read
 /// [featureFlagsProvider]. The default app-init path watches it from
 /// the central feature-flags screen so the migration runs the first
 /// time the user navigates there — there is no requirement to run it
-/// at app start. (#1373 phase 3a defers the explicit startup wire-up
-/// because that path lives in `app_initializer.dart`, which is on the
-/// hot-file list.)
+/// at app start. (#1373 phase 3a/3b defer the explicit startup
+/// wire-up because that path lives in `app_initializer.dart`, which
+/// is on the hot-file list.)
 @Riverpod(keepAlive: true)
 Future<void> legacyToggleMigration(Ref ref) async {
   final featureFlags = ref.watch(featureFlagsRepositoryProvider);
@@ -58,6 +68,7 @@ Future<void> legacyToggleMigration(Ref ref) async {
   }
   final settings = Hive.box<dynamic>(_settingsBoxName);
   final manifest = ref.read(featureManifestProvider);
+  final activeProfile = ref.watch(activeProfileProvider);
 
   // Defer the actual migration to the next microtask so this
   // provider's `build` returns fast and any synchronous reads of
@@ -69,6 +80,12 @@ Future<void> legacyToggleMigration(Ref ref) async {
         settings: settings,
         featureFlags: featureFlags,
         manifest: manifest,
+      );
+      await migrateUserProfileToggles(
+        settings: settings,
+        featureFlags: featureFlags,
+        manifest: manifest,
+        activeProfile: activeProfile,
       );
     } catch (e, st) {
       // Failure is non-fatal — the central state stays at manifest

--- a/lib/features/feature_management/application/legacy_toggle_migration_provider.g.dart
+++ b/lib/features/feature_management/application/legacy_toggle_migration_provider.g.dart
@@ -8,89 +8,116 @@ part of 'legacy_toggle_migration_provider.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// One-shot Riverpod hook that runs [migrateLegacyToggles] once after
-/// app startup (#1373 phase 3a).
+/// One-shot Riverpod hook that runs the legacy-toggle migrators once
+/// after app startup (#1373 phase 3a + 3b).
 ///
-/// Returns a [Future] that completes when the migration finishes (or
+/// Returns a [Future] that completes when both migrations finish (or
 /// resolves immediately to `null` when either the settings box or the
 /// central feature-flags repository is not yet available — in tests
 /// without Hive, or before [HiveBoxes.init] runs in production).
 ///
-/// The migration itself is idempotent and gated on the
-/// [hapticEcoCoachMigratedKey] flag, so re-firing this provider in
-/// tests / hot-reload is safe.
+/// Two migrators run in sequence:
+///   1. [migrateLegacyToggles] — settings-box-backed legacy keys
+///      (currently `hapticEcoCoachEnabled`).
+///   2. [migrateUserProfileToggles] — UserProfile-backed legacy fields
+///      (currently `gamificationEnabled`). This migrator is a no-op
+///      when the active profile has not loaded yet; it re-runs on
+///      subsequent launches until a profile is available, and only
+///      then writes the per-feature `*Migrated` gate flag.
+///
+/// Each migration is idempotent and gated on its own
+/// `*Migrated` flag, so re-firing this provider in tests / hot-reload
+/// is safe.
 ///
 /// `keepAlive: true` so the migration runs at most once per app
 /// lifetime — Riverpod will not rebuild the provider unless one of
-/// its dependencies changes (in this case, `featureFlagsRepository`,
-/// which itself is `keepAlive`).
+/// its dependencies changes (in this case, `featureFlagsRepository`
+/// or `activeProfile`, both of which are `keepAlive`).
 ///
 /// Wiring: any provider / widget can `ref.watch(...)` this to
-/// guarantee the migration has run before they read
+/// guarantee the migrations have run before they read
 /// [featureFlagsProvider]. The default app-init path watches it from
 /// the central feature-flags screen so the migration runs the first
 /// time the user navigates there — there is no requirement to run it
-/// at app start. (#1373 phase 3a defers the explicit startup wire-up
-/// because that path lives in `app_initializer.dart`, which is on the
-/// hot-file list.)
+/// at app start. (#1373 phase 3a/3b defer the explicit startup
+/// wire-up because that path lives in `app_initializer.dart`, which
+/// is on the hot-file list.)
 
 @ProviderFor(legacyToggleMigration)
 final legacyToggleMigrationProvider = LegacyToggleMigrationProvider._();
 
-/// One-shot Riverpod hook that runs [migrateLegacyToggles] once after
-/// app startup (#1373 phase 3a).
+/// One-shot Riverpod hook that runs the legacy-toggle migrators once
+/// after app startup (#1373 phase 3a + 3b).
 ///
-/// Returns a [Future] that completes when the migration finishes (or
+/// Returns a [Future] that completes when both migrations finish (or
 /// resolves immediately to `null` when either the settings box or the
 /// central feature-flags repository is not yet available — in tests
 /// without Hive, or before [HiveBoxes.init] runs in production).
 ///
-/// The migration itself is idempotent and gated on the
-/// [hapticEcoCoachMigratedKey] flag, so re-firing this provider in
-/// tests / hot-reload is safe.
+/// Two migrators run in sequence:
+///   1. [migrateLegacyToggles] — settings-box-backed legacy keys
+///      (currently `hapticEcoCoachEnabled`).
+///   2. [migrateUserProfileToggles] — UserProfile-backed legacy fields
+///      (currently `gamificationEnabled`). This migrator is a no-op
+///      when the active profile has not loaded yet; it re-runs on
+///      subsequent launches until a profile is available, and only
+///      then writes the per-feature `*Migrated` gate flag.
+///
+/// Each migration is idempotent and gated on its own
+/// `*Migrated` flag, so re-firing this provider in tests / hot-reload
+/// is safe.
 ///
 /// `keepAlive: true` so the migration runs at most once per app
 /// lifetime — Riverpod will not rebuild the provider unless one of
-/// its dependencies changes (in this case, `featureFlagsRepository`,
-/// which itself is `keepAlive`).
+/// its dependencies changes (in this case, `featureFlagsRepository`
+/// or `activeProfile`, both of which are `keepAlive`).
 ///
 /// Wiring: any provider / widget can `ref.watch(...)` this to
-/// guarantee the migration has run before they read
+/// guarantee the migrations have run before they read
 /// [featureFlagsProvider]. The default app-init path watches it from
 /// the central feature-flags screen so the migration runs the first
 /// time the user navigates there — there is no requirement to run it
-/// at app start. (#1373 phase 3a defers the explicit startup wire-up
-/// because that path lives in `app_initializer.dart`, which is on the
-/// hot-file list.)
+/// at app start. (#1373 phase 3a/3b defer the explicit startup
+/// wire-up because that path lives in `app_initializer.dart`, which
+/// is on the hot-file list.)
 
 final class LegacyToggleMigrationProvider
     extends $FunctionalProvider<AsyncValue<void>, void, FutureOr<void>>
     with $FutureModifier<void>, $FutureProvider<void> {
-  /// One-shot Riverpod hook that runs [migrateLegacyToggles] once after
-  /// app startup (#1373 phase 3a).
+  /// One-shot Riverpod hook that runs the legacy-toggle migrators once
+  /// after app startup (#1373 phase 3a + 3b).
   ///
-  /// Returns a [Future] that completes when the migration finishes (or
+  /// Returns a [Future] that completes when both migrations finish (or
   /// resolves immediately to `null` when either the settings box or the
   /// central feature-flags repository is not yet available — in tests
   /// without Hive, or before [HiveBoxes.init] runs in production).
   ///
-  /// The migration itself is idempotent and gated on the
-  /// [hapticEcoCoachMigratedKey] flag, so re-firing this provider in
-  /// tests / hot-reload is safe.
+  /// Two migrators run in sequence:
+  ///   1. [migrateLegacyToggles] — settings-box-backed legacy keys
+  ///      (currently `hapticEcoCoachEnabled`).
+  ///   2. [migrateUserProfileToggles] — UserProfile-backed legacy fields
+  ///      (currently `gamificationEnabled`). This migrator is a no-op
+  ///      when the active profile has not loaded yet; it re-runs on
+  ///      subsequent launches until a profile is available, and only
+  ///      then writes the per-feature `*Migrated` gate flag.
+  ///
+  /// Each migration is idempotent and gated on its own
+  /// `*Migrated` flag, so re-firing this provider in tests / hot-reload
+  /// is safe.
   ///
   /// `keepAlive: true` so the migration runs at most once per app
   /// lifetime — Riverpod will not rebuild the provider unless one of
-  /// its dependencies changes (in this case, `featureFlagsRepository`,
-  /// which itself is `keepAlive`).
+  /// its dependencies changes (in this case, `featureFlagsRepository`
+  /// or `activeProfile`, both of which are `keepAlive`).
   ///
   /// Wiring: any provider / widget can `ref.watch(...)` this to
-  /// guarantee the migration has run before they read
+  /// guarantee the migrations have run before they read
   /// [featureFlagsProvider]. The default app-init path watches it from
   /// the central feature-flags screen so the migration runs the first
   /// time the user navigates there — there is no requirement to run it
-  /// at app start. (#1373 phase 3a defers the explicit startup wire-up
-  /// because that path lives in `app_initializer.dart`, which is on the
-  /// hot-file list.)
+  /// at app start. (#1373 phase 3a/3b defer the explicit startup
+  /// wire-up because that path lives in `app_initializer.dart`, which
+  /// is on the hot-file list.)
   LegacyToggleMigrationProvider._()
     : super(
         from: null,
@@ -117,4 +144,4 @@ final class LegacyToggleMigrationProvider
 }
 
 String _$legacyToggleMigrationHash() =>
-    r'1014cf980f258759b3ce53c929150ec4d8658670';
+    r'28fd0649daf74093c0e9c3f9f0154f4a10fc5b0e';

--- a/lib/features/feature_management/data/legacy_toggle_migrator.dart
+++ b/lib/features/feature_management/data/legacy_toggle_migrator.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
 import '../../../core/storage/storage_keys.dart';
+import '../../profile/data/models/user_profile.dart';
 import '../domain/feature.dart';
 import '../domain/feature_manifest.dart';
 import 'feature_flags_repository.dart';
@@ -12,6 +13,13 @@ import 'feature_flags_repository.dart';
 /// toggle itself so a single read tells us whether the migration has
 /// already run.
 const String hapticEcoCoachMigratedKey = 'hapticEcoCoachMigrated';
+
+/// Settings-box key written once after the legacy
+/// `UserProfile.gamificationEnabled` value has been promoted into the
+/// central feature-flag set (#1373 phase 3b). Persisted in the same
+/// `settings` Hive box as the haptic-eco-coach gate so a single read
+/// tells us whether the gamification migration has already run.
+const String gamificationMigratedKey = 'gamificationMigrated';
 
 /// One-shot migrator that promotes legacy scattered toggles into the
 /// central [FeatureFlagsRepository] (#1373 phase 3a).
@@ -29,11 +37,18 @@ const String hapticEcoCoachMigratedKey = 'hapticEcoCoachMigrated';
 /// read with no writes. Safe to call from a `Future.microtask` on
 /// app-startup providers without blocking.
 ///
-/// Future phases (3b, 3c, …) extend this migrator with additional
-/// scattered toggles (`gamificationEnabled`, `showFuel`, `autoRecord`,
-/// etc.). Each new migration follows the same shape: read the legacy
-/// value, gate on a `<featureName>Migrated` flag, force-enable
-/// prerequisites first, persist, then write the gate flag.
+/// As of phase 3b a parallel entry point [migrateUserProfileToggles]
+/// handles UserProfile-backed legacy toggles (the
+/// `UserProfile.gamificationEnabled` field). The shape mirrors this
+/// function but takes the active profile as an extra (nullable) input
+/// because the legacy value lives on the profile entity rather than
+/// the settings box.
+///
+/// Future phases (3c, 3d, …) extend this migrator with additional
+/// scattered toggles (`showFuel`, `autoRecord`, etc.). Each new
+/// migration follows the same shape: read the legacy value, gate on a
+/// `<featureName>Migrated` flag, force-enable prerequisites first,
+/// persist, then write the gate flag.
 Future<void> migrateLegacyToggles({
   required Box<dynamic> settings,
   required FeatureFlagsRepository featureFlags,
@@ -43,6 +58,44 @@ Future<void> migrateLegacyToggles({
     settings: settings,
     featureFlags: featureFlags,
     manifest: manifest,
+  );
+}
+
+/// One-shot migrator for UserProfile-backed legacy toggles (#1373
+/// phase 3b).
+///
+/// Reads the legacy [UserProfile.gamificationEnabled] value from the
+/// passed-in [activeProfile]. The migrator is a no-op when [activeProfile]
+/// is null — the next launch will retry; idempotency is preserved by
+/// NOT writing the migrated-key flag in that case.
+///
+/// When a profile is present and the [gamificationMigratedKey] flag has
+/// not yet been written, the migrator promotes the legacy value into
+/// the central feature-flag set:
+///   - legacy true  → cascade-enable [Feature.obd2TripRecording]
+///                    (the manifest prerequisite) and [Feature.gamification]
+///   - legacy false → persist a state that EXCLUDES [Feature.gamification]
+///                    so the user's explicit opt-out survives. Without
+///                    this branch the manifest default (gamification=true)
+///                    would silently restore the surfaces the user
+///                    deliberately turned off.
+/// In both cases the [gamificationMigratedKey] gate is then set so
+/// subsequent runs are no-ops.
+///
+/// Safe to call alongside [migrateLegacyToggles] from the same provider
+/// (see `legacyToggleMigrationProvider`). The two functions touch
+/// disjoint settings-box keys.
+Future<void> migrateUserProfileToggles({
+  required Box<dynamic> settings,
+  required FeatureFlagsRepository featureFlags,
+  required FeatureManifest manifest,
+  required UserProfile? activeProfile,
+}) async {
+  await _migrateGamification(
+    settings: settings,
+    featureFlags: featureFlags,
+    manifest: manifest,
+    activeProfile: activeProfile,
   );
 }
 
@@ -88,6 +141,71 @@ Future<void> _migrateHapticEcoCoach({
   } catch (e, st) {
     debugPrint(
       'migrateLegacyToggles: writing $hapticEcoCoachMigratedKey failed: $e\n$st',
+    );
+  }
+}
+
+Future<void> _migrateGamification({
+  required Box<dynamic> settings,
+  required FeatureFlagsRepository featureFlags,
+  required FeatureManifest manifest,
+  required UserProfile? activeProfile,
+}) async {
+  // Already migrated → idempotent no-op. The user may have toggled
+  // gamification OFF after a previous migration; we must not re-promote
+  // the legacy `true` value.
+  if (settings.get(gamificationMigratedKey) == true) {
+    return;
+  }
+
+  // No profile loaded yet → try again next launch. We deliberately do
+  // NOT write the gate flag because that would lock in the manifest
+  // default and silently discard any explicit `gamificationEnabled =
+  // false` the user had set.
+  if (activeProfile == null) {
+    return;
+  }
+
+  // ignore: deprecated_member_use_from_same_package
+  final legacyValue = activeProfile.gamificationEnabled;
+
+  try {
+    final current = await featureFlags.loadEnabled();
+    if (legacyValue == true) {
+      // Force-enable the prerequisite first per the manifest's
+      // dependency graph — otherwise the central system would refuse
+      // the gamification enable on its first toggle attempt.
+      final entry = manifest.entryFor(Feature.gamification);
+      final next = <Feature>{
+        ...current,
+        ...entry.requires,
+        Feature.gamification,
+      };
+      await featureFlags.saveEnabled(next);
+    } else {
+      // Legacy explicit-false. Feature.gamification's manifest default
+      // is `true`, so a no-op (no write) would silently RESTORE the
+      // gamification surfaces for users who had explicitly opted out.
+      // Persist the current set with gamification removed so the
+      // user's preference survives the migration.
+      final next = {...current}..remove(Feature.gamification);
+      await featureFlags.saveEnabled(next);
+    }
+  } catch (e, st) {
+    // Don't block startup on a migration failure — the user can
+    // re-toggle from settings if the central state is missing.
+    debugPrint(
+      'migrateUserProfileToggles: gamification promote failed: $e\n$st',
+    );
+  }
+
+  // Always set the flag (even when the persistence above failed) so we
+  // never re-read the legacy field on subsequent launches.
+  try {
+    await settings.put(gamificationMigratedKey, true);
+  } catch (e, st) {
+    debugPrint(
+      'migrateUserProfileToggles: writing $gamificationMigratedKey failed: $e\n$st',
     );
   }
 }

--- a/lib/features/profile/data/models/user_profile.dart
+++ b/lib/features/profile/data/models/user_profile.dart
@@ -77,6 +77,9 @@ abstract class UserProfile with _$UserProfile {
     /// are hidden across the app — the underlying achievement
     /// evaluation continues to run so toggling back on instantly
     /// restores any earned badges.
+    @Deprecated(
+      'Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.',
+    )
     @Default(true) bool gamificationEnabled,
   }) = _UserProfile;
 

--- a/lib/features/profile/data/models/user_profile.freezed.dart
+++ b/lib/features/profile/data/models/user_profile.freezed.dart
@@ -41,7 +41,7 @@ mixin _$UserProfile {
 /// are hidden across the app — the underlying achievement
 /// evaluation continues to run so toggling back on instantly
 /// restores any earned badges.
- bool get gamificationEnabled;
+@Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') bool get gamificationEnabled;
 /// Create a copy of UserProfile
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -74,7 +74,7 @@ abstract mixin class $UserProfileCopyWith<$Res>  {
   factory $UserProfileCopyWith(UserProfile value, $Res Function(UserProfile) _then) = _$UserProfileCopyWithImpl;
 @useResult
 $Res call({
- String id, String name,@FuelTypeJsonConverter() FuelType preferredFuelType, double defaultSearchRadius, LandingScreen landingScreen, List<String> favoriteStationIds, String? homeZipCode, bool autoUpdatePosition, String? countryCode, String? languageCode, double routeSegmentKm, bool avoidHighways, bool showFuel, bool showElectric, String ratingMode, List<StationAmenity> preferredAmenities, String? defaultVehicleId,@FuelTypeJsonConverter() FuelType? hybridFuelChoice, bool showConsumptionTab, bool gamificationEnabled
+ String id, String name,@FuelTypeJsonConverter() FuelType preferredFuelType, double defaultSearchRadius, LandingScreen landingScreen, List<String> favoriteStationIds, String? homeZipCode, bool autoUpdatePosition, String? countryCode, String? languageCode, double routeSegmentKm, bool avoidHighways, bool showFuel, bool showElectric, String ratingMode, List<StationAmenity> preferredAmenities, String? defaultVehicleId,@FuelTypeJsonConverter() FuelType? hybridFuelChoice, bool showConsumptionTab,@Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') bool gamificationEnabled
 });
 
 
@@ -198,7 +198,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice,  bool showConsumptionTab,  bool gamificationEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice,  bool showConsumptionTab, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.')  bool gamificationEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _UserProfile() when $default != null:
 return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchRadius,_that.landingScreen,_that.favoriteStationIds,_that.homeZipCode,_that.autoUpdatePosition,_that.countryCode,_that.languageCode,_that.routeSegmentKm,_that.avoidHighways,_that.showFuel,_that.showElectric,_that.ratingMode,_that.preferredAmenities,_that.defaultVehicleId,_that.hybridFuelChoice,_that.showConsumptionTab,_that.gamificationEnabled);case _:
@@ -219,7 +219,7 @@ return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchR
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice,  bool showConsumptionTab,  bool gamificationEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice,  bool showConsumptionTab, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.')  bool gamificationEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _UserProfile():
 return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchRadius,_that.landingScreen,_that.favoriteStationIds,_that.homeZipCode,_that.autoUpdatePosition,_that.countryCode,_that.languageCode,_that.routeSegmentKm,_that.avoidHighways,_that.showFuel,_that.showElectric,_that.ratingMode,_that.preferredAmenities,_that.defaultVehicleId,_that.hybridFuelChoice,_that.showConsumptionTab,_that.gamificationEnabled);case _:
@@ -239,7 +239,7 @@ return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchR
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice,  bool showConsumptionTab,  bool gamificationEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice,  bool showConsumptionTab, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.')  bool gamificationEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _UserProfile() when $default != null:
 return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchRadius,_that.landingScreen,_that.favoriteStationIds,_that.homeZipCode,_that.autoUpdatePosition,_that.countryCode,_that.languageCode,_that.routeSegmentKm,_that.avoidHighways,_that.showFuel,_that.showElectric,_that.ratingMode,_that.preferredAmenities,_that.defaultVehicleId,_that.hybridFuelChoice,_that.showConsumptionTab,_that.gamificationEnabled);case _:
@@ -254,7 +254,7 @@ return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchR
 @JsonSerializable()
 
 class _UserProfile implements UserProfile {
-  const _UserProfile({required this.id, required this.name, @FuelTypeJsonConverter() this.preferredFuelType = FuelType.e10, this.defaultSearchRadius = 10.0, this.landingScreen = LandingScreen.nearest, final  List<String> favoriteStationIds = const [], this.homeZipCode, this.autoUpdatePosition = false, this.countryCode, this.languageCode, this.routeSegmentKm = 50.0, this.avoidHighways = false, this.showFuel = true, this.showElectric = true, this.ratingMode = 'local', final  List<StationAmenity> preferredAmenities = const [], this.defaultVehicleId, @FuelTypeJsonConverter() this.hybridFuelChoice, this.showConsumptionTab = false, this.gamificationEnabled = true}): _favoriteStationIds = favoriteStationIds,_preferredAmenities = preferredAmenities;
+  const _UserProfile({required this.id, required this.name, @FuelTypeJsonConverter() this.preferredFuelType = FuelType.e10, this.defaultSearchRadius = 10.0, this.landingScreen = LandingScreen.nearest, final  List<String> favoriteStationIds = const [], this.homeZipCode, this.autoUpdatePosition = false, this.countryCode, this.languageCode, this.routeSegmentKm = 50.0, this.avoidHighways = false, this.showFuel = true, this.showElectric = true, this.ratingMode = 'local', final  List<StationAmenity> preferredAmenities = const [], this.defaultVehicleId, @FuelTypeJsonConverter() this.hybridFuelChoice, this.showConsumptionTab = false, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') this.gamificationEnabled = true}): _favoriteStationIds = favoriteStationIds,_preferredAmenities = preferredAmenities;
   factory _UserProfile.fromJson(Map<String, dynamic> json) => _$UserProfileFromJson(json);
 
 @override final  String id;
@@ -316,7 +316,7 @@ class _UserProfile implements UserProfile {
 /// are hidden across the app — the underlying achievement
 /// evaluation continues to run so toggling back on instantly
 /// restores any earned badges.
-@override@JsonKey() final  bool gamificationEnabled;
+@override@JsonKey()@Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') final  bool gamificationEnabled;
 
 /// Create a copy of UserProfile
 /// with the given fields replaced by the non-null parameter values.
@@ -351,7 +351,7 @@ abstract mixin class _$UserProfileCopyWith<$Res> implements $UserProfileCopyWith
   factory _$UserProfileCopyWith(_UserProfile value, $Res Function(_UserProfile) _then) = __$UserProfileCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name,@FuelTypeJsonConverter() FuelType preferredFuelType, double defaultSearchRadius, LandingScreen landingScreen, List<String> favoriteStationIds, String? homeZipCode, bool autoUpdatePosition, String? countryCode, String? languageCode, double routeSegmentKm, bool avoidHighways, bool showFuel, bool showElectric, String ratingMode, List<StationAmenity> preferredAmenities, String? defaultVehicleId,@FuelTypeJsonConverter() FuelType? hybridFuelChoice, bool showConsumptionTab, bool gamificationEnabled
+ String id, String name,@FuelTypeJsonConverter() FuelType preferredFuelType, double defaultSearchRadius, LandingScreen landingScreen, List<String> favoriteStationIds, String? homeZipCode, bool autoUpdatePosition, String? countryCode, String? languageCode, double routeSegmentKm, bool avoidHighways, bool showFuel, bool showElectric, String ratingMode, List<StationAmenity> preferredAmenities, String? defaultVehicleId,@FuelTypeJsonConverter() FuelType? hybridFuelChoice, bool showConsumptionTab,@Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') bool gamificationEnabled
 });
 
 

--- a/lib/features/profile/presentation/widgets/gamification_settings_tile.dart
+++ b/lib/features/profile/presentation/widgets/gamification_settings_tile.dart
@@ -7,16 +7,20 @@ import '../../providers/profile_provider.dart';
 
 /// Settings-screen toggle for the master gamification opt-out (#1194).
 ///
-/// Persists by mutating the active [UserProfile.gamificationEnabled]
-/// flag through [activeProfileProvider]. The watch on
-/// [gamificationEnabledProvider] keeps the switch reactive — toggling
-/// it elsewhere (e.g. from a future "first-run" interstitial) flips
-/// the visible switch immediately.
+/// As of #1373 phase 3b mutation goes through the central
+/// `featureFlagsProvider` system via [gamificationEnabledProvider.set].
+/// The watch on [gamificationEnabledProvider] keeps the switch reactive
+/// — toggling it elsewhere (e.g. from a future "first-run" interstitial)
+/// flips the visible switch immediately.
 ///
 /// Renders nothing when no profile is loaded yet — the wrapping
 /// settings screen guards profile creation up-front, but a paranoid
 /// null check keeps test fixtures that omit the profile from
-/// throwing.
+/// throwing. The guard is no longer functionally required after the
+/// 3b migration (the feature flag store is independent of the active
+/// profile), but it minimises blast radius for the wider Settings
+/// screen and existing test fixtures that depend on this null-guard
+/// behaviour.
 class GamificationSettingsTile extends ConsumerWidget {
   const GamificationSettingsTile({super.key});
 
@@ -41,8 +45,7 @@ class GamificationSettingsTile extends ConsumerWidget {
         style: theme.textTheme.bodySmall,
       ),
       onChanged: (v) {
-        final updated = profile.copyWith(gamificationEnabled: v);
-        ref.read(activeProfileProvider.notifier).updateProfile(updated);
+        ref.read(gamificationEnabledProvider.notifier).set(v);
       },
       contentPadding: EdgeInsets.zero,
     );

--- a/lib/features/profile/providers/gamification_enabled_provider.dart
+++ b/lib/features/profile/providers/gamification_enabled_provider.dart
@@ -1,17 +1,25 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import 'profile_provider.dart';
+import '../../feature_management/application/feature_flags_provider.dart';
+import '../../feature_management/domain/feature.dart';
 
 part 'gamification_enabled_provider.g.dart';
 
 /// Master gate for gamification surfaces (#1194).
 ///
-/// Reads the [UserProfile.gamificationEnabled] flag from the active
-/// profile. Returns `true` when no profile is loaded yet so the very
-/// first frame on a cold launch keeps the existing behaviour — the
-/// underlying flag itself defaults to `true` for both freshly-created
-/// and migrated profiles, so this fall-back only applies before the
-/// active profile is resolved.
+/// As of #1373 phase 3b this is a thin shim over [featureFlagsProvider]
+/// — the canonical state lives in the central feature-flag set keyed by
+/// [Feature.gamification]. The legacy `UserProfile.gamificationEnabled`
+/// field is read once by `legacyToggleMigrationProvider` on first
+/// launch after upgrade (gated on a `gamificationMigratedKey` flag in
+/// the settings box) and promoted into the central set; subsequent
+/// reads/writes go through here.
+///
+/// The manifest defaults [Feature.gamification] to `true`, so
+/// fresh-install users see the same behaviour they had before this
+/// migration. Users who had toggled `gamificationEnabled = false` keep
+/// their preference because the migrator preserves the explicit-false
+/// value through the gate.
 ///
 /// Consumers wrap their gamification UI with:
 /// ```dart
@@ -23,8 +31,46 @@ part 'gamification_enabled_provider.g.dart';
 /// The achievement-engine itself is intentionally NOT gated — it keeps
 /// running so that toggling back on instantly restores any badges
 /// earned during the opt-out window.
-@riverpod
-bool gamificationEnabled(Ref ref) {
-  final profile = ref.watch(activeProfileProvider);
-  return profile?.gamificationEnabled ?? true;
+@Riverpod(keepAlive: true)
+class GamificationEnabled extends _$GamificationEnabled {
+  @override
+  bool build() {
+    return ref.watch(featureFlagsProvider).contains(Feature.gamification);
+  }
+
+  /// Delegate to [featureFlagsProvider]'s `enable` / `disable`. The
+  /// central provider enforces the manifest dependency graph
+  /// ([Feature.gamification] requires [Feature.obd2TripRecording]) and
+  /// throws [StateError] when a prerequisite is missing or a dependent
+  /// would block disabling.
+  ///
+  /// A [StateError] from a dependency-violation is intentionally
+  /// swallowed and the toggle stays at its prior state — see the
+  /// catch block below for why.
+  Future<void> set(bool value) async {
+    final notifier = ref.read(featureFlagsProvider.notifier);
+    try {
+      if (value) {
+        await notifier.enable(Feature.gamification);
+      } else {
+        await notifier.disable(Feature.gamification);
+      }
+      // The central provider throws a StateError specifically for
+      // dependency-violation; we want to swallow ONLY that — see the
+      // body comment for why. The lint deliberately discourages
+      // catching Error subclasses, but the central API's contract
+      // documents this exact StateError as the dependency-violation
+      // signal, so the catch is intentional and narrow.
+      // ignore: avoid_catching_errors
+    } on StateError {
+      // TODO(1373): Phase 2's settings UI canEnable / blockingDisable
+      // pre-check already guards this setter at the UI layer, so a
+      // dependency-violation here is a defensive-only catch — the UI
+      // path can't currently reach it. We swallow rather than rethrow
+      // so a programmatic caller (e.g. a test or a future call site)
+      // sees the toggle stay at its prior state instead of crashing
+      // the widget tree. Remove once every call site has been audited
+      // for `canEnable` pre-check coverage.
+    }
+  }
 }

--- a/lib/features/profile/providers/gamification_enabled_provider.g.dart
+++ b/lib/features/profile/providers/gamification_enabled_provider.g.dart
@@ -10,12 +10,19 @@ part of 'gamification_enabled_provider.dart';
 // ignore_for_file: type=lint, type=warning
 /// Master gate for gamification surfaces (#1194).
 ///
-/// Reads the [UserProfile.gamificationEnabled] flag from the active
-/// profile. Returns `true` when no profile is loaded yet so the very
-/// first frame on a cold launch keeps the existing behaviour — the
-/// underlying flag itself defaults to `true` for both freshly-created
-/// and migrated profiles, so this fall-back only applies before the
-/// active profile is resolved.
+/// As of #1373 phase 3b this is a thin shim over [featureFlagsProvider]
+/// — the canonical state lives in the central feature-flag set keyed by
+/// [Feature.gamification]. The legacy `UserProfile.gamificationEnabled`
+/// field is read once by `legacyToggleMigrationProvider` on first
+/// launch after upgrade (gated on a `gamificationMigratedKey` flag in
+/// the settings box) and promoted into the central set; subsequent
+/// reads/writes go through here.
+///
+/// The manifest defaults [Feature.gamification] to `true`, so
+/// fresh-install users see the same behaviour they had before this
+/// migration. Users who had toggled `gamificationEnabled = false` keep
+/// their preference because the migrator preserves the explicit-false
+/// value through the gate.
 ///
 /// Consumers wrap their gamification UI with:
 /// ```dart
@@ -28,17 +35,24 @@ part of 'gamification_enabled_provider.dart';
 /// running so that toggling back on instantly restores any badges
 /// earned during the opt-out window.
 
-@ProviderFor(gamificationEnabled)
+@ProviderFor(GamificationEnabled)
 final gamificationEnabledProvider = GamificationEnabledProvider._();
 
 /// Master gate for gamification surfaces (#1194).
 ///
-/// Reads the [UserProfile.gamificationEnabled] flag from the active
-/// profile. Returns `true` when no profile is loaded yet so the very
-/// first frame on a cold launch keeps the existing behaviour — the
-/// underlying flag itself defaults to `true` for both freshly-created
-/// and migrated profiles, so this fall-back only applies before the
-/// active profile is resolved.
+/// As of #1373 phase 3b this is a thin shim over [featureFlagsProvider]
+/// — the canonical state lives in the central feature-flag set keyed by
+/// [Feature.gamification]. The legacy `UserProfile.gamificationEnabled`
+/// field is read once by `legacyToggleMigrationProvider` on first
+/// launch after upgrade (gated on a `gamificationMigratedKey` flag in
+/// the settings box) and promoted into the central set; subsequent
+/// reads/writes go through here.
+///
+/// The manifest defaults [Feature.gamification] to `true`, so
+/// fresh-install users see the same behaviour they had before this
+/// migration. Users who had toggled `gamificationEnabled = false` keep
+/// their preference because the migrator preserves the explicit-false
+/// value through the gate.
 ///
 /// Consumers wrap their gamification UI with:
 /// ```dart
@@ -50,18 +64,23 @@ final gamificationEnabledProvider = GamificationEnabledProvider._();
 /// The achievement-engine itself is intentionally NOT gated — it keeps
 /// running so that toggling back on instantly restores any badges
 /// earned during the opt-out window.
-
 final class GamificationEnabledProvider
-    extends $FunctionalProvider<bool, bool, bool>
-    with $Provider<bool> {
+    extends $NotifierProvider<GamificationEnabled, bool> {
   /// Master gate for gamification surfaces (#1194).
   ///
-  /// Reads the [UserProfile.gamificationEnabled] flag from the active
-  /// profile. Returns `true` when no profile is loaded yet so the very
-  /// first frame on a cold launch keeps the existing behaviour — the
-  /// underlying flag itself defaults to `true` for both freshly-created
-  /// and migrated profiles, so this fall-back only applies before the
-  /// active profile is resolved.
+  /// As of #1373 phase 3b this is a thin shim over [featureFlagsProvider]
+  /// — the canonical state lives in the central feature-flag set keyed by
+  /// [Feature.gamification]. The legacy `UserProfile.gamificationEnabled`
+  /// field is read once by `legacyToggleMigrationProvider` on first
+  /// launch after upgrade (gated on a `gamificationMigratedKey` flag in
+  /// the settings box) and promoted into the central set; subsequent
+  /// reads/writes go through here.
+  ///
+  /// The manifest defaults [Feature.gamification] to `true`, so
+  /// fresh-install users see the same behaviour they had before this
+  /// migration. Users who had toggled `gamificationEnabled = false` keep
+  /// their preference because the migrator preserves the explicit-false
+  /// value through the gate.
   ///
   /// Consumers wrap their gamification UI with:
   /// ```dart
@@ -79,7 +98,7 @@ final class GamificationEnabledProvider
         argument: null,
         retry: null,
         name: r'gamificationEnabledProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -89,13 +108,7 @@ final class GamificationEnabledProvider
 
   @$internal
   @override
-  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
-
-  @override
-  bool create(Ref ref) {
-    return gamificationEnabled(ref);
-  }
+  GamificationEnabled create() => GamificationEnabled();
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(bool value) {
@@ -107,4 +120,49 @@ final class GamificationEnabledProvider
 }
 
 String _$gamificationEnabledHash() =>
-    r'e530fcd44461d673e10b3326825cbcaf94d0f3b4';
+    r'd7fcd834f133f5c0a09e13d51100bc49cb785a50';
+
+/// Master gate for gamification surfaces (#1194).
+///
+/// As of #1373 phase 3b this is a thin shim over [featureFlagsProvider]
+/// — the canonical state lives in the central feature-flag set keyed by
+/// [Feature.gamification]. The legacy `UserProfile.gamificationEnabled`
+/// field is read once by `legacyToggleMigrationProvider` on first
+/// launch after upgrade (gated on a `gamificationMigratedKey` flag in
+/// the settings box) and promoted into the central set; subsequent
+/// reads/writes go through here.
+///
+/// The manifest defaults [Feature.gamification] to `true`, so
+/// fresh-install users see the same behaviour they had before this
+/// migration. Users who had toggled `gamificationEnabled = false` keep
+/// their preference because the migrator preserves the explicit-false
+/// value through the gate.
+///
+/// Consumers wrap their gamification UI with:
+/// ```dart
+/// if (!ref.watch(gamificationEnabledProvider)) {
+///   return const SizedBox.shrink();
+/// }
+/// ```
+///
+/// The achievement-engine itself is intentionally NOT gated — it keeps
+/// running so that toggling back on instantly restores any badges
+/// earned during the opt-out window.
+
+abstract class _$GamificationEnabled extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
@@ -99,7 +99,7 @@ Future<void> _pumpScreen(
       fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
       activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
       vehicleProfileListProvider.overrideWith(() => _EmptyVehicleList()),
-      gamificationEnabledProvider.overrideWith((ref) => true),
+      gamificationEnabledProvider.overrideWithValue(true),
     ],
   );
 }

--- a/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
+++ b/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
@@ -140,9 +140,9 @@ Future<({_FixedTripHistoryList tripsNotifier})> _pumpDetail(
       vehicleProfileListProvider
           .overrideWith(() => _FixedVehicleProfileList(vehicles)),
       // #1194 — TripDetailBody now reads gamificationEnabledProvider;
-      // override here so it doesn't fall through to the (Hive-backed)
-      // active profile lookup that these tests don't seed.
-      gamificationEnabledProvider.overrideWith((ref) => true),
+      // override here so it doesn't fall through to the central
+      // featureFlagsProvider chain that these tests don't seed.
+      gamificationEnabledProvider.overrideWithValue(true),
       // #1209 — TripSummaryCard now watches tripFuelCostProvider, which
       // composes fillUpListProvider (Hive-backed). These tests don't
       // seed Hive; return null so the cost row hides cleanly.

--- a/test/features/consumption/presentation/widgets/fuel_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/fuel_tab_test.dart
@@ -47,7 +47,7 @@ void main() {
 
   List<Object> overrides({required bool gamification}) => [
         achievementsProvider.overrideWithValue(earned),
-        gamificationEnabledProvider.overrideWith((ref) => gamification),
+        gamificationEnabledProvider.overrideWithValue(gamification),
         activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
         fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
       ];
@@ -100,7 +100,7 @@ void main() {
       FuelTab(fillUps: correctionFills, stats: stats, l: null),
       overrides: [
         achievementsProvider.overrideWithValue(const <EarnedAchievement>[]),
-        gamificationEnabledProvider.overrideWith((ref) => false),
+        gamificationEnabledProvider.overrideWithValue(false),
         activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
         fillUpListProvider
             .overrideWith(() => _FixedFillUpList(correctionFills)),

--- a/test/features/consumption/presentation/widgets/trip_detail_body_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_detail_body_test.dart
@@ -72,7 +72,7 @@ TripDetailSample _sampleWithEngineLoad(int sec, double speed, double load) =>
 /// value so the underlying active-profile chain isn't traversed (those
 /// tests don't set up Hive).
 final List<Object> _defaultOverrides = [
-  gamificationEnabledProvider.overrideWith((ref) => true),
+  gamificationEnabledProvider.overrideWithValue(true),
 ];
 
 Future<void> _pump(WidgetTester tester, Widget body) =>

--- a/test/features/feature_management/data/legacy_toggle_migrator_test.dart
+++ b/test/features/feature_management/data/legacy_toggle_migrator_test.dart
@@ -7,6 +7,7 @@ import 'package:tankstellen/features/feature_management/data/feature_flags_repos
 import 'package:tankstellen/features/feature_management/data/legacy_toggle_migrator.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
 
 /// Coverage for [migrateLegacyToggles] (#1373 phase 3a).
 ///
@@ -207,5 +208,205 @@ void main() {
             'migrator must not write to the repository when the gate is set.',
       );
     });
+  });
+
+  group('migrateUserProfileToggles — gamification', () {
+    UserProfile profileWith({required bool gamification}) {
+      // The gamificationEnabled field is `@Deprecated` post-#1373
+      // phase 3b. The migrator still reads it for the one-shot promotion
+      // — see `legacy_toggle_migrator.dart` for the same suppression.
+      // ignore: deprecated_member_use_from_same_package
+      return UserProfile(
+        id: 'p1',
+        name: 'Test',
+        // ignore: deprecated_member_use_from_same_package
+        gamificationEnabled: gamification,
+      );
+    }
+
+    test(
+      'cascade-enables on activeProfile.gamificationEnabled = true — final '
+      'feature set contains both obd2TripRecording AND gamification',
+      () async {
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: profileWith(gamification: true),
+        );
+
+        final after = await repo.loadEnabled();
+        expect(
+          after,
+          contains(Feature.gamification),
+          reason:
+              'Legacy true must promote into the central feature-flag set '
+              'so the user does not have to re-enable gamification after '
+              'the migration.',
+        );
+        expect(
+          after,
+          contains(Feature.obd2TripRecording),
+          reason:
+              'Feature.gamification requires obd2TripRecording per the '
+              'manifest; enabling the dependent without the prerequisite '
+              'would leave the central state in a contract-violating shape.',
+        );
+        expect(
+          settings.get(gamificationMigratedKey),
+          isTrue,
+          reason:
+              'The migration gate must be set so a subsequent run is a '
+              'no-op and a user who later disables gamification does not '
+              'get it re-enabled on the next launch.',
+        );
+      },
+    );
+
+    test(
+      'preserves legacy false — explicit opt-out survives the manifest '
+      'default, migrated key written',
+      () async {
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: profileWith(gamification: false),
+        );
+
+        final after = await repo.loadEnabled();
+        expect(
+          after,
+          isNot(contains(Feature.gamification)),
+          reason:
+              'Feature.gamification has manifest defaultEnabled=true, so '
+              'a no-op (no write) would silently restore gamification for '
+              'users who had explicitly opted out. The migrator must '
+              'persist the user’s false choice by writing a state that '
+              'excludes Feature.gamification — otherwise the explicit '
+              'preference is lost across the migration.',
+        );
+        expect(
+          settings.get(gamificationMigratedKey),
+          isTrue,
+          reason:
+              'Even a legacy=false migration must set the gate so we '
+              'never re-read the deprecated field on subsequent launches.',
+        );
+      },
+    );
+
+    test(
+      'no-op on activeProfile == null — feature set unchanged AND migrated '
+      'key NOT written (will retry next launch)',
+      () async {
+        // Seed central state to a known shape so we can detect any writes.
+        await repo.saveEnabled(<Feature>{Feature.priceAlerts});
+
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: null,
+        );
+
+        final after = await repo.loadEnabled();
+        expect(
+          after,
+          equals(<Feature>{Feature.priceAlerts}),
+          reason:
+              'Without an active profile the migrator must be a complete '
+              'no-op — no central writes, the seeded state must be '
+              'preserved verbatim.',
+        );
+        expect(
+          settings.get(gamificationMigratedKey),
+          isNull,
+          reason:
+              'The migrated-key flag MUST NOT be written when no profile '
+              'is loaded — otherwise the next launch (when the profile '
+              'IS loaded) would skip the migration and silently lose any '
+              'explicit gamificationEnabled = false the user had set.',
+        );
+      },
+    );
+
+    test(
+      'idempotent — running twice with the same inputs does NOT re-promote '
+      '(second call exits at the migrated-key check)',
+      () async {
+        // First run promotes.
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: profileWith(gamification: true),
+        );
+        final afterFirst = await repo.loadEnabled();
+        expect(afterFirst, contains(Feature.gamification));
+        expect(settings.get(gamificationMigratedKey), isTrue);
+
+        // Simulate the user disabling gamification after the migration
+        // (e.g. via the central settings UI). The second run must NOT
+        // re-enable it.
+        final disabled = {...afterFirst}..remove(Feature.gamification);
+        await repo.saveEnabled(disabled);
+
+        // Second run with same activeProfile (legacy still true).
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: profileWith(gamification: true),
+        );
+
+        final afterSecond = await repo.loadEnabled();
+        expect(
+          afterSecond,
+          isNot(contains(Feature.gamification)),
+          reason:
+              'A second migration run must not re-promote the legacy true '
+              'value — the user has explicitly disabled gamification since '
+              'and that choice must survive.',
+        );
+      },
+    );
+
+    test(
+      'gate-skip when gamificationMigratedKey is already true — no read of '
+      'activeProfile.gamificationEnabled',
+      () async {
+        await settings.put(gamificationMigratedKey, true);
+        // Seed central state to a known shape so we can detect any writes.
+        await repo.saveEnabled(<Feature>{Feature.priceAlerts});
+
+        // Pass a profile with gamification=true; the migrator must skip
+        // it entirely because the gate is set.
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: profileWith(gamification: true),
+        );
+
+        final after = await repo.loadEnabled();
+        expect(
+          after,
+          isNot(contains(Feature.gamification)),
+          reason:
+              'When the migration gate is already set, the legacy field '
+              'must not be re-read and the central state must stay exactly '
+              'as the user left it after the first migration.',
+        );
+        expect(
+          after,
+          contains(Feature.priceAlerts),
+          reason:
+              'The seeded central state must be preserved verbatim — the '
+              'migrator must not write to the repository when the gate is '
+              'set.',
+        );
+      },
+    );
   });
 }

--- a/test/features/profile/presentation/widgets/gamification_settings_tile_test.dart
+++ b/test/features/profile/presentation/widgets/gamification_settings_tile_test.dart
@@ -3,25 +3,47 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/profile/data/repositories/profile_repository.dart';
 import 'package:tankstellen/features/profile/presentation/widgets/gamification_settings_tile.dart';
-import 'package:tankstellen/features/profile/providers/gamification_enabled_provider.dart';
 
 import '../../../../helpers/pump_app.dart';
 
 /// Widget tests for the gamification opt-out switch tile (#1194).
+///
+/// As of #1373 phase 3b the tile reads/writes through the central
+/// [featureFlagsProvider] rather than mutating the active
+/// [UserProfile.gamificationEnabled] field. The switch's KEY, label,
+/// subtitle and null-profile guard are unchanged from the pre-3b
+/// surface — this test file pins all four behaviours plus the new
+/// reactive-rebuild path that fires when the central state mutates
+/// via override.
+///
+/// Tests intentionally bypass the real Hive-backed
+/// [FeatureFlagsRepository] via a synthetic [_TestFeatureFlags]
+/// notifier — this matches the haptic-eco-coach test pattern from
+/// `feedback_hive_widget_test_teardown.md` and avoids fire-and-forget
+/// `box.put` hangs on Windows during `pumpAndSettle`.
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   testWidgets('renders the title and subtitle when an active profile exists',
       (tester) async {
     final storage = _InMemoryHiveStorage();
     final repo = ProfileRepository(storage);
     await repo.createProfile(name: 'P1');
+    final fakeFlags = _TestFeatureFlags(<Feature>{
+      Feature.obd2TripRecording,
+      Feature.gamification,
+    });
 
     await pumpApp(
       tester,
       const GamificationSettingsTile(),
       overrides: [
         profileRepositoryProvider.overrideWithValue(repo),
+        featureFlagsProvider.overrideWith(() => fakeFlags),
       ],
     );
 
@@ -30,11 +52,17 @@ void main() {
       find.textContaining('badges, scores and trophy icons'),
       findsOneWidget,
     );
-    // Switch is on by default for new profiles.
     final switchWidget = tester.widget<SwitchListTile>(
       find.byType(SwitchListTile),
     );
-    expect(switchWidget.value, isTrue);
+    expect(
+      switchWidget.value,
+      isTrue,
+      reason:
+          'Pre-seeded central state with Feature.gamification on must '
+          'hydrate the switch on first paint — otherwise the user would '
+          'have to flip it twice on every cold start.',
+    );
   });
 
   testWidgets('renders nothing when there is no active profile',
@@ -47,49 +75,148 @@ void main() {
       const GamificationSettingsTile(),
       overrides: [
         profileRepositoryProvider.overrideWithValue(repo),
+        featureFlagsProvider.overrideWith(() => _TestFeatureFlags()),
       ],
     );
 
-    expect(find.byType(SwitchListTile), findsNothing);
+    expect(
+      find.byType(SwitchListTile),
+      findsNothing,
+      reason:
+          'The null-profile guard MUST stay even after the 3b migration '
+          '— the wider Settings screen still requires a loaded profile '
+          'to render and existing test fixtures rely on this null-guard '
+          'behaviour.',
+    );
     expect(find.text('Show achievements & scores'), findsNothing);
   });
 
-  testWidgets('tapping the switch flips the gamification provider',
+  testWidgets('tapping the switch flips the central feature-flag set',
       (tester) async {
     final storage = _InMemoryHiveStorage();
     final repo = ProfileRepository(storage);
     await repo.createProfile(name: 'P1');
+    // Seed prerequisite (obd2TripRecording) so the central enable
+    // succeeds — without it the shim would silently swallow the
+    // dependency-violation StateError and the switch would not flip.
+    final fakeFlags = _TestFeatureFlags(<Feature>{Feature.obd2TripRecording});
 
     await pumpApp(
       tester,
       const GamificationSettingsTile(),
       overrides: [
         profileRepositoryProvider.overrideWithValue(repo),
+        featureFlagsProvider.overrideWith(() => fakeFlags),
       ],
     );
 
-    // Initial state: switch is on, provider returns true.
+    final switchFinder = find.byType(SwitchListTile);
     expect(
-      tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
-      isTrue,
-    );
-
-    await tester.tap(find.byType(SwitchListTile));
-    await tester.pumpAndSettle();
-
-    expect(
-      tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+      tester.widget<SwitchListTile>(switchFinder).value,
       isFalse,
+      reason: 'Initial: gamification absent from central set → switch off.',
     );
 
-    // Verify the underlying profile + provider both updated. We rebuild
-    // the ProviderContainer from the tree to assert the gamification
-    // provider directly reflects the new flag.
-    final element = tester.element(find.byType(GamificationSettingsTile));
-    final container = ProviderScope.containerOf(element);
-    expect(container.read(gamificationEnabledProvider), isFalse);
-    expect(repo.getActiveProfile()?.gamificationEnabled, isFalse);
+    await tester.tap(switchFinder);
+    // Two pumps: drain microtasks then advance simulated time so the
+    // notifier's `enable` Future settles before assertion. Pattern
+    // mirrors `feedback_hive_widget_test_teardown.md`.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      fakeFlags.state,
+      contains(Feature.gamification),
+      reason:
+          'Tapping the toggle must enable gamification in the central '
+          'feature-flag set so the setting survives an app restart via '
+          'the central repository (#1373 phase 3b). The legacy '
+          'UserProfile.gamificationEnabled mutation path is gone.',
+    );
+    expect(
+      tester.widget<SwitchListTile>(switchFinder).value,
+      isTrue,
+      reason: 'The switch must reflect the new central state immediately.',
+    );
   });
+
+  testWidgets(
+    'reactively flips when featureFlagsProvider mutates externally',
+    (tester) async {
+      final storage = _InMemoryHiveStorage();
+      final repo = ProfileRepository(storage);
+      await repo.createProfile(name: 'P1');
+      final fakeFlags = _TestFeatureFlags(<Feature>{
+        Feature.obd2TripRecording,
+        Feature.gamification,
+      });
+
+      await pumpApp(
+        tester,
+        const GamificationSettingsTile(),
+        overrides: [
+          profileRepositoryProvider.overrideWithValue(repo),
+          featureFlagsProvider.overrideWith(() => fakeFlags),
+        ],
+      );
+
+      final switchFinder = find.byType(SwitchListTile);
+      expect(
+        tester.widget<SwitchListTile>(switchFinder).value,
+        isTrue,
+        reason: 'Pre-seeded with gamification on → switch starts on.',
+      );
+
+      // External mutation: another consumer disables gamification on
+      // the central provider (e.g. a different settings surface or a
+      // deep-link handler). The tile must rebuild on the next frame.
+      final element = tester.element(find.byType(GamificationSettingsTile));
+      final container = ProviderScope.containerOf(element);
+      await container
+          .read(featureFlagsProvider.notifier)
+          .disable(Feature.gamification);
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(
+        tester.widget<SwitchListTile>(switchFinder).value,
+        isFalse,
+        reason:
+            'External writes to featureFlagsProvider must propagate to '
+            'the tile so the visible switch reflects the central state '
+            'without requiring a manual rebuild trigger.',
+      );
+    },
+  );
+}
+
+/// Synthetic in-memory [FeatureFlags] notifier for widget tests.
+///
+/// Mirrors the equivalent test double in
+/// `test/features/driving/presentation/driving_settings_section_test.dart`
+/// — the contract is the same: in-memory state, no Hive dependency,
+/// no `pumpAndSettle` hangs on Windows.
+class _TestFeatureFlags extends FeatureFlags {
+  _TestFeatureFlags([Set<Feature>? initial])
+      : _initial = initial ?? <Feature>{};
+
+  final Set<Feature> _initial;
+
+  @override
+  Set<Feature> build() => {..._initial};
+
+  @override
+  Future<void> enable(Feature feature) async {
+    if (state.contains(feature)) return;
+    state = {...state, feature};
+  }
+
+  @override
+  Future<void> disable(Feature feature) async {
+    if (!state.contains(feature)) return;
+    state = {...state}..remove(feature);
+  }
 }
 
 /// Minimal in-memory HiveStorage stand-in mirroring the helper used in

--- a/test/features/profile/providers/gamification_enabled_provider_test.dart
+++ b/test/features/profile/providers/gamification_enabled_provider_test.dart
@@ -1,145 +1,341 @@
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:tankstellen/core/storage/hive_storage.dart';
-import 'package:tankstellen/features/profile/data/repositories/profile_repository.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/data/feature_flags_repository.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/profile/providers/gamification_enabled_provider.dart';
-import 'package:tankstellen/features/profile/providers/profile_provider.dart';
 
-/// Tests for [gamificationEnabledProvider] (#1194 — opt-out toggle).
+/// Provider-layer coverage for the [gamificationEnabledProvider]
+/// (#1194). As of #1373 phase 3b this provider is a thin shim that
+/// delegates to [featureFlagsProvider]; tests assert that contract:
 ///
-/// The provider derives its value from the active [UserProfile.gamificationEnabled]
-/// flag. A null profile (cold-launch / first-frame) defaults to `true`
-/// so the existing UI keeps rendering until the profile resolves.
+///   1. Default state mirrors `featureFlagsProvider.contains(Feature.gamification)`
+///      (manifest default = `true`).
+///   2. `set(true)` enables `gamification` in the central provider.
+///   3. `set(false)` disables it.
+///   4. Cascade prerequisite: when the central provider is given a
+///      pre-seeded state with `obd2TripRecording` plus `gamification`,
+///      the shim surfaces the persisted-true state.
+///   5. A dependency-violation is swallowed and the toggle stays at
+///      its prior state — the central provider throws StateError when
+///      `obd2TripRecording` is missing; the shim's catch must surface
+///      that as "no-op" rather than a thrown error.
+///   6. Provider rebuilds when [featureFlagsProvider] changes externally.
+///   7. `keepAlive: true` survives consumer-tree teardown — the shim
+///      must not rebuild when its dependencies are unchanged across
+///      consumer detach/reattach cycles.
+///
+/// Migration concerns (the legacy `UserProfile.gamificationEnabled`
+/// → central state promotion) are covered in
+/// `test/features/feature_management/data/legacy_toggle_migrator_test.dart`.
 void main() {
-  group('gamificationEnabledProvider', () {
-    test('returns true when no profile is loaded', () {
-      final storage = _InMemoryHiveStorage();
-      final repo = ProfileRepository(storage);
+  TestWidgetsFlutterBinding.ensureInitialized();
 
-      final container = ProviderContainer(overrides: [
-        profileRepositoryProvider.overrideWithValue(repo),
-      ]);
-      addTearDown(container.dispose);
+  late Directory tmpDir;
+  late Box<dynamic> flagsBox;
+  late FeatureFlagsRepository repo;
 
-      // No profile created → activeProfile is null → provider returns
-      // the safe default.
-      expect(container.read(activeProfileProvider), isNull);
-      expect(container.read(gamificationEnabledProvider), isTrue);
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('gamification_shim_');
+    Hive.init(tmpDir.path);
+    flagsBox = await Hive.openBox<dynamic>(
+      'feature_flags_${DateTime.now().microsecondsSinceEpoch}',
+    );
+    repo = FeatureFlagsRepository(box: flagsBox);
+  });
+
+  tearDown(() async {
+    await flagsBox.deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  ProviderContainer makeContainer({List<Object> extraOverrides = const []}) {
+    final c = ProviderContainer(overrides: [
+      featureFlagsRepositoryProvider.overrideWithValue(repo),
+      ...extraOverrides.cast(),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  /// Drains the post-build async load on featureFlagsProvider so reads
+  /// observe the persisted set rather than the manifest-default
+  /// placeholder.
+  Future<void> pumpLoad(ProviderContainer c) async {
+    c.read(featureFlagsProvider);
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  group('gamificationEnabledProvider — shim over featureFlagsProvider', () {
+    test('defaults to true on a fresh install (manifest default)', () async {
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      expect(
+        container.read(gamificationEnabledProvider),
+        isTrue,
+        reason:
+            'Default-ON is the contract: existing users see no behaviour '
+            'change. Manifest declares Feature.gamification defaultEnabled=true.',
+      );
     });
 
-    test('returns true when profile has gamificationEnabled: true', () async {
-      final storage = _InMemoryHiveStorage();
-      final repo = ProfileRepository(storage);
-      await repo.createProfile(name: 'P1');
+    test('reads the central enabled-set on build', () async {
+      // Pre-seed central state with both prerequisite + dependent.
+      await repo.saveEnabled(<Feature>{
+        Feature.obd2TripRecording,
+        Feature.gamification,
+      });
 
-      final container = ProviderContainer(overrides: [
-        profileRepositoryProvider.overrideWithValue(repo),
-      ]);
-      addTearDown(container.dispose);
+      final container = makeContainer();
+      await pumpLoad(container);
 
-      // Default profile has gamificationEnabled: true.
-      expect(container.read(activeProfileProvider)?.gamificationEnabled, isTrue);
-      expect(container.read(gamificationEnabledProvider), isTrue);
-    });
-
-    test('returns false when profile has gamificationEnabled: false',
-        () async {
-      final storage = _InMemoryHiveStorage();
-      final repo = ProfileRepository(storage);
-      final profile = await repo.createProfile(name: 'P1');
-      await repo.updateProfile(
-        profile.copyWith(gamificationEnabled: false),
+      expect(
+        container.read(gamificationEnabledProvider),
+        isTrue,
+        reason:
+            'The shim must surface the central provider state — a '
+            'persisted-true in the central feature-flags repository is '
+            'the source of truth post-#1373 phase 3b.',
       );
 
-      final container = ProviderContainer(overrides: [
-        profileRepositoryProvider.overrideWithValue(repo),
-      ]);
-      addTearDown(container.dispose);
-
-      expect(container.read(gamificationEnabledProvider), isFalse);
+      // And mirrors a persisted-false explicitly.
+      await repo.saveEnabled(<Feature>{Feature.obd2TripRecording});
+      // Force a fresh container so the new persisted state is reloaded.
+      final container2 = makeContainer();
+      await pumpLoad(container2);
+      expect(
+        container2.read(gamificationEnabledProvider),
+        isFalse,
+        reason:
+            'A persisted central state without Feature.gamification must '
+            'surface as false, not the manifest default.',
+      );
     });
 
-    test('reactively flips when the active profile updates the flag',
+    test('set(true) enables gamification in the central provider', () async {
+      // Prerequisite must be on first or the central provider would
+      // throw StateError (which the shim swallows). Seed it.
+      await repo.saveEnabled(<Feature>{Feature.obd2TripRecording});
+
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      // Materialise so the read after `set` walks the in-memory state
+      // path rather than re-running build.
+      container.read(gamificationEnabledProvider);
+      await container
+          .read(gamificationEnabledProvider.notifier)
+          .set(true);
+
+      expect(
+        container.read(featureFlagsProvider),
+        contains(Feature.gamification),
+        reason:
+            'set(true) must route through featureFlagsProvider.enable so '
+            'the central state is the single source of truth — the legacy '
+            'UserProfile.gamificationEnabled field is no longer the '
+            'authoritative store.',
+      );
+      expect(
+        container.read(gamificationEnabledProvider),
+        isTrue,
+        reason:
+            'The shim state must reflect the central enable immediately so '
+            'consumers (BadgeShelf, achievement tabs, …) re-render without '
+            'waiting for the next provider invalidation.',
+      );
+    });
+
+    test('set(false) disables gamification in the central provider',
         () async {
-      final storage = _InMemoryHiveStorage();
-      final repo = ProfileRepository(storage);
-      final profile = await repo.createProfile(name: 'P1');
+      // Seed both on so we can flip gamification off.
+      await repo.saveEnabled(<Feature>{
+        Feature.obd2TripRecording,
+        Feature.gamification,
+      });
 
-      final container = ProviderContainer(overrides: [
-        profileRepositoryProvider.overrideWithValue(repo),
-      ]);
-      addTearDown(container.dispose);
+      final container = makeContainer();
+      await pumpLoad(container);
 
-      expect(container.read(gamificationEnabledProvider), isTrue);
+      container.read(gamificationEnabledProvider);
+      await container
+          .read(gamificationEnabledProvider.notifier)
+          .set(false);
 
-      // Mutate the profile via the provider's notifier — that's the
-      // path the settings UI uses.
-      await container.read(activeProfileProvider.notifier).updateProfile(
-            profile.copyWith(gamificationEnabled: false),
-          );
-      await Future.microtask(() {});
+      expect(
+        container.read(featureFlagsProvider),
+        isNot(contains(Feature.gamification)),
+      );
+      expect(container.read(gamificationEnabledProvider), isFalse);
+    });
 
+    test('set(true) is a no-op when prerequisite is missing — does NOT throw',
+        () async {
+      // Prerequisite obd2TripRecording is OFF AND we also ensure
+      // gamification is OFF in the persisted set to defeat the manifest
+      // default that would otherwise mask the dependency-violation
+      // path. Calling enable on the central provider would throw
+      // StateError; the shim must swallow it and leave the toggle at
+      // its prior state.
+      await repo.saveEnabled(<Feature>{});
+
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      // Sanity: starting state is false (no obd2TripRecording, no
+      // gamification persisted).
       expect(container.read(gamificationEnabledProvider), isFalse);
 
-      // Flip back.
-      await container.read(activeProfileProvider.notifier).updateProfile(
-            profile.copyWith(gamificationEnabled: true),
-          );
-      await Future.microtask(() {});
+      // No throw expected.
+      await container
+          .read(gamificationEnabledProvider.notifier)
+          .set(true);
 
-      expect(container.read(gamificationEnabledProvider), isTrue);
+      expect(
+        container.read(gamificationEnabledProvider),
+        isFalse,
+        reason:
+            'Dependency-violation must be silent at the shim layer — the '
+            'Phase 2 settings UI pre-checks `canEnable`, so reaching this '
+            'path means a programmatic / test caller bypassed the guard. '
+            'The shim swallows so the widget tree stays standing rather '
+            'than crashing on a developer mistake.',
+      );
+      expect(
+        container.read(featureFlagsProvider),
+        isNot(contains(Feature.gamification)),
+      );
     });
+
+    test('rebuilds when featureFlagsProvider changes via override mutation',
+        () async {
+      // Use the synthetic FeatureFlags notifier override so we can drive
+      // state changes from the test.
+      final fake = _TestFeatureFlags(<Feature>{Feature.obd2TripRecording});
+      final container = makeContainer(extraOverrides: [
+        featureFlagsProvider.overrideWith(() => fake),
+      ]);
+
+      // Initial: gamification absent → shim is false.
+      expect(container.read(gamificationEnabledProvider), isFalse);
+
+      // External mutation: enable gamification on the central provider.
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.gamification);
+
+      expect(
+        container.read(gamificationEnabledProvider),
+        isTrue,
+        reason:
+            'External writes to featureFlagsProvider (e.g. from settings '
+            'UI, a deep-link handler, or another shim) must propagate '
+            'through the gamification shim because it watches the central '
+            'state.',
+      );
+    });
+
+    test(
+      'keepAlive: true does not rebuild on repeat reads when no dependency '
+      'changed',
+      () async {
+        // We can't directly inspect ProviderElement identity (the API is
+        // @internal in riverpod 3.x), so we use a build-counting fake on
+        // the upstream featureFlagsProvider to assert that the shim does
+        // not re-trigger the upstream's `build` on consecutive reads.
+        // A non-keepAlive shim would dispose between reads and re-watch
+        // the upstream, bumping the counter.
+        final fake = _BuildCountingFlags(<Feature>{Feature.gamification});
+        final container = makeContainer(extraOverrides: [
+          featureFlagsProvider.overrideWith(() => fake),
+        ]);
+
+        // Materialise the shim once.
+        expect(container.read(gamificationEnabledProvider), isTrue);
+        final buildsAfterFirstRead = fake.buildCount;
+        expect(
+          buildsAfterFirstRead,
+          1,
+          reason: 'Initial materialisation should run the upstream build once.',
+        );
+
+        // A microtask hop and a second read — the shim must not have
+        // disposed in between (keepAlive:true), so the upstream build
+        // counter stays at 1.
+        await Future<void>.microtask(() {});
+        expect(container.read(gamificationEnabledProvider), isTrue);
+        expect(
+          fake.buildCount,
+          buildsAfterFirstRead,
+          reason:
+              'keepAlive:true must keep the shim alive across reads — '
+              'a re-trigger of the upstream `build` would mean the shim '
+              'disposed and re-subscribed, which would lose any in-flight '
+              'enable() call and racey-flicker the UI.',
+        );
+      },
+    );
   });
 }
 
-/// Minimal in-memory HiveStorage stand-in. Mirrors the helper used in
-/// `profile_provider_test.dart` so the two tests share a familiar shape.
-class _InMemoryHiveStorage extends Mock implements HiveStorage {
-  final Map<String, Map<String, dynamic>> _profiles = {};
-  String? _activeProfileId;
-  final Map<String, dynamic> _settings = {};
+/// Build-counting variant of [_TestFeatureFlags] for the keepAlive
+/// regression test — counts how many times `build` runs so the test
+/// can assert the shim does not re-subscribe to its upstream on
+/// consecutive reads.
+class _BuildCountingFlags extends FeatureFlags {
+  _BuildCountingFlags([Set<Feature>? initial])
+      : _initial = initial ?? <Feature>{};
+
+  final Set<Feature> _initial;
+  int buildCount = 0;
 
   @override
-  String? getActiveProfileId() => _activeProfileId;
-
-  @override
-  Future<void> setActiveProfileId(String id) async {
-    _activeProfileId = id;
+  Set<Feature> build() {
+    buildCount++;
+    return {..._initial};
   }
 
   @override
-  Map<String, dynamic>? getProfile(String id) {
-    final data = _profiles[id];
-    if (data == null) return null;
-    return Map<String, dynamic>.from(data);
+  Future<void> enable(Feature feature) async {
+    if (state.contains(feature)) return;
+    state = {...state, feature};
   }
 
   @override
-  List<Map<String, dynamic>> getAllProfiles() {
-    return _profiles.values
-        .map((p) => Map<String, dynamic>.from(p))
-        .toList();
+  Future<void> disable(Feature feature) async {
+    if (!state.contains(feature)) return;
+    state = {...state}..remove(feature);
+  }
+}
+
+/// Synthetic in-memory [FeatureFlags] notifier used to drive
+/// dependency-violation and external-mutation paths without going
+/// through the Hive-backed repository. Mirrors the equivalent test
+/// double in `test/features/driving/presentation/driving_settings_section_test.dart`.
+class _TestFeatureFlags extends FeatureFlags {
+  _TestFeatureFlags([Set<Feature>? initial])
+      : _initial = initial ?? <Feature>{};
+
+  final Set<Feature> _initial;
+
+  @override
+  Set<Feature> build() => {..._initial};
+
+  @override
+  Future<void> enable(Feature feature) async {
+    if (state.contains(feature)) return;
+    state = {...state, feature};
   }
 
   @override
-  Future<void> saveProfile(String id, Map<String, dynamic> profile) async {
-    _profiles[id] = Map<String, dynamic>.from(profile);
-  }
-
-  @override
-  Future<void> deleteProfile(String id) async {
-    _profiles.remove(id);
-  }
-
-  @override
-  int get profileCount => _profiles.length;
-
-  @override
-  dynamic getSetting(String key) => _settings[key];
-
-  @override
-  Future<void> putSetting(String key, dynamic value) async {
-    _settings[key] = value;
+  Future<void> disable(Feature feature) async {
+    if (!state.contains(feature)) return;
+    state = {...state}..remove(feature);
   }
 }

--- a/test/features/profile/providers/profile_provider_test.dart
+++ b/test/features/profile/providers/profile_provider_test.dart
@@ -1,3 +1,10 @@
+// `gamificationEnabled` is `@Deprecated` post-#1373 phase 3b but the
+// field is still around (kept for the one-shot migration read in
+// `legacy_toggle_migrator.dart`). These tests pin the persistence /
+// copyWith semantics that the migrator relies on, so they read the
+// deprecated field deliberately.
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';


### PR DESCRIPTION
## Why

Phase 3b of #1373 migrates the legacy `UserProfile.gamificationEnabled` toggle to the central `featureFlagsProvider` (`Feature.gamification`). Mirrors the haptic eco-coach shape from PR #1407 (phase 3a).

## What changed

- `gamificationEnabledProvider` is now a thin shim over `featureFlagsProvider` (mirrors `HapticEcoCoachEnabled`).
- `gamification_settings_tile.dart` mutates via `featureFlagsProvider.notifier` instead of `activeProfileProvider.notifier.updateProfile`.
- New `migrateUserProfileToggles` extends `legacy_toggle_migrator.dart` with a UserProfile-backed migration path. Cascade-enables `Feature.obd2TripRecording` (the manifest prerequisite) before `Feature.gamification`. Idempotent via a new `gamificationMigratedKey` flag.
- `legacyToggleMigrationProvider` now fires both migrators (settings-box and UserProfile) on each invocation.
- `UserProfile.gamificationEnabled` annotated `@Deprecated` (kept for one-shot migration read).
- 4 consumer test files migrated from the function-form `overrideWith((ref) => bool)` to the class-form-compatible `overrideWithValue(bool)`.

## Migration semantics

- For users with `gamificationEnabled = true` (the manifest default): on first launch after upgrade, `Feature.gamification` is enabled in the central set (with `Feature.obd2TripRecording` cascaded). UI behavior unchanged.
- For users who had toggled `gamificationEnabled = false`: the migrator persists a state that EXCLUDES `Feature.gamification` so the explicit opt-out survives. Without this branch the manifest default (`gamification.defaultEnabled = true`) would silently restore the surfaces the user had deliberately turned off — a deviation from the original prompt that became necessary because gamification's manifest default differs from haptic-eco-coach's.
- For users without an active profile loaded yet: the migrator is a no-op for this launch (no central writes, no gate-flag write) and retries on the next.

## Tests

- `test/features/profile/providers/gamification_enabled_provider_test.dart` - 7 cases for the shim (default, central read, set true/false, prerequisite-violation swallow, external-mutation reactivity, keepAlive build-counter regression).
- `test/features/profile/presentation/widgets/gamification_settings_tile_test.dart` - 4 cases for the rewired tile (label/subtitle, null-profile guard, tap-flips-central-state, external-mutation reactivity).
- `test/features/feature_management/data/legacy_toggle_migrator_test.dart` - 5 new cases for `migrateUserProfileToggles` (cascade-enable, preserve-explicit-false, null-profile no-op + no-gate-write, idempotent, gate-skip).
- All targeted suites green: 337 tests in `test/features/profile/` + `test/features/feature_management/`; 11 haptic-shim regression tests; 27 tests across the four migrated consumer files.

## Hot-file scope

No edits to `app_initializer.dart`, `hive_boxes.dart`, `storage_keys.dart`, ARB files, or `vehicle_profile.dart`. The migration provider remains wired via the feature-flags settings screen path (deferred until 3a's wiring concern is addressed in a separate PR).

## Phase status

- 3a (hapticEcoCoach) shipped in #1407
- **3b (gamification) <- this PR**
- 3c (showFuel/showElectric/showConsumptionTab) - UserProfile-backed, builds on this PR's pattern
- 3d (autoRecord per-vehicle) - VehicleProfile-backed, more complex
- 3e (syncBaselinesEnabled) - settings-box-backed
- 3f (unifiedSearchResultsEnabled) - settings-box-backed

Refs #1373 phase 3b