### PR TITLE
chore(profile): drop orphan UserProfile.showConsumptionTab field (Refs #1373 phase 3c)

### DIFF
--- a/lib/features/feature_management/application/legacy_toggle_migration_provider.dart
+++ b/lib/features/feature_management/application/legacy_toggle_migration_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../profile/data/models/user_profile.dart';
 import '../../profile/providers/profile_provider.dart';
 import '../data/legacy_toggle_migrator.dart';
 import 'feature_flags_provider.dart';
@@ -70,6 +71,14 @@ Future<void> legacyToggleMigration(Ref ref) async {
   final manifest = ref.read(featureManifestProvider);
   final activeProfile = ref.watch(activeProfileProvider);
 
+  // Phase 3c needs to write the active profile back through the
+  // repository so the freshly-serialised JSON drops the orphan
+  // `showConsumptionTab` key. Forward through ActiveProfile.updateProfile
+  // (not the raw repository) so the in-memory state stays in sync.
+  Future<void> saveActiveProfile(UserProfile profile) async {
+    await ref.read(activeProfileProvider.notifier).updateProfile(profile);
+  }
+
   // Defer the actual migration to the next microtask so this
   // provider's `build` returns fast and any synchronous reads of
   // [featureFlagsProvider] inside the same frame don't race the
@@ -86,6 +95,7 @@ Future<void> legacyToggleMigration(Ref ref) async {
         featureFlags: featureFlags,
         manifest: manifest,
         activeProfile: activeProfile,
+        saveActiveProfile: saveActiveProfile,
       );
     } catch (e, st) {
       // Failure is non-fatal — the central state stays at manifest

--- a/lib/features/feature_management/application/legacy_toggle_migration_provider.g.dart
+++ b/lib/features/feature_management/application/legacy_toggle_migration_provider.g.dart
@@ -144,4 +144,4 @@ final class LegacyToggleMigrationProvider
 }
 
 String _$legacyToggleMigrationHash() =>
-    r'28fd0649daf74093c0e9c3f9f0154f4a10fc5b0e';
+    r'f56d28476cf26cc102db777b9ad413103a99d2fb';

--- a/lib/features/feature_management/data/legacy_toggle_migrator.dart
+++ b/lib/features/feature_management/data/legacy_toggle_migrator.dart
@@ -48,6 +48,20 @@ const String syncBaselinesMigratedKey = 'syncBaselinesMigrated';
 /// vehicle bools continue to gate per-vehicle behaviour as before.
 const String autoRecordMigratedKey = 'autoRecordMigrated';
 
+/// Settings-box key written once after the orphan
+/// `UserProfile.showConsumptionTab` field has been stripped from the
+/// active profile's persisted JSON (#1373 phase 3c). This is NOT a
+/// promotion to a central feature — the field had zero consumers in
+/// `lib/` or `test/` (likely orphaned by #1342 when the
+/// carbon/Achievements tab was removed) so phase 3c is a pure
+/// deletion. The migrator step exists so an upgrading user with a
+/// persisted profile from before the field was deleted gets the
+/// orphan key cleared from disk on the next launch — without it the
+/// stale `showConsumptionTab: true` row would survive every
+/// re-serialisation as long as no other write path touched the
+/// profile.
+const String showConsumptionTabDroppedKey = 'showConsumptionTabDropped';
+
 /// One-shot migrator that promotes legacy scattered toggles into the
 /// central [FeatureFlagsRepository] (#1373 phase 3a).
 ///
@@ -104,6 +118,8 @@ const String autoRecordMigratedKey = 'autoRecordMigrated';
 ///   - 3a hapticEcoCoach (settings-box, default-false) ✅
 ///   - 3b gamification (UserProfile, default-true) ✅ via
 ///     [migrateUserProfileToggles]
+///   - 3c showConsumptionTab (UserProfile, ORPHAN deletion — not a
+///     central-feature migration) ✅ via [migrateUserProfileToggles]
 ///   - 3f unifiedSearchResults (settings-box, default-false) ✅
 ///   - 3e syncBaselines (settings-box, default-false) ✅
 ///   - 3d autoRecord (per-vehicle, default-true, WRAP not replace) ✅
@@ -140,7 +156,7 @@ Future<void> migrateLegacyToggles({
 }
 
 /// One-shot migrator for UserProfile-backed legacy toggles (#1373
-/// phase 3b).
+/// phase 3b + 3c).
 ///
 /// Reads the legacy [UserProfile.gamificationEnabled] value from the
 /// passed-in [activeProfile]. The migrator is a no-op when [activeProfile]
@@ -160,6 +176,24 @@ Future<void> migrateLegacyToggles({
 /// In both cases the [gamificationMigratedKey] gate is then set so
 /// subsequent runs are no-ops.
 ///
+/// Phase 3c additionally drops the orphan
+/// `UserProfile.showConsumptionTab` field. Because the field has zero
+/// consumers in `lib/` or `test/` (likely orphaned by #1342 when the
+/// carbon/Achievements tab was removed) phase 3c is a pure deletion,
+/// NOT a Feature-flag promotion. The drop step calls [saveActiveProfile]
+/// once per upgrading user so the freshly-serialised profile JSON no
+/// longer carries the orphan key. The Freezed `@Default` removal alone
+/// would handle deserialisation (an unknown key is silently ignored)
+/// but a re-serialise path that read-then-wrote the profile would
+/// preserve the stale row indefinitely; the explicit save closes that
+/// window. Idempotent via [showConsumptionTabDroppedKey].
+///
+/// [saveActiveProfile] is optional — when null (e.g. unit tests that
+/// don't wire the profile repository) the drop step still records the
+/// gate flag and returns. Production wires it to
+/// `ActiveProfile.updateProfile` via the
+/// `legacyToggleMigrationProvider`.
+///
 /// Safe to call alongside [migrateLegacyToggles] from the same provider
 /// (see `legacyToggleMigrationProvider`). The two functions touch
 /// disjoint settings-box keys.
@@ -168,12 +202,18 @@ Future<void> migrateUserProfileToggles({
   required FeatureFlagsRepository featureFlags,
   required FeatureManifest manifest,
   required UserProfile? activeProfile,
+  Future<void> Function(UserProfile profile)? saveActiveProfile,
 }) async {
   await _migrateGamification(
     settings: settings,
     featureFlags: featureFlags,
     manifest: manifest,
     activeProfile: activeProfile,
+  );
+  await _dropShowConsumptionTab(
+    settings: settings,
+    activeProfile: activeProfile,
+    saveActiveProfile: saveActiveProfile,
   );
 }
 
@@ -500,6 +540,87 @@ Future<void> _migrateAutoRecord({
   } catch (e, st) {
     debugPrint(
       'migrateLegacyToggles: writing $autoRecordMigratedKey failed: $e\n$st',
+    );
+  }
+}
+
+/// Phase-3c orphan deletion of the `UserProfile.showConsumptionTab`
+/// field (#1373 phase 3c).
+///
+/// The field had zero consumers in `lib/` or `test/` — likely orphaned
+/// by #1342 when the carbon/Achievements tab was removed — so this is
+/// a pure deletion, NOT a Feature-flag promotion. The Freezed
+/// `@Default` removal alone handles deserialisation (an unknown JSON
+/// key is silently ignored on read), but a re-serialise path that
+/// reads then writes the profile would preserve the stale
+/// `showConsumptionTab: true` row indefinitely. To close that window
+/// the migrator saves the active profile back via [saveActiveProfile]
+/// once on the upgrading user's first launch — the freshly serialised
+/// JSON does not contain the dropped key.
+///
+/// Idempotent — gated on [showConsumptionTabDroppedKey]. The flag is
+/// written even when [activeProfile] is null but only AFTER a
+/// successful save; an absent active profile defers the work to the
+/// next launch (mirrors the gamification step's null-profile handling).
+Future<void> _dropShowConsumptionTab({
+  required Box<dynamic> settings,
+  required UserProfile? activeProfile,
+  required Future<void> Function(UserProfile profile)? saveActiveProfile,
+}) async {
+  // Already dropped → idempotent no-op. Subsequent runs must not
+  // re-save the profile (a no-op write is cheap but unnecessary, and
+  // forwarding through the repository invalidates Riverpod listeners
+  // that re-fetch the profile every launch otherwise).
+  if (settings.get(showConsumptionTabDroppedKey) == true) {
+    return;
+  }
+
+  // No profile loaded yet → defer to next launch. We deliberately do
+  // NOT write the gate flag because that would skip the drop on the
+  // launch where the profile IS available, leaving the orphan key on
+  // disk forever.
+  if (activeProfile == null) {
+    return;
+  }
+
+  // No saver wired (e.g. unit tests that don't depend on the profile
+  // repository). Set the flag anyway so the test environment doesn't
+  // re-enter this branch on every provider rebuild.
+  if (saveActiveProfile == null) {
+    try {
+      await settings.put(showConsumptionTabDroppedKey, true);
+    } catch (e, st) {
+      debugPrint(
+        'migrateUserProfileToggles: writing $showConsumptionTabDroppedKey '
+        'failed: $e\n$st',
+      );
+    }
+    return;
+  }
+
+  try {
+    // Re-saving the same profile object writes a freshly serialised
+    // JSON map. After the field deletion `toJson()` no longer emits
+    // the orphan key, so persistence drops it for good.
+    await saveActiveProfile(activeProfile);
+  } catch (e, st) {
+    // Don't block startup on a save failure — the orphan key is inert
+    // (no consumer reads it) so leaving it for the next launch to
+    // retry is harmless. We deliberately DO NOT set the gate flag in
+    // this branch so the next launch tries again.
+    debugPrint(
+      'migrateUserProfileToggles: showConsumptionTab drop save failed: '
+      '$e\n$st',
+    );
+    return;
+  }
+
+  try {
+    await settings.put(showConsumptionTabDroppedKey, true);
+  } catch (e, st) {
+    debugPrint(
+      'migrateUserProfileToggles: writing $showConsumptionTabDroppedKey '
+      'failed: $e\n$st',
     );
   }
 }

--- a/lib/features/profile/data/models/user_profile.dart
+++ b/lib/features/profile/data/models/user_profile.dart
@@ -65,12 +65,6 @@ abstract class UserProfile with _$UserProfile {
     /// combustion fuel, they treat it like a petrol/diesel car.
     /// Defaults to null so existing profiles don't need migration.
     @FuelTypeJsonConverter() FuelType? hybridFuelChoice,
-    /// Opt-in visibility of the Consumption tab in the bottom nav
-    /// (#701). The tab stays hidden unless this is true AND at least
-    /// one vehicle is configured — the log is vehicle-centric and a
-    /// first-time user without a vehicle would only see the empty
-    /// state.
-    @Default(false) bool showConsumptionTab,
     /// Master toggle for gamification surfaces (#1194). Defaults to
     /// true so existing users see no behaviour change. When flipped
     /// off, badges, scores, achievement tabs, and trophy iconography

--- a/lib/features/profile/data/models/user_profile.freezed.dart
+++ b/lib/features/profile/data/models/user_profile.freezed.dart
@@ -30,12 +30,7 @@ mixin _$UserProfile {
 /// + station filters treat a hybrid like an EV; when set to any
 /// combustion fuel, they treat it like a petrol/diesel car.
 /// Defaults to null so existing profiles don't need migration.
-@FuelTypeJsonConverter() FuelType? get hybridFuelChoice;/// Opt-in visibility of the Consumption tab in the bottom nav
-/// (#701). The tab stays hidden unless this is true AND at least
-/// one vehicle is configured — the log is vehicle-centric and a
-/// first-time user without a vehicle would only see the empty
-/// state.
- bool get showConsumptionTab;/// Master toggle for gamification surfaces (#1194). Defaults to
+@FuelTypeJsonConverter() FuelType? get hybridFuelChoice;/// Master toggle for gamification surfaces (#1194). Defaults to
 /// true so existing users see no behaviour change. When flipped
 /// off, badges, scores, achievement tabs, and trophy iconography
 /// are hidden across the app — the underlying achievement
@@ -54,16 +49,16 @@ $UserProfileCopyWith<UserProfile> get copyWith => _$UserProfileCopyWithImpl<User
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.defaultSearchRadius, defaultSearchRadius) || other.defaultSearchRadius == defaultSearchRadius)&&(identical(other.landingScreen, landingScreen) || other.landingScreen == landingScreen)&&const DeepCollectionEquality().equals(other.favoriteStationIds, favoriteStationIds)&&(identical(other.homeZipCode, homeZipCode) || other.homeZipCode == homeZipCode)&&(identical(other.autoUpdatePosition, autoUpdatePosition) || other.autoUpdatePosition == autoUpdatePosition)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.languageCode, languageCode) || other.languageCode == languageCode)&&(identical(other.routeSegmentKm, routeSegmentKm) || other.routeSegmentKm == routeSegmentKm)&&(identical(other.avoidHighways, avoidHighways) || other.avoidHighways == avoidHighways)&&(identical(other.showFuel, showFuel) || other.showFuel == showFuel)&&(identical(other.showElectric, showElectric) || other.showElectric == showElectric)&&(identical(other.ratingMode, ratingMode) || other.ratingMode == ratingMode)&&const DeepCollectionEquality().equals(other.preferredAmenities, preferredAmenities)&&(identical(other.defaultVehicleId, defaultVehicleId) || other.defaultVehicleId == defaultVehicleId)&&(identical(other.hybridFuelChoice, hybridFuelChoice) || other.hybridFuelChoice == hybridFuelChoice)&&(identical(other.showConsumptionTab, showConsumptionTab) || other.showConsumptionTab == showConsumptionTab)&&(identical(other.gamificationEnabled, gamificationEnabled) || other.gamificationEnabled == gamificationEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.defaultSearchRadius, defaultSearchRadius) || other.defaultSearchRadius == defaultSearchRadius)&&(identical(other.landingScreen, landingScreen) || other.landingScreen == landingScreen)&&const DeepCollectionEquality().equals(other.favoriteStationIds, favoriteStationIds)&&(identical(other.homeZipCode, homeZipCode) || other.homeZipCode == homeZipCode)&&(identical(other.autoUpdatePosition, autoUpdatePosition) || other.autoUpdatePosition == autoUpdatePosition)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.languageCode, languageCode) || other.languageCode == languageCode)&&(identical(other.routeSegmentKm, routeSegmentKm) || other.routeSegmentKm == routeSegmentKm)&&(identical(other.avoidHighways, avoidHighways) || other.avoidHighways == avoidHighways)&&(identical(other.showFuel, showFuel) || other.showFuel == showFuel)&&(identical(other.showElectric, showElectric) || other.showElectric == showElectric)&&(identical(other.ratingMode, ratingMode) || other.ratingMode == ratingMode)&&const DeepCollectionEquality().equals(other.preferredAmenities, preferredAmenities)&&(identical(other.defaultVehicleId, defaultVehicleId) || other.defaultVehicleId == defaultVehicleId)&&(identical(other.hybridFuelChoice, hybridFuelChoice) || other.hybridFuelChoice == hybridFuelChoice)&&(identical(other.gamificationEnabled, gamificationEnabled) || other.gamificationEnabled == gamificationEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,preferredFuelType,defaultSearchRadius,landingScreen,const DeepCollectionEquality().hash(favoriteStationIds),homeZipCode,autoUpdatePosition,countryCode,languageCode,routeSegmentKm,avoidHighways,showFuel,showElectric,ratingMode,const DeepCollectionEquality().hash(preferredAmenities),defaultVehicleId,hybridFuelChoice,showConsumptionTab,gamificationEnabled]);
+int get hashCode => Object.hashAll([runtimeType,id,name,preferredFuelType,defaultSearchRadius,landingScreen,const DeepCollectionEquality().hash(favoriteStationIds),homeZipCode,autoUpdatePosition,countryCode,languageCode,routeSegmentKm,avoidHighways,showFuel,showElectric,ratingMode,const DeepCollectionEquality().hash(preferredAmenities),defaultVehicleId,hybridFuelChoice,gamificationEnabled]);
 
 @override
 String toString() {
-  return 'UserProfile(id: $id, name: $name, preferredFuelType: $preferredFuelType, defaultSearchRadius: $defaultSearchRadius, landingScreen: $landingScreen, favoriteStationIds: $favoriteStationIds, homeZipCode: $homeZipCode, autoUpdatePosition: $autoUpdatePosition, countryCode: $countryCode, languageCode: $languageCode, routeSegmentKm: $routeSegmentKm, avoidHighways: $avoidHighways, showFuel: $showFuel, showElectric: $showElectric, ratingMode: $ratingMode, preferredAmenities: $preferredAmenities, defaultVehicleId: $defaultVehicleId, hybridFuelChoice: $hybridFuelChoice, showConsumptionTab: $showConsumptionTab, gamificationEnabled: $gamificationEnabled)';
+  return 'UserProfile(id: $id, name: $name, preferredFuelType: $preferredFuelType, defaultSearchRadius: $defaultSearchRadius, landingScreen: $landingScreen, favoriteStationIds: $favoriteStationIds, homeZipCode: $homeZipCode, autoUpdatePosition: $autoUpdatePosition, countryCode: $countryCode, languageCode: $languageCode, routeSegmentKm: $routeSegmentKm, avoidHighways: $avoidHighways, showFuel: $showFuel, showElectric: $showElectric, ratingMode: $ratingMode, preferredAmenities: $preferredAmenities, defaultVehicleId: $defaultVehicleId, hybridFuelChoice: $hybridFuelChoice, gamificationEnabled: $gamificationEnabled)';
 }
 
 
