### PR TITLE
feat(catalog): per-engine-tech η_v defaults — schema + helper + backfill (Refs #1422 phase 1)

### DIFF
--- a/assets/reference_vehicles/vehicles.json
+++ b/assets/reference_vehicles/vehicles.json
@@ -10,7 +10,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "psaUds",
-    "notes": "PureTech 1.2 three-cylinder. Electric e-208 sibling shares body but uses electric fuelType."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "PureTech 1.2 three-cylinder turbo DI. Electric e-208 sibling shares body but uses electric fuelType."
   },
   {
     "make": "Peugeot",
@@ -23,7 +25,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "psaUds",
-    "notes": "EMP2 V3 platform, PureTech 130 most common variant."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "EMP2 V3 platform, PureTech 130 turbo DI most common variant."
   },
   {
     "make": "Peugeot",
@@ -36,7 +40,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.88,
     "odometerPidStrategy": "psaUds",
-    "notes": "BlueHDi 130; petrol 1.2 PureTech and PHEV variants exist."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "BlueHDi 130 turbo DI; petrol 1.2 PureTech and PHEV variants exist."
   },
   {
     "make": "Peugeot",
@@ -49,7 +55,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.88,
     "odometerPidStrategy": "psaUds",
-    "notes": "Seven-seater family SUV, shares EMP2 platform with 3008."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "BlueHDi 130 turbo DI; seven-seater family SUV, shares EMP2 platform with 3008."
   },
   {
     "make": "Renault",
@@ -62,7 +70,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "TCe 100 three-cylinder turbo. E-Tech hybrid uses 1.6 atmospheric."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "TCe 100 three-cylinder turbo DI. E-Tech hybrid uses 1.6 atmospheric."
   },
   {
     "make": "Renault",
@@ -75,7 +85,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "TCe 140 most common; dCi 115 diesel and E-Tech PHEV also sold."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "TCe 140 turbo DI most common; dCi 115 diesel and E-Tech PHEV also sold."
   },
   {
     "make": "Renault",
@@ -88,7 +100,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "CMF-B platform, shared with Clio V."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "TCe 100 turbo DI; CMF-B platform, shared with Clio V."
   },
   {
     "make": "Renault",
@@ -101,7 +115,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "TCe 140; replaced by Austral in 2022."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "TCe 140 turbo DI; replaced by Austral in 2022."
   },
   {
     "make": "Citroen",
@@ -114,7 +130,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "psaUds",
-    "notes": "PureTech 83. New gen IV launched 2024 keeps PSA UDS strategy."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "PureTech 83 turbo DI. New gen IV launched 2024 keeps PSA UDS strategy."
   },
   {
     "make": "Citroen",
@@ -127,7 +145,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "psaUds",
-    "notes": "PureTech 130 EAT8; e-C4 electric sibling on same body."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "PureTech 130 turbo DI EAT8; e-C4 electric sibling on same body."
   },
   {
     "make": "Citroen",
@@ -140,7 +160,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.88,
     "odometerPidStrategy": "psaUds",
-    "notes": "BlueHDi 130; PHEV 225 variant uses different VE — see notes for migration."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "BlueHDi 130 turbo DI; PHEV 225 variant uses different VE — see notes for migration."
   },
   {
     "make": "Dacia",
@@ -153,7 +175,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "TCe 90; CMF-B platform shared with Renault Clio V."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "TCe 90 turbo DI; CMF-B platform shared with Renault Clio V."
   },
   {
     "make": "Dacia",
@@ -166,7 +190,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "TCe 130; dCi 115 diesel and Bi-Fuel LPG variants also common."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "TCe 130 turbo DI; dCi 115 diesel and Bi-Fuel LPG variants also common."
   },
   {
     "make": "Volkswagen",
@@ -179,7 +205,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "vwUds",
-    "notes": "1.5 TSI eTSI mild-hybrid most common; GTI/GTD/GTE share PID strategy."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.5 TSI eTSI mild-hybrid turbo DI most common; GTI/GTD/GTE share PID strategy."
   },
   {
     "make": "Volkswagen",
@@ -192,7 +220,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "vwUds",
-    "notes": "1.0 TSI; MQB A0 platform shared with Skoda Fabia."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.0 TSI turbo DI; MQB A0 platform shared with Skoda Fabia."
   },
   {
     "make": "Volkswagen",
@@ -205,7 +235,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.88,
     "odometerPidStrategy": "vwUds",
-    "notes": "2.0 TDI most common; 1.5 TSI petrol and eHybrid variants exist."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "2.0 TDI turbo DI most common; 1.5 TSI petrol and eHybrid variants exist."
   },
   {
     "make": "Volkswagen",
@@ -218,7 +250,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.88,
     "odometerPidStrategy": "vwUds",
-    "notes": "2.0 TDI Evo; B9 generation (2024-) keeps vwUds strategy."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "2.0 TDI Evo turbo DI; B9 generation (2024-) keeps vwUds strategy."
   },
   {
     "make": "Ford",
@@ -231,7 +265,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.0 EcoBoost three-cylinder. Discontinued July 2023."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.0 EcoBoost three-cylinder turbo DI. Discontinued July 2023."
   },
   {
     "make": "Ford",
@@ -244,7 +280,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.0 EcoBoost mHEV; production ended 2025."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.0 EcoBoost mHEV turbo DI; production ended 2025."
   },
   {
     "make": "Ford",
@@ -257,7 +295,8 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "stdA6",
-    "notes": "2.5 Duratec FHEV/PHEV variants dominate EU sales."
+    "atkinsonCycle": true,
+    "notes": "2.5 Duratec FHEV/PHEV Atkinson cycle dominate EU sales."
   },
   {
     "make": "Opel",
@@ -270,7 +309,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "psaUds",
-    "notes": "Built on PSA CMP platform; shares engine + PID strategy with Peugeot 208."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "Built on PSA CMP platform; 1.2 PureTech turbo DI shares engine + PID strategy with Peugeot 208."
   },
   {
     "make": "Opel",
@@ -283,7 +324,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "psaUds",
-    "notes": "EMP2 V3 platform; shares PSA UDS strategy with Peugeot 308."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "EMP2 V3 platform; 1.2 PureTech turbo DI shares PSA UDS strategy with Peugeot 308."
   },
   {
     "make": "Toyota",
@@ -296,7 +339,8 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.88,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.5 Hybrid Dynamic Force; over 80% of EU sales are hybrid trim."
+    "atkinsonCycle": true,
+    "notes": "1.5 Hybrid Dynamic Force Atkinson cycle; over 80% of EU sales are hybrid trim."
   },
   {
     "make": "Toyota",
@@ -309,7 +353,8 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.88,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.8 Hybrid most common; 2.0 Hybrid sportier trim shares PID strategy."
+    "atkinsonCycle": true,
+    "notes": "1.8 Hybrid Atkinson most common; 2.0 Hybrid sportier trim shares PID strategy."
   },
   {
     "make": "Toyota",
@@ -322,7 +367,8 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.88,
     "odometerPidStrategy": "stdA6",
-    "notes": "2.5 Hybrid AWD-i; PHEV variant shares PID strategy."
+    "atkinsonCycle": true,
+    "notes": "2.5 Hybrid AWD-i Atkinson cycle; PHEV variant shares PID strategy."
   },
   {
     "make": "Skoda",
@@ -335,7 +381,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "vwUds",
-    "notes": "1.5 TSI eTSI; MQB Evo platform shared with VW Golf VIII."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.5 TSI eTSI turbo DI; MQB Evo platform shared with VW Golf VIII."
   },
   {
     "make": "Skoda",
@@ -348,7 +396,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "vwUds",
-    "notes": "1.0 TSI; MQB A0 platform shared with VW Polo."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.0 TSI turbo DI; MQB A0 platform shared with VW Polo."
   },
   {
     "make": "Fiat",
@@ -387,7 +437,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.6 T-GDi Smartstream HEV/PHEV; petrol and diesel mHEV also offered."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.6 T-GDi Smartstream HEV/PHEV turbo DI; petrol and diesel mHEV also offered."
   },
   {
     "make": "Hyundai",
@@ -400,7 +452,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.6 T-GDi HEV; Kona Electric sibling uses electric fuelType."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.6 T-GDi HEV turbo DI; Kona Electric sibling uses electric fuelType."
   },
   {
     "make": "BMW",
@@ -413,7 +467,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "bmwCan",
-    "notes": "118i 1.5 three-cylinder turbo; FAAR FWD platform."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "118i 1.5 three-cylinder turbo DI; FAAR FWD platform."
   },
   {
     "make": "BMW",
@@ -426,7 +482,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "bmwCan",
-    "notes": "320i B48 2.0 turbo; 330e PHEV and 320d diesel share PID strategy."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "320i B48 2.0 turbo DI; 330e PHEV and 320d diesel share PID strategy."
   },
   {
     "make": "BMW",
@@ -439,7 +497,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "bmwCan",
-    "notes": "sDrive20i B48; iX1 BEV sibling on same body."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "sDrive20i B48 turbo DI; iX1 BEV sibling on same body."
   },
   {
     "make": "Mini",
@@ -452,7 +512,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "bmwCan",
-    "notes": "1.5 three-cylinder B38; replaced by F66 in 2024."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.5 three-cylinder B38 turbo DI; replaced by F66 in 2024."
   },
   {
     "make": "Mercedes-Benz",
@@ -465,7 +527,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "A180 M282 1.3 turbo (Renault-sourced); A250e PHEV variant exists."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "A180 M282 1.3 turbo DI (Renault-sourced); A250e PHEV variant exists."
   },
   {
     "make": "Mercedes-Benz",
@@ -478,7 +542,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "stdA6",
-    "notes": "C200 M254 1.5 turbo with ISG mild-hybrid; MRA2 platform."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "C200 M254 1.5 turbo DI with ISG mild-hybrid; MRA2 platform."
   },
   {
     "make": "Mercedes-Benz",
@@ -491,7 +557,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "GLA 200 M282 1.3; shares MFA2 platform with W177 A-Class."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "GLA 200 M282 1.3 turbo DI; shares MFA2 platform with W177 A-Class."
   },
   {
     "make": "Audi",
@@ -504,7 +572,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "vwUds",
-    "notes": "35 TFSI 1.5 eTSI mild-hybrid; MQB Evo platform shared with Golf VIII."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "35 TFSI 1.5 eTSI turbo DI mild-hybrid; MQB Evo platform shared with Golf VIII."
   },
   {
     "make": "Audi",
@@ -517,7 +587,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.88,
     "odometerPidStrategy": "vwUds",
-    "notes": "40 TDI 2.0 EA288; 35/45 TFSI petrol variants share PID strategy."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "40 TDI 2.0 EA288 turbo DI; 35/45 TFSI petrol variants share PID strategy."
   },
   {
     "make": "Audi",
@@ -530,7 +602,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "vwUds",
-    "notes": "35 TFSI 1.5 EA211 evo; MQB A2 platform."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "35 TFSI 1.5 EA211 evo turbo DI; MQB A2 platform."
   },
   {
     "make": "SEAT",
@@ -543,7 +617,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "vwUds",
-    "notes": "1.0 TSI; MQB A0 platform shared with VW Polo and Skoda Fabia."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.0 TSI turbo DI; MQB A0 platform shared with VW Polo and Skoda Fabia."
   },
   {
     "make": "SEAT",
@@ -556,7 +632,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "vwUds",
-    "notes": "1.5 TSI eTSI; MQB Evo platform shared with VW Golf VIII and Skoda Octavia."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.5 TSI eTSI turbo DI; MQB Evo platform shared with VW Golf VIII and Skoda Octavia."
   },
   {
     "make": "Tesla",
@@ -595,7 +673,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.5 e-Power series hybrid; 1.3 DIG-T mHEV petrol also offered. CMF-C platform."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.5 e-Power series hybrid turbo DI; 1.3 DIG-T mHEV petrol also offered. CMF-C platform."
   },
   {
     "make": "Nissan",
@@ -608,7 +688,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.0 DIG-T HR10DDT; CMF-B platform shared with Renault Captur."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.0 DIG-T HR10DDT turbo DI; CMF-B platform shared with Renault Captur."
   },
   {
     "make": "Kia",
@@ -621,7 +703,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.6 T-GDi Smartstream HEV/PHEV; shares N3 platform with Hyundai Tucson IV."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.6 T-GDi Smartstream HEV/PHEV turbo DI; shares N3 platform with Hyundai Tucson IV."
   },
   {
     "make": "Kia",
@@ -634,7 +718,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.85,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.4 T-GDi Kappa; 1.0 T-GDi and 1.6 CRDi diesel variants share PID strategy."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.4 T-GDi Kappa turbo DI; 1.0 T-GDi and 1.6 CRDi diesel variants share PID strategy."
   },
   {
     "make": "Volvo",
@@ -647,7 +733,9 @@
     "transmission": "automatic",
     "volumetricEfficiency": 0.87,
     "odometerPidStrategy": "stdA6",
-    "notes": "B4 2.0 mild-hybrid; 1.5 T3 three-cylinder also offered. CMA platform."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "B4 2.0 turbo DI mild-hybrid; 1.5 T3 three-cylinder also offered. CMA platform."
   },
   {
     "make": "Dacia",
@@ -660,7 +748,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.95,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.5 dCi K9K Blue diesel. Sibling of TCe 130 petrol entry; tank 50 L."
+    "inductionType": "vnt",
+    "directInjection": true,
+    "notes": "1.5 dCi K9K Blue diesel VNT + DI. Sibling of TCe 130 petrol entry; tank 50 L."
   },
   {
     "make": "Dacia",
@@ -673,7 +763,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.95,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.5 dCi K9K Blue diesel. Stepway sibling shares engine; tank 50 L."
+    "inductionType": "vnt",
+    "directInjection": true,
+    "notes": "1.5 dCi K9K Blue diesel VNT + DI. Stepway sibling shares engine; tank 50 L."
   },
   {
     "make": "Renault",
@@ -686,7 +778,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.95,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.5 dCi 90 Energy. Common French city diesel; tank 45 L."
+    "inductionType": "vnt",
+    "directInjection": true,
+    "notes": "1.5 dCi 90 Energy VNT + DI. Common French city diesel; tank 45 L."
   },
   {
     "make": "Renault",
@@ -699,7 +793,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.95,
     "odometerPidStrategy": "stdA6",
-    "notes": "1.5 dCi K9K Energy diesel. Shares Clio IV platform; tank 45 L."
+    "inductionType": "vnt",
+    "directInjection": true,
+    "notes": "1.5 dCi K9K Energy diesel VNT + DI. Shares Clio IV platform; tank 45 L."
   },
   {
     "make": "Citroen",
@@ -712,7 +808,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.95,
     "odometerPidStrategy": "psaUds",
-    "notes": "1.5 BlueHDi DV5R diesel. Sibling of PureTech 83 petrol entry; tank 45 L."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.5 BlueHDi DV5R diesel turbo DI. Sibling of PureTech 83 petrol entry; tank 45 L."
   },
   {
     "make": "Peugeot",
@@ -725,7 +823,9 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.95,
     "odometerPidStrategy": "psaUds",
-    "notes": "1.5 BlueHDi DV5R diesel. Replaced earlier 1.6 HDi mid-cycle; tank 50 L."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.5 BlueHDi DV5R diesel turbo DI. Replaced earlier 1.6 HDi mid-cycle; tank 50 L."
   },
   {
     "make": "Volkswagen",
@@ -738,6 +838,8 @@
     "transmission": "manual",
     "volumetricEfficiency": 0.95,
     "odometerPidStrategy": "vwUds",
-    "notes": "1.6 TDI EA288 diesel; sibling of 1.0 TSI petrol entry. Tank 40 L."
+    "inductionType": "turbocharged",
+    "directInjection": true,
+    "notes": "1.6 TDI EA288 diesel turbo DI; sibling of 1.0 TSI petrol entry. Tank 40 L."
   }
 ]

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -558,10 +558,20 @@ class Obd2Service {
     // VE on VehicleProfile is a non-nullable double with its own
     // default (0.85). The manual override takes precedence so a user
     // can pin the value while the auto-learner is still bootstrapping.
+    //
+    // #1422 phase 1 — when the user's profile carries the legacy 0.85
+    // default AND the VeLearner hasn't accumulated any samples yet,
+    // fall through to the engine-tech-derived helper instead of the
+    // raw catalog literal. This kicks Atkinson / VNT diesel / DI turbo
+    // engines off 0.85 from day one, without disturbing existing
+    // VeLearner-converged users (samples > 0 keeps the stored value)
+    // or users who explicitly typed a non-default value through the
+    // calibration card.
     final volumetricEfficiency = vehicle?.manualVolumetricEfficiencyOverride ??
-        vehicle?.volumetricEfficiency ??
-        referenceVehicle?.volumetricEfficiency ??
-        estimator.kDefaultVolumetricEfficiency;
+        _resolveProfileVolumetricEfficiency(vehicle, referenceVehicle) ??
+        (referenceVehicle != null
+            ? defaultVolumetricEfficiency(referenceVehicle)
+            : estimator.kDefaultVolumetricEfficiency);
     final isDiesel = vehicle != null
         ? estimator.isDieselProfile(vehicle)
         : referenceVehicle?.fuelType.toLowerCase() == 'diesel';
@@ -1111,4 +1121,37 @@ class Obd2Service {
     final raw = await _transport.sendCommand(command);
     return _adapter.preParse(raw);
   }
+}
+
+/// Returns the user-profile η_v that should beat the catalog helper, or
+/// null when the engine-tech default should kick in instead (#1422 phase 1).
+///
+/// Resolution rules:
+///   - Profile is null → null (caller falls back to catalog helper).
+///   - Profile carries a learned EWMA value
+///     (`volumetricEfficiencySamples > 0`) → return the stored value, no
+///     matter what it is. The user's own car beats the table.
+///   - Profile carries a non-default value (anything ≠ 0.85) → return it.
+///     This covers users who typed a non-default value somewhere upstream
+///     even though the sample counter never bumped.
+///   - Profile sits at the cold-start default 0.85 with zero learned
+///     samples → null. Caller resolves
+///     `defaultVolumetricEfficiency(reference)` instead so a Dacia dCi
+///     gets 0.95 from day one rather than being stuck at 0.85 until
+///     VeLearner converges over several plein cycles.
+double? _resolveProfileVolumetricEfficiency(
+  VehicleProfile? vehicle,
+  ReferenceVehicle? referenceVehicle,
+) {
+  if (vehicle == null) return null;
+  // Without a reference vehicle to derive a better default from, the
+  // stored value is the best we have — even if it equals 0.85.
+  if (referenceVehicle == null) return vehicle.volumetricEfficiency;
+  if (vehicle.volumetricEfficiencySamples > 0) {
+    return vehicle.volumetricEfficiency;
+  }
+  if (vehicle.volumetricEfficiency != estimator.kDefaultVolumetricEfficiency) {
+    return vehicle.volumetricEfficiency;
+  }
+  return null;
 }

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
 import '../../../../core/storage/hive_boxes.dart';
