### PR TITLE
feat(features): migrate unifiedSearchResultsEnabled to central feature flags (Refs #1373 phase 3f)

### DIFF
--- a/lib/core/refuel/unified_search_results_enabled.dart
+++ b/lib/core/refuel/unified_search_results_enabled.dart
@@ -1,58 +1,72 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../storage/storage_keys.dart';
-import '../storage/storage_providers.dart';
+import '../../features/feature_management/application/feature_flags_provider.dart';
+import '../../features/feature_management/domain/feature.dart';
 
 part 'unified_search_results_enabled.g.dart';
 
 /// Feature flag for the #1116 phase-3 unified fuel + EV search results.
 ///
-/// Phase 3a (this PR) introduces only the flag and the
-/// [unifiedSearchResultsProvider] foundation; the search screen still
-/// reads `searchStateProvider` directly. Phase 3b ships the mixed
-/// fuel/EV card widgets, and phase 3c rewires the search screen to
-/// consume [unifiedSearchResultsProvider] when this flag is on.
+/// As of #1373 phase 3f this is a thin shim over [featureFlagsProvider]
+/// — the canonical state lives in the central feature-flag set keyed by
+/// [Feature.unifiedSearchResults]. The legacy
+/// `StorageKeys.unifiedSearchResultsEnabled` Hive-settings key is read
+/// once by the `legacyToggleMigrationProvider` on first launch after
+/// upgrade and promoted into the central set; subsequent reads/writes
+/// go through here.
 ///
-/// Persisted to the settings box so the user's preference survives
-/// restarts. Defaults to `false` because the unified UI is not yet
-/// shipping — flipping the flag without phase 3b/c installed produces
-/// an empty result list, which is the safer fallback than a partial
-/// rendering.
-///
-/// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
-/// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
-/// mutators.
+/// Defaults to `false` per the manifest because the unified UI is still
+/// converging — flipping the flag without all phase 3b/c surfaces
+/// installed produces an empty result list, which is the safer
+/// fallback than a partial rendering.
 @Riverpod(keepAlive: true)
 class UnifiedSearchResultsEnabled extends _$UnifiedSearchResultsEnabled {
   @override
   bool build() {
-    final storage = ref.watch(settingsStorageProvider);
-    final raw = storage.getSetting(StorageKeys.unifiedSearchResultsEnabled);
-    return raw is bool ? raw : false;
+    return ref
+        .watch(featureFlagsProvider)
+        .contains(Feature.unifiedSearchResults);
   }
 
-  /// Flip the flag. Persists the new value before updating [state] so a
-  /// crash mid-toggle leaves the persisted + observed state consistent.
+  /// Flip the flag. Delegates to [set] so the toggle/set paths share a
+  /// single dependency-violation guard and a single central-provider
+  /// write.
   Future<void> toggle() async {
-    final storage = ref.read(settingsStorageProvider);
-    final next = !state;
-    await storage.putSetting(
-      StorageKeys.unifiedSearchResultsEnabled,
-      next,
-    );
-    state = next;
+    await set(!state);
   }
 
-  /// Set the flag to [value]. Idempotent — calling with the current
-  /// value still rewrites the storage entry (cheap on Hive) so any
-  /// callers that depend on a `putSetting` side-effect (e.g. tests)
-  /// see a deterministic write.
+  /// Delegate to [featureFlagsProvider]'s `enable` / `disable`. The
+  /// downstream `unifiedSearchResultsProvider` watches this shim, so a
+  /// `set(true)` re-derives the unified card list immediately and a
+  /// `set(false)` collapses it back to the legacy fuel-only path.
+  ///
+  /// A [StateError] from a dependency-violation is intentionally
+  /// swallowed and the toggle stays at its prior state — see the
+  /// catch block below for why.
   Future<void> set(bool value) async {
-    final storage = ref.read(settingsStorageProvider);
-    await storage.putSetting(
-      StorageKeys.unifiedSearchResultsEnabled,
-      value,
-    );
-    state = value;
+    final notifier = ref.read(featureFlagsProvider.notifier);
+    try {
+      if (value) {
+        await notifier.enable(Feature.unifiedSearchResults);
+      } else {
+        await notifier.disable(Feature.unifiedSearchResults);
+      }
+      // The central provider throws a StateError specifically for
+      // dependency-violation; we want to swallow ONLY that — see the
+      // body comment for why. The lint deliberately discourages
+      // catching Error subclasses, but the central API's contract
+      // documents this exact StateError as the dependency-violation
+      // signal, so the catch is intentional and narrow.
+      // ignore: avoid_catching_errors
+    } on StateError {
+      // TODO(1373): Phase 2's settings UI already pre-checks
+      // `canEnable` / `blockingDisable` before invoking this setter, so
+      // a dependency-violation here is a defensive-only catch — the UI
+      // path can't currently reach it. We swallow rather than rethrow
+      // so a programmatic caller (e.g. a test or a future call site)
+      // sees the toggle stay at its prior state instead of crashing
+      // the widget tree. Remove once every call site has been audited
+      // for `canEnable` pre-check coverage.
+    }
   }
 }

--- a/lib/core/refuel/unified_search_results_enabled.g.dart
+++ b/lib/core/refuel/unified_search_results_enabled.g.dart
@@ -10,21 +10,18 @@ part of 'unified_search_results_enabled.dart';
 // ignore_for_file: type=lint, type=warning
 /// Feature flag for the #1116 phase-3 unified fuel + EV search results.
 ///
-/// Phase 3a (this PR) introduces only the flag and the
-/// [unifiedSearchResultsProvider] foundation; the search screen still
-/// reads `searchStateProvider` directly. Phase 3b ships the mixed
-/// fuel/EV card widgets, and phase 3c rewires the search screen to
-/// consume [unifiedSearchResultsProvider] when this flag is on.
+/// As of #1373 phase 3f this is a thin shim over [featureFlagsProvider]
+/// — the canonical state lives in the central feature-flag set keyed by
+/// [Feature.unifiedSearchResults]. The legacy
+/// `StorageKeys.unifiedSearchResultsEnabled` Hive-settings key is read
+/// once by the `legacyToggleMigrationProvider` on first launch after
+/// upgrade and promoted into the central set; subsequent reads/writes
+/// go through here.
 ///
-/// Persisted to the settings box so the user's preference survives
-/// restarts. Defaults to `false` because the unified UI is not yet
-/// shipping — flipping the flag without phase 3b/c installed produces
-/// an empty result list, which is the safer fallback than a partial
-/// rendering.
-///
-/// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
-/// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
-/// mutators.
+/// Defaults to `false` per the manifest because the unified UI is still
+/// converging — flipping the flag without all phase 3b/c surfaces
+/// installed produces an empty result list, which is the safer
+/// fallback than a partial rendering.
 
 @ProviderFor(UnifiedSearchResultsEnabled)
 final unifiedSearchResultsEnabledProvider =
@@ -32,40 +29,34 @@ final unifiedSearchResultsEnabledProvider =
 
 /// Feature flag for the #1116 phase-3 unified fuel + EV search results.
 ///
-/// Phase 3a (this PR) introduces only the flag and the
-/// [unifiedSearchResultsProvider] foundation; the search screen still
-/// reads `searchStateProvider` directly. Phase 3b ships the mixed
-/// fuel/EV card widgets, and phase 3c rewires the search screen to
-/// consume [unifiedSearchResultsProvider] when this flag is on.
+/// As of #1373 phase 3f this is a thin shim over [featureFlagsProvider]
+/// — the canonical state lives in the central feature-flag set keyed by
+/// [Feature.unifiedSearchResults]. The legacy
+/// `StorageKeys.unifiedSearchResultsEnabled` Hive-settings key is read
+/// once by the `legacyToggleMigrationProvider` on first launch after
+/// upgrade and promoted into the central set; subsequent reads/writes
+/// go through here.
 ///
-/// Persisted to the settings box so the user's preference survives
-/// restarts. Defaults to `false` because the unified UI is not yet
-/// shipping — flipping the flag without phase 3b/c installed produces
-/// an empty result list, which is the safer fallback than a partial
-/// rendering.
-///
-/// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
-/// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
-/// mutators.
+/// Defaults to `false` per the manifest because the unified UI is still
+/// converging — flipping the flag without all phase 3b/c surfaces
+/// installed produces an empty result list, which is the safer
+/// fallback than a partial rendering.
 final class UnifiedSearchResultsEnabledProvider
     extends $NotifierProvider<UnifiedSearchResultsEnabled, bool> {
   /// Feature flag for the #1116 phase-3 unified fuel + EV search results.
   ///
-  /// Phase 3a (this PR) introduces only the flag and the
-  /// [unifiedSearchResultsProvider] foundation; the search screen still
-  /// reads `searchStateProvider` directly. Phase 3b ships the mixed
-  /// fuel/EV card widgets, and phase 3c rewires the search screen to
-  /// consume [unifiedSearchResultsProvider] when this flag is on.
+  /// As of #1373 phase 3f this is a thin shim over [featureFlagsProvider]
+  /// — the canonical state lives in the central feature-flag set keyed by
+  /// [Feature.unifiedSearchResults]. The legacy
+  /// `StorageKeys.unifiedSearchResultsEnabled` Hive-settings key is read
+  /// once by the `legacyToggleMigrationProvider` on first launch after
+  /// upgrade and promoted into the central set; subsequent reads/writes
+  /// go through here.
   ///
-  /// Persisted to the settings box so the user's preference survives
-  /// restarts. Defaults to `false` because the unified UI is not yet
-  /// shipping — flipping the flag without phase 3b/c installed produces
-  /// an empty result list, which is the safer fallback than a partial
-  /// rendering.
-  ///
-  /// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
-  /// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
-  /// mutators.
+  /// Defaults to `false` per the manifest because the unified UI is still
+  /// converging — flipping the flag without all phase 3b/c surfaces
+  /// installed produces an empty result list, which is the safer
+  /// fallback than a partial rendering.
   UnifiedSearchResultsEnabledProvider._()
     : super(
         from: null,
@@ -94,25 +85,22 @@ final class UnifiedSearchResultsEnabledProvider
 }
 
 String _$unifiedSearchResultsEnabledHash() =>
-    r'f3861b3c635983e95666508988811f0937a77b15';
+    r'bd0c4c48b32ee20ae7ecce4037b844d23f513f48';
 
 /// Feature flag for the #1116 phase-3 unified fuel + EV search results.
 ///
-/// Phase 3a (this PR) introduces only the flag and the
-/// [unifiedSearchResultsProvider] foundation; the search screen still
-/// reads `searchStateProvider` directly. Phase 3b ships the mixed
-/// fuel/EV card widgets, and phase 3c rewires the search screen to
-/// consume [unifiedSearchResultsProvider] when this flag is on.
+/// As of #1373 phase 3f this is a thin shim over [featureFlagsProvider]
+/// — the canonical state lives in the central feature-flag set keyed by
+/// [Feature.unifiedSearchResults]. The legacy
+/// `StorageKeys.unifiedSearchResultsEnabled` Hive-settings key is read
+/// once by the `legacyToggleMigrationProvider` on first launch after
+/// upgrade and promoted into the central set; subsequent reads/writes
+/// go through here.
 ///
-/// Persisted to the settings box so the user's preference survives
-/// restarts. Defaults to `false` because the unified UI is not yet
-/// shipping — flipping the flag without phase 3b/c installed produces
-/// an empty result list, which is the safer fallback than a partial
-/// rendering.
-///
-/// Mirrors the [EvShowOnMap] pattern from `lib/features/ev/providers/
-/// ev_providers.dart`: keep-alive, Hive-backed, with [toggle] and [set]
-/// mutators.
+/// Defaults to `false` per the manifest because the unified UI is still
+/// converging — flipping the flag without all phase 3b/c surfaces
+/// installed produces an empty result list, which is the safer
+/// fallback than a partial rendering.
 
 abstract class _$UnifiedSearchResultsEnabled extends $Notifier<bool> {
   bool build();

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -79,6 +79,10 @@ class StorageKeys {
   /// fuel-only `searchStateProvider` consumption for
   /// `unifiedSearchResultsProvider`. UI cards land in phase 3b; this
   /// flag is a no-op until then.
+  @Deprecated(
+    'Migrated to Feature.unifiedSearchResults in #1373 phase 3f; '
+    'kept for one-shot migration read.',
+  )
   static const String unifiedSearchResultsEnabled =
       'unified_search_results_enabled';
 

--- a/lib/features/feature_management/data/legacy_toggle_migrator.dart
+++ b/lib/features/feature_management/data/legacy_toggle_migrator.dart
@@ -21,6 +21,13 @@ const String hapticEcoCoachMigratedKey = 'hapticEcoCoachMigrated';
 /// tells us whether the gamification migration has already run.
 const String gamificationMigratedKey = 'gamificationMigrated';
 
+/// Settings-box key written once after the legacy
+/// `unifiedSearchResultsEnabled` value has been promoted into the
+/// central feature-flag set (#1373 phase 3f). Persisted in the same
+/// `settings` Hive box as the legacy toggle itself so a single read
+/// tells us whether the migration has already run.
+const String unifiedSearchResultsMigratedKey = 'unifiedSearchResultsMigrated';
+
 /// One-shot migrator that promotes legacy scattered toggles into the
 /// central [FeatureFlagsRepository] (#1373 phase 3a).
 ///
@@ -44,17 +51,34 @@ const String gamificationMigratedKey = 'gamificationMigrated';
 /// because the legacy value lives on the profile entity rather than
 /// the settings box.
 ///
-/// Future phases (3c, 3d, …) extend this migrator with additional
-/// scattered toggles (`showFuel`, `autoRecord`, etc.). Each new
-/// migration follows the same shape: read the legacy value, gate on a
-/// `<featureName>Migrated` flag, force-enable prerequisites first,
-/// persist, then write the gate flag.
+/// Phase 3f (this PR) adds [_migrateUnifiedSearchResults] for the
+/// settings-box-backed `unifiedSearchResultsEnabled` toggle. It
+/// follows the same shape as [_migrateHapticEcoCoach] but with no
+/// prerequisites to cascade-enable (the manifest declares no
+/// `requires:` for [Feature.unifiedSearchResults]).
+///
+/// Phase status:
+///   - 3a hapticEcoCoach (settings-box, default-false) ✅
+///   - 3b gamification (UserProfile, default-true) ✅ via
+///     [migrateUserProfileToggles]
+///   - 3f unifiedSearchResults (settings-box, default-false) ✅
+///
+/// Future phases (3c, 3d, 3e) extend this migrator with additional
+/// scattered toggles (`showFuel`, `autoRecord`, `syncBaselinesEnabled`,
+/// etc.). Each new migration follows the same shape: read the legacy
+/// value, gate on a `<featureName>Migrated` flag, force-enable
+/// prerequisites first, persist, then write the gate flag.
 Future<void> migrateLegacyToggles({
   required Box<dynamic> settings,
   required FeatureFlagsRepository featureFlags,
   required FeatureManifest manifest,
 }) async {
   await _migrateHapticEcoCoach(
+    settings: settings,
+    featureFlags: featureFlags,
+    manifest: manifest,
+  );
+  await _migrateUnifiedSearchResults(
     settings: settings,
     featureFlags: featureFlags,
     manifest: manifest,
@@ -206,6 +230,56 @@ Future<void> _migrateGamification({
   } catch (e, st) {
     debugPrint(
       'migrateUserProfileToggles: writing $gamificationMigratedKey failed: $e\n$st',
+    );
+  }
+}
+
+Future<void> _migrateUnifiedSearchResults({
+  required Box<dynamic> settings,
+  required FeatureFlagsRepository featureFlags,
+  required FeatureManifest manifest,
+}) async {
+  // Already migrated → idempotent no-op. The user may have toggled
+  // unifiedSearchResults OFF after a previous migration; we must not
+  // re-promote the legacy `true` value.
+  if (settings.get(unifiedSearchResultsMigratedKey) == true) {
+    return;
+  }
+
+  // ignore: deprecated_member_use_from_same_package
+  final legacyValue = settings.get(StorageKeys.unifiedSearchResultsEnabled);
+
+  if (legacyValue == true) {
+    try {
+      final current = await featureFlags.loadEnabled();
+      // Force-enable any manifest-declared prerequisites first per the
+      // dependency graph. [Feature.unifiedSearchResults] currently has
+      // none, so this reduces to {...current, Feature.unifiedSearchResults},
+      // but we keep the spread for symmetry with the precedent — if the
+      // manifest later adds a requirement it won't silently break.
+      final entry = manifest.entryFor(Feature.unifiedSearchResults);
+      final next = <Feature>{
+        ...current,
+        ...entry.requires,
+        Feature.unifiedSearchResults,
+      };
+      await featureFlags.saveEnabled(next);
+    } catch (e, st) {
+      // Don't block startup on a migration failure — the user can
+      // re-toggle from settings if the central state is missing.
+      debugPrint(
+        'migrateLegacyToggles: unifiedSearchResults promote failed: $e\n$st',
+      );
+    }
+  }
+
+  // Always set the flag (even when legacyValue is false / null) so we
+  // never re-read the legacy key on subsequent launches.
+  try {
+    await settings.put(unifiedSearchResultsMigratedKey, true);
+  } catch (e, st) {
+    debugPrint(
+      'migrateLegacyToggles: writing $unifiedSearchResultsMigratedKey failed: $e\n$st',
     );
   }
 }

--- a/test/core/refuel/unified_search_results_enabled_test.dart
+++ b/test/core/refuel/unified_search_results_enabled_test.dart
@@ -1,154 +1,317 @@
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:hive/hive.dart';
 import 'package:tankstellen/core/refuel/unified_search_results_enabled.dart';
-import 'package:tankstellen/core/storage/storage_keys.dart';
-import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/data/feature_flags_repository.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
 
-/// Coverage for the #1116 phase 3a feature flag.
+/// Provider-layer coverage for the [unifiedSearchResultsEnabledProvider]
+/// (#1116). As of #1373 phase 3f this provider is a thin shim that
+/// delegates to [featureFlagsProvider]; tests assert that contract:
 ///
-/// Mirrors the [EvShowOnMap] test pattern in
-/// `test/features/ev/providers/ev_providers_test.dart` — a fake in-memory
-/// [SettingsStorage] is overridden into the container so reads + writes
-/// stay deterministic without a Hive box.
+///   1. Default state mirrors the manifest default for
+///      [Feature.unifiedSearchResults] (`false`).
+///   2. Reads return the central enabled-set membership for
+///      [Feature.unifiedSearchResults].
+///   3. `set(true)` enables `unifiedSearchResults` in the central provider.
+///   4. `set(false)` disables it.
+///   5. `toggle()` flips the current state.
+///   6. Provider rebuilds when [featureFlagsProvider] changes externally.
+///   7. A dependency-violation StateError thrown by a fake notifier is
+///      swallowed and the toggle stays at its prior state — the real
+///      central provider has no `requires:` for unifiedSearchResults so
+///      this path is defensive-only, but the catch must still cover it.
+///
+/// Migration concerns (the legacy
+/// `StorageKeys.unifiedSearchResultsEnabled` Hive key → central state
+/// promotion) are covered in
+/// `test/features/feature_management/data/legacy_toggle_migrator_test.dart`.
 void main() {
-  group('unifiedSearchResultsEnabledProvider', () {
-    test('defaults to false on a fresh storage', () {
-      final storage = _FakeSettings();
-      final container = ProviderContainer(
-        overrides: [settingsStorageProvider.overrideWithValue(storage)],
-      );
-      addTearDown(container.dispose);
+  TestWidgetsFlutterBinding.ensureInitialized();
 
+  late Directory tmpDir;
+  late Box<dynamic> flagsBox;
+  late FeatureFlagsRepository repo;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('unified_search_shim_');
+    Hive.init(tmpDir.path);
+    flagsBox = await Hive.openBox<dynamic>(
+      'feature_flags_${DateTime.now().microsecondsSinceEpoch}',
+    );
+    repo = FeatureFlagsRepository(box: flagsBox);
+  });
+
+  tearDown(() async {
+    await flagsBox.deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  ProviderContainer makeContainer({List<Object> extraOverrides = const []}) {
+    final c = ProviderContainer(overrides: [
+      featureFlagsRepositoryProvider.overrideWithValue(repo),
+      ...extraOverrides.cast(),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  /// Drains the post-build async load on featureFlagsProvider so reads
+  /// observe the persisted set rather than the manifest-default
+  /// placeholder.
+  Future<void> pumpLoad(ProviderContainer c) async {
+    c.read(featureFlagsProvider);
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  group('unifiedSearchResultsEnabledProvider — shim over featureFlagsProvider',
+      () {
+    test('defaults to false on a fresh profile', () async {
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      expect(
+        container.read(unifiedSearchResultsEnabledProvider),
+        isFalse,
+        reason:
+            'Default-OFF is the contract: a user who never opted into the '
+            'unified results UI must not see it. Manifest declares '
+            'unifiedSearchResults defaultEnabled=false.',
+      );
+    });
+
+    test('reads the central enabled-set on build', () async {
+      // Pre-seed central state with the unifiedSearchResults flag on.
+      await repo.saveEnabled(<Feature>{Feature.unifiedSearchResults});
+
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      expect(
+        container.read(unifiedSearchResultsEnabledProvider),
+        isTrue,
+        reason:
+            'The shim must surface the central provider state — a '
+            'persisted-true in the central feature-flags repository is '
+            'the source of truth post-#1373 phase 3f.',
+      );
+    });
+
+    test('set(true) enables unifiedSearchResults in the central provider',
+        () async {
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      // Materialise so the read after `set` walks the in-memory state
+      // path rather than re-running build.
+      container.read(unifiedSearchResultsEnabledProvider);
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .set(true);
+
+      expect(
+        container.read(featureFlagsProvider),
+        contains(Feature.unifiedSearchResults),
+        reason:
+            'set(true) must route through featureFlagsProvider.enable so '
+            'the central state is the single source of truth — the legacy '
+            'StorageKeys.unifiedSearchResultsEnabled is no longer the '
+            'authoritative store.',
+      );
+      expect(
+        container.read(unifiedSearchResultsEnabledProvider),
+        isTrue,
+        reason:
+            'The shim state must reflect the central enable immediately so '
+            'unifiedSearchResultsProvider re-derives the merged fuel/EV '
+            'list without waiting for the next provider invalidation.',
+      );
+    });
+
+    test('set(false) disables unifiedSearchResults in the central provider',
+        () async {
+      // Seed it on so we can flip it off.
+      await repo.saveEnabled(<Feature>{Feature.unifiedSearchResults});
+
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      container.read(unifiedSearchResultsEnabledProvider);
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .set(false);
+
+      expect(
+        container.read(featureFlagsProvider),
+        isNot(contains(Feature.unifiedSearchResults)),
+      );
+      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
+    });
+
+    test('toggle() flips the current state', () async {
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      // Starts false (manifest default).
+      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
+
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .toggle();
+      expect(
+        container.read(unifiedSearchResultsEnabledProvider),
+        isTrue,
+        reason:
+            'toggle() from false must flip to true and route through the '
+            'central provider so the persisted state and the in-memory '
+            'state stay in sync.',
+      );
+      expect(
+        container.read(featureFlagsProvider),
+        contains(Feature.unifiedSearchResults),
+      );
+
+      await container
+          .read(unifiedSearchResultsEnabledProvider.notifier)
+          .toggle();
+      expect(
+        container.read(unifiedSearchResultsEnabledProvider),
+        isFalse,
+        reason:
+            'toggle() from true must flip back to false — round-tripping '
+            'verifies both branches of the toggle delegate to set().',
+      );
+      expect(
+        container.read(featureFlagsProvider),
+        isNot(contains(Feature.unifiedSearchResults)),
+      );
+    });
+
+    test('rebuilds when featureFlagsProvider changes via override mutation',
+        () async {
+      // Use the synthetic FeatureFlags notifier override so we can drive
+      // state changes from the test.
+      final fake = _TestFeatureFlags();
+      final container = makeContainer(extraOverrides: [
+        featureFlagsProvider.overrideWith(() => fake),
+      ]);
+
+      // Initial: unifiedSearchResults absent → shim is false.
+      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
+
+      // External mutation: enable on the central provider directly.
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.unifiedSearchResults);
+
+      expect(
+        container.read(unifiedSearchResultsEnabledProvider),
+        isTrue,
+        reason:
+            'External writes to featureFlagsProvider (e.g. from settings '
+            'UI, a deep-link handler, or another shim) must propagate '
+            'through the unifiedSearchResults shim because it watches the '
+            'central state.',
+      );
+
+      // And back the other way.
+      await container
+          .read(featureFlagsProvider.notifier)
+          .disable(Feature.unifiedSearchResults);
       expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
     });
 
     test(
-      'reads persisted true value when storage already holds the flag',
-      () {
-        final storage = _FakeSettings()
-          ..putSetting(StorageKeys.unifiedSearchResultsEnabled, true);
-        final container = ProviderContainer(
-          overrides: [settingsStorageProvider.overrideWithValue(storage)],
-        );
-        addTearDown(container.dispose);
+      'set(true) swallows a dependency-violation StateError from the central '
+      'provider — toggle stays at its prior state',
+      () async {
+        // unifiedSearchResults has no manifest prerequisites, so the
+        // real central provider can't throw on enable. Use a spy fake
+        // that throws StateError to exercise the defensive `on
+        // StateError` catch in the shim.
+        final fake = _ThrowingFeatureFlags();
+        final container = makeContainer(extraOverrides: [
+          featureFlagsProvider.overrideWith(() => fake),
+        ]);
 
-        expect(container.read(unifiedSearchResultsEnabledProvider), isTrue);
+        // Sanity: starting state is false.
+        expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
+
+        // No throw expected — the shim's `on StateError` catch must
+        // swallow the dependency-violation signal.
+        await container
+            .read(unifiedSearchResultsEnabledProvider.notifier)
+            .set(true);
+
+        expect(
+          container.read(unifiedSearchResultsEnabledProvider),
+          isFalse,
+          reason:
+              'Dependency-violation must be silent at the shim layer — the '
+              'Phase 2 settings UI pre-checks `canEnable`, so reaching this '
+              'path means a programmatic / test caller bypassed the guard. '
+              'The shim swallows so the widget tree stays standing rather '
+              'than crashing on a developer mistake.',
+        );
+        expect(
+          container.read(featureFlagsProvider),
+          isNot(contains(Feature.unifiedSearchResults)),
+        );
       },
     );
-
-    test('non-bool persisted value falls back to false', () {
-      // Defensive: previous app versions or hand-edited Hive boxes may
-      // store the wrong type. The provider must not throw.
-      final storage = _FakeSettings()
-        ..putSetting(StorageKeys.unifiedSearchResultsEnabled, 'yes');
-      final container = ProviderContainer(
-        overrides: [settingsStorageProvider.overrideWithValue(storage)],
-      );
-      addTearDown(container.dispose);
-
-      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
-    });
-
-    test('toggle flips state and persists the new value', () async {
-      final storage = _FakeSettings();
-      final container = ProviderContainer(
-        overrides: [settingsStorageProvider.overrideWithValue(storage)],
-      );
-      addTearDown(container.dispose);
-
-      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
-
-      await container
-          .read(unifiedSearchResultsEnabledProvider.notifier)
-          .toggle();
-
-      expect(container.read(unifiedSearchResultsEnabledProvider), isTrue);
-      expect(
-        storage.getSetting(StorageKeys.unifiedSearchResultsEnabled),
-        isTrue,
-      );
-
-      await container
-          .read(unifiedSearchResultsEnabledProvider.notifier)
-          .toggle();
-
-      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
-      expect(
-        storage.getSetting(StorageKeys.unifiedSearchResultsEnabled),
-        isFalse,
-      );
-    });
-
-    test('set(value) writes through and updates state', () async {
-      final storage = _FakeSettings();
-      final container = ProviderContainer(
-        overrides: [settingsStorageProvider.overrideWithValue(storage)],
-      );
-      addTearDown(container.dispose);
-
-      await container
-          .read(unifiedSearchResultsEnabledProvider.notifier)
-          .set(true);
-      expect(container.read(unifiedSearchResultsEnabledProvider), isTrue);
-      expect(
-        storage.getSetting(StorageKeys.unifiedSearchResultsEnabled),
-        isTrue,
-      );
-
-      await container
-          .read(unifiedSearchResultsEnabledProvider.notifier)
-          .set(false);
-      expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
-      expect(
-        storage.getSetting(StorageKeys.unifiedSearchResultsEnabled),
-        isFalse,
-      );
-    });
-
-    test('set(true) is idempotent — repeated writes keep state at true',
-        () async {
-      final storage = _FakeSettings();
-      final container = ProviderContainer(
-        overrides: [settingsStorageProvider.overrideWithValue(storage)],
-      );
-      addTearDown(container.dispose);
-
-      await container
-          .read(unifiedSearchResultsEnabledProvider.notifier)
-          .set(true);
-      await container
-          .read(unifiedSearchResultsEnabledProvider.notifier)
-          .set(true);
-      expect(container.read(unifiedSearchResultsEnabledProvider), isTrue);
-    });
   });
 }
 
-class _FakeSettings implements SettingsStorage {
-  final Map<String, dynamic> _data = {};
+/// Synthetic in-memory [FeatureFlags] notifier used to drive
+/// external-mutation paths without going through the Hive-backed
+/// repository. Mirrors the equivalent test double in
+/// `test/features/profile/providers/gamification_enabled_provider_test.dart`.
+class _TestFeatureFlags extends FeatureFlags {
+  _TestFeatureFlags([Set<Feature>? initial])
+      : _initial = initial ?? <Feature>{};
+
+  final Set<Feature> _initial;
 
   @override
-  dynamic getSetting(String key) => _data[key];
+  Set<Feature> build() => {..._initial};
 
   @override
-  Future<void> putSetting(String key, dynamic value) async {
-    if (value == null) {
-      _data.remove(key);
-    } else {
-      _data[key] = value;
-    }
+  Future<void> enable(Feature feature) async {
+    if (state.contains(feature)) return;
+    state = {...state, feature};
   }
 
   @override
-  bool get isSetupComplete => false;
+  Future<void> disable(Feature feature) async {
+    if (!state.contains(feature)) return;
+    state = {...state}..remove(feature);
+  }
+}
+
+/// Spy fake that always throws [StateError] on `enable` / `disable` —
+/// used to exercise the shim's defensive `on StateError` catch even
+/// though [Feature.unifiedSearchResults] has no real manifest
+/// prerequisite that could trigger one in production.
+class _ThrowingFeatureFlags extends FeatureFlags {
+  @override
+  Set<Feature> build() => <Feature>{};
 
   @override
-  bool get isSetupSkipped => false;
+  Future<void> enable(Feature feature) async {
+    throw StateError(
+      'Cannot enable ${feature.name}: simulated dependency-violation',
+    );
+  }
 
   @override
-  Future<void> skipSetup() async {}
-
-  @override
-  Future<void> resetSetupSkip() async {}
+  Future<void> disable(Feature feature) async {
+    throw StateError(
+      'Cannot disable ${feature.name}: simulated blockingDisable',
+    );
+  }
 }

--- a/test/core/refuel/unified_search_results_provider_test.dart
+++ b/test/core/refuel/unified_search_results_provider_test.dart
@@ -7,7 +7,6 @@ import 'package:tankstellen/core/refuel/station_as_refuel_option.dart';
 import 'package:tankstellen/core/refuel/unified_search_results_enabled.dart';
 import 'package:tankstellen/core/refuel/unified_search_results_provider.dart';
 import 'package:tankstellen/core/services/service_result.dart';
-import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/profile/data/models/user_profile.dart';
@@ -121,6 +120,11 @@ ChargingStation _charger({String id = 'ev1', String? operator = 'Ionity'}) =>
 /// in-memory settings store. Profile is null by default so
 /// `selectedFuelTypeProvider` falls back to [FuelType.all]; tests that
 /// need a specific fuel type call `select()` on the notifier.
+///
+/// As of #1373 phase 3f the `unifiedSearchResultsEnabled` flag is
+/// backed by [featureFlagsProvider]. Tests flip the flag by overriding
+/// the shim provider directly with `overrideWithValue(true)` rather
+/// than writing to the legacy settings key.
 ProviderContainer _container({
   required AsyncValue<ServiceResult<List<SearchResultItem>>> fuel,
   required AsyncValue<ServiceResult<List<ChargingStation>>> ev,
@@ -133,13 +137,9 @@ ProviderContainer _container({
       activeProfileProvider.overrideWith(_NullProfile.new),
       searchStateProvider.overrideWith(() => _FakeSearchState(fuel)),
       eVSearchStateProvider.overrideWith(() => _FakeEvSearchState(ev)),
+      if (flagOn) unifiedSearchResultsEnabledProvider.overrideWithValue(true),
     ],
   );
-  if (flagOn) {
-    // Flip the persisted value before any read; the flag's `build` will
-    // observe `true` on first watch.
-    storage.putSetting(StorageKeys.unifiedSearchResultsEnabled, true);
-  }
   return container;
 }
 

--- a/test/features/feature_management/data/legacy_toggle_migrator_test.dart
+++ b/test/features/feature_management/data/legacy_toggle_migrator_test.dart
@@ -409,4 +409,139 @@ void main() {
       },
     );
   });
+
+  group('migrateLegacyToggles — unifiedSearchResults', () {
+    test(
+      'promotes legacy true → enables unifiedSearchResults; sets migration '
+      'flag (no prerequisites in the manifest, so no cascade)',
+      () async {
+        // ignore: deprecated_member_use_from_same_package
+        await settings.put(StorageKeys.unifiedSearchResultsEnabled, true);
+
+        await migrateLegacyToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+        );
+
+        final after = await repo.loadEnabled();
+        expect(
+          after,
+          contains(Feature.unifiedSearchResults),
+          reason:
+              'Legacy true must promote into the central feature-flag set '
+              'so the user does not have to re-enable unifiedSearchResults '
+              'after the migration.',
+        );
+        expect(
+          settings.get(unifiedSearchResultsMigratedKey),
+          isTrue,
+          reason:
+              'The migration gate must be set so a subsequent run is a '
+              'no-op and a user who later disables unifiedSearchResults '
+              'does not get it re-enabled on the next launch.',
+        );
+      },
+    );
+
+    test('legacy false → leaves central state untouched; sets migration flag',
+        () async {
+      // ignore: deprecated_member_use_from_same_package
+      await settings.put(StorageKeys.unifiedSearchResultsEnabled, false);
+
+      await migrateLegacyToggles(
+        settings: settings,
+        featureFlags: repo,
+        manifest: FeatureManifest.defaultManifest,
+      );
+
+      final after = await repo.loadEnabled();
+      expect(
+        after,
+        isNot(contains(Feature.unifiedSearchResults)),
+        reason:
+            'A legacy explicit-false must not promote anything — the '
+            'central system already defaults unifiedSearchResults to off '
+            '(manifest defaultEnabled=false), so a no-op write would have '
+            'been semantically equivalent anyway. Mirrors the haptic '
+            'precedent.',
+      );
+      expect(
+        settings.get(unifiedSearchResultsMigratedKey),
+        isTrue,
+        reason:
+            'Even a no-op migration must set the gate so we never re-read '
+            'the deprecated key on subsequent launches.',
+      );
+    });
+
+    test(
+      'legacy null (key never written) → no central state change; flag set',
+      () async {
+        await migrateLegacyToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+        );
+
+        final after = await repo.loadEnabled();
+        expect(
+          after,
+          isNot(contains(Feature.unifiedSearchResults)),
+          reason:
+              'A first-launch profile (no legacy value) must land at '
+              'central manifest defaults — unifiedSearchResults off.',
+        );
+        expect(
+          settings.get(unifiedSearchResultsMigratedKey),
+          isTrue,
+          reason:
+              'Absent legacy value still flips the gate so we do not '
+              're-do the work each launch.',
+        );
+      },
+    );
+
+    test(
+      'idempotent — running twice on legacy=true leaves the central state '
+      'unchanged the second time',
+      () async {
+        // ignore: deprecated_member_use_from_same_package
+        await settings.put(StorageKeys.unifiedSearchResultsEnabled, true);
+
+        // First run promotes.
+        await migrateLegacyToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+        );
+        final afterFirst = await repo.loadEnabled();
+        expect(afterFirst, contains(Feature.unifiedSearchResults));
+        expect(settings.get(unifiedSearchResultsMigratedKey), isTrue);
+
+        // Simulate the user disabling unifiedSearchResults after the
+        // migration (e.g. via the central settings UI). The second run
+        // must NOT re-enable it.
+        final disabled = {...afterFirst}..remove(Feature.unifiedSearchResults);
+        await repo.saveEnabled(disabled);
+
+        // Second run.
+        await migrateLegacyToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+        );
+
+        final afterSecond = await repo.loadEnabled();
+        expect(
+          afterSecond,
+          isNot(contains(Feature.unifiedSearchResults)),
+          reason:
+              'A second migration run must not re-promote the legacy true '
+              'value — the user has explicitly disabled '
+              'unifiedSearchResults since and that choice must survive.',
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Why

Phase 3f of #1373 migrates the legacy `StorageKeys.unifiedSearchResultsEnabled` Hive-settings toggle to the central `featureFlagsProvider` (`Feature.unifiedSearchResults`). Mirrors the haptic eco-coach shape from PR #1407 (phase 3a) — both toggles are settings-box-backed with `defaultEnabled=false`, so the no-op-write-gate pattern (matching haptic) is correct without the explicit-persist-false fix that 3b needed for default-true features.

## What changed

- `UnifiedSearchResultsEnabled` is now a thin shim over `featureFlagsProvider` (mirrors `HapticEcoCoachEnabled`). `set()` and `toggle()` both delegate to `featureFlagsProvider.notifier.enable/disable(Feature.unifiedSearchResults)`.
- New `_migrateUnifiedSearchResults` extends `legacy_toggle_migrator.dart`. Idempotent via `unifiedSearchResultsMigratedKey`. No prerequisites in the manifest, so no cascade-enable.
- `legacyToggleMigrationProvider` already calls `migrateLegacyToggles` (which now also fires the unifiedSearchResults migration).
- `StorageKeys.unifiedSearchResultsEnabled` annotated `@Deprecated` (kept for one-shot migration read).

## Migration semantics

- For users with `unifiedSearchResultsEnabled = true`: `Feature.unifiedSearchResults` is enabled in the central set on first launch after upgrade.
- For users with `unifiedSearchResultsEnabled = false` or absent: feature stays disabled (matches manifest default). Migrated-key flag is written so subsequent launches don't re-read.

## Tests

- `test/core/refuel/unified_search_results_enabled_test.dart` — rewritten as 7 cases for the shim contract
- `test/features/feature_management/data/legacy_toggle_migrator_test.dart` — 4 new cases for `_migrateUnifiedSearchResults`
- Downstream consumer tests (`unified_search_results_provider_test`, `search_results_content_test`) audited; `unified_search_results_provider_test` migrated from settings-key write to `unifiedSearchResultsEnabledProvider.overrideWithValue(true)`. `search_results_content_test` already used `overrideWith(notifier-class)` against the shim — still compiles unchanged.

## Hot-file scope

No edits to `app_initializer.dart`, `hive_boxes.dart`, ARB files, `vehicle_profile.dart`, or `user_profile.dart`.

## Phase status

- 3a (hapticEcoCoach) shipped #1407
- 3b (gamification) shipped #1410
- 3c (showFuel/showElectric/showConsumptionTab) — UserProfile-backed, mirrors 3b
- 3d (autoRecord per-vehicle) — VehicleProfile-backed, more complex
- 3e (syncBaselinesEnabled) — settings-box-backed but needs a NEW provider (consumers currently read Hive directly)
- **3f (unifiedSearchResults) <- this PR**

Refs #1373 phase 3f