@@ -74,7 +69,7 @@ abstract mixin class $UserProfileCopyWith<$Res>  {
   factory $UserProfileCopyWith(UserProfile value, $Res Function(UserProfile) _then) = _$UserProfileCopyWithImpl;
 @useResult
 $Res call({
- String id, String name,@FuelTypeJsonConverter() FuelType preferredFuelType, double defaultSearchRadius, LandingScreen landingScreen, List<String> favoriteStationIds, String? homeZipCode, bool autoUpdatePosition, String? countryCode, String? languageCode, double routeSegmentKm, bool avoidHighways, bool showFuel, bool showElectric, String ratingMode, List<StationAmenity> preferredAmenities, String? defaultVehicleId,@FuelTypeJsonConverter() FuelType? hybridFuelChoice, bool showConsumptionTab,@Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') bool gamificationEnabled
+ String id, String name,@FuelTypeJsonConverter() FuelType preferredFuelType, double defaultSearchRadius, LandingScreen landingScreen, List<String> favoriteStationIds, String? homeZipCode, bool autoUpdatePosition, String? countryCode, String? languageCode, double routeSegmentKm, bool avoidHighways, bool showFuel, bool showElectric, String ratingMode, List<StationAmenity> preferredAmenities, String? defaultVehicleId,@FuelTypeJsonConverter() FuelType? hybridFuelChoice,@Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') bool gamificationEnabled
 });
 
 
@@ -91,7 +86,7 @@ class _$UserProfileCopyWithImpl<$Res>
 
 /// Create a copy of UserProfile
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? preferredFuelType = null,Object? defaultSearchRadius = null,Object? landingScreen = null,Object? favoriteStationIds = null,Object? homeZipCode = freezed,Object? autoUpdatePosition = null,Object? countryCode = freezed,Object? languageCode = freezed,Object? routeSegmentKm = null,Object? avoidHighways = null,Object? showFuel = null,Object? showElectric = null,Object? ratingMode = null,Object? preferredAmenities = null,Object? defaultVehicleId = freezed,Object? hybridFuelChoice = freezed,Object? showConsumptionTab = null,Object? gamificationEnabled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? preferredFuelType = null,Object? defaultSearchRadius = null,Object? landingScreen = null,Object? favoriteStationIds = null,Object? homeZipCode = freezed,Object? autoUpdatePosition = null,Object? countryCode = freezed,Object? languageCode = freezed,Object? routeSegmentKm = null,Object? avoidHighways = null,Object? showFuel = null,Object? showElectric = null,Object? ratingMode = null,Object? preferredAmenities = null,Object? defaultVehicleId = freezed,Object? hybridFuelChoice = freezed,Object? gamificationEnabled = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -111,8 +106,7 @@ as bool,ratingMode: null == ratingMode ? _self.ratingMode : ratingMode // ignore
 as String,preferredAmenities: null == preferredAmenities ? _self.preferredAmenities : preferredAmenities // ignore: cast_nullable_to_non_nullable
 as List<StationAmenity>,defaultVehicleId: freezed == defaultVehicleId ? _self.defaultVehicleId : defaultVehicleId // ignore: cast_nullable_to_non_nullable
 as String?,hybridFuelChoice: freezed == hybridFuelChoice ? _self.hybridFuelChoice : hybridFuelChoice // ignore: cast_nullable_to_non_nullable
-as FuelType?,showConsumptionTab: null == showConsumptionTab ? _self.showConsumptionTab : showConsumptionTab // ignore: cast_nullable_to_non_nullable
-as bool,gamificationEnabled: null == gamificationEnabled ? _self.gamificationEnabled : gamificationEnabled // ignore: cast_nullable_to_non_nullable
+as FuelType?,gamificationEnabled: null == gamificationEnabled ? _self.gamificationEnabled : gamificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -198,10 +192,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice,  bool showConsumptionTab, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.')  bool gamificationEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.')  bool gamificationEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _UserProfile() when $default != null:
-return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchRadius,_that.landingScreen,_that.favoriteStationIds,_that.homeZipCode,_that.autoUpdatePosition,_that.countryCode,_that.languageCode,_that.routeSegmentKm,_that.avoidHighways,_that.showFuel,_that.showElectric,_that.ratingMode,_that.preferredAmenities,_that.defaultVehicleId,_that.hybridFuelChoice,_that.showConsumptionTab,_that.gamificationEnabled);case _:
+return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchRadius,_that.landingScreen,_that.favoriteStationIds,_that.homeZipCode,_that.autoUpdatePosition,_that.countryCode,_that.languageCode,_that.routeSegmentKm,_that.avoidHighways,_that.showFuel,_that.showElectric,_that.ratingMode,_that.preferredAmenities,_that.defaultVehicleId,_that.hybridFuelChoice,_that.gamificationEnabled);case _:
   return orElse();
 
 }