+import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../domain/services/gear_inference.dart';
 import '../../domain/trip_recorder.dart';
@@ -150,6 +151,14 @@ class TripRecordingController {
   /// null, `readFuelRateLPerHour` falls back to its generic 1.0 L /
   /// η_v 0.85 defaults — still honest, just less precise.
   final VehicleProfile? _vehicle;
+
+  /// Reference catalog row matched to [_vehicle] at construction
+  /// (#1422 phase 1). Drives the engine-tech-derived η_v default so a
+  /// fresh Dacia dCi profile resolves 0.95 instead of the legacy 0.85
+  /// catalog literal until VeLearner converges. Null when the active
+  /// vehicle has no catalog match (custom EV, niche import, etc.) — the
+  /// controller falls back to the stored profile value.
+  final ReferenceVehicle? _referenceVehicle;
 
   /// Vehicle id tagged on paused snapshots + trip-history finalisations
   /// (#797 phase 1). The controller itself doesn't know about the
@@ -366,6 +375,7 @@ class TripRecordingController {
     Duration pollInterval = const Duration(milliseconds: 250),
     DateTime Function()? now,
     VehicleProfile? vehicle,
+    ReferenceVehicle? referenceVehicle,
     String? vehicleId,
     PidScheduler? scheduler,
     PausedTripRepository? pausedRepo,
@@ -387,6 +397,7 @@ class TripRecordingController {
         _pollInterval = pollInterval,
         _now = now ?? DateTime.now,
         _vehicle = vehicle,
+        _referenceVehicle = referenceVehicle,
         _vehicleId = vehicleId,
         _schedulerOverride = scheduler,
         _pausedRepoOverride = pausedRepo,
@@ -1275,9 +1286,17 @@ class TripRecordingController {
             ?.round() ??
         _vehicle?.engineDisplacementCc ??
         1000;
+    // #1422 phase 1 — same precedence as Obd2Service.readFuelRateLPerHour:
+    // manual override → stored profile (when learned or non-default) →
+    // engine-tech helper on the reference catalog row → hard 0.85
+    // fallback. The two paths must agree so the live integrator and
+    // the pull-mode estimator produce identical numbers for the same
+    // tick.
     final ve = _vehicle?.manualVolumetricEfficiencyOverride ??
-        _vehicle?.volumetricEfficiency ??
-        0.85;
+        _resolveControllerProfileVe() ??
+        (_referenceVehicle != null
+            ? defaultVolumetricEfficiency(_referenceVehicle)
+            : 0.85);
     final collector = _breadcrumbCollector;
 
     // Step 1: direct PID 5E. Already post-trim, no correction.
@@ -1398,6 +1417,29 @@ class TripRecordingController {
       volumetricEfficiency: ve,
     );
     return corrected;
+  }
+
+  /// Returns the user profile's η_v that should beat the engine-tech
+  /// helper, or null when the helper should kick in instead (#1422
+  /// phase 1). Mirrors the rules in [_resolveProfileVolumetricEfficiency]
+  /// in `obd2_service.dart` so both the live integrator and the
+  /// pull-mode estimator agree on a per-tick basis.
+  ///
+  /// Profile null → null (caller will use the helper or hard fallback).
+  /// Without a reference catalog row the stored profile value is the
+  /// best we can do, even if it equals the legacy 0.85 default.
+  /// Otherwise: keep the stored value when the VeLearner has logged at
+  /// least one sample OR when the value differs from the legacy 0.85
+  /// default. A cold-start profile sitting on 0.85 with zero samples
+  /// returns null, letting the engine-tech helper provide a closer
+  /// initial guess (e.g. 0.95 for a Dacia dCi VNT diesel).
+  double? _resolveControllerProfileVe() {
+    final v = _vehicle;
+    if (v == null) return null;
+    if (_referenceVehicle == null) return v.volumetricEfficiency;
+    if (v.volumetricEfficiencySamples > 0) return v.volumetricEfficiency;
+    if (v.volumetricEfficiency != 0.85) return v.volumetricEfficiency;
+    return null;
   }
 
   /// Apply the STFT + LTFT correction used on the MAF / speed-density

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -15,6 +15,9 @@ import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../sync/providers/baseline_sync_enabled_provider.dart';
+import '../../vehicle/data/reference_vehicle_catalog_provider.dart';
+import '../../vehicle/data/vehicle_profile_catalog_matcher.dart';
+import '../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/baseline_store.dart';
@@ -279,9 +282,17 @@ class TripRecording extends _$TripRecording {
     // fresh suspicion-rate denominator for THIS recording.
     breadcrumbs.clear();
     service.breadcrumbCollector = breadcrumbs;
+    // #1422 phase 1 — match the active vehicle to the bundled catalog
+    // so the controller can fall through to the engine-tech-derived
+    // η_v default (e.g. 0.95 for a Dacia dCi VNT diesel) instead of
+    // the legacy 0.85 catalog literal until VeLearner converges. Null
+    // on a no-vehicle / no-catalog / no-match path; the controller then
+    // falls back to the stored profile value as before.
+    final matchedReference = _tryMatchReferenceVehicle(activeVehicle);
     final ctl = TripRecordingController(
       service: service,
       vehicle: activeVehicle,
+      referenceVehicle: matchedReference,
       vehicleId: eagerVehicleId,
       pinnedAdapterMac: pinnedMac,
       automatic: automatic,
@@ -430,6 +441,27 @@ class TripRecording extends _$TripRecording {
       return ref.read(activeVehicleProfileProvider);
     } catch (e, st) {
       debugPrint('TripRecording: active vehicle unavailable: $e\n$st');
+      return null;
+    }
+  }
+
+  /// Resolve the catalog row for [profile], returning null when the
+  /// catalog hasn't loaded yet, the profile is null, or no tier of
+  /// [VehicleProfileCatalogMatcher.bestMatch] hits (#1422 phase 1).
+  /// Swallows provider-wiring errors the same way [_tryReadActiveVehicle]
+  /// does so widget tests don't have to override the catalog graph just
+  /// to start a recording.
+  ReferenceVehicle? _tryMatchReferenceVehicle(VehicleProfile? profile) {
+    if (profile == null) return null;
+    try {
+      final catalog = ref.read(referenceVehicleCatalogProvider).value;
+      if (catalog == null || catalog.isEmpty) return null;
+      return VehicleProfileCatalogMatcher.bestMatch(
+        profile: profile,
+        catalog: catalog,
+      );
+    } catch (e, st) {
+      debugPrint('TripRecording: reference catalog unavailable: $e\n$st');
       return null;
     }
   }

--- a/lib/features/vehicle/domain/entities/reference_vehicle.dart
+++ b/lib/features/vehicle/domain/entities/reference_vehicle.dart
@@ -3,6 +3,56 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'reference_vehicle.freezed.dart';
 part 'reference_vehicle.g.dart';
 
+/// Engine induction technology (#1422 phase 1).
+///
+/// Drives the η_v (volumetric efficiency) defaulting helper
+/// [defaultVolumetricEfficiency]: a turbocharged direct-injection engine
+/// runs ~0.93 at cruise where a naturally-aspirated port-injection engine
+/// runs ~0.85, so a single 0.85 catalog default systematically
+/// under-fuels the live integrator on modern downsized engines until the
+/// VeLearner converges (#1397).
+///
+/// Stored as a string in JSON via the freezed serializer so adding a new
+/// type (e.g. "millerCycle", "twoStrokeDiesel") stays JSON-only.
+///
+/// Values:
+///   - [naturallyAspirated] — atmospheric intake, no compressor.
+///   - [turbocharged]       — exhaust-driven turbocharger, fixed-vane.
+///   - [supercharged]       — belt-driven mechanical compressor.
+///   - [vnt]                — variable-nozzle turbocharger, used on
+///                            modern common-rail diesels (PSA BlueHDi,
+///                            Renault dCi, VW TDI etc.). Higher BMEP
+///                            range than a fixed-vane turbo.
+enum InductionType { naturallyAspirated, turbocharged, supercharged, vnt }
+
+/// Returns the typical cruise η_v for a reference vehicle's engine
+/// technology (#1422 phase 1).
+///
+/// Used as the third tier in the fuel-rate resolution chain
+/// (#1397): manual override → stored profile value (when explicitly
+/// learned / non-default) → [defaultVolumetricEfficiency] → hard fallback.
+///
+/// Derived values come from the spec table in #1422:
+///   - Atkinson cycle (Toyota HSD)        → 0.70
+///   - VNT diesel (assumed DI in modern)  → 0.95
+///   - Turbo / supercharged + DI          → 0.93
+///   - Turbo / supercharged + port inj.   → 0.90
+///   - NA + DI                            → 0.88
+///   - NA + port injection (legacy fwd)   → 0.85
+///
+/// The legacy 0.85 path is preserved bit-for-bit so existing rows that
+/// don't carry the new fields still resolve to the same value they did
+/// before #1422.
+double defaultVolumetricEfficiency(ReferenceVehicle v) {
+  if (v.atkinsonCycle) return 0.70;
+  if (v.inductionType == InductionType.vnt) return 0.95;
+  if (v.inductionType == InductionType.turbocharged ||
+      v.inductionType == InductionType.supercharged) {
+    return v.directInjection ? 0.93 : 0.90;
+  }
+  return v.directInjection ? 0.88 : 0.85;
+}
+
 /// A single entry in the reference vehicle catalog (#950 phase 1).
 ///
 /// The catalog ships ~30 popular EU passenger cars compiled from
@@ -63,6 +113,22 @@ abstract class ReferenceVehicle with _$ReferenceVehicle {
     ///   - "unknown" — no working strategy known; consumer falls back to
     ///                 trip integration.
     @Default('stdA6') String odometerPidStrategy,
+
+    /// Engine induction technology (#1422 phase 1). Drives
+    /// [defaultVolumetricEfficiency]. Defaults to
+    /// [InductionType.naturallyAspirated] so legacy rows without the
+    /// field deserialize unchanged.
+    @Default(InductionType.naturallyAspirated) InductionType inductionType,
+
+    /// Whether the engine uses gasoline / diesel direct injection
+    /// (#1422 phase 1). Defaults to false for backward-compat with
+    /// rows that pre-date the schema addition.
+    @Default(false) bool directInjection,
+
+    /// Whether the engine runs the Atkinson cycle (#1422 phase 1).
+    /// Toyota HSD (Prius / Yaris HSD / Auris HSD / Corolla Hybrid),
+    /// Mazda Skyactiv-X. Defaults to false.
+    @Default(false) bool atkinsonCycle,
 
     /// Optional free-form notes (e.g. "PHEV variant uses different VE").
     String? notes,

--- a/lib/features/vehicle/domain/entities/reference_vehicle.freezed.dart
+++ b/lib/features/vehicle/domain/entities/reference_vehicle.freezed.dart
@@ -39,7 +39,17 @@ mixin _$ReferenceVehicle {
 ///   - "vwUds"   — VAG group (VW, Skoda, Seat, Audi) UDS PID.
 ///   - "unknown" — no working strategy known; consumer falls back to
 ///                 trip integration.
- String get odometerPidStrategy;/// Optional free-form notes (e.g. "PHEV variant uses different VE").
+ String get odometerPidStrategy;/// Engine induction technology (#1422 phase 1). Drives
+/// [defaultVolumetricEfficiency]. Defaults to
+/// [InductionType.naturallyAspirated] so legacy rows without the
+/// field deserialize unchanged.
+ InductionType get inductionType;/// Whether the engine uses gasoline / diesel direct injection
+/// (#1422 phase 1). Defaults to false for backward-compat with
+/// rows that pre-date the schema addition.
+ bool get directInjection;/// Whether the engine runs the Atkinson cycle (#1422 phase 1).
+/// Toyota HSD (Prius / Yaris HSD / Auris HSD / Corolla Hybrid),
+/// Mazda Skyactiv-X. Defaults to false.
+ bool get atkinsonCycle;/// Optional free-form notes (e.g. "PHEV variant uses different VE").
  String? get notes;
 /// Create a copy of ReferenceVehicle
 /// with the given fields replaced by the non-null parameter values.
@@ -53,16 +63,16 @@ $ReferenceVehicleCopyWith<ReferenceVehicle> get copyWith => _$ReferenceVehicleCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ReferenceVehicle&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.generation, generation) || other.generation == generation)&&(identical(other.yearStart, yearStart) || other.yearStart == yearStart)&&(identical(other.yearEnd, yearEnd) || other.yearEnd == yearEnd)&&(identical(other.displacementCc, displacementCc) || other.displacementCc == displacementCc)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.transmission, transmission) || other.transmission == transmission)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.odometerPidStrategy, odometerPidStrategy) || other.odometerPidStrategy == odometerPidStrategy)&&(identical(other.notes, notes) || other.notes == notes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ReferenceVehicle&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.generation, generation) || other.generation == generation)&&(identical(other.yearStart, yearStart) || other.yearStart == yearStart)&&(identical(other.yearEnd, yearEnd) || other.yearEnd == yearEnd)&&(identical(other.displacementCc, displacementCc) || other.displacementCc == displacementCc)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.transmission, transmission) || other.transmission == transmission)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.odometerPidStrategy, odometerPidStrategy) || other.odometerPidStrategy == odometerPidStrategy)&&(identical(other.inductionType, inductionType) || other.inductionType == inductionType)&&(identical(other.directInjection, directInjection) || other.directInjection == directInjection)&&(identical(other.atkinsonCycle, atkinsonCycle) || other.atkinsonCycle == atkinsonCycle)&&(identical(other.notes, notes) || other.notes == notes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,make,model,generation,yearStart,yearEnd,displacementCc,fuelType,transmission,volumetricEfficiency,odometerPidStrategy,notes);
+int get hashCode => Object.hash(runtimeType,make,model,generation,yearStart,yearEnd,displacementCc,fuelType,transmission,volumetricEfficiency,odometerPidStrategy,inductionType,directInjection,atkinsonCycle,notes);
 
 @override
 String toString() {
-  return 'ReferenceVehicle(make: $make, model: $model, generation: $generation, yearStart: $yearStart, yearEnd: $yearEnd, displacementCc: $displacementCc, fuelType: $fuelType, transmission: $transmission, volumetricEfficiency: $volumetricEfficiency, odometerPidStrategy: $odometerPidStrategy, notes: $notes)';
+  return 'ReferenceVehicle(make: $make, model: $model, generation: $generation, yearStart: $yearStart, yearEnd: $yearEnd, displacementCc: $displacementCc, fuelType: $fuelType, transmission: $transmission, volumetricEfficiency: $volumetricEfficiency, odometerPidStrategy: $odometerPidStrategy, inductionType: $inductionType, directInjection: $directInjection, atkinsonCycle: $atkinsonCycle, notes: $notes)';
 }
 
 
