### PR TITLE
feat(obd2): wire PSA passive CAN listener into Obd2Service streaming (Closes #1418)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../../../vehicle/domain/entities/reference_vehicle.dart';
@@ -903,6 +905,180 @@ class Obd2Service {
       debugPrint('OBD2 readVin failed: $e\n$st');
       return null;
     }
+  }
+
+  /// PSA instrument-cluster broadcast frame ID (#1418). Mirrors
+  /// `PsaFuelLevelCanDecoder.frameId` — kept as a private constant
+  /// here so the data layer doesn't import the decoder (decoder
+  /// depends on stream shape, not the other way around).
+  static const int _psaFuelLevelFrameId = 0x0E6;
+
+  /// Set the ELM327's CAN receive-address filter to the PSA
+  /// instrument-cluster frame `0x0E6` (#1418). Only frames matching
+  /// this 11-bit ID are surfaced by the next `STMA`.
+  static const String _atCraPsaFuelLevelCommand = 'ATCRA 0E6\r';
+
+  /// STN listen-mode start (#1418). After this returns OK, the
+  /// adapter starts emitting frame lines on the raw byte channel
+  /// without the trailing `>` prompt that [sendCommand] normally
+  /// waits on.
+  static const String _stmaCommand = 'STMA\r';
+
+  /// STN listen-mode stop (#1418). Sent via
+  /// [Obd2Transport.sendListenModeStop] on stream cancel — the prompt
+  /// won't come back until the adapter exits listen-mode, so the
+  /// regular [sendCommand] path can't carry it.
+  static const String _stmpCommand = 'STMP\r';
+
+  /// Open a passive CAN-frame stream filtered to the PSA
+  /// instrument-cluster broadcast frame `0x0E6` (#1418).
+  ///
+  /// Sends [`ATCRA 0E6`] (CAN receive-address filter for frame ID
+  /// `0x0E6`, the PSA EMP2 BSI broadcast) followed by [`STMA`] (STN
+  /// listen-mode start) on first listen, then parses each
+  /// listen-mode line of the form `0E6 D <len> <byte0> <byte1> …`
+  /// into a `(int id, List<int> payload)` record. On
+  /// stream-subscription cancel, sends [`STMP`] so the adapter
+  /// returns to normal mode.
+  ///
+  /// The output is a broadcast stream so the high-level
+  /// `psaFuelLevelProvider` can subscribe + cancel without disturbing
+  /// the underlying channel — multiple consumers (e.g. the trip
+  /// recorder + a diagnostic overlay) can share one listen-mode
+  /// session in a future epic.
+  ///
+  /// **Pre-conditions** (caller's responsibility):
+  ///   * The ELM channel must be open ([connect] succeeded).
+  ///   * The adapter must report
+  ///     [Obd2AdapterCapability.passiveCanCapable]. The high-level
+  ///     [`psaFuelLevelProvider`] enforces this gate; the data layer
+  ///     here stays dumb so a future caller that knows what it is
+  ///     doing (e.g. a debug screen on an STN clone) can opt in
+  ///     without re-implementing the gate.
+  ///
+  /// **What this method does NOT do**:
+  ///   * It does not block on the [`PsaFuelLevelCanDecoder`]; it
+  ///     emits raw `(id, payload)` tuples. The decoder's
+  ///     [`PsaFuelLevelCanDecoder.filterFuelLevelStream`] consumer
+  ///     transforms tuples into litres.
+  ///   * It does not validate the listen-mode response — malformed
+  ///     lines (wrong frame id, short payload, non-hex bytes) are
+  ///     silently dropped so a buffer-overflow burst doesn't kill
+  ///     the stream.
+  ///
+  /// Phase 5 of #1401 (PR #1417) shipped the pure-data decoder; this
+  /// method is the streaming-transport wiring the decoder docstring
+  /// promised. Errors on the underlying line stream propagate to the
+  /// returned stream — the gating provider downgrades on failure.
+  Stream<({int id, List<int> payload})> canFrameStream() {
+    final raw = _transport;
+    if (raw is! Obd2ListenModeTransport) {
+      // The transport doesn't support raw line streaming — surface a
+      // clear error rather than silently emitting nothing. The
+      // capability gate at the provider layer should already have
+      // caught this; surfacing it here makes the failure mode
+      // obvious if a future caller bypasses the gate.
+      return Stream.error(
+        UnsupportedError(
+          'Obd2Service.canFrameStream requires an '
+          'Obd2ListenModeTransport (e.g. on STN-chip adapters). '
+          'Current transport: ${raw.runtimeType}',
+        ),
+      );
+    }
+    // Capture the promoted reference so the closures below see the
+    // listen-mode interface. Dart's flow analysis won't carry the
+    // `is!` promotion through a `final` capture into function
+    // literals — a typed cast is the cleanest way to fix it.
+    final listenTransport = raw as Obd2ListenModeTransport;
+    late StreamController<({int id, List<int> payload})> controller;
+    StreamSubscription<String>? sub;
+
+    Future<void> setup() async {
+      try {
+        // Setup: filter then start listen mode. Both commands respond
+        // with OK + `>` so the regular sendCommand path is fine.
+        await _transport.sendCommand(_atCraPsaFuelLevelCommand);
+        await _transport.sendCommand(_stmaCommand);
+        // Subscribe to raw lines AFTER STMA so we don't accidentally
+        // consume the OK reply as a frame.
+        sub = listenTransport.openListenLineStream().listen(
+          (line) {
+            final frame = _parseListenModeLine(line);
+            if (frame != null && !controller.isClosed) {
+              controller.add(frame);
+            }
+          },
+          onError: (Object e, StackTrace st) {
+            if (!controller.isClosed) controller.addError(e, st);
+          },
+          onDone: () {
+            if (!controller.isClosed) controller.close();
+          },
+        );
+      } catch (e, st) {
+        // Any setup failure surfaces on the stream so the caller
+        // sees it — never silently swallow.
+        if (!controller.isClosed) {
+          controller.addError(e, st);
+          await controller.close();
+        }
+      }
+    }
+
+    Future<void> teardown() async {
+      // Unhook the listener BEFORE sending STMP so the adapter's exit
+      // ack (if any) doesn't show up as a stray `frame line`.
+      await sub?.cancel();
+      sub = null;
+      try {
+        await listenTransport.sendListenModeStop(_stmpCommand);
+      } catch (e, st) {
+        // Best-effort: the user has already cancelled, no point
+        // crashing on a STMP write that might fail because the
+        // channel is mid-disconnect.
+        debugPrint('OBD2 canFrameStream STMP failed: $e\n$st');
+      }
+    }
+
+    controller = StreamController<({int id, List<int> payload})>.broadcast(
+      onListen: setup,
+      onCancel: teardown,
+    );
+    return controller.stream;
+  }
+
+  /// Parse one STN listen-mode line of the form
+  /// `0E6 D 8 12 34 56 78 9A BC DE F0` (frame id, `D`ata indicator,
+  /// length, then [length] hex byte tokens) into the decoder's
+  /// `(id, payload)` record (#1418).
+  ///
+  /// Returns `null` for any malformed line — wrong frame id (only
+  /// the PSA fuel-level frame is wanted here), missing length, length
+  /// mismatch, or non-hex byte tokens. The stream silently drops
+  /// nulls so a malformed burst doesn't kill the consumer.
+  static ({int id, List<int> payload})? _parseListenModeLine(String line) {
+    final tokens = line.trim().split(RegExp(r'\s+'));
+    // Need at minimum: id, "D", length, plus one byte = 4 tokens.
+    if (tokens.length < 4) return null;
+    final parsedId = int.tryParse(tokens[0], radix: 16);
+    if (parsedId != _psaFuelLevelFrameId) return null;
+    if (tokens[1].toUpperCase() != 'D') return null;
+    final length = int.tryParse(tokens[2], radix: 16);
+    if (length == null) return null;
+    final byteTokens = tokens.sublist(3);
+    if (byteTokens.length != length) return null;
+    final payload = <int>[];
+    for (final token in byteTokens) {
+      final byte = int.tryParse(token, radix: 16);
+      if (byte == null || byte < 0 || byte > 0xFF) return null;
+      payload.add(byte);
+    }
+    // The `parsedId != _psaFuelLevelFrameId` early-return above
+    // proves non-null here, but the record-field type system can't
+    // track that proof — fall back to the local constant which is
+    // both non-null and equal.
+    return (id: _psaFuelLevelFrameId, payload: payload);
   }
 
   /// Close the transport connection. Safe to call multiple times.