@@ -219,10 +213,10 @@ return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchR
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice,  bool showConsumptionTab, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.')  bool gamificationEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.')  bool gamificationEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _UserProfile():
-return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchRadius,_that.landingScreen,_that.favoriteStationIds,_that.homeZipCode,_that.autoUpdatePosition,_that.countryCode,_that.languageCode,_that.routeSegmentKm,_that.avoidHighways,_that.showFuel,_that.showElectric,_that.ratingMode,_that.preferredAmenities,_that.defaultVehicleId,_that.hybridFuelChoice,_that.showConsumptionTab,_that.gamificationEnabled);case _:
+return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchRadius,_that.landingScreen,_that.favoriteStationIds,_that.homeZipCode,_that.autoUpdatePosition,_that.countryCode,_that.languageCode,_that.routeSegmentKm,_that.avoidHighways,_that.showFuel,_that.showElectric,_that.ratingMode,_that.preferredAmenities,_that.defaultVehicleId,_that.hybridFuelChoice,_that.gamificationEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -239,10 +233,10 @@ return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchR
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice,  bool showConsumptionTab, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.')  bool gamificationEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @FuelTypeJsonConverter()  FuelType preferredFuelType,  double defaultSearchRadius,  LandingScreen landingScreen,  List<String> favoriteStationIds,  String? homeZipCode,  bool autoUpdatePosition,  String? countryCode,  String? languageCode,  double routeSegmentKm,  bool avoidHighways,  bool showFuel,  bool showElectric,  String ratingMode,  List<StationAmenity> preferredAmenities,  String? defaultVehicleId, @FuelTypeJsonConverter()  FuelType? hybridFuelChoice, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.')  bool gamificationEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _UserProfile() when $default != null:
-return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchRadius,_that.landingScreen,_that.favoriteStationIds,_that.homeZipCode,_that.autoUpdatePosition,_that.countryCode,_that.languageCode,_that.routeSegmentKm,_that.avoidHighways,_that.showFuel,_that.showElectric,_that.ratingMode,_that.preferredAmenities,_that.defaultVehicleId,_that.hybridFuelChoice,_that.showConsumptionTab,_that.gamificationEnabled);case _:
+return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchRadius,_that.landingScreen,_that.favoriteStationIds,_that.homeZipCode,_that.autoUpdatePosition,_that.countryCode,_that.languageCode,_that.routeSegmentKm,_that.avoidHighways,_that.showFuel,_that.showElectric,_that.ratingMode,_that.preferredAmenities,_that.defaultVehicleId,_that.hybridFuelChoice,_that.gamificationEnabled);case _:
   return null;
 
 }
