### PR TITLE
feat(features): migrate syncBaselinesEnabled to central feature flags (Refs #1373 phase 3e)

### DIFF
--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -48,6 +48,10 @@ class StorageKeys {
   /// #780 — opt-in switch for per-vehicle baseline sync. Defaults to
   /// false (off) so users who only want favourite sync aren't
   /// silently uploading driving data.
+  @Deprecated(
+    'Migrated to Feature.baselineSync in #1373 phase 3e; '
+    'kept for one-shot migration read.',
+  )
   static const String syncBaselinesEnabled = 'sync_baselines_enabled';
 
   /// #950 phase 4 — flag set once the

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -10,12 +10,11 @@ import '../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../core/feedback/auto_record_badge_service.dart';
 import '../../../core/location/geolocator_wrapper.dart';
 import '../../../core/storage/hive_boxes.dart';
-import '../../../core/storage/storage_keys.dart';
-import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/baselines_sync.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
 import '../../search/domain/entities/fuel_type.dart';
+import '../../sync/providers/baseline_sync_enabled_provider.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/baseline_store.dart';
@@ -1098,11 +1097,10 @@ class TripRecording extends _$TripRecording {
       // users who never toggled it in the sync setup screen don't
       // silently upload driving data. Ungated favourite sync etc.
       // are unaffected.
-      final settings = ref.read(settingsStorageProvider);
-      final enabled = settings.getSetting(
-            StorageKeys.syncBaselinesEnabled,
-          ) ==
-          true;
+      // #1373 phase 3e — read the central feature flag instead of the
+      // legacy Hive key. ref.read (not watch) — this is a one-shot
+      // gate at flush time, not a reactive dependency.
+      final enabled = ref.read(baselineSyncEnabledProvider);
       if (!enabled) return;
       if (!Hive.isBoxOpen(HiveBoxes.obd2Baselines)) return;
       final box = Hive.box<String>(HiveBoxes.obd2Baselines);

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'0afd9a7db4deb150378a58a4d111c1a02de400e7';
+String _$tripRecordingHash() => r'9fd909bf590c330723e3c3e429ee9a18874c37e7';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/feature_management/data/legacy_toggle_migrator.dart
+++ b/lib/features/feature_management/data/legacy_toggle_migrator.dart
@@ -28,6 +28,13 @@ const String gamificationMigratedKey = 'gamificationMigrated';
 /// tells us whether the migration has already run.
 const String unifiedSearchResultsMigratedKey = 'unifiedSearchResultsMigrated';
 
+/// Settings-box key written once after the legacy
+/// `syncBaselinesEnabled` value has been promoted into the central
+/// feature-flag set (#1373 phase 3e). Persisted in the same
+/// `settings` Hive box as the legacy toggle itself so a single read
+/// tells us whether the migration has already run.
+const String syncBaselinesMigratedKey = 'syncBaselinesMigrated';
+
 /// One-shot migrator that promotes legacy scattered toggles into the
 /// central [FeatureFlagsRepository] (#1373 phase 3a).
 ///
@@ -51,20 +58,28 @@ const String unifiedSearchResultsMigratedKey = 'unifiedSearchResultsMigrated';
 /// because the legacy value lives on the profile entity rather than
 /// the settings box.
 ///
-/// Phase 3f (this PR) adds [_migrateUnifiedSearchResults] for the
+/// Phase 3f adds [_migrateUnifiedSearchResults] for the
 /// settings-box-backed `unifiedSearchResultsEnabled` toggle. It
 /// follows the same shape as [_migrateHapticEcoCoach] but with no
 /// prerequisites to cascade-enable (the manifest declares no
 /// `requires:` for [Feature.unifiedSearchResults]).
+///
+/// Phase 3e (this PR) adds [_migrateSyncBaselines] for the
+/// settings-box-backed `syncBaselinesEnabled` toggle. The manifest
+/// declares [Feature.tankSync] as a hard prerequisite of
+/// [Feature.baselineSync], so the cascade promotes BOTH on a legacy
+/// `true` (mirroring the haptic precedent's
+/// `obd2TripRecording → hapticEcoCoach` cascade).
 ///
 /// Phase status:
 ///   - 3a hapticEcoCoach (settings-box, default-false) ✅
 ///   - 3b gamification (UserProfile, default-true) ✅ via
 ///     [migrateUserProfileToggles]
 ///   - 3f unifiedSearchResults (settings-box, default-false) ✅
+///   - 3e syncBaselines (settings-box, default-false) ✅
 ///
-/// Future phases (3c, 3d, 3e) extend this migrator with additional
-/// scattered toggles (`showFuel`, `autoRecord`, `syncBaselinesEnabled`,
+/// Future phases (3c, 3d) extend this migrator with additional
+/// scattered toggles (`showConsumptionTab`, per-vehicle `autoRecord`,
 /// etc.). Each new migration follows the same shape: read the legacy
 /// value, gate on a `<featureName>Migrated` flag, force-enable
 /// prerequisites first, persist, then write the gate flag.
@@ -79,6 +94,11 @@ Future<void> migrateLegacyToggles({
     manifest: manifest,
   );
   await _migrateUnifiedSearchResults(
+    settings: settings,
+    featureFlags: featureFlags,
+    manifest: manifest,
+  );
+  await _migrateSyncBaselines(
     settings: settings,
     featureFlags: featureFlags,
     manifest: manifest,
@@ -280,6 +300,56 @@ Future<void> _migrateUnifiedSearchResults({
   } catch (e, st) {
     debugPrint(
       'migrateLegacyToggles: writing $unifiedSearchResultsMigratedKey failed: $e\n$st',
+    );
+  }
+}
+
+Future<void> _migrateSyncBaselines({
+  required Box<dynamic> settings,
+  required FeatureFlagsRepository featureFlags,
+  required FeatureManifest manifest,
+}) async {
+  // Already migrated → idempotent no-op. The user may have toggled
+  // syncBaselines OFF after a previous migration; we must not
+  // re-promote the legacy `true` value.
+  if (settings.get(syncBaselinesMigratedKey) == true) {
+    return;
+  }
+
+  // ignore: deprecated_member_use_from_same_package
+  final legacyValue = settings.get(StorageKeys.syncBaselinesEnabled);
+
+  if (legacyValue == true) {
+    try {
+      final current = await featureFlags.loadEnabled();
+      // Force-enable the prerequisite first per the manifest's
+      // dependency graph — [Feature.baselineSync] requires
+      // [Feature.tankSync], so the cascade promotes both. Without
+      // this the central system would refuse the baselineSync enable
+      // on its first toggle attempt.
+      final entry = manifest.entryFor(Feature.baselineSync);
+      final next = <Feature>{
+        ...current,
+        ...entry.requires,
+        Feature.baselineSync,
+      };
+      await featureFlags.saveEnabled(next);
+    } catch (e, st) {
+      // Don't block startup on a migration failure — the user can
+      // re-toggle from settings if the central state is missing.
+      debugPrint(
+        'migrateLegacyToggles: syncBaselines promote failed: $e\n$st',
+      );
+    }
+  }
+
+  // Always set the flag (even when legacyValue is false / null) so we
+  // never re-read the legacy key on subsequent launches.
+  try {
+    await settings.put(syncBaselinesMigratedKey, true);
+  } catch (e, st) {
+    debugPrint(
+      'migrateLegacyToggles: writing $syncBaselinesMigratedKey failed: $e\n$st',
     );
   }
 }

--- a/lib/features/profile/presentation/widgets/privacy_dashboard/synced_data_card.dart
+++ b/lib/features/profile/presentation/widgets/privacy_dashboard/synced_data_card.dart
@@ -2,9 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../../../core/storage/storage_keys.dart';
-import '../../../../../core/storage/storage_providers.dart';
 import '../../../../../l10n/app_localizations.dart';
+import '../../../../sync/providers/baseline_sync_enabled_provider.dart';
 import '../../../providers/privacy_data_provider.dart';
 import 'privacy_data_row.dart';
 
@@ -95,9 +94,7 @@ class _SyncEnabledBody extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final userId = snapshot.syncUserId;
-    final settings = ref.watch(settingsStorageProvider);
-    final baselineSyncOn =
-        settings.getSetting(StorageKeys.syncBaselinesEnabled) == true;
+    final baselineSyncOn = ref.watch(baselineSyncEnabledProvider);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -135,11 +132,7 @@ class _SyncEnabledBody extends ConsumerWidget {
             style: theme.textTheme.bodySmall,
           ),
           onChanged: (v) async {
-            await settings.putSetting(
-              StorageKeys.syncBaselinesEnabled,
-              v,
-            );
-            ref.invalidate(settingsStorageProvider);
+            await ref.read(baselineSyncEnabledProvider.notifier).set(v);
           },
           contentPadding: EdgeInsets.zero,
         ),

--- a/lib/features/sync/providers/baseline_sync_enabled_provider.dart
+++ b/lib/features/sync/providers/baseline_sync_enabled_provider.dart
@@ -1,0 +1,72 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../feature_management/application/feature_flags_provider.dart';
+import '../../feature_management/domain/feature.dart';
+
+part 'baseline_sync_enabled_provider.g.dart';
+
+/// Persisted opt-in switch for per-vehicle driving-baseline sync via
+/// TankSync (#780). As of #1373 phase 3e this is a thin shim over
+/// [featureFlagsProvider] — the canonical state lives in the central
+/// feature-flag set keyed by [Feature.baselineSync]. The legacy
+/// [StorageKeys.syncBaselinesEnabled] Hive-settings key is read once
+/// by the `legacyToggleMigrationProvider` on first launch after
+/// upgrade and promoted into the central set; subsequent reads/writes
+/// go through here.
+///
+/// [Feature.baselineSync] declares [Feature.tankSync] as a hard
+/// prerequisite in the manifest, so a `set(true)` will fail unless
+/// `tankSync` is already enabled (the migrator cascade-enables both).
+/// The settings UI is expected to pre-check `canEnable` before invoking
+/// the setter; the defensive `on StateError` catch below is a backstop
+/// for programmatic callers that bypass that guard.
+///
+/// `keepAlive: true` so a flush at the end of a trip (which reads this
+/// provider one-shot via `ref.read`) observes the same notifier as the
+/// settings screen that flipped it.
+@Riverpod(keepAlive: true)
+class BaselineSyncEnabled extends _$BaselineSyncEnabled {
+  @override
+  bool build() {
+    return ref.watch(featureFlagsProvider).contains(Feature.baselineSync);
+  }
+
+  /// Delegate to [featureFlagsProvider]'s `enable` / `disable`. The
+  /// downstream `_syncBaselineAfterFlush` reads this value via
+  /// `ref.read` at flush time — there's no reactive subscriber to
+  /// invalidate, so the only consumer of a state flip is the next
+  /// trip's flush.
+  ///
+  /// A [StateError] from a dependency-violation is intentionally
+  /// swallowed and the toggle stays at its prior state — see the
+  /// catch block below for why.
+  Future<void> set(bool value) async {
+    final notifier = ref.read(featureFlagsProvider.notifier);
+    try {
+      if (value) {
+        await notifier.enable(Feature.baselineSync);
+      } else {
+        await notifier.disable(Feature.baselineSync);
+      }
+      // The central provider throws a StateError specifically for
+      // dependency-violation (Feature.baselineSync requires
+      // Feature.tankSync per the manifest); we want to swallow ONLY
+      // that — see the body comment for why. The lint deliberately
+      // discourages catching Error subclasses, but the central API's
+      // contract documents this exact StateError as the
+      // dependency-violation signal, so the catch is intentional and
+      // narrow.
+      // ignore: avoid_catching_errors
+    } on StateError {
+      // TODO(1373): The settings UI's canEnable / blockingDisable
+      // pre-check already guards against the dependency-violation
+      // path before invoking this setter, so a StateError here is a
+      // defensive-only catch — the UI path can't currently reach it.
+      // We swallow rather than rethrow so a programmatic caller (e.g.
+      // a test or the trip-recording flush hook) sees the toggle stay
+      // at its prior state instead of crashing the widget tree.
+      // Remove once every call site has been audited for canEnable
+      // pre-check coverage.
+    }
+  }
+}

--- a/lib/features/sync/providers/baseline_sync_enabled_provider.g.dart
+++ b/lib/features/sync/providers/baseline_sync_enabled_provider.g.dart
@@ -1,0 +1,140 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'baseline_sync_enabled_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Persisted opt-in switch for per-vehicle driving-baseline sync via
+/// TankSync (#780). As of #1373 phase 3e this is a thin shim over
+/// [featureFlagsProvider] — the canonical state lives in the central
+/// feature-flag set keyed by [Feature.baselineSync]. The legacy
+/// [StorageKeys.syncBaselinesEnabled] Hive-settings key is read once
+/// by the `legacyToggleMigrationProvider` on first launch after
+/// upgrade and promoted into the central set; subsequent reads/writes
+/// go through here.
+///
+/// [Feature.baselineSync] declares [Feature.tankSync] as a hard
+/// prerequisite in the manifest, so a `set(true)` will fail unless
+/// `tankSync` is already enabled (the migrator cascade-enables both).
+/// The settings UI is expected to pre-check `canEnable` before invoking
+/// the setter; the defensive `on StateError` catch below is a backstop
+/// for programmatic callers that bypass that guard.
+///
+/// `keepAlive: true` so a flush at the end of a trip (which reads this
+/// provider one-shot via `ref.read`) observes the same notifier as the
+/// settings screen that flipped it.
+
+@ProviderFor(BaselineSyncEnabled)
+final baselineSyncEnabledProvider = BaselineSyncEnabledProvider._();
+
+/// Persisted opt-in switch for per-vehicle driving-baseline sync via
+/// TankSync (#780). As of #1373 phase 3e this is a thin shim over
+/// [featureFlagsProvider] — the canonical state lives in the central
+/// feature-flag set keyed by [Feature.baselineSync]. The legacy
+/// [StorageKeys.syncBaselinesEnabled] Hive-settings key is read once
+/// by the `legacyToggleMigrationProvider` on first launch after
+/// upgrade and promoted into the central set; subsequent reads/writes
+/// go through here.
+///
+/// [Feature.baselineSync] declares [Feature.tankSync] as a hard
+/// prerequisite in the manifest, so a `set(true)` will fail unless
+/// `tankSync` is already enabled (the migrator cascade-enables both).
+/// The settings UI is expected to pre-check `canEnable` before invoking
+/// the setter; the defensive `on StateError` catch below is a backstop
+/// for programmatic callers that bypass that guard.
+///
+/// `keepAlive: true` so a flush at the end of a trip (which reads this
+/// provider one-shot via `ref.read`) observes the same notifier as the
+/// settings screen that flipped it.
+final class BaselineSyncEnabledProvider
+    extends $NotifierProvider<BaselineSyncEnabled, bool> {
+  /// Persisted opt-in switch for per-vehicle driving-baseline sync via
+  /// TankSync (#780). As of #1373 phase 3e this is a thin shim over
+  /// [featureFlagsProvider] — the canonical state lives in the central
+  /// feature-flag set keyed by [Feature.baselineSync]. The legacy
+  /// [StorageKeys.syncBaselinesEnabled] Hive-settings key is read once
+  /// by the `legacyToggleMigrationProvider` on first launch after
+  /// upgrade and promoted into the central set; subsequent reads/writes
+  /// go through here.
+  ///
+  /// [Feature.baselineSync] declares [Feature.tankSync] as a hard
+  /// prerequisite in the manifest, so a `set(true)` will fail unless
+  /// `tankSync` is already enabled (the migrator cascade-enables both).
+  /// The settings UI is expected to pre-check `canEnable` before invoking
+  /// the setter; the defensive `on StateError` catch below is a backstop
+  /// for programmatic callers that bypass that guard.
+  ///
+  /// `keepAlive: true` so a flush at the end of a trip (which reads this
+  /// provider one-shot via `ref.read`) observes the same notifier as the
+  /// settings screen that flipped it.
+  BaselineSyncEnabledProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'baselineSyncEnabledProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$baselineSyncEnabledHash();
+
+  @$internal
+  @override
+  BaselineSyncEnabled create() => BaselineSyncEnabled();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$baselineSyncEnabledHash() =>
+    r'f720cd43ea15882893d6be855bb2e8e1652732b1';
+
+/// Persisted opt-in switch for per-vehicle driving-baseline sync via
+/// TankSync (#780). As of #1373 phase 3e this is a thin shim over
+/// [featureFlagsProvider] — the canonical state lives in the central
+/// feature-flag set keyed by [Feature.baselineSync]. The legacy
+/// [StorageKeys.syncBaselinesEnabled] Hive-settings key is read once
+/// by the `legacyToggleMigrationProvider` on first launch after
+/// upgrade and promoted into the central set; subsequent reads/writes
+/// go through here.
+///
+/// [Feature.baselineSync] declares [Feature.tankSync] as a hard
+/// prerequisite in the manifest, so a `set(true)` will fail unless
+/// `tankSync` is already enabled (the migrator cascade-enables both).
+/// The settings UI is expected to pre-check `canEnable` before invoking
+/// the setter; the defensive `on StateError` catch below is a backstop
+/// for programmatic callers that bypass that guard.
+///
+/// `keepAlive: true` so a flush at the end of a trip (which reads this
+/// provider one-shot via `ref.read`) observes the same notifier as the
+/// settings screen that flipped it.
+
+abstract class _$BaselineSyncEnabled extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/feature_management/data/legacy_toggle_migrator_test.dart
+++ b/test/features/feature_management/data/legacy_toggle_migrator_test.dart
@@ -544,4 +544,164 @@ void main() {
       },
     );
   });
+
+  group('migrateLegacyToggles — syncBaselines', () {
+    test(
+      'promotes legacy true → cascade-enables both Feature.tankSync '
+      '(prerequisite) AND Feature.baselineSync; sets migration flag',
+      () async {
+        // ignore: deprecated_member_use_from_same_package
+        await settings.put(StorageKeys.syncBaselinesEnabled, true);
+
+        await migrateLegacyToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+        );
+
+        final after = await repo.loadEnabled();
+        expect(
+          after,
+          contains(Feature.baselineSync),
+          reason:
+              'Legacy true must promote into the central feature-flag set '
+              'so the user does not have to re-enable baseline sync after '
+              'the migration.',
+        );
+        expect(
+          after,
+          contains(Feature.tankSync),
+          reason:
+              'baselineSync requires tankSync per the manifest; enabling '
+              'the dependent without the prerequisite would leave the '
+              'central state in a contract-violating shape. Mirrors the '
+              'haptic precedent which cascades obd2TripRecording.',
+        );
+        expect(
+          settings.get(syncBaselinesMigratedKey),
+          isTrue,
+          reason:
+              'The migration gate must be set so a subsequent run is a '
+              'no-op and a user who later disables baselineSync does not '
+              'get it re-enabled on the next launch.',
+        );
+      },
+    );
+
+    test('legacy false → leaves central state untouched; sets migration flag',
+        () async {
+      // ignore: deprecated_member_use_from_same_package
+      await settings.put(StorageKeys.syncBaselinesEnabled, false);
+
+      await migrateLegacyToggles(
+        settings: settings,
+        featureFlags: repo,
+        manifest: FeatureManifest.defaultManifest,
+      );
+
+      final after = await repo.loadEnabled();
+      expect(
+        after,
+        isNot(contains(Feature.baselineSync)),
+        reason:
+            'A legacy explicit-false must not promote anything — the '
+            'central system already defaults baselineSync to off '
+            '(manifest defaultEnabled=false), so a no-op write is '
+            'semantically equivalent.',
+      );
+      expect(
+        after,
+        isNot(contains(Feature.tankSync)),
+        reason:
+            'tankSync must NOT be cascade-enabled when the legacy value '
+            'is false — the cascade only runs on the legacy=true branch.',
+      );
+      expect(
+        settings.get(syncBaselinesMigratedKey),
+        isTrue,
+        reason:
+            'Even a no-op migration must set the gate so we never '
+            're-read the deprecated key on subsequent launches.',
+      );
+    });
+
+    test(
+      'legacy null (key never written) → no central state change; flag set',
+      () async {
+        await migrateLegacyToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+        );
+
+        final after = await repo.loadEnabled();
+        expect(
+          after,
+          isNot(contains(Feature.baselineSync)),
+          reason:
+              'A first-launch profile (no legacy value) must land at '
+              'central manifest defaults — baselineSync off.',
+        );
+        expect(
+          settings.get(syncBaselinesMigratedKey),
+          isTrue,
+          reason:
+              'Absent legacy value still flips the gate so we do not '
+              're-do the work each launch.',
+        );
+      },
+    );
+
+    test(
+      'idempotent — running twice on legacy=true leaves the central state '
+      'unchanged the second time (user disable survives)',
+      () async {
+        // ignore: deprecated_member_use_from_same_package
+        await settings.put(StorageKeys.syncBaselinesEnabled, true);
+
+        // First run promotes (cascades tankSync + baselineSync).
+        await migrateLegacyToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+        );
+        final afterFirst = await repo.loadEnabled();
+        expect(afterFirst, contains(Feature.baselineSync));
+        expect(afterFirst, contains(Feature.tankSync));
+        expect(settings.get(syncBaselinesMigratedKey), isTrue);
+
+        // Simulate the user disabling baselineSync after the migration
+        // (e.g. via the central settings UI). The tankSync prereq stays
+        // because favourite sync depends on it independently. The
+        // second run must NOT re-enable baselineSync.
+        final disabled = {...afterFirst}..remove(Feature.baselineSync);
+        await repo.saveEnabled(disabled);
+
+        // Second run.
+        await migrateLegacyToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+        );
+
+        final afterSecond = await repo.loadEnabled();
+        expect(
+          afterSecond,
+          isNot(contains(Feature.baselineSync)),
+          reason:
+              'A second migration run must not re-promote the legacy '
+              'true value — the user has explicitly disabled '
+              'baselineSync since and that choice must survive.',
+        );
+        expect(
+          afterSecond,
+          contains(Feature.tankSync),
+          reason:
+              'tankSync must remain enabled — the user only disabled '
+              'baselineSync, and the migrator must not touch unrelated '
+              'features on the idempotent second run.',
+        );
+      },
+    );
+  });
 }

