### PR TITLE
feat(obd2): PSA fuel-level CAN frame decoder for instrument cluster 0x0E6 (Refs #1401 phase 5)

### DIFF
--- a/lib/features/consumption/data/obd2/can_frame_decoders/psa_fuel_level_can_decoder.dart
+++ b/lib/features/consumption/data/obd2/can_frame_decoders/psa_fuel_level_can_decoder.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Pure CAN-frame decoder for the PSA instrument-cluster broadcast
+/// frame `0x0E6` (#1401 phase 5 — passive listening sibling of
+/// phase 4's `PsaOemPidTable`).
+///
+/// On the PSA platform 2 / EMP2 generation (post-2008 Peugeot, Citroën
+/// and DS — 308, 3008, 508 et al.) the instrument cluster broadcasts
+/// the fuel level continuously as part of frame `0x0E6`. Reading it
+/// passively avoids the 1-2 Hz active-polling round-trip cost of
+/// `PsaOemPidTable` and yields a 10-20 Hz sample rate — fast enough
+/// to power the variance-detection branch of the fill-up
+/// reconciliation flow without saturating the bus.
+///
+/// ## Capability gate
+///
+/// Passive sniffing requires the STN-chip family
+/// (`Obd2AdapterCapability.passiveCanCapable`). On a `oemPidsCapable`
+/// adapter the caller falls through to the active-polling path. Phase 5
+/// ships only this pure parser — the transport that produces the input
+/// `(id, payload)` stream (STN listen-mode commands `STMA` / `ATCRA
+/// 0E6`, line parsing, etc.) is the responsibility of a follow-up
+/// issue that wires `Obd2Service.canFrameStream()` into a provider
+/// gated on `passiveCanCapable`.
+///
+/// ## Wire format
+///
+/// Frame `0x0E6` carries vehicle-status data across at least 8 bytes.
+/// Bytes 4 and 5 (zero-indexed) contain the fuel level encoded as an
+/// unsigned 16-bit big-endian integer scaled `× 2` — i.e. the raw
+/// value is litres × 2, so `litres = raw / 2.0`. A value of 90
+/// (`0x00 0x5A`) therefore represents 45.0 L.
+///
+/// **Byte order — big-endian.** CAN payload conventions vary by OEM
+/// (Motorola/big-endian for PSA, Renault, Mercedes; Intel/little-endian
+/// for VAG, BMW). The PSA EMP2 instrument cluster uses big-endian
+/// throughout per the platform's published CAN matrix (the same
+/// convention `PsaOemPidTable` relies on for its `0x6FA / 21 51` reply
+/// scaling). If a future trace shows a real PSA emitting bytes in the
+/// reverse order, change the shift here AND add a regression test that
+/// pins the captured frame.
+///
+/// ## Sanity
+///
+/// The parser intentionally does NOT clamp. Real PSA tanks cap around
+/// 70-80 L, so a decoded value of 32767.5 L (`0xFF 0xFF`) is a wire
+/// error, not an empty tank — but clamping is the caller's job
+/// (cross-check against the vehicle profile's tank capacity). Treating
+/// "this litres value is bigger than any tank" as a hard fault here
+/// would silently swallow a real bug in our endianness assumption.
+///
+/// Returns `null` (never throws) when the frame cannot be decoded:
+///   * `frameId != 0x0E6` (not the cluster broadcast);
+///   * payload shorter than 6 bytes (bytes 4 and 5 unreadable).
+class PsaFuelLevelCanDecoder {
+  const PsaFuelLevelCanDecoder();
+
+  /// PSA instrument-cluster broadcast frame ID. Standard 11-bit CAN
+  /// identifier — every EMP2 BSI emits this at ~10-20 Hz while the
+  /// ignition is on. Constant rather than configurable: a different
+  /// frame ID would mean a different OEM, which would mean a different
+  /// decoder class.
+  static const int frameId = 0x0E6;
+
+  /// Stable identifier mirroring `OemPidTable.oemKey` so logs and
+  /// diagnostics can correlate active-polling and passive-listening
+  /// reads on the same vehicle. Not user-facing.
+  String get oemKey => 'PSA';
+
+  /// Apply [decodeFuelLevelLitres] to every frame in [rawFrames] and
+  /// emit one litres value per successfully-decoded frame. Frames with
+  /// the wrong ID or a too-short payload are silently skipped — they're
+  /// not errors, just other traffic on the bus.
+  ///
+  /// Errors on the input stream propagate to the output stream
+  /// unchanged. The caller decides whether to retry or surface the
+  /// failure.
+  ///
+  /// The output stream completes when [rawFrames] completes.
+  Stream<double> filterFuelLevelStream(
+    Stream<({int id, List<int> payload})> rawFrames,
+  ) async* {
+    await for (final frame in rawFrames) {
+      final litres = decodeFuelLevelLitres(frame.id, frame.payload);
+      if (litres != null) yield litres;
+    }
+  }
+}
+
+/// Pure decoder for the PSA `0x0E6` fuel-level field.
+///
+/// See [PsaFuelLevelCanDecoder] for the full wire-format / endianness
+/// rationale. Exposed as a top-level function so tests can hit it
+/// without instantiating the class — and so a future caller that
+/// already has its own stream wiring can decode a single frame
+/// without taking the streaming dependency.
+///
+/// Returns:
+///   * `raw / 2.0` (litres) on success;
+///   * `null` if [frameId] is not [PsaFuelLevelCanDecoder.frameId];
+///   * `null` if [payload] is shorter than 6 bytes.
+@visibleForTesting
+double? decodeFuelLevelLitres(int frameId, List<int> payload) {
+  if (frameId != PsaFuelLevelCanDecoder.frameId) return null;
+  if (payload.length < 6) return null;
+  // Big-endian uint16 across bytes 4-5. The `& 0xFF` guards against a
+  // caller that hands us signed-byte ints (Dart's `List<int>` is
+  // unconstrained — a value parsed from a hex string with a leading
+  // `F` would already be `>=0`, but a `ByteData` slice could in
+  // principle be negative on some legacy paths).
+  final raw = ((payload[4] & 0xFF) << 8) | (payload[5] & 0xFF);
+  return raw / 2.0;
+}

--- a/test/features/consumption/data/obd2/can_frame_decoders/psa_fuel_level_can_decoder_test.dart
+++ b/test/features/consumption/data/obd2/can_frame_decoders/psa_fuel_level_can_decoder_test.dart
@@ -1,0 +1,217 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/can_frame_decoders/psa_fuel_level_can_decoder.dart';
+
+void main() {
+  group('decodeFuelLevelLitres — pure parser (#1401 phase 5)', () {
+    test('canonical frame: bytes 4-5 = 0x00,0x5A → 45.0 L', () {
+      // raw = 0x005A = 90; litres = 90 / 2 = 45.0.
+      final litres = decodeFuelLevelLitres(
+        0x0E6,
+        const [0x00, 0x00, 0x00, 0x00, 0x00, 0x5A],
+      );
+      expect(litres, 45.0);
+    });
+
+    test('endianness probe: bytes 4-5 = 0x00,0x80 → 64.0 L (NOT 0.25)', () {
+      // 0x0080 big-endian = 128 → 64.0 L.
+      // If we'd accidentally used little-endian we'd read 0x8000 = 32768
+      // → 16384.0 L (or worse, single-byte 0x80 = 128 → 64.0 by accident).
+      // The trailing 0xFF byte is decoy padding — only bytes 4-5 matter.
+      final litres = decodeFuelLevelLitres(
+        0x0E6,
+        const [0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0xFF],
+      );
+      expect(litres, 64.0);
+    });
+
+    test('empty tank: bytes 4-5 = 0x00,0x00 → 0.0 L', () {
+      final litres = decodeFuelLevelLitres(
+        0x0E6,
+        const [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+      );
+      expect(litres, 0.0);
+    });
+
+    test('boundary high: bytes 4-5 = 0xFF,0xFF → 32767.5 L (parser does '
+        'not clamp; caller must sanity-check vs tank capacity)', () {
+      // Real PSA tanks cap ~70-80 L, so this value would be a wire
+      // error in production — but the decoder intentionally returns
+      // the math so a real bug in the endianness assumption surfaces
+      // instead of being silently masked.
+      final litres = decodeFuelLevelLitres(
+        0x0E6,
+        const [0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF],
+      );
+      expect(litres, 32767.5);
+    });
+
+    test('full 8-byte payload: only bytes 4-5 are read, the rest is '
+        'ignored', () {
+      // Realistic 8-byte CAN payload — every byte populated, bytes 4-5
+      // = 0x00,0x64 = 100 → 50.0 L. The other bytes are deliberately
+      // non-zero to prove they don't influence the result.
+      final litres = decodeFuelLevelLitres(
+        0x0E6,
+        const [0x12, 0x34, 0x56, 0x78, 0x00, 0x64, 0xAB, 0xCD],
+      );
+      expect(litres, 50.0);
+    });
+
+    test('wrong frame id (e.g. 0x123) returns null even with a '
+        'valid-looking payload', () {
+      final litres = decodeFuelLevelLitres(
+        0x123,
+        const [0x00, 0x00, 0x00, 0x00, 0x00, 0x5A],
+      );
+      expect(litres, isNull);
+    });
+
+    test('frame id one off (0x0E5 / 0x0E7) returns null', () {
+      // Adjacent frames on the bus carry different signals — must not
+      // accidentally match.
+      expect(
+        decodeFuelLevelLitres(
+          0x0E5,
+          const [0x00, 0x00, 0x00, 0x00, 0x00, 0x5A],
+        ),
+        isNull,
+      );
+      expect(
+        decodeFuelLevelLitres(
+          0x0E7,
+          const [0x00, 0x00, 0x00, 0x00, 0x00, 0x5A],
+        ),
+        isNull,
+      );
+    });
+
+    test('short payload (4 bytes — byte 5 missing) returns null', () {
+      final litres = decodeFuelLevelLitres(
+        0x0E6,
+        const [0x00, 0x00, 0x00, 0x00],
+      );
+      expect(litres, isNull);
+    });
+
+    test('boundary short payload: exactly 5 bytes still null (need '
+        'index 5)', () {
+      // Off-by-one guard — we read payload[5], so length must be >= 6,
+      // not >= 5.
+      final litres = decodeFuelLevelLitres(
+        0x0E6,
+        const [0x00, 0x00, 0x00, 0x00, 0x5A],
+      );
+      expect(litres, isNull);
+    });
+
+    test('empty payload returns null (does not throw)', () {
+      // Defensive: a real adapter that emits a frame line with no
+      // payload bytes (corrupt frame, listen-mode buffer flush) must
+      // not crash the stream.
+      final litres = decodeFuelLevelLitres(0x0E6, const []);
+      expect(litres, isNull);
+    });
+
+    test('exposes 0x0E6 as the frame id constant', () {
+      // Pin the constant so a future "rename for a different platform"
+      // surfaces here — phase 5 is hard-coded to PSA EMP2.
+      expect(PsaFuelLevelCanDecoder.frameId, 0x0E6);
+    });
+
+    test('oemKey is "PSA" (mirrors OemPidTable convention)', () {
+      expect(const PsaFuelLevelCanDecoder().oemKey, 'PSA');
+    });
+  });
+
+  group('PsaFuelLevelCanDecoder.filterFuelLevelStream (#1401 phase 5)', () {
+    test('emits one litres value per PSA frame in a pure-PSA stream',
+        () async {
+      const decoder = PsaFuelLevelCanDecoder();
+      final input = Stream<({int id, List<int> payload})>.fromIterable([
+        (id: 0x0E6, payload: const [0x00, 0x00, 0x00, 0x00, 0x00, 0x5A]),
+        (id: 0x0E6, payload: const [0x00, 0x00, 0x00, 0x00, 0x00, 0x64]),
+        (id: 0x0E6, payload: const [0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+      ]);
+
+      final out = await decoder.filterFuelLevelStream(input).toList();
+      expect(out, [45.0, 50.0, 0.0]);
+    });
+
+    test('mixed stream: only emits values for 0x0E6, drops other '
+        'frame ids', () async {
+      const decoder = PsaFuelLevelCanDecoder();
+      final input = Stream<({int id, List<int> payload})>.fromIterable([
+        // Speed broadcast — different frame, must be skipped.
+        (id: 0x0B6, payload: const [0x00, 0x00, 0x12, 0x34, 0x56, 0x78]),
+        (id: 0x0E6, payload: const [0x00, 0x00, 0x00, 0x00, 0x00, 0x5A]),
+        // Random bus traffic.
+        (id: 0x123, payload: const [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+        (id: 0x0E6, payload: const [0x00, 0x00, 0x00, 0x00, 0x00, 0x64]),
+      ]);
+
+      final out = await decoder.filterFuelLevelStream(input).toList();
+      expect(out, [45.0, 50.0]);
+    });
+
+    test('skips PSA frames with too-short payload (no exception)',
+        () async {
+      // A real STN listen-mode buffer can occasionally emit a partial
+      // frame on overflow. Skipping silently keeps the consumer's
+      // monotonic-sample assumptions intact.
+      const decoder = PsaFuelLevelCanDecoder();
+      final input = Stream<({int id, List<int> payload})>.fromIterable([
+        (id: 0x0E6, payload: const [0x00, 0x00, 0x00, 0x00, 0x00, 0x5A]),
+        (id: 0x0E6, payload: const [0x00, 0x00]),
+        (id: 0x0E6, payload: const [0x00, 0x00, 0x00, 0x00, 0x00, 0x64]),
+      ]);
+
+      final out = await decoder.filterFuelLevelStream(input).toList();
+      expect(out, [45.0, 50.0]);
+    });
+
+    test('empty input stream → empty output stream', () async {
+      const decoder = PsaFuelLevelCanDecoder();
+      const input = Stream<({int id, List<int> payload})>.empty();
+
+      final out = await decoder.filterFuelLevelStream(input).toList();
+      expect(out, isEmpty);
+    });
+
+    test('errors on the input stream propagate (decoder does not '
+        'swallow)', () async {
+      // The transport layer needs to surface adapter disconnects /
+      // listen-mode failures so the gating provider can downgrade to
+      // active polling. Swallowing here would hide that signal.
+      const decoder = PsaFuelLevelCanDecoder();
+      final controller =
+          StreamController<({int id, List<int> payload})>();
+      final received = <double>[];
+      Object? caughtError;
+      final completer = Completer<void>();
+
+      decoder.filterFuelLevelStream(controller.stream).listen(
+            received.add,
+            onError: (Object e, StackTrace _) {
+              caughtError = e;
+              completer.complete();
+            },
+            onDone: () {
+              if (!completer.isCompleted) completer.complete();
+            },
+          );
+
+      controller.add(
+        (id: 0x0E6, payload: const [0x00, 0x00, 0x00, 0x00, 0x00, 0x5A]),
+      );
+      controller.addError(StateError('listen-mode dropped'));
+      // Don't close — the error should still surface.
+      await completer.future;
+      await controller.close();
+
+      expect(received, [45.0]);
+      expect(caughtError, isA<StateError>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 5 of #1401 — passive-listening sibling of the phase-4 `PsaOemPidTable` (active polling). Adds a pure data-layer decoder for the PSA EMP2 instrument-cluster broadcast frame `0x0E6`, which carries fuel level in bytes 4-5 as an unsigned 16-bit big-endian integer scaled `× 2` (so `litres = raw / 2.0`).

### Narrowed scope (intentional)

Decoder + stream filter only — **no transport hookup**. STN listen-mode plumbing (`STMA` / `ATCRA 0E6`, raw frame parsing, `Obd2Service.canFrameStream()`) is deferred to follow-up #1418 so this PR stays self-contained and independently testable.

### What ships

- `lib/features/consumption/data/obd2/can_frame_decoders/psa_fuel_level_can_decoder.dart`
  - `PsaFuelLevelCanDecoder` class + `frameId = 0x0E6` constant + `oemKey == 'PSA'` (mirrors `OemPidTable` convention)
  - `decodeFuelLevelLitres(int frameId, List<int> payload)` — pure parser, returns null on wrong frame id / short payload, never throws
  - `filterFuelLevelStream(Stream<({int id, List<int> payload})>)` — applies the decoder to a stream, drops non-matching frames, propagates errors
- `test/features/consumption/data/obd2/can_frame_decoders/psa_fuel_level_can_decoder_test.dart`
  - 17 tests: pure-parser happy/boundary/short/wrong-id paths, endianness probe, stream-filter mixed/empty/error-propagation cases

### Byte-order decision

**Big-endian.** PSA EMP2 follows Motorola/big-endian throughout per the platform's published CAN matrix (same convention `PsaOemPidTable` already uses for its `0x6FA / 21 51` reply). The decoder docstring documents this explicitly so a future reverse-engineering session that turns up little-endian evidence has a clear pin to challenge.

### Follow-up

#1418 tracks the transport wiring (Obd2Service stream + capability-gated provider). Phases 6-7 of #1401 still remain after that lands — this PR is `Refs`, not `Closes`.

## Test plan

- [x] `flutter analyze` — clean (0 issues)
- [x] `flutter test test/features/consumption/data/obd2/can_frame_decoders/` — 17/17 passing
- [ ] CI green (full suite)

Refs #1401