@@ -254,7 +248,7 @@ return $default(_that.id,_that.name,_that.preferredFuelType,_that.defaultSearchR
 @JsonSerializable()
 
 class _UserProfile implements UserProfile {
-  const _UserProfile({required this.id, required this.name, @FuelTypeJsonConverter() this.preferredFuelType = FuelType.e10, this.defaultSearchRadius = 10.0, this.landingScreen = LandingScreen.nearest, final  List<String> favoriteStationIds = const [], this.homeZipCode, this.autoUpdatePosition = false, this.countryCode, this.languageCode, this.routeSegmentKm = 50.0, this.avoidHighways = false, this.showFuel = true, this.showElectric = true, this.ratingMode = 'local', final  List<StationAmenity> preferredAmenities = const [], this.defaultVehicleId, @FuelTypeJsonConverter() this.hybridFuelChoice, this.showConsumptionTab = false, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') this.gamificationEnabled = true}): _favoriteStationIds = favoriteStationIds,_preferredAmenities = preferredAmenities;
+  const _UserProfile({required this.id, required this.name, @FuelTypeJsonConverter() this.preferredFuelType = FuelType.e10, this.defaultSearchRadius = 10.0, this.landingScreen = LandingScreen.nearest, final  List<String> favoriteStationIds = const [], this.homeZipCode, this.autoUpdatePosition = false, this.countryCode, this.languageCode, this.routeSegmentKm = 50.0, this.avoidHighways = false, this.showFuel = true, this.showElectric = true, this.ratingMode = 'local', final  List<StationAmenity> preferredAmenities = const [], this.defaultVehicleId, @FuelTypeJsonConverter() this.hybridFuelChoice, @Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') this.gamificationEnabled = true}): _favoriteStationIds = favoriteStationIds,_preferredAmenities = preferredAmenities;
   factory _UserProfile.fromJson(Map<String, dynamic> json) => _$UserProfileFromJson(json);
 
 @override final  String id;
@@ -304,12 +298,6 @@ class _UserProfile implements UserProfile {
 /// combustion fuel, they treat it like a petrol/diesel car.
 /// Defaults to null so existing profiles don't need migration.
 @override@FuelTypeJsonConverter() final  FuelType? hybridFuelChoice;
-/// Opt-in visibility of the Consumption tab in the bottom nav
-/// (#701). The tab stays hidden unless this is true AND at least
-/// one vehicle is configured — the log is vehicle-centric and a
-/// first-time user without a vehicle would only see the empty
-/// state.
-@override@JsonKey() final  bool showConsumptionTab;
 /// Master toggle for gamification surfaces (#1194). Defaults to
 /// true so existing users see no behaviour change. When flipped
 /// off, badges, scores, achievement tabs, and trophy iconography
@@ -331,16 +319,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.defaultSearchRadius, defaultSearchRadius) || other.defaultSearchRadius == defaultSearchRadius)&&(identical(other.landingScreen, landingScreen) || other.landingScreen == landingScreen)&&const DeepCollectionEquality().equals(other._favoriteStationIds, _favoriteStationIds)&&(identical(other.homeZipCode, homeZipCode) || other.homeZipCode == homeZipCode)&&(identical(other.autoUpdatePosition, autoUpdatePosition) || other.autoUpdatePosition == autoUpdatePosition)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.languageCode, languageCode) || other.languageCode == languageCode)&&(identical(other.routeSegmentKm, routeSegmentKm) || other.routeSegmentKm == routeSegmentKm)&&(identical(other.avoidHighways, avoidHighways) || other.avoidHighways == avoidHighways)&&(identical(other.showFuel, showFuel) || other.showFuel == showFuel)&&(identical(other.showElectric, showElectric) || other.showElectric == showElectric)&&(identical(other.ratingMode, ratingMode) || other.ratingMode == ratingMode)&&const DeepCollectionEquality().equals(other._preferredAmenities, _preferredAmenities)&&(identical(other.defaultVehicleId, defaultVehicleId) || other.defaultVehicleId == defaultVehicleId)&&(identical(other.hybridFuelChoice, hybridFuelChoice) || other.hybridFuelChoice == hybridFuelChoice)&&(identical(other.showConsumptionTab, showConsumptionTab) || other.showConsumptionTab == showConsumptionTab)&&(identical(other.gamificationEnabled, gamificationEnabled) || other.gamificationEnabled == gamificationEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.preferredFuelType, preferredFuelType) || other.preferredFuelType == preferredFuelType)&&(identical(other.defaultSearchRadius, defaultSearchRadius) || other.defaultSearchRadius == defaultSearchRadius)&&(identical(other.landingScreen, landingScreen) || other.landingScreen == landingScreen)&&const DeepCollectionEquality().equals(other._favoriteStationIds, _favoriteStationIds)&&(identical(other.homeZipCode, homeZipCode) || other.homeZipCode == homeZipCode)&&(identical(other.autoUpdatePosition, autoUpdatePosition) || other.autoUpdatePosition == autoUpdatePosition)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.languageCode, languageCode) || other.languageCode == languageCode)&&(identical(other.routeSegmentKm, routeSegmentKm) || other.routeSegmentKm == routeSegmentKm)&&(identical(other.avoidHighways, avoidHighways) || other.avoidHighways == avoidHighways)&&(identical(other.showFuel, showFuel) || other.showFuel == showFuel)&&(identical(other.showElectric, showElectric) || other.showElectric == showElectric)&&(identical(other.ratingMode, ratingMode) || other.ratingMode == ratingMode)&&const DeepCollectionEquality().equals(other._preferredAmenities, _preferredAmenities)&&(identical(other.defaultVehicleId, defaultVehicleId) || other.defaultVehicleId == defaultVehicleId)&&(identical(other.hybridFuelChoice, hybridFuelChoice) || other.hybridFuelChoice == hybridFuelChoice)&&(identical(other.gamificationEnabled, gamificationEnabled) || other.gamificationEnabled == gamificationEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,preferredFuelType,defaultSearchRadius,landingScreen,const DeepCollectionEquality().hash(_favoriteStationIds),homeZipCode,autoUpdatePosition,countryCode,languageCode,routeSegmentKm,avoidHighways,showFuel,showElectric,ratingMode,const DeepCollectionEquality().hash(_preferredAmenities),defaultVehicleId,hybridFuelChoice,showConsumptionTab,gamificationEnabled]);
+int get hashCode => Object.hashAll([runtimeType,id,name,preferredFuelType,defaultSearchRadius,landingScreen,const DeepCollectionEquality().hash(_favoriteStationIds),homeZipCode,autoUpdatePosition,countryCode,languageCode,routeSegmentKm,avoidHighways,showFuel,showElectric,ratingMode,const DeepCollectionEquality().hash(_preferredAmenities),defaultVehicleId,hybridFuelChoice,gamificationEnabled]);
 
 @override
 String toString() {
-  return 'UserProfile(id: $id, name: $name, preferredFuelType: $preferredFuelType, defaultSearchRadius: $defaultSearchRadius, landingScreen: $landingScreen, favoriteStationIds: $favoriteStationIds, homeZipCode: $homeZipCode, autoUpdatePosition: $autoUpdatePosition, countryCode: $countryCode, languageCode: $languageCode, routeSegmentKm: $routeSegmentKm, avoidHighways: $avoidHighways, showFuel: $showFuel, showElectric: $showElectric, ratingMode: $ratingMode, preferredAmenities: $preferredAmenities, defaultVehicleId: $defaultVehicleId, hybridFuelChoice: $hybridFuelChoice, showConsumptionTab: $showConsumptionTab, gamificationEnabled: $gamificationEnabled)';
+  return 'UserProfile(id: $id, name: $name, preferredFuelType: $preferredFuelType, defaultSearchRadius: $defaultSearchRadius, landingScreen: $landingScreen, favoriteStationIds: $favoriteStationIds, homeZipCode: $homeZipCode, autoUpdatePosition: $autoUpdatePosition, countryCode: $countryCode, languageCode: $languageCode, routeSegmentKm: $routeSegmentKm, avoidHighways: $avoidHighways, showFuel: $showFuel, showElectric: $showElectric, ratingMode: $ratingMode, preferredAmenities: $preferredAmenities, defaultVehicleId: $defaultVehicleId, hybridFuelChoice: $hybridFuelChoice, gamificationEnabled: $gamificationEnabled)';
 }
 
 