--- a/lib/features/consumption/data/obd2/obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/obd2_transport.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 /// Abstract transport layer for OBD-II communication.
 ///
 /// Implementations handle the actual I/O (Bluetooth, TCP, serial).
@@ -17,10 +19,64 @@ abstract class Obd2Transport {
   bool get isConnected;
 }
 
+/// Optional capability mixin — transports that support the STN-chip
+/// listen-mode protocol (#1418) implement this in addition to
+/// [Obd2Transport]. [Obd2Service.canFrameStream] type-checks for it
+/// before opening listen-mode so transports that lack support
+/// surface a clean [UnsupportedError] from the gate, not a deeper
+/// stack.
+///
+/// Why a separate interface instead of additional abstract methods on
+/// [Obd2Transport]: ten-plus existing test fakes `implements
+/// Obd2Transport` directly. Adding required members would force every
+/// fake to add boilerplate even for tests that don't touch listen
+/// mode. The opt-in interface keeps the cost on the listen-mode test
+/// path only.
+abstract class Obd2ListenModeTransport {
+  /// Open a continuous line-stream mode for STN-chip listen-mode CAN
+  /// sniffing (#1418). After the caller has sent the listen-mode
+  /// setup commands (e.g. `ATCRA 0E6` + `STMA`) via
+  /// [Obd2Transport.sendCommand], the adapter starts emitting frame
+  /// lines without the trailing `>` prompt that the regular
+  /// `sendCommand` path waits on. This method exposes those lines
+  /// as a broadcast stream so a higher layer can parse them into
+  /// `(id, payload)` tuples.
+  Stream<String> openListenLineStream();
+
+  /// Counterpart to [openListenLineStream]: send [command] (typically
+  /// `STMP`) without waiting for the `>` prompt that
+  /// [Obd2Transport.sendCommand] requires (#1418). On real hardware
+  /// the prompt does not arrive until listen-mode exits, so the
+  /// regular `sendCommand` path would deadlock.
+  Future<void> sendListenModeStop(String command);
+}
+
 /// A fake transport for testing that returns pre-configured responses.