@@ -73,7 +83,7 @@ abstract mixin class $ReferenceVehicleCopyWith<$Res>  {
   factory $ReferenceVehicleCopyWith(ReferenceVehicle value, $Res Function(ReferenceVehicle) _then) = _$ReferenceVehicleCopyWithImpl;
 @useResult
 $Res call({
- String make, String model, String generation, int yearStart, int? yearEnd, int displacementCc, String fuelType, String transmission, double volumetricEfficiency, String odometerPidStrategy, String? notes
+ String make, String model, String generation, int yearStart, int? yearEnd, int displacementCc, String fuelType, String transmission, double volumetricEfficiency, String odometerPidStrategy, InductionType inductionType, bool directInjection, bool atkinsonCycle, String? notes
 });
 
 
@@ -90,7 +100,7 @@ class _$ReferenceVehicleCopyWithImpl<$Res>
 
 /// Create a copy of ReferenceVehicle
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? make = null,Object? model = null,Object? generation = null,Object? yearStart = null,Object? yearEnd = freezed,Object? displacementCc = null,Object? fuelType = null,Object? transmission = null,Object? volumetricEfficiency = null,Object? odometerPidStrategy = null,Object? notes = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? make = null,Object? model = null,Object? generation = null,Object? yearStart = null,Object? yearEnd = freezed,Object? displacementCc = null,Object? fuelType = null,Object? transmission = null,Object? volumetricEfficiency = null,Object? odometerPidStrategy = null,Object? inductionType = null,Object? directInjection = null,Object? atkinsonCycle = null,Object? notes = freezed,}) {
   return _then(_self.copyWith(
 make: null == make ? _self.make : make // ignore: cast_nullable_to_non_nullable
 as String,model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
@@ -102,7 +112,10 @@ as int,fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nu
 as String,transmission: null == transmission ? _self.transmission : transmission // ignore: cast_nullable_to_non_nullable
 as String,volumetricEfficiency: null == volumetricEfficiency ? _self.volumetricEfficiency : volumetricEfficiency // ignore: cast_nullable_to_non_nullable
 as double,odometerPidStrategy: null == odometerPidStrategy ? _self.odometerPidStrategy : odometerPidStrategy // ignore: cast_nullable_to_non_nullable
-as String,notes: freezed == notes ? _self.notes : notes // ignore: cast_nullable_to_non_nullable
+as String,inductionType: null == inductionType ? _self.inductionType : inductionType // ignore: cast_nullable_to_non_nullable
+as InductionType,directInjection: null == directInjection ? _self.directInjection : directInjection // ignore: cast_nullable_to_non_nullable
+as bool,atkinsonCycle: null == atkinsonCycle ? _self.atkinsonCycle : atkinsonCycle // ignore: cast_nullable_to_non_nullable
+as bool,notes: freezed == notes ? _self.notes : notes // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -188,10 +201,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String make,  String model,  String generation,  int yearStart,  int? yearEnd,  int displacementCc,  String fuelType,  String transmission,  double volumetricEfficiency,  String odometerPidStrategy,  String? notes)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String make,  String model,  String generation,  int yearStart,  int? yearEnd,  int displacementCc,  String fuelType,  String transmission,  double volumetricEfficiency,  String odometerPidStrategy,  InductionType inductionType,  bool directInjection,  bool atkinsonCycle,  String? notes)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ReferenceVehicle() when $default != null:
-return $default(_that.make,_that.model,_that.generation,_that.yearStart,_that.yearEnd,_that.displacementCc,_that.fuelType,_that.transmission,_that.volumetricEfficiency,_that.odometerPidStrategy,_that.notes);case _:
+return $default(_that.make,_that.model,_that.generation,_that.yearStart,_that.yearEnd,_that.displacementCc,_that.fuelType,_that.transmission,_that.volumetricEfficiency,_that.odometerPidStrategy,_that.inductionType,_that.directInjection,_that.atkinsonCycle,_that.notes);case _:
   return orElse();
 
 }
@@ -209,10 +222,10 @@ return $default(_that.make,_that.model,_that.generation,_that.yearStart,_that.ye
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String make,  String model,  String generation,  int yearStart,  int? yearEnd,  int displacementCc,  String fuelType,  String transmission,  double volumetricEfficiency,  String odometerPidStrategy,  String? notes)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String make,  String model,  String generation,  int yearStart,  int? yearEnd,  int displacementCc,  String fuelType,  String transmission,  double volumetricEfficiency,  String odometerPidStrategy,  InductionType inductionType,  bool directInjection,  bool atkinsonCycle,  String? notes)  $default,) {final _that = this;
 switch (_that) {
 case _ReferenceVehicle():
-return $default(_that.make,_that.model,_that.generation,_that.yearStart,_that.yearEnd,_that.displacementCc,_that.fuelType,_that.transmission,_that.volumetricEfficiency,_that.odometerPidStrategy,_that.notes);case _:
+return $default(_that.make,_that.model,_that.generation,_that.yearStart,_that.yearEnd,_that.displacementCc,_that.fuelType,_that.transmission,_that.volumetricEfficiency,_that.odometerPidStrategy,_that.inductionType,_that.directInjection,_that.atkinsonCycle,_that.notes);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -229,10 +242,10 @@ return $default(_that.make,_that.model,_that.generation,_that.yearStart,_that.ye
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String make,  String model,  String generation,  int yearStart,  int? yearEnd,  int displacementCc,  String fuelType,  String transmission,  double volumetricEfficiency,  String odometerPidStrategy,  String? notes)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String make,  String model,  String generation,  int yearStart,  int? yearEnd,  int displacementCc,  String fuelType,  String transmission,  double volumetricEfficiency,  String odometerPidStrategy,  InductionType inductionType,  bool directInjection,  bool atkinsonCycle,  String? notes)?  $default,) {final _that = this;
 switch (_that) {
 case _ReferenceVehicle() when $default != null:
-return $default(_that.make,_that.model,_that.generation,_that.yearStart,_that.yearEnd,_that.displacementCc,_that.fuelType,_that.transmission,_that.volumetricEfficiency,_that.odometerPidStrategy,_that.notes);case _:
+return $default(_that.make,_that.model,_that.generation,_that.yearStart,_that.yearEnd,_that.displacementCc,_that.fuelType,_that.transmission,_that.volumetricEfficiency,_that.odometerPidStrategy,_that.inductionType,_that.directInjection,_that.atkinsonCycle,_that.notes);case _:
   return null;
 
 }
@@ -244,7 +257,7 @@ return $default(_that.make,_that.model,_that.generation,_that.yearStart,_that.ye
 @JsonSerializable()
 
 class _ReferenceVehicle extends ReferenceVehicle {
-  const _ReferenceVehicle({required this.make, required this.model, required this.generation, required this.yearStart, this.yearEnd, required this.displacementCc, required this.fuelType, required this.transmission, this.volumetricEfficiency = 0.85, this.odometerPidStrategy = 'stdA6', this.notes}): super._();
+  const _ReferenceVehicle({required this.make, required this.model, required this.generation, required this.yearStart, this.yearEnd, required this.displacementCc, required this.fuelType, required this.transmission, this.volumetricEfficiency = 0.85, this.odometerPidStrategy = 'stdA6', this.inductionType = InductionType.naturallyAspirated, this.directInjection = false, this.atkinsonCycle = false, this.notes}): super._();
   factory _ReferenceVehicle.fromJson(Map<String, dynamic> json) => _$ReferenceVehicleFromJson(json);
 
 /// Manufacturer brand, e.g. "Peugeot", "Renault".
@@ -281,6 +294,19 @@ class _ReferenceVehicle extends ReferenceVehicle {
 ///   - "unknown" — no working strategy known; consumer falls back to
 ///                 trip integration.
 @override@JsonKey() final  String odometerPidStrategy;
+/// Engine induction technology (#1422 phase 1). Drives
+/// [defaultVolumetricEfficiency]. Defaults to
+/// [InductionType.naturallyAspirated] so legacy rows without the
+/// field deserialize unchanged.
+@override@JsonKey() final  InductionType inductionType;
+/// Whether the engine uses gasoline / diesel direct injection
+/// (#1422 phase 1). Defaults to false for backward-compat with
+/// rows that pre-date the schema addition.
+@override@JsonKey() final  bool directInjection;
+/// Whether the engine runs the Atkinson cycle (#1422 phase 1).
+/// Toyota HSD (Prius / Yaris HSD / Auris HSD / Corolla Hybrid),
+/// Mazda Skyactiv-X. Defaults to false.
+@override@JsonKey() final  bool atkinsonCycle;
 /// Optional free-form notes (e.g. "PHEV variant uses different VE").
 @override final  String? notes;
 
@@ -297,16 +323,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ReferenceVehicle&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.generation, generation) || other.generation == generation)&&(identical(other.yearStart, yearStart) || other.yearStart == yearStart)&&(identical(other.yearEnd, yearEnd) || other.yearEnd == yearEnd)&&(identical(other.displacementCc, displacementCc) || other.displacementCc == displacementCc)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.transmission, transmission) || other.transmission == transmission)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.odometerPidStrategy, odometerPidStrategy) || other.odometerPidStrategy == odometerPidStrategy)&&(identical(other.notes, notes) || other.notes == notes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ReferenceVehicle&&(identical(other.make, make) || other.make == make)&&(identical(other.model, model) || other.model == model)&&(identical(other.generation, generation) || other.generation == generation)&&(identical(other.yearStart, yearStart) || other.yearStart == yearStart)&&(identical(other.yearEnd, yearEnd) || other.yearEnd == yearEnd)&&(identical(other.displacementCc, displacementCc) || other.displacementCc == displacementCc)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.transmission, transmission) || other.transmission == transmission)&&(identical(other.volumetricEfficiency, volumetricEfficiency) || other.volumetricEfficiency == volumetricEfficiency)&&(identical(other.odometerPidStrategy, odometerPidStrategy) || other.odometerPidStrategy == odometerPidStrategy)&&(identical(other.inductionType, inductionType) || other.inductionType == inductionType)&&(identical(other.directInjection, directInjection) || other.directInjection == directInjection)&&(identical(other.atkinsonCycle, atkinsonCycle) || other.atkinsonCycle == atkinsonCycle)&&(identical(other.notes, notes) || other.notes == notes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,make,model,generation,yearStart,yearEnd,displacementCc,fuelType,transmission,volumetricEfficiency,odometerPidStrategy,notes);
+int get hashCode => Object.hash(runtimeType,make,model,generation,yearStart,yearEnd,displacementCc,fuelType,transmission,volumetricEfficiency,odometerPidStrategy,inductionType,directInjection,atkinsonCycle,notes);
 
 @override
 String toString() {
-  return 'ReferenceVehicle(make: $make, model: $model, generation: $generation, yearStart: $yearStart, yearEnd: $yearEnd, displacementCc: $displacementCc, fuelType: $fuelType, transmission: $transmission, volumetricEfficiency: $volumetricEfficiency, odometerPidStrategy: $odometerPidStrategy, notes: $notes)';
+  return 'ReferenceVehicle(make: $make, model: $model, generation: $generation, yearStart: $yearStart, yearEnd: $yearEnd, displacementCc: $displacementCc, fuelType: $fuelType, transmission: $transmission, volumetricEfficiency: $volumetricEfficiency, odometerPidStrategy: $odometerPidStrategy, inductionType: $inductionType, directInjection: $directInjection, atkinsonCycle: $atkinsonCycle, notes: $notes)';
 }
 
 