@@ -351,7 +339,7 @@ abstract mixin class _$UserProfileCopyWith<$Res> implements $UserProfileCopyWith
   factory _$UserProfileCopyWith(_UserProfile value, $Res Function(_UserProfile) _then) = __$UserProfileCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name,@FuelTypeJsonConverter() FuelType preferredFuelType, double defaultSearchRadius, LandingScreen landingScreen, List<String> favoriteStationIds, String? homeZipCode, bool autoUpdatePosition, String? countryCode, String? languageCode, double routeSegmentKm, bool avoidHighways, bool showFuel, bool showElectric, String ratingMode, List<StationAmenity> preferredAmenities, String? defaultVehicleId,@FuelTypeJsonConverter() FuelType? hybridFuelChoice, bool showConsumptionTab,@Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') bool gamificationEnabled
+ String id, String name,@FuelTypeJsonConverter() FuelType preferredFuelType, double defaultSearchRadius, LandingScreen landingScreen, List<String> favoriteStationIds, String? homeZipCode, bool autoUpdatePosition, String? countryCode, String? languageCode, double routeSegmentKm, bool avoidHighways, bool showFuel, bool showElectric, String ratingMode, List<StationAmenity> preferredAmenities, String? defaultVehicleId,@FuelTypeJsonConverter() FuelType? hybridFuelChoice,@Deprecated('Migrated to Feature.gamification in #1373 phase 3b; kept for one-shot migration read.') bool gamificationEnabled
 });
 
 
