### PR TITLE
feat(obd2): PSA fuel-level OEM PID table at 6FA/2151 (Refs #1401 phase 4)

### DIFF
--- a/lib/features/consumption/data/obd2/oem_pid_registry.dart
+++ b/lib/features/consumption/data/obd2/oem_pid_registry.dart
@@ -1,15 +1,23 @@
 import 'adapter_capability.dart';
 import 'oem_pid_table.dart';
+import 'oem_pid_tables/psa_oem_pid_table.dart';
 
 /// Registry of [OemPidTable] implementations keyed by VIN WMI prefix
-/// (#1401 phase 3).
+/// (#1401 phase 3, expanded phase 4).
 ///
-/// Phase 3 ships the registry empty by default — the first concrete
-/// table (PSA) lands in phase 4. Until then, [resolveForCapability]
-/// returns null for every VIN, so callers behave as if the feature
-/// were off. This serves as the implicit kill-switch while a proper
+/// Two construction paths:
+///
+///   * `OemPidRegistry()` — empty by default. Production callers that
+///     have not opted into OEM reads (or tests) hit this path; every
+///     lookup returns null and the feature is effectively off.
+///   * `OemPidRegistry.withDefaults()` — pre-populated with every
+///     shipped OEM table (PSA in phase 4; more in subsequent issues).
+///     Production code that wants OEM reads switches to this factory.
+///
+/// The default-empty constructor is the kill-switch while a proper
 /// `experimental_oem_pids` feature flag is plumbed in alongside the
-/// #1373 feature-management rework.
+/// #1373 feature-management rework — flipping a single call site
+/// between the two constructors disables OEM reads everywhere.
 ///
 /// ## Capability gate
 ///
@@ -37,11 +45,28 @@ class OemPidRegistry {
   /// "Overlap precedence" in the class docstring.
   final List<OemPidTable> _tables;
 
-  /// Create a registry holding [tables]. The default empty list is
-  /// the production path until phase 4 lands the PSA table; tests
-  /// inject fakes via the parameter.
+  /// Create a registry holding [tables]. The default empty list keeps
+  /// the registry inert — production callers wanting OEM reads must
+  /// either inject explicit tables or use [OemPidRegistry.withDefaults].
+  /// Tests inject fakes via the parameter.
   OemPidRegistry({List<OemPidTable> tables = const []})
       : _tables = List.unmodifiable(tables);
+
+  /// Production factory pre-populating the registry with every
+  /// shipped OEM table (#1401 phase 4 onward).
+  ///
+  /// Phase 4 ships PSA only; subsequent phases / issues will append
+  /// VAG, BMW, Toyota and friends. Call sites opt into OEM reads by
+  /// switching from the default constructor (empty / inert) to this
+  /// factory — which is the kill-switch story described in the class
+  /// docstring. The empty default constructor remains the implicit
+  /// "feature off" state until [resolveForCapability] grows a proper
+  /// `experimental_oem_pids` flag check alongside #1373.
+  factory OemPidRegistry.withDefaults() => OemPidRegistry(
+        tables: const [
+          PsaOemPidTable(),
+        ],
+      );
 
   /// Find the table claiming [wmiPrefix] (3 upper-case VIN chars).
   ///

--- a/lib/features/consumption/data/obd2/oem_pid_tables/psa_oem_pid_table.dart
+++ b/lib/features/consumption/data/obd2/oem_pid_tables/psa_oem_pid_table.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/foundation.dart';
+
+import '../oem_pid_table.dart';
+
+/// PSA (Peugeot / Citroën / DS) OEM fuel-level table (#1401 phase 4).
+///
+/// Reads the exact litres-in-tank value from the Body Systems Interface
+/// (BSI) ECU via UDS service `0x21` (Read Data by Local Identifier),
+/// local identifier `0x51`. The byte returned by the BSI is scaled
+/// `× 0.5` to yield litres — so a `0x5A` byte (90 decimal) maps to
+/// 45.0 L. Range covers 0.0 – 127.5 L on a single byte, more than
+/// enough for every PSA fuel tank ever produced.
+///
+/// ## Wire protocol
+///
+/// After the standard ELM327 init the table issues:
+///
+/// ```
+/// AT SH 6FA\r   // switch transmit header to BSI
+/// 2151\r        // service 0x21, LID 0x51 (fuel level)
+/// AT SH 7DF\r   // best-effort restore broadcast header
+/// ```
+///
+/// The expected positive response is `67A 03 61 51 XX` where:
+///   * `67A` is the BSI's response header (some adapters strip it
+///     entirely when ATH0 is in effect — the parser tolerates both
+///     shapes).
+///   * `03` is the UDS payload length (3 bytes).
+///   * `61` is service ID + 0x40 (positive-response echo of `0x21`).
+///   * `51` is the echoed local identifier.
+///   * `XX` is the fuel-level byte; litres = `XX × 0.5`.
+///
+/// A negative response of the form `7F 21 XX` (e.g. `7F 21 31`,
+/// "subFunctionNotSupported") is returned by older PSAs (pre-2008
+/// platform 1) and by non-PSA cars whose BSI cannot route this LID.
+/// The parser maps these to `null` so the caller falls back to the
+/// standard PID `0x2F` percentage path. Any other unparseable response
+/// (empty, garbage, truncated) also returns `null` — *never* an
+/// exception. The trip-recording fuel sampler treats a null result as
+/// "fall back" — never as "tank is empty".
+///
+/// ## WMI prefixes claimed
+///
+/// The four prefixes covered here (`VF3`, `VF7`, `VR1`, `VR3`) are
+/// PSA's France/Stellantis-era passenger-car WMIs as catalogued in
+/// `lib/features/vehicle/data/wmi_table.dart`:
+///
+/// | Prefix | Brand    | Source            |
+/// |--------|----------|-------------------|
+/// | VF3    | Peugeot  | wmi_table.dart    |
+/// | VF7    | Citroën  | wmi_table.dart    |
+/// | VR1    | Citroën  | wmi_table.dart    |
+/// | VR3    | Peugeot  | wmi_table.dart    |
+///
+/// The `0x6FA / 21 51` command is documented for the post-2008 PSA
+/// platform 2 / EMP2 BSI generation (308 / 3008 / 508 et al.). Older
+/// PSAs that share these WMI prefixes will return the negative-response
+/// path and fall back gracefully to PID `0x2F`. Opel (`W0L`) was
+/// acquired by PSA in 2017 but uses a distinct BSI architecture —
+/// not claimed here pending dedicated reverse-engineering.
+class PsaOemPidTable implements OemPidTable {
+  const PsaOemPidTable();
+
+  /// Pre-allocated set so const-construction stays cheap and the
+  /// registry can hand the same instance back repeatedly without
+  /// allocating a new set each time it inspects the prefixes.
+  static const Set<String> _prefixes = {'VF3', 'VF7', 'VR1', 'VR3'};
+
+  /// `AT SH` value that points the adapter at the BSI's RX address.
+  /// PSA uses `0x6FA` for the diagnostic tester → BSI request frame;
+  /// the BSI responds on `0x67A`. The `\r` terminator matches the
+  /// existing [Elm327Commands] convention so [Obd2RawCommandPort]
+  /// implementations can pass it through verbatim.
+  @visibleForTesting
+  static const String setBsiHeaderCommand = 'AT SH 6FA\r';
+
+  /// UDS Read-Data-By-Local-Identifier request: service `0x21`, LID
+  /// `0x51` (fuel level on the PSA BSI platform 2 / EMP2 generation).
+  @visibleForTesting
+  static const String fuelLevelCommand = '2151\r';
+
+  /// Restore the broadcast header (`0x7DF`, OBD-II functional
+  /// addressing) so the next caller's vanilla mode-01 PID isn't routed
+  /// at the BSI by accident. Best-effort — failure is swallowed; the
+  /// next OEM read would re-issue `AT SH` anyway.
+  @visibleForTesting
+  static const String restoreBroadcastHeaderCommand = 'AT SH 7DF\r';
+
+  @override
+  String get oemKey => 'PSA';
+
+  @override
+  Set<String> get supportedWmiPrefixes => _prefixes;
+
+  @override
+  Future<double?> readFuelLevelLitres(Obd2RawCommandPort port) async {
+    // Switch the adapter to BSI's address. Some clones reject `AT SH`
+    // entirely; if the response carries an explicit "?" or "ERROR" we
+    // bail out before sending the data request — there's nothing to
+    // parse and the caller will fall back to PID 0x2F.
+    final headerAck = await port.sendRaw(setBsiHeaderCommand);
+    if (_isAdapterError(headerAck)) {
+      // Don't even try the data request — keeps the OBD-II loop from
+      // hanging on a guaranteed timeout.
+      return null;
+    }
+
+    final raw = await port.sendRaw(fuelLevelCommand);
+    final litres = parsePsaFuelLevelLitres(raw);
+
+    // Best-effort restore of the broadcast header so subsequent
+    // standard-PID reads don't accidentally target the BSI. Failure
+    // is fine — the next OEM read would re-issue AT SH anyway, and
+    // this is documented as best-effort in the class docstring.
+    try {
+      await port.sendRaw(restoreBroadcastHeaderCommand);
+    } on Object {
+      // Intentional swallow — port contract says it shouldn't throw,
+      // but we don't want a single misbehaving adapter to bubble an
+      // unrelated error up through a successful litres read.
+    }
+
+    return litres;
+  }
+}
+
+/// Detect adapter-side rejection of an `AT SH` (or any other AT)
+/// command. Real ELM327s answer `OK\r>`; clones that don't support
+/// header-switching answer `?\r>` or `ERROR\r>` (occasionally
+/// `STOPPED`). An empty response means the port couldn't even round-
+/// trip — also a hard-fail signal.
+bool _isAdapterError(String raw) {
+  final cleaned = raw.replaceAll('>', '').trim().toUpperCase();
+  if (cleaned.isEmpty) return true;
+  if (cleaned.contains('?')) return true;
+  if (cleaned.contains('ERROR')) return true;
+  if (cleaned.contains('STOPPED')) return true;
+  if (cleaned.contains('UNABLE')) return true;
+  return false;
+}
+
+/// Pure parser for the BSI fuel-level response (#1401 phase 4).
+///
+/// Tolerates the response shapes a real ELM327 produces:
+///   * full headered `'67A 03 61 51 XX'`,
+///   * header-stripped (ATH0) `'03 61 51 XX'`,
+///   * `'61 51 XX'` (some adapters drop the length byte too),
+///   * lower-case hex, mixed whitespace, prompt-character noise (`>`),
+///   * the original request echoed on its own line above the
+///     response (`'2151\r67A 03 61 51 5A'`).
+///
+/// Returns `null` for:
+///   * empty / whitespace / null,
+///   * negative response `7F 21 XX`,
+///   * any frame that doesn't carry the `61 51` echo,
+///   * a fuel-level byte that fails hex parsing.
+///
+/// Litres are derived as `byte * 0.5` per PSA BSI scaling. The byte
+/// range is the full unsigned 0..255, mapping to 0.0..127.5 L.
+double? parsePsaFuelLevelLitres(String? raw) {
+  if (raw == null) return null;
+
+  // Normalise whitespace, prompt characters and case. The ELM327
+  // delivers `\r`-separated frames with a trailing `>` prompt; some
+  // adapters also echo the request back on its own line.
+  final cleaned = raw.replaceAll('>', ' ').trim();
+  if (cleaned.isEmpty) return null;
+
+  // Walk every line so we can ignore the echoed request. A single-
+  // line response (most adapters with ATE0) hits this loop once.
+  for (final line in cleaned.split(RegExp(r'[\r\n]+'))) {
+    final tokens = line
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((t) => t.isNotEmpty)
+        .map((t) => t.toUpperCase())
+        .toList();
+    if (tokens.isEmpty) continue;
+
+    // Ignore the echoed request line (`2151`) — same prefix the
+    // table sent — so we don't mistake it for a malformed response.
+    if (tokens.length == 1 && tokens.first == '2151') continue;
+
+    // Negative response: `7F 21 XX`. Branch BEFORE searching for the
+    // `61 51` echo so we return null cleanly without falling through
+    // to the "no payload found" branch.
+    if (tokens.length >= 2 && tokens[0] == '7F' && tokens[1] == '21') {
+      return null;
+    }
+
+    // Search for the `61 51 XX` payload anywhere in the token stream.
+    // This naturally handles all three header shapes above without
+    // committing to a specific framing.
+    for (var i = 0; i + 2 < tokens.length; i++) {
+      if (tokens[i] == '61' && tokens[i + 1] == '51') {
+        final byte = int.tryParse(tokens[i + 2], radix: 16);
+        if (byte == null) return null;
+        return byte * 0.5;
+      }
+    }
+  }
+
+  return null;
+}

--- a/test/features/consumption/data/obd2/oem_pid_registry_test.dart
+++ b/test/features/consumption/data/obd2/oem_pid_registry_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_capability.dart';
 import 'package:tankstellen/features/consumption/data/obd2/oem_pid_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/oem_pid_table.dart';
+import 'package:tankstellen/features/consumption/data/obd2/oem_pid_tables/psa_oem_pid_table.dart';
 
 /// Lightweight [OemPidTable] stand-in that does not actually issue
 /// commands — registry tests only care about lookup mechanics, not
@@ -235,6 +236,55 @@ void main() {
         final hit = registry.lookupByWmi('VF3');
         expect(hit, same(psaPrimary));
         expect(hit?.oemKey, 'PSA-primary');
+      });
+    });
+
+    group('withDefaults factory (#1401 phase 4)', () {
+      test('finds PsaOemPidTable for a Peugeot VIN (VF3 prefix)', () {
+        final registry = OemPidRegistry.withDefaults();
+
+        final hit = registry.lookupByVin('VF31234567890ABCD');
+
+        expect(hit, isA<PsaOemPidTable>());
+        expect(hit?.oemKey, 'PSA');
+      });
+
+      test('finds PsaOemPidTable for a Citroën VIN (VF7 prefix)', () {
+        final registry = OemPidRegistry.withDefaults();
+
+        expect(
+          registry.lookupByVin('VF71234567890ABCD'),
+          isA<PsaOemPidTable>(),
+        );
+      });
+
+      test('returns null for non-PSA VINs (e.g. BMW WBA prefix)', () {
+        final registry = OemPidRegistry.withDefaults();
+
+        // WBA is BMW — not registered in phase 4. Subsequent epic
+        // phases / issues may add it; this test pins the current
+        // PSA-only scope so a future "added BMW" PR has to update
+        // the assertion deliberately.
+        expect(registry.lookupByVin('WBA1234567890ABCD'), isNull);
+      });
+
+      test('respects the capability gate even with the PSA table loaded', () {
+        final registry = OemPidRegistry.withDefaults();
+
+        expect(
+          registry.resolveForCapability(
+            'VF31234567890ABCD',
+            Obd2AdapterCapability.standardOnly,
+          ),
+          isNull,
+        );
+        expect(
+          registry.resolveForCapability(
+            'VF31234567890ABCD',
+            Obd2AdapterCapability.oemPidsCapable,
+          ),
+          isA<PsaOemPidTable>(),
+        );
       });
     });
 