-class FakeObd2Transport implements Obd2Transport {
+///
+/// Listen-mode (#1418) is opt-in: tests that need
+/// [Obd2ListenModeTransport.openListenLineStream] emit lines via
+/// [pushListenLine] and observe stop commands in
+/// [listenStopCommands]. Tests that don't touch listen-mode get the
+/// pre-#1418 behaviour unchanged.
+class FakeObd2Transport
+    implements Obd2Transport, Obd2ListenModeTransport {
   final Map<String, String> _responses;
   bool _connected = false;
+
+  /// Commands captured by [sendListenModeStop]. Inspected by #1418
+  /// tests to assert that the service sends `STMP` on cancel.
+  final List<String> listenStopCommands = [];
+
+  /// Commands captured by [sendCommand]. Available for tests that
+  /// want to assert ordering / arguments without writing yet another
+  /// recording transport. Pre-existing tests that consult
+  /// [_responses] keep working unchanged.
+  final List<String> sentCommands = [];
+
+  // Closed in [disconnect]; the linter can't follow the assignment
+  // through the nullable field, so silence the warning here.
+  // ignore: close_sinks
+  StreamController<String>? _listenLines;
 
   FakeObd2Transport([Map<String, String>? responses])
       : _responses = responses ?? {};
@@ -32,12 +88,46 @@ class FakeObd2Transport implements Obd2Transport {
   Future<String> sendCommand(String command) async {
     if (!_connected) throw StateError('Not connected');
     final cmd = command.trim();
+    sentCommands.add(cmd);
     return _responses[cmd] ?? 'NO DATA>';
   }
 
   @override
-  Future<void> disconnect() async => _connected = false;
+  Future<void> disconnect() async {
+    _connected = false;
+    final ctrl = _listenLines;
+    _listenLines = null;
+    if (ctrl != null && !ctrl.isClosed) {
+      await ctrl.close();
+    }
+  }
 
   @override
   bool get isConnected => _connected;
+
+  @override
+  Stream<String> openListenLineStream() {
+    // The controller is owned by the transport (closed in
+    // [disconnect]), not by this method's caller. Suppress the lint
+    // — the alternative would be a per-call short-lived controller
+    // that breaks fan-out for multiple consumers.
+    // ignore: close_sinks
+    final ctrl = _listenLines ??= StreamController<String>.broadcast();
+    return ctrl.stream;
+  }
+
+  @override
+  Future<void> sendListenModeStop(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    listenStopCommands.add(command.trim());
+  }
+
+  /// Push a line into the listen-mode stream. No-op when no consumer
+  /// has called [openListenLineStream] yet — keeps tests that wire
+  /// the producer before the consumer working.
+  void pushListenLine(String line) {
+    final ctrl = _listenLines;
+    if (ctrl == null || ctrl.isClosed) return;
+    ctrl.add(line);
+  }
 }

--- a/lib/features/consumption/providers/psa_fuel_level_provider.dart
+++ b/lib/features/consumption/providers/psa_fuel_level_provider.dart
@@ -1,0 +1,94 @@
+// PSA passive-CAN fuel-level stream provider (#1418).
+//
+// Wires the data-layer [Obd2Service.canFrameStream] (the streaming
+// transport added by #1418) through the pure-data
+// [PsaFuelLevelCanDecoder] (#1401 phase 5 / PR #1417) and exposes the
+// resulting litres-in-tank stream behind a Riverpod `StreamProvider`.
+//
+// ## Capability gate
+//
+// The decoder only makes sense on STN-chip adapters that support
+// passive listen-mode (`STMA` / `ATCRA`) — i.e. exactly
+// [Obd2AdapterCapability.passiveCanCapable]. Lower tiers
+// ([standardOnly], [oemPidsCapable]) fall through to the active-poll
+// `PsaOemPidTable` path that phase 4 ships; emitting nothing here is
+// the expected, "not supported on this adapter" first-class state.
+// We deliberately do NOT throw — the trip-recording flow's
+// `ref.listen` opt-in (separate epic phase) treats "no events" as
+// "no passive samples this trip" and rolls forward unchanged.
+//
+// ## Service injection seam
+//
+// The live [Obd2Service] is owned outside Riverpod today (the
+// auto-record orchestrator + trip recording controller hold it
+// privately). Rather than introduce a fourth owner of the live
+// service, this file exposes [psaFuelLevelObd2ServiceProvider] as an
+// override seam: in production it returns `null` (the wiring epic
+// that propagates the live service across providers is filed
+// separately); in tests it's overridden with a service backed by a
+// fake transport.
+//
+// While the production wiring is incomplete, [psaFuelLevelProvider]
+// emits no events — exactly the same shape as a real
+// `standardOnly` adapter. The trip recorder's opt-in subscription
+// works either way.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../data/obd2/adapter_capability.dart';
+import '../data/obd2/can_frame_decoders/psa_fuel_level_can_decoder.dart';
+import '../data/obd2/obd2_service.dart';
+
+part 'psa_fuel_level_provider.g.dart';
+
+/// Override seam for the live [Obd2Service] (#1418).
+///
+/// Returns `null` in production — the live service is currently
+/// owned by `Obd2ConnectionService` / the trip-recording stack and
+/// is not exposed through Riverpod. The follow-up epic that
+/// elevates the live service into Riverpod will replace this
+/// default; until then [psaFuelLevelProvider] emits an empty stream
+/// (the gate falls through to the `null` branch below).
+///
+/// Tests override this with a service backed by a fake transport so
+/// they can exercise the gate + decoder pipe without touching real
+/// Bluetooth.
+@riverpod
+Obd2Service? psaFuelLevelObd2Service(Ref ref) => null;
+
+/// Stream of decoded litres-in-tank from the PSA instrument-cluster
+/// passive-CAN broadcast frame `0x0E6` (#1418).
+///
+/// Emits nothing (no events, never errors) when:
+///   * the live [Obd2Service] override seam is unset
+///     ([psaFuelLevelObd2ServiceProvider] returns `null`), or
+///   * the connected adapter's runtime capability tier is not
+///     [Obd2AdapterCapability.passiveCanCapable].
+///
+/// Otherwise subscribes to [Obd2Service.canFrameStream] and pipes
+/// the raw `(id, payload)` records through
+/// [PsaFuelLevelCanDecoder.filterFuelLevelStream] which yields one
+/// litres value per successfully-decoded frame.
+///
+/// `keepAlive: false` — listener teardown is automatic when no UI
+/// subscribes, which sends `STMP` to the adapter so the bus returns
+/// to normal mode. The trip-recording flow can opt in via
+/// `ref.listen` in a separate epic phase.
+@riverpod
+Stream<double> psaFuelLevel(Ref ref) {
+  final service = ref.watch(psaFuelLevelObd2ServiceProvider);
+  if (service == null) {
+    // No live service plumbed in yet — empty stream is the
+    // first-class "not available" state. The decoder + gate fire
+    // only when the override seam returns a real service.
+    return const Stream<double>.empty();
+  }
+  if (service.capability != Obd2AdapterCapability.passiveCanCapable) {
+    // Capability gate (#1418): exact match. `oemPidsCapable` and
+    // `standardOnly` fall through to the active-poll PSA OEM PID
+    // table; this provider is the passive-only branch.
+    return const Stream<double>.empty();
+  }
+  const decoder = PsaFuelLevelCanDecoder();
+  return decoder.filterFuelLevelStream(service.canFrameStream());
+}

--- a/lib/features/consumption/providers/psa_fuel_level_provider.g.dart
+++ b/lib/features/consumption/providers/psa_fuel_level_provider.g.dart
@@ -1,0 +1,178 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'psa_fuel_level_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Override seam for the live [Obd2Service] (#1418).
+///
+/// Returns `null` in production — the live service is currently
+/// owned by `Obd2ConnectionService` / the trip-recording stack and
+/// is not exposed through Riverpod. The follow-up epic that
+/// elevates the live service into Riverpod will replace this
+/// default; until then [psaFuelLevelProvider] emits an empty stream
+/// (the gate falls through to the `null` branch below).
+///
+/// Tests override this with a service backed by a fake transport so
+/// they can exercise the gate + decoder pipe without touching real
+/// Bluetooth.
+
+@ProviderFor(psaFuelLevelObd2Service)
+final psaFuelLevelObd2ServiceProvider = PsaFuelLevelObd2ServiceProvider._();
+
+/// Override seam for the live [Obd2Service] (#1418).
+///
+/// Returns `null` in production — the live service is currently
+/// owned by `Obd2ConnectionService` / the trip-recording stack and
+/// is not exposed through Riverpod. The follow-up epic that
+/// elevates the live service into Riverpod will replace this
+/// default; until then [psaFuelLevelProvider] emits an empty stream
+/// (the gate falls through to the `null` branch below).
+///
+/// Tests override this with a service backed by a fake transport so
+/// they can exercise the gate + decoder pipe without touching real
+/// Bluetooth.
+
+final class PsaFuelLevelObd2ServiceProvider
+    extends $FunctionalProvider<Obd2Service?, Obd2Service?, Obd2Service?>
+    with $Provider<Obd2Service?> {
+  /// Override seam for the live [Obd2Service] (#1418).
+  ///
+  /// Returns `null` in production — the live service is currently
+  /// owned by `Obd2ConnectionService` / the trip-recording stack and
+  /// is not exposed through Riverpod. The follow-up epic that
+  /// elevates the live service into Riverpod will replace this
+  /// default; until then [psaFuelLevelProvider] emits an empty stream
+  /// (the gate falls through to the `null` branch below).
+  ///
+  /// Tests override this with a service backed by a fake transport so
+  /// they can exercise the gate + decoder pipe without touching real
+  /// Bluetooth.
+  PsaFuelLevelObd2ServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'psaFuelLevelObd2ServiceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$psaFuelLevelObd2ServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<Obd2Service?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Obd2Service? create(Ref ref) {
+    return psaFuelLevelObd2Service(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Obd2Service? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Obd2Service?>(value),
+    );
+  }
+}
+
+String _$psaFuelLevelObd2ServiceHash() =>
+    r'f7fafc3a855b74dbd3b72688f778df5dccdf7c15';
+
+/// Stream of decoded litres-in-tank from the PSA instrument-cluster
+/// passive-CAN broadcast frame `0x0E6` (#1418).
+///
+/// Emits nothing (no events, never errors) when:
+///   * the live [Obd2Service] override seam is unset
+///     ([psaFuelLevelObd2ServiceProvider] returns `null`), or
+///   * the connected adapter's runtime capability tier is not
+///     [Obd2AdapterCapability.passiveCanCapable].
+///
+/// Otherwise subscribes to [Obd2Service.canFrameStream] and pipes
+/// the raw `(id, payload)` records through
+/// [PsaFuelLevelCanDecoder.filterFuelLevelStream] which yields one
+/// litres value per successfully-decoded frame.
+///
+/// `keepAlive: false` — listener teardown is automatic when no UI
+/// subscribes, which sends `STMP` to the adapter so the bus returns
+/// to normal mode. The trip-recording flow can opt in via
+/// `ref.listen` in a separate epic phase.
+
+@ProviderFor(psaFuelLevel)
+final psaFuelLevelProvider = PsaFuelLevelProvider._();
+
+/// Stream of decoded litres-in-tank from the PSA instrument-cluster
+/// passive-CAN broadcast frame `0x0E6` (#1418).
+///
+/// Emits nothing (no events, never errors) when:
+///   * the live [Obd2Service] override seam is unset
+///     ([psaFuelLevelObd2ServiceProvider] returns `null`), or
+///   * the connected adapter's runtime capability tier is not
+///     [Obd2AdapterCapability.passiveCanCapable].
+///
+/// Otherwise subscribes to [Obd2Service.canFrameStream] and pipes
+/// the raw `(id, payload)` records through
+/// [PsaFuelLevelCanDecoder.filterFuelLevelStream] which yields one
+/// litres value per successfully-decoded frame.
+///
+/// `keepAlive: false` — listener teardown is automatic when no UI
+/// subscribes, which sends `STMP` to the adapter so the bus returns
+/// to normal mode. The trip-recording flow can opt in via
+/// `ref.listen` in a separate epic phase.
+
+final class PsaFuelLevelProvider
+    extends $FunctionalProvider<AsyncValue<double>, double, Stream<double>>
+    with $FutureModifier<double>, $StreamProvider<double> {
+  /// Stream of decoded litres-in-tank from the PSA instrument-cluster
+  /// passive-CAN broadcast frame `0x0E6` (#1418).
+  ///
+  /// Emits nothing (no events, never errors) when:
+  ///   * the live [Obd2Service] override seam is unset
+  ///     ([psaFuelLevelObd2ServiceProvider] returns `null`), or
+  ///   * the connected adapter's runtime capability tier is not
+  ///     [Obd2AdapterCapability.passiveCanCapable].
+  ///
+  /// Otherwise subscribes to [Obd2Service.canFrameStream] and pipes
+  /// the raw `(id, payload)` records through
+  /// [PsaFuelLevelCanDecoder.filterFuelLevelStream] which yields one
+  /// litres value per successfully-decoded frame.
+  ///
+  /// `keepAlive: false` — listener teardown is automatic when no UI
+  /// subscribes, which sends `STMP` to the adapter so the bus returns
+  /// to normal mode. The trip-recording flow can opt in via
+  /// `ref.listen` in a separate epic phase.
+  PsaFuelLevelProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'psaFuelLevelProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$psaFuelLevelHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<double> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
+
+  @override
+  Stream<double> create(Ref ref) {
+    return psaFuelLevel(ref);
+  }
+}
+
+String _$psaFuelLevelHash() => r'd8b15ad498ab2773176d74bd464673ba9bb065e1';

--- a/test/features/consumption/data/obd2/obd2_service_can_frame_stream_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_can_frame_stream_test.dart
@@ -1,0 +1,294 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+
+/// Tests for [Obd2Service.canFrameStream] (#1418).
+///
+/// Wires the existing [FakeObd2Transport] (extended in #1418 with
+/// listen-mode hooks) into the service and pins:
+///   * setup commands (`ATCRA 0E6` + `STMA`) on first listen
+///   * teardown command (`STMP`) on cancel
+///   * STN listen-mode line parsing into the decoder's
+///     `(id, payload)` record
+///   * malformed-line resilience (no exception, no emission)
+
+const _initResponses = {
+  'ATZ': 'ELM327 v1.5>',
+  'ATE0': 'OK>',
+  'ATL0': 'OK>',
+  'ATH0': 'OK>',
+  'ATSP0': 'OK>',
+  // Setup commands respond with OK + prompt — same pattern as the
+  // rest of the init sequence.
+  'ATCRA 0E6': 'OK>',
+  'STMA': 'OK>',
+};
+
+Future<({Obd2Service service, FakeObd2Transport transport})> _connected({
+  Map<String, String>? extra,
+}) async {
+  final transport = FakeObd2Transport({..._initResponses, ...?extra});
+  final service = Obd2Service(transport);
+  await service.connect();
+  // The service captures init commands too; tests typically only care
+  // about commands sent AFTER connect, so reset the recorder here.
+  transport.sentCommands.clear();
+  return (service: service, transport: transport);
+}
+
+void main() {
+  group('Obd2Service.canFrameStream — setup + teardown commands (#1418)', () {
+    test(
+        'first listen sends ATCRA 0E6 then STMA in that order — '
+        'capability-gated by the provider, not enforced here',
+        () async {
+      final (:service, :transport) = await _connected();
+
+      final stream = service.canFrameStream();
+      // No listener attached yet → no commands sent. The broadcast
+      // controller's onListen fires only after `listen` runs.
+      expect(transport.sentCommands, isEmpty);
+
+      final sub = stream.listen((_) {});
+      // onListen runs setup() asynchronously — wait for the two
+      // sendCommand awaits to land.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        transport.sentCommands,
+        equals(['ATCRA 0E6', 'STMA']),
+        reason: 'filter must be set BEFORE listen-mode start so the '
+            'first emitted frame is already filtered to 0x0E6',
+      );
+
+      await sub.cancel();
+    });
+
+    test('cancel sends STMP via sendListenModeStop — never via sendCommand '
+        '(the prompt is not coming back until listen-mode exits)',
+        () async {
+      final (:service, :transport) = await _connected();
+      final sub = service.canFrameStream().listen((_) {});
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      await sub.cancel();
+
+      expect(transport.listenStopCommands, equals(['STMP']));
+      // Critically: the regular sendCommand log should NOT also see
+      // STMP — using sendCommand for STMP would deadlock on real
+      // hardware because the adapter's listen-mode swallows `>`.
+      expect(transport.sentCommands, isNot(contains('STMP')));
+    });
+
+    test(
+        'broadcast stream — second listener does NOT re-send setup; '
+        'first cancel does NOT send STMP while a second listener is '
+        'still attached', () async {
+      final (:service, :transport) = await _connected();
+      final stream = service.canFrameStream();
+
+      final s1 = stream.listen((_) {});
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      transport.sentCommands.clear();
+
+      final s2 = stream.listen((_) {});
+      await Future<void>.delayed(Duration.zero);
+      // No re-setup — the controller's onListen fires once.
+      expect(transport.sentCommands, isEmpty);
+
+      await s1.cancel();
+      // Still one listener active → broadcast controller's onCancel
+      // does NOT fire yet → no STMP.
+      expect(transport.listenStopCommands, isEmpty);
+
+      await s2.cancel();
+      // Now last listener is gone → STMP fires.
+      expect(transport.listenStopCommands, equals(['STMP']));
+    });
+  });
+
+  group('Obd2Service.canFrameStream — line parsing (#1418)', () {
+    test(
+        'well-formed STN line "0E6 D 8 12 34 56 78 9A BC DE F0" parses '
+        'into (0x0E6, [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0])',
+        () async {
+      final (:service, :transport) = await _connected();
+      final stream = service.canFrameStream();
+      final received = <({int id, List<int> payload})>[];
+      final sub = stream.listen(received.add);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pushListenLine('0E6 D 8 12 34 56 78 9A BC DE F0');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.first.id, 0x0E6);
+      expect(
+        received.first.payload,
+        equals([0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]),
+      );
+
+      await sub.cancel();
+    });
+
+    test('canonical PSA fuel-level line "0E6 D 6 00 00 00 00 00 5A" '
+        'parses to a 6-byte payload', () async {
+      // 6-byte payload — the smallest length the decoder accepts
+      // (bytes 4-5 must be readable). Pins the length-vs-byte-count
+      // check.
+      final (:service, :transport) = await _connected();
+      final received = <({int id, List<int> payload})>[];
+      final sub = service.canFrameStream().listen(received.add);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 5A');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.first.payload, equals([0, 0, 0, 0, 0, 0x5A]));
+
+      await sub.cancel();
+    });
+
+    test('multiple frames in sequence emit in order', () async {
+      final (:service, :transport) = await _connected();
+      final received = <List<int>>[];
+      final sub = service.canFrameStream().listen(
+            (frame) => received.add(frame.payload),
+          );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 5A');
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 64');
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 00');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, [
+        [0, 0, 0, 0, 0, 0x5A],
+        [0, 0, 0, 0, 0, 0x64],
+        [0, 0, 0, 0, 0, 0x00],
+      ]);
+
+      await sub.cancel();
+    });
+
+    test('case-insensitive: lowercase hex tokens parse identically',
+        () async {
+      // Some STN firmwares emit lowercase hex; the parser must not
+      // reject them.
+      final (:service, :transport) = await _connected();
+      final received = <int>[];
+      final sub = service.canFrameStream().listen(
+            (frame) => received.add(frame.payload.last),
+          );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pushListenLine('0e6 d 6 00 00 00 00 00 5a');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, [0x5A]);
+      await sub.cancel();
+    });
+  });
+
+  group('Obd2Service.canFrameStream — malformed input is silently dropped '
+      '(#1418)', () {
+    test('wrong frame id ("0B6 D 6 ...") drops without emission', () async {
+      // Adjacent broadcast on a real PSA bus — must not match.
+      final (:service, :transport) = await _connected();
+      final received = <({int id, List<int> payload})>[];
+      final sub = service.canFrameStream().listen(received.add);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pushListenLine('0B6 D 6 11 22 33 44 55 66');
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 5A');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.first.id, 0x0E6);
+      await sub.cancel();
+    });
+
+    test('short payload (length=8 but only 4 byte tokens) drops; subsequent '
+        'good frame still emits — the stream survives', () async {
+      final (:service, :transport) = await _connected();
+      final received = <int>[];
+      final sub = service.canFrameStream().listen(
+            (frame) => received.add(frame.payload.length),
+          );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pushListenLine('0E6 D 8 12 34 56 78');
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 5A');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, [6]);
+      await sub.cancel();
+    });
+
+    test('non-hex byte token ("0E6 D 6 00 00 00 00 00 ZZ") drops without '
+        'crashing', () async {
+      // ZZ is not parseable as hex → tryParse returns null → frame
+      // dropped. The stream must not surface the error.
+      final (:service, :transport) = await _connected();
+      final received = <({int id, List<int> payload})>[];
+      Object? streamError;
+      final sub = service.canFrameStream().listen(
+            received.add,
+            onError: (Object e, StackTrace _) => streamError = e,
+          );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 ZZ');
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 5A');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.first.payload.last, 0x5A);
+      expect(streamError, isNull);
+      await sub.cancel();
+    });
+
+    test('empty / whitespace-only line drops silently', () async {
+      final (:service, :transport) = await _connected();
+      final received = <({int id, List<int> payload})>[];
+      final sub = service.canFrameStream().listen(received.add);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pushListenLine('');
+      transport.pushListenLine('   ');
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 5A');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      await sub.cancel();
+    });
+
+    test('missing "D" indicator ("0E6 X 6 ...") drops', () async {
+      // Some adapter modes emit `T` (tx) or other indicators on the
+      // same line; only `D` (data) is wanted.
+      final (:service, :transport) = await _connected();
+      final received = <({int id, List<int> payload})>[];
+      final sub = service.canFrameStream().listen(received.add);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pushListenLine('0E6 X 6 00 00 00 00 00 5A');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, isEmpty);
+      await sub.cancel();
+    });
+  });
+}