--- a/test/features/profile/presentation/widgets/privacy_dashboard/synced_data_card_test.dart
+++ b/test/features/profile/presentation/widgets/privacy_dashboard/synced_data_card_test.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/features/profile/presentation/widgets/privacy_dashboard/privacy_data_row.dart';
 import 'package:tankstellen/features/profile/presentation/widgets/privacy_dashboard/synced_data_card.dart';
 import 'package:tankstellen/features/profile/providers/privacy_data_provider.dart';
+import 'package:tankstellen/features/sync/providers/baseline_sync_enabled_provider.dart';
 
 import '../../../../../helpers/mock_providers.dart';
 import '../../../../../helpers/pump_app.dart';
@@ -31,14 +31,38 @@ PrivacyDataSnapshot _snapshot({
       estimatedTotalBytes: 1024,
     );
 
+/// Override [baselineSyncEnabledProvider] with a fixed boolean. Used
+/// instead of seeding the legacy [StorageKeys.syncBaselinesEnabled]
+/// Hive key after the #1373 phase 3e migration — the canonical state
+/// now lives in the central feature-flag set.
+Object _baselineSyncOverride(bool value) {
+  return baselineSyncEnabledProvider.overrideWith(() => _FakeBaselineSync(value));
+}
+
+class _FakeBaselineSync extends BaselineSyncEnabled {
+  _FakeBaselineSync(this._value);
+
+  final bool _value;
+
+  @override
+  bool build() => _value;
+
+  @override
+  Future<void> set(bool value) async {
+    state = value;
+  }
+}
+
 void main() {
   group('SyncedDataCard', () {
     testWidgets('header renders cloud icon + bold title', (tester) async {
       final overrides = standardTestOverrides();
+      // Default the toggle to false so the disabled-body branch is
+      // exercised cleanly.
       await pumpApp(
         tester,
         SyncedDataCard(snapshot: _snapshot()),
-        overrides: overrides.overrides,
+        overrides: [...overrides.overrides, _baselineSyncOverride(false)],
       );
 
       expect(find.byIcon(Icons.cloud_outlined), findsOneWidget);
@@ -54,7 +78,7 @@ void main() {
       await pumpApp(
         tester,
         SyncedDataCard(snapshot: _snapshot(syncEnabled: false)),
-        overrides: overrides.overrides,
+        overrides: [...overrides.overrides, _baselineSyncOverride(false)],
       );
 
       // Disabled banner has the cloud_off icon + the disabled copy.
@@ -75,7 +99,9 @@ void main() {
         'enabled snapshot renders sync mode, masked user id, and CTA',
         (tester) async {
       final overrides = standardTestOverrides();
-      // syncBaselinesToggle starts as false (default getSetting → null).
+      // syncBaselinesToggle starts as false (default per manifest).
+      // Stub out generic getSetting calls to keep mocktail happy if the
+      // widget reads any unrelated settings.
       when(() => overrides.mockStorage.getSetting(any()))
           .thenReturn(null);
 
@@ -89,7 +115,7 @@ void main() {
             syncUserId: 'abcd1234-aaaa-bbbb-cccc-deadbeefcafe',
           ),
         ),
-        overrides: overrides.overrides,
+        overrides: [...overrides.overrides, _baselineSyncOverride(false)],
       );
 
       // Two PrivacyDataRows: sync mode + user id.
@@ -121,7 +147,7 @@ void main() {
         SyncedDataCard(
           snapshot: _snapshot(syncEnabled: true),
         ),
-        overrides: overrides.overrides,
+        overrides: [...overrides.overrides, _baselineSyncOverride(false)],
       );
 
       // Two rows still render — but their values fall back to "-".
@@ -130,31 +156,7 @@ void main() {
     });
 
     testWidgets(
-        'baseline-sync toggle reflects stored value (true)',
-        (tester) async {
-      final overrides = standardTestOverrides();
-      when(() => overrides.mockStorage
-              .getSetting(StorageKeys.syncBaselinesEnabled))
-          .thenReturn(true);
-      // Anything else returns null.
-      when(() => overrides.mockStorage.getSetting(
-              any(that: isNot(StorageKeys.syncBaselinesEnabled))))
-          .thenReturn(null);
-
-      await pumpApp(
-        tester,
-        SyncedDataCard(snapshot: _snapshot(syncEnabled: true)),
-        overrides: overrides.overrides,
-      );
-
-      final toggle = tester.widget<SwitchListTile>(
-        find.byKey(const Key('syncBaselinesToggle')),
-      );
-      expect(toggle.value, isTrue);
-    });
-
-    testWidgets(
-        'baseline-sync toggle is OFF when stored value is missing/false',
+        'baseline-sync toggle reflects the central feature-flag value (true)',
         (tester) async {
       final overrides = standardTestOverrides();
       when(() => overrides.mockStorage.getSetting(any()))
@@ -163,7 +165,33 @@ void main() {
       await pumpApp(
         tester,
         SyncedDataCard(snapshot: _snapshot(syncEnabled: true)),
-        overrides: overrides.overrides,
+        overrides: [...overrides.overrides, _baselineSyncOverride(true)],
+      );
+
+      final toggle = tester.widget<SwitchListTile>(
+        find.byKey(const Key('syncBaselinesToggle')),
+      );
+      expect(
+        toggle.value,
+        isTrue,
+        reason:
+            'After #1373 phase 3e the toggle reads from '
+            'baselineSyncEnabledProvider — a true override must surface '
+            'as a checked switch.',
+      );
+    });
+
+    testWidgets(
+        'baseline-sync toggle is OFF when the central feature-flag is false',
+        (tester) async {
+      final overrides = standardTestOverrides();
+      when(() => overrides.mockStorage.getSetting(any()))
+          .thenReturn(null);
+
+      await pumpApp(
+        tester,
+        SyncedDataCard(snapshot: _snapshot(syncEnabled: true)),
+        overrides: [...overrides.overrides, _baselineSyncOverride(false)],
       );
 
       final toggle = tester.widget<SwitchListTile>(
@@ -188,7 +216,7 @@ void main() {
       await pumpApp(
         tester,
         SyncedDataCard(snapshot: _snapshot(syncEnabled: true)),
-        overrides: overrides.overrides,
+        overrides: [...overrides.overrides, _baselineSyncOverride(false)],
       );
 
       expect(

--- a/test/features/sync/providers/baseline_sync_enabled_provider_test.dart
+++ b/test/features/sync/providers/baseline_sync_enabled_provider_test.dart
@@ -1,0 +1,337 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/data/feature_flags_repository.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/sync/providers/baseline_sync_enabled_provider.dart';
+
+/// Provider-layer coverage for the [baselineSyncEnabledProvider]
+/// (#780). As of #1373 phase 3e this provider is a thin shim that
+/// delegates to [featureFlagsProvider]; tests assert that contract:
+///
+///   1. Default state mirrors the manifest default for
+///      [Feature.baselineSync] (`false`).
+///   2. Reads return the central enabled-set membership for
+///      [Feature.baselineSync] when both the prereq and dependent
+///      are seeded.
+///   3. `set(true)` enables `baselineSync` AND keeps `tankSync`
+///      (cascade enforced by the central provider).
+///   4. `set(false)` disables `baselineSync` but the `tankSync`
+///      prereq stays — only the dependent is removed.
+///   5. `set(true)` is a no-op when the `tankSync` prerequisite is
+///      missing — the dependency-violation StateError is swallowed.
+///   6. External writes to [featureFlagsProvider] propagate to the
+///      shim via `ref.watch`.
+///   7. A dependency-violation StateError thrown by a fake notifier
+///      is swallowed and the toggle stays at its prior state.
+///
+/// Migration concerns (the legacy [StorageKeys.syncBaselinesEnabled]
+/// Hive key → central state promotion) are covered in
+/// `test/features/feature_management/data/legacy_toggle_migrator_test.dart`.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late Box<dynamic> flagsBox;
+  late FeatureFlagsRepository repo;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('baseline_sync_shim_');
+    Hive.init(tmpDir.path);
+    flagsBox = await Hive.openBox<dynamic>(
+      'feature_flags_${DateTime.now().microsecondsSinceEpoch}',
+    );
+    repo = FeatureFlagsRepository(box: flagsBox);
+  });
+
+  tearDown(() async {
+    await flagsBox.deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  ProviderContainer makeContainer({List<Object> extraOverrides = const []}) {
+    final c = ProviderContainer(overrides: [
+      featureFlagsRepositoryProvider.overrideWithValue(repo),
+      ...extraOverrides.cast(),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  /// Drains the post-build async load on featureFlagsProvider so reads
+  /// observe the persisted set rather than the manifest-default
+  /// placeholder.
+  Future<void> pumpLoad(ProviderContainer c) async {
+    c.read(featureFlagsProvider);
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  group('baselineSyncEnabledProvider — shim over featureFlagsProvider', () {
+    test('defaults to false on a fresh profile', () async {
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      expect(
+        container.read(baselineSyncEnabledProvider),
+        isFalse,
+        reason:
+            'Default-OFF is the contract: a user who never toggles the '
+            'switch must not silently upload driving data. Manifest '
+            'declares baselineSync defaultEnabled=false.',
+      );
+    });
+
+    test('reads the central enabled-set on build', () async {
+      // Pre-seed central state with both the prerequisite (tankSync)
+      // and the dependent (baselineSync). Without tankSync the central
+      // provider would reject the seeded set.
+      await repo.saveEnabled(<Feature>{
+        Feature.tankSync,
+        Feature.baselineSync,
+      });
+
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      expect(
+        container.read(baselineSyncEnabledProvider),
+        isTrue,
+        reason:
+            'The shim must surface the central provider state — a '
+            'persisted-true in the central feature-flags repository is '
+            'the source of truth post-#1373 phase 3e.',
+      );
+    });
+
+    test('set(true) enables baselineSync AND keeps the tankSync prereq',
+        () async {
+      // Prerequisite must be on first or the central provider would
+      // throw StateError (which the shim swallows). Seed it.
+      await repo.saveEnabled(<Feature>{Feature.tankSync});
+
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      // Materialise so the read after `set` walks the in-memory state
+      // path rather than re-running build.
+      container.read(baselineSyncEnabledProvider);
+      await container.read(baselineSyncEnabledProvider.notifier).set(true);
+
+      final after = container.read(featureFlagsProvider);
+      expect(
+        after,
+        contains(Feature.baselineSync),
+        reason:
+            'set(true) must route through featureFlagsProvider.enable so '
+            'the central state is the single source of truth — the legacy '
+            'StorageKeys.syncBaselinesEnabled is no longer the '
+            'authoritative store.',
+      );
+      expect(
+        after,
+        contains(Feature.tankSync),
+        reason:
+            'tankSync is the manifest-declared prerequisite of '
+            'baselineSync. Enabling baselineSync must NOT silently '
+            'remove the prereq — the central provider preserves it.',
+      );
+      expect(
+        container.read(baselineSyncEnabledProvider),
+        isTrue,
+        reason:
+            'The shim state must reflect the central enable immediately '
+            'so the next trip flush observes the new value via ref.read.',
+      );
+    });
+
+    test('set(false) disables baselineSync but tankSync prereq stays',
+        () async {
+      // Seed both on so we can flip baselineSync off.
+      await repo.saveEnabled(<Feature>{
+        Feature.tankSync,
+        Feature.baselineSync,
+      });
+
+      final container = makeContainer();
+      await pumpLoad(container);
+
+      container.read(baselineSyncEnabledProvider);
+      await container.read(baselineSyncEnabledProvider.notifier).set(false);
+
+      final after = container.read(featureFlagsProvider);
+      expect(
+        after,
+        isNot(contains(Feature.baselineSync)),
+      );
+      expect(
+        after,
+        contains(Feature.tankSync),
+        reason:
+            'Disabling baselineSync must only remove the dependent — '
+            'tankSync is independently useful (favourite sync, etc.) '
+            'and must not be cascade-disabled when one of its '
+            'dependents is turned off.',
+      );
+      expect(container.read(baselineSyncEnabledProvider), isFalse);
+    });
+
+    test(
+      'set(true) is a no-op when the tankSync prerequisite is missing — '
+      'does NOT throw',
+      () async {
+        // Prerequisite tankSync is OFF. Calling enable on the central
+        // provider would throw StateError; the shim must swallow it
+        // and leave the toggle at its prior state.
+        final container = makeContainer();
+        await pumpLoad(container);
+
+        // No throw expected.
+        await container.read(baselineSyncEnabledProvider.notifier).set(true);
+
+        expect(
+          container.read(baselineSyncEnabledProvider),
+          isFalse,
+          reason:
+              'Dependency-violation must be silent at the shim layer — '
+              'the settings UI is expected to pre-check `canEnable` '
+              'before invoking the setter, so reaching this path means '
+              'a programmatic / test caller bypassed the guard. The '
+              'shim swallows so the widget tree stays standing rather '
+              'than crashing on a developer mistake.',
+        );
+        expect(
+          container.read(featureFlagsProvider),
+          isNot(contains(Feature.baselineSync)),
+        );
+      },
+    );
+
+    test('rebuilds when featureFlagsProvider changes via override mutation',
+        () async {
+      // Use the synthetic FeatureFlags notifier override so we can
+      // drive state changes from the test without going through the
+      // dependency-cascade enforcement (the synthetic fake doesn't
+      // enforce the manifest graph).
+      final fake = _TestFeatureFlags(<Feature>{Feature.tankSync});
+      final container = makeContainer(extraOverrides: [
+        featureFlagsProvider.overrideWith(() => fake),
+      ]);
+
+      // Initial: baselineSync absent → shim is false.
+      expect(container.read(baselineSyncEnabledProvider), isFalse);
+
+      // External mutation: enable on the central provider directly.
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.baselineSync);
+
+      expect(
+        container.read(baselineSyncEnabledProvider),
+        isTrue,
+        reason:
+            'External writes to featureFlagsProvider (e.g. from settings '
+            'UI, a deep-link handler, or another shim) must propagate '
+            'through the baselineSync shim because it watches the '
+            'central state.',
+      );
+
+      // And back the other way.
+      await container
+          .read(featureFlagsProvider.notifier)
+          .disable(Feature.baselineSync);
+      expect(container.read(baselineSyncEnabledProvider), isFalse);
+    });
+
+    test(
+      'set(true) swallows a dependency-violation StateError from the central '
+      'provider — toggle stays at its prior state',
+      () async {
+        // Use a spy fake that always throws StateError to exercise the
+        // defensive `on StateError` catch in the shim. The real central
+        // provider throws this exact error when the manifest
+        // prerequisite is missing.
+        final fake = _ThrowingFeatureFlags();
+        final container = makeContainer(extraOverrides: [
+          featureFlagsProvider.overrideWith(() => fake),
+        ]);
+
+        // Sanity: starting state is false.
+        expect(container.read(baselineSyncEnabledProvider), isFalse);
+
+        // No throw expected — the shim's `on StateError` catch must
+        // swallow the dependency-violation signal.
+        await container.read(baselineSyncEnabledProvider.notifier).set(true);
+
+        expect(
+          container.read(baselineSyncEnabledProvider),
+          isFalse,
+          reason:
+              'Dependency-violation must be silent at the shim layer — '
+              'the settings UI pre-checks `canEnable`, so reaching this '
+              'path means a programmatic / test caller bypassed the '
+              'guard. The shim swallows so the widget tree stays '
+              'standing rather than crashing on a developer mistake.',
+        );
+        expect(
+          container.read(featureFlagsProvider),
+          isNot(contains(Feature.baselineSync)),
+        );
+      },
+    );
+  });
+}
+
+/// Synthetic in-memory [FeatureFlags] notifier used to drive
+/// external-mutation paths without going through the Hive-backed
+/// repository AND without enforcing the manifest dependency graph.
+/// Mirrors the equivalent test double in
+/// `test/core/refuel/unified_search_results_enabled_test.dart`.
+class _TestFeatureFlags extends FeatureFlags {
+  _TestFeatureFlags([Set<Feature>? initial])
+      : _initial = initial ?? <Feature>{};
+
+  final Set<Feature> _initial;
+
+  @override
+  Set<Feature> build() => {..._initial};
+
+  @override
+  Future<void> enable(Feature feature) async {
+    if (state.contains(feature)) return;
+    state = {...state, feature};
+  }
+
+  @override
+  Future<void> disable(Feature feature) async {
+    if (!state.contains(feature)) return;
+    state = {...state}..remove(feature);
+  }
+}
+
+/// Spy fake that always throws [StateError] on `enable` / `disable` —
+/// used to exercise the shim's defensive `on StateError` catch even
+/// when the call would otherwise succeed (e.g. when the prereq is
+/// satisfied but the central API is mocked to fail).
+class _ThrowingFeatureFlags extends FeatureFlags {
+  @override
+  Set<Feature> build() => <Feature>{};
+
+  @override
+  Future<void> enable(Feature feature) async {
+    throw StateError(
+      'Cannot enable ${feature.name}: simulated dependency-violation',
+    );
+  }
+
+  @override
+  Future<void> disable(Feature feature) async {
+    throw StateError(
+      'Cannot disable ${feature.name}: simulated blockingDisable',
+    );
+  }
+}


### PR DESCRIPTION
## Why

Phase 3e of #1373 migrates the legacy `StorageKeys.syncBaselinesEnabled` Hive-settings toggle to the central `featureFlagsProvider` (`Feature.baselineSync`). Differs from 3a/3f because the previous code had NO Riverpod provider — consumers (`trip_recording_provider._syncBaselineAfterFlush`, `synced_data_card`) read directly from Hive. This PR creates a new `baselineSyncEnabledProvider` shim and rewires both consumers.

## What changed

- New `lib/features/sync/providers/baseline_sync_enabled_provider.dart` — `BaselineSyncEnabled` shim mirrors `HapticEcoCoachEnabled` (reads `featureFlagsProvider.contains(Feature.baselineSync)`; `set()` delegates to the central notifier).
- `trip_recording_provider.dart` `_syncBaselineAfterFlush`: replaced `settings.getSetting(StorageKeys.syncBaselinesEnabled)` with `ref.read(baselineSyncEnabledProvider)`. One-shot read at flush time (NOT `ref.watch` — flag is a gate, not a reactive dep). Removed two now-unused imports (`storage_keys.dart`, `storage_providers.dart`) — they were the sole references in the file post-rewire.
- `synced_data_card.dart`: read site routes through the new provider; write site calls `ref.read(baselineSyncEnabledProvider.notifier).set(v)`. The `ref.invalidate(settingsStorageProvider)` is gone — featureFlagsProvider's notifier emits state changes itself.
- New `_migrateSyncBaselines` extends `legacy_toggle_migrator.dart`. Cascade-enables `Feature.tankSync` (manifest prerequisite) before `Feature.baselineSync`. Idempotent via `syncBaselinesMigratedKey`.
- `StorageKeys.syncBaselinesEnabled` annotated `@Deprecated`.

## Migration semantics

- For users with `syncBaselinesEnabled = true`: on first launch after upgrade, `Feature.baselineSync` is enabled in the central set with `Feature.tankSync` cascaded. Existing baseline sync continues uninterrupted.
- For users with `syncBaselinesEnabled = false` or absent: stays disabled. Migrated-key flag is written so subsequent launches skip the legacy read.

## Tests

- `test/features/sync/providers/baseline_sync_enabled_provider_test.dart` — 7 cases for the new shim (default-off, central read, set(true)/set(false) preserve cascade rules, missing-prereq no-op, external mutation propagation, defensive StateError swallow).
- `test/features/feature_management/data/legacy_toggle_migrator_test.dart` — 4 new cases for `_migrateSyncBaselines` (legacy true cascade, legacy false no-cascade, legacy null, idempotent on second run).
- `synced_data_card_test.dart` — rewired all toggle-touching cases to use `baselineSyncEnabledProvider.overrideWith()` instead of `mockStorage.getSetting(StorageKeys.syncBaselinesEnabled)`.
- `trip_recording_provider_test.dart` — audited; the existing tests do not exercise `_syncBaselineAfterFlush`, so no harness changes were needed (the file passes verbatim).

## Hot-file scope

No edits to `app_initializer.dart`, `hive_boxes.dart`, ARB files, `vehicle_profile.dart`, `user_profile.dart`, `oem_pid_registry.dart`, or `oem_pid_table.dart`.

## Phase status

- 3a (hapticEcoCoach) shipped #1407
- 3b (gamification) shipped #1410
- 3f (unifiedSearchResults) shipped #1413
- **3e (syncBaselinesEnabled) - this PR**
- 3c (showConsumptionTab) - UserProfile field exists with no consumers (likely orphan from #1342 carbon removal); trivial migration but very low value
- 3d (autoRecord per-vehicle) - VehicleProfile-backed, more complex

Refs #1373 phase 3e