--- a/test/features/consumption/data/obd2/oem_pid_tables/psa_oem_pid_table_test.dart
+++ b/test/features/consumption/data/obd2/oem_pid_tables/psa_oem_pid_table_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/oem_pid_table.dart';
+import 'package:tankstellen/features/consumption/data/obd2/oem_pid_tables/psa_oem_pid_table.dart';
+
+/// Programmable in-memory [Obd2RawCommandPort]. Records every command
+/// the table sends so the integration test can assert the wire-level
+/// sequence (`AT SH 6FA` → `2151` → `AT SH 7DF`). Returns a canned
+/// response per command; unknown commands resolve to an empty string —
+/// the same shape a real adapter delivers on NO DATA. Mirrors the fake
+/// in `oem_pid_table_test.dart` so the two suites read the same way.
+class _FakePort implements Obd2RawCommandPort {
+  final List<String> sent = [];
+  final Map<String, String> responses;
+
+  _FakePort([this.responses = const {}]);
+
+  @override
+  Future<String> sendRaw(String command) async {
+    sent.add(command);
+    return responses[command] ?? '';
+  }
+}
+
+void main() {
+  group('parsePsaFuelLevelLitres — pure parser (#1401 phase 4)', () {
+    test('canonical headered response — 0x5A → 45.0 L', () {
+      // 0x5A = 90 decimal; 90 * 0.5 = 45.0 L.
+      expect(parsePsaFuelLevelLitres('67A 03 61 51 5A'), 45.0);
+    });
+
+    test('tolerates whitespace, lowercase and ELM327 prompt noise', () {
+      // Real adapters sandwich the response between a leading prompt
+      // and a trailing `\r>`. Lowercase hex shows up on a few clones
+      // even with ATCAF1 set.
+      expect(
+        parsePsaFuelLevelLitres('>67a 03 61 51 5a\r\n>'),
+        45.0,
+      );
+    });
+
+    test('header-stripped response (ATH0) — `03 61 51 XX` still parses', () {
+      // Some adapters (or our own ATH0 init) drop the `67A` header
+      // entirely. The parser locates `61 51` anywhere in the token
+      // stream so this shape works without a special branch.
+      expect(parsePsaFuelLevelLitres('03 61 51 5A'), 45.0);
+    });
+
+    test('boundary: byte 0x00 → 0.0 L (empty tank reading)', () {
+      expect(parsePsaFuelLevelLitres('67A 03 61 51 00'), 0.0);
+    });
+
+    test('boundary: byte 0xFF → 127.5 L (parser does not clamp)', () {
+      // Range top of the single-byte scaling. A real PSA tank caps
+      // around ~70 L so 127.5 would never appear in the wild, but
+      // the parser intentionally does not clamp — clamping is the
+      // caller's job (sanity-checking against tank capacity).
+      expect(parsePsaFuelLevelLitres('67A 03 61 51 FF'), 127.5);
+    });
+
+    test('negative response `7F 21 XX` → null', () {
+      // PSA BSI returns `7F 21 31` ("subFunctionNotSupported") on
+      // older platform-1 cars or on non-PSA BSIs. Caller falls back
+      // to PID 0x2F percentage path.
+      expect(parsePsaFuelLevelLitres('7F 21 31'), isNull);
+    });
+
+    test('null / empty / whitespace-only → null', () {
+      expect(parsePsaFuelLevelLitres(null), isNull);
+      expect(parsePsaFuelLevelLitres(''), isNull);
+      expect(parsePsaFuelLevelLitres('   \r\n\t'), isNull);
+      // Prompt-only response (a real ELM327 emits this when nothing
+      // follows the request — adapter is alive but the ECU didn't
+      // answer in time).
+      expect(parsePsaFuelLevelLitres('>'), isNull);
+    });
+
+    test('echoed request line is ignored, response on next line parses', () {
+      // Some adapters echo the request back even with ATE0 if the
+      // hardware UART buffered the bytes already. The parser walks
+      // every line and stops at the one carrying `61 51`.
+      expect(
+        parsePsaFuelLevelLitres('2151\r67A 03 61 51 5A'),
+        45.0,
+      );
+    });
+
+    test('payload byte that is not valid hex → null', () {
+      // Defensive: a corrupted byte (e.g. 'ZZ') must NOT throw —
+      // the OEM read contract is "null on any parse failure".
+      expect(parsePsaFuelLevelLitres('67A 03 61 51 ZZ'), isNull);
+    });
+
+    test('truncated frame missing the data byte → null', () {
+      expect(parsePsaFuelLevelLitres('67A 03 61 51'), isNull);
+    });
+
+    test('garbage frame without the `61 51` echo → null', () {
+      // Wrong service-mode echo, e.g. an unrelated PID response that
+      // happened to land in the buffer.
+      expect(parsePsaFuelLevelLitres('41 0D 64'), isNull);
+    });
+  });
+
+  group('PsaOemPidTable identity (#1401 phase 4)', () {
+    test('oemKey is "PSA"', () {
+      expect(const PsaOemPidTable().oemKey, 'PSA');
+    });
+
+    test('claims VF3 / VF7 / VR1 / VR3 (post-2008 PSA passenger cars)', () {
+      expect(
+        const PsaOemPidTable().supportedWmiPrefixes,
+        {'VF3', 'VF7', 'VR1', 'VR3'},
+      );
+    });
+  });
+
+  group('PsaOemPidTable.readFuelLevelLitres — wire sequence (#1401 phase 4)',
+      () {
+    test('sends AT SH 6FA → 2151 → AT SH 7DF and returns 45.0 L for 0x5A',
+        () async {
+      const table = PsaOemPidTable();
+      final port = _FakePort({
+        'AT SH 6FA\r': 'OK\r>',
+        '2151\r': '67A 03 61 51 5A\r>',
+        'AT SH 7DF\r': 'OK\r>',
+      });
+
+      final litres = await table.readFuelLevelLitres(port);
+
+      expect(litres, 45.0);
+      // Order matters: header switch must happen BEFORE the data
+      // request, restore must happen AFTER.
+      expect(port.sent, [
+        'AT SH 6FA\r',
+        '2151\r',
+        'AT SH 7DF\r',
+      ]);
+    });
+
+    test('returns null on the BSI negative response and still restores header',
+        () async {
+      const table = PsaOemPidTable();
+      final port = _FakePort({
+        'AT SH 6FA\r': 'OK\r>',
+        '2151\r': '7F 21 31\r>',
+        'AT SH 7DF\r': 'OK\r>',
+      });
+
+      final litres = await table.readFuelLevelLitres(port);
+
+      expect(litres, isNull);
+      // Restore is best-effort but happens regardless of the data
+      // request's outcome — leaving the adapter pointed at the BSI
+      // would poison subsequent standard-PID reads.
+      expect(port.sent.last, 'AT SH 7DF\r');
+    });
+
+    test(
+        'bails out of the data request when the adapter rejects AT SH (clones)',
+        () async {
+      const table = PsaOemPidTable();
+      // A clone that doesn't support `AT SH` answers `?` to the
+      // header-switch command. The table must NOT proceed to send
+      // `2151` — that would hang the loop on a guaranteed timeout.
+      final port = _FakePort({
+        'AT SH 6FA\r': '?\r>',
+      });
+
+      final litres = await table.readFuelLevelLitres(port);
+
+      expect(litres, isNull);
+      expect(port.sent, ['AT SH 6FA\r']);
+    });
+
+    test('returns null and restores header when ECU is silent (empty data)',
+        () async {
+      const table = PsaOemPidTable();
+      final port = _FakePort({
+        'AT SH 6FA\r': 'OK\r>',
+        '2151\r': '',
+        'AT SH 7DF\r': 'OK\r>',
+      });
+
+      final litres = await table.readFuelLevelLitres(port);
+
+      expect(litres, isNull);
+      // Header restore still runs — it's best-effort.
+      expect(port.sent, [
+        'AT SH 6FA\r',
+        '2151\r',
+        'AT SH 7DF\r',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 4 of #1401 — the first concrete `OemPidTable` implementation, plus opt-in registry wiring.

- **`PsaOemPidTable`** (Peugeot / Citroën / DS) reads exact litres-in-tank from the PSA Body Systems Interface (BSI) ECU.
- **Wire sequence:** `AT SH 6FA` (switch to BSI) → `2151` (UDS service `0x21`, local identifier `0x51` = fuel level) → `AT SH 7DF` (best-effort restore broadcast header).
- **Scaling:** `byte * 0.5` → litres. `0x5A` (90 dec) maps to 45.0 L; range 0.0 – 127.5 L.
- **Negative response (`7F 21 XX`)** maps to `null` — older PSAs (pre-2008 platform 1) and non-PSA BSIs land here, and the caller falls back to standard PID `0x2F`.
- **`OemPidRegistry.withDefaults()`** factory pre-registers `PsaOemPidTable`. The empty default constructor stays — flipping a single call site between the two constructors is the kill-switch until the `experimental_oem_pids` flag is plumbed in alongside #1373.

## WMI prefixes claimed

| Prefix | Brand    | Source                            |
|--------|----------|-----------------------------------|
| VF3    | Peugeot  | `lib/features/vehicle/data/wmi_table.dart` |
| VF7    | Citroën  | `lib/features/vehicle/data/wmi_table.dart` |
| VR1    | Citroën  | `lib/features/vehicle/data/wmi_table.dart` |
| VR3    | Peugeot  | `lib/features/vehicle/data/wmi_table.dart` |

`W0L` (Opel — acquired by PSA in 2017) is intentionally **not** claimed; Opel uses a distinct BSI architecture and needs dedicated reverse-engineering before joining the table.

## Parser robustness

`parsePsaFuelLevelLitres(String?)` is a `@visibleForTesting`-style top-level helper that tolerates every adapter quirk we know of:
- full headered `'67A 03 61 51 XX'`,
- header-stripped (ATH0) `'03 61 51 XX'` or even bare `'61 51 XX'`,
- lower-case hex, mixed whitespace, prompt characters (`>`),
- request echo on a separate line (`'2151\r67A 03 61 51 5A'`),
- garbage / truncated / negative-response / non-hex byte → `null` (never an exception).

The clone-tolerance branch in `readFuelLevelLitres` short-circuits when `AT SH` returns `?` / `ERROR` / `STOPPED` / `UNABLE` / empty — so cheap clones that don't support header switching can't hang the OBD-II loop on a guaranteed timeout while waiting for `2151`'s answer.

## Out of scope (subsequent phases)

- Wiring into `obd2_service.dart` — phase 5 (passive sniff) and phase 7 (fill-up reconciliation) own that.
- Feature-flag plumbing for `experimental_oem_pids` — intentionally still unwired; `withDefaults()` is opt-in by callers.
- Other OEMs (VAG, BMW, Toyota, Renault, Ford) — each is its own follow-up issue.

## Test plan

- [x] `flutter analyze` — clean (0 issues, includes `test/`).
- [x] `flutter test test/features/consumption/data/obd2/` — 768 / 768 pass.
- [x] 15 new PSA tests covering parser tolerance + integration wire sequence.
- [x] 4 new `withDefaults()` tests confirming PSA lookup hit/miss + capability gate still respected.
- [ ] CI runs the full suite.

Refs #1401

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>