--- a/test/features/consumption/providers/psa_fuel_level_provider_test.dart
+++ b/test/features/consumption/providers/psa_fuel_level_provider_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_capability.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/providers/psa_fuel_level_provider.dart';
+
+/// Tests for [psaFuelLevelProvider] (#1418).
+///
+/// Pins the capability gate (`passiveCanCapable` exact-or-above —
+/// matches the data-layer comment in [psa_fuel_level_can_decoder.dart])
+/// and the wiring through [PsaFuelLevelCanDecoder] into Riverpod.
+
+const _initResponses = {
+  'ATZ': 'STN1110 v4.0.4>',
+  'ATE0': 'OK>',
+  'ATL0': 'OK>',
+  'ATH0': 'OK>',
+  'ATSP0': 'OK>',
+  'ATCRA 0E6': 'OK>',
+  'STMA': 'OK>',
+  // ATI is what `connect` uses to detect capability — the response
+  // string drives the [Obd2AdapterCapability] tier.
+  'ATI': 'STN1110 v4.0.4>',
+};
+
+/// Build a connected [Obd2Service] whose [Obd2Service.capability]
+/// reports [tier]. We achieve this by handing in the firmware string
+/// the data-layer parser would produce that tier for.
+Future<({Obd2Service service, FakeObd2Transport transport})> _serviceFor(
+  Obd2AdapterCapability tier,
+) async {
+  final ati = switch (tier) {
+    Obd2AdapterCapability.passiveCanCapable => 'STN1110 v4.0.4>',
+    Obd2AdapterCapability.oemPidsCapable => 'ELM327 v2.2>',
+    Obd2AdapterCapability.standardOnly => 'ELM327 v1.5>',
+  };
+  final transport = FakeObd2Transport({..._initResponses, 'ATI': ati});
+  final service = Obd2Service(transport);
+  await service.connect();
+  // Sanity: the parser must actually produce the requested tier — if
+  // the firmware string maps differently we want the test to fail
+  // here, not silently in the provider.
+  expect(service.capability, equals(tier));
+  return (service: service, transport: transport);
+}
+
+void main() {
+  group('psaFuelLevelProvider gate (#1418)', () {
+    test(
+        'no service plumbed → empty stream (production default — '
+        'first-class "not available" state, never throws)', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // Default override seam returns null in production; provider
+      // must short-circuit to an empty stream.
+      final values = <double>[];
+      final sub = container.listen(
+        psaFuelLevelProvider,
+        (prev, next) {
+          if (next.hasValue) values.add(next.value!);
+        },
+      );
+      addTearDown(sub.close);
+      // Drain pending events.
+      await Future<void>.delayed(Duration.zero);
+      // Stream is empty, completes immediately — AsyncValue settles
+      // with no data.
+      expect(values, isEmpty);
+    });
+
+    test('standardOnly capability → empty stream (no setup commands '
+        'sent, gate falls through to active-poll path)', () async {
+      final (:service, :transport) =
+          await _serviceFor(Obd2AdapterCapability.standardOnly);
+      transport.sentCommands.clear();
+
+      final container = ProviderContainer(
+        overrides: [
+          psaFuelLevelObd2ServiceProvider.overrideWithValue(service),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final values = <double>[];
+      final sub = container.listen(
+        psaFuelLevelProvider,
+        (prev, next) {
+          if (next.hasValue) values.add(next.value!);
+        },
+      );
+      addTearDown(sub.close);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(values, isEmpty);
+      // Gate enforced on the provider — service must NOT have been
+      // poked into listen mode at all.
+      expect(transport.sentCommands, isNot(contains('STMA')));
+      expect(transport.sentCommands, isNot(contains('ATCRA 0E6')));
+    });
+
+    test(
+        'oemPidsCapable capability → empty stream (passive-CAN gate '
+        'is exact-tier, falls through to phase-4 active polling on '
+        '`oemPidsCapable`)', () async {
+      // Mirrors the decoder file's docstring:
+      //   "Passive sniffing requires the STN-chip family
+      //    (`Obd2AdapterCapability.passiveCanCapable`). On a
+      //    `oemPidsCapable` adapter the caller falls through to the
+      //    active-polling path."
+      final (:service, :transport) =
+          await _serviceFor(Obd2AdapterCapability.oemPidsCapable);
+      transport.sentCommands.clear();
+
+      final container = ProviderContainer(
+        overrides: [
+          psaFuelLevelObd2ServiceProvider.overrideWithValue(service),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final values = <double>[];
+      final sub = container.listen(
+        psaFuelLevelProvider,
+        (prev, next) {
+          if (next.hasValue) values.add(next.value!);
+        },
+      );
+      addTearDown(sub.close);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(values, isEmpty);
+      expect(transport.sentCommands, isNot(contains('STMA')));
+    });
+
+    test(
+        'passiveCanCapable capability → forwards decoded litres from '
+        'real CAN frames pushed through the transport — full gate + '
+        'decoder pipe end-to-end', () async {
+      final (:service, :transport) =
+          await _serviceFor(Obd2AdapterCapability.passiveCanCapable);
+      transport.sentCommands.clear();
+
+      final container = ProviderContainer(
+        overrides: [
+          psaFuelLevelObd2ServiceProvider.overrideWithValue(service),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final values = <double>[];
+      final sub = container.listen(
+        psaFuelLevelProvider,
+        (prev, next) {
+          if (next.hasValue) values.add(next.value!);
+        },
+      );
+      addTearDown(sub.close);
+      // Setup must run BEFORE we push any frames.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // Sanity: setup commands fired now that the gate opened.
+      expect(transport.sentCommands, contains('ATCRA 0E6'));
+      expect(transport.sentCommands, contains('STMA'));
+
+      // Push a canonical PSA frame: bytes 4-5 = 0x00,0x5A → 45.0 L.
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 5A');
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(values, equals([45.0]));
+
+      // A second frame with bytes 4-5 = 0x00,0x64 → 50.0 L.
+      transport.pushListenLine('0E6 D 6 00 00 00 00 00 64');
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(values, equals([45.0, 50.0]));
+    });
+
+    test('passiveCanCapable but the bus emits a non-PSA frame → no '
+        'litres value forwarded (decoder filters by frame id)', () async {
+      final (:service, :transport) =
+          await _serviceFor(Obd2AdapterCapability.passiveCanCapable);
+      transport.sentCommands.clear();
+
+      final container = ProviderContainer(
+        overrides: [
+          psaFuelLevelObd2ServiceProvider.overrideWithValue(service),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final values = <double>[];
+      final sub = container.listen(
+        psaFuelLevelProvider,
+        (prev, next) {
+          if (next.hasValue) values.add(next.value!);
+        },
+      );
+      addTearDown(sub.close);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // Speed broadcast on PSA — different frame id, should not
+      // produce a fuel-level reading.
+      transport.pushListenLine('0B6 D 6 00 00 12 34 56 78');
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(values, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 5 of #1401 (PR #1417) shipped `PsaFuelLevelCanDecoder` as a pure data-layer parser whose docstring promised a follow-up that would "wire `Obd2Service.canFrameStream()` into a provider gated on `passiveCanCapable`". This is that follow-up — backend-only, no UI strings.

### (a) `Obd2Service.canFrameStream()` data-layer method

- Sends `ATCRA 0E6` (CAN receive-address filter for the PSA EMP2 instrument-cluster broadcast frame) + `STMA` (STN listen-mode start) on first listen.
- Parses each STN listen-mode line (`0E6 D <len> <byte0> ...`) into a `({int id, List<int> payload})` record matching the existing decoder's input shape.
- Returns a broadcast stream so multiple consumers (trip recorder + future debug overlay) can share one listen-mode session.
- Sends `STMP` on cancel via a new `Obd2ListenModeTransport` capability interface — separate from `Obd2Transport` so the ten-plus existing test fakes that `implements Obd2Transport` directly don't need new boilerplate.
- Silently drops malformed lines (wrong frame id, length mismatch, non-hex bytes) so a buffer-overflow burst doesn't kill the consumer.

### (b) Capability-gated `psaFuelLevelProvider` (NEW)

- Stream provider in `lib/features/consumption/providers/psa_fuel_level_provider.dart`.
- Gate: exactly `Obd2AdapterCapability.passiveCanCapable`. `standardOnly` and `oemPidsCapable` fall through to an empty stream (matches the decoder's docstring on phase-4 active-polling fallback).
- Override seam `psaFuelLevelObd2ServiceProvider` returns `null` in production until a future epic phase elevates the live `Obd2Service` into Riverpod. Tests override with a real service backed by a fake transport.
- `keepAlive: false` so the broadcast controller's `onCancel` fires `STMP` automatically when the last listener drops.

### (c) Tests

- `test/features/consumption/data/obd2/obd2_service_can_frame_stream_test.dart` — 12 tests covering setup/teardown commands, broadcast fan-out, well-formed line parsing (incl. lowercase hex), malformed-line resilience.
- `test/features/consumption/providers/psa_fuel_level_provider_test.dart` — 5 tests covering no-service / `standardOnly` / `oemPidsCapable` empty-stream paths, end-to-end `passiveCanCapable` forwarding, and non-PSA frame filtering.

## Out of scope (explicit per #1418)

- Real `BluetoothObd2Transport` listen-mode wiring — separate hardware-test issue.
- Capability provider plumbing — #1419 just shipped that.
- Trip-recording integration — separate epic phase.

## Test plan

- [x] `flutter analyze` clean (zero issues)
- [x] `flutter test test/features/consumption/data/obd2/` — all 802 tests pass (incl. 12 new `canFrameStream` tests)
- [x] `flutter test test/features/consumption/providers/psa_fuel_level_provider_test.dart` — all 5 new gate/forwarding tests pass
- [x] No unrelated `.g.dart` drift; only `psa_fuel_level_provider.g.dart` is a new generated file
- [x] No `lib/l10n/**` touched (backend-only PR)

Closes #1418
Refs #1401