@@ -368,7 +356,7 @@ class __$UserProfileCopyWithImpl<$Res>
 
 /// Create a copy of UserProfile
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? preferredFuelType = null,Object? defaultSearchRadius = null,Object? landingScreen = null,Object? favoriteStationIds = null,Object? homeZipCode = freezed,Object? autoUpdatePosition = null,Object? countryCode = freezed,Object? languageCode = freezed,Object? routeSegmentKm = null,Object? avoidHighways = null,Object? showFuel = null,Object? showElectric = null,Object? ratingMode = null,Object? preferredAmenities = null,Object? defaultVehicleId = freezed,Object? hybridFuelChoice = freezed,Object? showConsumptionTab = null,Object? gamificationEnabled = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? preferredFuelType = null,Object? defaultSearchRadius = null,Object? landingScreen = null,Object? favoriteStationIds = null,Object? homeZipCode = freezed,Object? autoUpdatePosition = null,Object? countryCode = freezed,Object? languageCode = freezed,Object? routeSegmentKm = null,Object? avoidHighways = null,Object? showFuel = null,Object? showElectric = null,Object? ratingMode = null,Object? preferredAmenities = null,Object? defaultVehicleId = freezed,Object? hybridFuelChoice = freezed,Object? gamificationEnabled = null,}) {
   return _then(_UserProfile(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -388,8 +376,7 @@ as bool,ratingMode: null == ratingMode ? _self.ratingMode : ratingMode // ignore
 as String,preferredAmenities: null == preferredAmenities ? _self._preferredAmenities : preferredAmenities // ignore: cast_nullable_to_non_nullable
 as List<StationAmenity>,defaultVehicleId: freezed == defaultVehicleId ? _self.defaultVehicleId : defaultVehicleId // ignore: cast_nullable_to_non_nullable
 as String?,hybridFuelChoice: freezed == hybridFuelChoice ? _self.hybridFuelChoice : hybridFuelChoice // ignore: cast_nullable_to_non_nullable
-as FuelType?,showConsumptionTab: null == showConsumptionTab ? _self.showConsumptionTab : showConsumptionTab // ignore: cast_nullable_to_non_nullable
-as bool,gamificationEnabled: null == gamificationEnabled ? _self.gamificationEnabled : gamificationEnabled // ignore: cast_nullable_to_non_nullable
+as FuelType?,gamificationEnabled: null == gamificationEnabled ? _self.gamificationEnabled : gamificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/lib/features/profile/data/models/user_profile.g.dart
+++ b/lib/features/profile/data/models/user_profile.g.dart
@@ -43,7 +43,6 @@ _UserProfile _$UserProfileFromJson(Map<String, dynamic> json) => _UserProfile(
     json['hybridFuelChoice'],
     const FuelTypeJsonConverter().fromJson,
   ),
-  showConsumptionTab: json['showConsumptionTab'] as bool? ?? false,
   gamificationEnabled: json['gamificationEnabled'] as bool? ?? true,
 );
 
@@ -74,7 +73,6 @@ Map<String, dynamic> _$UserProfileToJson(_UserProfile instance) =>
         instance.hybridFuelChoice,
         const FuelTypeJsonConverter().toJson,
       ),
-      'showConsumptionTab': instance.showConsumptionTab,
       'gamificationEnabled': instance.gamificationEnabled,
     };
 