@@ -317,7 +343,7 @@ abstract mixin class _$ReferenceVehicleCopyWith<$Res> implements $ReferenceVehic
   factory _$ReferenceVehicleCopyWith(_ReferenceVehicle value, $Res Function(_ReferenceVehicle) _then) = __$ReferenceVehicleCopyWithImpl;
 @override @useResult
 $Res call({
- String make, String model, String generation, int yearStart, int? yearEnd, int displacementCc, String fuelType, String transmission, double volumetricEfficiency, String odometerPidStrategy, String? notes
+ String make, String model, String generation, int yearStart, int? yearEnd, int displacementCc, String fuelType, String transmission, double volumetricEfficiency, String odometerPidStrategy, InductionType inductionType, bool directInjection, bool atkinsonCycle, String? notes
 });
 
 
@@ -334,7 +360,7 @@ class __$ReferenceVehicleCopyWithImpl<$Res>
 
 /// Create a copy of ReferenceVehicle
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? make = null,Object? model = null,Object? generation = null,Object? yearStart = null,Object? yearEnd = freezed,Object? displacementCc = null,Object? fuelType = null,Object? transmission = null,Object? volumetricEfficiency = null,Object? odometerPidStrategy = null,Object? notes = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? make = null,Object? model = null,Object? generation = null,Object? yearStart = null,Object? yearEnd = freezed,Object? displacementCc = null,Object? fuelType = null,Object? transmission = null,Object? volumetricEfficiency = null,Object? odometerPidStrategy = null,Object? inductionType = null,Object? directInjection = null,Object? atkinsonCycle = null,Object? notes = freezed,}) {
   return _then(_ReferenceVehicle(
 make: null == make ? _self.make : make // ignore: cast_nullable_to_non_nullable
 as String,model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
@@ -346,7 +372,10 @@ as int,fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nu
 as String,transmission: null == transmission ? _self.transmission : transmission // ignore: cast_nullable_to_non_nullable
 as String,volumetricEfficiency: null == volumetricEfficiency ? _self.volumetricEfficiency : volumetricEfficiency // ignore: cast_nullable_to_non_nullable
 as double,odometerPidStrategy: null == odometerPidStrategy ? _self.odometerPidStrategy : odometerPidStrategy // ignore: cast_nullable_to_non_nullable
-as String,notes: freezed == notes ? _self.notes : notes // ignore: cast_nullable_to_non_nullable
+as String,inductionType: null == inductionType ? _self.inductionType : inductionType // ignore: cast_nullable_to_non_nullable
+as InductionType,directInjection: null == directInjection ? _self.directInjection : directInjection // ignore: cast_nullable_to_non_nullable
+as bool,atkinsonCycle: null == atkinsonCycle ? _self.atkinsonCycle : atkinsonCycle // ignore: cast_nullable_to_non_nullable
+as bool,notes: freezed == notes ? _self.notes : notes // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/lib/features/vehicle/domain/entities/reference_vehicle.g.dart
+++ b/lib/features/vehicle/domain/entities/reference_vehicle.g.dart
@@ -19,6 +19,11 @@ _ReferenceVehicle _$ReferenceVehicleFromJson(Map<String, dynamic> json) =>
       volumetricEfficiency:
           (json['volumetricEfficiency'] as num?)?.toDouble() ?? 0.85,
       odometerPidStrategy: json['odometerPidStrategy'] as String? ?? 'stdA6',
+      inductionType:
+          $enumDecodeNullable(_$InductionTypeEnumMap, json['inductionType']) ??
+          InductionType.naturallyAspirated,
+      directInjection: json['directInjection'] as bool? ?? false,
+      atkinsonCycle: json['atkinsonCycle'] as bool? ?? false,
       notes: json['notes'] as String?,
     );
 
@@ -34,5 +39,15 @@ Map<String, dynamic> _$ReferenceVehicleToJson(_ReferenceVehicle instance) =>
       'transmission': instance.transmission,
       'volumetricEfficiency': instance.volumetricEfficiency,
       'odometerPidStrategy': instance.odometerPidStrategy,
+      'inductionType': _$InductionTypeEnumMap[instance.inductionType]!,
+      'directInjection': instance.directInjection,
+      'atkinsonCycle': instance.atkinsonCycle,
       'notes': instance.notes,
     };
+
+const _$InductionTypeEnumMap = {
+  InductionType.naturallyAspirated: 'naturallyAspirated',
+  InductionType.turbocharged: 'turbocharged',
+  InductionType.supercharged: 'supercharged',
+  InductionType.vnt: 'vnt',
+};

--- a/test/features/consumption/data/obd2/eta_v_resolution_chain_test.dart
+++ b/test/features/consumption/data/obd2/eta_v_resolution_chain_test.dart
@@ -1,0 +1,333 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/reference_vehicle.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+// Shared AT-init boilerplate so the tests focus on the resolution chain.
+const _initResponses = {
+  'ATZ': 'ELM327 v1.5>',
+  'ATE0': 'OK>',
+  'ATL0': 'OK>',
+  'ATH0': 'OK>',
+  'ATSP0': 'OK>',
+};
+
+// Standard speed-density-only fixture: PID 5E + MAF off, MAP 65 kPa,
+// IAT 30 °C, RPM 2500. Trims unsupported. Forces the speed-density
+// branch where the resolution chain matters.
+const _speedDensityResponses = {
+  '015E': 'NO DATA>',
+  '0110': 'NO DATA>',
+  '010B': '41 0B 41>', // MAP 65 kPa
+  '010F': '41 0F 46>', // IAT 30 °C
+  '010C': '41 0C 27 10>', // RPM 2500
+  '0106': 'NO DATA>',
+  '0107': 'NO DATA>',
+};
+
+/// Tests for the η_v resolution chain extension landed in #1422 phase 1.
+///
+/// Builds on top of the #1397 chain (`fuel_rate_resolution_chain_test.dart`)
+/// — those tests pin manual-override / stored-vehicle / catalog-literal
+/// precedence. This file pins the new behaviour: when the user's profile
+/// sits on the cold-start 0.85 default with zero VeLearner samples AND a
+/// reference catalog row is available, the chain should call
+/// [defaultVolumetricEfficiency] instead of using the catalog literal —
+/// so a Dacia dCi VNT diesel resolves 0.95 from day one rather than 0.85.
+///
+/// Order of precedence (post-#1422):
+///   1. `vehicle.manualVolumetricEfficiencyOverride`
+///   2. `vehicle.volumetricEfficiency` when learned (samples > 0) OR
+///      explicitly non-default (≠ 0.85)
+///   3. `defaultVolumetricEfficiency(referenceVehicle)`
+///   4. `kDefaultVolumetricEfficiency` (0.85) — only when no reference
+///      row resolves at all.
+void main() {
+  // VNT diesel reference. Engine-tech helper resolves to 0.95;
+  // the legacy `referenceVehicle.volumetricEfficiency` literal is 0.85
+  // so we can prove the helper is consulted (not the literal).
+  const dustnerDci = ReferenceVehicle(
+    make: 'Dacia',
+    model: 'Duster',
+    generation: 'II dCi 115 (2017-2024)',
+    yearStart: 2017,
+    yearEnd: 2024,
+    displacementCc: 1461,
+    fuelType: 'diesel',
+    transmission: 'manual',
+    volumetricEfficiency: 0.85,
+    odometerPidStrategy: 'stdA6',
+    inductionType: InductionType.vnt,
+    directInjection: true,
+  );
+
+  // Turbo + DI petrol reference (e.g. 1.2 PureTech). Helper → 0.93.
+  const peugeot208 = ReferenceVehicle(
+    make: 'Peugeot',
+    model: '208',
+    generation: 'II (2019-)',
+    yearStart: 2019,
+    displacementCc: 1199,
+    fuelType: 'petrol',
+    transmission: 'manual',
+    volumetricEfficiency: 0.85,
+    odometerPidStrategy: 'psaUds',
+    inductionType: InductionType.turbocharged,
+    directInjection: true,
+  );
+
+  Future<Obd2Service> connect() async {
+    final transport = FakeObd2Transport({
+      ..._initResponses,
+      ..._speedDensityResponses,
+    });
+    final service = Obd2Service(transport);
+    await service.connect();
+    return service;
+  }
+
+  group('Obd2Service η_v engine-tech defaults (#1422 phase 1)', () {
+    test('manual override wins over the engine-tech helper', () async {
+      // User typed 0.78 into the calibration card. Even with a VNT
+      // diesel reference whose helper would say 0.95, the override wins.
+      final service = await connect();
+      const profile = VehicleProfile(
+        id: 'v',
+        name: 'Duster (manual override)',
+        engineDisplacementCc: 1461,
+        preferredFuelType: 'diesel',
+        manualVolumetricEfficiencyOverride: 0.78,
+      );
+
+      final rate = await service.readFuelRateLPerHour(
+        vehicle: profile,
+        referenceVehicle: dustnerDci,
+      );
+      final expected = estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1461,
+        volumetricEfficiency: 0.78,
+        afr: kDieselAfr,
+        fuelDensityGPerL: kDieselDensityGPerL,
+      );
+      expect(rate, isNotNull);
+      expect(rate, closeTo(expected!, 1e-3));
+    });
+
+    test(
+        'stored non-default profile value (e.g. 0.91) wins over the helper',
+        () async {
+      // Profile carries a non-default 0.91 — could be from VeLearner or
+      // a previous app version that wrote a derived value. The helper
+      // would say 0.93 for the turbo+DI 208 reference, but the stored
+      // user value is the source of truth once it diverges from 0.85.
+      final service = await connect();
+      const profile = VehicleProfile(
+        id: 'v',
+        name: '208 (stored non-default)',
+        engineDisplacementCc: 1199,
+        volumetricEfficiency: 0.91,
+        preferredFuelType: 'petrol',
+      );
+
+      final rate = await service.readFuelRateLPerHour(
+        vehicle: profile,
+        referenceVehicle: peugeot208,
+      );
+      final expected = estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1199,
+        volumetricEfficiency: 0.91,
+        afr: kPetrolAfr,
+        fuelDensityGPerL: kPetrolDensityGPerL,
+      );
+      expect(rate, closeTo(expected!, 1e-3));
+    });
+
+    test(
+        'stored learned value (samples > 0) wins even when equal to 0.85',
+        () async {
+      // VeLearner converged on 0.85 (rare but possible); samples > 0
+      // signals "this 0.85 is intentional". Don't override with helper.
+      final service = await connect();
+      const profile = VehicleProfile(
+        id: 'v',
+        name: 'Duster (VeLearner converged)',
+        engineDisplacementCc: 1461,
+        preferredFuelType: 'diesel',
+        // ignore: avoid_redundant_argument_values
+        volumetricEfficiency: 0.85,
+        volumetricEfficiencySamples: 3,
+      );
+
+      final rate = await service.readFuelRateLPerHour(
+        vehicle: profile,
+        referenceVehicle: dustnerDci,
+      );
+      final expected = estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1461,
+        volumetricEfficiency: 0.85,
+        afr: kDieselAfr,
+        fuelDensityGPerL: kDieselDensityGPerL,
+      );
+      expect(rate, closeTo(expected!, 1e-3));
+    });
+
+    test(
+        'cold-start profile (0.85, samples == 0) + VNT reference '
+        'falls through to helper 0.95 (the headline behaviour change)',
+        () async {
+      // The motivating case: a fresh user picks Dacia Duster dCi from
+      // the catalog, the wizard writes the VehicleProfile with the
+      // default 0.85 + 0 samples. Pre-#1422 the chain returned 0.85
+      // (the catalog literal). Post-#1422 the helper kicks in and
+      // returns 0.95.
+      final service = await connect();
+      const profile = VehicleProfile(
+        id: 'v',
+        name: 'Duster (cold-start)',
+        engineDisplacementCc: 1461,
+        preferredFuelType: 'diesel',
+        // VehicleProfile defaults: volumetricEfficiency = 0.85, samples = 0.
+      );
+
+      final rate = await service.readFuelRateLPerHour(
+        vehicle: profile,
+        referenceVehicle: dustnerDci,
+      );
+      final expected = estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1461,
+        volumetricEfficiency: 0.95, // helper, NOT catalog literal 0.85
+        afr: kDieselAfr,
+        fuelDensityGPerL: kDieselDensityGPerL,
+      );
+      expect(rate, isNotNull);
+      expect(expected, isNotNull);
+      expect(rate, closeTo(expected!, 1e-3));
+
+      // Sanity: the pre-#1422 path (0.85) would have produced an
+      // observably smaller rate. Pin the headline behaviour change.
+      final pre1422Rate = estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1461,
+        volumetricEfficiency: 0.85,
+        afr: kDieselAfr,
+        fuelDensityGPerL: kDieselDensityGPerL,
+      )!;
+      expect(rate! - pre1422Rate, greaterThan(0.0),
+          reason: '0.95 helper should produce a higher L/h than 0.85 '
+              'literal for the same MAP/IAT/RPM');
+    });
+
+    test(
+        'turbo + DI petrol reference cold-start resolves 0.93 not '
+        'catalog 0.85', () async {
+      // 1.2 PureTech pattern: catalog literal stays at 0.85 (intentional
+      // — VeLearner-converged users keep their values), but a fresh
+      // profile gets 0.93 from the helper.
+      final service = await connect();
+      const profile = VehicleProfile(
+        id: 'v',
+        name: '208 (cold-start)',
+        engineDisplacementCc: 1199,
+        preferredFuelType: 'petrol',
+      );
+      final rate = await service.readFuelRateLPerHour(
+        vehicle: profile,
+        referenceVehicle: peugeot208,
+      );
+      final expected = estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1199,
+        volumetricEfficiency: 0.93,
+        afr: kPetrolAfr,
+        fuelDensityGPerL: kPetrolDensityGPerL,
+      );
+      expect(rate, closeTo(expected!, 1e-3));
+    });
+
+    test(
+        'no reference vehicle resolved → kDefaultVolumetricEfficiency '
+        '0.85 hard fallback', () async {
+      // No catalog match (e.g. niche import). The helper has nothing
+      // to derive from, so the chain lands on the legacy 0.85 constant.
+      final service = await connect();
+      const profile = VehicleProfile(
+        id: 'v',
+        name: 'Niche import (no catalog match)',
+        engineDisplacementCc: 1500,
+        preferredFuelType: 'petrol',
+      );
+
+      final rate = await service.readFuelRateLPerHour(
+        vehicle: profile,
+        // No referenceVehicle.
+      );
+      final expected = estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1500,
+        volumetricEfficiency: kDefaultVolumetricEfficiency,
+        afr: kPetrolAfr,
+        fuelDensityGPerL: kPetrolDensityGPerL,
+      );
+      expect(rate, closeTo(expected!, 1e-3));
+    });
+
+    test(
+        'cold-start profile + atkinson reference resolves 0.70 '
+        '(Toyota Hybrid)', () async {
+      // Atkinson takes precedence over induction; a fresh Yaris HSD
+      // profile gets 0.70 not 0.85.
+      const yarisHybrid = ReferenceVehicle(
+        make: 'Toyota',
+        model: 'Yaris',
+        generation: 'IV (2020-)',
+        yearStart: 2020,
+        displacementCc: 1490,
+        fuelType: 'hybrid',
+        transmission: 'automatic',
+        volumetricEfficiency: 0.88,
+        atkinsonCycle: true,
+      );
+      final service = await connect();
+      const profile = VehicleProfile(
+        id: 'v',
+        name: 'Yaris HSD (cold-start)',
+        engineDisplacementCc: 1490,
+        preferredFuelType: 'petrol',
+      );
+
+      final rate = await service.readFuelRateLPerHour(
+        vehicle: profile,
+        referenceVehicle: yarisHybrid,
+      );
+      final expected = estimateFuelRateLPerHourFromMap(
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+        engineDisplacementCc: 1490,
+        volumetricEfficiency: 0.70,
+        afr: kPetrolAfr,
+        fuelDensityGPerL: kPetrolDensityGPerL,
+      );
+      expect(rate, closeTo(expected!, 1e-3));
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -829,7 +829,8 @@ void main() {
     );
 
     // VW Golf VIII — 1498 cc, vwUds. The VW odometer command is
-    // 222203 returning a 3-byte km value.
+    // 222203 returning a 3-byte km value. 1.5 TSI turbo DI engine —
+    // #1422 phase 1 helper derives 0.93 for this combo.
     const vwGolf = ReferenceVehicle(
       make: 'Volkswagen',
       model: 'Golf',
@@ -840,6 +841,8 @@ void main() {
       transmission: 'automatic',
       volumetricEfficiency: 0.87,
       odometerPidStrategy: 'vwUds',
+      inductionType: InductionType.turbocharged,
+      directInjection: true,
     );
 
     // Fictional vehicle the catalog does not cover. Phase 2 callers
@@ -929,7 +932,15 @@ void main() {
 
     test(
         'readFuelRateLPerHour with VW Golf ReferenceVehicle uses 1498 cc + '
-        '0.87 VE (catalog values, not 1000 cc / 0.85 default)', () async {
+        '0.93 VE (turbo+DI engine-tech default, not 1000 cc / 0.85 default)',
+        () async {
+      // #1422 phase 1 — when no VehicleProfile is supplied the chain
+      // now consults `defaultVolumetricEfficiency(referenceVehicle)`
+      // instead of the catalog `volumetricEfficiency` literal. The VW
+      // Golf VIII 1.5 TSI is turbocharged + direct-injected, so the
+      // helper returns 0.93 (not the literal 0.87 the catalog ships).
+      // A turbo+DI engine that runs at 0.85 is the bug #1422 was filed
+      // to fix; the regression test below pins the new behaviour.
       final transport = FakeObd2Transport({
         ..._initResponses,
         '015E': 'NO DATA>',
@@ -951,13 +962,13 @@ void main() {
         iatCelsius: 30,
         rpm: 2500,
         engineDisplacementCc: 1498,
-        volumetricEfficiency: 0.87,
+        volumetricEfficiency: 0.93,
       );
       expect(rate, isNotNull);
       expect(expected, isNotNull);
       expect(rate, closeTo(expected!, 1e-3));
 
-      // Sanity: 1498 cc / 0.87 VE must produce a clearly different
+      // Sanity: 1498 cc / 0.93 VE must produce a clearly different
       // rate from the 1000 cc / 0.85 generic default.
       final defaultRate = Obd2Service.estimateFuelRateLPerHourFromMap(
         mapKpa: 65,

--- a/test/features/vehicle/domain/entities/reference_vehicle_test.dart
+++ b/test/features/vehicle/domain/entities/reference_vehicle_test.dart
@@ -47,6 +47,167 @@ void main() {
       expect(restored.volumetricEfficiency, 0.85);
       expect(restored.odometerPidStrategy, 'stdA6');
       expect(restored.notes, isNull);
+      // #1422 phase 1 — engine-tech defaults round-trip.
+      expect(restored.inductionType, InductionType.naturallyAspirated);
+      expect(restored.directInjection, isFalse);
+      expect(restored.atkinsonCycle, isFalse);
+    });
+
+    group('engine-tech schema (#1422 phase 1)', () {
+      test('legacy JSON without new fields deserializes with defaults', () {
+        // Mirrors a row that pre-dates #1422: no inductionType, no
+        // directInjection, no atkinsonCycle keys at all.
+        final legacyJson = <String, dynamic>{
+          'make': 'Peugeot',
+          'model': '107',
+          'generation': 'I (2005-2014)',
+          'yearStart': 2005,
+          'yearEnd': 2014,
+          'displacementCc': 998,
+          'fuelType': 'petrol',
+          'transmission': 'manual',
+        };
+
+        final parsed = ReferenceVehicle.fromJson(legacyJson);
+        expect(parsed.inductionType, InductionType.naturallyAspirated);
+        expect(parsed.directInjection, isFalse);
+        expect(parsed.atkinsonCycle, isFalse);
+        // Helper falls through to the legacy 0.85 number for an
+        // NA + port-injection engine — bit-for-bit compat.
+        expect(defaultVolumetricEfficiency(parsed), 0.85);
+      });
+
+      test('VNT diesel + DI JSON round-trips correctly', () {
+        const original = ReferenceVehicle(
+          make: 'Dacia',
+          model: 'Duster',
+          generation: 'II dCi 115 (2017-2024)',
+          yearStart: 2017,
+          yearEnd: 2024,
+          displacementCc: 1461,
+          fuelType: 'diesel',
+          transmission: 'manual',
+          inductionType: InductionType.vnt,
+          directInjection: true,
+        );
+
+        final json = original.toJson();
+        expect(json['inductionType'], 'vnt');
+        expect(json['directInjection'], isTrue);
+        expect(json['atkinsonCycle'], isFalse);
+
+        final restored = ReferenceVehicle.fromJson(json);
+        expect(restored, equals(original));
+        expect(restored.inductionType, InductionType.vnt);
+        expect(restored.directInjection, isTrue);
+      });
+
+      test('every InductionType serializes to its expected string', () {
+        for (final entry in {
+          InductionType.naturallyAspirated: 'naturallyAspirated',
+          InductionType.turbocharged: 'turbocharged',
+          InductionType.supercharged: 'supercharged',
+          InductionType.vnt: 'vnt',
+        }.entries) {
+          final original = ReferenceVehicle(
+            make: 'X',
+            model: 'Y',
+            generation: 'I',
+            yearStart: 2020,
+            displacementCc: 1500,
+            fuelType: 'petrol',
+            transmission: 'manual',
+            inductionType: entry.key,
+          );
+          final json = original.toJson();
+          expect(json['inductionType'], entry.value,
+              reason: '${entry.key} serialization');
+
+          final restored = ReferenceVehicle.fromJson(json);
+          expect(restored.inductionType, entry.key);
+        }
+      });
+
+      test('atkinsonCycle round-trips when true', () {
+        const original = ReferenceVehicle(
+          make: 'Toyota',
+          model: 'Yaris',
+          generation: 'IV (2020-)',
+          yearStart: 2020,
+          displacementCc: 1490,
+          fuelType: 'hybrid',
+          transmission: 'automatic',
+          atkinsonCycle: true,
+        );
+        final restored = ReferenceVehicle.fromJson(original.toJson());
+        expect(restored.atkinsonCycle, isTrue);
+      });
+    });
+
+    group('defaultVolumetricEfficiency helper (#1422 phase 1)', () {
+      const baseRow = ReferenceVehicle(
+        make: 'X',
+        model: 'Y',
+        generation: 'I',
+        yearStart: 2020,
+        displacementCc: 1500,
+        fuelType: 'petrol',
+        transmission: 'manual',
+      );
+
+      test('atkinsonCycle short-circuits to 0.70 (Toyota HSD)', () {
+        // Atkinson takes precedence over induction + DI flags.
+        final v = baseRow.copyWith(
+          atkinsonCycle: true,
+          inductionType: InductionType.turbocharged,
+          directInjection: true,
+        );
+        expect(defaultVolumetricEfficiency(v), 0.70);
+      });
+
+      test('VNT induction returns 0.95 (modern common-rail diesel)', () {
+        final v = baseRow.copyWith(
+          inductionType: InductionType.vnt,
+          directInjection: true,
+        );
+        expect(defaultVolumetricEfficiency(v), 0.95);
+      });
+
+      test('turbo + DI returns 0.93', () {
+        final v = baseRow.copyWith(
+          inductionType: InductionType.turbocharged,
+          directInjection: true,
+        );
+        expect(defaultVolumetricEfficiency(v), 0.93);
+      });
+
+      test('supercharged + DI also returns 0.93', () {
+        final v = baseRow.copyWith(
+          inductionType: InductionType.supercharged,
+          directInjection: true,
+        );
+        expect(defaultVolumetricEfficiency(v), 0.93);
+      });
+
+      test('turbo + port injection returns 0.90', () {
+        final v = baseRow.copyWith(
+          inductionType: InductionType.turbocharged,
+        );
+        expect(defaultVolumetricEfficiency(v), 0.90);
+      });
+
+      test('NA + DI returns 0.88', () {
+        final v = baseRow.copyWith(
+          directInjection: true,
+        );
+        expect(defaultVolumetricEfficiency(v), 0.88);
+      });
+
+      test('NA + port injection returns 0.85 (legacy fallback)', () {
+        // Bit-for-bit compat with the pre-#1422 0.85 default — every
+        // catalog row that doesn't carry the new fields lands here.
+        expect(defaultVolumetricEfficiency(baseRow), 0.85);
+      });
     });
 
     group('coversYear', () {


### PR DESCRIPTION
## Summary

Phase 1 of #1422 (η_v engine-tech defaults). Ships sections A–D of the spec:

- `InductionType` enum (NA / turbocharged / supercharged / vnt) + 3 new fields on `ReferenceVehicle` (`inductionType`, `directInjection`, `atkinsonCycle`), all with `@Default` so legacy JSON deserializes unchanged
- `defaultVolumetricEfficiency(ReferenceVehicle)` helper covering all 5 paths from the spec table — Atkinson 0.70, VNT 0.95, turbo+DI 0.93, turbo NA 0.90, NA+DI 0.88, NA port-injection 0.85 (legacy fallback)
- Catalog backfill: 49 of 57 rows tagged with correct induction + DI + Atkinson flags (Dacia/Renault dCi → VNT+DI, Citroen/Peugeot BlueHDi + VW TDI → turbo+DI, VW TSI / Audi TFSI / Ford EcoBoost / PSA PureTech / etc. → turbo+DI petrol, Toyota Hybrid + Ford Kuga FHEV → Atkinson). The 8 untagged rows (Tesla EVs, Fiat 500/Panda atmospheric) keep the @Default NA + no DI behaviour, which the helper resolves to 0.85 — bit-for-bit compat with pre-#1422
- Resolution-chain wiring in both `Obd2Service.readFuelRateLPerHour` and `TripRecordingController._deriveFuelRateLPerHour`: the helper now takes precedence over `referenceVehicle.volumetricEfficiency` literal. Manual override + stored profile values that are non-default OR have `volumetricEfficiencySamples > 0` (VeLearner-converged) still win, so existing users see no regression
- `TripRecordingController` gained a `referenceVehicle` constructor parameter; `tripRecordingProvider.start` now matches the active profile against the bundled catalog via `VehicleProfileCatalogMatcher.bestMatch` and passes the result through

## Out of scope (phase 2)

Section E of the spec — `CalibrationSection` origin tag enrichment ("(catalog: VNT diesel + DI default)") — needs new ARB strings, deferred until competing PR #1421 unblocks l10n. Tracked in #1422.

## Test plan

- [x] All 5 helper paths covered with unit tests (`test/features/vehicle/domain/entities/reference_vehicle_test.dart`)
- [x] Legacy JSON (no new fields) deserializes with NA + no DI + no Atkinson defaults — backward-compat
- [x] All 57 catalog entries deserialize cleanly after backfill (asset round-trip test stays green)
- [x] Resolution-chain integration tests cover manual-override / stored-non-default / stored-learned (samples > 0) / cold-start helper-kicks-in / no-reference hard-fallback paths (`test/features/consumption/data/obd2/eta_v_resolution_chain_test.dart`)
- [x] User vehicle with default 0.85 + Dacia dCi reference now resolves to 0.95 (the headline behaviour change)
- [x] `obd2_service_test.dart` consumer test updated: VW Golf 1.5 TSI now resolves 0.93 (helper) instead of 0.87 (literal). Comment in the test calls out the new behaviour
- [x] All 804 obd2 tests + 616 vehicle tests + 150 consumption-provider tests green; lint suite clean
- [x] `flutter analyze` clean (0 issues)

Refs #1422