--- a/test/features/feature_management/data/legacy_toggle_migrator_test.dart
+++ b/test/features/feature_management/data/legacy_toggle_migrator_test.dart
@@ -932,4 +932,178 @@ void main() {
       },
     );
   });
+
+  /// Phase-3c orphan-deletion coverage for `UserProfile.showConsumptionTab`.
+  ///
+  /// Distinct from the gamification / haptic / sync precedents because
+  /// the migrator does NOT promote anything into the central feature
+  /// flag set — the field had zero consumers in `lib/` or `test/`
+  /// (likely orphaned by #1342) so phase 3c is a pure deletion. The
+  /// migrator only exists to strip the orphan key from any active
+  /// profile that was persisted before the field was removed; one save
+  /// through the repository writes a fresh JSON without the dropped key.
+  group('migrateUserProfileToggles — showConsumptionTab drop (phase 3c)', () {
+    test(
+      'first run with an active profile invokes the saver and sets the '
+      'gate flag',
+      () async {
+        const profile = UserProfile(id: 'p1', name: 'Test');
+        var savedCount = 0;
+        UserProfile? lastSaved;
+
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: profile,
+          saveActiveProfile: (p) async {
+            savedCount += 1;
+            lastSaved = p;
+          },
+        );
+
+        expect(
+          savedCount,
+          1,
+          reason:
+              'The drop step must call the repository saver exactly once '
+              'per upgrading user — the freshly-serialised JSON drops the '
+              'orphan showConsumptionTab key.',
+        );
+        expect(
+          lastSaved,
+          same(profile),
+          reason:
+              'The saver must receive the active profile verbatim — the '
+              'migrator does not mutate the profile, only triggers a '
+              're-serialisation through repository.updateProfile so '
+              'toJson() runs against the post-deletion shape.',
+        );
+        expect(
+          settings.get(showConsumptionTabDroppedKey),
+          isTrue,
+          reason:
+              'The migration gate must be set so a subsequent run does '
+              'not re-enter the saver branch (idempotency + avoids '
+              'invalidating Riverpod listeners on every launch).',
+        );
+      },
+    );
+
+    test(
+      'second run after the gate is set is a no-op (saver not invoked)',
+      () async {
+        const profile = UserProfile(id: 'p1', name: 'Test');
+        await settings.put(showConsumptionTabDroppedKey, true);
+        var savedCount = 0;
+
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: profile,
+          saveActiveProfile: (p) async {
+            savedCount += 1;
+          },
+        );
+
+        expect(
+          savedCount,
+          0,
+          reason:
+              'When the gate flag is already set the migrator must not '
+              're-save the profile — re-serialisation is idempotent on '
+              'the wire, but invalidates the active-profile Riverpod '
+              'listener and triggers spurious rebuilds.',
+        );
+      },
+    );
+
+    test(
+      'no active profile → no save, gate NOT set (will retry next launch)',
+      () async {
+        var savedCount = 0;
+
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: null,
+          saveActiveProfile: (p) async {
+            savedCount += 1;
+          },
+        );
+
+        expect(
+          savedCount,
+          0,
+          reason:
+              'Without an active profile there is nothing to re-serialise — '
+              'the saver must not fire.',
+        );
+        expect(
+          settings.get(showConsumptionTabDroppedKey),
+          isNull,
+          reason:
+              'The gate flag MUST NOT be written when no profile is loaded '
+              '— otherwise the next launch (when the profile IS loaded) '
+              'would skip the drop step and the orphan key would survive '
+              'on disk forever.',
+        );
+      },
+    );
+
+    test(
+      'saver-failure does NOT set the gate so the next launch retries',
+      () async {
+        const profile = UserProfile(id: 'p1', name: 'Test');
+
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: profile,
+          saveActiveProfile: (p) async {
+            throw StateError('disk full simulation');
+          },
+        );
+
+        expect(
+          settings.get(showConsumptionTabDroppedKey),
+          isNull,
+          reason:
+              'A save failure must keep the gate unset — the orphan key '
+              'is inert (no consumer reads it) so retrying on the next '
+              'launch is the correct recovery, not silent gate-set.',
+        );
+      },
+    );
+
+    test(
+      'no saver wired (callback null) → gate flag still set so test '
+      'environments are not re-entered every provider rebuild',
+      () async {
+        const profile = UserProfile(id: 'p1', name: 'Test');
+
+        await migrateUserProfileToggles(
+          settings: settings,
+          featureFlags: repo,
+          manifest: FeatureManifest.defaultManifest,
+          activeProfile: profile,
+          // saveActiveProfile omitted — covers the unit-test path that
+          // doesn't wire the profile repository.
+        );
+
+        expect(
+          settings.get(showConsumptionTabDroppedKey),
+          isTrue,
+          reason:
+              'When no saver is wired the migrator cannot strip the orphan '
+              'key — but it must still set the gate so a watcher in a unit '
+              'test that rebuilds the provider does not re-enter this '
+              'branch on every rebuild.',
+        );
+      },
+    );
+  });
 }

--- a/test/features/profile/data/models/user_profile_test.dart
+++ b/test/features/profile/data/models/user_profile_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+
+/// Pin the post-#1373-phase-3c shape of [UserProfile]:
+///   - the orphan `showConsumptionTab` field is GONE (it had no consumers
+///     in `lib/` or `test/`, likely orphaned by #1342 when the
+///     carbon/Achievements tab was removed).
+///   - JSON containing a stray `showConsumptionTab` key from a profile
+///     persisted before the deletion still deserialises — Freezed /
+///     json_serializable silently ignore unknown keys, so an upgrading
+///     user's stored profile does NOT crash on first read.
+void main() {
+  group('UserProfile — phase 3c orphan field deletion', () {
+    test('UserProfile no longer exposes a showConsumptionTab member', () {
+      const profile = UserProfile(id: 'p1', name: 'Default');
+      // Round-trip the profile through JSON and confirm the key is not
+      // emitted on write either. Without the field declaration toJson
+      // cannot synthesise the key, so this assertion would have been
+      // impossible before phase 3c.
+      final encoded = profile.toJson();
+      expect(
+        encoded.containsKey('showConsumptionTab'),
+        isFalse,
+        reason:
+            'Phase 3c removed UserProfile.showConsumptionTab as a pure '
+            'orphan deletion (no consumers in lib/ or test/). The '
+            'serialised JSON must not carry the dropped key — otherwise '
+            'the field is effectively still alive on the wire and a '
+            'future reader could revive it.',
+      );
+    });
+
+    test(
+      'legacy profile JSON with a stray showConsumptionTab: true key '
+      'deserialises (silently ignored)',
+      () {
+        // Mirrors the shape of a profile persisted before the field was
+        // removed: every required key plus the dropped `showConsumptionTab`.
+        // The migrator's safety pass (in legacy_toggle_migrator.dart) will
+        // re-save the profile back so the orphan key gets stripped on
+        // disk; here we only guarantee the in-memory decode path does
+        // not throw.
+        final legacyJson = <String, dynamic>{
+          'id': 'legacy-1',
+          'name': 'Upgraded user',
+          'showConsumptionTab': true,
+        };
+
+        final decoded = UserProfile.fromJson(legacyJson);
+
+        expect(
+          decoded.id,
+          'legacy-1',
+          reason:
+              'Required fields must round-trip even when the JSON carries '
+              'orphan keys from a previous schema.',
+        );
+        expect(
+          decoded.toJson().containsKey('showConsumptionTab'),
+          isFalse,
+          reason:
+              'Re-serialising the decoded profile must drop the orphan '
+              'key — the migrator depends on this so that one save through '
+              'the repository removes the legacy row from disk.',
+        );
+      },
+    );
+
+    test(
+      'legacy profile JSON with showConsumptionTab: false also deserialises',
+      () {
+        // Belt-and-braces: the false branch matters too because the
+        // pre-deletion default was false, so most upgrading users will
+        // have the explicit-false value persisted.
+        final legacyJson = <String, dynamic>{
+          'id': 'legacy-2',
+          'name': 'Upgraded user',
+          'showConsumptionTab': false,
+        };
+
+        final decoded = UserProfile.fromJson(legacyJson);
+
+        expect(decoded.id, 'legacy-2');
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Phase 3c of #1373 is a **deletion**, not a Feature-flag migration. `UserProfile.showConsumptionTab` has zero consumers in `lib/` or `test/` (likely orphaned by #1342 when the carbon/Achievements tab was removed). Adding a `Feature.showConsumptionTab` toggle would be pure overhead — there's no UI to gate.

- Removed the field from `UserProfile`
- Migrator strips the legacy `showConsumptionTab` key from any persisted profile JSON on next launch (idempotent via `showConsumptionTabDroppedKey` gate flag)
- Removed mention from `legacy_toggle_migrator.dart` doc comment

## Test plan

- [x] UserProfile no longer carries the field; constructor + JSON round-trip green
- [x] JSON with stray `showConsumptionTab: true` deserializes (silently ignored)
- [x] Migrator's drop-step covered: first-run saves profile back, second-run no-op, no-active-profile no-op
- [x] Existing `legacy_toggle_migrator_test.dart` cases still green

Refs #1373 phase 3c